### PR TITLE
Remove flow node/connection limits

### DIFF
--- a/.changelog/43471.txt
+++ b/.changelog/43471.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bedrockagent_flow: Remove node and connection limits
+```

--- a/.changelog/43471.txt
+++ b/.changelog/43471.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_bedrockagent_flow: Remove node and connection limits
+resource/aws_bedrockagent_flow: Remove `definition.connection` and `definition.node` list length limits
 ```

--- a/internal/service/bedrockagent/flow.go
+++ b/internal/service/bedrockagent/flow.go
@@ -118,9 +118,6 @@ func (r *flowResource) Schema(ctx context.Context, request resource.SchemaReques
 					Blocks: map[string]schema.Block{
 						"connection": schema.ListNestedBlock{
 							CustomType: fwtypes.NewListNestedObjectTypeOf[flowConnectionModel](ctx),
-							Validators: []validator.List{
-								listvalidator.SizeBetween(0, 20),
-							},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
 									names.AttrName: schema.StringAttribute{
@@ -204,9 +201,6 @@ func (r *flowResource) Schema(ctx context.Context, request resource.SchemaReques
 						},
 						"node": schema.ListNestedBlock{
 							CustomType: fwtypes.NewListNestedObjectTypeOf[flowNodeModel](ctx),
-							Validators: []validator.List{
-								listvalidator.SizeBetween(0, 40),
-							},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
 									names.AttrName: schema.StringAttribute{


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This removes the limits on the number of nodes and connections within a flow. It is possible to create a flow which exceed the limits currently defined in the validators.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #43470

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccBedrockAgentFlow PKG=bedrockagent
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/bedrockagent/... -v -count 1 -parallel 20 -run='TestAccBedrockAgentFlow'  -timeout 360m -vet=off
2025/07/21 15:53:44 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/21 15:53:44 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockAgentFlow_basic
=== PAUSE TestAccBedrockAgentFlow_basic
=== RUN   TestAccBedrockAgentFlow_disappears
=== PAUSE TestAccBedrockAgentFlow_disappears
=== RUN   TestAccBedrockAgentFlow_withEncryptionKey
=== PAUSE TestAccBedrockAgentFlow_withEncryptionKey
=== RUN   TestAccBedrockAgentFlow_tags
=== PAUSE TestAccBedrockAgentFlow_tags
=== RUN   TestAccBedrockAgentFlow_withDefinition
=== PAUSE TestAccBedrockAgentFlow_withDefinition
=== CONT  TestAccBedrockAgentFlow_basic
=== CONT  TestAccBedrockAgentFlow_tags
=== CONT  TestAccBedrockAgentFlow_withEncryptionKey
=== CONT  TestAccBedrockAgentFlow_disappears
=== CONT  TestAccBedrockAgentFlow_withDefinition
--- PASS: TestAccBedrockAgentFlow_disappears (10.39s)
--- PASS: TestAccBedrockAgentFlow_basic (11.76s)
--- PASS: TestAccBedrockAgentFlow_withEncryptionKey (11.81s)
--- PASS: TestAccBedrockAgentFlow_withDefinition (12.04s)
--- PASS: TestAccBedrockAgentFlow_tags (26.56s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       29.589s
```
