### PR TITLE
Technical debt: Use `internal/retry` for `tfresource.RetryWhenIsOneOf` and `tfresource.RetryWhenAWSErrCodeContains`

### DIFF
--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -901,7 +901,7 @@ func resourceDistributionCreate(ctx context.Context, d *schema.ResourceData, met
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
-	input := &cloudfront.CreateDistributionWithTagsInput{
+	input := cloudfront.CreateDistributionWithTagsInput{
 		DistributionConfigWithTags: &awstypes.DistributionConfigWithTags{
 			DistributionConfig: expandDistributionConfig(d),
 			Tags:               &awstypes.Tags{Items: []awstypes.Tag{}},
@@ -918,7 +918,7 @@ func resourceDistributionCreate(ctx context.Context, d *schema.ResourceData, met
 		timeout = 1 * time.Minute
 	)
 	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.InvalidViewerCertificate](ctx, timeout, func() (any, error) {
-		return conn.CreateDistributionWithTags(ctx, input)
+		return conn.CreateDistributionWithTags(ctx, &input)
 	})
 
 	if err != nil {
@@ -1034,7 +1034,7 @@ func resourceDistributionUpdate(ctx context.Context, d *schema.ResourceData, met
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
-		input := &cloudfront.UpdateDistributionInput{
+		input := cloudfront.UpdateDistributionInput{
 			DistributionConfig: expandDistributionConfig(d),
 			Id:                 aws.String(d.Id()),
 			IfMatch:            aws.String(d.Get("etag").(string)),
@@ -1046,7 +1046,7 @@ func resourceDistributionUpdate(ctx context.Context, d *schema.ResourceData, met
 			timeout = 1 * time.Minute
 		)
 		_, err := tfresource.RetryWhenIsA[*awstypes.InvalidViewerCertificate](ctx, timeout, func() (any, error) {
-			return conn.UpdateDistribution(ctx, input)
+			return conn.UpdateDistribution(ctx, &input)
 		})
 
 		// Refresh our ETag if it is out of date and attempt update again.
@@ -1060,7 +1060,7 @@ func resourceDistributionUpdate(ctx context.Context, d *schema.ResourceData, met
 
 			input.IfMatch = aws.String(etag)
 
-			_, err = conn.UpdateDistribution(ctx, input)
+			_, err = conn.UpdateDistribution(ctx, &input)
 		}
 
 		if err != nil {
@@ -1142,7 +1142,7 @@ func resourceDistributionDelete(ctx context.Context, d *schema.ResourceData, met
 		const (
 			timeout = 1 * time.Minute
 		)
-		_, err = tfresource.RetryWhenIsOneOf2[*awstypes.PreconditionFailed, *awstypes.InvalidIfMatchVersion](ctx, timeout, func() (any, error) {
+		_, err = tfresource.RetryWhenIsOneOf2[any, *awstypes.PreconditionFailed, *awstypes.InvalidIfMatchVersion](ctx, timeout, func(ctx context.Context) (any, error) {
 			return nil, deleteDistribution(ctx, conn, d.Id())
 		})
 	}
@@ -1177,12 +1177,12 @@ func deleteDistribution(ctx context.Context, conn *cloudfront.Client, id string)
 		return err
 	}
 
-	input := &cloudfront.DeleteDistributionInput{
+	input := cloudfront.DeleteDistributionInput{
 		Id:      aws.String(id),
 		IfMatch: aws.String(etag),
 	}
 
-	_, err = conn.DeleteDistribution(ctx, input)
+	_, err = conn.DeleteDistribution(ctx, &input)
 
 	if err != nil {
 		return fmt.Errorf("deleting CloudFront Distribution (%s): %w", id, err)
@@ -1224,14 +1224,14 @@ func disableDistribution(ctx context.Context, conn *cloudfront.Client, id string
 		return nil
 	}
 
-	input := &cloudfront.UpdateDistributionInput{
+	input := cloudfront.UpdateDistributionInput{
 		DistributionConfig: output.Distribution.DistributionConfig,
 		Id:                 aws.String(id),
 		IfMatch:            output.ETag,
 	}
 	input.DistributionConfig.Enabled = aws.Bool(false)
 
-	_, err = conn.UpdateDistribution(ctx, input)
+	_, err = conn.UpdateDistribution(ctx, &input)
 
 	if err != nil {
 		return fmt.Errorf("updating CloudFront Distribution (%s): %w", id, err)
@@ -1245,11 +1245,11 @@ func disableDistribution(ctx context.Context, conn *cloudfront.Client, id string
 }
 
 func findDistributionByID(ctx context.Context, conn *cloudfront.Client, id string) (*cloudfront.GetDistributionOutput, error) {
-	input := &cloudfront.GetDistributionInput{
+	input := cloudfront.GetDistributionInput{
 		Id: aws.String(id),
 	}
 
-	output, err := conn.GetDistribution(ctx, input)
+	output, err := conn.GetDistribution(ctx, &input)
 
 	if errs.IsA[*awstypes.NoSuchDistribution](err) {
 		return nil, &retry.NotFoundError{

--- a/internal/service/datazone/domain.go
+++ b/internal/service/datazone/domain.go
@@ -151,7 +151,7 @@ func (r *domainResource) Create(ctx context.Context, request resource.CreateRequ
 	const (
 		timeout = 30 * time.Second
 	)
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeContains(ctx, timeout, func() (any, error) {
+	output, err := tfresource.RetryWhenAWSErrCodeContains(ctx, timeout, func(ctx context.Context) (*datazone.CreateDomainOutput, error) {
 		return conn.CreateDomain(ctx, &input)
 	}, errCodeAccessDenied)
 
@@ -162,7 +162,6 @@ func (r *domainResource) Create(ctx context.Context, request resource.CreateRequ
 	}
 
 	// Set values for unknowns.
-	output := outputRaw.(*datazone.CreateDomainOutput)
 	data.ARN = fwflex.StringToFramework(ctx, output.Arn)
 	data.ID = fwflex.StringToFramework(ctx, output.Id)
 	data.PortalURL = fwflex.StringToFramework(ctx, output.PortalUrl)

--- a/internal/service/ec2/tags.go
+++ b/internal/service/ec2/tags.go
@@ -25,7 +25,7 @@ func createTags(ctx context.Context, conn *ec2.Client, identifier string, tags [
 
 	newTagsMap := keyValueTags(ctx, tags)
 
-	_, err := tfresource.RetryWhenAWSErrCodeContains(ctx, eventualConsistencyTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeContains(ctx, eventualConsistencyTimeout, func(ctx context.Context) (any, error) {
 		return nil, updateTags(ctx, conn, identifier, nil, newTagsMap, optFns...)
 	}, ".NotFound")
 

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -310,7 +310,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta any
 	const (
 		timeout = 10 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsOneOf4[*awstypes.ClusterContainsContainerInstancesException, *awstypes.ClusterContainsServicesException, *awstypes.ClusterContainsTasksException, *awstypes.UpdateInProgressException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsOneOf4[any, *awstypes.ClusterContainsContainerInstancesException, *awstypes.ClusterContainsServicesException, *awstypes.ClusterContainsTasksException, *awstypes.UpdateInProgressException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteCluster(ctx, &ecs.DeleteClusterInput{
 			Cluster: aws.String(d.Id()),
 		})

--- a/internal/service/kms/grant.go
+++ b/internal/service/kms/grant.go
@@ -177,7 +177,7 @@ func resourceGrantCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 	// Error Codes: https://docs.aws.amazon.com/sdk-for-go/api/service/kms/#KMS.CreateGrant
 	// Under some circumstances a newly created IAM Role doesn't show up and causes
 	// an InvalidArnException to be thrown.
-	outputRaw, err := tfresource.RetryWhenIsOneOf3[*awstypes.DependencyTimeoutException, *awstypes.KMSInternalException, *awstypes.InvalidArnException](ctx, propagationTimeout, func() (any, error) {
+	output, err := tfresource.RetryWhenIsOneOf3[*kms.CreateGrantOutput, *awstypes.DependencyTimeoutException, *awstypes.KMSInternalException, *awstypes.InvalidArnException](ctx, propagationTimeout, func(ctx context.Context) (*kms.CreateGrantOutput, error) {
 		return conn.CreateGrant(ctx, input)
 	})
 
@@ -185,7 +185,6 @@ func resourceGrantCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 		return sdkdiag.AppendErrorf(diags, "creating KMS Grant for Key (%s): %s", keyID, err)
 	}
 
-	output := outputRaw.(*kms.CreateGrantOutput)
 	grantID := aws.ToString(output.GrantId)
 	d.SetId(grantCreateResourceID(keyID, grantID))
 	d.Set("grant_token", output.GrantToken)

--- a/internal/service/kms/key.go
+++ b/internal/service/kms/key.go
@@ -566,7 +566,7 @@ func updateKeyPolicy(ctx context.Context, conn *kms.Client, resourceTypeName, ke
 		return err
 	}
 
-	updateFunc := func() (any, error) {
+	updateFunc := func(ctx context.Context) (any, error) {
 		var err error
 		input := kms.PutKeyPolicyInput{
 			BypassPolicyLockoutSafetyCheck: bypassPolicyLockoutSafetyCheck,
@@ -580,7 +580,7 @@ func updateKeyPolicy(ctx context.Context, conn *kms.Client, resourceTypeName, ke
 		return nil, err
 	}
 
-	if _, err := tfresource.RetryWhenIsOneOf2[*awstypes.NotFoundException, *awstypes.MalformedPolicyDocumentException](ctx, propagationTimeout, updateFunc); err != nil {
+	if _, err := tfresource.RetryWhenIsOneOf2[any, *awstypes.NotFoundException, *awstypes.MalformedPolicyDocumentException](ctx, propagationTimeout, updateFunc); err != nil {
 		return fmt.Errorf("updating %s (%s) policy: %w", resourceTypeName, keyID, err)
 	}
 
@@ -595,7 +595,7 @@ func updateKeyPolicy(ctx context.Context, conn *kms.Client, resourceTypeName, ke
 func updateKeyRotationEnabled(ctx context.Context, conn *kms.Client, resourceTypeName, keyID string, enabled bool, rotationPeriod int) error {
 	var action string
 
-	updateFunc := func() (any, error) {
+	updateFunc := func(ctx context.Context) (any, error) {
 		var err error
 
 		if enabled {
@@ -620,7 +620,7 @@ func updateKeyRotationEnabled(ctx context.Context, conn *kms.Client, resourceTyp
 		return nil, err
 	}
 
-	if _, err := tfresource.RetryWhenIsOneOf2[*awstypes.NotFoundException, *awstypes.DisabledException](ctx, keyRotationUpdatedTimeout, updateFunc); err != nil {
+	if _, err := tfresource.RetryWhenIsOneOf2[any, *awstypes.NotFoundException, *awstypes.DisabledException](ctx, keyRotationUpdatedTimeout, updateFunc); err != nil {
 		return fmt.Errorf("%s %s (%s) rotation: %w", action, resourceTypeName, keyID, err)
 	}
 

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/attrmap"
+	"github.com/hashicorp/terraform-provider-aws/internal/backoff"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -268,7 +269,7 @@ func resourceTopicCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
 	name := topicName(d)
-	input := &sns.CreateTopicInput{
+	input := sns.CreateTopicInput{
 		Name: aws.String(name),
 		Tags: getTagsIn(ctx),
 	}
@@ -291,13 +292,13 @@ func resourceTopicCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 		delete(attributes, topicAttributeNameFIFOThroughputScope)
 	}
 
-	output, err := conn.CreateTopic(ctx, input)
+	output, err := conn.CreateTopic(ctx, &input)
 
 	// Some partitions (e.g. ISO) may not support tag-on-create.
 	if input.Tags != nil && errs.IsUnsupportedOperationInPartitionError(meta.(*conns.AWSClient).Partition(ctx), err) {
 		input.Tags = nil
 
-		output, err = conn.CreateTopic(ctx, input)
+		output, err = conn.CreateTopic(ctx, &input)
 	}
 
 	if err != nil {
@@ -394,9 +395,10 @@ func resourceTopicDelete(ctx context.Context, d *schema.ResourceData, meta any) 
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
 	log.Printf("[DEBUG] Deleting SNS Topic: %s", d.Id())
-	_, err := conn.DeleteTopic(ctx, &sns.DeleteTopicInput{
+	input := sns.DeleteTopicInput{
 		TopicArn: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteTopic(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
 		return diags
@@ -467,14 +469,14 @@ func putTopicAttribute(ctx context.Context, conn *sns.Client, arn string, name, 
 	const (
 		timeout = 2 * time.Minute
 	)
-	input := &sns.SetTopicAttributesInput{
+	input := sns.SetTopicAttributesInput{
 		AttributeName:  aws.String(name),
 		AttributeValue: aws.String(value),
 		TopicArn:       aws.String(arn),
 	}
 
 	_, err := tfresource.RetryWhenIsA[*types.InvalidParameterException](ctx, timeout, func() (any, error) {
-		return conn.SetTopicAttributes(ctx, input)
+		return conn.SetTopicAttributes(ctx, &input)
 	})
 
 	if err != nil {
@@ -496,34 +498,32 @@ func topicName(d sdkv2.ResourceDiffer) string {
 // is populated with valid AWS principals, i.e. the principal is either an AWS Account ID or an ARN.
 // nosemgrep:ci.aws-in-func-name
 func findTopicAttributesWithValidAWSPrincipalsByARN(ctx context.Context, conn *sns.Client, arn string) (map[string]string, error) {
-	var attributes map[string]string
-	err := tfresource.Retry(ctx, propagationTimeout, func() *retry.RetryError {
-		var err error
+	var (
+		attributes map[string]string
+		err        error
+	)
+	for l := backoff.NewLoop(propagationTimeout); l.Continue(ctx); {
 		attributes, err = findTopicAttributesByARN(ctx, conn, arn)
 		if err != nil {
-			return retry.NonRetryableError(err)
+			break
 		}
 
-		valid, err := tfiam.PolicyHasValidAWSPrincipals(attributes[topicAttributeNamePolicy])
-		if err != nil {
-			return retry.NonRetryableError(err)
+		var valid bool
+		valid, err = tfiam.PolicyHasValidAWSPrincipals(attributes[topicAttributeNamePolicy])
+		if err != nil || valid {
+			break
 		}
-		if !valid {
-			return retry.RetryableError(errors.New("contains invalid principals"))
-		}
-
-		return nil
-	})
+	}
 
 	return attributes, err
 }
 
 func findTopicAttributesByARN(ctx context.Context, conn *sns.Client, arn string) (map[string]string, error) {
-	input := &sns.GetTopicAttributesInput{
+	input := sns.GetTopicAttributesInput{
 		TopicArn: aws.String(arn),
 	}
 
-	output, err := conn.GetTopicAttributes(ctx, input)
+	output, err := conn.GetTopicAttributes(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
 		return nil, &retry.NotFoundError{

--- a/internal/service/wafv2/rule_group.go
+++ b/internal/service/wafv2/rule_group.go
@@ -315,7 +315,7 @@ func resourceRuleGroupDelete(ctx context.Context, d *schema.ResourceData, meta a
 	const (
 		timeout = 5 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsOneOf2[*awstypes.WAFAssociatedItemException, *awstypes.WAFUnavailableEntityException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsOneOf2[any, *awstypes.WAFAssociatedItemException, *awstypes.WAFUnavailableEntityException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteRuleGroup(ctx, input)
 	})
 

--- a/internal/service/wafv2/web_acl.go
+++ b/internal/service/wafv2/web_acl.go
@@ -464,7 +464,7 @@ func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 			if newLockToken := aws.ToString(output.LockToken); newLockToken != aclLockToken {
 				// Retrieved a new lock token, retry due to other processes modifying the web acl out of band (See: https://docs.aws.amazon.com/sdk-for-go/api/service/shield/#Shield.EnableApplicationLayerAutomaticResponse)
 				input.LockToken = aws.String(newLockToken)
-				_, err = tfresource.RetryWhenIsOneOf2[*awstypes.WAFAssociatedItemException, *awstypes.WAFUnavailableEntityException](ctx, timeout, func() (any, error) {
+				_, err = tfresource.RetryWhenIsOneOf2[any, *awstypes.WAFAssociatedItemException, *awstypes.WAFUnavailableEntityException](ctx, timeout, func(ctx context.Context) (any, error) {
 					return conn.UpdateWebACL(ctx, input)
 				})
 
@@ -500,7 +500,7 @@ func resourceWebACLDelete(ctx context.Context, d *schema.ResourceData, meta any)
 	const (
 		timeout = 5 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsOneOf2[*awstypes.WAFAssociatedItemException, *awstypes.WAFUnavailableEntityException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsOneOf2[any, *awstypes.WAFAssociatedItemException, *awstypes.WAFUnavailableEntityException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteWebACL(ctx, input)
 	})
 
@@ -515,7 +515,7 @@ func resourceWebACLDelete(ctx context.Context, d *schema.ResourceData, meta any)
 		if newLockToken := aws.ToString(output.LockToken); newLockToken != aclLockToken {
 			// Retrieved a new lock token, retry due to other processes modifying the web acl out of band (See: https://docs.aws.amazon.com/sdk-for-go/api/service/shield/#Shield.EnableApplicationLayerAutomaticResponse)
 			input.LockToken = aws.String(newLockToken)
-			_, err = tfresource.RetryWhenIsOneOf2[*awstypes.WAFAssociatedItemException, *awstypes.WAFUnavailableEntityException](ctx, timeout, func() (any, error) {
+			_, err = tfresource.RetryWhenIsOneOf2[any, *awstypes.WAFAssociatedItemException, *awstypes.WAFUnavailableEntityException](ctx, timeout, func(ctx context.Context) (any, error) {
 				return conn.DeleteWebACL(ctx, input)
 			})
 

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -118,8 +118,8 @@ func RetryGWhenAWSErrCodeEquals[T any](ctx context.Context, timeout time.Duratio
 }
 
 // RetryWhenAWSErrCodeContains retries the specified function when it returns an AWS error containing the specified code.
-func RetryWhenAWSErrCodeContains(ctx context.Context, timeout time.Duration, f func() (any, error), code string) (any, error) { // nosemgrep:ci.aws-in-func-name
-	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
+func RetryWhenAWSErrCodeContains[T any](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error), code string) (T, error) { // nosemgrep:ci.aws-in-func-name
+	return retryWhen(ctx, timeout, f, func(err error) (bool, error) {
 		if tfawserr.ErrCodeContains(err, code) {
 			return true, err
 		}

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -159,8 +159,8 @@ func RetryWhenIsOneOf2[T1, T2 error](ctx context.Context, timeout time.Duration,
 	})
 }
 
-func RetryWhenIsOneOf3[T1, T2, T3 error](ctx context.Context, timeout time.Duration, f func() (any, error)) (any, error) {
-	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
+func RetryWhenIsOneOf3[T any, T1, T2, T3 error](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error)) (T, error) {
+	return retryWhen(ctx, timeout, f, func(err error) (bool, error) {
 		if errs.IsA[T1](err) || errs.IsA[T2](err) || errs.IsA[T3](err) {
 			return true, err
 		}
@@ -170,7 +170,7 @@ func RetryWhenIsOneOf3[T1, T2, T3 error](ctx context.Context, timeout time.Durat
 }
 
 func RetryWhenIsOneOf4[T any, T1, T2, T3, T4 error](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error)) (T, error) {
-	return reetryWhen(ctx, timeout, f, func(err error) (bool, error) {
+	return retryWhen(ctx, timeout, f, func(err error) (bool, error) {
 		if errs.IsA[T1](err) || errs.IsA[T2](err) || errs.IsA[T3](err) || errs.IsA[T4](err) {
 			return true, err
 		}
@@ -366,8 +366,7 @@ func Retry(ctx context.Context, timeout time.Duration, f sdkretry.RetryFunc, opt
 
 type retryable func(error) (bool, error)
 
-// TODO Rename to `retryWhen` after refactoring complete.
-func reetryWhen[T any](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error), retryable retryable, opts ...backoff.Option) (T, error) {
+func retryWhen[T any](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error), retryable retryable, opts ...backoff.Option) (T, error) {
 	return retry.Op(f).If(func(_ T, err error) (bool, error) {
 		return retryable(err)
 	})(ctx, timeout, opts...)

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -149,8 +149,8 @@ func RetryWhenIsA[T error](ctx context.Context, timeout time.Duration, f func() 
 	})
 }
 
-func RetryWhenIsOneOf2[T1, T2 error](ctx context.Context, timeout time.Duration, f func() (any, error)) (any, error) {
-	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
+func RetryWhenIsOneOf2[T any, T1, T2 error](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error)) (T, error) {
+	return retryWhen(ctx, timeout, f, func(err error) (bool, error) {
 		if errs.IsA[T1](err) || errs.IsA[T2](err) {
 			return true, err
 		}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Use the new primitives in `internal/retry` (as a replacement for the SDKv2 `helper/retry` package) for `tfresource.RetryWhenIsOneOf(2|3|4)` and `tfresource.RetryWhenAWSErrCodeContains`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/42554.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43267.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43341.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43412.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccECSCluster_basic' PKG=ecs
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/ecs/... -v -count 1 -parallel 20  -run=TestAccECSCluster_basic -timeout 360m -vet=off
2025/07/23 14:39:18 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/23 14:39:18 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSCluster_basic
=== PAUSE TestAccECSCluster_basic
=== CONT  TestAccECSCluster_basic
--- PASS: TestAccECSCluster_basic (25.04s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	30.164s
```
```console
% make testacc TESTARGS='-run=TestAccKMSGrant_basic' PKG=kms
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/kms/... -v -count 1 -parallel 20  -run=TestAccKMSGrant_basic -timeout 360m -vet=off
2025/07/23 14:43:36 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/23 14:43:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKMSGrant_basic
=== PAUSE TestAccKMSGrant_basic
=== CONT  TestAccKMSGrant_basic
--- PASS: TestAccKMSGrant_basic (30.87s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	36.086s
```
```console
% make testacc TESTARGS='-run=TestAccWAFV2RuleGroup_basic' PKG=wafv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/wafv2/... -v -count 1 -parallel 20  -run=TestAccWAFV2RuleGroup_basic -timeout 360m -vet=off
2025/07/23 14:51:22 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/23 14:51:22 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccWAFV2RuleGroup_basic
=== PAUSE TestAccWAFV2RuleGroup_basic
=== CONT  TestAccWAFV2RuleGroup_basic
--- PASS: TestAccWAFV2RuleGroup_basic (17.14s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafv2	22.421s
```
```console
% make testacc TESTARGS='-run=TestAccLambdaPermission_basic' PKG=lambda 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/lambda/... -v -count 1 -parallel 20  -run=TestAccLambdaPermission_basic -timeout 360m -vet=off
2025/07/23 14:54:37 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/23 14:54:37 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaPermission_basic
=== PAUSE TestAccLambdaPermission_basic
=== CONT  TestAccLambdaPermission_basic
--- PASS: TestAccLambdaPermission_basic (29.93s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	35.152s
```
```console
% make testacc TESTARGS='-run=TestAccKMSKey_isEnabled' PKG=kms
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/kms/... -v -count 1 -parallel 20  -run=TestAccKMSKey_isEnabled -timeout 360m -vet=off
2025/07/23 14:58:06 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/23 14:58:06 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKMSKey_isEnabled
=== PAUSE TestAccKMSKey_isEnabled
=== CONT  TestAccKMSKey_isEnabled
--- PASS: TestAccKMSKey_isEnabled (333.87s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	339.057s
```
```console
% make testacc TESTARGS='-run=TestAccCloudFrontDistribution_basic' PKG=cloudfront
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/cloudfront/... -v -count 1 -parallel 20  -run=TestAccCloudFrontDistribution_basic -timeout 360m -vet=off
2025/07/23 15:07:31 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/23 15:07:31 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudFrontDistribution_basic
=== PAUSE TestAccCloudFrontDistribution_basic
=== CONT  TestAccCloudFrontDistribution_basic
--- PASS: TestAccCloudFrontDistribution_basic (370.86s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	375.929s
```
```console
% make testacc TESTARGS='-run=TestAccDataZoneDomain_basic' PKG=datazone
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/datazone/... -v -count 1 -parallel 20  -run=TestAccDataZoneDomain_basic -timeout 360m -vet=off
2025/07/23 16:12:54 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/23 16:12:54 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDataZoneDomain_basic
=== PAUSE TestAccDataZoneDomain_basic
=== CONT  TestAccDataZoneDomain_basic
--- PASS: TestAccDataZoneDomain_basic (27.13s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/datazone	32.382s
```