### PR TITLE
Resource Identity: Passes Identity Spec to SDKv2 custom imports

### DIFF
--- a/internal/generate/servicepackage/main.go
+++ b/internal/generate/servicepackage/main.go
@@ -181,6 +181,7 @@ type ResourceDatum struct {
 	SingletonIdentity                 bool
 	MutableIdentity                   bool
 	WrappedImport                     bool
+	CustomImport                      bool
 	goImports                         []goImport
 	IdentityDuplicateAttrs            []string
 	ImportIDHandler                   string
@@ -411,6 +412,9 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 						d.WrappedImport = b
 					}
 				}
+
+			case "CustomImport":
+				d.CustomImport = true
 
 			case "ArnIdentity":
 				d.ARNIdentity = true
@@ -644,7 +648,7 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 					v.sdkResources[typeName] = d
 				}
 
-			case "IdentityAttribute", "ArnIdentity", "ImportIDHandler", "MutableIdentity", "SingletonIdentity", "Region", "Tags", "WrappedImport", "V60SDKv2Fix", "IdentityFix":
+			case "IdentityAttribute", "ArnIdentity", "ImportIDHandler", "MutableIdentity", "SingletonIdentity", "Region", "Tags", "WrappedImport", "V60SDKv2Fix", "IdentityFix", "CustomImport":
 				// Handled above.
 			case "ArnFormat", "IdAttrFormat", "NoImport", "Testing":
 				// Ignored.

--- a/internal/generate/servicepackage/service_package_gen.go.gtpl
+++ b/internal/generate/servicepackage/service_package_gen.go.gtpl
@@ -224,7 +224,11 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 				{{- end }}
 				{{- if $value.WrappedImport }}
 					Import: inttypes.FrameworkImport{
-						WrappedImport: true,
+						{{- if $value.CustomImport }}
+							CustomImport: true,
+						{{- else }}
+							WrappedImport: true,
+						{{- end }}
 						{{- if ne $value.ImportIDHandler "" }}
 							ImportID: {{ $value.ImportIDHandler }}{},
 						{{- end }}
@@ -424,7 +428,11 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 				{{- end }}
 				{{- if $value.WrappedImport }}
 					Import: inttypes.SDKv2Import{
-						WrappedImport: true,
+						{{- if $value.CustomImport }}
+							CustomImport: true,
+						{{- else }}
+							WrappedImport: true,
+						{{- end }}
 						{{- if ne $value.ImportIDHandler "" }}
 							ImportID: {{ $value.ImportIDHandler }}{},
 						{{- end }}

--- a/internal/provider/sdkv2/identity_interceptor.go
+++ b/internal/provider/sdkv2/identity_interceptor.go
@@ -131,7 +131,7 @@ func newParameterizedIdentityImporter(identitySpec inttypes.Identity, importSpec
 		} else {
 			return &schema.ResourceImporter{
 				StateContext: func(ctx context.Context, rd *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-					if err := importer.RegionalMultipleParameterized(ctx, rd, identitySpec.Attributes, importSpec, meta.(importer.AWSClient)); err != nil {
+					if err := importer.RegionalMultipleParameterized(ctx, rd, identitySpec, importSpec, meta.(importer.AWSClient)); err != nil {
 						return nil, err
 					}
 

--- a/internal/provider/sdkv2/identity_interceptor.go
+++ b/internal/provider/sdkv2/identity_interceptor.go
@@ -191,3 +191,15 @@ func singletonIdentityResourceImporter(identity inttypes.Identity) *schema.Resou
 		}
 	}
 }
+
+func customResourceImporter(r *schema.Resource, identity *inttypes.Identity, importSpec *inttypes.SDKv2Import) {
+	importF := r.Importer.StateContext
+
+	r.Importer = &schema.ResourceImporter{
+		StateContext: func(ctx context.Context, rd *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+			ctx = importer.Context(ctx, identity, importSpec)
+
+			return importF(ctx, rd, meta)
+		},
+	}
+}

--- a/internal/provider/sdkv2/identity_interceptor.go
+++ b/internal/provider/sdkv2/identity_interceptor.go
@@ -96,11 +96,10 @@ func newResourceIdentity(v inttypes.Identity) *schema.ResourceIdentity {
 
 func newParameterizedIdentityImporter(identitySpec inttypes.Identity, importSpec *inttypes.SDKv2Import) *schema.ResourceImporter {
 	if identitySpec.IsSingleParameter {
-		attr := identitySpec.Attributes[len(identitySpec.Attributes)-1]
 		if identitySpec.IsGlobalResource {
 			return &schema.ResourceImporter{
 				StateContext: func(ctx context.Context, rd *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-					if err := importer.GlobalSingleParameterized(ctx, rd, attr, meta.(importer.AWSClient)); err != nil {
+					if err := importer.GlobalSingleParameterized(ctx, rd, identitySpec, meta.(importer.AWSClient)); err != nil {
 						return nil, err
 					}
 

--- a/internal/provider/sdkv2/identity_interceptor.go
+++ b/internal/provider/sdkv2/identity_interceptor.go
@@ -147,7 +147,7 @@ func arnIdentityResourceImporter(identity inttypes.Identity) *schema.ResourceImp
 	if identity.IsGlobalResource {
 		return &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, rd *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-				if err := importer.GlobalARN(ctx, rd, identity.IdentityAttribute, identity.IdentityDuplicateAttrs); err != nil {
+				if err := importer.GlobalARN(ctx, rd, identity); err != nil {
 					return nil, err
 				}
 

--- a/internal/provider/sdkv2/identity_interceptor.go
+++ b/internal/provider/sdkv2/identity_interceptor.go
@@ -157,7 +157,7 @@ func arnIdentityResourceImporter(identity inttypes.Identity) *schema.ResourceImp
 	} else {
 		return &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, rd *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-				if err := importer.RegionalARN(ctx, rd, identity.IdentityAttribute, identity.IdentityDuplicateAttrs); err != nil {
+				if err := importer.RegionalARN(ctx, rd, identity); err != nil {
 					return nil, err
 				}
 

--- a/internal/provider/sdkv2/identity_interceptor.go
+++ b/internal/provider/sdkv2/identity_interceptor.go
@@ -121,7 +121,7 @@ func newParameterizedIdentityImporter(identitySpec inttypes.Identity, importSpec
 		if identitySpec.IsGlobalResource {
 			return &schema.ResourceImporter{
 				StateContext: func(ctx context.Context, rd *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-					if err := importer.GlobalMultipleParameterized(ctx, rd, identitySpec.Attributes, importSpec, meta.(importer.AWSClient)); err != nil {
+					if err := importer.GlobalMultipleParameterized(ctx, rd, identitySpec, importSpec, meta.(importer.AWSClient)); err != nil {
 						return nil, err
 					}
 

--- a/internal/provider/sdkv2/identity_interceptor.go
+++ b/internal/provider/sdkv2/identity_interceptor.go
@@ -110,7 +110,7 @@ func newParameterizedIdentityImporter(identitySpec inttypes.Identity, importSpec
 		} else {
 			return &schema.ResourceImporter{
 				StateContext: func(ctx context.Context, rd *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-					if err := importer.RegionalSingleParameterized(ctx, rd, attr, meta.(importer.AWSClient)); err != nil {
+					if err := importer.RegionalSingleParameterized(ctx, rd, identitySpec, meta.(importer.AWSClient)); err != nil {
 						return nil, err
 					}
 

--- a/internal/provider/sdkv2/importer/arn.go
+++ b/internal/provider/sdkv2/importer/arn.go
@@ -87,14 +87,16 @@ func RegionalARNValue(_ context.Context, rd *schema.ResourceData, attrName strin
 	return nil
 }
 
-func GlobalARN(_ context.Context, rd *schema.ResourceData, attrName string, duplicateAttrs []string) error {
+func GlobalARN(_ context.Context, rd *schema.ResourceData, identitySpec inttypes.Identity) error {
+	attr := identitySpec.Attributes[0]
+
 	if rd.Id() != "" {
 		_, err := arn.Parse(rd.Id())
 		if err != nil {
 			return fmt.Errorf("could not parse import ID %q as ARN: %s", rd.Id(), err)
 		}
-		rd.Set(attrName, rd.Id())
-		for _, attr := range duplicateAttrs {
+		rd.Set(attr.ResourceAttributeName(), rd.Id())
+		for _, attr := range identitySpec.IdentityDuplicateAttrs {
 			setAttribute(rd, attr, rd.Id())
 		}
 
@@ -106,23 +108,23 @@ func GlobalARN(_ context.Context, rd *schema.ResourceData, attrName string, dupl
 		return err
 	}
 
-	arnRaw, ok := identity.GetOk(attrName)
+	arnRaw, ok := identity.GetOk(attr.Name())
 	if !ok {
-		return fmt.Errorf("identity attribute %q is required", attrName)
+		return fmt.Errorf("identity attribute %q is required", attr.Name())
 	}
 
 	arnVal, ok := arnRaw.(string)
 	if !ok {
-		return fmt.Errorf("identity attribute %q: expected string, got %T", attrName, arnRaw)
+		return fmt.Errorf("identity attribute %q: expected string, got %T", attr.Name(), arnRaw)
 	}
 
 	_, err = arn.Parse(arnVal)
 	if err != nil {
-		return fmt.Errorf("identity attribute %q: could not parse %q as ARN: %s", attrName, arnVal, err)
+		return fmt.Errorf("identity attribute %q: could not parse %q as ARN: %s", attr.Name(), arnVal, err)
 	}
 
-	rd.Set(attrName, arnVal)
-	for _, attr := range duplicateAttrs {
+	rd.Set(attr.ResourceAttributeName(), arnVal)
+	for _, attr := range identitySpec.IdentityDuplicateAttrs {
 		setAttribute(rd, attr, arnVal)
 	}
 

--- a/internal/provider/sdkv2/importer/arn.go
+++ b/internal/provider/sdkv2/importer/arn.go
@@ -9,17 +9,20 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func RegionalARN(_ context.Context, rd *schema.ResourceData, attrName string, duplicateAttrs []string) error {
+func RegionalARN(_ context.Context, rd *schema.ResourceData, identitySpec inttypes.Identity) error {
+	attr := identitySpec.Attributes[0]
+
 	if rd.Id() != "" {
 		arnARN, err := arn.Parse(rd.Id())
 		if err != nil {
 			return fmt.Errorf("could not parse import ID %q as ARN: %s", rd.Id(), err)
 		}
-		rd.Set(attrName, rd.Id())
-		for _, attr := range duplicateAttrs {
+		rd.Set(attr.ResourceAttributeName(), rd.Id())
+		for _, attr := range identitySpec.IdentityDuplicateAttrs {
 			setAttribute(rd, attr, rd.Id())
 		}
 
@@ -39,25 +42,25 @@ func RegionalARN(_ context.Context, rd *schema.ResourceData, attrName string, du
 		return err
 	}
 
-	arnRaw, ok := identity.GetOk(attrName)
+	arnRaw, ok := identity.GetOk(attr.Name())
 	if !ok {
-		return fmt.Errorf("identity attribute %q is required", attrName)
+		return fmt.Errorf("identity attribute %q is required", attr.Name())
 	}
 
 	arnVal, ok := arnRaw.(string)
 	if !ok {
-		return fmt.Errorf("identity attribute %q: expected string, got %T", attrName, arnRaw)
+		return fmt.Errorf("identity attribute %q: expected string, got %T", attr.Name(), arnRaw)
 	}
 
 	arnARN, err := arn.Parse(arnVal)
 	if err != nil {
-		return fmt.Errorf("identity attribute %q: could not parse %q as ARN: %s", attrName, arnVal, err)
+		return fmt.Errorf("identity attribute %q: could not parse %q as ARN: %s", attr.Name(), arnVal, err)
 	}
 
 	rd.Set(names.AttrRegion, arnARN.Region)
 
-	rd.Set(attrName, arnVal)
-	for _, attr := range duplicateAttrs {
+	rd.Set(attr.ResourceAttributeName(), arnVal)
+	for _, attr := range identitySpec.IdentityDuplicateAttrs {
 		setAttribute(rd, attr, arnVal)
 	}
 

--- a/internal/provider/sdkv2/importer/arn_test.go
+++ b/internal/provider/sdkv2/importer/arn_test.go
@@ -338,7 +338,11 @@ func TestGlobalARN_ImportID_Invalid_NotAnARN(t *testing.T) {
 	rd := schema.TestResourceDataRaw(t, globalARNSchema, map[string]any{})
 	rd.SetId("not a valid ARN")
 
-	err := importer.GlobalARN(context.Background(), rd, "arn", []string{"id"})
+	identity := inttypes.RegionalARNIdentityNamed("arn",
+		inttypes.WithIdentityDuplicateAttrs("id"),
+	)
+
+	err := importer.GlobalARN(context.Background(), rd, identity)
 	if err != nil {
 		if !strings.HasPrefix(err.Error(), "could not parse import ID") {
 			t.Fatalf("Unexpected error: %s", err)
@@ -361,7 +365,11 @@ func TestGlobalARN_ImportID_Valid(t *testing.T) {
 	}.String()
 	rd.SetId(arn)
 
-	err := importer.GlobalARN(context.Background(), rd, "arn", []string{"id"})
+	identity := inttypes.RegionalARNIdentityNamed("arn",
+		inttypes.WithIdentityDuplicateAttrs("id"),
+	)
+
+	err := importer.GlobalARN(context.Background(), rd, identity)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -382,7 +390,11 @@ func TestGlobalARN_Identity_Invalid_AttributeNotSet(t *testing.T) {
 
 	rd := schema.TestResourceDataWithIdentityRaw(t, globalARNSchema, globalARNIdentitySchema, map[string]string{})
 
-	err := importer.GlobalARN(context.Background(), rd, "arn", []string{"id"})
+	identity := inttypes.RegionalARNIdentityNamed("arn",
+		inttypes.WithIdentityDuplicateAttrs("id"),
+	)
+
+	err := importer.GlobalARN(context.Background(), rd, identity)
 	if err != nil {
 		if err.Error() != fmt.Sprintf("identity attribute %q is required", "arn") {
 			t.Fatalf("Unexpected error: %s", err)
@@ -399,7 +411,11 @@ func TestGlobalARN_Identity_Invalid_NotAnARN(t *testing.T) {
 		"arn": "not a valid ARN",
 	})
 
-	err := importer.GlobalARN(context.Background(), rd, "arn", []string{"id"})
+	identity := inttypes.RegionalARNIdentityNamed("arn",
+		inttypes.WithIdentityDuplicateAttrs("id"),
+	)
+
+	err := importer.GlobalARN(context.Background(), rd, identity)
 	if err != nil {
 		if !strings.HasPrefix(err.Error(), fmt.Sprintf("identity attribute %q: could not parse", "arn")) {
 			t.Fatalf("Unexpected error: %s", err)
@@ -423,7 +439,11 @@ func TestGlobalARN_Identity_Valid(t *testing.T) {
 		"arn": arn,
 	})
 
-	err := importer.GlobalARN(context.Background(), rd, "arn", []string{"id"})
+	identity := inttypes.RegionalARNIdentityNamed("arn",
+		inttypes.WithIdentityDuplicateAttrs("id"),
+	)
+
+	err := importer.GlobalARN(context.Background(), rd, identity)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -452,7 +472,11 @@ func TestGlobalARN_DuplicateAttrs_ImportID_Valid(t *testing.T) {
 	}.String()
 	rd.SetId(arn)
 
-	err := importer.GlobalARN(context.Background(), rd, "arn", []string{"id", "attr"})
+	identity := inttypes.RegionalARNIdentityNamed("arn",
+		inttypes.WithIdentityDuplicateAttrs("id", "attr"),
+	)
+
+	err := importer.GlobalARN(context.Background(), rd, identity)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -482,7 +506,11 @@ func TestGlobalARN_DuplicateAttrs_Identity_Valid(t *testing.T) {
 		"arn": arn,
 	})
 
-	err := importer.GlobalARN(context.Background(), rd, "arn", []string{"id", "attr"})
+	identity := inttypes.RegionalARNIdentityNamed("arn",
+		inttypes.WithIdentityDuplicateAttrs("id", "attr"),
+	)
+
+	err := importer.GlobalARN(context.Background(), rd, identity)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}

--- a/internal/provider/sdkv2/importer/arn_test.go
+++ b/internal/provider/sdkv2/importer/arn_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2/importer"
 	"github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2/internal/attribute"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 )
 
 var regionalARNSchema = map[string]*schema.Schema{
@@ -41,7 +42,11 @@ func TestRegionalARN_ImportID_Invalid_NotAnARN(t *testing.T) {
 	rd := schema.TestResourceDataRaw(t, regionalARNSchema, map[string]any{})
 	rd.SetId("not a valid ARN")
 
-	err := importer.RegionalARN(context.Background(), rd, "arn", []string{"id"})
+	identity := inttypes.RegionalARNIdentityNamed("arn",
+		inttypes.WithIdentityDuplicateAttrs("id"),
+	)
+
+	err := importer.RegionalARN(context.Background(), rd, identity)
 	if err != nil {
 		if !strings.HasPrefix(err.Error(), "could not parse import ID") {
 			t.Fatalf("Unexpected error: %s", err)
@@ -65,7 +70,11 @@ func TestRegionalARN_ImportID_Invalid_WrongRegion(t *testing.T) {
 		Resource:  "res-abc123",
 	}.String())
 
-	err := importer.RegionalARN(context.Background(), rd, "arn", []string{"id"})
+	identity := inttypes.RegionalARNIdentityNamed("arn",
+		inttypes.WithIdentityDuplicateAttrs("id"),
+	)
+
+	err := importer.RegionalARN(context.Background(), rd, identity)
 	if err != nil {
 		if !strings.HasPrefix(err.Error(), "the region passed for import") {
 			t.Fatalf("Unexpected error: %s", err)
@@ -89,7 +98,11 @@ func TestRegionalARN_ImportID_Valid_DefaultRegion(t *testing.T) {
 	}.String()
 	rd.SetId(arn)
 
-	err := importer.RegionalARN(context.Background(), rd, "arn", []string{"id"})
+	identity := inttypes.RegionalARNIdentityNamed("arn",
+		inttypes.WithIdentityDuplicateAttrs("id"),
+	)
+
+	err := importer.RegionalARN(context.Background(), rd, identity)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -124,7 +137,11 @@ func TestRegionalARN_ImportID_Valid_RegionOverride(t *testing.T) {
 	}.String()
 	rd.SetId(arn)
 
-	err := importer.RegionalARN(context.Background(), rd, "arn", []string{"id"})
+	identity := inttypes.RegionalARNIdentityNamed("arn",
+		inttypes.WithIdentityDuplicateAttrs("id"),
+	)
+
+	err := importer.RegionalARN(context.Background(), rd, identity)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -148,7 +165,11 @@ func TestRegionalARN_Identity_Invalid_AttributeNotSet(t *testing.T) {
 
 	rd := schema.TestResourceDataWithIdentityRaw(t, regionalARNSchema, regionalARNIdentitySchema, map[string]string{})
 
-	err := importer.RegionalARN(context.Background(), rd, "arn", []string{"id"})
+	identity := inttypes.RegionalARNIdentityNamed("arn",
+		inttypes.WithIdentityDuplicateAttrs("id"),
+	)
+
+	err := importer.RegionalARN(context.Background(), rd, identity)
 	if err != nil {
 		if err.Error() != fmt.Sprintf("identity attribute %q is required", "arn") {
 			t.Fatalf("Unexpected error: %s", err)
@@ -165,7 +186,11 @@ func TestRegionalARN_Identity_Invalid_NotAnARN(t *testing.T) {
 		"arn": "not a valid ARN",
 	})
 
-	err := importer.RegionalARN(context.Background(), rd, "arn", []string{"id"})
+	identity := inttypes.RegionalARNIdentityNamed("arn",
+		inttypes.WithIdentityDuplicateAttrs("id"),
+	)
+
+	err := importer.RegionalARN(context.Background(), rd, identity)
 	if err != nil {
 		if !strings.HasPrefix(err.Error(), fmt.Sprintf("identity attribute %q: could not parse", "arn")) {
 			t.Fatalf("Unexpected error: %s", err)
@@ -190,7 +215,11 @@ func TestRegionalARN_Identity_Valid(t *testing.T) {
 		"arn": arn,
 	})
 
-	err := importer.RegionalARN(context.Background(), rd, "arn", []string{"id"})
+	identity := inttypes.RegionalARNIdentityNamed("arn",
+		inttypes.WithIdentityDuplicateAttrs("id"),
+	)
+
+	err := importer.RegionalARN(context.Background(), rd, identity)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -223,7 +252,11 @@ func TestRegionalARN_DuplicateAttrs_ImportID_Valid(t *testing.T) {
 	}.String()
 	rd.SetId(arn)
 
-	err := importer.RegionalARN(context.Background(), rd, "arn", []string{"id", "attr"})
+	identity := inttypes.RegionalARNIdentityNamed("arn",
+		inttypes.WithIdentityDuplicateAttrs("id", "attr"),
+	)
+
+	err := importer.RegionalARN(context.Background(), rd, identity)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -257,7 +290,11 @@ func TestRegionalARN_DuplicateAttrs_Identity_Valid(t *testing.T) {
 		"arn": arn,
 	})
 
-	err := importer.RegionalARN(context.Background(), rd, "arn", []string{"id", "attr"})
+	identity := inttypes.RegionalARNIdentityNamed("arn",
+		inttypes.WithIdentityDuplicateAttrs("id", "attr"),
+	)
+
+	err := importer.RegionalARN(context.Background(), rd, identity)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}

--- a/internal/provider/sdkv2/importer/context.go
+++ b/internal/provider/sdkv2/importer/context.go
@@ -22,18 +22,18 @@ func Context(ctx context.Context, identity *inttypes.Identity, importSpec *intty
 	return ctx
 }
 
-func IdentitySpec(ctx context.Context) *inttypes.Identity {
+func IdentitySpec(ctx context.Context) inttypes.Identity {
 	val := ctx.Value(identitySpecKey)
 	if identity, ok := val.(*inttypes.Identity); ok {
-		return identity
+		return *identity
 	}
-	return nil
+	return inttypes.Identity{}
 }
 
-func ImportSpec(ctx context.Context) *inttypes.SDKv2Import {
+func ImportSpec(ctx context.Context) inttypes.SDKv2Import {
 	val := ctx.Value(importSpecKey)
 	if importSpec, ok := val.(*inttypes.SDKv2Import); ok {
-		return importSpec
+		return *importSpec
 	}
-	return nil
+	return inttypes.SDKv2Import{}
 }

--- a/internal/provider/sdkv2/importer/context.go
+++ b/internal/provider/sdkv2/importer/context.go
@@ -1,0 +1,39 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package importer
+
+import (
+	"context"
+
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+)
+
+type contextKey int
+
+const (
+	identitySpecKey contextKey = 1
+	importSpecKey   contextKey = 2
+)
+
+func Context(ctx context.Context, identity *inttypes.Identity, importSpec *inttypes.SDKv2Import) context.Context {
+	ctx = context.WithValue(ctx, identitySpecKey, identity)
+	ctx = context.WithValue(ctx, importSpecKey, importSpec)
+	return ctx
+}
+
+func IdentitySpec(ctx context.Context) *inttypes.Identity {
+	val := ctx.Value(identitySpecKey)
+	if identity, ok := val.(*inttypes.Identity); ok {
+		return identity
+	}
+	return nil
+}
+
+func ImportSpec(ctx context.Context) *inttypes.SDKv2Import {
+	val := ctx.Value(importSpecKey)
+	if importSpec, ok := val.(*inttypes.SDKv2Import); ok {
+		return importSpec
+	}
+	return nil
+}

--- a/internal/provider/sdkv2/importer/parameterized.go
+++ b/internal/provider/sdkv2/importer/parameterized.go
@@ -12,7 +12,9 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func RegionalSingleParameterized(ctx context.Context, rd *schema.ResourceData, attr inttypes.IdentityAttribute, client AWSClient) error {
+func RegionalSingleParameterized(ctx context.Context, rd *schema.ResourceData, identitySpec inttypes.Identity, client AWSClient) error {
+	attr := identitySpec.Attributes[len(identitySpec.Attributes)-1]
+
 	if rd.Id() != "" {
 		importID := rd.Id()
 		if attr.ResourceAttributeName() != names.AttrID {

--- a/internal/provider/sdkv2/importer/parameterized.go
+++ b/internal/provider/sdkv2/importer/parameterized.go
@@ -92,7 +92,7 @@ func GlobalSingleParameterized(ctx context.Context, rd *schema.ResourceData, ide
 	return nil
 }
 
-func RegionalMultipleParameterized(ctx context.Context, rd *schema.ResourceData, attrs []inttypes.IdentityAttribute, importSpec *inttypes.SDKv2Import, client AWSClient) error {
+func RegionalMultipleParameterized(ctx context.Context, rd *schema.ResourceData, identitySpec inttypes.Identity, importSpec *inttypes.SDKv2Import, client AWSClient) error {
 	if rd.Id() != "" {
 		id, parts, err := importSpec.ImportID.Parse(rd.Id())
 		if err != nil {
@@ -117,7 +117,7 @@ func RegionalMultipleParameterized(ctx context.Context, rd *schema.ResourceData,
 			return err
 		}
 
-		for _, attr := range attrs {
+		for _, attr := range identitySpec.Attributes {
 			switch attr.Name() {
 			case names.AttrAccountID, names.AttrRegion:
 				// Do nothing

--- a/internal/provider/sdkv2/importer/parameterized.go
+++ b/internal/provider/sdkv2/importer/parameterized.go
@@ -54,7 +54,9 @@ func RegionalSingleParameterized(ctx context.Context, rd *schema.ResourceData, i
 	return nil
 }
 
-func GlobalSingleParameterized(ctx context.Context, rd *schema.ResourceData, attr inttypes.IdentityAttribute, client AWSClient) error {
+func GlobalSingleParameterized(ctx context.Context, rd *schema.ResourceData, identitySpec inttypes.Identity, client AWSClient) error {
+	attr := identitySpec.Attributes[len(identitySpec.Attributes)-1]
+
 	if rd.Id() != "" {
 		importID := rd.Id()
 		if attr.ResourceAttributeName() != names.AttrID {

--- a/internal/provider/sdkv2/importer/parameterized.go
+++ b/internal/provider/sdkv2/importer/parameterized.go
@@ -141,7 +141,7 @@ func RegionalMultipleParameterized(ctx context.Context, rd *schema.ResourceData,
 	return nil
 }
 
-func GlobalMultipleParameterized(ctx context.Context, rd *schema.ResourceData, attrs []inttypes.IdentityAttribute, importSpec *inttypes.SDKv2Import, client AWSClient) error {
+func GlobalMultipleParameterized(ctx context.Context, rd *schema.ResourceData, identitySpec inttypes.Identity, importSpec *inttypes.SDKv2Import, client AWSClient) error {
 	if rd.Id() != "" {
 		id, parts, err := importSpec.ImportID.Parse(rd.Id())
 		if err != nil {
@@ -162,7 +162,7 @@ func GlobalMultipleParameterized(ctx context.Context, rd *schema.ResourceData, a
 			return err
 		}
 
-		for _, attr := range attrs {
+		for _, attr := range identitySpec.Attributes {
 			switch attr.Name() {
 			case names.AttrAccountID:
 				// Do nothing

--- a/internal/provider/sdkv2/importer/parameterized_test.go
+++ b/internal/provider/sdkv2/importer/parameterized_test.go
@@ -95,8 +95,7 @@ func TestRegionalSingleParameterized_ByImportID(t *testing.T) {
 			})
 			d.SetId(tc.inputID)
 
-			attr := identitySpec.Attributes[len(identitySpec.Attributes)-1]
-			err := importer.RegionalSingleParameterized(ctx, d, attr, client)
+			err := importer.RegionalSingleParameterized(ctx, d, identitySpec, client)
 			if tc.expectError {
 				if err == nil {
 					t.Fatal("Expected error, got none")
@@ -282,8 +281,7 @@ func TestRegionalSingleParameterized_ByIdentity(t *testing.T) {
 			identitySchema := identity.NewIdentitySchema(tc.identitySpec)
 			d := schema.TestResourceDataWithIdentityRaw(t, regionalSingleParameterizedSchema, identitySchema, tc.identityAttrs)
 
-			attr := tc.identitySpec.Attributes[len(tc.identitySpec.Attributes)-1]
-			err := importer.RegionalSingleParameterized(ctx, d, attr, client)
+			err := importer.RegionalSingleParameterized(ctx, d, tc.identitySpec, client)
 			if tc.expectError {
 				if err == nil {
 					t.Fatal("Expected error, got none")

--- a/internal/provider/sdkv2/importer/parameterized_test.go
+++ b/internal/provider/sdkv2/importer/parameterized_test.go
@@ -626,7 +626,7 @@ func TestRegionalMutipleParameterized_ByImportID(t *testing.T) {
 			})
 			d.SetId(tc.inputID)
 
-			err := importer.RegionalMultipleParameterized(ctx, d, identitySpec.Attributes, &importSpec, client)
+			err := importer.RegionalMultipleParameterized(ctx, d, identitySpec, &importSpec, client)
 			if tc.expectError {
 				if err == nil {
 					t.Fatal("Expected error, got none")
@@ -783,7 +783,7 @@ func TestRegionalMutipleParameterized_ByIdentity(t *testing.T) {
 			identitySchema := identity.NewIdentitySchema(tc.identitySpec)
 			d := schema.TestResourceDataWithIdentityRaw(t, regionalMultipleParameterizedSchema, identitySchema, tc.identityAttrs)
 
-			err := importer.RegionalMultipleParameterized(ctx, d, tc.identitySpec.Attributes, &importSpec, client)
+			err := importer.RegionalMultipleParameterized(ctx, d, tc.identitySpec, &importSpec, client)
 			if tc.expectError {
 				if err == nil {
 					t.Fatal("Expected error, got none")

--- a/internal/provider/sdkv2/importer/parameterized_test.go
+++ b/internal/provider/sdkv2/importer/parameterized_test.go
@@ -373,8 +373,7 @@ func TestGlobalSingleParameterized_ByImportID(t *testing.T) {
 			d := schema.TestResourceDataRaw(t, globalSingleParameterizedSchema, map[string]any{})
 			d.SetId(tc.inputID)
 
-			attr := identitySpec.Attributes[len(identitySpec.Attributes)-1]
-			err := importer.GlobalSingleParameterized(ctx, d, attr, client)
+			err := importer.GlobalSingleParameterized(ctx, d, identitySpec, client)
 			if tc.expectError {
 				if err == nil {
 					t.Fatal("Expected error, got none")
@@ -503,8 +502,7 @@ func TestGlobalSingleParameterized_ByIdentity(t *testing.T) {
 			identitySchema := identity.NewIdentitySchema(identitySpec)
 			d := schema.TestResourceDataWithIdentityRaw(t, globalSingleParameterizedSchema, identitySchema, tc.identityAttrs)
 
-			attr := identitySpec.Attributes[len(identitySpec.Attributes)-1]
-			err := importer.GlobalSingleParameterized(ctx, d, attr, client)
+			err := importer.GlobalSingleParameterized(ctx, d, identitySpec, client)
 			if tc.expectError {
 				if err == nil {
 					t.Fatal("Expected error, got none")

--- a/internal/provider/sdkv2/importer/parameterized_test.go
+++ b/internal/provider/sdkv2/importer/parameterized_test.go
@@ -892,7 +892,7 @@ func TestGlobalMutipleParameterized_ByImportID(t *testing.T) {
 			d := schema.TestResourceDataRaw(t, globalMultipleParameterizedSchema, map[string]any{})
 			d.SetId(tc.inputID)
 
-			err := importer.GlobalMultipleParameterized(ctx, d, identitySpec.Attributes, &importSpec, client)
+			err := importer.GlobalMultipleParameterized(ctx, d, identitySpec, &importSpec, client)
 			if tc.expectError {
 				if err == nil {
 					t.Fatal("Expected error, got none")
@@ -985,7 +985,7 @@ func TestGlobalMutipleParameterized_ByIdentity(t *testing.T) {
 			identitySchema := identity.NewIdentitySchema(tc.identitySpec)
 			d := schema.TestResourceDataWithIdentityRaw(t, globalMultipleParameterizedSchema, identitySchema, tc.identityAttrs)
 
-			err := importer.GlobalMultipleParameterized(ctx, d, tc.identitySpec.Attributes, &importSpec, client)
+			err := importer.GlobalMultipleParameterized(ctx, d, tc.identitySpec, &importSpec, client)
 			if tc.expectError {
 				if err == nil {
 					t.Fatal("Expected error, got none")

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -715,6 +715,14 @@ func (p *sdkProvider) initialize(ctx context.Context) (map[string]conns.ServiceP
 				interceptors = append(interceptors, newIdentityInterceptor(resource.Identity.Attributes))
 			}
 
+			if resource.Import.CustomImport {
+				if r.Importer == nil || r.Importer.StateContext == nil {
+					errs = append(errs, fmt.Errorf("resource type %s: uses CustomImport but does not define an import function", typeName))
+					continue
+				}
+
+				customResourceImporter(r, &resource.Identity, &resource.Import)
+			}
 			if resource.Import.WrappedImport {
 				if r.Importer != nil && r.Importer.StateContext != nil {
 					errs = append(errs, fmt.Errorf("resource type %s: uses WrappedImport but defines an import function", typeName))

--- a/internal/service/acmpca/certificate.go
+++ b/internal/service/acmpca/certificate.go
@@ -40,7 +40,7 @@ import (
 // @SDKResource("aws_acmpca_certificate", name="Certificate")
 // @ArnIdentity
 // @V60SDKv2Fix
-// @WrappedImport(false)
+// @CustomImport
 // @Testing(importIgnore="certificate_signing_request;signing_algorithm;template_arn;validity")
 // @Testing(plannableImportAction="Replace")
 func resourceCertificate() *schema.Resource {

--- a/internal/service/acmpca/certificate.go
+++ b/internal/service/acmpca/certificate.go
@@ -53,7 +53,9 @@ func resourceCertificate() *schema.Resource {
 		// arn:aws:acm-pca:eu-west-1:555885746124:certificate-authority/08322ede-92f9-4200-8f21-c7d12b2b6edb/certificate/a4e9c2aa2ccfab625b1b9136464cd3a6
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-				if err := importer.RegionalARN(ctx, d, names.AttrARN, []string{names.AttrID}); err != nil {
+				identitySpec := importer.IdentitySpec(ctx)
+
+				if err := importer.RegionalARN(ctx, d, identitySpec); err != nil {
 					return nil, err
 				}
 

--- a/internal/service/acmpca/certificate_authority.go
+++ b/internal/service/acmpca/certificate_authority.go
@@ -50,10 +50,11 @@ func resourceCertificateAuthority() *schema.Resource {
 		UpdateWithoutTimeout: resourceCertificateAuthorityUpdate,
 		DeleteWithoutTimeout: resourceCertificateAuthorityDelete,
 
-		// TODO: handle default values on Import
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-				if err := importer.RegionalARN(ctx, d, names.AttrARN, []string{names.AttrID}); err != nil {
+				identitySpec := importer.IdentitySpec(ctx)
+
+				if err := importer.RegionalARN(ctx, d, identitySpec); err != nil {
 					return nil, err
 				}
 

--- a/internal/service/acmpca/certificate_authority.go
+++ b/internal/service/acmpca/certificate_authority.go
@@ -38,7 +38,7 @@ const (
 // @Tags(identifierAttribute="arn")
 // @ArnIdentity
 // @V60SDKv2Fix
-// @WrappedImport(false)
+// @CustomImport
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/acmpca/types;types.CertificateAuthority")
 // @Testing(generator="acctest.RandomDomainName()")
 // @Testing(importIgnore="permanent_deletion_time_in_days")

--- a/internal/service/acmpca/service_package_gen.go
+++ b/internal/service/acmpca/service_package_gen.go
@@ -57,6 +57,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 				inttypes.WithIdentityDuplicateAttrs(names.AttrID),
 				inttypes.WithV6_0SDKv2Fix(),
 			),
+			Import: inttypes.SDKv2Import{
+				CustomImport: true,
+			},
 		},
 		{
 			Factory:  resourceCertificateAuthority,
@@ -70,6 +73,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 				inttypes.WithIdentityDuplicateAttrs(names.AttrID),
 				inttypes.WithV6_0SDKv2Fix(),
 			),
+			Import: inttypes.SDKv2Import{
+				CustomImport: true,
+			},
 		},
 		{
 			Factory:  resourceCertificateAuthorityCertificate,

--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -49,7 +50,13 @@ func resourceJobDefinition() *schema.Resource {
 		// TODO: handle default values on Import
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, rd *schema.ResourceData, _ any) ([]*schema.ResourceData, error) {
-				if err := importer.RegionalARN(ctx, rd, names.AttrARN, []string{names.AttrID}); err != nil {
+				// The identitySpec can be retrieved from the context when Mutable Identity is supported
+				// identitySpec := importer.IdentitySpec(ctx)
+				identity := inttypes.RegionalARNIdentity(
+					inttypes.WithIdentityDuplicateAttrs(names.AttrID),
+				)
+
+				if err := importer.RegionalARN(ctx, rd, identity); err != nil {
 					return nil, err
 				}
 

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -31,7 +31,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2/importer"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
-	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -44,7 +43,7 @@ const (
 // @SDKResource("aws_iam_role", name="Role")
 // @Tags(identifierAttribute="name", resourceType="Role")
 // @IdentityAttribute("name")
-// @WrappedImport(false)
+// @CustomImport
 // @V60SDKv2Fix
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/iam/types;types.Role")
 // @Testing(idAttrDuplicates="name")
@@ -57,7 +56,9 @@ func resourceRole() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, rd *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-				if err := importer.GlobalSingleParameterized(ctx, rd, inttypes.StringIdentityAttribute(names.AttrName, true), meta.(importer.AWSClient)); err != nil {
+				identitySpec := importer.IdentitySpec(ctx)
+
+				if err := importer.GlobalSingleParameterized(ctx, rd, identitySpec, meta.(importer.AWSClient)); err != nil {
 					return nil, err
 				}
 

--- a/internal/service/iam/service_package_gen.go
+++ b/internal/service/iam/service_package_gen.go
@@ -273,6 +273,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			Identity: inttypes.GlobalSingleParameterIdentity(names.AttrName,
 				inttypes.WithV6_0SDKv2Fix(),
 			),
+			Import: inttypes.SDKv2Import{
+				CustomImport: true,
+			},
 		},
 		{
 			Factory:  resourceRolePolicy,

--- a/internal/service/organizations/account.go
+++ b/internal/service/organizations/account.go
@@ -27,14 +27,13 @@ import ( // nosemgrep:ci.semgrep.aws.multiple-service-imports
 	"github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2/importer"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
-	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @SDKResource("aws_organizations_account", name="Account")
 // @Tags(identifierAttribute="id")
 // @IdentityAttribute("id")
-// @WrappedImport(false)
+// @CustomImport
 // @Testing(tagsTest=false, identityTest=false)
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/organizations/types;awstypes;awstypes.Account")
 // @Testing(serialize=true)
@@ -352,7 +351,9 @@ func resourceAccountImportState(ctx context.Context, d *schema.ResourceData, met
 			d.SetId(d.Id())
 		}
 	} else {
-		if err := importer.GlobalSingleParameterized(ctx, d, inttypes.StringIdentityAttribute(names.AttrID, true), meta.(importer.AWSClient)); err != nil {
+		identitySpec := importer.IdentitySpec(ctx)
+
+		if err := importer.GlobalSingleParameterized(ctx, d, identitySpec, meta.(importer.AWSClient)); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/service/organizations/organization.go
+++ b/internal/service/organizations/organization.go
@@ -24,13 +24,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2/importer"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
-	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @SDKResource("aws_organizations_organization", name="Organization")
 // @IdentityAttribute("id")
-// @WrappedImport(false)
+// @CustomImport
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/organizations/types;awstypes;awstypes.Organization")
 // @Testing(serialize=true)
 // @Testing(preIdentityVersion="6.4.0")
@@ -387,7 +386,9 @@ func resourceOrganizationDelete(ctx context.Context, d *schema.ResourceData, met
 }
 
 func resourceOrganizationImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	if err := importer.GlobalSingleParameterized(ctx, d, inttypes.StringIdentityAttribute(names.AttrID, true), meta.(importer.AWSClient)); err != nil {
+	identitySpec := importer.IdentitySpec(ctx)
+
+	if err := importer.GlobalSingleParameterized(ctx, d, identitySpec, meta.(importer.AWSClient)); err != nil {
 		return nil, err
 	}
 

--- a/internal/service/organizations/policy.go
+++ b/internal/service/organizations/policy.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2/importer"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
-	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -30,7 +29,7 @@ import (
 // @SDKResource("aws_organizations_policy", name="Policy")
 // @Tags(identifierAttribute="id")
 // @IdentityAttribute("id")
-// @WrappedImport(false)
+// @CustomImport
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/organizations/types;awstypes;awstypes.Policy")
 // @Testing(serialize=true)
 // @Testing(preIdentityVersion="6.4.0")
@@ -202,7 +201,9 @@ func resourcePolicyDelete(ctx context.Context, d *schema.ResourceData, meta any)
 }
 
 func resourcePolicyImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	if err := importer.GlobalSingleParameterized(ctx, d, inttypes.StringIdentityAttribute(names.AttrID, true), meta.(importer.AWSClient)); err != nil {
+	identitySpec := importer.IdentitySpec(ctx)
+
+	if err := importer.GlobalSingleParameterized(ctx, d, identitySpec, meta.(importer.AWSClient)); err != nil {
 		return nil, err
 	}
 

--- a/internal/service/organizations/service_package_gen.go
+++ b/internal/service/organizations/service_package_gen.go
@@ -114,6 +114,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			}),
 			Region:   unique.Make(inttypes.ResourceRegionDisabled()),
 			Identity: inttypes.GlobalSingleParameterIdentity(names.AttrID),
+			Import: inttypes.SDKv2Import{
+				CustomImport: true,
+			},
 		},
 		{
 			Factory:  resourceDelegatedAdministrator,
@@ -135,6 +138,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			Name:     "Organization",
 			Region:   unique.Make(inttypes.ResourceRegionDisabled()),
 			Identity: inttypes.GlobalSingleParameterIdentity(names.AttrID),
+			Import: inttypes.SDKv2Import{
+				CustomImport: true,
+			},
 		},
 		{
 			Factory:  resourceOrganizationalUnit,
@@ -158,6 +164,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			}),
 			Region:   unique.Make(inttypes.ResourceRegionDisabled()),
 			Identity: inttypes.GlobalSingleParameterIdentity(names.AttrID),
+			Import: inttypes.SDKv2Import{
+				CustomImport: true,
+			},
 		},
 		{
 			Factory:  resourcePolicyAttachment,

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -65,7 +65,7 @@ func resourceBucket() *schema.Resource {
 			StateContext: func(ctx context.Context, rd *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				identitySpec := importer.IdentitySpec(ctx)
 
-				if err := importer.RegionalSingleParameterized(ctx, rd, identitySpec.Attributes[len(identitySpec.Attributes)-1], meta.(importer.AWSClient)); err != nil {
+				if err := importer.RegionalSingleParameterized(ctx, rd, identitySpec, meta.(importer.AWSClient)); err != nil {
 					return nil, err
 				}
 

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -38,7 +38,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2/importer"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
-	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -52,7 +51,7 @@ const (
 // @SDKResource("aws_s3_bucket", name="Bucket")
 // @Tags(identifierAttribute="bucket", resourceType="Bucket")
 // @IdentityAttribute("bucket")
-// @WrappedImport(false)
+// @CustomImport
 // @V60SDKv2Fix
 // @Testing(idAttrDuplicates="bucket")
 func resourceBucket() *schema.Resource {
@@ -64,7 +63,9 @@ func resourceBucket() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, rd *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-				if err := importer.RegionalSingleParameterized(ctx, rd, inttypes.StringIdentityAttribute(names.AttrBucket, true), meta.(importer.AWSClient)); err != nil {
+				identitySpec := importer.IdentitySpec(ctx)
+
+				if err := importer.RegionalSingleParameterized(ctx, rd, identitySpec.Attributes[len(identitySpec.Attributes)-1], meta.(importer.AWSClient)); err != nil {
 					return nil, err
 				}
 

--- a/internal/service/s3/service_package_gen.go
+++ b/internal/service/s3/service_package_gen.go
@@ -125,6 +125,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			Identity: inttypes.RegionalSingleParameterIdentity(names.AttrBucket,
 				inttypes.WithV6_0SDKv2Fix(),
 			),
+			Import: inttypes.SDKv2Import{
+				CustomImport: true,
+			},
 		},
 		{
 			Factory:  resourceBucketAccelerateConfiguration,

--- a/internal/types/service_package.go
+++ b/internal/types/service_package.go
@@ -390,5 +390,6 @@ type SDKv2ImportID interface {
 
 type SDKv2Import struct {
 	WrappedImport bool
+	CustomImport  bool
 	ImportID      SDKv2ImportID // Multi-Parameter
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Passes Identity Spec to SDKv2 custom imports rather than requiring developers to hardcode the Identity attributes in the custom import function.

Adds `@CustomImport` annotation

Builds on #43496
