### PR TITLE
Resource Identity: Adds attribute name mapping for Framework resource types

### DIFF
--- a/internal/provider/framework/identity_interceptor.go
+++ b/internal/provider/framework/identity_interceptor.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -18,7 +17,7 @@ import (
 var _ resourceCRUDInterceptor = identityInterceptor{}
 
 type identityInterceptor struct {
-	attributes []string
+	attributes []inttypes.IdentityAttribute
 }
 
 func (r identityInterceptor) create(ctx context.Context, opts interceptorOptions[resource.CreateRequest, resource.CreateResponse]) diag.Diagnostics {
@@ -32,28 +31,28 @@ func (r identityInterceptor) create(ctx context.Context, opts interceptorOptions
 			break
 		}
 
-		for _, attrName := range r.attributes {
-			switch attrName {
+		for _, att := range r.attributes {
+			switch att.Name() {
 			case names.AttrAccountID:
-				diags.Append(identity.SetAttribute(ctx, path.Root(attrName), awsClient.AccountID(ctx))...)
+				diags.Append(identity.SetAttribute(ctx, path.Root(att.Name()), awsClient.AccountID(ctx))...)
 				if diags.HasError() {
 					return diags
 				}
 
 			case names.AttrRegion:
-				diags.Append(identity.SetAttribute(ctx, path.Root(attrName), awsClient.Region(ctx))...)
+				diags.Append(identity.SetAttribute(ctx, path.Root(att.Name()), awsClient.Region(ctx))...)
 				if diags.HasError() {
 					return diags
 				}
 
 			default:
 				var attrVal attr.Value
-				diags.Append(response.State.GetAttribute(ctx, path.Root(attrName), &attrVal)...)
+				diags.Append(response.State.GetAttribute(ctx, path.Root(att.ResourceAttributeName()), &attrVal)...)
 				if diags.HasError() {
 					return diags
 				}
 
-				diags.Append(identity.SetAttribute(ctx, path.Root(attrName), attrVal)...)
+				diags.Append(identity.SetAttribute(ctx, path.Root(att.Name()), attrVal)...)
 				if diags.HasError() {
 					return diags
 				}
@@ -78,28 +77,28 @@ func (r identityInterceptor) read(ctx context.Context, opts interceptorOptions[r
 			break
 		}
 
-		for _, attrName := range r.attributes {
-			switch attrName {
+		for _, att := range r.attributes {
+			switch att.Name() {
 			case names.AttrAccountID:
-				diags.Append(identity.SetAttribute(ctx, path.Root(attrName), awsClient.AccountID(ctx))...)
+				diags.Append(identity.SetAttribute(ctx, path.Root(att.Name()), awsClient.AccountID(ctx))...)
 				if diags.HasError() {
 					return diags
 				}
 
 			case names.AttrRegion:
-				diags.Append(identity.SetAttribute(ctx, path.Root(attrName), awsClient.Region(ctx))...)
+				diags.Append(identity.SetAttribute(ctx, path.Root(att.Name()), awsClient.Region(ctx))...)
 				if diags.HasError() {
 					return diags
 				}
 
 			default:
 				var attrVal attr.Value
-				diags.Append(response.State.GetAttribute(ctx, path.Root(attrName), &attrVal)...)
+				diags.Append(response.State.GetAttribute(ctx, path.Root(att.ResourceAttributeName()), &attrVal)...)
 				if diags.HasError() {
 					return diags
 				}
 
-				diags.Append(identity.SetAttribute(ctx, path.Root(attrName), attrVal)...)
+				diags.Append(identity.SetAttribute(ctx, path.Root(att.Name()), attrVal)...)
 				if diags.HasError() {
 					return diags
 				}
@@ -122,8 +121,6 @@ func (r identityInterceptor) delete(ctx context.Context, opts interceptorOptions
 
 func newIdentityInterceptor(attributes []inttypes.IdentityAttribute) identityInterceptor {
 	return identityInterceptor{
-		attributes: tfslices.ApplyToAll(attributes, func(v inttypes.IdentityAttribute) string {
-			return v.Name()
-		}),
+		attributes: attributes,
 	}
 }

--- a/internal/provider/framework/importer/parameterized.go
+++ b/internal/provider/framework/importer/parameterized.go
@@ -82,18 +82,20 @@ func MultipleParameterized(ctx context.Context, client AWSClient, request resour
 				// Do nothing
 
 			default:
-				attrPath := path.Root(attr.Name())
+				identityPath := path.Root(attr.Name())
+				resourcePath := path.Root(attr.ResourceAttributeName())
+
 				var parameterAttr types.String
-				response.Diagnostics.Append(identity.GetAttribute(ctx, attrPath, &parameterAttr)...)
+				response.Diagnostics.Append(identity.GetAttribute(ctx, identityPath, &parameterAttr)...)
 				if response.Diagnostics.HasError() {
 					return
 				}
 				parameterVal := parameterAttr.ValueString()
 
-				response.Diagnostics.Append(response.State.SetAttribute(ctx, attrPath, parameterVal)...)
+				response.Diagnostics.Append(response.State.SetAttribute(ctx, resourcePath, parameterVal)...)
 
 				if identity := response.Identity; identity != nil {
-					response.Diagnostics.Append(identity.SetAttribute(ctx, attrPath, parameterVal)...)
+					response.Diagnostics.Append(identity.SetAttribute(ctx, identityPath, parameterVal)...)
 				}
 			}
 		}

--- a/internal/provider/framework/importer/parameterized.go
+++ b/internal/provider/framework/importer/parameterized.go
@@ -15,7 +15,9 @@ import (
 )
 
 func SingleParameterized(ctx context.Context, client AWSClient, request resource.ImportStateRequest, identitySpec *inttypes.Identity, importSpec *inttypes.FrameworkImport, response *resource.ImportStateResponse) {
-	attrPath := path.Root(identitySpec.IdentityAttribute)
+	attr := identitySpec.Attributes[len(identitySpec.Attributes)-1]
+	identityPath := path.Root(attr.Name())
+	resourcePath := path.Root(attr.ResourceAttributeName())
 
 	parameterVal := request.ID
 
@@ -26,18 +28,18 @@ func SingleParameterized(ctx context.Context, client AWSClient, request resource
 		}
 
 		var parameterAttr types.String
-		response.Diagnostics.Append(identity.GetAttribute(ctx, attrPath, &parameterAttr)...)
+		response.Diagnostics.Append(identity.GetAttribute(ctx, identityPath, &parameterAttr)...)
 		if response.Diagnostics.HasError() {
 			return
 		}
 		parameterVal = parameterAttr.ValueString()
 	}
 
-	response.Diagnostics.Append(response.State.SetAttribute(ctx, attrPath, parameterVal)...)
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, resourcePath, parameterVal)...)
 
 	if identity := response.Identity; identity != nil {
 		response.Diagnostics.Append(identity.SetAttribute(ctx, path.Root(names.AttrAccountID), client.AccountID(ctx))...)
-		response.Diagnostics.Append(identity.SetAttribute(ctx, attrPath, parameterVal)...)
+		response.Diagnostics.Append(identity.SetAttribute(ctx, identityPath, parameterVal)...)
 	}
 
 	if !identitySpec.IsGlobalResource {

--- a/internal/types/service_package.go
+++ b/internal/types/service_package.go
@@ -280,6 +280,24 @@ func GlobalSingleParameterIdentity(name string, opts ...IdentityOptsFunc) Identi
 	return identity
 }
 
+func GlobalSingleParameterIdentityWithMappedName(name string, resourceAttributeName string, opts ...IdentityOptsFunc) Identity {
+	identity := Identity{
+		IsGlobalResource:  true,
+		IdentityAttribute: name,
+		Attributes: []IdentityAttribute{
+			StringIdentityAttribute("account_id", false),
+			StringIdentityAttributeWithMappedName(name, true, resourceAttributeName),
+		},
+		IsSingleParameter: true,
+	}
+
+	for _, opt := range opts {
+		opt(&identity)
+	}
+
+	return identity
+}
+
 func GlobalParameterizedIdentity(attributes []IdentityAttribute, opts ...IdentityOptsFunc) Identity {
 	baseAttributes := []IdentityAttribute{
 		StringIdentityAttribute("account_id", false),

--- a/internal/types/service_package.go
+++ b/internal/types/service_package.go
@@ -100,7 +100,7 @@ type Identity struct {
 	IsSingleton            bool   // Singleton
 	IsARN                  bool   // ARN
 	IsGlobalARNFormat      bool   // ARN
-	IdentityAttribute      string // ARN, Framework Single-Parameter
+	IdentityAttribute      string // ARN
 	IDAttrShadowsAttr      string
 	Attributes             []IdentityAttribute
 	IdentityDuplicateAttrs []string
@@ -228,7 +228,6 @@ func RegionalResourceWithGlobalARNFormatNamed(name string, opts ...IdentityOptsF
 
 func RegionalSingleParameterIdentity(name string, opts ...IdentityOptsFunc) Identity {
 	identity := Identity{
-		IdentityAttribute: name,
 		Attributes: []IdentityAttribute{
 			StringIdentityAttribute("account_id", false),
 			StringIdentityAttribute("region", false),
@@ -246,7 +245,6 @@ func RegionalSingleParameterIdentity(name string, opts ...IdentityOptsFunc) Iden
 
 func RegionalSingleParameterIdentityWithMappedName(name string, resourceAttributeName string, opts ...IdentityOptsFunc) Identity {
 	identity := Identity{
-		IdentityAttribute: name,
 		Attributes: []IdentityAttribute{
 			StringIdentityAttribute("account_id", false),
 			StringIdentityAttribute("region", false),
@@ -264,8 +262,7 @@ func RegionalSingleParameterIdentityWithMappedName(name string, resourceAttribut
 
 func GlobalSingleParameterIdentity(name string, opts ...IdentityOptsFunc) Identity {
 	identity := Identity{
-		IsGlobalResource:  true,
-		IdentityAttribute: name,
+		IsGlobalResource: true,
 		Attributes: []IdentityAttribute{
 			StringIdentityAttribute("account_id", false),
 			StringIdentityAttribute(name, true),
@@ -282,8 +279,7 @@ func GlobalSingleParameterIdentity(name string, opts ...IdentityOptsFunc) Identi
 
 func GlobalSingleParameterIdentityWithMappedName(name string, resourceAttributeName string, opts ...IdentityOptsFunc) Identity {
 	identity := Identity{
-		IsGlobalResource:  true,
-		IdentityAttribute: name,
+		IsGlobalResource: true,
 		Attributes: []IdentityAttribute{
 			StringIdentityAttribute("account_id", false),
 			StringIdentityAttributeWithMappedName(name, true, resourceAttributeName),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Adds attribute name mapping for Framework resource types. Name mapping was added to SDKv2 resource types in #43476 
