### PR TITLE
[bugfix] aws_ecs_service: Allow unspecified `test_listener_rule` in `load_balancer.advanced_configuration` block

### DIFF
--- a/.changelog/43558.txt
+++ b/.changelog/43558.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_service: Fix unspecified `test_listener_rule` incorrectly being set as empty string in `load_balancer.advanced_configuration` block
+```

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -2818,8 +2818,10 @@ func expandServiceLoadBalancers(tfList []any) []awstypes.LoadBalancer {
 			apiObject.AdvancedConfiguration = &awstypes.AdvancedConfiguration{
 				AlternateTargetGroupArn: aws.String(config["alternate_target_group_arn"].(string)),
 				ProductionListenerRule:  aws.String(config["production_listener_rule"].(string)),
-				TestListenerRule:        aws.String(config["test_listener_rule"].(string)),
 				RoleArn:                 aws.String(config[names.AttrRoleARN].(string)),
+			}
+			if v, ok := config["test_listener_rule"].(string); ok && v != "" {
+				apiObject.AdvancedConfiguration.TestListenerRule = aws.String(v)
 			}
 		}
 
@@ -2851,9 +2853,11 @@ func flattenServiceLoadBalancers(apiObjects []awstypes.LoadBalancer) []any {
 				map[string]any{
 					"alternate_target_group_arn": aws.ToString(apiObject.AdvancedConfiguration.AlternateTargetGroupArn),
 					"production_listener_rule":   aws.ToString(apiObject.AdvancedConfiguration.ProductionListenerRule),
-					"test_listener_rule":         aws.ToString(apiObject.AdvancedConfiguration.TestListenerRule),
 					names.AttrRoleARN:            aws.ToString(apiObject.AdvancedConfiguration.RoleArn),
 				},
+			}
+			if apiObject.AdvancedConfiguration.TestListenerRule != nil {
+				tfMap["advanced_configuration"].([]any)[0].(map[string]any)["test_listener_rule"] = aws.ToString(apiObject.AdvancedConfiguration.TestListenerRule)
 			}
 		}
 

--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -1212,6 +1212,60 @@ func TestAccECSService_BlueGreenDeployment_waitServiceActive(t *testing.T) {
 	})
 }
 
+func TestAccECSService_BlueGreenDeployment_withoutTestListenerRule(t *testing.T) {
+	ctx := acctest.Context(t)
+	var service awstypes.Service
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)[:16] // Use shorter name to avoid target group name length issues
+	resourceName := "aws_ecs_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckServiceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceConfig_blueGreenDeployment_withoutTestListenerRule(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "deployment_configuration.0.strategy", "BLUE_GREEN"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer.0.advanced_configuration.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "load_balancer.0.advanced_configuration.0.alternate_target_group_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "load_balancer.0.advanced_configuration.0.production_listener_rule"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer.0.advanced_configuration.0.test_listener_rule", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "load_balancer.0.advanced_configuration.0.role_arn"),
+				),
+			},
+			{
+				// Set test_listener_rule
+				Config: testAccServiceConfig_blueGreenDeployment_basic(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "deployment_configuration.0.strategy", "BLUE_GREEN"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer.0.advanced_configuration.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "load_balancer.0.advanced_configuration.0.alternate_target_group_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "load_balancer.0.advanced_configuration.0.production_listener_rule"),
+					resource.TestCheckResourceAttrSet(resourceName, "load_balancer.0.advanced_configuration.0.test_listener_rule"),
+					resource.TestCheckResourceAttrSet(resourceName, "load_balancer.0.advanced_configuration.0.role_arn"),
+				),
+			},
+			{
+				// Remove test_listener_rule again
+				Config: testAccServiceConfig_blueGreenDeployment_withoutTestListenerRule(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "deployment_configuration.0.strategy", "BLUE_GREEN"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer.0.advanced_configuration.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "load_balancer.0.advanced_configuration.0.alternate_target_group_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "load_balancer.0.advanced_configuration.0.production_listener_rule"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer.0.advanced_configuration.0.test_listener_rule", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "load_balancer.0.advanced_configuration.0.role_arn"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccECSService_DeploymentConfiguration_strategy(t *testing.T) {
 	// Test for deployment configuration strategy
 	ctx := acctest.Context(t)
@@ -3492,6 +3546,84 @@ resource "aws_ecs_service" "test" {
       alternate_target_group_arn = aws_lb_target_group.alternate.arn
       production_listener_rule   = aws_lb_listener_rule.production.arn
       test_listener_rule         = aws_lb_listener_rule.test.arn
+      role_arn                   = aws_iam_role.global.arn
+    }
+  }
+
+  wait_for_steady_state = %[2]t
+
+  depends_on = [
+    aws_iam_role_policy_attachment.global_admin_attach,
+    aws_iam_role_policy.ecs_elb_permissions,
+    aws_iam_role_policy_attachment.ecs_service_role
+  ]
+}
+`, rName, waitSteadyState))
+}
+
+func testAccServiceConfig_blueGreenDeployment_withoutTestListenerRule(rName string, waitSteadyState bool) string {
+	return acctest.ConfigCompose(testAccServiceConfig_blueGreenDeploymentBase(rName), fmt.Sprintf(`
+resource "aws_ecs_service" "test" {
+  name            = %[1]q
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.test.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  deployment_configuration {
+    strategy             = "BLUE_GREEN"
+    bake_time_in_minutes = 2
+
+    lifecycle_hook {
+      hook_target_arn  = aws_lambda_function.hook_success.arn
+      role_arn         = aws_iam_role.global.arn
+      lifecycle_stages = ["POST_SCALE_UP", "POST_TEST_TRAFFIC_SHIFT"]
+    }
+
+    lifecycle_hook {
+      hook_target_arn  = aws_lambda_function.hook_success.arn
+      role_arn         = aws_iam_role.global.arn
+      lifecycle_stages = ["TEST_TRAFFIC_SHIFT", "POST_PRODUCTION_TRAFFIC_SHIFT"]
+    }
+  }
+
+  service_connect_configuration {
+    enabled   = true
+    namespace = aws_service_discovery_http_namespace.test.arn
+
+    service {
+      client_alias {
+        dns_name = "test-service.local"
+        port     = 8080
+
+        test_traffic_rules {
+          header {
+            name = "x-test-header"
+            value {
+              exact = "test-value"
+            }
+          }
+        }
+      }
+      discovery_name = "test-service"
+      port_name      = "http"
+    }
+  }
+
+  network_configuration {
+    security_groups  = [aws_security_group.test.id]
+    subnets          = aws_subnet.test[*].id
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.primary.arn
+    container_name   = "test"
+    container_port   = 80
+
+    advanced_configuration {
+      alternate_target_group_arn = aws_lb_target_group.alternate.arn
+      production_listener_rule   = aws_lb_listener_rule.production.arn
       role_arn                   = aws_iam_role.global.arn
     }
   }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Fixed the expander and flattener for the `test_listener_rule` argument in the `load_balancer.advanced_configuration` block to treat it as optional and allow it to be unspecified.

  * Previously, an unspecified `test_listener_rule` was incorrectly set as an empty string in the `load_balancer.advanced_configuration` block.

### Relations
Closes #43552


### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccECSService_ PKG=ecs                                           
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSService_'  -timeout 360m -vet=off
2025/07/26 00:25:29 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/26 00:25:29 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSService_Identity_Basic
=== PAUSE TestAccECSService_Identity_Basic
=== RUN   TestAccECSService_Identity_RegionOverride
=== PAUSE TestAccECSService_Identity_RegionOverride
=== RUN   TestAccECSService_disappears
=== PAUSE TestAccECSService_disappears
=== RUN   TestAccECSService_LatticeConfigurations
=== PAUSE TestAccECSService_LatticeConfigurations
=== RUN   TestAccECSService_PlacementStrategy_unnormalized
=== PAUSE TestAccECSService_PlacementStrategy_unnormalized
=== RUN   TestAccECSService_CapacityProviderStrategy_basic
=== PAUSE TestAccECSService_CapacityProviderStrategy_basic
=== RUN   TestAccECSService_CapacityProviderStrategy_forceNewDeployment
=== PAUSE TestAccECSService_CapacityProviderStrategy_forceNewDeployment
=== RUN   TestAccECSService_CapacityProviderStrategy_update
=== PAUSE TestAccECSService_CapacityProviderStrategy_update
=== RUN   TestAccECSService_VolumeConfiguration_basic
=== PAUSE TestAccECSService_VolumeConfiguration_basic
=== RUN   TestAccECSService_VolumeConfiguration_volumeInitializationRate
=== PAUSE TestAccECSService_VolumeConfiguration_volumeInitializationRate
=== RUN   TestAccECSService_VolumeConfiguration_tagSpecifications
=== PAUSE TestAccECSService_VolumeConfiguration_tagSpecifications
=== RUN   TestAccECSService_VolumeConfiguration_update
=== PAUSE TestAccECSService_VolumeConfiguration_update
=== RUN   TestAccECSService_VolumeConfiguration_throughputTypeChange
=== PAUSE TestAccECSService_VolumeConfiguration_throughputTypeChange
=== RUN   TestAccECSService_familyAndRevision
=== PAUSE TestAccECSService_familyAndRevision
=== RUN   TestAccECSService_healthCheckGracePeriodSeconds
=== PAUSE TestAccECSService_healthCheckGracePeriodSeconds
=== RUN   TestAccECSService_iamRole
=== PAUSE TestAccECSService_iamRole
=== RUN   TestAccECSService_DeploymentControllerType_codeDeploy
=== PAUSE TestAccECSService_DeploymentControllerType_codeDeploy
=== RUN   TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
=== PAUSE TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
=== RUN   TestAccECSService_DeploymentControllerType_external
=== PAUSE TestAccECSService_DeploymentControllerType_external
=== RUN   TestAccECSService_DeploymentControllerMutability_codeDeployToECS
=== PAUSE TestAccECSService_DeploymentControllerMutability_codeDeployToECS
=== RUN   TestAccECSService_alarmsAdd
=== PAUSE TestAccECSService_alarmsAdd
=== RUN   TestAccECSService_alarmsUpdate
=== PAUSE TestAccECSService_alarmsUpdate
=== RUN   TestAccECSService_BlueGreenDeployment_basic
=== PAUSE TestAccECSService_BlueGreenDeployment_basic
=== RUN   TestAccECSService_BlueGreenDeployment_circuitBreakerRollback
=== PAUSE TestAccECSService_BlueGreenDeployment_circuitBreakerRollback
=== RUN   TestAccECSService_BlueGreenDeployment_createFailure
=== PAUSE TestAccECSService_BlueGreenDeployment_createFailure
=== RUN   TestAccECSService_BlueGreenDeployment_changeStrategy
=== PAUSE TestAccECSService_BlueGreenDeployment_changeStrategy
=== RUN   TestAccECSService_BlueGreenDeployment_updateFailure
=== PAUSE TestAccECSService_BlueGreenDeployment_updateFailure
=== RUN   TestAccECSService_BlueGreenDeployment_updateInPlace
=== PAUSE TestAccECSService_BlueGreenDeployment_updateInPlace
=== RUN   TestAccECSService_BlueGreenDeployment_waitServiceActive
=== PAUSE TestAccECSService_BlueGreenDeployment_waitServiceActive
=== RUN   TestAccECSService_BlueGreenDeployment_withoutTestListenerRule
=== PAUSE TestAccECSService_BlueGreenDeployment_withoutTestListenerRule
=== RUN   TestAccECSService_DeploymentConfiguration_strategy
=== PAUSE TestAccECSService_DeploymentConfiguration_strategy
=== RUN   TestAccECSService_DeploymentValues_basic
=== PAUSE TestAccECSService_DeploymentValues_basic
=== RUN   TestAccECSService_DeploymentValues_minZeroMaxOneHundred
=== PAUSE TestAccECSService_DeploymentValues_minZeroMaxOneHundred
=== RUN   TestAccECSService_deploymentCircuitBreaker
=== PAUSE TestAccECSService_deploymentCircuitBreaker
=== RUN   TestAccECSService_loadBalancerChanges
=== PAUSE TestAccECSService_loadBalancerChanges
=== RUN   TestAccECSService_clusterName
=== PAUSE TestAccECSService_clusterName
=== RUN   TestAccECSService_alb
=== PAUSE TestAccECSService_alb
=== RUN   TestAccECSService_multipleTargetGroups
=== PAUSE TestAccECSService_multipleTargetGroups
=== RUN   TestAccECSService_forceNewDeployment
=== PAUSE TestAccECSService_forceNewDeployment
=== RUN   TestAccECSService_forceNewDeploymentTriggers
=== PAUSE TestAccECSService_forceNewDeploymentTriggers
=== RUN   TestAccECSService_PlacementStrategy_basic
=== PAUSE TestAccECSService_PlacementStrategy_basic
=== RUN   TestAccECSService_PlacementStrategy_missing
=== PAUSE TestAccECSService_PlacementStrategy_missing
=== RUN   TestAccECSService_PlacementConstraints_basic
=== PAUSE TestAccECSService_PlacementConstraints_basic
=== RUN   TestAccECSService_PlacementConstraints_emptyExpression
=== PAUSE TestAccECSService_PlacementConstraints_emptyExpression
=== RUN   TestAccECSService_LaunchTypeFargate_basic
=== PAUSE TestAccECSService_LaunchTypeFargate_basic
=== RUN   TestAccECSService_LaunchTypeFargate_platformVersion
=== PAUSE TestAccECSService_LaunchTypeFargate_platformVersion
=== RUN   TestAccECSService_LaunchTypeFargate_waitForSteadyState
=== PAUSE TestAccECSService_LaunchTypeFargate_waitForSteadyState
=== RUN   TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
=== PAUSE TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
=== RUN   TestAccECSService_LaunchTypeEC2_network
=== PAUSE TestAccECSService_LaunchTypeEC2_network
=== RUN   TestAccECSService_DaemonSchedulingStrategy_basic
=== PAUSE TestAccECSService_DaemonSchedulingStrategy_basic
=== RUN   TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
=== PAUSE TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
=== RUN   TestAccECSService_replicaSchedulingStrategy
=== PAUSE TestAccECSService_replicaSchedulingStrategy
=== RUN   TestAccECSService_ServiceRegistries_basic
=== PAUSE TestAccECSService_ServiceRegistries_basic
=== RUN   TestAccECSService_ServiceRegistries_container
=== PAUSE TestAccECSService_ServiceRegistries_container
=== RUN   TestAccECSService_ServiceRegistries_changes
=== PAUSE TestAccECSService_ServiceRegistries_changes
=== RUN   TestAccECSService_ServiceRegistries_removal
=== PAUSE TestAccECSService_ServiceRegistries_removal
=== RUN   TestAccECSService_ServiceConnect_basic
=== PAUSE TestAccECSService_ServiceConnect_basic
=== RUN   TestAccECSService_ServiceConnect_full
=== PAUSE TestAccECSService_ServiceConnect_full
=== RUN   TestAccECSService_ServiceConnect_tls_with_empty_timeout
=== PAUSE TestAccECSService_ServiceConnect_tls_with_empty_timeout
=== RUN   TestAccECSService_ServiceConnect_ingressPortOverride
=== PAUSE TestAccECSService_ServiceConnect_ingressPortOverride
=== RUN   TestAccECSService_ServiceConnect_remove
=== PAUSE TestAccECSService_ServiceConnect_remove
=== RUN   TestAccECSService_Tags_basic
=== PAUSE TestAccECSService_Tags_basic
=== RUN   TestAccECSService_Tags_managed
=== PAUSE TestAccECSService_Tags_managed
=== RUN   TestAccECSService_Tags_propagate
=== PAUSE TestAccECSService_Tags_propagate
=== RUN   TestAccECSService_executeCommand
=== PAUSE TestAccECSService_executeCommand
=== RUN   TestAccECSService_AvailabilityZoneRebalancing
=== PAUSE TestAccECSService_AvailabilityZoneRebalancing
=== CONT  TestAccECSService_basic
=== CONT  TestAccECSService_deploymentCircuitBreaker
=== CONT  TestAccECSService_DeploymentConfiguration_strategy
=== CONT  TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
=== CONT  TestAccECSService_DeploymentValues_minZeroMaxOneHundred
=== CONT  TestAccECSService_DeploymentValues_basic
=== CONT  TestAccECSService_AvailabilityZoneRebalancing
=== CONT  TestAccECSService_executeCommand
=== CONT  TestAccECSService_Tags_propagate
=== CONT  TestAccECSService_Tags_managed
=== CONT  TestAccECSService_Tags_basic
=== CONT  TestAccECSService_ServiceConnect_remove
=== CONT  TestAccECSService_ServiceConnect_ingressPortOverride
=== CONT  TestAccECSService_ServiceConnect_tls_with_empty_timeout
=== CONT  TestAccECSService_ServiceConnect_full
=== CONT  TestAccECSService_ServiceConnect_basic
=== CONT  TestAccECSService_ServiceRegistries_removal
=== CONT  TestAccECSService_ServiceRegistries_changes
=== CONT  TestAccECSService_ServiceRegistries_container
=== CONT  TestAccECSService_DeploymentControllerType_codeDeploy
--- PASS: TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum (52.52s)
=== CONT  TestAccECSService_ServiceRegistries_basic
--- PASS: TestAccECSService_DeploymentValues_minZeroMaxOneHundred (87.23s)
=== CONT  TestAccECSService_replicaSchedulingStrategy
--- PASS: TestAccECSService_Tags_managed (87.35s)
=== CONT  TestAccECSService_PlacementStrategy_unnormalized
--- PASS: TestAccECSService_deploymentCircuitBreaker (88.51s)
=== CONT  TestAccECSService_CapacityProviderStrategy_update
--- PASS: TestAccECSService_Tags_propagate (91.43s)
=== CONT  TestAccECSService_CapacityProviderStrategy_forceNewDeployment
--- PASS: TestAccECSService_executeCommand (94.03s)
=== CONT  TestAccECSService_CapacityProviderStrategy_basic
--- PASS: TestAccECSService_DeploymentValues_basic (98.88s)
=== CONT  TestAccECSService_disappears
--- PASS: TestAccECSService_AvailabilityZoneRebalancing (100.56s)
=== CONT  TestAccECSService_LatticeConfigurations
--- PASS: TestAccECSService_Tags_basic (104.08s)
=== CONT  TestAccECSService_PlacementConstraints_basic
--- PASS: TestAccECSService_basic (115.90s)
=== CONT  TestAccECSService_DaemonSchedulingStrategy_basic
--- PASS: TestAccECSService_DeploymentConfiguration_strategy (122.99s)
=== CONT  TestAccECSService_LaunchTypeEC2_network
--- PASS: TestAccECSService_ServiceRegistries_removal (150.53s)
=== CONT  TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
--- PASS: TestAccECSService_PlacementStrategy_unnormalized (65.97s)
=== CONT  TestAccECSService_LaunchTypeFargate_waitForSteadyState
--- PASS: TestAccECSService_replicaSchedulingStrategy (66.29s)
=== CONT  TestAccECSService_LaunchTypeFargate_platformVersion
--- PASS: TestAccECSService_DaemonSchedulingStrategy_basic (42.58s)
=== CONT  TestAccECSService_LaunchTypeFargate_basic
--- PASS: TestAccECSService_CapacityProviderStrategy_forceNewDeployment (73.54s)
=== CONT  TestAccECSService_PlacementConstraints_emptyExpression
--- PASS: TestAccECSService_ServiceConnect_basic (178.76s)
=== CONT  TestAccECSService_VolumeConfiguration_throughputTypeChange
--- PASS: TestAccECSService_PlacementConstraints_basic (78.08s)
=== CONT  TestAccECSService_iamRole
--- PASS: TestAccECSService_ServiceRegistries_container (182.86s)
=== CONT  TestAccECSService_healthCheckGracePeriodSeconds
--- PASS: TestAccECSService_ServiceConnect_remove (187.86s)
=== CONT  TestAccECSService_familyAndRevision
--- PASS: TestAccECSService_ServiceConnect_ingressPortOverride (195.31s)
=== CONT  TestAccECSService_BlueGreenDeployment_circuitBreakerRollback
--- PASS: TestAccECSService_ServiceConnect_full (195.85s)
=== CONT  TestAccECSService_VolumeConfiguration_basic
--- PASS: TestAccECSService_ServiceConnect_tls_with_empty_timeout (196.03s)
=== CONT  TestAccECSService_VolumeConfiguration_update
--- PASS: TestAccECSService_LaunchTypeEC2_network (74.42s)
=== CONT  TestAccECSService_VolumeConfiguration_tagSpecifications
--- PASS: TestAccECSService_ServiceRegistries_basic (152.84s)
=== CONT  TestAccECSService_VolumeConfiguration_volumeInitializationRate
--- PASS: TestAccECSService_iamRole (43.53s)
=== CONT  TestAccECSService_forceNewDeployment
--- PASS: TestAccECSService_PlacementConstraints_emptyExpression (68.88s)
=== CONT  TestAccECSService_BlueGreenDeployment_withoutTestListenerRule
--- PASS: TestAccECSService_CapacityProviderStrategy_basic (162.40s)
=== CONT  TestAccECSService_BlueGreenDeployment_waitServiceActive
--- PASS: TestAccECSService_VolumeConfiguration_tagSpecifications (85.14s)
=== CONT  TestAccECSService_BlueGreenDeployment_updateInPlace
--- PASS: TestAccECSService_VolumeConfiguration_basic (86.89s)
=== CONT  TestAccECSService_BlueGreenDeployment_updateFailure
--- PASS: TestAccECSService_disappears (195.08s)
=== CONT  TestAccECSService_BlueGreenDeployment_changeStrategy
--- PASS: TestAccECSService_VolumeConfiguration_throughputTypeChange (122.35s)
=== CONT  TestAccECSService_BlueGreenDeployment_createFailure
--- PASS: TestAccECSService_familyAndRevision (113.97s)
=== CONT  TestAccECSService_Identity_Basic
--- PASS: TestAccECSService_DeploymentControllerType_codeDeploy (306.22s)
=== CONT  TestAccECSService_PlacementStrategy_basic
--- PASS: TestAccECSService_VolumeConfiguration_update (115.48s)
=== CONT  TestAccECSService_forceNewDeploymentTriggers
--- PASS: TestAccECSService_forceNewDeployment (87.25s)
=== CONT  TestAccECSService_alarmsAdd
--- PASS: TestAccECSService_ServiceRegistries_changes (321.74s)
=== CONT  TestAccECSService_BlueGreenDeployment_basic
--- PASS: TestAccECSService_LaunchTypeFargate_platformVersion (174.96s)
=== CONT  TestAccECSService_alarmsUpdate
--- PASS: TestAccECSService_LaunchTypeFargate_waitForSteadyState (183.02s)
=== CONT  TestAccECSService_Identity_RegionOverride
--- PASS: TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState (187.11s)
=== CONT  TestAccECSService_PlacementStrategy_missing
--- PASS: TestAccECSService_PlacementStrategy_missing (1.11s)
=== CONT  TestAccECSService_alb
--- PASS: TestAccECSService_VolumeConfiguration_volumeInitializationRate (142.32s)
=== CONT  TestAccECSService_DeploymentControllerType_external
--- PASS: TestAccECSService_LaunchTypeFargate_basic (198.79s)
=== CONT  TestAccECSService_multipleTargetGroups
--- PASS: TestAccECSService_CapacityProviderStrategy_update (274.03s)
=== CONT  TestAccECSService_clusterName
--- PASS: TestAccECSService_Identity_Basic (68.05s)
=== CONT  TestAccECSService_DeploymentControllerMutability_codeDeployToECS
--- PASS: TestAccECSService_forceNewDeploymentTriggers (68.81s)
=== CONT  TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
--- PASS: TestAccECSService_DeploymentControllerType_external (33.91s)
=== CONT  TestAccECSService_loadBalancerChanges
--- PASS: TestAccECSService_LatticeConfigurations (294.84s)
--- PASS: TestAccECSService_alarmsAdd (89.58s)
--- PASS: TestAccECSService_Identity_RegionOverride (71.05s)
--- PASS: TestAccECSService_alarmsUpdate (79.19s)
--- PASS: TestAccECSService_PlacementStrategy_basic (104.15s)
--- PASS: TestAccECSService_clusterName (65.69s)
--- PASS: TestAccECSService_healthCheckGracePeriodSeconds (334.10s)
--- PASS: TestAccECSService_alb (285.96s)
--- PASS: TestAccECSService_multipleTargetGroups (276.81s)
--- PASS: TestAccECSService_BlueGreenDeployment_createFailure (340.92s)
--- PASS: TestAccECSService_loadBalancerChanges (290.01s)
--- PASS: TestAccECSService_DeploymentControllerMutability_codeDeployToECS (303.44s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod (460.06s)
--- PASS: TestAccECSService_BlueGreenDeployment_waitServiceActive (978.64s)
--- PASS: TestAccECSService_BlueGreenDeployment_updateInPlace (1101.25s)
--- PASS: TestAccECSService_BlueGreenDeployment_updateFailure (1115.40s)
--- PASS: TestAccECSService_BlueGreenDeployment_basic (1429.68s)
--- PASS: TestAccECSService_BlueGreenDeployment_withoutTestListenerRule (1840.68s)
--- PASS: TestAccECSService_BlueGreenDeployment_changeStrategy (2012.48s)
--- PASS: TestAccECSService_BlueGreenDeployment_circuitBreakerRollback (3495.23s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        3694.225s
```
