### PR TITLE
fix error in aws_dx_hosted_connection resource creation

### DIFF
--- a/.changelog/43499.txt
+++ b/.changelog/43499.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dx_hosted_connection: Fix `DescribeHostedConnections failed for connection dxcon-xxxx doesn't exist` by pointing to the correct connection ID when doing the describe.
+```

--- a/internal/service/directconnect/hosted_connection.go
+++ b/internal/service/directconnect/hosted_connection.go
@@ -139,21 +139,24 @@ func resourceHostedConnectionRead(ctx context.Context, d *schema.ResourceData, m
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DirectConnectClient(ctx)
 
-	connection, err := findHostedConnectionByID(ctx, conn, d.Id())
+	// Get both the hosted connection ID and the parent connection ID
+	hostedConnectionID := d.Id()
+	parentConnectionID := d.Get(names.AttrConnectionID).(string)
+
+	connection, err := findHostedConnectionByID(ctx, conn, hostedConnectionID, parentConnectionID)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] Direct Connect Hosted Connection (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] Direct Connect Hosted Connection (%s) not found, removing from state", hostedConnectionID)
 		d.SetId("")
 		return diags
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading Direct Connect Hosted Connection (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Direct Connect Hosted Connection (%s): %s", hostedConnectionID, err)
 	}
 
-	// Cannot set the following attributes from the response:
-	// - connection_id: conn.ConnectionId is this resource's ID, not the ID of the interconnect or LAG
-	// - tags: conn.Tags seems to always come back empty and DescribeTags needs to be called from the owner account
+	// Set the connection_id (parent/interconnect ID) and other attributes
+	d.Set(names.AttrConnectionID, parentConnectionID)
 	d.Set("aws_device", connection.AwsDeviceV2)
 	d.Set("connection_region", connection.Region)
 	d.Set("has_logical_redundancy", connection.HasLogicalRedundancy)
@@ -176,18 +179,33 @@ func resourceHostedConnectionDelete(ctx context.Context, d *schema.ResourceData,
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DirectConnectClient(ctx)
 
-	if err := deleteConnection(ctx, conn, d.Id(), waitHostedConnectionDeleted); err != nil {
+	// Get the parent connection ID
+	parentConnectionID := d.Get(names.AttrConnectionID).(string)
+
+	// Create a wrapper function that adapts waitHostedConnectionDeleted to match the expected signature
+	waiterWrapper := func(ctx context.Context, conn *directconnect.Client, connectionID string) (*awstypes.Connection, error) {
+		return waitHostedConnectionDeleted(ctx, conn, connectionID, parentConnectionID)
+	}
+
+	if err := deleteConnection(ctx, conn, d.Id(), waiterWrapper); err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	return diags
 }
 
-func findHostedConnectionByID(ctx context.Context, conn *directconnect.Client, id string) (*awstypes.Connection, error) {
+func findHostedConnectionByID(ctx context.Context, conn *directconnect.Client, hostedConnectionID, parentConnectionID string) (*awstypes.Connection, error) {
+	// Use the parent connection ID for the API call
 	input := &directconnect.DescribeHostedConnectionsInput{
-		ConnectionId: aws.String(id),
+		ConnectionId: aws.String(parentConnectionID),
 	}
-	output, err := findHostedConnection(ctx, conn, input, tfslices.PredicateTrue[*awstypes.Connection]())
+
+	// Create a predicate to filter by the hosted connection ID
+	predicate := func(c *awstypes.Connection) bool {
+		return aws.ToString(c.ConnectionId) == hostedConnectionID
+	}
+
+	output, err := findHostedConnection(ctx, conn, input, predicate)
 
 	if err != nil {
 		return nil, err
@@ -234,9 +252,9 @@ func findHostedConnections(ctx context.Context, conn *directconnect.Client, inpu
 	return tfslices.Filter(output.Connections, tfslices.PredicateValue(filter)), nil
 }
 
-func statusHostedConnection(ctx context.Context, conn *directconnect.Client, id string) retry.StateRefreshFunc {
+func statusHostedConnection(ctx context.Context, conn *directconnect.Client, hostedConnectionID string, parentConnectionID string) retry.StateRefreshFunc {
 	return func() (any, string, error) {
-		output, err := findHostedConnectionByID(ctx, conn, id)
+		output, err := findHostedConnectionByID(ctx, conn, hostedConnectionID, parentConnectionID)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil
@@ -250,14 +268,14 @@ func statusHostedConnection(ctx context.Context, conn *directconnect.Client, id 
 	}
 }
 
-func waitHostedConnectionDeleted(ctx context.Context, conn *directconnect.Client, id string) (*awstypes.Connection, error) {
+func waitHostedConnectionDeleted(ctx context.Context, conn *directconnect.Client, hostedConnectionID string, parentConnectionID string) (*awstypes.Connection, error) {
 	const (
 		timeout = 10 * time.Minute
 	)
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.ConnectionStatePending, awstypes.ConnectionStateOrdering, awstypes.ConnectionStateAvailable, awstypes.ConnectionStateRequested, awstypes.ConnectionStateDeleting),
 		Target:  []string{},
-		Refresh: statusHostedConnection(ctx, conn, id),
+		Refresh: statusHostedConnection(ctx, conn, hostedConnectionID, parentConnectionID),
 		Timeout: timeout,
 	}
 

--- a/internal/service/directconnect/hosted_connection_test.go
+++ b/internal/service/directconnect/hosted_connection_test.go
@@ -60,7 +60,9 @@ func testAccCheckHostedConnectionDestroy(ctx context.Context, providerFunc func(
 				continue
 			}
 
-			_, err := tfdirectconnect.FindHostedConnectionByID(ctx, conn, rs.Primary.ID)
+			// Get the parent connection ID from the resource attributes
+			parentConnectionID := rs.Primary.Attributes[names.AttrConnectionID]
+			_, err := tfdirectconnect.FindHostedConnectionByID(ctx, conn, rs.Primary.ID, parentConnectionID)
 
 			if tfresource.NotFound(err) {
 				continue
@@ -86,7 +88,10 @@ func testAccCheckHostedConnectionExists(ctx context.Context, n string) resource.
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		_, err := tfdirectconnect.FindHostedConnectionByID(ctx, conn, rs.Primary.ID)
+		// Get the parent connection ID from the resource state
+		parentConnectionID := rs.Primary.Attributes[names.AttrConnectionID]
+
+		_, err := tfdirectconnect.FindHostedConnectionByID(ctx, conn, rs.Primary.ID, parentConnectionID)
 
 		return err
 	}

--- a/website/docs/r/dx_hosted_connection.html.markdown
+++ b/website/docs/r/dx_hosted_connection.html.markdown
@@ -39,7 +39,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `aws_device` - The Direct Connect endpoint on which the physical connection terminates.
 * `connection_region` - The AWS Region where the connection is located.
 * `has_logical_redundancy` - Indicates whether the connection supports a secondary BGP peer in the same address family (IPv4/IPv6).
-* `id` - The ID of the connection.
+* `id` - The ID of the hosted connection.
 * `jumbo_frame_capable` - Boolean value representing if jumbo frames have been enabled for this connection.
 * `lag_id` - The ID of the LAG.
 * `loa_issue_time` - The time of the most recent call to [DescribeLoa](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeLoa.html) for this connection.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR fixes the creation of the resource aws_dx_hosted_connection. Prior to this fix, the describe action after creation was failing due to the use of the incorrect Connection ID (it was using the Hosted Connection ID created and not the Interconnect/LAG ID). With this fix, now creation, describe, and delete actions are properly configured.

### Relations

Closes #43499

### References

Describe action - https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeHostedConnections.html - where it shows that the ID needed is the interconnect or LAG ID.

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccDirectConnectHostedConnection_basic PKG=directconnect GO_VER=go
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/directconnect/... -v -count 1 -parallel 20 -run='TestAccDirectConnectHostedConnection_basic'  -timeout 360m -vet=off
2025/07/22 23:01:14 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/22 23:01:14 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDirectConnectHostedConnection_basic
=== PAUSE TestAccDirectConnectHostedConnection_basic
=== CONT  TestAccDirectConnectHostedConnection_basic
--- PASS: TestAccDirectConnectHostedConnection_basic (14.46s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/directconnect      19.468s
...
```
