### PR TITLE
feat: add deletion protection for verifiedpermissions_policy_store

### DIFF
--- a/.changelog/43452.txt
+++ b/.changelog/43452.txt
@@ -3,5 +3,5 @@ data-source/aws_verifiedpermissions_policy_store: Add `deletion_protection` attr
 ```
 
 ```release-note:enhancement
-resource/aws_verifiedpermissions_policy_store: Add `deletion_protection` attribute
+resource/aws_verifiedpermissions_policy_store: Add `deletion_protection` argument
 ```

--- a/.changelog/43452.txt
+++ b/.changelog/43452.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+data-source/aws_verifiedpermissions_policy_store: Add `deletion_protection` attribute
+```
+
+```release-note:enhancement
+resource/aws_verifiedpermissions_policy_store: Add `deletion_protection` attribute
+```

--- a/internal/service/verifiedpermissions/policy_store.go
+++ b/internal/service/verifiedpermissions/policy_store.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -57,7 +56,6 @@ func (r *policyStoreResource) Schema(ctx context.Context, request resource.Schem
 				Optional:   true,
 				Computed:   true,
 				CustomType: fwtypes.StringEnumType[awstypes.DeletionProtection](),
-				Default:    stringdefault.StaticString(string(awstypes.DeletionProtectionDisabled)),
 			},
 			names.AttrDescription: schema.StringAttribute{
 				Optional: true,
@@ -182,7 +180,7 @@ func (r *policyStoreResource) Update(ctx context.Context, request resource.Updat
 
 	conn := r.Meta().VerifiedPermissionsClient(ctx)
 
-	if !new.Description.Equal(old.Description) || !new.ValidationSettings.Equal(old.ValidationSettings) || !new.DeletionProtection.Equal(old.DeletionProtection) {
+	if !new.DeletionProtection.Equal(old.DeletionProtection) || !new.Description.Equal(old.Description) || !new.ValidationSettings.Equal(old.ValidationSettings) {
 		var input verifiedpermissions.UpdatePolicyStoreInput
 		response.Diagnostics.Append(fwflex.Expand(ctx, new, &input)...)
 		if response.Diagnostics.HasError() {

--- a/internal/service/verifiedpermissions/policy_store.go
+++ b/internal/service/verifiedpermissions/policy_store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -52,6 +53,12 @@ func (r *policyStoreResource) Schema(ctx context.Context, request resource.Schem
 	s := schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			names.AttrARN: framework.ARNAttributeComputedOnly(),
+			names.AttrDeletionProtection: schema.StringAttribute{
+				Optional:   true,
+				Computed:   true,
+				CustomType: fwtypes.StringEnumType[awstypes.DeletionProtection](),
+				Default:    stringdefault.StaticString(string(awstypes.DeletionProtectionDisabled)),
+			},
 			names.AttrDescription: schema.StringAttribute{
 				Optional: true,
 			},
@@ -175,7 +182,7 @@ func (r *policyStoreResource) Update(ctx context.Context, request resource.Updat
 
 	conn := r.Meta().VerifiedPermissionsClient(ctx)
 
-	if !new.Description.Equal(old.Description) || !new.ValidationSettings.Equal(old.ValidationSettings) {
+	if !new.Description.Equal(old.Description) || !new.ValidationSettings.Equal(old.ValidationSettings) || !new.DeletionProtection.Equal(old.DeletionProtection) {
 		var input verifiedpermissions.UpdatePolicyStoreInput
 		response.Diagnostics.Append(fwflex.Expand(ctx, new, &input)...)
 		if response.Diagnostics.HasError() {
@@ -231,6 +238,7 @@ type policyStoreResourceModel struct {
 	framework.WithRegionModel
 	ARN                types.String                                        `tfsdk:"arn"`
 	Description        types.String                                        `tfsdk:"description"`
+	DeletionProtection fwtypes.StringEnum[awstypes.DeletionProtection]     `tfsdk:"deletion_protection"`
 	ID                 types.String                                        `tfsdk:"id"`
 	PolicyStoreID      types.String                                        `tfsdk:"policy_store_id"`
 	Tags               tftags.Map                                          `tfsdk:"tags"`

--- a/internal/service/verifiedpermissions/policy_store_data_source.go
+++ b/internal/service/verifiedpermissions/policy_store_data_source.go
@@ -41,6 +41,10 @@ func (d *policyStoreDataSource) Schema(ctx context.Context, request datasource.S
 				CustomType: timetypes.RFC3339Type{},
 				Computed:   true,
 			},
+			names.AttrDeletionProtection: schema.StringAttribute{
+				Computed:   true,
+				CustomType: fwtypes.StringEnumType[awstypes.DeletionProtection](),
+			},
 			names.AttrDescription: schema.StringAttribute{
 				Computed: true,
 			},
@@ -87,6 +91,7 @@ type policyStoreDataSourceModel struct {
 	framework.WithRegionModel
 	ARN                types.String                                             `tfsdk:"arn"`
 	CreatedDate        timetypes.RFC3339                                        `tfsdk:"created_date"`
+	DeletionProtection fwtypes.StringEnum[awstypes.DeletionProtection]          `tfsdk:"deletion_protection"`
 	Description        types.String                                             `tfsdk:"description"`
 	ID                 types.String                                             `tfsdk:"id"`
 	LastUpdatedDate    timetypes.RFC3339                                        `tfsdk:"last_updated_date"`

--- a/internal/service/verifiedpermissions/policy_store_data_source_test.go
+++ b/internal/service/verifiedpermissions/policy_store_data_source_test.go
@@ -38,6 +38,7 @@ func TestAccVerifiedPermissionsPolicyStoreDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPolicyStoreExists(ctx, dataSourceName, &policystore),
 					resource.TestCheckResourceAttrPair(resourceName, "validation_settings.0.mode", dataSourceName, "validation_settings.0.mode"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDeletionProtection, "DISABLED"),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrDescription, dataSourceName, names.AttrDescription),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, dataSourceName, names.AttrARN),
 					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrCreatedDate),

--- a/website/docs/d/verifiedpermissions_policy_store.html.markdown
+++ b/website/docs/d/verifiedpermissions_policy_store.html.markdown
@@ -33,6 +33,7 @@ This data source exports the following attributes in addition to the arguments a
 
 * `arn` - The ARN of the Policy Store.
 * `created_date` - The date the Policy Store was created.
+* `deletion_protection` - Whether the policy store can be deleted.
 * `last_updated_date` - The date the Policy Store was last updated.
 * `tags` - Map of key-value pairs associated with the policy store.
 * `validation_settings` - Validation settings for the policy store.

--- a/website/docs/r/verifiedpermissions_policy_store.html.markdown
+++ b/website/docs/r/verifiedpermissions_policy_store.html.markdown
@@ -32,7 +32,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `deletion_protection` - (Optional) Specifies whether the policy store can be deleted. If enabled, the policy store can't be deleted. Valid Values: `ENABLED`, `DISABLED`. Default value: `DISABLED`. 
+* `deletion_protection` - (Optional) Specifies whether the policy store can be deleted. If enabled, the policy store can't be deleted. Valid Values: `ENABLED`, `DISABLED`. Default value: `DISABLED`.
 * `description` - (Optional) A description of the Policy Store.
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 

--- a/website/docs/r/verifiedpermissions_policy_store.html.markdown
+++ b/website/docs/r/verifiedpermissions_policy_store.html.markdown
@@ -32,6 +32,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `deletion_protection` - (Optional) Specifies whether the policy store can be deleted. If enabled, the policy store can't be deleted. Valid Values: `ENABLED`, `DISABLED`. Default value: `DISABLED`. 
 * `description` - (Optional) A description of the Policy Store.
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Add deletion protection support for the Amazon Verified Permissions Policy Store.

### Relations

Closes #43330

### References

- [AWS What`s new](https://aws.amazon.com/about-aws/whats-new/2025/04/amazon-verified-permissions-policy-store-deletion-protection/?nc1=h_ls)
- [CreatePolicyStore API](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_CreatePolicyStore.html)

### Output from Acceptance Testing

Resource

```console
❯ make testacc TESTS=TestAccVerifiedPermissionsPolicyStore  PKG=verifiedpermissions
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/verifiedpermissions/... -v -count 1 -parallel 20 -run='TestAccVerifiedPermissionsPolicyStore'  -timeout 360m -vet=off
2025/07/19 11:48:11 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/19 11:48:11 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVerifiedPermissionsPolicyStoreDataSource_basic
=== PAUSE TestAccVerifiedPermissionsPolicyStoreDataSource_basic
=== RUN   TestAccVerifiedPermissionsPolicyStoreDataSource_tags
=== PAUSE TestAccVerifiedPermissionsPolicyStoreDataSource_tags
=== RUN   TestAccVerifiedPermissionsPolicyStore_basic
=== PAUSE TestAccVerifiedPermissionsPolicyStore_basic
=== RUN   TestAccVerifiedPermissionsPolicyStore_update
=== PAUSE TestAccVerifiedPermissionsPolicyStore_update
=== RUN   TestAccVerifiedPermissionsPolicyStore_deletionProtection
=== PAUSE TestAccVerifiedPermissionsPolicyStore_deletionProtection
=== RUN   TestAccVerifiedPermissionsPolicyStore_disappears
=== PAUSE TestAccVerifiedPermissionsPolicyStore_disappears
=== RUN   TestAccVerifiedPermissionsPolicyStore_tags
=== PAUSE TestAccVerifiedPermissionsPolicyStore_tags
=== CONT  TestAccVerifiedPermissionsPolicyStoreDataSource_basic
=== CONT  TestAccVerifiedPermissionsPolicyStore_deletionProtection
=== CONT  TestAccVerifiedPermissionsPolicyStore_tags
=== CONT  TestAccVerifiedPermissionsPolicyStore_disappears
=== CONT  TestAccVerifiedPermissionsPolicyStoreDataSource_tags
=== CONT  TestAccVerifiedPermissionsPolicyStore_update
=== CONT  TestAccVerifiedPermissionsPolicyStore_basic
--- PASS: TestAccVerifiedPermissionsPolicyStoreDataSource_basic (37.80s)
--- PASS: TestAccVerifiedPermissionsPolicyStoreDataSource_tags (37.80s)
--- PASS: TestAccVerifiedPermissionsPolicyStore_disappears (42.71s)
--- PASS: TestAccVerifiedPermissionsPolicyStore_basic (44.18s)
--- PASS: TestAccVerifiedPermissionsPolicyStore_update (55.10s)
--- PASS: TestAccVerifiedPermissionsPolicyStore_deletionProtection (70.67s)
--- PASS: TestAccVerifiedPermissionsPolicyStore_tags (76.81s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/verifiedpermissions        77.027s
```

Data source 

```console
❯ make testacc TESTS=TestAccVerifiedPermissionsPolicyStoreDataSource  PKG=verifiedpermissions
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/verifiedpermissions/... -v -count 1 -parallel 20 -run='TestAccVerifiedPermissionsPolicyStoreDataSource'  -timeout 360m -vet=off
2025/07/19 12:41:36 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/19 12:41:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVerifiedPermissionsPolicyStoreDataSource_basic
=== PAUSE TestAccVerifiedPermissionsPolicyStoreDataSource_basic
=== RUN   TestAccVerifiedPermissionsPolicyStoreDataSource_tags
=== PAUSE TestAccVerifiedPermissionsPolicyStoreDataSource_tags
=== CONT  TestAccVerifiedPermissionsPolicyStoreDataSource_basic
=== CONT  TestAccVerifiedPermissionsPolicyStoreDataSource_tags
--- PASS: TestAccVerifiedPermissionsPolicyStoreDataSource_tags (25.83s)
--- PASS: TestAccVerifiedPermissionsPolicyStoreDataSource_basic (25.83s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/verifiedpermissions        26.055s
```
