### PR TITLE
 fix: Fix aws_s3_object attr references in aws_comprehend tests

### DIFF
--- a/internal/service/comprehend/document_classifier_test.go
+++ b/internal/service/comprehend/document_classifier_test.go
@@ -1619,7 +1619,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [
@@ -1645,7 +1645,7 @@ resource "aws_comprehend_document_classifier" "test" {
   language_code = "en"
   mode          = "MULTI_CLASS"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [
@@ -1675,7 +1675,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [
@@ -1701,7 +1701,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [
@@ -1726,7 +1726,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [
@@ -1752,7 +1752,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [
@@ -1777,8 +1777,8 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri      = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
-    test_s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri      = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
+    test_s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [
@@ -1803,7 +1803,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri          = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri          = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     label_delimiter = %q
   }
 
@@ -1830,7 +1830,7 @@ resource "aws_comprehend_document_classifier" "test" {
   language_code = "en"
   mode          = "MULTI_CLASS"
   input_data_config {
-    s3_uri          = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri          = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     label_delimiter = %q
   }
 
@@ -1857,7 +1857,7 @@ resource "aws_comprehend_document_classifier" "test" {
   language_code = "en"
   mode          = "MULTI_LABEL"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.multilabel.id}"
+    s3_uri = "s3://${aws_s3_object.multilabel.bucket}/${aws_s3_object.multilabel.key}"
   }
 
   depends_on = [
@@ -1887,7 +1887,7 @@ resource "aws_comprehend_document_classifier" "test" {
   language_code = "en"
   mode          = "MULTI_LABEL"
   input_data_config {
-    s3_uri          = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.multilabel.id}"
+    s3_uri          = "s3://${aws_s3_object.multilabel.bucket}/${aws_s3_object.multilabel.key}"
     label_delimiter = %[2]q
   }
 
@@ -1916,7 +1916,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [
@@ -1982,7 +1982,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [
@@ -2044,7 +2044,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [
@@ -2072,7 +2072,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [
@@ -2137,7 +2137,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [
@@ -2201,7 +2201,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [
@@ -2230,7 +2230,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [
@@ -2260,7 +2260,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [
@@ -2286,7 +2286,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   output_data_config {
@@ -2317,7 +2317,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   output_data_config {
@@ -2373,7 +2373,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   output_data_config {
@@ -2429,7 +2429,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   output_data_config {
@@ -2490,7 +2490,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   output_data_config {
@@ -2551,7 +2551,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   output_data_config {
@@ -2607,7 +2607,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   output_data_config {
@@ -2638,7 +2638,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   output_data_config {
@@ -2832,7 +2832,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [
@@ -2940,7 +2940,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [
@@ -3041,7 +3041,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [

--- a/internal/service/comprehend/entity_recognizer_test.go
+++ b/internal/service/comprehend/entity_recognizer_test.go
@@ -1081,11 +1081,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 
@@ -1124,11 +1124,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 
@@ -1163,11 +1163,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 
@@ -1201,11 +1201,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 
@@ -1240,11 +1240,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 
@@ -1278,12 +1278,12 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri      = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
-      test_s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri      = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.key}"
+      test_s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 
@@ -1317,11 +1317,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     annotations {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.annotations.id}"
+      s3_uri = "s3://${aws_s3_object.annotations.bucket}/${aws_s3_object.annotations.key}"
     }
   }
 
@@ -1355,13 +1355,13 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri      = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
-      test_s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri      = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
+      test_s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     annotations {
-      s3_uri      = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.annotations.id}"
-      test_s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.annotations.id}"
+      s3_uri      = "s3://${aws_s3_object.annotations.bucket}/${aws_s3_object.annotations.key}"
+      test_s3_uri = "s3://${aws_s3_object.annotations.bucket}/${aws_s3_object.annotations.key}"
     }
   }
 
@@ -1395,12 +1395,12 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     annotations {
-      s3_uri      = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.annotations.id}"
-      test_s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.annotations.id}"
+      s3_uri      = "s3://${aws_s3_object.annotations.bucket}/${aws_s3_object.annotations.key}"
+      test_s3_uri = "s3://${aws_s3_object.annotations.bucket}/${aws_s3_object.annotations.key}"
     }
   }
 
@@ -1434,12 +1434,12 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri      = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
-      test_s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri      = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
+      test_s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     annotations {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.annotations.id}"
+      s3_uri = "s3://${aws_s3_object.annotations.bucket}/${aws_s3_object.annotations.key}"
     }
   }
 
@@ -1476,11 +1476,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 
@@ -1554,11 +1554,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 
@@ -1629,11 +1629,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 
@@ -1670,11 +1670,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 
@@ -1748,11 +1748,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 
@@ -1825,11 +1825,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 
@@ -1867,11 +1867,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 
@@ -1910,11 +1910,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 
@@ -2063,11 +2063,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 
@@ -2184,11 +2184,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 
@@ -2298,11 +2298,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 

--- a/internal/service/comprehend/testdata/DocumentClassifier/basic/main_gen.tf
+++ b/internal/service/comprehend/testdata/DocumentClassifier/basic/main_gen.tf
@@ -8,7 +8,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [

--- a/internal/service/comprehend/testdata/DocumentClassifier/basic_v5.100.0/main_gen.tf
+++ b/internal/service/comprehend/testdata/DocumentClassifier/basic_v5.100.0/main_gen.tf
@@ -8,7 +8,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [

--- a/internal/service/comprehend/testdata/DocumentClassifier/basic_v6.0.0/main_gen.tf
+++ b/internal/service/comprehend/testdata/DocumentClassifier/basic_v6.0.0/main_gen.tf
@@ -8,7 +8,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [

--- a/internal/service/comprehend/testdata/DocumentClassifier/region_override/main_gen.tf
+++ b/internal/service/comprehend/testdata/DocumentClassifier/region_override/main_gen.tf
@@ -10,7 +10,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [

--- a/internal/service/comprehend/testdata/EntityRecognizer/basic/main_gen.tf
+++ b/internal/service/comprehend/testdata/EntityRecognizer/basic/main_gen.tf
@@ -16,11 +16,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 

--- a/internal/service/comprehend/testdata/EntityRecognizer/basic_v5.100.0/main_gen.tf
+++ b/internal/service/comprehend/testdata/EntityRecognizer/basic_v5.100.0/main_gen.tf
@@ -16,11 +16,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 

--- a/internal/service/comprehend/testdata/EntityRecognizer/basic_v6.0.0/main_gen.tf
+++ b/internal/service/comprehend/testdata/EntityRecognizer/basic_v6.0.0/main_gen.tf
@@ -16,11 +16,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 

--- a/internal/service/comprehend/testdata/EntityRecognizer/region_override/main_gen.tf
+++ b/internal/service/comprehend/testdata/EntityRecognizer/region_override/main_gen.tf
@@ -18,11 +18,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 

--- a/internal/service/comprehend/testdata/tmpl/document_classifier_tags.gtpl
+++ b/internal/service/comprehend/testdata/tmpl/document_classifier_tags.gtpl
@@ -6,7 +6,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
   language_code = "en"
   input_data_config {
-    s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+    s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
   }
 
   depends_on = [

--- a/internal/service/comprehend/testdata/tmpl/entity_recognizer_tags.gtpl
+++ b/internal/service/comprehend/testdata/tmpl/entity_recognizer_tags.gtpl
@@ -14,11 +14,11 @@ resource "aws_comprehend_entity_recognizer" "test" {
     }
 
     documents {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.documents.id}"
+      s3_uri = "s3://${aws_s3_object.documents.bucket}/${aws_s3_object.documents.key}"
     }
 
     entity_list {
-      s3_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.entities.id}"
+      s3_uri = "s3://${aws_s3_object.entities.bucket}/${aws_s3_object.entities.key}"
     }
   }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to fix the references to `aws_s3_object` attributes in `internal/service/comprehend/document_classifier_test.go`, `internal/service/comprehend/entity_recognizer_test.go`, and the Terraform config templates in `testdata` directory.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #43420

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

**Note:** The `_Identity_ExistingResource` test case fails for both resources and it looks to be caused by the acceptance tests not recognizing the older provider version, similar to what I've seen while fixing another resource. I will need help fixing it and rerunning the tests as needed, as these tests are also not cheap to run due to the model training cost.

For `document_classifier_test.go`:

```console
$ make testacc TESTS=TestAccComprehendDocumentClassifier_ PKG=comprehend
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/comprehend/... -v -count 1 -parallel 20 -run='TestAccComprehendDocumentClassifier_'  -timeout 360m -vet=off
2025/07/20 17:12:20 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/20 17:12:20 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccComprehendDocumentClassifier_Identity_Basic
=== PAUSE TestAccComprehendDocumentClassifier_Identity_Basic
=== RUN   TestAccComprehendDocumentClassifier_Identity_RegionOverride
=== PAUSE TestAccComprehendDocumentClassifier_Identity_RegionOverride
=== RUN   TestAccComprehendDocumentClassifier_Identity_ExistingResource
=== PAUSE TestAccComprehendDocumentClassifier_Identity_ExistingResource
=== RUN   TestAccComprehendDocumentClassifier_basic
=== PAUSE TestAccComprehendDocumentClassifier_basic
=== RUN   TestAccComprehendDocumentClassifier_disappears
=== PAUSE TestAccComprehendDocumentClassifier_disappears
=== RUN   TestAccComprehendDocumentClassifier_versionName
=== PAUSE TestAccComprehendDocumentClassifier_versionName
=== RUN   TestAccComprehendDocumentClassifier_versionNameEmpty
=== PAUSE TestAccComprehendDocumentClassifier_versionNameEmpty
=== RUN   TestAccComprehendDocumentClassifier_versionNameGenerated
=== PAUSE TestAccComprehendDocumentClassifier_versionNameGenerated
=== RUN   TestAccComprehendDocumentClassifier_versionNamePrefix
=== PAUSE TestAccComprehendDocumentClassifier_versionNamePrefix
=== RUN   TestAccComprehendDocumentClassifier_testDocuments
=== PAUSE TestAccComprehendDocumentClassifier_testDocuments
=== RUN   TestAccComprehendDocumentClassifier_SingleLabel_ValidateNoDelimiterSet
=== PAUSE TestAccComprehendDocumentClassifier_SingleLabel_ValidateNoDelimiterSet
=== RUN   TestAccComprehendDocumentClassifier_multiLabel_basic
=== PAUSE TestAccComprehendDocumentClassifier_multiLabel_basic
=== RUN   TestAccComprehendDocumentClassifier_outputDataConfig_basic
=== PAUSE TestAccComprehendDocumentClassifier_outputDataConfig_basic
=== RUN   TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyCreateID
=== PAUSE TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyCreateID
=== RUN   TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyCreateARN
=== PAUSE TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyCreateARN
=== RUN   TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyCreateAliasName
=== PAUSE TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyCreateAliasName
=== RUN   TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyCreateAliasARN
=== PAUSE TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyCreateAliasARN
=== RUN   TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyAdd
=== PAUSE TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyAdd
=== RUN   TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyUpdate
=== PAUSE TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyUpdate
=== RUN   TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyRemove
=== PAUSE TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyRemove
=== RUN   TestAccComprehendDocumentClassifier_multiLabel_labelDelimiter
=== PAUSE TestAccComprehendDocumentClassifier_multiLabel_labelDelimiter
=== RUN   TestAccComprehendDocumentClassifier_KMSKeys_CreateIDs
=== PAUSE TestAccComprehendDocumentClassifier_KMSKeys_CreateIDs
=== RUN   TestAccComprehendDocumentClassifier_KMSKeys_CreateARNs
=== PAUSE TestAccComprehendDocumentClassifier_KMSKeys_CreateARNs
=== RUN   TestAccComprehendDocumentClassifier_KMSKeys_Add
=== PAUSE TestAccComprehendDocumentClassifier_KMSKeys_Add
=== RUN   TestAccComprehendDocumentClassifier_KMSKeys_Update
=== PAUSE TestAccComprehendDocumentClassifier_KMSKeys_Update
=== RUN   TestAccComprehendDocumentClassifier_KMSKeys_Remove
=== PAUSE TestAccComprehendDocumentClassifier_KMSKeys_Remove
=== RUN   TestAccComprehendDocumentClassifier_VPCConfig_Create
=== PAUSE TestAccComprehendDocumentClassifier_VPCConfig_Create
=== RUN   TestAccComprehendDocumentClassifier_VPCConfig_Add
=== PAUSE TestAccComprehendDocumentClassifier_VPCConfig_Add
=== RUN   TestAccComprehendDocumentClassifier_VPCConfig_Remove
=== PAUSE TestAccComprehendDocumentClassifier_VPCConfig_Remove
=== RUN   TestAccComprehendDocumentClassifier_tags
=== PAUSE TestAccComprehendDocumentClassifier_tags
=== RUN   TestAccComprehendDocumentClassifier_DefaultTags_providerOnly
=== PAUSE TestAccComprehendDocumentClassifier_DefaultTags_providerOnly
=== CONT  TestAccComprehendDocumentClassifier_Identity_Basic
=== CONT  TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyCreateAliasARN
=== CONT  TestAccComprehendDocumentClassifier_testDocuments
=== CONT  TestAccComprehendDocumentClassifier_VPCConfig_Remove
=== CONT  TestAccComprehendDocumentClassifier_multiLabel_labelDelimiter
=== CONT  TestAccComprehendDocumentClassifier_VPCConfig_Create
=== CONT  TestAccComprehendDocumentClassifier_KMSKeys_Remove
=== CONT  TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyCreateAliasName
=== CONT  TestAccComprehendDocumentClassifier_versionNamePrefix
=== CONT  TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyCreateARN
=== CONT  TestAccComprehendDocumentClassifier_KMSKeys_CreateARNs
=== CONT  TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyCreateID
=== CONT  TestAccComprehendDocumentClassifier_outputDataConfig_basic
=== CONT  TestAccComprehendDocumentClassifier_multiLabel_basic
=== CONT  TestAccComprehendDocumentClassifier_SingleLabel_ValidateNoDelimiterSet
=== CONT  TestAccComprehendDocumentClassifier_KMSKeys_Update
=== CONT  TestAccComprehendDocumentClassifier_DefaultTags_providerOnly
=== CONT  TestAccComprehendDocumentClassifier_tags
=== CONT  TestAccComprehendDocumentClassifier_KMSKeys_Add
=== CONT  TestAccComprehendDocumentClassifier_KMSKeys_CreateIDs
=== NAME  TestAccComprehendDocumentClassifier_Identity_Basic
    document_classifier_identity_gen_test.go:30: Terraform CLI version 1.10.5 is below minimum version 1.12.0: skipping test
--- SKIP: TestAccComprehendDocumentClassifier_Identity_Basic (1.02s)
=== CONT  TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyUpdate
--- PASS: TestAccComprehendDocumentClassifier_SingleLabel_ValidateNoDelimiterSet (19.00s)
=== CONT  TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyRemove
--- PASS: TestAccComprehendDocumentClassifier_testDocuments (2324.39s)
=== CONT  TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyAdd
--- PASS: TestAccComprehendDocumentClassifier_versionNamePrefix (2326.01s)
=== CONT  TestAccComprehendDocumentClassifier_disappears
--- PASS: TestAccComprehendDocumentClassifier_DefaultTags_providerOnly (2366.18s)
=== CONT  TestAccComprehendDocumentClassifier_versionNameGenerated
--- PASS: TestAccComprehendDocumentClassifier_outputDataConfig_basic (2460.28s)
=== CONT  TestAccComprehendDocumentClassifier_versionNameEmpty
--- PASS: TestAccComprehendDocumentClassifier_tags (2476.13s)
=== CONT  TestAccComprehendDocumentClassifier_VPCConfig_Add
--- PASS: TestAccComprehendDocumentClassifier_multiLabel_basic (2945.76s)
=== CONT  TestAccComprehendDocumentClassifier_versionName
--- PASS: TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyCreateID (4150.49s)
=== CONT  TestAccComprehendDocumentClassifier_Identity_ExistingResource
    document_classifier_identity_gen_test.go:236: Terraform CLI version 1.10.5 is below minimum version 1.12.0: skipping test
--- SKIP: TestAccComprehendDocumentClassifier_Identity_ExistingResource (0.19s)
=== CONT  TestAccComprehendDocumentClassifier_basic
--- PASS: TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyCreateAliasARN (4161.59s)
=== CONT  TestAccComprehendDocumentClassifier_Identity_RegionOverride
    document_classifier_identity_gen_test.go:115: Terraform CLI version 1.10.5 is below minimum version 1.12.0: skipping test
--- SKIP: TestAccComprehendDocumentClassifier_Identity_RegionOverride (0.17s)
--- PASS: TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyCreateAliasName (4183.41s)
--- PASS: TestAccComprehendDocumentClassifier_KMSKeys_CreateIDs (4419.38s)
--- PASS: TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyCreateARN (4449.34s)
--- PASS: TestAccComprehendDocumentClassifier_KMSKeys_Add (4750.81s)
--- PASS: TestAccComprehendDocumentClassifier_versionNameEmpty (3368.20s)
--- PASS: TestAccComprehendDocumentClassifier_KMSKeys_CreateARNs (5983.80s)
--- PASS: TestAccComprehendDocumentClassifier_versionNameGenerated (3647.36s)
--- PASS: TestAccComprehendDocumentClassifier_disappears (3787.45s)
--- PASS: TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyRemove (6142.69s)
--- PASS: TestAccComprehendDocumentClassifier_VPCConfig_Create (6561.16s)
--- PASS: TestAccComprehendDocumentClassifier_multiLabel_labelDelimiter (6686.64s)
--- PASS: TestAccComprehendDocumentClassifier_KMSKeys_Update (6701.39s)
--- PASS: TestAccComprehendDocumentClassifier_KMSKeys_Remove (7708.89s)
--- PASS: TestAccComprehendDocumentClassifier_basic (3682.14s)
--- PASS: TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyUpdate (8031.01s)
--- PASS: TestAccComprehendDocumentClassifier_outputDataConfig_kmsKeyAdd (5935.82s)
--- PASS: TestAccComprehendDocumentClassifier_VPCConfig_Add (6009.70s)
--- PASS: TestAccComprehendDocumentClassifier_versionName (7023.54s)
--- PASS: TestAccComprehendDocumentClassifier_VPCConfig_Remove (10201.18s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/comprehend 10201.494s

$
```

```console
$ make testacc TESTS="TestAccComprehendDocumentClassifier_Identity_" PKG=comprehend
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/comprehend/... -v -count 1 -parallel 20 -run='TestAccComprehendDocumentClassifier_Identity_'  -timeout 360m -vet=off
2025/07/20 21:30:27 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/20 21:30:27 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccComprehendDocumentClassifier_Identity_Basic
=== PAUSE TestAccComprehendDocumentClassifier_Identity_Basic
=== RUN   TestAccComprehendDocumentClassifier_Identity_RegionOverride
=== PAUSE TestAccComprehendDocumentClassifier_Identity_RegionOverride
=== RUN   TestAccComprehendDocumentClassifier_Identity_ExistingResource
=== PAUSE TestAccComprehendDocumentClassifier_Identity_ExistingResource
=== CONT  TestAccComprehendDocumentClassifier_Identity_Basic
=== CONT  TestAccComprehendDocumentClassifier_Identity_ExistingResource
=== CONT  TestAccComprehendDocumentClassifier_Identity_RegionOverride
=== NAME  TestAccComprehendDocumentClassifier_Identity_ExistingResource
    document_classifier_identity_gen_test.go:236: Step 1/3 error: Post-apply refresh state check(s) failed:
        aws_comprehend_document_classifier.test - Identity found in state, and was not expected.
--- FAIL: TestAccComprehendDocumentClassifier_Identity_ExistingResource (2323.13s)
--- PASS: TestAccComprehendDocumentClassifier_Identity_RegionOverride (2325.11s)
--- PASS: TestAccComprehendDocumentClassifier_Identity_Basic (2326.28s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/comprehend 2326.549s
FAIL
make: *** [GNUmakefile:642: testacc] Error 1

$
```

For `entity_recognizer_test.go`:

```console
$ make testacc TESTS="TestAccComprehendEntityRecognizer_" PKG=comprehend
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/comprehend/... -v -count 1 -parallel 20 -run='TestAccComprehendEntityRecognizer_'  -timeout 360m -vet=off
2025/07/20 20:07:07 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/20 20:07:07 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccComprehendEntityRecognizer_Identity_Basic
=== PAUSE TestAccComprehendEntityRecognizer_Identity_Basic
=== RUN   TestAccComprehendEntityRecognizer_Identity_RegionOverride
=== PAUSE TestAccComprehendEntityRecognizer_Identity_RegionOverride
=== RUN   TestAccComprehendEntityRecognizer_Identity_ExistingResource
=== PAUSE TestAccComprehendEntityRecognizer_Identity_ExistingResource
=== RUN   TestAccComprehendEntityRecognizer_basic
=== PAUSE TestAccComprehendEntityRecognizer_basic
=== RUN   TestAccComprehendEntityRecognizer_disappears
=== PAUSE TestAccComprehendEntityRecognizer_disappears
=== RUN   TestAccComprehendEntityRecognizer_versionName
=== PAUSE TestAccComprehendEntityRecognizer_versionName
=== RUN   TestAccComprehendEntityRecognizer_versionNameEmpty
=== PAUSE TestAccComprehendEntityRecognizer_versionNameEmpty
=== RUN   TestAccComprehendEntityRecognizer_versionNameGenerated
=== PAUSE TestAccComprehendEntityRecognizer_versionNameGenerated
=== RUN   TestAccComprehendEntityRecognizer_versionNamePrefix
=== PAUSE TestAccComprehendEntityRecognizer_versionNamePrefix
=== RUN   TestAccComprehendEntityRecognizer_documents_testDocuments
=== PAUSE TestAccComprehendEntityRecognizer_documents_testDocuments
=== RUN   TestAccComprehendEntityRecognizer_annotations_basic
=== PAUSE TestAccComprehendEntityRecognizer_annotations_basic
=== RUN   TestAccComprehendEntityRecognizer_annotations_testDocuments
=== PAUSE TestAccComprehendEntityRecognizer_annotations_testDocuments
=== RUN   TestAccComprehendEntityRecognizer_annotations_validateNoTestDocuments
=== PAUSE TestAccComprehendEntityRecognizer_annotations_validateNoTestDocuments
=== RUN   TestAccComprehendEntityRecognizer_annotations_validateNoTestAnnotations
=== PAUSE TestAccComprehendEntityRecognizer_annotations_validateNoTestAnnotations
=== RUN   TestAccComprehendEntityRecognizer_KMSKeys_CreateIDs
=== PAUSE TestAccComprehendEntityRecognizer_KMSKeys_CreateIDs
=== RUN   TestAccComprehendEntityRecognizer_KMSKeys_CreateARNs
=== PAUSE TestAccComprehendEntityRecognizer_KMSKeys_CreateARNs
=== RUN   TestAccComprehendEntityRecognizer_KMSKeys_Update
=== PAUSE TestAccComprehendEntityRecognizer_KMSKeys_Update
=== RUN   TestAccComprehendEntityRecognizer_VPCConfig_Create
=== PAUSE TestAccComprehendEntityRecognizer_VPCConfig_Create
=== RUN   TestAccComprehendEntityRecognizer_VPCConfig_Update
=== PAUSE TestAccComprehendEntityRecognizer_VPCConfig_Update
=== RUN   TestAccComprehendEntityRecognizer_tags
=== PAUSE TestAccComprehendEntityRecognizer_tags
=== RUN   TestAccComprehendEntityRecognizer_DefaultTags_providerOnly
=== PAUSE TestAccComprehendEntityRecognizer_DefaultTags_providerOnly
=== CONT  TestAccComprehendEntityRecognizer_Identity_Basic
=== CONT  TestAccComprehendEntityRecognizer_annotations_testDocuments
=== CONT  TestAccComprehendEntityRecognizer_documents_testDocuments
=== CONT  TestAccComprehendEntityRecognizer_KMSKeys_Update
=== CONT  TestAccComprehendEntityRecognizer_KMSKeys_CreateIDs
=== CONT  TestAccComprehendEntityRecognizer_tags
=== CONT  TestAccComprehendEntityRecognizer_VPCConfig_Update
=== CONT  TestAccComprehendEntityRecognizer_VPCConfig_Create
=== CONT  TestAccComprehendEntityRecognizer_KMSKeys_CreateARNs
=== CONT  TestAccComprehendEntityRecognizer_versionNameEmpty
=== CONT  TestAccComprehendEntityRecognizer_annotations_basic
=== CONT  TestAccComprehendEntityRecognizer_annotations_validateNoTestDocuments
=== CONT  TestAccComprehendEntityRecognizer_basic
=== CONT  TestAccComprehendEntityRecognizer_versionName
=== CONT  TestAccComprehendEntityRecognizer_disappears
=== CONT  TestAccComprehendEntityRecognizer_versionNameGenerated
=== CONT  TestAccComprehendEntityRecognizer_versionNamePrefix
=== CONT  TestAccComprehendEntityRecognizer_Identity_ExistingResource
=== CONT  TestAccComprehendEntityRecognizer_Identity_RegionOverride
=== CONT  TestAccComprehendEntityRecognizer_DefaultTags_providerOnly
--- PASS: TestAccComprehendEntityRecognizer_annotations_validateNoTestDocuments (6.28s)
=== CONT  TestAccComprehendEntityRecognizer_annotations_validateNoTestAnnotations
--- PASS: TestAccComprehendEntityRecognizer_annotations_validateNoTestAnnotations (6.24s)
=== NAME  TestAccComprehendEntityRecognizer_Identity_ExistingResource
    entity_recognizer_identity_gen_test.go:236: Step 1/3 error: Post-apply refresh state check(s) failed:
        aws_comprehend_entity_recognizer.test - Identity found in state, and was not expected.
--- FAIL: TestAccComprehendEntityRecognizer_Identity_ExistingResource (1108.69s)
--- PASS: TestAccComprehendEntityRecognizer_Identity_Basic (1120.40s)
--- PASS: TestAccComprehendEntityRecognizer_Identity_RegionOverride (1121.53s)
--- PASS: TestAccComprehendEntityRecognizer_DefaultTags_providerOnly (1143.44s)
--- PASS: TestAccComprehendEntityRecognizer_annotations_basic (1177.90s)
--- PASS: TestAccComprehendEntityRecognizer_versionNameGenerated (1180.64s)
--- PASS: TestAccComprehendEntityRecognizer_basic (1181.61s)
--- PASS: TestAccComprehendEntityRecognizer_versionNamePrefix (1181.98s)
--- PASS: TestAccComprehendEntityRecognizer_versionNameEmpty (1235.62s)
--- PASS: TestAccComprehendEntityRecognizer_disappears (1806.09s)
--- PASS: TestAccComprehendEntityRecognizer_KMSKeys_CreateARNs (1868.22s)
--- PASS: TestAccComprehendEntityRecognizer_documents_testDocuments (1869.54s)
--- PASS: TestAccComprehendEntityRecognizer_tags (1901.76s)
--- PASS: TestAccComprehendEntityRecognizer_annotations_testDocuments (1903.53s)
--- PASS: TestAccComprehendEntityRecognizer_versionName (1978.00s)
--- PASS: TestAccComprehendEntityRecognizer_KMSKeys_CreateIDs (1989.68s)
--- PASS: TestAccComprehendEntityRecognizer_VPCConfig_Create (2223.24s)
--- PASS: TestAccComprehendEntityRecognizer_VPCConfig_Update (3269.68s)
--- PASS: TestAccComprehendEntityRecognizer_KMSKeys_Update (3679.53s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/comprehend 3679.817s
FAIL
make: *** [GNUmakefile:642: testacc] Error 1

$
```