### PR TITLE
fix: Fix aws_s3_object attr references in aws_lambda_layer_version tests

### DIFF
--- a/internal/service/lambda/layer_version_test.go
+++ b/internal/service/lambda/layer_version_test.go
@@ -422,8 +422,8 @@ resource "aws_s3_object" "lambda_code" {
 }
 
 resource "aws_lambda_layer_version" "test" {
-  s3_bucket  = aws_s3_bucket.lambda_bucket.id
-  s3_key     = aws_s3_object.lambda_code.id
+  s3_bucket  = aws_s3_object.lambda_code.bucket
+  s3_key     = aws_s3_object.lambda_code.key
   layer_name = %[1]q
 }
 `, rName)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to fix the references to `aws_s3_object` attributes in `internal/service/lambda/function_test.go`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #43420

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccLambdaLayerVersion_s3 PKG=lambda
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaLayerVersion_s3'  -timeout 360m -vet=off
2025/07/20 02:36:13 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/20 02:36:13 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaLayerVersion_s3
=== PAUSE TestAccLambdaLayerVersion_s3
=== CONT  TestAccLambdaLayerVersion_s3
--- PASS: TestAccLambdaLayerVersion_s3 (25.87s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     26.151s

$
```
