### PR TITLE
r/lb_listener(doc): Add weighted target groups example

### DIFF
--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -39,6 +39,45 @@ resource "aws_lb_listener" "front_end" {
 }
 ```
 
+With weighted target groups:
+
+```terraform
+resource "aws_lb" "front_end" {
+  # ...
+}
+
+resource "aws_lb_target_group" "front_end_blue" {
+  # ...
+}
+
+resource "aws_lb_target_group" "front_end_green" {
+  # ...
+}
+
+resource "aws_lb_listener" "front_end" {
+  load_balancer_arn = aws_lb.front_end.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = "arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"
+
+  default_action {
+    type = "forward"
+
+    forward {
+      target_group {
+        arn    = aws_lb_target_group.front_end_blue.arn
+        weight = 100
+      }
+      target_group {
+        arn    = aws_lb_target_group.front_end_green.arn
+        weight = 0
+      }
+    }
+  }
+}
+```
+
 To a NLB:
 
 ```terraform


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Hello! Thank you for maintaining this provider👍 

This PR adds a comprehensive example for configuring ALB listener default forward actions with weighted target groups to the `aws_lb_listener` resource documentation.

ALB listeners support weighted target groups for default actions. The `target_group_arn` parameter documentation states:

> To route to one or more target groups, use a forward block instead.

This means users should use `forward` block instead of `target_group_arn` for weighted routing, but there is no complete example showing how to actually implement this configuration. Having example code would make this much clearer for users.

This is my motivation for creating this pull request😀

Please feel free to point out if anything needs improvement or adjustment.
Thank you!

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

~~Closes #0000~~

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener
- https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```