### PR TITLE
Delete duplicated definition from transcribe_vocabulary.html.markdown

### DIFF
--- a/website/docs/r/transcribe_vocabulary.html.markdown
+++ b/website/docs/r/transcribe_vocabulary.html.markdown
@@ -47,7 +47,6 @@ resource "aws_transcribe_vocabulary" "example" {
 The following arguments are required:
 
 * `language_code` - (Required) The language code you selected for your vocabulary.
-* `vocabulary_file_uri` - (Required) The Amazon S3 location (URI) of the text file that contains your custom vocabulary.
 * `vocabulary_name` - (Required) The name of the Vocabulary.
 
 The following arguments are optional:


### PR DESCRIPTION
This pull request only updates the documentation. I noticed that the `vocabulary_file_uri` parameter is defined twice in the Markdown file, one instance is marked "Required", and the other "Optional". Because the implementation treats this parameter as optional, we should delete the first (required) entry.