### PR TITLE
Fix typo in aws_bedrock_agent_collaborator documentation

### DIFF
--- a/website/docs/r/bedrockagent_agent_collaborator.html.markdown
+++ b/website/docs/r/bedrockagent_agent_collaborator.html.markdown
@@ -108,7 +108,7 @@ The following arguments are required:
 
 * `agent_id` - (Required) ID if the agent to associate the collaborator.
 * `collaboration_instruction` - (Required) Instruction to give the collaborator.
-* `collbaorator_name` - (Required) Name of this collaborator.
+* `collaborator_name` - (Required) Name of this collaborator.
 
 The following arguments are optional:
 


### PR DESCRIPTION
Fixes #43380

Corrected a spelling mistake in the documentation for the `aws_bedrock_agent_collaborator` resource.
Replaced `collbaorator_name` with the correct spelling `collaborator_name`.