### PR TITLE
[WIP] aws_kinesisanalyticsv2_application :: Snapshot restore configuration bug #43003

### DIFF
--- a/internal/service/kinesisanalyticsv2/application.go
+++ b/internal/service/kinesisanalyticsv2/application.go
@@ -284,7 +284,6 @@ func resourceApplication() *schema.Resource {
 											Elem: &schema.Resource{
 												Schema: map[string]*schema.Schema{
 													"application_restore_type": {
-														// NOTE: Set as required in Cloudformation: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-kinesisanalyticsv2-application-applicationrestoreconfiguration.html
 														Type:             schema.TypeString,
 														Required:         true,
 														ValidateDiagFunc: enum.Validate[awstypes.ApplicationRestoreType](),

--- a/internal/service/kinesisanalyticsv2/application_test.go
+++ b/internal/service/kinesisanalyticsv2/application_test.go
@@ -1272,6 +1272,51 @@ func TestAccKinesisAnalyticsV2Application_FlinkApplication_restoreFromSnapshot(t
 	})
 }
 
+func TestAccKinesisAnalyticsV2Application_FlinkApplication_snapshotToggleRestoreTypeBug(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.ApplicationDetail
+	resourceName := "aws_kinesisanalyticsv2_application.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KinesisAnalyticsV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
+		Steps: []resource.TestStep{
+			// Step 1: Create application with snapshots enabled and SKIP_RESTORE_FROM_SNAPSHOT
+			{
+				Config: testAccApplicationConfig_snapshotToggleBug(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "application_configuration.0.application_snapshot_configuration.0.snapshots_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "application_configuration.0.run_configuration.0.application_restore_configuration.0.application_restore_type", "SKIP_RESTORE_FROM_SNAPSHOT"),
+				),
+			},
+			// Step 2: Disable snapshots but maintain SKIP_RESTORE_FROM_SNAPSHOT
+			{
+				Config: testAccApplicationConfig_snapshotToggleBug(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "application_configuration.0.application_snapshot_configuration.0.snapshots_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "application_configuration.0.run_configuration.0.application_restore_configuration.0.application_restore_type", "SKIP_RESTORE_FROM_SNAPSHOT"),
+				),
+			},
+			// Step 3: Re-enable snapshots - application_restore_type should remain SKIP_RESTORE_FROM_SNAPSHOT
+			{
+				Config: testAccApplicationConfig_snapshotToggleBug(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "application_configuration.0.application_snapshot_configuration.0.snapshots_enabled", acctest.CtTrue),
+					// This is the critical check - the restore type should remain SKIP_RESTORE_FROM_SNAPSHOT
+					// but the bug causes it to default to restore from latest snapshot
+					resource.TestCheckResourceAttr(resourceName, "application_configuration.0.run_configuration.0.application_restore_configuration.0.application_restore_type", "SKIP_RESTORE_FROM_SNAPSHOT"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKinesisAnalyticsV2Application_FlinkApplicationStartApplication_onCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ApplicationDetail
@@ -5749,4 +5794,84 @@ resource "aws_kinesisanalyticsv2_application" "test" {
   }
 }
 `, rName))
+}
+
+func testAccApplicationConfig_snapshotToggleBug(rName string, snapshotsEnabled bool) string {
+	return acctest.ConfigCompose(
+		testAccApplicationConfig_baseServiceExecutionIAMRole(rName),
+		testAccApplicationConfig_baseFlinkApplication(rName),
+		fmt.Sprintf(`
+resource "aws_kinesisanalyticsv2_application" "test" {
+  name                   = %[1]q
+  runtime_environment    = "FLINK-1_20"
+  service_execution_role = aws_iam_role.test[0].arn
+  start_application      = true
+
+  application_configuration {
+    application_code_configuration {
+      code_content {
+        s3_content_location {
+          bucket_arn     = aws_s3_bucket.test.arn
+          file_key       = aws_s3_object.test[0].key
+          object_version = aws_s3_object.test[0].version_id
+        }
+      }
+
+      code_content_type = "ZIPFILE"
+    }
+
+    application_snapshot_configuration {
+      snapshots_enabled = %[2]t
+    }
+
+    environment_properties {
+      property_group {
+        property_group_id = "InputStream0"
+
+        property_map = {
+          "aws.region"  = data.aws_region.current.region
+          "stream.name" = aws_kinesis_stream.input.name
+        }
+      }
+
+      property_group {
+        property_group_id = "OutputStream0"
+
+        property_map = {
+          "aws.region"  = data.aws_region.current.region
+          "stream.name" = aws_kinesis_stream.output.name
+        }
+      }
+    }
+
+    flink_application_configuration {
+      checkpoint_configuration {
+        configuration_type = "DEFAULT"
+      }
+
+      monitoring_configuration {
+        configuration_type = "CUSTOM"
+        log_level          = "DEBUG"
+        metrics_level      = "TASK"
+      }
+
+      parallelism_configuration {
+        auto_scaling_enabled = true
+        configuration_type   = "CUSTOM"
+        parallelism          = 1
+        parallelism_per_kpu  = 1
+      }
+    }
+
+    run_configuration {
+      application_restore_configuration {
+        application_restore_type = "SKIP_RESTORE_FROM_SNAPSHOT"
+      }
+      flink_run_configuration {
+        allow_non_restored_state = false
+      }
+    }
+  }
+}
+`, rName, snapshotsEnabled))
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

**No changes to security controls.**

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR fixes a bug in the `aws_kinesisanalyticsv2_application` resource where the `application_restore_type` configuration would incorrectly revert to AWS default behavior when toggling snapshot configurations.

**The Issue:**
When users configured `application_restore_type = "SKIP_RESTORE_FROM_SNAPSHOT"` and then toggled the `snapshots_enabled` setting on and off, the provider would fail to maintain the user's explicitly configured restore type, causing the application to unexpectedly restore from the latest snapshot instead of skipping restoration as intended.

**The Fix:**
1. Changed `application_restore_type` from Optional/Computed to Required to align with [CloudFormation requirements](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-kinesisanalyticsv2-application-applicationrestoreconfiguration.html)
2. Modified the update logic to always apply `application_restore_configuration` when set, preventing dangerous AWS defaults from taking precedence
3. Added comprehensive test coverage to verify the fix works correctly across snapshot toggle scenarios

This ensures that user-specified restoration behavior is consistently maintained regardless of other configuration changes.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Closes #43003 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- [AWS CloudFormation Documentation - ApplicationRestoreConfiguration](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-kinesisanalyticsv2-application-applicationrestoreconfiguration.html)
- [AWS Doc - Incompatible Snapshots](https://docs.aws.amazon.com/managed-flink/latest/java/how-snapshots.html#how-fault-snapshot-restore)


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
➜  terraform-provider-aws git:(b-aws_kinesisanalyticsv2_application-43003) ✗ AWS_PROFILE=Built-Dev/BuiltAdmin AWS_DEFAULT_REGION=us-east-1 make testacc TESTS=snapshot PKG=kinesisanalyticsv2 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/kinesisanalyticsv2/... -v -count 1 -parallel 20 -run='snapshot'  -timeout 360m -vet=off
2025/07/22 09:26:14 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/22 09:26:14 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKinesisAnalyticsV2Application_FlinkApplication_snapshotToggleRestoreTypeBug
=== PAUSE TestAccKinesisAnalyticsV2Application_FlinkApplication_snapshotToggleRestoreTypeBug
=== CONT  TestAccKinesisAnalyticsV2Application_FlinkApplication_snapshotToggleRestoreTypeBug
--- PASS: TestAccKinesisAnalyticsV2Application_FlinkApplication_snapshotToggleRestoreTypeBug (613.51s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalyticsv2	617.802s

...
```
