### PR TITLE
r/aws_quicksight_account_subscription: add import support

### DIFF
--- a/.changelog/43501.txt
+++ b/.changelog/43501.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_quicksight_account_subscription: Add import support. This resource can now be imported via the `aws_account_id` argument.
+```

--- a/internal/service/quicksight/account_subscription.go
+++ b/internal/service/quicksight/account_subscription.go
@@ -31,6 +31,10 @@ func resourceAccountSubscription() *schema.Resource {
 		ReadWithoutTimeout:   resourceAccountSubscriptionRead,
 		DeleteWithoutTimeout: resourceAccountSubscriptionDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 			Read:   schema.DefaultTimeout(10 * time.Minute),

--- a/internal/service/quicksight/account_subscription_test.go
+++ b/internal/service/quicksight/account_subscription_test.go
@@ -13,6 +13,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -45,9 +46,10 @@ func testAccAccountSubscription_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName: resourceName,
-				ImportState:  false,
-				RefreshState: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"authentication_method"}, // Not returned from the DescribeAccountSubscription API
 			},
 		},
 	})
@@ -76,6 +78,11 @@ func testAccAccountSubscription_disappears(t *testing.T) {
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfquicksight.ResourceAccountSubscription(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 		},
 	})

--- a/website/docs/r/quicksight_account_subscription.html.markdown
+++ b/website/docs/r/quicksight_account_subscription.html.markdown
@@ -63,4 +63,17 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-You cannot import this resource.
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import a QuickSight Account Subscription using `aws_account_id`. For example:
+
+```terraform
+import {
+  to = aws_quicksight_account_subscription.example
+  id = "012345678901"
+}
+```
+
+Using `terraform import`, import a QuickSight Account Subscription using `aws_account_id`. For example:
+
+```console
+% terraform import aws_quicksight_account_subscription.example "012345678901"
+```


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This resource can now be imported via the `aws_account_id` argument.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #43351


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=quicksight TESTS="TestAccQuickSight_serial/AccountSubscription/"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSight_serial/AccountSubscription/'  -timeout 360m -vet=off
2025/07/22 15:34:57 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/22 15:34:57 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccQuickSight_serial (306.55s)
    --- PASS: TestAccQuickSight_serial/AccountSubscription (306.55s)
        --- PASS: TestAccQuickSight_serial/AccountSubscription/disappears (143.91s)
        --- PASS: TestAccQuickSight_serial/AccountSubscription/basic (162.64s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 312.517s
```

