### PR TITLE
fix: Fix aws_s3_object attr references in aws_config_conformance_pack and aws_config_organization_conformance_pack tests

### DIFF
--- a/internal/service/configservice/conformance_pack_test.go
+++ b/internal/service/configservice/conformance_pack_test.go
@@ -687,7 +687,7 @@ EOT
 resource "aws_config_conformance_pack" "test" {
   depends_on      = [aws_config_configuration_recorder.test]
   name            = %q
-  template_s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.id}"
+  template_s3_uri = "s3://${aws_s3_object.test.bucket}/${aws_s3_object.test.key}"
 }
 `, bucketName, rName))
 }
@@ -728,7 +728,7 @@ Resources:
         SourceIdentifier: IAM_PASSWORD_POLICY
     Type: AWS::Config::ConfigRule
 EOT
-  template_s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.id}"
+  template_s3_uri = "s3://${aws_s3_object.test.bucket}/${aws_s3_object.test.key}"
 }
 `, rName))
 }

--- a/internal/service/configservice/organization_conformance_pack_test.go
+++ b/internal/service/configservice/organization_conformance_pack_test.go
@@ -652,7 +652,7 @@ func testAccOrganizationConformancePackConfig_s3Template(rName, bName string) st
 resource "aws_config_organization_conformance_pack" "test" {
   depends_on      = [aws_config_configuration_recorder.test, aws_organizations_organization.test]
   name            = %q
-  template_s3_uri = "s3://${aws_s3_bucket.test.id}/${aws_s3_object.test.id}"
+  template_s3_uri = "s3://${aws_s3_object.test.bucket}/${aws_s3_object.test.key}"
 }
 
 resource "aws_s3_bucket" "test" {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to fix the references to `aws_s3_object` attributes in `internal/service/configservice/conformance_pack_test.go` and `internal/service/configservice/organization_conformance_pack_test.go`.

Note that running these acceptance tests are a bit of a pain because it requires Config not be be set up initially and each account only allows a single customer managed trail. I opted to running them in a region which I do not typically use where Config is not set up.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #43420

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

For `conformance_pack_test.go`:
```console
$ export ACCTEST_PARALLELISM=1

$ export AWS_DEFAULT_REGION=eu-central-1

Anthony@DESKTOP-397NMN2 MINGW64 ~/git/terraform-provider-aws (f-aws_configservice-fix_s3_object_attr_refs)
$ make testacc TESTS='TestAccConfigService_serial/^ConformancePack/S3' PKG=configservice
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/configservice/... -v -count 1 -parallel 1 -run='TestAccConfigService_serial/^ConformancePack/S3'  -timeout 360m -vet=off
2025/07/20 15:16:08 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/20 15:16:08 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccConfigService_serial
=== PAUSE TestAccConfigService_serial
=== CONT  TestAccConfigService_serial
=== RUN   TestAccConfigService_serial/ConformancePack
=== RUN   TestAccConfigService_serial/ConformancePack/S3Delivery
=== RUN   TestAccConfigService_serial/ConformancePack/S3Template
=== RUN   TestAccConfigService_serial/ConformancePack/S3TemplateAndTemplateBody
=== RUN   TestAccConfigService_serial/ConformancePack/updateS3Delivery
=== RUN   TestAccConfigService_serial/ConformancePack/updateS3Template
--- PASS: TestAccConfigService_serial (848.36s)
    --- PASS: TestAccConfigService_serial/ConformancePack (848.36s)
        --- PASS: TestAccConfigService_serial/ConformancePack/S3Delivery (153.00s)
        --- PASS: TestAccConfigService_serial/ConformancePack/S3Template (142.10s)
        --- PASS: TestAccConfigService_serial/ConformancePack/S3TemplateAndTemplateBody (149.16s)
        --- PASS: TestAccConfigService_serial/ConformancePack/updateS3Delivery (202.33s)
        --- PASS: TestAccConfigService_serial/ConformancePack/updateS3Template (201.77s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/configservice      848.612s

$
```

For `organization_conformance_pack_test.go`:

```console
$ export ACCTEST_PARALLELISM=1

$ export AWS_DEFAULT_REGION=eu-central-1

$ make testacc TESTS='TestAccConfigService_serial/^OrganizationConformancePack/S3' PKG=configservice
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/configservice/... -v -count 1 -parallel 1 -run='TestAccConfigService_serial/^OrganizationConformancePack/S3'  -timeout 360m -vet=off
2025/07/20 15:41:08 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/20 15:41:08 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccConfigService_serial
=== PAUSE TestAccConfigService_serial
=== CONT  TestAccConfigService_serial
=== RUN   TestAccConfigService_serial/OrganizationConformancePack
=== RUN   TestAccConfigService_serial/OrganizationConformancePack/updateS3Delivery
=== RUN   TestAccConfigService_serial/OrganizationConformancePack/updateS3Template
=== RUN   TestAccConfigService_serial/OrganizationConformancePack/S3Delivery
=== RUN   TestAccConfigService_serial/OrganizationConformancePack/S3Template
--- PASS: TestAccConfigService_serial (2116.57s)
    --- PASS: TestAccConfigService_serial/OrganizationConformancePack (2116.57s)
        --- PASS: TestAccConfigService_serial/OrganizationConformancePack/updateS3Delivery (620.40s)
        --- PASS: TestAccConfigService_serial/OrganizationConformancePack/updateS3Template (607.61s)
        --- PASS: TestAccConfigService_serial/OrganizationConformancePack/S3Delivery (448.82s)
        --- PASS: TestAccConfigService_serial/OrganizationConformancePack/S3Template (439.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/configservice      2116.894s

$
```