### PR TITLE
fix: Fix aws_s3_object attr references in aws_elasticbeanstalk tests

### DIFF
--- a/internal/service/elasticbeanstalk/application_version_test.go
+++ b/internal/service/elasticbeanstalk/application_version_test.go
@@ -220,8 +220,8 @@ resource "aws_elastic_beanstalk_application" "default" {
 resource "aws_elastic_beanstalk_application_version" "default" {
   application = aws_elastic_beanstalk_application.default.name
   name        = "tf-test-version-label-%d"
-  bucket      = aws_s3_bucket.default.id
-  key         = aws_s3_object.default.id
+  bucket      = aws_s3_object.default.bucket
+  key         = aws_s3_object.default.key
 }
 `, randInt, randInt, randInt)
 }
@@ -246,8 +246,8 @@ resource "aws_elastic_beanstalk_application" "first" {
 resource "aws_elastic_beanstalk_application_version" "first" {
   application = aws_elastic_beanstalk_application.first.name
   name        = "tf-test-version-label-%d"
-  bucket      = aws_s3_bucket.default.id
-  key         = aws_s3_object.default.id
+  bucket      = aws_s3_object.default.bucket
+  key         = aws_s3_object.default.key
 }
 
 resource "aws_elastic_beanstalk_application" "second" {
@@ -258,8 +258,8 @@ resource "aws_elastic_beanstalk_application" "second" {
 resource "aws_elastic_beanstalk_application_version" "second" {
   application = aws_elastic_beanstalk_application.second.name
   name        = "tf-test-version-label-%d"
-  bucket      = aws_s3_bucket.default.id
-  key         = aws_s3_object.default.id
+  bucket      = aws_s3_object.default.bucket
+  key         = aws_s3_object.default.key
 }
 `, randInt, randInt, randInt, randInt, randInt)
 }
@@ -284,8 +284,8 @@ resource "aws_elastic_beanstalk_application" "default" {
 resource "aws_elastic_beanstalk_application_version" "default" {
   application = aws_elastic_beanstalk_application.default.name
   name        = "tf-test-version-label-%[1]d"
-  bucket      = aws_s3_bucket.default.id
-  key         = aws_s3_object.default.id
+  bucket      = aws_s3_object.default.bucket
+  key         = aws_s3_object.default.key
 
   tags = {
     firstTag  = "%[2]s"
@@ -315,8 +315,8 @@ resource "aws_elastic_beanstalk_application" "default" {
 resource "aws_elastic_beanstalk_application_version" "default" {
   application = aws_elastic_beanstalk_application.default.name
   name        = "tf-test-version-label-%[1]d"
-  bucket      = aws_s3_bucket.default.id
-  key         = aws_s3_object.default.id
+  bucket      = aws_s3_object.default.bucket
+  key         = aws_s3_object.default.key
 
   tags = {
     firstTag  = "%[2]s"
@@ -347,8 +347,8 @@ resource "aws_elastic_beanstalk_application" "default" {
 resource "aws_elastic_beanstalk_application_version" "default" {
   application = aws_elastic_beanstalk_application.default.name
   name        = "tf-test-version-label-%d"
-  bucket      = aws_s3_bucket.default.id
-  key         = aws_s3_object.default.id
+  bucket      = aws_s3_object.default.bucket
+  key         = aws_s3_object.default.key
   process     = %s
 }
 `, randInt, randInt, randInt, process)

--- a/internal/service/elasticbeanstalk/environment_test.go
+++ b/internal/service/elasticbeanstalk/environment_test.go
@@ -1377,8 +1377,8 @@ resource "aws_s3_object" "test" {
 
 resource "aws_elastic_beanstalk_application_version" "test" {
   application = aws_elastic_beanstalk_application.test.name
-  bucket      = aws_s3_bucket.test.id
-  key         = aws_s3_object.test.id
+  bucket      = aws_s3_object.test.bucket
+  key         = aws_s3_object.test.key
   name        = "%[1]s-1"
 }
 
@@ -1441,8 +1441,8 @@ resource "aws_s3_object" "test" {
 
 resource "aws_elastic_beanstalk_application_version" "test" {
   application = aws_elastic_beanstalk_application.test.name
-  bucket      = aws_s3_bucket.test.id
-  key         = aws_s3_object.test.id
+  bucket      = aws_s3_object.test.bucket
+  key         = aws_s3_object.test.key
   name        = "%[1]s-2"
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to fix the references to `aws_s3_object` attributes in `internal/service/elasticbeanstalk/application_version_test.go` and `internal/service/elasticbeanstalk/environment_test.go`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #43420

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

For `application_version_test.go`:

```console
$ make testacc TESTS=TestAccElasticBeanstalkApplicationVersion_ PKG=elasticbeanstalk
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/elasticbeanstalk/... -v -count 1 -parallel 20 -run='TestAccElasticBeanstalkApplicationVersion_'  -timeout 360m -vet=off
2025/07/20 16:57:01 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/20 16:57:01 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_basic
=== PAUSE TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_basic
=== RUN   TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_duplicateLabels
=== PAUSE TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_duplicateLabels
=== RUN   TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_tags
=== PAUSE TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_tags
=== RUN   TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_process
=== PAUSE TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_process
=== CONT  TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_basic
=== CONT  TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_tags
=== CONT  TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_duplicateLabels
=== CONT  TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_process
--- PASS: TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_basic (34.71s)
--- PASS: TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_duplicateLabels (46.20s)
--- PASS: TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_process (58.13s)
--- PASS: TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_tags (95.77s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticbeanstalk   96.048s

$
```

For `environment_test.go`:

```console
$ make testacc TESTS=TestAccElasticBeanstalkEnvironment_label PKG=elasticbeanstalk
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/elasticbeanstalk/... -v -count 1 -parallel 20 -run='TestAccElasticBeanstalkEnvironment_label'  -timeout 360m -vet=off
2025/07/20 16:47:49 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/20 16:47:49 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccElasticBeanstalkEnvironment_label
=== PAUSE TestAccElasticBeanstalkEnvironment_label
=== CONT  TestAccElasticBeanstalkEnvironment_label
--- PASS: TestAccElasticBeanstalkEnvironment_label (511.59s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticbeanstalk   511.905s

$
```