### PR TITLE
bug: fix aws_dms_replication_task waiter issue

### DIFF
--- a/internal/service/dms/consts.go
+++ b/internal/service/dms/consts.go
@@ -33,6 +33,10 @@ const (
 	replicationTaskStatusStopping  = "stopping"
 	replicationTaskStatusRunning   = "running"
 	replicationTaskStatusStarting  = "starting"
+
+	replicationTaskStatusStoppedFullLoadOnlyFinished = "stopped_FULL_LOAD_ONLY_FINISHED"
+	replicationTaskStatusStoppedAfterFullLoad        = "stopped_STOPPED_AFTER_FULL_LOAD"
+	replicationTaskStatusStoppedAfterCachedEvents    = "stopped_STOPPED_AFTER_CACHED_EVENTS"
 )
 
 const (


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
If a task is already stopped due to finishing it's task, the stop reason needs to be checked to validate the reason to make sure its maybe already finished
```go

	// The reason the replication task was stopped. This response parameter can return
	// one of the following values:
	//
	//   - "Stop Reason NORMAL" – The task completed successfully with no additional
	//   information returned.
	//
	//   - "Stop Reason RECOVERABLE_ERROR"
	//
	//   - "Stop Reason FATAL_ERROR"
	//
	//   - "Stop Reason FULL_LOAD_ONLY_FINISHED" – The task completed the full load
	//   phase. DMS applied cached changes if you set StopTaskCachedChangesApplied to
	//   true .
	//
	//   - "Stop Reason STOPPED_AFTER_FULL_LOAD" – Full load completed, with cached
	//   changes not applied
	//
	//   - "Stop Reason STOPPED_AFTER_CACHED_EVENTS" – Full load completed, with cached
	//   changes applied
	//
	//   - "Stop Reason EXPRESS_LICENSE_LIMITS_REACHED"
	//
	//   - "Stop Reason STOPPED_AFTER_DDL_APPLY" – User-defined stop task after DDL
	//   applied
	//
	//   - "Stop Reason STOPPED_DUE_TO_LOW_MEMORY"
	//
	//   - "Stop Reason STOPPED_DUE_TO_LOW_DISK"
	//
	//   - "Stop Reason STOPPED_AT_SERVER_TIME" – User-defined server time for stopping
	//   task
	//
	//   - "Stop Reason STOPPED_AT_COMMIT_TIME" – User-defined commit time for stopping
	//   task
	//
	//   - "Stop Reason RECONFIGURATION_RESTART"
	//
	//   - "Stop Reason RECYCLE_TASK"
```

### Relations
Closes #43466

### References

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
