### PR TITLE
[Enhancement] aws_wafv2_web_acl: Support `asn` custom key in `rate_based_statement`

### DIFF
--- a/.changelog/43506.txt
+++ b/.changelog/43506.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_wafv2_web_acl: Add `asn` to `rate_based_statement` block
+```

--- a/.changelog/43506.txt
+++ b/.changelog/43506.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_wafv2_web_acl: Add `asn` to `rate_based_statement` block
+resource/aws_wafv2_web_acl: Add support for `asn` custom key in `rate_based_statement block`
 ```

--- a/.changelog/43506.txt
+++ b/.changelog/43506.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_wafv2_web_acl: Add support for `asn` custom key in `rate_based_statement block`
+resource/aws_wafv2_web_acl: Add `statement.rate_based_statement.custom_key.asn` argument
 ```

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -1774,6 +1774,9 @@ func expandRateBasedStatementCustomKeys(l []any) []awstypes.RateBasedStatementCu
 	for _, ck := range l {
 		r := awstypes.RateBasedStatementCustomKey{}
 		m := ck.(map[string]any)
+		if v, ok := m["asn"]; ok && len(v.([]any)) > 0 {
+			r.ASN = &awstypes.RateLimitAsn{}
+		}
 		if v, ok := m["cookie"]; ok {
 			r.Cookie = expandRateLimitCookie(v.([]any))
 		}
@@ -3379,6 +3382,11 @@ func flattenRateBasedStatementCustomKeys(apiObject []awstypes.RateBasedStatement
 	for i, o := range apiObject {
 		tfMap := map[string]any{}
 
+		if o.ASN != nil {
+			tfMap["asn"] = []any{
+				map[string]any{},
+			}
+		}
 		if o.Cookie != nil {
 			tfMap["cookie"] = flattenRateLimitCookie(o.Cookie)
 		}

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -1083,6 +1083,7 @@ func rateBasedStatementSchema(level int) *schema.Schema {
 					MaxItems: 5,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
+							"asn": emptySchema(),
 							"cookie": {
 								Type:     schema.TypeList,
 								Optional: true,

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -2069,6 +2069,7 @@ func TestAccWAFV2WebACL_RateBased_customKeys(t *testing.T) {
 						"statement.0.rate_based_statement.0.forwarded_ip_config.#":                       "0",
 						"statement.0.rate_based_statement.0.limit":                                       "50000",
 						"statement.0.rate_based_statement.0.scope_down_statement.#":                      "0",
+						"statement.0.rate_based_statement.0.custom_key.0.asn.#":                          "0",
 						"statement.0.rate_based_statement.0.custom_key.0.cookie.#":                       "1",
 						"statement.0.rate_based_statement.0.custom_key.0.forwarded_ip.#":                 "0",
 						"statement.0.rate_based_statement.0.custom_key.0.http_method.#":                  "0",
@@ -2098,6 +2099,7 @@ func TestAccWAFV2WebACL_RateBased_customKeys(t *testing.T) {
 						"statement.0.rate_based_statement.0.forwarded_ip_config.#":          "1",
 						"statement.0.rate_based_statement.0.limit":                          "50000",
 						"statement.0.rate_based_statement.0.scope_down_statement.#":         "0",
+						"statement.0.rate_based_statement.0.custom_key.0.asn.#":             "0",
 						"statement.0.rate_based_statement.0.custom_key.0.cookie.#":          "1",
 						"statement.0.rate_based_statement.0.custom_key.0.forwarded_ip.#":    "0",
 						"statement.0.rate_based_statement.0.custom_key.0.http_method.#":     "0",
@@ -2127,6 +2129,7 @@ func TestAccWAFV2WebACL_RateBased_customKeys(t *testing.T) {
 						"statement.0.rate_based_statement.0.forwarded_ip_config.#":          "0",
 						"statement.0.rate_based_statement.0.limit":                          "50000",
 						"statement.0.rate_based_statement.0.scope_down_statement.#":         "0",
+						"statement.0.rate_based_statement.0.custom_key.0.asn.#":             "0",
 						"statement.0.rate_based_statement.0.custom_key.0.cookie.#":          "0",
 						"statement.0.rate_based_statement.0.custom_key.0.forwarded_ip.#":    "0",
 						"statement.0.rate_based_statement.0.custom_key.0.http_method.#":     "1",
@@ -2155,6 +2158,7 @@ func TestAccWAFV2WebACL_RateBased_customKeys(t *testing.T) {
 						"statement.0.rate_based_statement.0.forwarded_ip_config.#":                       "0",
 						"statement.0.rate_based_statement.0.limit":                                       "50000",
 						"statement.0.rate_based_statement.0.scope_down_statement.#":                      "0",
+						"statement.0.rate_based_statement.0.custom_key.0.asn.#":                          "0",
 						"statement.0.rate_based_statement.0.custom_key.0.cookie.#":                       "0",
 						"statement.0.rate_based_statement.0.custom_key.0.forwarded_ip.#":                 "0",
 						"statement.0.rate_based_statement.0.custom_key.0.http_method.#":                  "0",
@@ -2184,6 +2188,7 @@ func TestAccWAFV2WebACL_RateBased_customKeys(t *testing.T) {
 						"statement.0.rate_based_statement.0.forwarded_ip_config.#":          "0",
 						"statement.0.rate_based_statement.0.limit":                          "50000",
 						"statement.0.rate_based_statement.0.scope_down_statement.#":         "0",
+						"statement.0.rate_based_statement.0.custom_key.0.asn.#":             "0",
 						"statement.0.rate_based_statement.0.custom_key.0.cookie.#":          "1",
 						"statement.0.rate_based_statement.0.custom_key.0.forwarded_ip.#":    "0",
 						"statement.0.rate_based_statement.0.custom_key.0.http_method.#":     "0",
@@ -2213,6 +2218,7 @@ func TestAccWAFV2WebACL_RateBased_customKeys(t *testing.T) {
 						"statement.0.rate_based_statement.0.forwarded_ip_config.#":                               "0",
 						"statement.0.rate_based_statement.0.limit":                                               "50000",
 						"statement.0.rate_based_statement.0.scope_down_statement.#":                              "0",
+						"statement.0.rate_based_statement.0.custom_key.0.asn.#":                                  "0",
 						"statement.0.rate_based_statement.0.custom_key.0.cookie.#":                               "0",
 						"statement.0.rate_based_statement.0.custom_key.0.forwarded_ip.#":                         "0",
 						"statement.0.rate_based_statement.0.custom_key.0.http_method.#":                          "0",
@@ -2242,6 +2248,7 @@ func TestAccWAFV2WebACL_RateBased_customKeys(t *testing.T) {
 						"statement.0.rate_based_statement.0.forwarded_ip_config.#":                             "0",
 						"statement.0.rate_based_statement.0.limit":                                             "50000",
 						"statement.0.rate_based_statement.0.scope_down_statement.#":                            "0",
+						"statement.0.rate_based_statement.0.custom_key.0.asn.#":                                "0",
 						"statement.0.rate_based_statement.0.custom_key.0.cookie.#":                             "0",
 						"statement.0.rate_based_statement.0.custom_key.0.forwarded_ip.#":                       "0",
 						"statement.0.rate_based_statement.0.custom_key.0.http_method.#":                        "0",
@@ -2271,6 +2278,7 @@ func TestAccWAFV2WebACL_RateBased_customKeys(t *testing.T) {
 						"statement.0.rate_based_statement.0.forwarded_ip_config.#":                         "0",
 						"statement.0.rate_based_statement.0.limit":                                         "50000",
 						"statement.0.rate_based_statement.0.scope_down_statement.#":                        "0",
+						"statement.0.rate_based_statement.0.custom_key.0.asn.#":                            "0",
 						"statement.0.rate_based_statement.0.custom_key.0.cookie.#":                         "0",
 						"statement.0.rate_based_statement.0.custom_key.0.forwarded_ip.#":                   "0",
 						"statement.0.rate_based_statement.0.custom_key.0.http_method.#":                    "0",
@@ -2319,6 +2327,7 @@ func TestAccWAFV2WebACL_RateBased_customKeys(t *testing.T) {
 						"statement.0.rate_based_statement.0.forwarded_ip_config.#":                       "0",
 						"statement.0.rate_based_statement.0.limit":                                       "50000",
 						"statement.0.rate_based_statement.0.scope_down_statement.#":                      "0",
+						"statement.0.rate_based_statement.0.custom_key.0.asn.#":                          "0",
 						"statement.0.rate_based_statement.0.custom_key.0.cookie.#":                       "1",
 						"statement.0.rate_based_statement.0.custom_key.0.forwarded_ip.#":                 "0",
 						"statement.0.rate_based_statement.0.custom_key.0.http_method.#":                  "0",
@@ -2347,6 +2356,7 @@ func TestAccWAFV2WebACL_RateBased_customKeys(t *testing.T) {
 						"statement.0.rate_based_statement.0.evaluation_window_sec":                            "300",
 						"statement.0.rate_based_statement.0.limit":                                            "50000",
 						"statement.0.rate_based_statement.0.scope_down_statement.#":                           "0",
+						"statement.0.rate_based_statement.0.custom_key.0.asn.#":                               "0",
 						"statement.0.rate_based_statement.0.custom_key.0.cookie.#":                            "1",
 						"statement.0.rate_based_statement.0.custom_key.0.forwarded_ip.#":                      "0",
 						"statement.0.rate_based_statement.0.custom_key.0.http_method.#":                       "0",
@@ -2377,6 +2387,7 @@ func TestAccWAFV2WebACL_RateBased_customKeys(t *testing.T) {
 						"statement.0.rate_based_statement.0.forwarded_ip_config.#":                       "0",
 						"statement.0.rate_based_statement.0.limit":                                       "50000",
 						"statement.0.rate_based_statement.0.scope_down_statement.#":                      "0",
+						"statement.0.rate_based_statement.0.custom_key.0.asn.#":                          "0",
 						"statement.0.rate_based_statement.0.custom_key.0.cookie.#":                       "1",
 						"statement.0.rate_based_statement.0.custom_key.0.forwarded_ip.#":                 "0",
 						"statement.0.rate_based_statement.0.custom_key.0.http_method.#":                  "0",
@@ -2405,6 +2416,7 @@ func TestAccWAFV2WebACL_RateBased_customKeys(t *testing.T) {
 						"statement.0.rate_based_statement.0.evaluation_window_sec":                            "300",
 						"statement.0.rate_based_statement.0.limit":                                            "50000",
 						"statement.0.rate_based_statement.0.scope_down_statement.#":                           "0",
+						"statement.0.rate_based_statement.0.custom_key.0.asn.#":                               "0",
 						"statement.0.rate_based_statement.0.custom_key.0.cookie.#":                            "1",
 						"statement.0.rate_based_statement.0.custom_key.0.forwarded_ip.#":                      "0",
 						"statement.0.rate_based_statement.0.custom_key.0.http_method.#":                       "0",
@@ -2416,6 +2428,65 @@ func TestAccWAFV2WebACL_RateBased_customKeys(t *testing.T) {
 						"statement.0.rate_based_statement.0.custom_key.0.uri_path.#":                          "0",
 						"statement.0.rate_based_statement.0.custom_key.1.ja4_fingerprint.#":                   "1",
 						"statement.0.rate_based_statement.0.custom_key.1.ja4_fingerprint.0.fallback_behavior": "NO_MATCH",
+					}),
+				),
+			},
+			{
+				Config: testAccWebACLConfig_rateBasedStatement_customKeysBasic(webACLName, names.AttrHeader, "x-forwrded-for"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLExists(ctx, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "wafv2", regexache.MustCompile(`regional/webacl/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, webACLName),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtRulePound, "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"statement.#":                                                                    "1",
+						"statement.0.rate_based_statement.#":                                             "1",
+						"statement.0.rate_based_statement.0.custom_key.#":                                "1",
+						"statement.0.rate_based_statement.0.aggregate_key_type":                          "CUSTOM_KEYS",
+						"statement.0.rate_based_statement.0.evaluation_window_sec":                       "300",
+						"statement.0.rate_based_statement.0.forwarded_ip_config.#":                       "0",
+						"statement.0.rate_based_statement.0.limit":                                       "50000",
+						"statement.0.rate_based_statement.0.scope_down_statement.#":                      "0",
+						"statement.0.rate_based_statement.0.custom_key.0.asn.#":                          "0",
+						"statement.0.rate_based_statement.0.custom_key.0.cookie.#":                       "0",
+						"statement.0.rate_based_statement.0.custom_key.0.forwarded_ip.#":                 "0",
+						"statement.0.rate_based_statement.0.custom_key.0.http_method.#":                  "0",
+						"statement.0.rate_based_statement.0.custom_key.0.header.#":                       "1",
+						"statement.0.rate_based_statement.0.custom_key.0.ip.#":                           "0",
+						"statement.0.rate_based_statement.0.custom_key.0.label_namespace.#":              "0",
+						"statement.0.rate_based_statement.0.custom_key.0.query_argument.#":               "0",
+						"statement.0.rate_based_statement.0.custom_key.0.query_string.#":                 "0",
+						"statement.0.rate_based_statement.0.custom_key.0.uri_path.#":                     "0",
+						"statement.0.rate_based_statement.0.custom_key.0.header.0.text_transformation.#": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccWebACLConfig_rateBasedStatement_customKeysASN(webACLName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLExists(ctx, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "wafv2", regexache.MustCompile(`regional/webacl/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, webACLName),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtRulePound, "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"statement.#":                                                       "1",
+						"statement.0.rate_based_statement.#":                                "1",
+						"statement.0.rate_based_statement.0.custom_key.#":                   "1",
+						"statement.0.rate_based_statement.0.aggregate_key_type":             "CUSTOM_KEYS",
+						"statement.0.rate_based_statement.0.evaluation_window_sec":          "300",
+						"statement.0.rate_based_statement.0.forwarded_ip_config.#":          "0",
+						"statement.0.rate_based_statement.0.limit":                          "50000",
+						"statement.0.rate_based_statement.0.scope_down_statement.#":         "0",
+						"statement.0.rate_based_statement.0.custom_key.0.asn.#":             "1",
+						"statement.0.rate_based_statement.0.custom_key.0.cookie.#":          "0",
+						"statement.0.rate_based_statement.0.custom_key.0.forwarded_ip.#":    "0",
+						"statement.0.rate_based_statement.0.custom_key.0.http_method.#":     "0",
+						"statement.0.rate_based_statement.0.custom_key.0.header.#":          "0",
+						"statement.0.rate_based_statement.0.custom_key.0.ip.#":              "0",
+						"statement.0.rate_based_statement.0.custom_key.0.label_namespace.#": "0",
+						"statement.0.rate_based_statement.0.custom_key.0.query_argument.#":  "0",
+						"statement.0.rate_based_statement.0.custom_key.0.query_string.#":    "0",
+						"statement.0.rate_based_statement.0.custom_key.0.uri_path.#":        "0",
 					}),
 				),
 			},
@@ -6408,6 +6479,57 @@ resource "aws_wafv2_web_acl" "test" {
           ja4_fingerprint {
             fallback_behavior = "NO_MATCH"
           }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  tags = {
+    Tag1 = "Value1"
+    Tag2 = "Value2"
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, rName)
+}
+
+func testAccWebACLConfig_rateBasedStatement_customKeysASN(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl" "test" {
+  name        = %[1]q
+  description = %[1]q
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      count {}
+    }
+
+    statement {
+      rate_based_statement {
+        aggregate_key_type = "CUSTOM_KEYS"
+        limit              = 50000
+
+        custom_key {
+          asn {}
         }
       }
     }

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -1120,6 +1120,7 @@ Aggregate the request counts using one or more web request components as the agg
 
 The `custom_key` block supports the following arguments:
 
+* `asn` - (Optional) Use an Autonomous System Number (ASN) derived from the request's originating or forwarded IP address as an aggregate key. See [RateLimit `asn`](#ratelimit-asn-block) below for details.
 * `cookie` - (Optional) Use the value of a cookie in the request as an aggregate key. See [RateLimit `cookie`](#ratelimit-cookie-block) below for details.
 * `forwarded_ip` - (Optional) Use the first IP address in an HTTP header as an aggregate key. See [`forwarded_ip`](#ratelimit-forwarded_ip-block) below for details.
 * `http_method` - (Optional) Use the request's HTTP method as an aggregate key. See [RateLimit `http_method`](#ratelimit-http_method-block) below for details.
@@ -1131,6 +1132,12 @@ The `custom_key` block supports the following arguments:
 * `query_argument` - (Optional) Use the specified query argument as an aggregate key. See [RateLimit `query_argument`](#ratelimit-query_argument-block) below for details.
 * `query_string` - (Optional) Use the request's query string as an aggregate key. See [RateLimit `query_string`](#ratelimit-query_string-block) below for details.
 * `uri_path` - (Optional) Use the request's URI path as an aggregate key. See [RateLimit `uri_path`](#ratelimit-uri_path-block) below for details.
+
+### RateLimit `asn` Block
+
+Use an Autonomous System Number (ASN) derived from the request's originating or forwarded IP address as an aggregate key. Each distinct ASN contributes to the aggregation instance.
+
+The `asn` block is configured as an empty block `{}`.
 
 ### RateLimit `cookie` Block
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* Added `asn` (empty block) as `custom_key` to `rate_based_statement`.

### Relations

Closes #43492 

### References
https://docs.aws.amazon.com/ja_jp/waf/latest/APIReference/API_RateBasedStatementCustomKey.html#WAF-Type-RateBasedStatementCustomKey-ASN

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccWAFV2WebACL_ PKG=wafv2 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACL_'  -timeout 360m -vet=off
2025/07/23 07:37:39 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/23 07:37:39 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccWAFV2WebACL_basic
=== PAUSE TestAccWAFV2WebACL_basic
=== RUN   TestAccWAFV2WebACL_nameGenerated
=== PAUSE TestAccWAFV2WebACL_nameGenerated
=== RUN   TestAccWAFV2WebACL_namePrefix
=== PAUSE TestAccWAFV2WebACL_namePrefix
=== RUN   TestAccWAFV2WebACL_Update_rule
=== PAUSE TestAccWAFV2WebACL_Update_rule
=== RUN   TestAccWAFV2WebACL_Update_ruleProperties
=== PAUSE TestAccWAFV2WebACL_Update_ruleProperties
=== RUN   TestAccWAFV2WebACL_Update_nameForceNew
=== PAUSE TestAccWAFV2WebACL_Update_nameForceNew
=== RUN   TestAccWAFV2WebACL_disappears
=== PAUSE TestAccWAFV2WebACL_disappears
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_antiDDosRuleSet
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_antiDDosRuleSet
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== RUN   TestAccWAFV2WebACL_minimal
=== PAUSE TestAccWAFV2WebACL_minimal
=== RUN   TestAccWAFV2WebACL_RateBased_basic
=== PAUSE TestAccWAFV2WebACL_RateBased_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_basic
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_body
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_body
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_urlFragment
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_urlFragment
=== RUN   TestAccWAFV2WebACL_GeoMatch_basic
=== PAUSE TestAccWAFV2WebACL_GeoMatch_basic
=== RUN   TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== PAUSE TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== RUN   TestAccWAFV2WebACL_LabelMatchStatement
=== PAUSE TestAccWAFV2WebACL_LabelMatchStatement
=== RUN   TestAccWAFV2WebACL_RuleLabels
=== PAUSE TestAccWAFV2WebACL_RuleLabels
=== RUN   TestAccWAFV2WebACL_IPSetReference_basic
=== PAUSE TestAccWAFV2WebACL_IPSetReference_basic
=== RUN   TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== PAUSE TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== RUN   TestAccWAFV2WebACL_RateBased_customKeys
=== PAUSE TestAccWAFV2WebACL_RateBased_customKeys
=== RUN   TestAccWAFV2WebACL_RateBased_forwardedIP
=== PAUSE TestAccWAFV2WebACL_RateBased_forwardedIP
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_basic
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_basic
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== RUN   TestAccWAFV2WebACL_Custom_requestHandling
=== PAUSE TestAccWAFV2WebACL_Custom_requestHandling
=== RUN   TestAccWAFV2WebACL_Custom_response
=== PAUSE TestAccWAFV2WebACL_Custom_response
=== RUN   TestAccWAFV2WebACL_tags
=== PAUSE TestAccWAFV2WebACL_tags
=== RUN   TestAccWAFV2WebACL_RateBased_maxNested
=== PAUSE TestAccWAFV2WebACL_RateBased_maxNested
=== RUN   TestAccWAFV2WebACL_Operators_maxNested
=== PAUSE TestAccWAFV2WebACL_Operators_maxNested
=== RUN   TestAccWAFV2WebACL_tokenDomains
=== PAUSE TestAccWAFV2WebACL_tokenDomains
=== RUN   TestAccWAFV2WebACL_associationConfigCloudFront
=== PAUSE TestAccWAFV2WebACL_associationConfigCloudFront
=== RUN   TestAccWAFV2WebACL_associationConfigRegional
=== PAUSE TestAccWAFV2WebACL_associationConfigRegional
=== RUN   TestAccWAFV2WebACL_CloudFrontScope
=== PAUSE TestAccWAFV2WebACL_CloudFrontScope
=== RUN   TestAccWAFV2WebACL_ruleJSON
=== PAUSE TestAccWAFV2WebACL_ruleJSON
=== RUN   TestAccWAFV2WebACL_ruleJSONToRule
=== PAUSE TestAccWAFV2WebACL_ruleJSONToRule
=== RUN   TestAccWAFV2WebACL_dataProtectionConfig
=== PAUSE TestAccWAFV2WebACL_dataProtectionConfig
=== RUN   TestAccWAFV2WebACL_dataProtectionConfigMultiple
=== PAUSE TestAccWAFV2WebACL_dataProtectionConfigMultiple
=== RUN   TestAccWAFV2WebACL_ASNMatchStatement
=== PAUSE TestAccWAFV2WebACL_ASNMatchStatement
=== RUN   TestAccWAFV2WebACL_RateBased_ASNMatchStatement
=== PAUSE TestAccWAFV2WebACL_RateBased_ASNMatchStatement
=== CONT  TestAccWAFV2WebACL_basic
=== CONT  TestAccWAFV2WebACL_LabelMatchStatement
=== CONT  TestAccWAFV2WebACL_RateBased_maxNested
=== CONT  TestAccWAFV2WebACL_ruleJSON
=== CONT  TestAccWAFV2WebACL_associationConfigCloudFront
=== CONT  TestAccWAFV2WebACL_tokenDomains
=== CONT  TestAccWAFV2WebACL_Custom_requestHandling
=== CONT  TestAccWAFV2WebACL_RateBased_ASNMatchStatement
=== CONT  TestAccWAFV2WebACL_ASNMatchStatement
=== CONT  TestAccWAFV2WebACL_ruleJSONToRule
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== CONT  TestAccWAFV2WebACL_RateBased_customKeys
=== CONT  TestAccWAFV2WebACL_dataProtectionConfig
=== CONT  TestAccWAFV2WebACL_Custom_response
=== CONT  TestAccWAFV2WebACL_RateBased_forwardedIP
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== CONT  TestAccWAFV2WebACL_dataProtectionConfigMultiple
=== CONT  TestAccWAFV2WebACL_IPSetReference_basic
=== CONT  TestAccWAFV2WebACL_tags
=== CONT  TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== NAME  TestAccWAFV2WebACL_associationConfigCloudFront
    web_acl_test.go:3302: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccWAFV2WebACL_associationConfigCloudFront (6.79s)
=== CONT  TestAccWAFV2WebACL_RuleLabels
--- PASS: TestAccWAFV2WebACL_basic (54.54s)
=== CONT  TestAccWAFV2WebACL_CloudFrontScope
    web_acl_test.go:3399: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccWAFV2WebACL_CloudFrontScope (0.00s)
=== CONT  TestAccWAFV2WebACL_Operators_maxNested
--- PASS: TestAccWAFV2WebACL_dataProtectionConfigMultiple (63.82s)
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_basic
--- PASS: TestAccWAFV2WebACL_RateBased_maxNested (67.23s)
=== CONT  TestAccWAFV2WebACL_associationConfigRegional
--- PASS: TestAccWAFV2WebACL_ASNMatchStatement (82.18s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
--- PASS: TestAccWAFV2WebACL_RateBased_ASNMatchStatement (84.77s)
=== CONT  TestAccWAFV2WebACL_GeoMatch_forwardedIP
--- PASS: TestAccWAFV2WebACL_IPSetReference_basic (87.00s)
=== CONT  TestAccWAFV2WebACL_GeoMatch_basic
--- PASS: TestAccWAFV2WebACL_ruleJSONToRule (94.88s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_urlFragment
--- PASS: TestAccWAFV2WebACL_ruleJSON (108.76s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
--- PASS: TestAccWAFV2WebACL_RateBased_forwardedIP (114.10s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_body
--- PASS: TestAccWAFV2WebACL_tokenDomains (119.71s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
--- PASS: TestAccWAFV2WebACL_LabelMatchStatement (129.74s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint
--- PASS: TestAccWAFV2WebACL_Operators_maxNested (79.01s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
--- PASS: TestAccWAFV2WebACL_associationConfigRegional (79.44s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_basic
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule (158.02s)
=== CONT  TestAccWAFV2WebACL_RateBased_basic
--- PASS: TestAccWAFV2WebACL_tags (168.76s)
=== CONT  TestAccWAFV2WebACL_minimal
--- PASS: TestAccWAFV2WebACL_RuleLabels (170.82s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_basic
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation (180.26s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
--- PASS: TestAccWAFV2WebACL_Custom_response (183.10s)
--- PASS: TestAccWAFV2WebACL_dataProtectionConfig (213.17s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_antiDDosRuleSet
--- PASS: TestAccWAFV2WebACL_minimal (73.97s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion (166.30s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
--- PASS: TestAccWAFV2WebACL_GeoMatch_forwardedIP (164.56s)
=== CONT  TestAccWAFV2WebACL_Update_ruleProperties
--- PASS: TestAccWAFV2WebACL_GeoMatch_basic (163.99s)
=== CONT  TestAccWAFV2WebACL_disappears
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl (81.46s)
=== CONT  TestAccWAFV2WebACL_Update_nameForceNew
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_urlFragment (170.78s)
=== CONT  TestAccWAFV2WebACL_namePrefix
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_basic (202.65s)
=== CONT  TestAccWAFV2WebACL_Update_rule
--- PASS: TestAccWAFV2WebACL_IPSetReference_forwardedIP (269.41s)
=== CONT  TestAccWAFV2WebACL_nameGenerated
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_jsonBody (164.01s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_headerOrder (178.24s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_body (176.07s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint (165.52s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint (167.67s)
--- PASS: TestAccWAFV2WebACL_Custom_requestHandling (304.27s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_basic (159.54s)
--- PASS: TestAccWAFV2WebACL_RateBased_basic (157.08s)
--- PASS: TestAccWAFV2WebACL_disappears (69.51s)
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet (146.23s)
--- PASS: TestAccWAFV2WebACL_namePrefix (67.41s)
--- PASS: TestAccWAFV2WebACL_nameGenerated (66.13s)
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_antiDDosRuleSet (130.82s)
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet (112.27s)
--- PASS: TestAccWAFV2WebACL_Update_nameForceNew (94.37s)
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig (108.15s)
--- PASS: TestAccWAFV2WebACL_Update_rule (97.92s)
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_basic (198.77s)
--- PASS: TestAccWAFV2WebACL_Update_ruleProperties (133.60s)
--- PASS: TestAccWAFV2WebACL_RateBased_customKeys (499.95s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      503.651s

```
