### PR TITLE
docs(eks): correct default value for bootstrap_cluster_creator_admin_…

### DIFF
--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -300,6 +300,7 @@ This resource supports the following arguments:
 * `comment` (Optional) - Any comments you want to include about the distribution.
 * `continuous_deployment_policy_id` (Optional) - Identifier of a continuous deployment policy. This argument should only be set on a production distribution. See the [`aws_cloudfront_continuous_deployment_policy` resource](./cloudfront_continuous_deployment_policy.html.markdown) for additional details.
 * `custom_error_response` (Optional) - One or more [custom error response](#custom-error-response-arguments) elements (multiples allowed).
+ > **Note:** When specifying either `response_page_path` or `response_code`, **both** must be set. Omitting one will result in an API error from CloudFront.
 * `default_cache_behavior` (Required) - [Default cache behavior](#default-cache-behavior-arguments) for this distribution (maximum one). Requires either `cache_policy_id` (preferred) or `forwarded_values` (deprecated) be set.
 * `default_root_object` (Optional) - Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL.
 * `enabled` (Required) - Whether the distribution is enabled to accept end user requests for content.

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -418,7 +418,7 @@ resource "aws_cloudfront_distribution" "example" {
 
 #### Custom Error Response Arguments
 
-~> **NOTE:** When specifying either `response_page_path` or `response_code`, **both** must be set. Omitting one will result in an API error from CloudFront.
+~> **NOTE:** When specifying either `response_page_path` or `response_code`, **both** must be set.
 
 * `error_caching_min_ttl` (Optional) - Minimum amount of time you want HTTP error codes to stay in CloudFront caches before CloudFront queries your origin to see whether the object has been updated.
 * `error_code` (Required) - 4xx or 5xx HTTP status code that you want to customize.

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -300,7 +300,6 @@ This resource supports the following arguments:
 * `comment` (Optional) - Any comments you want to include about the distribution.
 * `continuous_deployment_policy_id` (Optional) - Identifier of a continuous deployment policy. This argument should only be set on a production distribution. See the [`aws_cloudfront_continuous_deployment_policy` resource](./cloudfront_continuous_deployment_policy.html.markdown) for additional details.
 * `custom_error_response` (Optional) - One or more [custom error response](#custom-error-response-arguments) elements (multiples allowed).
- > **Note:** When specifying either `response_page_path` or `response_code`, **both** must be set. Omitting one will result in an API error from CloudFront.
 * `default_cache_behavior` (Required) - [Default cache behavior](#default-cache-behavior-arguments) for this distribution (maximum one). Requires either `cache_policy_id` (preferred) or `forwarded_values` (deprecated) be set.
 * `default_root_object` (Optional) - Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL.
 * `enabled` (Required) - Whether the distribution is enabled to accept end user requests for content.
@@ -418,6 +417,8 @@ resource "aws_cloudfront_distribution" "example" {
 * `whitelisted_names` (Optional) - If you have specified `whitelist` to `forward`, the whitelisted cookies that you want CloudFront to forward to your origin.
 
 #### Custom Error Response Arguments
+
+~> **NOTE:** When specifying either `response_page_path` or `response_code`, **both** must be set. Omitting one will result in an API error from CloudFront.
 
 * `error_caching_min_ttl` (Optional) - Minimum amount of time you want HTTP error codes to stay in CloudFront caches before CloudFront queries your origin to see whether the object has been updated.
 * `error_code` (Required) - 4xx or 5xx HTTP status code that you want to customize.

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -365,7 +365,7 @@ The following arguments are optional:
 The `access_config` configuration block supports the following arguments:
 
 * `authentication_mode` - (Optional) The authentication mode for the cluster. Valid values are `CONFIG_MAP`, `API` or `API_AND_CONFIG_MAP`
-* `bootstrap_cluster_creator_admin_permissions` - (Optional) Whether or not to bootstrap the access config values to the cluster. Default is `false`.
+* `bootstrap_cluster_creator_admin_permissions` - (Optional) Whether or not to bootstrap the access config values to the cluster. Default is `true`.
 
 ### compute_config
 


### PR DESCRIPTION
### Description

This PR updates the documentation for the `aws_eks_cluster` resource to reflect the correct default value of `bootstrap_cluster_creator_admin_permissions`, which is `true` (not `false` as currently documented).  
This aligns with the Terraform AWS Provider schema and AWS API behavior.

### Relations

Closes #43404.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/40904.

### Notes

- Documentation-only change
- Labeled as `good first issue`
- Happy to receive f
