### PR TITLE
[Enhancement] aws_ebs_volume:  Support `volume_initilization_rate` argument

### DIFF
--- a/internal/service/ec2/ebs_volume.go
+++ b/internal/service/ec2/ebs_volume.go
@@ -377,6 +377,13 @@ func resourceEBSVolumeCustomizeDiff(_ context.Context, diff *schema.ResourceDiff
 		if throughput > 0 && volumeType != awstypes.VolumeTypeGp3 {
 			return fmt.Errorf("'throughput' must not be set when 'type' is '%s'", volumeType)
 		}
+
+		config := diff.GetRawConfig()
+		if v := config.GetAttr(names.AttrSnapshotID); v.IsKnown() && v.IsNull() {
+			if v := config.GetAttr("volume_initialization_rate"); v.IsKnown() && !v.IsNull() {
+				return fmt.Errorf("'volume_initialization_rate' must not be set unless 'snapshot_id' is set")
+			}
+		}
 	} else {
 		// Update.
 

--- a/internal/service/ec2/ebs_volume.go
+++ b/internal/service/ec2/ebs_volume.go
@@ -121,6 +121,11 @@ func resourceEBSVolume() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"volume_initialization_rate": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(100, 300),
+			},
 		},
 	}
 }
@@ -171,6 +176,10 @@ func resourceEBSVolumeCreate(ctx context.Context, d *schema.ResourceData, meta a
 		input.VolumeType = awstypes.VolumeType(value.(string))
 	}
 
+	if value, ok := d.GetOk("volume_initialization_rate"); ok {
+		input.VolumeInitializationRate = aws.Int32(int32(value.(int)))
+	}
+
 	output, err := conn.CreateVolume(ctx, &input)
 
 	if err != nil {
@@ -215,6 +224,7 @@ func resourceEBSVolumeRead(ctx context.Context, d *schema.ResourceData, meta any
 	d.Set(names.AttrSnapshotID, volume.SnapshotId)
 	d.Set(names.AttrThroughput, volume.Throughput)
 	d.Set(names.AttrType, volume.VolumeType)
+	d.Set("volume_initialization_rate", volume.VolumeInitializationRate)
 
 	setTagsOut(ctx, volume.Tags)
 

--- a/internal/service/ec2/ebs_volume_data_source.go
+++ b/internal/service/ec2/ebs_volume_data_source.go
@@ -90,6 +90,10 @@ func dataSourceEBSVolume() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"volume_initialization_rate": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -148,6 +152,7 @@ func dataSourceEBSVolumeRead(ctx context.Context, d *schema.ResourceData, meta a
 	d.Set(names.AttrSnapshotID, volume.SnapshotId)
 	d.Set(names.AttrThroughput, volume.Throughput)
 	d.Set("volume_id", volume.VolumeId)
+	d.Set("volume_initialization_rate", volume.VolumeInitializationRate)
 	d.Set(names.AttrVolumeType, volume.VolumeType)
 
 	setTagsOut(ctx, volume.Tags)

--- a/internal/service/ec2/ebs_volume_data_source_test.go
+++ b/internal/service/ec2/ebs_volume_data_source_test.go
@@ -66,6 +66,36 @@ func TestAccEC2EBSVolumeDataSource_multipleFilters(t *testing.T) {
 	})
 }
 
+func TestAccEC2EBSVolumeDataSource_snapshotIdAndVolumeInitializationRate(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_ebs_volume.test"
+	dataSourceName := "data.aws_ebs_volume.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEBSVolumeDataSourceConfig_snapshotIdAndVolumeInitializationRate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEBSVolumeIDDataSource(dataSourceName),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrCreateTime, resourceName, names.AttrCreateTime),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrSize, resourceName, names.AttrSize),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrTags, resourceName, names.AttrTags),
+					resource.TestCheckResourceAttrPair(dataSourceName, "outpost_arn", resourceName, "outpost_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "multi_attach_enabled", resourceName, "multi_attach_enabled"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrThroughput, resourceName, names.AttrThroughput),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrSnapshotID, resourceName, names.AttrSnapshotID),
+					resource.TestCheckResourceAttrPair(dataSourceName, "volume_initialization_rate", resourceName, "volume_initialization_rate"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckEBSVolumeIDDataSource(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -142,5 +172,54 @@ data "aws_ebs_volume" "test" {
     values = [aws_ebs_volume.test.type]
   }
 }
+`, rName))
+}
+
+func testAccEBSVolumeDataSourceConfig_snapshotIdAndVolumeInitializationRate(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
+resource "aws_ebs_volume" "source" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  size              = 10
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ebs_snapshot" "test" {
+  volume_id = aws_ebs_volume.source.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ebs_volume" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  snapshot_id       = aws_ebs_snapshot.test.id
+
+  volume_initialization_rate = 100
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_ebs_volume" "test" {
+  most_recent = true
+
+  filter {
+    name   = "tag:Name"
+    values = [%[1]q]
+  }
+
+  filter {
+    name   = "volume-type"
+    values = [aws_ebs_volume.test.type]
+  }
+}
+
 `, rName))
 }

--- a/internal/service/ec2/ebs_volume_test.go
+++ b/internal/service/ec2/ebs_volume_test.go
@@ -875,6 +875,47 @@ func TestAccEC2EBSVolume_snapshotIDAndSize(t *testing.T) {
 	})
 }
 
+func TestAccEC2EBSVolume_snapshotIDAndVolumeInitializationRate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.Volume
+	resourceName := "aws_ebs_volume.test"
+	snapshotResourceName := "aws_ebs_snapshot.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckVolumeDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEBSVolumeConfig_snapshotIdAndVolumeInitializationRate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVolumeExists(ctx, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "ec2", regexache.MustCompile(`volume/vol-.+`)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, names.AttrIOPS, "100"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrKMSKeyID, ""),
+					resource.TestCheckResourceAttr(resourceName, "multi_attach_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "outpost_arn", ""),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrSnapshotID, snapshotResourceName, names.AttrID),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrThroughput, "0"),
+					resource.TestCheckResourceAttr(resourceName, "volume_initialization_rate", "100"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "gp2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"final_snapshot"},
+			},
+		},
+	})
+}
+
 func TestAccEC2EBSVolume_finalSnapshot(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Volume
@@ -1416,6 +1457,40 @@ resource "aws_ebs_volume" "test" {
   }
 }
 `, rName, size))
+}
+
+func testAccEBSVolumeConfig_snapshotIdAndVolumeInitializationRate(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
+resource "aws_ebs_volume" "source" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  size              = 10
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ebs_snapshot" "test" {
+  volume_id = aws_ebs_volume.source.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ebs_volume" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  snapshot_id       = aws_ebs_snapshot.test.id
+
+  volume_initialization_rate = 100
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
 }
 
 func testAccEBSVolumeConfig_finalSnapshot(rName string) string {

--- a/internal/service/ec2/ebs_volume_test.go
+++ b/internal/service/ec2/ebs_volume_test.go
@@ -916,6 +916,23 @@ func TestAccEC2EBSVolume_snapshotIDAndVolumeInitializationRate(t *testing.T) {
 	})
 }
 
+func TestAccEC2EBSVolume_volumeInitializationRateWithoutSnapshot(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckVolumeDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccEBSVolumeConfig_volumeInitializationRateWithoutSnapshotId,
+				ExpectError: regexache.MustCompile(`'volume_initialization_rate' must not be set unless 'snapshot_id' is set`),
+			},
+		},
+	})
+}
+
 func TestAccEC2EBSVolume_finalSnapshot(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Volume
@@ -1492,6 +1509,16 @@ resource "aws_ebs_volume" "test" {
 }
 `, rName))
 }
+
+var testAccEBSVolumeConfig_volumeInitializationRateWithoutSnapshotId = acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
+resource "aws_ebs_volume" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  type              = "gp2"
+  size              = 1
+
+  volume_initialization_rate = 100
+}
+`)
 
 func testAccEBSVolumeConfig_finalSnapshot(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`

--- a/website/docs/d/ebs_volume.html.markdown
+++ b/website/docs/d/ebs_volume.html.markdown
@@ -59,6 +59,7 @@ This data source exports the following attributes in addition to the arguments a
 * `throughput` - Throughput that the volume supports, in MiB/s.
 * `volume_id` - Volume ID (e.g., vol-59fcb34e).
 * `volume_type` - Type of EBS volume.
+* `volume_initialization_rate` - EBS provisioned rate for volume initialization, in MiB/s, at which to download the snapshot blocks from Amazon S3 to the volume.
 
 ## Timeouts
 

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -40,6 +40,7 @@ This resource supports the following arguments:
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `throughput` - (Optional) Throughput that the volume supports, in MiB/s. Only valid for `type` of `gp3`.
 * `type` - (Optional) Type of EBS volume. Can be `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1` or `st1` (Default: `gp2`).
+* `volume_initialization_rate` - (Optional) EBS provisioned rate for volume initialization, in MiB/s, at which to download the snapshot blocks from Amazon S3 to the volume.
 
 ~> **NOTE:** At least one of `size` or `snapshot_id` is required.
 

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -40,7 +40,7 @@ This resource supports the following arguments:
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `throughput` - (Optional) Throughput that the volume supports, in MiB/s. Only valid for `type` of `gp3`.
 * `type` - (Optional) Type of EBS volume. Can be `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1` or `st1` (Default: `gp2`).
-* `volume_initialization_rate` - (Optional) EBS provisioned rate for volume initialization, in MiB/s, at which to download the snapshot blocks from Amazon S3 to the volume.
+* `volume_initialization_rate` - (Optional) EBS provisioned rate for volume initialization, in MiB/s, at which to download the snapshot blocks from Amazon S3 to the volume. This argument can only be set if `snapshot_id` is specified.
 
 ~> **NOTE:** At least one of `size` or `snapshot_id` is required.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Adds support for the `volume_initialization_rate` argument in the `aws_ebs_volume` resource.
* This attribute is applicable only when creating a volume from a snapshot.

  * Therefore, updating this argument has no effect on the resource.
* `volume_initialization_rate` cannot be specified unless `snapshot_id` is set. (If `volume_initialization_rate` is set without a `snapshot_id`, the AWS API returns a 400 error.)
  To raise this error during the plan phase, a check is added in the `customDiff` function to ensure `snapshot_id` is set when `volume_initialization_rate` is specified.

### Relations
Closes #42518

### References
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVolume.html

### Output from Acceptance Testing
```console
$ make testacc TESTS=TestAccEC2EBSVolume_ PKG=ec2                                                                
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2EBSVolume_'  -timeout 360m -vet=off
2025/07/27 17:46:57 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/27 17:46:57 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEC2EBSVolume_basic
=== PAUSE TestAccEC2EBSVolume_basic
=== RUN   TestAccEC2EBSVolume_disappears
=== PAUSE TestAccEC2EBSVolume_disappears
=== RUN   TestAccEC2EBSVolume_updateAttachedEBSVolume
=== PAUSE TestAccEC2EBSVolume_updateAttachedEBSVolume
=== RUN   TestAccEC2EBSVolume_updateSize
=== PAUSE TestAccEC2EBSVolume_updateSize
=== RUN   TestAccEC2EBSVolume_updateType
=== PAUSE TestAccEC2EBSVolume_updateType
=== RUN   TestAccEC2EBSVolume_UpdateIops_io1
=== PAUSE TestAccEC2EBSVolume_UpdateIops_io1
=== RUN   TestAccEC2EBSVolume_UpdateIops_io2
=== PAUSE TestAccEC2EBSVolume_UpdateIops_io2
=== RUN   TestAccEC2EBSVolume_kmsKey
=== PAUSE TestAccEC2EBSVolume_kmsKey
=== RUN   TestAccEC2EBSVolume_noIops
=== PAUSE TestAccEC2EBSVolume_noIops
=== RUN   TestAccEC2EBSVolume_invalidIopsForType
=== PAUSE TestAccEC2EBSVolume_invalidIopsForType
=== RUN   TestAccEC2EBSVolume_invalidThroughputForType
=== PAUSE TestAccEC2EBSVolume_invalidThroughputForType
=== RUN   TestAccEC2EBSVolume_withTags
=== PAUSE TestAccEC2EBSVolume_withTags
=== RUN   TestAccEC2EBSVolume_multiAttach_io1
=== PAUSE TestAccEC2EBSVolume_multiAttach_io1
=== RUN   TestAccEC2EBSVolume_multiAttach_io2
=== PAUSE TestAccEC2EBSVolume_multiAttach_io2
=== RUN   TestAccEC2EBSVolume_multiAttach_gp2
=== PAUSE TestAccEC2EBSVolume_multiAttach_gp2
=== RUN   TestAccEC2EBSVolume_outpost
=== PAUSE TestAccEC2EBSVolume_outpost
=== RUN   TestAccEC2EBSVolume_GP3_basic
=== PAUSE TestAccEC2EBSVolume_GP3_basic
=== RUN   TestAccEC2EBSVolume_GP3_iops
=== PAUSE TestAccEC2EBSVolume_GP3_iops
=== RUN   TestAccEC2EBSVolume_GP3_throughput
=== PAUSE TestAccEC2EBSVolume_GP3_throughput
=== RUN   TestAccEC2EBSVolume_gp3ToGP2
=== PAUSE TestAccEC2EBSVolume_gp3ToGP2
=== RUN   TestAccEC2EBSVolume_io1ToGP3
=== PAUSE TestAccEC2EBSVolume_io1ToGP3
=== RUN   TestAccEC2EBSVolume_snapshotID
=== PAUSE TestAccEC2EBSVolume_snapshotID
=== RUN   TestAccEC2EBSVolume_snapshotIDAndSize
=== PAUSE TestAccEC2EBSVolume_snapshotIDAndSize
=== RUN   TestAccEC2EBSVolume_snapshotIDAndVolumeInitializationRate
=== PAUSE TestAccEC2EBSVolume_snapshotIDAndVolumeInitializationRate
=== RUN   TestAccEC2EBSVolume_volumeInitializationRateWithoutSnapshot
=== PAUSE TestAccEC2EBSVolume_volumeInitializationRateWithoutSnapshot
=== RUN   TestAccEC2EBSVolume_finalSnapshot
=== PAUSE TestAccEC2EBSVolume_finalSnapshot
=== CONT  TestAccEC2EBSVolume_basic
=== CONT  TestAccEC2EBSVolume_multiAttach_io2
=== CONT  TestAccEC2EBSVolume_io1ToGP3
=== CONT  TestAccEC2EBSVolume_finalSnapshot
=== CONT  TestAccEC2EBSVolume_volumeInitializationRateWithoutSnapshot
=== CONT  TestAccEC2EBSVolume_snapshotIDAndVolumeInitializationRate
=== CONT  TestAccEC2EBSVolume_snapshotIDAndSize
=== CONT  TestAccEC2EBSVolume_snapshotID
=== CONT  TestAccEC2EBSVolume_kmsKey
=== CONT  TestAccEC2EBSVolume_multiAttach_io1
=== CONT  TestAccEC2EBSVolume_withTags
=== CONT  TestAccEC2EBSVolume_invalidThroughputForType
=== CONT  TestAccEC2EBSVolume_invalidIopsForType
=== CONT  TestAccEC2EBSVolume_noIops
=== CONT  TestAccEC2EBSVolume_updateType
=== CONT  TestAccEC2EBSVolume_UpdateIops_io2
=== CONT  TestAccEC2EBSVolume_UpdateIops_io1
=== CONT  TestAccEC2EBSVolume_updateAttachedEBSVolume
=== CONT  TestAccEC2EBSVolume_updateSize
=== CONT  TestAccEC2EBSVolume_GP3_iops
--- PASS: TestAccEC2EBSVolume_volumeInitializationRateWithoutSnapshot (12.10s)
=== CONT  TestAccEC2EBSVolume_gp3ToGP2
--- PASS: TestAccEC2EBSVolume_invalidThroughputForType (12.20s)
=== CONT  TestAccEC2EBSVolume_GP3_throughput
--- PASS: TestAccEC2EBSVolume_invalidIopsForType (12.27s)
=== CONT  TestAccEC2EBSVolume_outpost
    ebs_volume_test.go:502: skipping since no Outposts found
--- SKIP: TestAccEC2EBSVolume_outpost (0.67s)
=== CONT  TestAccEC2EBSVolume_GP3_basic
--- PASS: TestAccEC2EBSVolume_basic (66.94s)
=== CONT  TestAccEC2EBSVolume_multiAttach_gp2
--- PASS: TestAccEC2EBSVolume_multiAttach_gp2 (2.49s)
=== CONT  TestAccEC2EBSVolume_disappears
--- PASS: TestAccEC2EBSVolume_multiAttach_io2 (71.54s)
--- PASS: TestAccEC2EBSVolume_noIops (71.56s)
--- PASS: TestAccEC2EBSVolume_multiAttach_io1 (73.28s)
--- PASS: TestAccEC2EBSVolume_GP3_basic (60.37s)
--- PASS: TestAccEC2EBSVolume_kmsKey (92.83s)
--- PASS: TestAccEC2EBSVolume_updateType (98.38s)
--- PASS: TestAccEC2EBSVolume_updateSize (98.85s)
--- PASS: TestAccEC2EBSVolume_UpdateIops_io2 (98.99s)
--- PASS: TestAccEC2EBSVolume_UpdateIops_io1 (99.41s)
--- PASS: TestAccEC2EBSVolume_GP3_iops (99.60s)
--- PASS: TestAccEC2EBSVolume_GP3_throughput (90.76s)
--- PASS: TestAccEC2EBSVolume_gp3ToGP2 (90.93s)
--- PASS: TestAccEC2EBSVolume_io1ToGP3 (103.18s)
--- PASS: TestAccEC2EBSVolume_withTags (104.94s)
--- PASS: TestAccEC2EBSVolume_disappears (40.49s)
--- PASS: TestAccEC2EBSVolume_snapshotID (119.59s)
--- PASS: TestAccEC2EBSVolume_snapshotIDAndSize (128.47s)
--- PASS: TestAccEC2EBSVolume_finalSnapshot (130.81s)
--- PASS: TestAccEC2EBSVolume_snapshotIDAndVolumeInitializationRate (132.61s)
--- PASS: TestAccEC2EBSVolume_updateAttachedEBSVolume (191.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        195.266s

```
