### PR TITLE
Fixes in-place UpdateService stabilization

### DIFF
--- a/.changelog/43502.txt
+++ b/.changelog/43502.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+resource/aws_ecs_service: Improve stabilization logic to handle both new deployments and in-place updates correctly.
+```
+```release-note:note
+resource/aws_ecs_service: Acceptance tests cannot fully reproduce scenarios with deployments older than 3 months. Community feedback on this fix is appreciated, particularly for long-running ECS services with in-place updates.
+```

--- a/.changelog/43502.txt
+++ b/.changelog/43502.txt
@@ -1,6 +1,7 @@
 ```release-note:bug
-resource/aws_ecs_service: Improve stabilization logic to handle both new deployments and in-place updates correctly.
+resource/aws_ecs_service: Improve stabilization logic to handle both new deployments and in-place updates correctly. This fixes a regression introduced in [v6.4.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#640-july-17-2025)
 ```
+
 ```release-note:note
-resource/aws_ecs_service: Acceptance tests cannot fully reproduce scenarios with deployments older than 3 months. Community feedback on this fix is appreciated, particularly for long-running ECS services with in-place updates.
+resource/aws_ecs_service: Acceptance tests cannot fully reproduce scenarios with deployments older than 3 months. Community feedback on this fix is appreciated, particularly for long-running ECS services with in-place updates
 ```

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -2253,7 +2253,7 @@ func waitServiceStable(ctx context.Context, conn *ecs.Client, serviceName, clust
 }
 
 // Does not return tags.
-func waitServiceActive(ctx context.Context, conn *ecs.Client, serviceName, clusterNameOrARN string, timeout time.Duration) (*awstypes.Service, error) {
+func waitServiceActive(ctx context.Context, conn *ecs.Client, serviceName, clusterNameOrARN string, timeout time.Duration) (*awstypes.Service, error) { //nolint:unparam
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{serviceStatusInactive, serviceStatusDraining},
 		Target:  []string{serviceStatusActive},

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -1412,6 +1412,7 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta any
 		input.VolumeConfigurations = expandServiceVolumeConfigurations(ctx, v.([]any))
 	}
 
+	operationTime := time.Now().UTC()
 	output, err := retryServiceCreate(ctx, conn, &input)
 
 	// Some partitions (e.g. ISO) may not support tag-on-create.
@@ -1428,11 +1429,11 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta any
 	d.SetId(aws.ToString(output.Service.ServiceArn))
 	d.Set(names.AttrARN, output.Service.ServiceArn)
 
-	fn := waitServiceActive
 	if d.Get("wait_for_steady_state").(bool) {
-		fn = waitServiceStable
-	}
-	if _, err := fn(ctx, conn, d.Id(), d.Get("cluster").(string), d.Timeout(schema.TimeoutCreate)); err != nil {
+		if _, err := waitServiceStable(ctx, conn, d.Id(), d.Get("cluster").(string), operationTime, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for ECS Service (%s) create: %s", d.Id(), err)
+		}
+	} else if _, err := waitServiceActive(ctx, conn, d.Id(), d.Get("cluster").(string), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for ECS Service (%s) create: %s", d.Id(), err)
 	}
 
@@ -1766,6 +1767,7 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta any
 			serviceUpdateTimeout = 2 * time.Minute
 			timeout              = propagationTimeout + serviceUpdateTimeout
 		)
+		operationTime := time.Now().UTC()
 		_, err := tfresource.RetryWhen(ctx, timeout,
 			func() (any, error) {
 				return conn.UpdateService(ctx, &input)
@@ -1787,11 +1789,11 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta any
 			return sdkdiag.AppendErrorf(diags, "updating ECS Service (%s): %s", d.Id(), err)
 		}
 
-		fn := waitServiceActive
 		if d.Get("wait_for_steady_state").(bool) {
-			fn = waitServiceStable
-		}
-		if _, err := fn(ctx, conn, d.Id(), cluster, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			if _, err := waitServiceStable(ctx, conn, d.Id(), cluster, operationTime, d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return sdkdiag.AppendErrorf(diags, "waiting for ECS Service (%s) update: %s", d.Id(), err)
+			}
+		} else if _, err := waitServiceActive(ctx, conn, d.Id(), cluster, d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for ECS Service (%s) update: %s", d.Id(), err)
 		}
 	}
@@ -2094,106 +2096,109 @@ func statusService(ctx context.Context, conn *ecs.Client, serviceName, clusterNa
 	}
 }
 
-func statusServiceWaitForStable(ctx context.Context, conn *ecs.Client, serviceName, clusterNameOrARN string) retry.StateRefreshFunc {
-	cachedDeploymentArn := new(string)
+func statusServiceWaitForStable(ctx context.Context, conn *ecs.Client, serviceName, clusterNameOrARN string, operationTime time.Time) retry.StateRefreshFunc {
+	var primaryTaskSet *awstypes.Deployment
+	var primaryDeploymentArn *string
+	var isNewPrimaryDeployment bool
 
 	return func() (any, string, error) {
-		outputRaw, status, err := statusService(ctx, conn, serviceName, clusterNameOrARN)()
-
+		outputRaw, serviceStatus, err := statusService(ctx, conn, serviceName, clusterNameOrARN)()
 		if err != nil {
 			return nil, "", err
 		}
 
-		if status != serviceStatusActive {
-			return outputRaw, status, nil
+		if serviceStatus != serviceStatusActive {
+			return outputRaw, serviceStatus, nil
 		}
 
 		output := outputRaw.(*awstypes.Service)
 
-		// For ECS deployment controller, check the deployment status
-		if output.DeploymentController != nil && output.DeploymentController.Type == awstypes.DeploymentControllerTypeEcs {
-			status, err := checkServiceDeploymentStatus(ctx, conn, aws.ToString(output.ServiceArn), clusterNameOrARN, cachedDeploymentArn)
+		if primaryTaskSet == nil {
+			primaryTaskSet = findPrimaryTaskSet(output.Deployments)
+
+			if primaryTaskSet != nil && primaryTaskSet.CreatedAt != nil {
+				createdAtUTC := primaryTaskSet.CreatedAt.UTC()
+				isNewPrimaryDeployment = createdAtUTC.After(operationTime)
+			}
+		}
+
+		isNewECSDeployment := output.DeploymentController != nil &&
+			output.DeploymentController.Type == awstypes.DeploymentControllerTypeEcs &&
+			isNewPrimaryDeployment
+
+		// For new deployments with ECS deployment controller, check the deployment status
+		if isNewECSDeployment {
+			if primaryDeploymentArn == nil {
+				serviceArn := aws.ToString(output.ServiceArn)
+
+				var err error
+				primaryDeploymentArn, err = findPrimaryDeploymentARN(ctx, conn, primaryTaskSet, serviceArn, clusterNameOrARN, operationTime)
+
+				if err != nil {
+					return nil, "", err
+				}
+				if primaryDeploymentArn == nil {
+					return output, serviceStatusPending, nil
+				}
+			}
+			deploymentStatus, err := findDeploymentStatus(ctx, conn, *primaryDeploymentArn)
 			if err != nil {
 				return nil, "", err
 			}
-			return output, status, nil
+			return output, deploymentStatus, nil
 		}
 
-		// For other deployment controllers, check based on desired count
+		// For other deployment controllers or in-place updates, check based on desired count
 		if n, dc, rc := len(output.Deployments), output.DesiredCount, output.RunningCount; n == 1 && dc == rc {
-			status = serviceStatusStable
+			serviceStatus = serviceStatusStable
 		} else {
-			status = serviceStatusPending
+			serviceStatus = serviceStatusPending
 		}
 
-		return output, status, nil
+		return output, serviceStatus, nil
 	}
 }
 
-func checkServiceDeploymentStatus(ctx context.Context, conn *ecs.Client, serviceArn, clusterNameOrARN string, cachedDeploymentArn *string) (string, error) {
-	primaryDeployment, err := getPrimaryDeployment(ctx, conn, serviceArn, clusterNameOrARN)
-	if err != nil {
-		return "", err
+func findPrimaryTaskSet(deployments []awstypes.Deployment) *awstypes.Deployment {
+	for _, deployment := range deployments {
+		if aws.ToString(deployment.Status) == "PRIMARY" {
+			return &deployment
+		}
 	}
-	if primaryDeployment == nil {
-		return serviceStatusPending, nil
-	}
-
-	deploymentArn, err := getDeploymentARN(ctx, conn, primaryDeployment, serviceArn, clusterNameOrARN, cachedDeploymentArn)
-	if err != nil {
-		return "", err
-	}
-	if deploymentArn == nil {
-		return serviceStatusPending, nil
-	}
-
-	return getDeploymentStatus(ctx, conn, *deploymentArn)
+	return nil
 }
 
-func getPrimaryDeployment(ctx context.Context, conn *ecs.Client, serviceArn, clusterNameOrARN string) (*awstypes.Deployment, error) {
-	input := ecs.DescribeServicesInput{
-		Services: []string{serviceArn},
-		Cluster:  aws.String(clusterNameOrARN),
+func findPrimaryDeploymentARN(ctx context.Context, conn *ecs.Client, primaryTaskSet *awstypes.Deployment, serviceArn, clusterNameOrARN string, operationTime time.Time) (*string, error) {
+	parts := strings.Split(aws.ToString(primaryTaskSet.Id), "/")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("invalid primary task set ID format: %s", aws.ToString(primaryTaskSet.Id))
+	}
+	taskSetID := parts[1]
+
+	input := &ecs.ListServiceDeploymentsInput{
+		Cluster: aws.String(clusterNameOrARN),
+		Service: aws.String(serviceNameFromARN(serviceArn)),
+		CreatedAt: &awstypes.CreatedAt{
+			After: &operationTime,
+		},
 	}
 
-	output, err := conn.DescribeServices(ctx, &input)
+	output, err := conn.ListServiceDeployments(ctx, input)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(output.Services) == 0 {
-		return nil, fmt.Errorf("service not found")
-	}
-
-	service := output.Services[0]
-
-	for _, deployment := range service.Deployments {
-		if aws.ToString(deployment.Status) == "PRIMARY" {
-			return &deployment, nil
+	// Find deployment matching task set
+	for _, deployment := range output.ServiceDeployments {
+		if strings.Contains(aws.ToString(deployment.TargetServiceRevisionArn), taskSetID) {
+			return deployment.ServiceDeploymentArn, nil
 		}
 	}
 
 	return nil, nil
 }
 
-func getDeploymentARN(ctx context.Context, conn *ecs.Client, primaryDeployment *awstypes.Deployment, serviceArn, clusterNameOrARN string, cachedDeploymentArn *string) (*string, error) {
-	if aws.ToString(cachedDeploymentArn) != "" {
-		return cachedDeploymentArn, nil
-	}
-
-	deploymentArn, err := getLatestDeployment(ctx, conn, primaryDeployment, serviceArn, clusterNameOrARN)
-	if err != nil {
-		return nil, err
-	}
-
-	if deploymentArn != nil {
-		*cachedDeploymentArn = *deploymentArn
-	}
-
-	return deploymentArn, nil
-}
-
-func getDeploymentStatus(ctx context.Context, conn *ecs.Client, deploymentArn string) (string, error) {
+func findDeploymentStatus(ctx context.Context, conn *ecs.Client, deploymentArn string) (string, error) {
 	input := ecs.DescribeServiceDeploymentsInput{
 		ServiceDeploymentArns: []string{deploymentArn},
 	}
@@ -2227,43 +2232,14 @@ func getDeploymentStatus(ctx context.Context, conn *ecs.Client, deploymentArn st
 	}
 }
 
-func getLatestDeployment(ctx context.Context, conn *ecs.Client, primaryTaskSet *awstypes.Deployment, serviceArn, clusterNameOrARN string) (*string, error) {
-	parts := strings.Split(aws.ToString(primaryTaskSet.Id), "/")
-	if len(parts) < 2 {
-		return nil, fmt.Errorf("invalid primary task set ID format: %s", aws.ToString(primaryTaskSet.Id))
-	}
-	taskSetID := parts[1]
-
-	input := ecs.ListServiceDeploymentsInput{
-		Cluster: aws.String(clusterNameOrARN),
-		Service: aws.String(serviceNameFromARN(serviceArn)),
-		CreatedAt: &awstypes.CreatedAt{
-			After: primaryTaskSet.CreatedAt,
-		},
-	}
-
-	output, err := conn.ListServiceDeployments(ctx, &input)
-	if err != nil {
-		return nil, err
-	}
-
-	// Find deployment matching task set
-	for _, deployment := range output.ServiceDeployments {
-		if strings.Contains(aws.ToString(deployment.TargetServiceRevisionArn), taskSetID) {
-			return deployment.ServiceDeploymentArn, nil
-		}
-	}
-
-	return nil, nil
-}
-
 // waitServiceStable waits for an ECS Service to reach the status "ACTIVE" and have all desired tasks running.
 // Does not return tags.
-func waitServiceStable(ctx context.Context, conn *ecs.Client, serviceName, clusterNameOrARN string, timeout time.Duration) (*awstypes.Service, error) {
+func waitServiceStable(ctx context.Context, conn *ecs.Client, serviceName, clusterNameOrARN string, operationTime time.Time, timeout time.Duration) (*awstypes.Service, error) {
+
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{serviceStatusInactive, serviceStatusDraining, serviceStatusPending},
 		Target:  []string{serviceStatusStable},
-		Refresh: statusServiceWaitForStable(ctx, conn, serviceName, clusterNameOrARN),
+		Refresh: statusServiceWaitForStable(ctx, conn, serviceName, clusterNameOrARN, operationTime),
 		Timeout: timeout,
 	}
 

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -2235,7 +2235,6 @@ func findDeploymentStatus(ctx context.Context, conn *ecs.Client, deploymentArn s
 // waitServiceStable waits for an ECS Service to reach the status "ACTIVE" and have all desired tasks running.
 // Does not return tags.
 func waitServiceStable(ctx context.Context, conn *ecs.Client, serviceName, clusterNameOrARN string, operationTime time.Time, timeout time.Duration) (*awstypes.Service, error) { //nolint:unparam
-
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{serviceStatusInactive, serviceStatusDraining, serviceStatusPending},
 		Target:  []string{serviceStatusStable},

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -2234,7 +2234,7 @@ func findDeploymentStatus(ctx context.Context, conn *ecs.Client, deploymentArn s
 
 // waitServiceStable waits for an ECS Service to reach the status "ACTIVE" and have all desired tasks running.
 // Does not return tags.
-func waitServiceStable(ctx context.Context, conn *ecs.Client, serviceName, clusterNameOrARN string, operationTime time.Time, timeout time.Duration) (*awstypes.Service, error) {
+func waitServiceStable(ctx context.Context, conn *ecs.Client, serviceName, clusterNameOrARN string, operationTime time.Time, timeout time.Duration) (*awstypes.Service, error) { //nolint:unparam
 
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{serviceStatusInactive, serviceStatusDraining, serviceStatusPending},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR addresses an issue with the ECS Service provider's stabilization logic for Terraform. The problem occurred during in-place updates where the primary deployment being updated was more than 3 months old. The ListServiceDeployments API call, which is used to obtain the primary deployment ARN, filters using a CreatedAt attribute that must be within 3 months from now.

The solution introduces a new approach to handle both new deployments and in-place updates:

  1.    For new deployments (including those resulting from changes to immutable properties), we use the new stabilization logic that checks deployment status.
  2.    For in-place updates of mutable properties, we fall back to the old stabilization logic based on desired count.

This is achieved by passing the UTC time of the operation into the stabilization code and comparing it with the primary deployment's creation time.

- Flow diagram for new stabilization logic:
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/0f3a293d-93d3-49bd-b990-90e5bb2e69b2" />

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Fixes #43445 
Relates #43434 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
➜  private-ecs-terraform-provider-aws git:(f-blue-green-release) ✗ make testacc TESTS=TestAccECSService PKG=ecs
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/ecs/... -v -count 1 -parallel 3  -run='TestAccECSService'  -timeout 360m -vet=off
2025/07/22 18:32:02 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/22 18:32:02 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSServiceDataSource_basic
=== PAUSE TestAccECSServiceDataSource_basic
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSService_Identity_Basic
=== PAUSE TestAccECSService_Identity_Basic
=== RUN   TestAccECSService_Identity_RegionOverride
=== PAUSE TestAccECSService_Identity_RegionOverride
=== RUN   TestAccECSService_disappears
=== PAUSE TestAccECSService_disappears
=== RUN   TestAccECSService_LatticeConfigurations
=== PAUSE TestAccECSService_LatticeConfigurations
=== RUN   TestAccECSService_PlacementStrategy_unnormalized
=== PAUSE TestAccECSService_PlacementStrategy_unnormalized
=== RUN   TestAccECSService_CapacityProviderStrategy_basic
=== PAUSE TestAccECSService_CapacityProviderStrategy_basic
=== RUN   TestAccECSService_CapacityProviderStrategy_forceNewDeployment
=== PAUSE TestAccECSService_CapacityProviderStrategy_forceNewDeployment
=== RUN   TestAccECSService_CapacityProviderStrategy_update
=== PAUSE TestAccECSService_CapacityProviderStrategy_update
=== RUN   TestAccECSService_VolumeConfiguration_basic
=== PAUSE TestAccECSService_VolumeConfiguration_basic
=== RUN   TestAccECSService_VolumeConfiguration_volumeInitializationRate
=== PAUSE TestAccECSService_VolumeConfiguration_volumeInitializationRate
=== RUN   TestAccECSService_VolumeConfiguration_tagSpecifications
=== PAUSE TestAccECSService_VolumeConfiguration_tagSpecifications
=== RUN   TestAccECSService_VolumeConfiguration_update
=== PAUSE TestAccECSService_VolumeConfiguration_update
=== RUN   TestAccECSService_VolumeConfiguration_throughputTypeChange
=== PAUSE TestAccECSService_VolumeConfiguration_throughputTypeChange
=== RUN   TestAccECSService_familyAndRevision
=== PAUSE TestAccECSService_familyAndRevision
=== RUN   TestAccECSService_healthCheckGracePeriodSeconds
=== PAUSE TestAccECSService_healthCheckGracePeriodSeconds
=== RUN   TestAccECSService_iamRole
=== PAUSE TestAccECSService_iamRole
=== RUN   TestAccECSService_DeploymentControllerType_codeDeploy
=== PAUSE TestAccECSService_DeploymentControllerType_codeDeploy
=== RUN   TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
=== PAUSE TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
=== RUN   TestAccECSService_DeploymentControllerType_external
=== PAUSE TestAccECSService_DeploymentControllerType_external
=== RUN   TestAccECSService_DeploymentControllerMutability_codeDeployToECS
=== PAUSE TestAccECSService_DeploymentControllerMutability_codeDeployToECS
=== RUN   TestAccECSService_alarmsAdd
=== PAUSE TestAccECSService_alarmsAdd
=== RUN   TestAccECSService_alarmsUpdate
=== PAUSE TestAccECSService_alarmsUpdate
=== RUN   TestAccECSService_BlueGreenDeployment_basic
=== PAUSE TestAccECSService_BlueGreenDeployment_basic
=== RUN   TestAccECSService_BlueGreenDeployment_circuitBreakerRollback
=== PAUSE TestAccECSService_BlueGreenDeployment_circuitBreakerRollback
=== RUN   TestAccECSService_BlueGreenDeployment_createFailure
=== PAUSE TestAccECSService_BlueGreenDeployment_createFailure
=== RUN   TestAccECSService_BlueGreenDeployment_changeStrategy
=== PAUSE TestAccECSService_BlueGreenDeployment_changeStrategy
=== RUN   TestAccECSService_BlueGreenDeployment_updateFailure
=== PAUSE TestAccECSService_BlueGreenDeployment_updateFailure
=== RUN   TestAccECSService_BlueGreenDeployment_updateInPlace
=== PAUSE TestAccECSService_BlueGreenDeployment_updateInPlace
=== RUN   TestAccECSService_BlueGreenDeployment_waitServiceActive
=== PAUSE TestAccECSService_BlueGreenDeployment_waitServiceActive
=== RUN   TestAccECSService_DeploymentConfiguration_strategy
=== PAUSE TestAccECSService_DeploymentConfiguration_strategy
=== RUN   TestAccECSService_DeploymentValues_basic
=== PAUSE TestAccECSService_DeploymentValues_basic
=== RUN   TestAccECSService_DeploymentValues_minZeroMaxOneHundred
=== PAUSE TestAccECSService_DeploymentValues_minZeroMaxOneHundred
=== RUN   TestAccECSService_deploymentCircuitBreaker
=== PAUSE TestAccECSService_deploymentCircuitBreaker
=== RUN   TestAccECSService_loadBalancerChanges
=== PAUSE TestAccECSService_loadBalancerChanges
=== RUN   TestAccECSService_clusterName
=== PAUSE TestAccECSService_clusterName
=== RUN   TestAccECSService_alb
=== PAUSE TestAccECSService_alb
=== RUN   TestAccECSService_multipleTargetGroups
=== PAUSE TestAccECSService_multipleTargetGroups
=== RUN   TestAccECSService_forceNewDeployment
=== PAUSE TestAccECSService_forceNewDeployment
=== RUN   TestAccECSService_forceNewDeploymentTriggers
=== PAUSE TestAccECSService_forceNewDeploymentTriggers
=== RUN   TestAccECSService_PlacementStrategy_basic
=== PAUSE TestAccECSService_PlacementStrategy_basic
=== RUN   TestAccECSService_PlacementStrategy_missing
=== PAUSE TestAccECSService_PlacementStrategy_missing
=== RUN   TestAccECSService_PlacementConstraints_basic
=== PAUSE TestAccECSService_PlacementConstraints_basic
=== RUN   TestAccECSService_PlacementConstraints_emptyExpression
=== PAUSE TestAccECSService_PlacementConstraints_emptyExpression
=== RUN   TestAccECSService_LaunchTypeFargate_basic
=== PAUSE TestAccECSService_LaunchTypeFargate_basic
=== RUN   TestAccECSService_LaunchTypeFargate_platformVersion
=== PAUSE TestAccECSService_LaunchTypeFargate_platformVersion
=== RUN   TestAccECSService_LaunchTypeFargate_waitForSteadyState
=== PAUSE TestAccECSService_LaunchTypeFargate_waitForSteadyState
=== RUN   TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
=== PAUSE TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
=== RUN   TestAccECSService_LaunchTypeEC2_network
=== PAUSE TestAccECSService_LaunchTypeEC2_network
=== RUN   TestAccECSService_DaemonSchedulingStrategy_basic
=== PAUSE TestAccECSService_DaemonSchedulingStrategy_basic
=== RUN   TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
=== PAUSE TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
=== RUN   TestAccECSService_replicaSchedulingStrategy
=== PAUSE TestAccECSService_replicaSchedulingStrategy
=== RUN   TestAccECSService_ServiceRegistries_basic
=== PAUSE TestAccECSService_ServiceRegistries_basic
=== RUN   TestAccECSService_ServiceRegistries_container
=== PAUSE TestAccECSService_ServiceRegistries_container
=== RUN   TestAccECSService_ServiceRegistries_changes
=== PAUSE TestAccECSService_ServiceRegistries_changes
=== RUN   TestAccECSService_ServiceRegistries_removal
=== PAUSE TestAccECSService_ServiceRegistries_removal
=== RUN   TestAccECSService_ServiceConnect_basic
=== PAUSE TestAccECSService_ServiceConnect_basic
=== RUN   TestAccECSService_ServiceConnect_full
=== PAUSE TestAccECSService_ServiceConnect_full
=== RUN   TestAccECSService_ServiceConnect_tls_with_empty_timeout
=== PAUSE TestAccECSService_ServiceConnect_tls_with_empty_timeout
=== RUN   TestAccECSService_ServiceConnect_ingressPortOverride
=== PAUSE TestAccECSService_ServiceConnect_ingressPortOverride
=== RUN   TestAccECSService_ServiceConnect_remove
=== PAUSE TestAccECSService_ServiceConnect_remove
=== RUN   TestAccECSService_Tags_basic
=== PAUSE TestAccECSService_Tags_basic
=== RUN   TestAccECSService_Tags_managed
=== PAUSE TestAccECSService_Tags_managed
=== RUN   TestAccECSService_Tags_propagate
=== PAUSE TestAccECSService_Tags_propagate
=== RUN   TestAccECSService_executeCommand
=== PAUSE TestAccECSService_executeCommand
=== RUN   TestAccECSService_AvailabilityZoneRebalancing
=== PAUSE TestAccECSService_AvailabilityZoneRebalancing
=== CONT  TestAccECSServiceDataSource_basic
=== CONT  TestAccECSService_deploymentCircuitBreaker
=== CONT  TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
--- PASS: TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum (41.03s)
=== CONT  TestAccECSService_PlacementConstraints_basic
--- PASS: TestAccECSServiceDataSource_basic (72.37s)
=== CONT  TestAccECSService_DaemonSchedulingStrategy_basic
--- PASS: TestAccECSService_deploymentCircuitBreaker (72.39s)
=== CONT  TestAccECSService_LaunchTypeEC2_network
--- PASS: TestAccECSService_DaemonSchedulingStrategy_basic (39.23s)
=== CONT  TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
--- PASS: TestAccECSService_PlacementConstraints_basic (81.64s)
=== CONT  TestAccECSService_LaunchTypeFargate_waitForSteadyState
--- PASS: TestAccECSService_LaunchTypeEC2_network (65.43s)
=== CONT  TestAccECSService_LaunchTypeFargate_platformVersion
--- PASS: TestAccECSService_LaunchTypeFargate_platformVersion (78.21s)
=== CONT  TestAccECSService_LaunchTypeFargate_basic
--- PASS: TestAccECSService_LaunchTypeFargate_waitForSteadyState (167.15s)
=== CONT  TestAccECSService_PlacementConstraints_emptyExpression
--- PASS: TestAccECSService_LaunchTypeFargate_basic (78.35s)
=== CONT  TestAccECSService_forceNewDeployment
--- PASS: TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState (207.44s)
=== CONT  TestAccECSService_PlacementStrategy_missing
=== CONT  TestAccECSService_PlacementStrategy_basic
--- PASS: TestAccECSService_PlacementStrategy_missing (0.72s)
--- PASS: TestAccECSService_forceNewDeployment (58.91s)
=== CONT  TestAccECSService_forceNewDeploymentTriggers
--- PASS: TestAccECSService_PlacementConstraints_emptyExpression (70.62s)
=== CONT  TestAccECSService_alb
--- PASS: TestAccECSService_PlacementStrategy_basic (88.62s)
=== CONT  TestAccECSService_multipleTargetGroups
--- PASS: TestAccECSService_forceNewDeploymentTriggers (69.62s)
=== CONT  TestAccECSService_iamRole
--- PASS: TestAccECSService_iamRole (38.77s)
=== CONT  TestAccECSService_DeploymentValues_minZeroMaxOneHundred
--- PASS: TestAccECSService_DeploymentValues_minZeroMaxOneHundred (70.72s)
=== CONT  TestAccECSService_DeploymentValues_basic
--- PASS: TestAccECSService_DeploymentValues_basic (70.33s)
=== CONT  TestAccECSService_DeploymentConfiguration_strategy
--- PASS: TestAccECSService_alb (272.44s)
=== CONT  TestAccECSService_BlueGreenDeployment_waitServiceActive
--- PASS: TestAccECSService_multipleTargetGroups (278.99s)
=== CONT  TestAccECSService_BlueGreenDeployment_updateInPlace
--- PASS: TestAccECSService_DeploymentConfiguration_strategy (87.70s)
=== CONT  TestAccECSService_BlueGreenDeployment_updateFailure
--- PASS: TestAccECSService_BlueGreenDeployment_waitServiceActive (950.38s)
=== CONT  TestAccECSService_BlueGreenDeployment_changeStrategy
--- PASS: TestAccECSService_BlueGreenDeployment_updateInPlace (1042.86s)
=== CONT  TestAccECSService_BlueGreenDeployment_createFailure
--- PASS: TestAccECSService_BlueGreenDeployment_updateFailure (1100.86s)
=== CONT  TestAccECSService_BlueGreenDeployment_circuitBreakerRollback
--- PASS: TestAccECSService_BlueGreenDeployment_createFailure (353.81s)
=== CONT  TestAccECSService_BlueGreenDeployment_basic
--- PASS: TestAccECSService_BlueGreenDeployment_basic (1430.53s)
=== CONT  TestAccECSService_alarmsUpdate
--- PASS: TestAccECSService_BlueGreenDeployment_changeStrategy (1989.03s)
=== CONT  TestAccECSService_alarmsAdd
--- PASS: TestAccECSService_alarmsUpdate (69.32s)
=== CONT  TestAccECSService_DeploymentControllerMutability_codeDeployToECS
--- PASS: TestAccECSService_alarmsAdd (68.90s)
=== CONT  TestAccECSService_DeploymentControllerType_external
--- PASS: TestAccECSService_DeploymentControllerType_external (40.97s)
=== CONT  TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
--- PASS: TestAccECSService_DeploymentControllerMutability_codeDeployToECS (286.92s)
=== CONT  TestAccECSService_DeploymentControllerType_codeDeploy
--- PASS: TestAccECSService_DeploymentControllerType_codeDeploy (263.58s)
=== CONT  TestAccECSService_clusterName
--- PASS: TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod (496.92s)
=== CONT  TestAccECSService_loadBalancerChanges
--- PASS: TestAccECSService_clusterName (70.57s)
=== CONT  TestAccECSService_CapacityProviderStrategy_update
    service_test.go:437: Step 1/4 error: Error running apply: exit status 1
--- PASS: TestAccECSService_CapacityProviderStrategy_update (56.82s)
=== CONT  TestAccECSService_healthCheckGracePeriodSeconds
--- PASS: TestAccECSService_loadBalancerChanges (284.50s)
=== CONT  TestAccECSService_familyAndRevision
--- PASS: TestAccECSService_familyAndRevision (80.00s)
=== CONT  TestAccECSService_VolumeConfiguration_throughputTypeChange
--- PASS: TestAccECSService_healthCheckGracePeriodSeconds (303.49s)
=== CONT  TestAccECSService_VolumeConfiguration_update
=== NAME  TestAccECSService_VolumeConfiguration_throughputTypeChange
    service_test.go:639: Step 1/2 error: Check failed: Check 6/7 error: aws_ecs_service.test: Attribute 'volume_configuration.0.managed_ebs_volume.0.throughput' expected "", got "0"
--- FAIL: TestAccECSService_VolumeConfiguration_throughputTypeChange (69.41s)
=== CONT  TestAccECSService_VolumeConfiguration_tagSpecifications
--- PASS: TestAccECSService_VolumeConfiguration_tagSpecifications (74.97s)
=== CONT  TestAccECSService_VolumeConfiguration_volumeInitializationRate
--- PASS: TestAccECSService_VolumeConfiguration_update (134.63s)
=== CONT  TestAccECSService_VolumeConfiguration_basic
--- PASS: TestAccECSService_VolumeConfiguration_basic (74.63s)
=== CONT  TestAccECSService_LatticeConfigurations
--- PASS: TestAccECSService_VolumeConfiguration_volumeInitializationRate (126.89s)
=== CONT  TestAccECSService_CapacityProviderStrategy_forceNewDeployment
    service_test.go:399: Step 1/2 error: Error running apply: exit status 1
--- PASS: TestAccECSService_CapacityProviderStrategy_forceNewDeployment (17.70s)
=== CONT  TestAccECSService_CapacityProviderStrategy_basic
--- PASS: TestAccECSService_CapacityProviderStrategy_basic (17.47s)
=== CONT  TestAccECSService_PlacementStrategy_unnormalized
--- PASS: TestAccECSService_PlacementStrategy_unnormalized (60.08s)
=== CONT  TestAccECSService_ServiceConnect_tls_with_empty_timeout
--- PASS: TestAccECSService_ServiceConnect_tls_with_empty_timeout (167.90s)
=== CONT  TestAccECSService_AvailabilityZoneRebalancing
--- PASS: TestAccECSService_AvailabilityZoneRebalancing (74.59s)
=== CONT  TestAccECSService_executeCommand
--- PASS: TestAccECSService_executeCommand (58.59s)
=== CONT  TestAccECSService_Tags_propagate
--- PASS: TestAccECSService_BlueGreenDeployment_circuitBreakerRollback (3430.68s)
=== CONT  TestAccECSService_Tags_managed
--- PASS: TestAccECSService_Tags_propagate (66.93s)
=== CONT  TestAccECSService_Tags_basic
--- PASS: TestAccECSService_Tags_managed (59.39s)
=== CONT  TestAccECSService_ServiceConnect_remove
--- PASS: TestAccECSService_Tags_basic (58.79s)
=== CONT  TestAccECSService_ServiceConnect_ingressPortOverride
--- PASS: TestAccECSService_ServiceConnect_remove (148.02s)
=== CONT  TestAccECSService_ServiceRegistries_basic
--- PASS: TestAccECSService_LatticeConfigurations (670.46s)
=== CONT  TestAccECSService_ServiceRegistries_container
--- PASS: TestAccECSService_ServiceConnect_ingressPortOverride (167.19s)
=== CONT  TestAccECSService_ServiceRegistries_changes
--- PASS: TestAccECSService_ServiceRegistries_basic (154.85s)
=== CONT  TestAccECSService_ServiceConnect_full
--- PASS: TestAccECSService_ServiceRegistries_container (155.32s)
=== CONT  TestAccECSService_ServiceConnect_basic
--- PASS: TestAccECSService_ServiceRegistries_changes (237.42s)
=== CONT  TestAccECSService_ServiceRegistries_removal
--- PASS: TestAccECSService_ServiceConnect_full (167.53s)
=== CONT  TestAccECSService_Identity_RegionOverride
--- PASS: TestAccECSService_ServiceConnect_basic (152.33s)
=== CONT  TestAccECSService_disappears
--- PASS: TestAccECSService_Identity_RegionOverride (60.90s)
=== CONT  TestAccECSService_Identity_Basic
--- PASS: TestAccECSService_ServiceRegistries_removal (118.33s)
=== CONT  TestAccECSService_basic
--- PASS: TestAccECSService_Identity_Basic (62.83s)
=== CONT  TestAccECSService_replicaSchedulingStrategy
--- PASS: TestAccECSService_basic (71.78s)
--- PASS: TestAccECSService_disappears (179.94s)
--- PASS: TestAccECSService_replicaSchedulingStrategy (59.52s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/ecs        5938.964s
FAIL
make: *** [testacc] Error 1
```
Failure is transient and unrelated to this change (see #38475).