### PR TITLE
Prevent planned `forces replacement` on `region` when upgrading from a pre-v6.0.0 provider version and `-refresh=false` is in effect

### DIFF
--- a/.changelog/#####.txt
+++ b/.changelog/#####.txt
@@ -1,0 +1,3 @@
+```release-note:biug
+provider: Prevent planned `forces replacement` on `region` when upgrading from a pre-v6.0.0 provider version and `-refresh=false` is in effect
+```

--- a/internal/service/appfabric/app_bundle_test.go
+++ b/internal/service/appfabric/app_bundle_test.go
@@ -189,6 +189,134 @@ func testAccAppBundle_upgradeFromV5(t *testing.T) {
 	})
 }
 
+func testAccAppBundle_upgradeFromV5PlanRefreshFalse(t *testing.T) {
+	ctx := acctest.Context(t)
+	var appbundle awstypes.AppBundle
+	resourceName := "aws_appfabric_app_bundle.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, names.AppFabricServiceID),
+		CheckDestroy: testAccCheckAppBundleDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.100.0",
+					},
+				},
+				Config: testAccAppBundleConfig_basic,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAppBundleExists(ctx, resourceName, &appbundle),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoValue(resourceName, tfjsonpath.New(names.AttrRegion)),
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccAppBundleConfig_basic,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAppBundleExists(ctx, resourceName, &appbundle),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+				},
+			},
+		},
+	})
+}
+
+func testAccAppBundle_upgradeFromV5WithUpdatePlanRefreshFalse(t *testing.T) {
+	ctx := acctest.Context(t)
+	var appbundle awstypes.AppBundle
+	resourceName := "aws_appfabric_app_bundle.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, names.AppFabricServiceID),
+		CheckDestroy: testAccCheckAppBundleDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.100.0",
+					},
+				},
+				Config: testAccAppBundleConfig_tags1(acctest.CtKey1, acctest.CtValue1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAppBundleExists(ctx, resourceName, &appbundle),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoValue(resourceName, tfjsonpath.New(names.AttrRegion)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+						acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+					})),
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccAppBundleConfig_tags1(acctest.CtKey1, acctest.CtValue1Updated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAppBundleExists(ctx, resourceName, &appbundle),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+						acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1Updated),
+					})),
+				},
+			},
+		},
+	})
+}
+
 func testAccAppBundle_regionCreateNull(t *testing.T) {
 	ctx := acctest.Context(t)
 	var appbundle awstypes.AppBundle
@@ -425,6 +553,16 @@ resource "aws_appfabric_app_bundle" "test" {
   customer_managed_key_arn = aws_kms_key.test.arn
 }
 `, rName)
+}
+
+func testAccAppBundleConfig_tags1(tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_appfabric_app_bundle" "test" {
+  tags = {
+    %[1]q = %[2]q
+  }
+}
+`, tagKey1, tagValue1)
 }
 
 func testAccAppBundleConfig_region(region string) string {

--- a/internal/service/appfabric/appfabric_test.go
+++ b/internal/service/appfabric/appfabric_test.go
@@ -21,14 +21,16 @@ func TestAccAppFabric_serial(t *testing.T) {
 
 	testCases := map[string]map[string]func(t *testing.T){
 		"AppBundle": {
-			acctest.CtBasic:       testAccAppBundle_basic,
-			acctest.CtDisappears:  testAccAppBundle_disappears,
-			"cmk":                 testAccAppBundle_cmk,
-			"tags":                testAccAppFabricAppBundle_tagsSerial,
-			"regionCreateNull":    testAccAppBundle_regionCreateNull,
-			"regionCreateNonNull": testAccAppBundle_regionCreateNonNull,
-			"upgradeFromV5":       testAccAppBundle_upgradeFromV5,
-			"Identity":            testAccAppFabricAppBundle_IdentitySerial,
+			acctest.CtBasic:                 testAccAppBundle_basic,
+			acctest.CtDisappears:            testAccAppBundle_disappears,
+			"cmk":                           testAccAppBundle_cmk,
+			"tags":                          testAccAppFabricAppBundle_tagsSerial,
+			"regionCreateNull":              testAccAppBundle_regionCreateNull,
+			"regionCreateNonNull":           testAccAppBundle_regionCreateNonNull,
+			"upgradeFromV5":                 testAccAppBundle_upgradeFromV5,
+			"upgradeFromV5PlanRefreshFalse": testAccAppBundle_upgradeFromV5PlanRefreshFalse,
+			"upgradeFromV5WithUpdatePlanRefreshFalse": testAccAppBundle_upgradeFromV5WithUpdatePlanRefreshFalse,
+			"Identity": testAccAppFabricAppBundle_IdentitySerial,
 		},
 		"AppAuthorization": {
 			acctest.CtBasic:      testAccAppAuthorization_basic,

--- a/internal/service/appfabric/appfabric_test.go
+++ b/internal/service/appfabric/appfabric_test.go
@@ -29,8 +29,10 @@ func TestAccAppFabric_serial(t *testing.T) {
 			"regionCreateNonNull":           testAccAppBundle_regionCreateNonNull,
 			"upgradeFromV5":                 testAccAppBundle_upgradeFromV5,
 			"upgradeFromV5PlanRefreshFalse": testAccAppBundle_upgradeFromV5PlanRefreshFalse,
-			"upgradeFromV5WithUpdatePlanRefreshFalse": testAccAppBundle_upgradeFromV5WithUpdatePlanRefreshFalse,
-			"Identity": testAccAppFabricAppBundle_IdentitySerial,
+			"upgradeFromV5WithUpdatePlanRefreshFalse":    testAccAppBundle_upgradeFromV5WithUpdatePlanRefreshFalse,
+			"upgradeFromV5WithDefaultRegionRefreshFalse": testAccAppBundle_upgradeFromV5WithDefaultRegionRefreshFalse,
+			"upgradeFromV5WithNewRegionRefreshFalse":     testAccAppBundle_upgradeFromV5WithNewRegionRefreshFalse,
+			"Identity":                                   testAccAppFabricAppBundle_IdentitySerial,
 		},
 		"AppAuthorization": {
 			acctest.CtBasic:      testAccAppAuthorization_basic,

--- a/internal/service/ec2/vpc_test.go
+++ b/internal/service/ec2/vpc_test.go
@@ -736,6 +736,126 @@ func TestAccVPC_upgradeFromV5(t *testing.T) {
 	})
 }
 
+func TestAccVPC_upgradeFromV5PlanRefreshFalse(t *testing.T) {
+	ctx := acctest.Context(t)
+	var vpc awstypes.Vpc
+	resourceName := "aws_vpc.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t),
+		CheckDestroy: testAccCheckVPCDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.100.0",
+					},
+				},
+				Config: testAccVPCConfig_basic,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckVPCExists(ctx, resourceName, &vpc),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoValue(resourceName, tfjsonpath.New(names.AttrRegion)),
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccVPCConfig_basic,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckVPCExists(ctx, resourceName, &vpc),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccVPC_upgradeFromV5WithUpdatePlanRefreshFalse(t *testing.T) {
+	ctx := acctest.Context(t)
+	var vpc awstypes.Vpc
+	resourceName := "aws_vpc.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t),
+		CheckDestroy: testAccCheckVPCDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.100.0",
+					},
+				},
+				Config: testAccVPCConfig_tags1(acctest.CtKey1, acctest.CtValue1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckVPCExists(ctx, resourceName, &vpc),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoValue(resourceName, tfjsonpath.New(names.AttrRegion)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+						acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+					})),
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccVPCConfig_tags1(acctest.CtKey1, acctest.CtValue1Updated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckVPCExists(ctx, resourceName, &vpc),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+						acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1Updated),
+					})),
+				},
+			},
+		},
+	})
+}
+
 func TestAccVPC_regionCreateNull(t *testing.T) {
 	ctx := acctest.Context(t)
 	var vpc awstypes.Vpc

--- a/internal/service/ec2/vpc_test.go
+++ b/internal/service/ec2/vpc_test.go
@@ -856,6 +856,135 @@ func TestAccVPC_upgradeFromV5WithUpdatePlanRefreshFalse(t *testing.T) {
 	})
 }
 
+func TestAccVPC_upgradeFromV5WithDefaultRegionRefreshFalse(t *testing.T) {
+	ctx := acctest.Context(t)
+	var vpc awstypes.Vpc
+	resourceName := "aws_vpc.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t),
+		CheckDestroy: testAccCheckVPCDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.100.0",
+					},
+				},
+				Config: testAccVPCConfig_tags1("Name", rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckVPCExists(ctx, resourceName, &vpc),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoValue(resourceName, tfjsonpath.New(names.AttrRegion)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+						"Name": knownvalue.StringExact(rName),
+					})),
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccVPCConfig_region(rName, acctest.Region()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckVPCExists(ctx, resourceName, &vpc),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+						"Name": knownvalue.StringExact(rName),
+					})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccVPC_upgradeFromV5WithNewRegionRefreshFalse(t *testing.T) {
+	ctx := acctest.Context(t)
+	var vpc awstypes.Vpc
+	resourceName := "aws_vpc.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t),
+		CheckDestroy: testAccCheckVPCDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.100.0",
+					},
+				},
+				Config: testAccVPCConfig_tags1("Name", rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckVPCExists(ctx, resourceName, &vpc),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoValue(resourceName, tfjsonpath.New(names.AttrRegion)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+						"Name": knownvalue.StringExact(rName),
+					})),
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccVPCConfig_region(rName, acctest.AlternateRegion()),
+				// Can't call 'acctest.CheckVPCExists' as the VPC's in the alternate Region.
+				// Check: resource.ComposeAggregateTestCheckFunc(
+				// 	acctest.CheckVPCExists(ctx, resourceName, &vpc),
+				// ),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.AlternateRegion())),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+						"Name": knownvalue.StringExact(rName),
+					})),
+				},
+			},
+		},
+	})
+}
+
 func TestAccVPC_regionCreateNull(t *testing.T) {
 	ctx := acctest.Context(t)
 	var vpc awstypes.Vpc


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

For Framework resources there is an edge case in the seamless upgrade from a pre-**v6.0.0** provider when an attribute has changed and `terraform plan -refresh=false` is used. In such cases, the new `region` attribute erroneously reports `forces replacement`.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% git commit -m "Add 'TestAccVPC_upgradeFromV5WithDefaultRegionRefreshFalse' and 'TestAccVPC_upgradeFromV5WithNewRegionRefreshFalse'."
[v6.0.0-upgrade-refresh=false-region 7404e39a97b] Add 'TestAccVPC_upgradeFromV5WithDefaultRegionRefreshFalse' and 'TestAccVPC_upgradeFromV5WithNewRegionRefreshFalse'.
 1 file changed, 129 insertions(+)
kewbank@kewbank-GVKJJ17KYT terraform-provider-aws % make testacc TESTARGS='-run=TestAccVPC_upgradeFromV5' PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPC_upgradeFromV5 -timeout 360m -vet=off
2025/07/23 11:29:56 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/23 11:29:56 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPC_upgradeFromV5
=== PAUSE TestAccVPC_upgradeFromV5
=== RUN   TestAccVPC_upgradeFromV5PlanRefreshFalse
=== PAUSE TestAccVPC_upgradeFromV5PlanRefreshFalse
=== RUN   TestAccVPC_upgradeFromV5WithUpdatePlanRefreshFalse
=== PAUSE TestAccVPC_upgradeFromV5WithUpdatePlanRefreshFalse
=== RUN   TestAccVPC_upgradeFromV5WithDefaultRegionRefreshFalse
=== PAUSE TestAccVPC_upgradeFromV5WithDefaultRegionRefreshFalse
=== RUN   TestAccVPC_upgradeFromV5WithNewRegionRefreshFalse
=== PAUSE TestAccVPC_upgradeFromV5WithNewRegionRefreshFalse
=== CONT  TestAccVPC_upgradeFromV5
=== CONT  TestAccVPC_upgradeFromV5WithDefaultRegionRefreshFalse
=== CONT  TestAccVPC_upgradeFromV5WithNewRegionRefreshFalse
=== CONT  TestAccVPC_upgradeFromV5WithUpdatePlanRefreshFalse
=== CONT  TestAccVPC_upgradeFromV5PlanRefreshFalse
--- PASS: TestAccVPC_upgradeFromV5WithNewRegionRefreshFalse (86.41s)
--- PASS: TestAccVPC_upgradeFromV5 (90.21s)
--- PASS: TestAccVPC_upgradeFromV5WithDefaultRegionRefreshFalse (102.15s)
--- PASS: TestAccVPC_upgradeFromV5PlanRefreshFalse (108.97s)
--- PASS: TestAccVPC_upgradeFromV5WithUpdatePlanRefreshFalse (112.02s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	117.288s
```

```console
% AWS_DEFAULT_REGION=us-east-1 make testacc TESTARGS='-run=TestAccAppFabric_serial/^AppBundle$$' PKG=appfabric 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/appfabric/... -v -count 1 -parallel 20  -run=TestAccAppFabric_serial/^AppBundle$ -timeout 360m -vet=off
2025/07/23 10:44:19 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/23 10:44:19 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAppFabric_serial
=== PAUSE TestAccAppFabric_serial
=== CONT  TestAccAppFabric_serial
=== RUN   TestAccAppFabric_serial/AppBundle
=== RUN   TestAccAppFabric_serial/AppBundle/upgradeFromV5PlanRefreshFalse
=== RUN   TestAccAppFabric_serial/AppBundle/upgradeFromV5WithUpdatePlanRefreshFalse
=== RUN   TestAccAppFabric_serial/AppBundle/upgradeFromV5WithNewRegionRefreshFalse
=== RUN   TestAccAppFabric_serial/AppBundle/Identity
=== RUN   TestAccAppFabric_serial/AppBundle/Identity/basic
=== RUN   TestAccAppFabric_serial/AppBundle/Identity/ExistingResource
=== RUN   TestAccAppFabric_serial/AppBundle/Identity/RegionOverride
=== RUN   TestAccAppFabric_serial/AppBundle/disappears
=== RUN   TestAccAppFabric_serial/AppBundle/tags
=== RUN   TestAccAppFabric_serial/AppBundle/tags/EmptyTag_OnCreate
=== RUN   TestAccAppFabric_serial/AppBundle/tags/DefaultTags_updateToProviderOnly
=== RUN   TestAccAppFabric_serial/AppBundle/tags/DefaultTags_updateToResourceOnly
=== RUN   TestAccAppFabric_serial/AppBundle/tags/DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccAppFabric_serial/AppBundle/tags/IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccAppFabric_serial/AppBundle/tags/basic
=== RUN   TestAccAppFabric_serial/AppBundle/tags/EmptyTag_OnUpdate_Add
=== RUN   TestAccAppFabric_serial/AppBundle/tags/DefaultTags_overlapping
=== RUN   TestAccAppFabric_serial/AppBundle/tags/DefaultTags_emptyResourceTag
=== RUN   TestAccAppFabric_serial/AppBundle/tags/ComputedTag_OnUpdate_Add
=== RUN   TestAccAppFabric_serial/AppBundle/tags/AddOnUpdate
=== RUN   TestAccAppFabric_serial/AppBundle/tags/EmptyTag_OnUpdate_Replace
=== RUN   TestAccAppFabric_serial/AppBundle/tags/DefaultTags_providerOnly
=== RUN   TestAccAppFabric_serial/AppBundle/tags/DefaultTags_nonOverlapping
=== RUN   TestAccAppFabric_serial/AppBundle/tags/DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccAppFabric_serial/AppBundle/tags/ComputedTag_OnCreate
=== RUN   TestAccAppFabric_serial/AppBundle/tags/ComputedTag_OnUpdate_Replace
=== RUN   TestAccAppFabric_serial/AppBundle/tags/IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccAppFabric_serial/AppBundle/tags/null
=== RUN   TestAccAppFabric_serial/AppBundle/tags/EmptyMap
=== RUN   TestAccAppFabric_serial/AppBundle/regionCreateNull
=== RUN   TestAccAppFabric_serial/AppBundle/upgradeFromV5
=== RUN   TestAccAppFabric_serial/AppBundle/upgradeFromV5WithDefaultRegionRefreshFalse
=== RUN   TestAccAppFabric_serial/AppBundle/basic
=== RUN   TestAccAppFabric_serial/AppBundle/cmk
=== RUN   TestAccAppFabric_serial/AppBundle/regionCreateNonNull
--- PASS: TestAccAppFabric_serial (957.05s)
    --- PASS: TestAccAppFabric_serial/AppBundle (957.05s)
        --- PASS: TestAccAppFabric_serial/AppBundle/upgradeFromV5PlanRefreshFalse (51.40s)
        --- PASS: TestAccAppFabric_serial/AppBundle/upgradeFromV5WithUpdatePlanRefreshFalse (51.38s)
        --- PASS: TestAccAppFabric_serial/AppBundle/upgradeFromV5WithNewRegionRefreshFalse (53.66s)
        --- PASS: TestAccAppFabric_serial/AppBundle/Identity (119.25s)
            --- PASS: TestAccAppFabric_serial/AppBundle/Identity/basic (15.64s)
            --- PASS: TestAccAppFabric_serial/AppBundle/Identity/ExistingResource (73.54s)
            --- PASS: TestAccAppFabric_serial/AppBundle/Identity/RegionOverride (20.07s)
        --- PASS: TestAccAppFabric_serial/AppBundle/disappears (18.22s)
        --- PASS: TestAccAppFabric_serial/AppBundle/tags (420.45s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/EmptyTag_OnCreate (19.73s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/DefaultTags_updateToProviderOnly (17.90s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/DefaultTags_updateToResourceOnly (17.08s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/DefaultTags_nullNonOverlappingResourceTag (11.31s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/IgnoreTags_Overlap_ResourceTag (24.52s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/basic (37.65s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/EmptyTag_OnUpdate_Add (26.31s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/DefaultTags_overlapping (29.15s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/DefaultTags_emptyResourceTag (11.08s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/ComputedTag_OnUpdate_Add (21.47s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/AddOnUpdate (17.56s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/EmptyTag_OnUpdate_Replace (17.58s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/DefaultTags_providerOnly (38.49s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/DefaultTags_nonOverlapping (29.37s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/DefaultTags_nullOverlappingResourceTag (11.09s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/ComputedTag_OnCreate (14.52s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/ComputedTag_OnUpdate_Replace (21.56s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/IgnoreTags_Overlap_DefaultTag (22.41s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/null (10.90s)
            --- PASS: TestAccAppFabric_serial/AppBundle/tags/EmptyMap (10.76s)
        --- PASS: TestAccAppFabric_serial/AppBundle/regionCreateNull (41.01s)
        --- PASS: TestAccAppFabric_serial/AppBundle/upgradeFromV5 (50.45s)
        --- PASS: TestAccAppFabric_serial/AppBundle/upgradeFromV5WithDefaultRegionRefreshFalse (51.08s)
        --- PASS: TestAccAppFabric_serial/AppBundle/basic (20.75s)
        --- PASS: TestAccAppFabric_serial/AppBundle/cmk (47.00s)
        --- PASS: TestAccAppFabric_serial/AppBundle/regionCreateNonNull (32.40s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appfabric	961.821s
```

### Previously

```console
% AWS_DEFAULT_REGION=us-east-1 make testacc TESTARGS='-run=TestAccAppFabric_serial/^AppBundle$$/^upgradeFromV5' PKG=appfabric
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/appfabric/... -v -count 1 -parallel 20  -run=TestAccAppFabric_serial/^AppBundle$/^upgradeFromV5 -timeout 360m -vet=off
2025/07/23 10:03:47 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/23 10:03:47 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAppFabric_serial
=== PAUSE TestAccAppFabric_serial
=== CONT  TestAccAppFabric_serial
=== RUN   TestAccAppFabric_serial/AppBundle
=== RUN   TestAccAppFabric_serial/AppBundle/upgradeFromV5WithUpdatePlanRefreshFalse
    app_bundle_test.go:258: Step 2/2 error: Pre-apply plan check(s) failed:
        'aws_appfabric_app_bundle.test' - expected Update, got action(s): [delete create]
=== RUN   TestAccAppFabric_serial/AppBundle/upgradeFromV5
=== RUN   TestAccAppFabric_serial/AppBundle/upgradeFromV5PlanRefreshFalse
--- FAIL: TestAccAppFabric_serial (138.20s)
    --- FAIL: TestAccAppFabric_serial/AppBundle (138.20s)
        --- FAIL: TestAccAppFabric_serial/AppBundle/upgradeFromV5WithUpdatePlanRefreshFalse (37.24s)
        --- PASS: TestAccAppFabric_serial/AppBundle/upgradeFromV5 (49.79s)
        --- PASS: TestAccAppFabric_serial/AppBundle/upgradeFromV5PlanRefreshFalse (51.17s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/appfabric	143.332s
FAIL
make: *** [testacc] Error 1
```
