### PR TITLE
[Enhancement] aws_ssm_service_setting: Fix perpetual diff issue by supporting short format (with `/ssm/` prefix) for `setting_id`

### DIFF
--- a/.changelog/43562.txt
+++ b/.changelog/43562.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ssm_service_setting: Support short format (with `/ssm/` prefix) for `setting_id`
+```

--- a/internal/service/ssm/service_setting.go
+++ b/internal/service/ssm/service_setting.go
@@ -8,16 +8,20 @@ import (
 	"log"
 	"time"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -41,6 +45,10 @@ func resourceServiceSetting() *schema.Resource {
 			"setting_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ValidateFunc: validation.Any(
+					verify.ValidARN,
+					validation.StringMatch(regexache.MustCompile(`^/ssm/`), "setting_id must begin with '/ssm/'"),
+				),
 			},
 			"setting_value": {
 				Type:     schema.TypeString,
@@ -70,7 +78,19 @@ func resourceServiceSettingUpdate(ctx context.Context, d *schema.ResourceData, m
 		return sdkdiag.AppendErrorf(diags, "updating SSM Service Setting (%s): %s", settingID, err)
 	}
 
-	d.SetId(settingID)
+	// While settingID can be either a full ARN or an ID with "/ssm/" prefix, id is always ARN
+	if arn.IsARN(settingID) {
+		d.SetId(settingID)
+	} else {
+		settingARN := arn.ARN{
+			Partition: meta.(*conns.AWSClient).Partition(ctx),
+			Region:    meta.(*conns.AWSClient).Region(ctx),
+			AccountID: meta.(*conns.AWSClient).AccountID(ctx),
+			Service:   "ssm",
+			Resource:  "servicesetting" + settingID,
+		}
+		d.SetId(settingARN.String())
+	}
 
 	if _, err := waitServiceSettingUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for SSM Service Setting (%s) update: %s", d.Id(), err)
@@ -96,9 +116,15 @@ func resourceServiceSettingRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	d.Set(names.AttrARN, output.ARN)
-	// AWS SSM service setting API requires the entire ARN as input,
-	// but setting_id in the output is only a part of ARN.
-	d.Set("setting_id", output.ARN)
+	// setting_id begins with "/ssm/" prefix, according to the AWS documentation
+	// https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetServiceSetting.html#API_GetServiceSetting_RequestSyntax
+	// However, the full ARN format can be accepted by the AWS API as well and the first implementation of this resource assumed the full ARN format for setting_id.
+	// For backwards compatibility, support both formats.
+	if arn.IsARN(d.Get("setting_id").(string)) {
+		d.Set("setting_id", output.ARN)
+	} else {
+		d.Set("setting_id", output.SettingId)
+	}
 	d.Set("setting_value", output.SettingValue)
 	d.Set(names.AttrStatus, output.Status)
 

--- a/internal/service/ssm/service_setting_test.go
+++ b/internal/service/ssm/service_setting_test.go
@@ -20,13 +20,24 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccSSMServiceSetting_basic(t *testing.T) {
+func TestAccSSMServiceSetting_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		acctest.CtBasic:     testAccServiceSetting_basic,
+		"upgradeFromV6_5_0": testAccServiceSetting_upgradeFromV6_5_0,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccServiceSetting_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var setting awstypes.ServiceSetting
 	resourceName := "aws_ssm_service_setting.test"
 	settingID := "/ssm/parameter-store/high-throughput-enabled"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -86,12 +97,12 @@ func TestAccSSMServiceSetting_basic(t *testing.T) {
 	})
 }
 
-func TestAccSSMServiceSetting_upgradeFromV6_5_0(t *testing.T) {
+func testAccServiceSetting_upgradeFromV6_5_0(t *testing.T) {
 	ctx := acctest.Context(t)
 	var setting awstypes.ServiceSetting
 	resourceName := "aws_ssm_service_setting.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckServiceSettingDestroy(ctx),

--- a/internal/service/ssm/service_setting_test.go
+++ b/internal/service/ssm/service_setting_test.go
@@ -37,7 +37,7 @@ func TestAccSSMServiceSetting_basic(t *testing.T) {
 					testAccServiceSettingExists(ctx, resourceName, &setting),
 					resource.TestCheckResourceAttr(resourceName, "setting_id", settingID),
 					resource.TestCheckResourceAttr(resourceName, "setting_value", acctest.CtFalse),
-					resource.TestCheckResourceAttrPair(resourceName, "id", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrARN),
 				),
 			},
 			{
@@ -51,7 +51,7 @@ func TestAccSSMServiceSetting_basic(t *testing.T) {
 					testAccServiceSettingExists(ctx, resourceName, &setting),
 					resource.TestCheckResourceAttr(resourceName, "setting_id", settingID),
 					resource.TestCheckResourceAttr(resourceName, "setting_value", acctest.CtTrue),
-					resource.TestCheckResourceAttrPair(resourceName, "id", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrARN),
 				),
 			},
 			{
@@ -60,7 +60,7 @@ func TestAccSSMServiceSetting_basic(t *testing.T) {
 					testAccServiceSettingExists(ctx, resourceName, &setting),
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, "setting_id", "ssm", "servicesetting"+settingID),
 					resource.TestCheckResourceAttr(resourceName, "setting_value", acctest.CtFalse),
-					resource.TestCheckResourceAttrPair(resourceName, "id", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrARN),
 				),
 			},
 			{
@@ -78,7 +78,7 @@ func TestAccSSMServiceSetting_basic(t *testing.T) {
 					testAccServiceSettingExists(ctx, resourceName, &setting),
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, "setting_id", "ssm", "servicesetting"+settingID),
 					resource.TestCheckResourceAttr(resourceName, "setting_value", acctest.CtTrue),
-					resource.TestCheckResourceAttrPair(resourceName, "id", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrARN),
 				),
 			},
 		},

--- a/internal/service/ssm/service_setting_test.go
+++ b/internal/service/ssm/service_setting_test.go
@@ -37,6 +37,7 @@ func TestAccSSMServiceSetting_basic(t *testing.T) {
 					testAccServiceSettingExists(ctx, resourceName, &setting),
 					resource.TestCheckResourceAttr(resourceName, "setting_id", settingID),
 					resource.TestCheckResourceAttr(resourceName, "setting_value", acctest.CtFalse),
+					resource.TestCheckResourceAttrPair(resourceName, "id", resourceName, "arn"),
 				),
 			},
 			{
@@ -50,6 +51,7 @@ func TestAccSSMServiceSetting_basic(t *testing.T) {
 					testAccServiceSettingExists(ctx, resourceName, &setting),
 					resource.TestCheckResourceAttr(resourceName, "setting_id", settingID),
 					resource.TestCheckResourceAttr(resourceName, "setting_value", acctest.CtTrue),
+					resource.TestCheckResourceAttrPair(resourceName, "id", resourceName, "arn"),
 				),
 			},
 			{
@@ -58,6 +60,7 @@ func TestAccSSMServiceSetting_basic(t *testing.T) {
 					testAccServiceSettingExists(ctx, resourceName, &setting),
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, "setting_id", "ssm", "servicesetting"+settingID),
 					resource.TestCheckResourceAttr(resourceName, "setting_value", acctest.CtFalse),
+					resource.TestCheckResourceAttrPair(resourceName, "id", resourceName, "arn"),
 				),
 			},
 			{
@@ -75,6 +78,7 @@ func TestAccSSMServiceSetting_basic(t *testing.T) {
 					testAccServiceSettingExists(ctx, resourceName, &setting),
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, "setting_id", "ssm", "servicesetting"+settingID),
 					resource.TestCheckResourceAttr(resourceName, "setting_value", acctest.CtTrue),
+					resource.TestCheckResourceAttrPair(resourceName, "id", resourceName, "arn"),
 				),
 			},
 		},

--- a/website/docs/r/ssm_service_setting.html.markdown
+++ b/website/docs/r/ssm_service_setting.html.markdown
@@ -24,7 +24,7 @@ resource "aws_ssm_service_setting" "test_setting" {
 This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `setting_id` - (Required) ID of the service setting.
+* `setting_id` - (Required) ID of the service setting. Valid values are shown in the [AWS documentation](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetServiceSetting.html#API_GetServiceSetting_RequestSyntax).
 * `setting_value` - (Required) Value of the service setting.
 
 ## Attribute Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.


### Description

* The `setting_id` for the `aws_ssm_service_setting` resource typically begins with the `/ssm/` prefix (referred to as the "short format" below), according to the [AWS documentation](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetServiceSetting.html#API_GetServiceSetting_RequestSyntax)

  * However, the AWS API also accepts the full ARN format, and the current implementation of this resource assumes that `setting_id` is provided in that format.
  * As reported in #43551, when `setting_id` is specified using the short format, the API call succeeds, but a difference arises between the configuration and the state, since the state stores `setting_id` in the full ARN format.

* This PR updates the implementation to also accept the short format for `setting_id`.

  * While the [AWS documentation](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetServiceSetting.html#API_GetServiceSetting_RequestSyntax) appears to assume the use of the short format in API calls, this change maintains backward compatibility by supporting both formats. The full ARN format continues to be accepted.
    * If `setting_id` is specified in the ARN format in the configuration, it will be stored in the state as a full ARN.
    * If the short format is used in the configuration, it will be stored in the state as-is (short format).

  * The `id` field remains stored as the full ARN for backward compatibility.

  * The documentation has been updated to include a reference to valid values for `setting_id`.

### Relations

Closes #43551

### References
https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetServiceSetting.html#API_GetServiceSetting_RequestSyntax

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccSSMServiceSetting_ PKG=ssm     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMServiceSetting_'  -timeout 360m -vet=off
2025/07/26 09:45:21 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/26 09:45:21 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSSMServiceSetting_basic
=== PAUSE TestAccSSMServiceSetting_basic
=== CONT  TestAccSSMServiceSetting_basic
--- PASS: TestAccSSMServiceSetting_basic (64.13s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        67.921s
```
