### PR TITLE
[bug fix] aws_appsync_api_cache: Fix "missing required field" errors during update

### DIFF
--- a/.changelog/43523.txt
+++ b/.changelog/43523.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_appsync_api_cache: Fix "missing required field" error during update
+```

--- a/internal/service/appsync/api_cache.go
+++ b/internal/service/appsync/api_cache.go
@@ -47,11 +47,13 @@ func resourceAPICache() *schema.Resource {
 			"at_rest_encryption_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"transit_encryption_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"ttl": {

--- a/internal/service/appsync/api_cache.go
+++ b/internal/service/appsync/api_cache.go
@@ -133,19 +133,10 @@ func resourceAPICacheUpdate(ctx context.Context, d *schema.ResourceData, meta an
 	conn := meta.(*conns.AWSClient).AppSyncClient(ctx)
 
 	input := &appsync.UpdateApiCacheInput{
-		ApiId: aws.String(d.Id()),
-	}
-
-	if d.HasChange("api_caching_behavior") {
-		input.ApiCachingBehavior = awstypes.ApiCachingBehavior(d.Get("api_caching_behavior").(string))
-	}
-
-	if d.HasChange("ttl") {
-		input.Ttl = int64(d.Get("ttl").(int))
-	}
-
-	if d.HasChange(names.AttrType) {
-		input.Type = awstypes.ApiCacheType(d.Get(names.AttrType).(string))
+		ApiId:              aws.String(d.Id()),
+		ApiCachingBehavior: awstypes.ApiCachingBehavior(d.Get("api_caching_behavior").(string)),
+		Ttl:                int64(d.Get("ttl").(int)),
+		Type:               awstypes.ApiCacheType(d.Get(names.AttrType).(string)),
 	}
 
 	_, err := conn.UpdateApiCache(ctx, input)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Fixed the update process to avoid "missing required field" errors, reported by #43519 .

  * `apiCachingBehavior`, `ttl`, and `type` are required attributes for the `UpdateApiCache` action, but they were previously only specified when changes were detected.

* Added an acceptance test to validate the update process.

### Relations
Closes #43519 

### References
https://docs.aws.amazon.com/appsync/latest/APIReference/API_UpdateApiCache.html


### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccAppSync_serial/ApiCache PKG=appsync
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/appsync/... -v -count 1 -parallel 20 -run='TestAccAppSync_serial/ApiCache'  -timeout 360m -vet=off
2025/07/24 07:06:07 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/24 07:06:07 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAppSync_serial
=== PAUSE TestAccAppSync_serial
=== CONT  TestAccAppSync_serial
=== RUN   TestAccAppSync_serial/ApiCache
=== RUN   TestAccAppSync_serial/ApiCache/basic
=== RUN   TestAccAppSync_serial/ApiCache/disappears
--- PASS: TestAccAppSync_serial (2447.87s)
    --- PASS: TestAccAppSync_serial/ApiCache (2447.87s)
        --- PASS: TestAccAppSync_serial/ApiCache/basic (1634.70s)
        --- PASS: TestAccAppSync_serial/ApiCache/disappears (813.17s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appsync    2451.552s

```
