### PR TITLE
Technical debt: Use `internal/retry` for `tfresource.RetryWhenIsAErrorMessageContains`

### DIFF
--- a/internal/generate/tags/templates/get_tag_body.gtpl
+++ b/internal/generate/tags/templates/get_tag_body.gtpl
@@ -23,8 +23,8 @@ func {{ .GetTagFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{
 	}
 
 	{{ if .RetryTagOps }}
-	output, err := tfresource.RetryGWhenIsAErrorMessageContains[*{{ .AWSService }}.{{ .RetryTagsListTagsType }}, *{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
-		func() (*{{ .AWSService }}.{{ .RetryTagsListTagsType }}, error) {
+	output, err := tfresource.RetryWhenIsAErrorMessageContains[*{{ .AWSService }}.{{ .RetryTagsListTagsType }}, *{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
+		func(ctx context.Context) (*{{ .AWSService }}.{{ .RetryTagsListTagsType }}, error) {
 			return conn.{{ .ListTagsOp }}(ctx, &input, optFns...)
 		},
 		"{{ .RetryErrorMessage }}",

--- a/internal/generate/tags/templates/list_tags_body.gtpl
+++ b/internal/generate/tags/templates/list_tags_body.gtpl
@@ -27,8 +27,8 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 	}
 {{- if .ListTagsOpPaginated }}
     {{- if .RetryTagOps }}
-	output, err := tfresource.RetryGWhenIsAErrorMessageContains[*{{ .AWSService }}.{{ .RetryTagsListTagsType }}, *{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
-		func() (*{{ .AWSService }}.{{ .RetryTagsListTagsType }}, error) {
+	output, err := tfresource.RetryWhenIsAErrorMessageContains[*{{ .AWSService }}.{{ .RetryTagsListTagsType }}, *{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
+		func(ctx context.Context) (*{{ .AWSService }}.{{ .RetryTagsListTagsType }}, error) {
 			var output []awstypes.{{ or .TagType2 .TagType }}
 
 			pages := {{ .AWSService }}.New{{ .ListTagsOp }}Paginator(conn, &input)
@@ -139,8 +139,8 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 {{- else }}
 
     {{ if .RetryTagOps }}
-	output, err := tfresource.RetryGWhenIsAErrorMessageContains[*{{ .AWSService }}.{{ .RetryTagsListTagsType }}, *{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
-		func() (*{{ .AWSService }}.{{ .RetryTagsListTagsType }}, error) {
+	output, err := tfresource.RetryWhenIsAErrorMessageContains[*{{ .AWSService }}.{{ .RetryTagsListTagsType }}, *{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
+		func(ctx context.Context) (*{{ .AWSService }}.{{ .RetryTagsListTagsType }}, error) {
 			return conn.{{ .ListTagsOp }}(ctx, &input, optFns...)
 		},
 		"{{ .RetryErrorMessage }}",

--- a/internal/generate/tags/templates/update_tags_body.gtpl
+++ b/internal/generate/tags/templates/update_tags_body.gtpl
@@ -62,8 +62,8 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 		{{- end }}
 	}
 	{{ if .RetryTagOps }}
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
+		func(ctx context.Context) (any, error) {
 			return conn.{{ .TagOp }}(ctx, &input, optFns...)
 		},
 		"{{ .RetryErrorMessage }}",
@@ -112,8 +112,8 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 			{{- end }}
 		}
 		{{ if .RetryTagOps }}
-		_, err := tfresource.RetryWhenIsAErrorMessageContains[*{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
-			func() (any, error) {
+		_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
+			func(ctx context.Context) (any, error) {
 				return conn.{{ .UntagOp }}(ctx, &input, optFns...)
 			},
 			"{{ .RetryErrorMessage }}",
@@ -161,8 +161,8 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 		}
 
 		{{ if .RetryTagOps }}
-		_, err := tfresource.RetryWhenIsAErrorMessageContains[*{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
-			func() (any, error) {
+		_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
+			func(ctx context.Context) (any, error) {
 				return conn.{{ .TagOp }}(ctx, &input, optFns...)
 			},
 			"{{ .RetryErrorMessage }}",

--- a/internal/generate/tagstests/main.go
+++ b/internal/generate/tagstests/main.go
@@ -732,6 +732,11 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 						d.PreChecks = append(d.PreChecks, codeBlock{
 							Code: "acctest.PreCheckAlternateAccount(t)",
 						})
+						d.GoImports = append(d.GoImports,
+							goImport{
+								Path: "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema",
+							},
+						)
 					}
 				}
 				if attr, ok := args.Keyword["serialize"]; ok {

--- a/internal/service/accessanalyzer/analyzer.go
+++ b/internal/service/accessanalyzer/analyzer.go
@@ -219,8 +219,8 @@ func resourceAnalyzerCreate(ctx context.Context, d *schema.ResourceData, meta an
 	}
 
 	// Handle Organizations eventual consistency.
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*types.ValidationException](ctx, organizationCreationTimeout,
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.ValidationException](ctx, organizationCreationTimeout,
+		func(ctx context.Context) (any, error) {
 			return conn.CreateAnalyzer(ctx, &input)
 		},
 		"You must create an organization",

--- a/internal/service/acmpca/certificate.go
+++ b/internal/service/acmpca/certificate.go
@@ -166,7 +166,7 @@ func resourceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta
 		input.Validity = validity
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidStateException](ctx, certificateAuthorityActiveTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.InvalidStateException](ctx, certificateAuthorityActiveTimeout, func(ctx context.Context) (any, error) {
 		return conn.IssueCertificate(ctx, &input)
 	}, "The certificate authority is not in a valid state for issuing certificates")
 

--- a/internal/service/amplify/app.go
+++ b/internal/service/amplify/app.go
@@ -423,7 +423,7 @@ func resourceAppCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 		input.Repository = aws.String(v.(string))
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.BadRequestException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.BadRequestException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateApp(ctx, &input)
 	}, "role provided cannot be assumed")
 

--- a/internal/service/apprunner/service.go
+++ b/internal/service/apprunner/service.go
@@ -463,7 +463,7 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta any
 		input.ObservabilityConfiguration = expandServiceObservabilityConfiguration(v.([]any))
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidRequestException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.InvalidRequestException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateService(ctx, input)
 	}, "Error in assuming instance role")
 

--- a/internal/service/appstream/image_builder.go
+++ b/internal/service/appstream/image_builder.go
@@ -232,7 +232,7 @@ func resourceImageBuilderCreate(ctx context.Context, d *schema.ResourceData, met
 		input.VpcConfig = expandImageBuilderVPCConfig(v.([]any))
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidRoleException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidRoleException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateImageBuilder(ctx, &input)
 	}, "encountered an error because your IAM role")
 

--- a/internal/service/backup/plan.go
+++ b/internal/service/backup/plan.go
@@ -287,7 +287,7 @@ func resourcePlanDelete(ctx context.Context, d *schema.ResourceData, meta any) d
 	const (
 		timeout = 2 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidRequestException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidRequestException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteBackupPlan(ctx, &backup.DeleteBackupPlanInput{
 			BackupPlanId: aws.String(d.Id()),
 		})

--- a/internal/service/bedrock/model_invocation_logging_configuration.go
+++ b/internal/service/bedrock/model_invocation_logging_configuration.go
@@ -237,8 +237,8 @@ func (r *modelInvocationLoggingConfigurationResource) putModelInvocationLoggingC
 	// Example:
 	//   ValidationException: Failed to validate permissions for log group: <group>, with role: <role>. Verify
 	//   the IAM role permissions are correct.
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.ValidationException](ctx, propagationTimeout,
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ValidationException](ctx, propagationTimeout,
+		func(ctx context.Context) (any, error) {
 			return conn.PutModelInvocationLoggingConfiguration(ctx, input)
 		},
 		"Failed to validate permissions for log group",

--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -415,8 +415,8 @@ func prepareAgent(ctx context.Context, conn *bedrockagent.Client, id string, tim
 		AgentId: aws.String(id),
 	}
 
-	_, err := retryOpIfPreparing[*bedrockagent.PrepareAgentOutput](ctx, timeout,
-		func() (*bedrockagent.PrepareAgentOutput, error) {
+	_, err := retryOpIfPreparing(ctx, timeout,
+		func(ctx context.Context) (*bedrockagent.PrepareAgentOutput, error) {
 			return conn.PrepareAgent(ctx, &input)
 		},
 	)
@@ -514,7 +514,7 @@ func prepareSupervisorToReleaseCollaborator(ctx context.Context, conn *bedrockag
 }
 
 func updateAgentWithRetry(ctx context.Context, conn *bedrockagent.Client, input bedrockagent.UpdateAgentInput, timeout time.Duration) (*bedrockagent.UpdateAgentOutput, error) {
-	return tfresource.RetryGWhen[*bedrockagent.UpdateAgentOutput](ctx, timeout,
+	return tfresource.RetryGWhen(ctx, timeout,
 		func() (*bedrockagent.UpdateAgentOutput, error) {
 			return conn.UpdateAgent(ctx, &input)
 		},
@@ -533,8 +533,8 @@ func updateAgentWithRetry(ctx context.Context, conn *bedrockagent.Client, input 
 // the agent is in a Preparing state
 //
 // Use this to wrap operations which may run concurrently against the same agent.
-func retryOpIfPreparing[T any](ctx context.Context, timeout time.Duration, f func() (T, error)) (T, error) {
-	return tfresource.RetryGWhenIsAErrorMessageContains[T, *awstypes.ValidationException](ctx, timeout, f,
+func retryOpIfPreparing[T any](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error)) (T, error) {
+	return tfresource.RetryWhenIsAErrorMessageContains[T, *awstypes.ValidationException](ctx, timeout, f,
 		"in Preparing state",
 	)
 }

--- a/internal/service/bedrockagent/agent_action_group.go
+++ b/internal/service/bedrockagent/agent_action_group.go
@@ -257,7 +257,7 @@ func (r *agentActionGroupResource) Create(ctx context.Context, request resource.
 
 	timeout := r.CreateTimeout(ctx, data.Timeouts)
 
-	output, err := retryOpIfPreparing[*bedrockagent.CreateAgentActionGroupOutput](ctx, timeout, func() (*bedrockagent.CreateAgentActionGroupOutput, error) {
+	output, err := retryOpIfPreparing(ctx, timeout, func(ctx context.Context) (*bedrockagent.CreateAgentActionGroupOutput, error) {
 		return conn.CreateAgentActionGroup(ctx, input)
 	})
 
@@ -284,7 +284,7 @@ func (r *agentActionGroupResource) Create(ctx context.Context, request resource.
 	}
 
 	if output.AgentActionGroup.ParentActionSignature != "" {
-		data.ParentActionGroupSignature = fwtypes.StringEnumValue[awstypes.ActionGroupSignature](output.AgentActionGroup.ParentActionSignature)
+		data.ParentActionGroupSignature = fwtypes.StringEnumValue(output.AgentActionGroup.ParentActionSignature)
 	}
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
@@ -325,7 +325,7 @@ func (r *agentActionGroupResource) Read(ctx context.Context, request resource.Re
 	}
 
 	if output.ParentActionSignature != "" {
-		data.ParentActionGroupSignature = fwtypes.StringEnumValue[awstypes.ActionGroupSignature](output.ParentActionSignature)
+		data.ParentActionGroupSignature = fwtypes.StringEnumValue(output.ParentActionSignature)
 	}
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
@@ -358,7 +358,7 @@ func (r *agentActionGroupResource) Update(ctx context.Context, request resource.
 			return
 		}
 
-		_, err := retryOpIfPreparing[*bedrockagent.UpdateAgentActionGroupOutput](ctx, timeout, func() (*bedrockagent.UpdateAgentActionGroupOutput, error) {
+		_, err := retryOpIfPreparing(ctx, timeout, func(ctx context.Context) (*bedrockagent.UpdateAgentActionGroupOutput, error) {
 			return conn.UpdateAgentActionGroup(ctx, input)
 		})
 
@@ -384,7 +384,7 @@ func (r *agentActionGroupResource) Update(ctx context.Context, request resource.
 
 	new.ActionGroupState = fwtypes.StringEnumValue(output.ActionGroupState)
 	if output.ParentActionSignature != "" {
-		new.ParentActionGroupSignature = fwtypes.StringEnumValue[awstypes.ActionGroupSignature](output.ParentActionSignature)
+		new.ParentActionGroupSignature = fwtypes.StringEnumValue(output.ParentActionSignature)
 	}
 	response.Diagnostics.Append(response.State.Set(ctx, &new)...)
 }
@@ -407,7 +407,7 @@ func (r *agentActionGroupResource) Delete(ctx context.Context, request resource.
 
 	timeout := r.DeleteTimeout(ctx, data.Timeouts)
 
-	_, err := retryOpIfPreparing[*bedrockagent.DeleteAgentActionGroupOutput](ctx, timeout, func() (*bedrockagent.DeleteAgentActionGroupOutput, error) {
+	_, err := retryOpIfPreparing(ctx, timeout, func(ctx context.Context) (*bedrockagent.DeleteAgentActionGroupOutput, error) {
 		return conn.DeleteAgentActionGroup(ctx, &input)
 	})
 

--- a/internal/service/bedrockagent/agent_collaborator.go
+++ b/internal/service/bedrockagent/agent_collaborator.go
@@ -147,8 +147,8 @@ func (r *agentCollaboratorResource) Create(ctx context.Context, request resource
 	}
 
 	timeout := r.CreateTimeout(ctx, data.Timeouts)
-	output, err := retryOpIfPreparing[*bedrockagent.AssociateAgentCollaboratorOutput](ctx, timeout,
-		func() (*bedrockagent.AssociateAgentCollaboratorOutput, error) {
+	output, err := retryOpIfPreparing(ctx, timeout,
+		func(ctx context.Context) (*bedrockagent.AssociateAgentCollaboratorOutput, error) {
 			return conn.AssociateAgentCollaborator(ctx, &input)
 		},
 	)
@@ -246,8 +246,8 @@ func (r *agentCollaboratorResource) Update(ctx context.Context, request resource
 		}
 
 		timeout := r.UpdateTimeout(ctx, new.Timeouts)
-		_, err := retryOpIfPreparing[*bedrockagent.UpdateAgentCollaboratorOutput](ctx, timeout,
-			func() (*bedrockagent.UpdateAgentCollaboratorOutput, error) {
+		_, err := retryOpIfPreparing(ctx, timeout,
+			func(ctx context.Context) (*bedrockagent.UpdateAgentCollaboratorOutput, error) {
 				return conn.UpdateAgentCollaborator(ctx, &input)
 			},
 		)
@@ -284,8 +284,8 @@ func (r *agentCollaboratorResource) Delete(ctx context.Context, request resource
 	}
 
 	timeout := r.DeleteTimeout(ctx, data.Timeouts)
-	_, err := retryOpIfPreparing[*bedrockagent.DisassociateAgentCollaboratorOutput](ctx, timeout,
-		func() (*bedrockagent.DisassociateAgentCollaboratorOutput, error) {
+	_, err := retryOpIfPreparing(ctx, timeout,
+		func(ctx context.Context) (*bedrockagent.DisassociateAgentCollaboratorOutput, error) {
 			return conn.DisassociateAgentCollaborator(ctx, &input)
 		},
 	)

--- a/internal/service/bedrockagent/agent_knowledge_base_association.go
+++ b/internal/service/bedrockagent/agent_knowledge_base_association.go
@@ -112,8 +112,8 @@ func (r *agentKnowledgeBaseAssociationResource) Create(ctx context.Context, requ
 
 	timeout := r.CreateTimeout(ctx, data.Timeouts)
 
-	_, err := retryOpIfPreparing[*bedrockagent.AssociateAgentKnowledgeBaseOutput](ctx, timeout,
-		func() (*bedrockagent.AssociateAgentKnowledgeBaseOutput, error) {
+	_, err := retryOpIfPreparing(ctx, timeout,
+		func(ctx context.Context) (*bedrockagent.AssociateAgentKnowledgeBaseOutput, error) {
 			return conn.AssociateAgentKnowledgeBase(ctx, input)
 		})
 
@@ -199,8 +199,8 @@ func (r *agentKnowledgeBaseAssociationResource) Update(ctx context.Context, requ
 
 	timeout := r.UpdateTimeout(ctx, new.Timeouts)
 
-	_, err := retryOpIfPreparing[*bedrockagent.UpdateAgentKnowledgeBaseOutput](ctx, timeout,
-		func() (*bedrockagent.UpdateAgentKnowledgeBaseOutput, error) {
+	_, err := retryOpIfPreparing(ctx, timeout,
+		func(ctx context.Context) (*bedrockagent.UpdateAgentKnowledgeBaseOutput, error) {
 			return conn.UpdateAgentKnowledgeBase(ctx, input)
 		})
 
@@ -235,8 +235,8 @@ func (r *agentKnowledgeBaseAssociationResource) Delete(ctx context.Context, requ
 
 	timeout := r.DeleteTimeout(ctx, data.Timeouts)
 
-	_, err := retryOpIfPreparing[*bedrockagent.DisassociateAgentKnowledgeBaseOutput](ctx, timeout,
-		func() (*bedrockagent.DisassociateAgentKnowledgeBaseOutput, error) {
+	_, err := retryOpIfPreparing(ctx, timeout,
+		func(ctx context.Context) (*bedrockagent.DisassociateAgentKnowledgeBaseOutput, error) {
 			return conn.DisassociateAgentKnowledgeBase(ctx, &input)
 		})
 

--- a/internal/service/cloud9/environment_ec2.go
+++ b/internal/service/cloud9/environment_ec2.go
@@ -142,7 +142,7 @@ func resourceEnvironmentEC2Create(ctx context.Context, d *schema.ResourceData, m
 		input.SubnetId = aws.String(v.(string))
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.NotFoundException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.NotFoundException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateEnvironmentEC2(ctx, input)
 	}, "User")
 

--- a/internal/service/codeartifact/domain.go
+++ b/internal/service/codeartifact/domain.go
@@ -96,7 +96,7 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		input.EncryptionKey = aws.String(v.(string))
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.ValidationException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.ValidationException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateDomain(ctx, input)
 	}, "KMS key not found")
 

--- a/internal/service/codebuild/fleet.go
+++ b/internal/service/codebuild/fleet.go
@@ -262,7 +262,7 @@ func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	// InvalidInputException: CodeBuild is not authorized to perform
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidInputException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.InvalidInputException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateFleet(ctx, input)
 	}, "ot authorized to perform")
 
@@ -398,7 +398,7 @@ func resourceFleetUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 
 	input.Tags = getTagsIn(ctx)
 
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidInputException](ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.InvalidInputException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.UpdateFleet(ctx, input)
 	}, "ot authorized to perform")
 

--- a/internal/service/codebuild/project.go
+++ b/internal/service/codebuild/project.go
@@ -882,7 +882,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta any
 
 	// InvalidInputException: CodeBuild is not authorized to perform
 	// InvalidInputException: Not authorized to perform DescribeSecurityGroups
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidInputException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.InvalidInputException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateProject(ctx, input)
 	}, "ot authorized to perform")
 
@@ -1146,7 +1146,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		// But its a slice of pointers so if not set for every update, they get removed.
 		input.Tags = getTagsIn(ctx)
 
-		_, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidInputException](ctx, propagationTimeout, func() (any, error) {
+		_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.InvalidInputException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 			return conn.UpdateProject(ctx, input)
 		}, "ot authorized to perform")
 

--- a/internal/service/codepipeline/codepipeline.go
+++ b/internal/service/codepipeline/codepipeline.go
@@ -653,7 +653,7 @@ func resourcePipelineCreate(ctx context.Context, d *schema.ResourceData, meta an
 		Tags:     getTagsIn(ctx),
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidStructureException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.InvalidStructureException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreatePipeline(ctx, input)
 	}, "not authorized")
 

--- a/internal/service/configservice/delivery_channel.go
+++ b/internal/service/configservice/delivery_channel.go
@@ -165,7 +165,7 @@ func resourceDeliveryChannelDelete(ctx context.Context, d *schema.ResourceData, 
 		timeout = 30 * time.Second
 	)
 	log.Printf("[DEBUG] Deleting ConfigService Delivery Channel: %s", d.Id())
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*types.LastDeliveryChannelDeleteFailedException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.LastDeliveryChannelDeleteFailedException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteDeliveryChannel(ctx, &configservice.DeleteDeliveryChannelInput{
 			DeliveryChannelName: aws.String(d.Id()),
 		})

--- a/internal/service/datasync/agent.go
+++ b/internal/service/datasync/agent.go
@@ -283,7 +283,7 @@ func resourceAgentDelete(ctx context.Context, d *schema.ResourceData, meta any) 
 	const (
 		timeout = 2 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidRequestException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidRequestException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteAgent(ctx, &input)
 	}, "in-use by these location(s)")
 

--- a/internal/service/directconnect/connection_association.go
+++ b/internal/service/directconnect/connection_association.go
@@ -106,8 +106,8 @@ func deleteConnectionLAGAssociation(ctx context.Context, conn *directconnect.Cli
 	const (
 		timeout = 1 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.DirectConnectClientException](ctx, timeout,
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.DirectConnectClientException](ctx, timeout,
+		func(ctx context.Context) (any, error) {
 			return conn.DisassociateConnectionFromLag(ctx, input)
 		}, "is in a transitioning state")
 

--- a/internal/service/docdb/global_cluster.go
+++ b/internal/service/docdb/global_cluster.go
@@ -291,7 +291,7 @@ func resourceGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, me
 
 	log.Printf("[DEBUG] Deleting DocumentDB Global Cluster: %s", d.Id())
 
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidGlobalClusterStateFault](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidGlobalClusterStateFault](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteGlobalCluster(ctx, &docdb.DeleteGlobalClusterInput{
 			GlobalClusterIdentifier: aws.String(d.Id()),
 		})

--- a/internal/service/ds/directory.go
+++ b/internal/service/ds/directory.go
@@ -367,7 +367,7 @@ func resourceDirectoryDelete(ctx context.Context, d *schema.ResourceData, meta a
 	conn := meta.(*conns.AWSClient).DSClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Directory Service Directory: %s", d.Id())
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.ClientException](ctx, directoryApplicationDeauthorizedPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ClientException](ctx, directoryApplicationDeauthorizedPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteDirectory(ctx, &directoryservice.DeleteDirectoryInput{
 			DirectoryId: aws.String(d.Id()),
 		})

--- a/internal/service/ds/shared_directory_accepter.go
+++ b/internal/service/ds/shared_directory_accepter.go
@@ -118,7 +118,7 @@ func resourceSharedDirectoryAccepterDelete(ctx context.Context, d *schema.Resour
 	conn := meta.(*conns.AWSClient).DSClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Directory Service Shared Directory Accepter: %s", d.Id())
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.ClientException](ctx, directoryApplicationDeauthorizedPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ClientException](ctx, directoryApplicationDeauthorizedPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteDirectory(ctx, &directoryservice.DeleteDirectoryInput{
 			DirectoryId: aws.String(d.Id()),
 		})

--- a/internal/service/ecr/repository_policy.go
+++ b/internal/service/ecr/repository_policy.go
@@ -65,7 +65,7 @@ func resourceRepositoryPolicyPut(ctx context.Context, d *schema.ResourceData, me
 		RepositoryName: aws.String(repositoryName),
 	}
 
-	_, err = tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidParameterException](ctx, propagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryWhenIsAErrorMessageContains[any, *types.InvalidParameterException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.SetRepositoryPolicy(ctx, input)
 	}, "Principal not found")
 

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -343,7 +343,7 @@ func resourceClusterImport(ctx context.Context, d *schema.ResourceData, meta any
 }
 
 func retryClusterCreate(ctx context.Context, conn *ecs.Client, input *ecs.CreateClusterInput) (*ecs.CreateClusterOutput, error) {
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidParameterException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidParameterException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateCluster(ctx, input)
 	}, "Unable to assume the service linked role")
 

--- a/internal/service/efs/file_system_policy.go
+++ b/internal/service/efs/file_system_policy.go
@@ -67,7 +67,7 @@ func resourceFileSystemPolicyPut(ctx context.Context, d *schema.ResourceData, me
 		Policy:                         aws.String(policy),
 	}
 
-	_, err = tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidPolicyException](ctx, propagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidPolicyException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutFileSystemPolicy(ctx, input)
 	}, "Policy contains invalid Principal block")
 

--- a/internal/service/eks/access_entry.go
+++ b/internal/service/eks/access_entry.go
@@ -118,7 +118,7 @@ func resourceAccessEntryCreate(ctx context.Context, d *schema.ResourceData, meta
 		input.Username = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidParameterException](ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.InvalidParameterException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateAccessEntry(ctx, input)
 	}, "The specified principalArn is invalid: invalid principal")
 

--- a/internal/service/eks/access_policy_association.go
+++ b/internal/service/eks/access_policy_association.go
@@ -112,7 +112,7 @@ func resourceAccessPolicyAssociationCreate(ctx context.Context, d *schema.Resour
 		PrincipalArn: aws.String(principalARN),
 	}
 
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*types.ResourceNotFoundException](ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.ResourceNotFoundException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.AssociateAccessPolicy(ctx, input)
 	}, "The specified principalArn could not be found")
 

--- a/internal/service/eks/fargate_profile.go
+++ b/internal/service/eks/fargate_profile.go
@@ -131,7 +131,7 @@ func resourceFargateProfileCreate(ctx context.Context, d *schema.ResourceData, m
 
 	// Retry for IAM eventual consistency on error:
 	// InvalidParameterException: Misconfigured PodExecutionRole Trust Policy; Please add the eks-fargate-pods.amazonaws.com Service Principal
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidParameterException](ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.InvalidParameterException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateFargateProfile(ctx, input)
 	}, "Misconfigured PodExecutionRole Trust Policy")
 

--- a/internal/service/eks/pod_identity_association.go
+++ b/internal/service/eks/pod_identity_association.go
@@ -133,7 +133,7 @@ func (r *podIdentityAssociationResource) Create(ctx context.Context, request res
 	input.ClientRequestToken = aws.String(sdkid.UniqueId())
 	input.Tags = getTagsIn(ctx)
 
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidParameterException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidParameterException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreatePodIdentityAssociation(ctx, &input)
 	}, "Role provided in the request does not exist")
 
@@ -213,7 +213,7 @@ func (r *podIdentityAssociationResource) Update(ctx context.Context, request res
 		// Set values for unknowns.
 		input.ClientRequestToken = aws.String(sdkid.UniqueId())
 
-		outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidParameterException](ctx, propagationTimeout, func() (any, error) {
+		outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidParameterException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 			return conn.UpdatePodIdentityAssociation(ctx, &input)
 		}, "Role provided in the request does not exist")
 

--- a/internal/service/elasticache/tags_gen.go
+++ b/internal/service/elasticache/tags_gen.go
@@ -26,8 +26,8 @@ func listTags(ctx context.Context, conn *elasticache.Client, identifier string, 
 		ResourceName: aws.String(identifier),
 	}
 
-	output, err := tfresource.RetryGWhenIsAErrorMessageContains[*elasticache.ListTagsForResourceOutput, *awstypes.InvalidReplicationGroupStateFault](ctx, 15*time.Minute,
-		func() (*elasticache.ListTagsForResourceOutput, error) {
+	output, err := tfresource.RetryWhenIsAErrorMessageContains[*elasticache.ListTagsForResourceOutput, *awstypes.InvalidReplicationGroupStateFault](ctx, 15*time.Minute,
+		func(ctx context.Context) (*elasticache.ListTagsForResourceOutput, error) {
 			return conn.ListTagsForResource(ctx, &input, optFns...)
 		},
 		"not in available state",

--- a/internal/service/elasticache/tags_gen.go
+++ b/internal/service/elasticache/tags_gen.go
@@ -130,8 +130,8 @@ func updateTags(ctx context.Context, conn *elasticache.Client, identifier string
 			TagKeys:      removedTags.Keys(),
 		}
 
-		_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidReplicationGroupStateFault](ctx, 15*time.Minute,
-			func() (any, error) {
+		_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidReplicationGroupStateFault](ctx, 15*time.Minute,
+			func(ctx context.Context) (any, error) {
 				return conn.RemoveTagsFromResource(ctx, &input, optFns...)
 			},
 			"not in available state",
@@ -150,8 +150,8 @@ func updateTags(ctx context.Context, conn *elasticache.Client, identifier string
 			Tags:         svcTags(updatedTags),
 		}
 
-		_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidReplicationGroupStateFault](ctx, 15*time.Minute,
-			func() (any, error) {
+		_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidReplicationGroupStateFault](ctx, 15*time.Minute,
+			func(ctx context.Context) (any, error) {
 				return conn.AddTagsToResource(ctx, &input, optFns...)
 			},
 			"not in available state",

--- a/internal/service/elasticsearch/domain_policy.go
+++ b/internal/service/elasticsearch/domain_policy.go
@@ -71,8 +71,8 @@ func resourceDomainPolicyUpsert(ctx context.Context, d *schema.ResourceData, met
 		DomainName:     aws.String(domainName),
 	}
 
-	_, err = tfresource.RetryWhenIsAErrorMessageContains[*awstypes.ValidationException](ctx, propagationTimeout,
-		func() (any, error) {
+	_, err = tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ValidationException](ctx, propagationTimeout,
+		func(ctx context.Context) (any, error) {
 			return conn.UpdateElasticsearchDomainConfig(ctx, input)
 		}, "A change/update is in progress")
 

--- a/internal/service/elasticsearch/domain_saml_options.go
+++ b/internal/service/elasticsearch/domain_saml_options.go
@@ -120,8 +120,8 @@ func resourceDomainSAMLOptionsPut(ctx context.Context, d *schema.ResourceData, m
 		DomainName: aws.String(domainName),
 	}
 
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.ValidationException](ctx, propagationTimeout,
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ValidationException](ctx, propagationTimeout,
+		func(ctx context.Context) (any, error) {
 			return conn.UpdateElasticsearchDomainConfig(ctx, input)
 		}, "A change/update is in progress")
 

--- a/internal/service/elb/load_balancer.go
+++ b/internal/service/elb/load_balancer.go
@@ -699,7 +699,7 @@ func resourceLoadBalancerUpdate(ctx context.Context, d *schema.ResourceData, met
 				Subnets:          add,
 			}
 
-			_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidConfigurationRequestException](ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+			_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidConfigurationRequestException](ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 				return conn.AttachLoadBalancerToSubnets(ctx, input)
 			}, "cannot be attached to multiple subnets in the same AZ")
 

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -773,7 +773,7 @@ func resourceTargetGroupDelete(ctx context.Context, d *schema.ResourceData, meta
 	const (
 		timeout = 2 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.ResourceInUseException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ResourceInUseException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteTargetGroup(ctx, &elasticloadbalancingv2.DeleteTargetGroupInput{
 			TargetGroupArn: aws.String(d.Id()),
 		})

--- a/internal/service/elbv2/trust_store.go
+++ b/internal/service/elbv2/trust_store.go
@@ -220,7 +220,7 @@ func resourceTrustStoreDelete(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	log.Printf("[DEBUG] Deleting ELBv2 Trust Store: %s", d.Id())
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.TrustStoreInUseException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.TrustStoreInUseException](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteTrustStore(ctx, &elasticloadbalancingv2.DeleteTrustStoreInput{
 			TrustStoreArn: aws.String(d.Id()),
 		})

--- a/internal/service/gamelift/fleet.go
+++ b/internal/service/gamelift/fleet.go
@@ -298,7 +298,7 @@ func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 		input.ScriptId = aws.String(v.(string))
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidRequestException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidRequestException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateFleet(ctx, input)
 	}, "GameLift is not authorized to perform")
 
@@ -435,7 +435,7 @@ func resourceFleetDelete(ctx context.Context, d *schema.ResourceData, meta any) 
 	const (
 		timeout = 60 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidRequestException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidRequestException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteFleet(ctx, &gamelift.DeleteFleetInput{
 			FleetId: aws.String(d.Id()),
 		})

--- a/internal/service/gamelift/game_server_group.go
+++ b/internal/service/gamelift/game_server_group.go
@@ -223,7 +223,7 @@ func resourceGameServerGroupCreate(ctx context.Context, d *schema.ResourceData, 
 		input.VpcSubnets = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidRequestException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidRequestException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateGameServerGroup(ctx, input)
 	}, "GameLift is not authorized to perform")
 
@@ -339,7 +339,7 @@ func resourceGameServerGroupDelete(ctx context.Context, d *schema.ResourceData, 
 	const (
 		timeout = 10 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidRequestException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidRequestException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteGameServerGroup(ctx, &gamelift.DeleteGameServerGroupInput{
 			GameServerGroupName: aws.String(d.Id()),
 		})

--- a/internal/service/glue/ml_transform.go
+++ b/internal/service/glue/ml_transform.go
@@ -227,7 +227,7 @@ func resourceMLTransformCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	log.Printf("[DEBUG] Creating Glue ML Transform: %+v", input)
 
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidInputException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidInputException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateMLTransform(ctx, input)
 	}, "Unable to assume role")
 

--- a/internal/service/guardduty/detector.go
+++ b/internal/service/guardduty/detector.go
@@ -247,7 +247,7 @@ func resourceDetectorDelete(ctx context.Context, d *schema.ResourceData, meta an
 	conn := meta.(*conns.AWSClient).GuardDutyClient(ctx)
 
 	log.Printf("[DEBUG] Deleting GuardDuty Detector: %s", d.Id())
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.BadRequestException](ctx, membershipPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.BadRequestException](ctx, membershipPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteDetector(ctx, &guardduty.DeleteDetectorInput{
 			DetectorId: aws.String(d.Id()),
 		})

--- a/internal/service/iam/server_certificate.go
+++ b/internal/service/iam/server_certificate.go
@@ -255,7 +255,7 @@ func resourceServerCertificateDelete(ctx context.Context, d *schema.ResourceData
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
 	log.Printf("[DEBUG] Deleting IAM Server Certificate: %s", d.Id())
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.DeleteConflictException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.DeleteConflictException](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteServerCertificate(ctx, &iam.DeleteServerCertificateInput{
 			ServerCertificateName: aws.String(d.Get(names.AttrName).(string)),
 		})

--- a/internal/service/keyspaces/keyspace.go
+++ b/internal/service/keyspaces/keyspace.go
@@ -169,8 +169,8 @@ func resourceKeyspaceDelete(ctx context.Context, d *schema.ResourceData, meta an
 	conn := meta.(*conns.AWSClient).KeyspacesClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Keyspaces Keyspace: (%s)", d.Id())
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*types.ConflictException](ctx, d.Timeout(schema.TimeoutDelete),
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.ConflictException](ctx, d.Timeout(schema.TimeoutDelete),
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteKeyspace(ctx, &keyspaces.DeleteKeyspaceInput{
 				KeyspaceName: aws.String(d.Id()),
 			})

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -1026,7 +1026,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta an
 			FunctionName: aws.String(d.Id()),
 		}
 
-		outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.ResourceConflictException](ctx, lambdaPropagationTimeout, func() (any, error) {
+		outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ResourceConflictException](ctx, lambdaPropagationTimeout, func(ctx context.Context) (any, error) {
 			return conn.PublishVersion(ctx, &input)
 		}, "in progress")
 
@@ -1063,7 +1063,7 @@ func resourceFunctionDelete(ctx context.Context, d *schema.ResourceData, meta an
 	input := lambda.DeleteFunctionInput{
 		FunctionName: aws.String(d.Id()),
 	}
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidParameterValueException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidParameterValueException](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteFunction(ctx, &input)
 	}, "because it is a replicated function")
 

--- a/internal/service/logs/group.go
+++ b/internal/service/logs/group.go
@@ -243,7 +243,7 @@ func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) 
 	input := cloudwatchlogs.DeleteLogGroupInput{
 		LogGroupName: aws.String(d.Id()),
 	}
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.OperationAbortedException](ctx, 1*time.Minute, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.OperationAbortedException](ctx, 1*time.Minute, func(ctx context.Context) (any, error) {
 		return conn.DeleteLogGroup(ctx, &input)
 	}, "try again")
 

--- a/internal/service/m2/application.go
+++ b/internal/service/m2/application.go
@@ -157,7 +157,7 @@ func (r *applicationResource) Create(ctx context.Context, request resource.Creat
 	input.ClientToken = aws.String(sdkid.UniqueId())
 	input.Tags = getTagsIn(ctx)
 
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.AccessDeniedException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.AccessDeniedException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateApplication(ctx, &input)
 	}, "does not have proper Trust Policy for M2 service")
 

--- a/internal/service/memorydb/parameter_group.go
+++ b/internal/service/memorydb/parameter_group.go
@@ -186,7 +186,7 @@ func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 			const (
 				timeout = 30 * time.Second
 			)
-			_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidParameterGroupStateFault](ctx, timeout, func() (any, error) {
+			_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidParameterGroupStateFault](ctx, timeout, func(ctx context.Context) (any, error) {
 				return conn.ResetParameterGroup(ctx, input)
 			}, " has pending changes")
 

--- a/internal/service/neptune/cluster.go
+++ b/internal/service/neptune/cluster.go
@@ -823,7 +823,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	log.Printf("[DEBUG] Deleting Neptune Cluster: %s", d.Id())
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidDBClusterStateFault](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidDBClusterStateFault](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteDBCluster(ctx, input)
 	}, "is not currently in the available state")
 

--- a/internal/service/neptune/global_cluster.go
+++ b/internal/service/neptune/global_cluster.go
@@ -262,7 +262,7 @@ func resourceGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	log.Printf("[DEBUG] Deleting Neptune Global Cluster: %s", d.Id())
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidGlobalClusterStateFault](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidGlobalClusterStateFault](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteGlobalCluster(ctx, &neptune.DeleteGlobalClusterInput{
 			GlobalClusterIdentifier: aws.String(d.Id()),
 		})

--- a/internal/service/neptune/parameter_group.go
+++ b/internal/service/neptune/parameter_group.go
@@ -246,7 +246,7 @@ func delDBParameterGroupParameters(ctx context.Context, conn *neptune.Client, na
 			Parameters:           chunk,
 		}
 
-		_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidDBParameterGroupStateFault](ctx, dbParameterGroupParametersDeleteRetryTimeout, func() (any, error) {
+		_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidDBParameterGroupStateFault](ctx, dbParameterGroupParametersDeleteRetryTimeout, func(ctx context.Context) (any, error) {
 			return conn.ResetDBParameterGroup(ctx, input)
 		}, "has pending changes")
 

--- a/internal/service/networkfirewall/firewall_policy.go
+++ b/internal/service/networkfirewall/firewall_policy.go
@@ -336,7 +336,7 @@ func resourceFirewallPolicyDelete(ctx context.Context, d *schema.ResourceData, m
 	const (
 		timeout = 10 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidOperationException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidOperationException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteFirewallPolicy(ctx, &networkfirewall.DeleteFirewallPolicyInput{
 			FirewallPolicyArn: aws.String(d.Id()),
 		})

--- a/internal/service/networkfirewall/resource_policy.go
+++ b/internal/service/networkfirewall/resource_policy.go
@@ -111,7 +111,7 @@ func resourceResourcePolicyDelete(ctx context.Context, d *schema.ResourceData, m
 	const (
 		timeout = 2 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidResourcePolicyException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidResourcePolicyException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteResourcePolicy(ctx, &networkfirewall.DeleteResourcePolicyInput{
 			ResourceArn: aws.String(d.Id()),
 		})

--- a/internal/service/networkfirewall/rule_group.go
+++ b/internal/service/networkfirewall/rule_group.go
@@ -597,7 +597,7 @@ func resourceRuleGroupDelete(ctx context.Context, d *schema.ResourceData, meta a
 	const (
 		timeout = 10 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidOperationException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidOperationException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteRuleGroup(ctx, &networkfirewall.DeleteRuleGroupInput{
 			RuleGroupArn: aws.String(d.Id()),
 		})

--- a/internal/service/networkmanager/vpc_attachment.go
+++ b/internal/service/networkmanager/vpc_attachment.go
@@ -310,7 +310,7 @@ func resourceVPCAttachmentDelete(ctx context.Context, d *schema.ResourceData, me
 	const (
 		timeout = 5 * time.Minute
 	)
-	_, err = tfresource.RetryWhenIsAErrorMessageContains[*awstypes.ValidationException](ctx, timeout, func() (any, error) {
+	_, err = tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ValidationException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteAttachment(ctx, &networkmanager.DeleteAttachmentInput{
 			AttachmentId: aws.String(d.Id()),
 		})

--- a/internal/service/opensearch/domain_policy.go
+++ b/internal/service/opensearch/domain_policy.go
@@ -92,8 +92,8 @@ func resourceDomainPolicyUpsert(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "policy (%s) is invalid JSON: %s", policy, err)
 	}
 
-	_, err = tfresource.RetryWhenIsAErrorMessageContains[*awstypes.ValidationException](ctx, propagationTimeout,
-		func() (any, error) {
+	_, err = tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ValidationException](ctx, propagationTimeout,
+		func(ctx context.Context) (any, error) {
 			return conn.UpdateDomainConfig(ctx, &opensearch.UpdateDomainConfigInput{
 				DomainName:     aws.String(domainName),
 				AccessPolicies: aws.String(policy),

--- a/internal/service/opensearch/domain_saml_options.go
+++ b/internal/service/opensearch/domain_saml_options.go
@@ -155,7 +155,7 @@ func resourceDomainSAMLOptionsPut(ctx context.Context, d *schema.ResourceData, m
 
 	log.Printf("[DEBUG] Updating OpenSearch domain SAML Options %#v", config)
 
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.ValidationException](ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ValidationException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.UpdateDomainConfig(ctx, &opensearch.UpdateDomainConfigInput{
 			DomainName:              aws.String(domainName),
 			AdvancedSecurityOptions: &config,
@@ -182,7 +182,7 @@ func resourceDomainSAMLOptionsDelete(ctx context.Context, d *schema.ResourceData
 	domainName := d.Get(names.AttrDomainName).(string)
 	config := awstypes.AdvancedSecurityOptionsInput{}
 
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.ValidationException](ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ValidationException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.UpdateDomainConfig(ctx, &opensearch.UpdateDomainConfigInput{
 			DomainName:              aws.String(domainName),
 			AdvancedSecurityOptions: &config,

--- a/internal/service/pinpoint/event_stream.go
+++ b/internal/service/pinpoint/event_stream.go
@@ -69,7 +69,7 @@ func resourceEventStreamUpsert(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	// Retry for IAM eventual consistency
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.BadRequestException](ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.BadRequestException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutEventStream(ctx, &req)
 	}, "make sure the IAM Role is configured correctly")
 

--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -540,8 +540,8 @@ func resourceClusterInstanceDelete(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	log.Printf("[DEBUG] Deleting RDS Cluster Instance: %s", d.Id())
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidDBClusterStateFault](ctx, d.Timeout(schema.TimeoutDelete),
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.InvalidDBClusterStateFault](ctx, d.Timeout(schema.TimeoutDelete),
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteDBInstance(ctx, input)
 		},
 		"Delete the replica cluster before deleting")

--- a/internal/service/rds/cluster_parameter_group.go
+++ b/internal/service/rds/cluster_parameter_group.go
@@ -243,7 +243,7 @@ func resourceClusterParameterGroupUpdate(ctx context.Context, d *schema.Resource
 			const (
 				timeout = 3 * time.Minute
 			)
-			_, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidDBParameterGroupStateFault](ctx, timeout, func() (any, error) {
+			_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.InvalidDBParameterGroupStateFault](ctx, timeout, func(ctx context.Context) (any, error) {
 				return conn.ResetDBClusterParameterGroup(ctx, &input)
 			}, "has pending changes")
 

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -363,7 +363,7 @@ func resourceGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, me
 		globalClusterClusterDeleteTimeout = 5 * time.Minute
 	)
 	timeout := max(deadline.Remaining(), globalClusterClusterDeleteTimeout)
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidGlobalClusterStateFault](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.InvalidGlobalClusterStateFault](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteGlobalCluster(ctx, &rds.DeleteGlobalClusterInput{
 			GlobalClusterIdentifier: aws.String(d.Id()),
 		})

--- a/internal/service/rds/proxy_target.go
+++ b/internal/service/rds/proxy_target.go
@@ -118,8 +118,8 @@ func resourceProxyTargetCreate(ctx context.Context, d *schema.ResourceData, meta
 	const (
 		timeout = 5 * time.Minute
 	)
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidDBInstanceStateFault](ctx, timeout,
-		func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.InvalidDBInstanceStateFault](ctx, timeout,
+		func(ctx context.Context) (any, error) {
 			return conn.RegisterDBProxyTargets(ctx, input)
 		},
 		"CREATING")

--- a/internal/service/redshift/logging.go
+++ b/internal/service/redshift/logging.go
@@ -94,8 +94,8 @@ func (r *loggingResource) Create(ctx context.Context, req resource.CreateRequest
 
 	// Retry InvalidClusterState faults, which can occur when logging is enabled
 	// immediately after being disabled (ie. resource replacement).
-	out, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidClusterStateFault](ctx, propagationTimeout,
-		func() (any, error) {
+	out, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidClusterStateFault](ctx, propagationTimeout,
+		func(ctx context.Context) (any, error) {
 			return conn.EnableLogging(ctx, in)
 		},
 		"There is an operation running on the Cluster",
@@ -171,8 +171,8 @@ func (r *loggingResource) Update(ctx context.Context, req resource.UpdateRequest
 
 		// Retry InvalidClusterState faults, which can occur when logging is enabled
 		// immediately after being disabled (ie. resource replacement).
-		out, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidClusterStateFault](ctx, propagationTimeout,
-			func() (any, error) {
+		out, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidClusterStateFault](ctx, propagationTimeout,
+			func(ctx context.Context) (any, error) {
 				return conn.EnableLogging(ctx, in)
 			},
 			"There is an operation running on the Cluster",
@@ -210,8 +210,8 @@ func (r *loggingResource) Delete(ctx context.Context, req resource.DeleteRequest
 	}
 
 	// Retry InvalidClusterState faults, which can occur when logging is being enabled.
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidClusterStateFault](ctx, propagationTimeout,
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidClusterStateFault](ctx, propagationTimeout,
+		func(ctx context.Context) (any, error) {
 			return conn.DisableLogging(ctx, in)
 		},
 		"There is an operation running on the Cluster",

--- a/internal/service/redshiftserverless/namespace.go
+++ b/internal/service/redshiftserverless/namespace.go
@@ -303,8 +303,8 @@ func resourceNamespaceDelete(ctx context.Context, d *schema.ResourceData, meta a
 	conn := meta.(*conns.AWSClient).RedshiftServerlessClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Redshift Serverless Namespace: %s", d.Id())
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.ConflictException](ctx, namespaceDeletedTimeout,
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ConflictException](ctx, namespaceDeletedTimeout,
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteNamespace(ctx, &redshiftserverless.DeleteNamespaceInput{
 				NamespaceName: aws.String(d.Id()),
 			})

--- a/internal/service/redshiftserverless/workgroup.go
+++ b/internal/service/redshiftserverless/workgroup.go
@@ -516,8 +516,8 @@ func resourceWorkgroupDelete(ctx context.Context, d *schema.ResourceData, meta a
 	const (
 		retryTimeout = 10 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.ConflictException](ctx, retryTimeout,
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ConflictException](ctx, retryTimeout,
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteWorkgroup(ctx, &redshiftserverless.DeleteWorkgroupInput{
 				WorkgroupName: aws.String(d.Id()),
 			})

--- a/internal/service/secretsmanager/secret.go
+++ b/internal/service/secretsmanager/secret.go
@@ -442,7 +442,7 @@ func removeSecretReplicas(ctx context.Context, conn *secretsmanager.Client, id s
 }
 
 func putSecretPolicy(ctx context.Context, conn *secretsmanager.Client, input *secretsmanager.PutResourcePolicyInput) (*secretsmanager.PutResourcePolicyOutput, error) {
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.MalformedPolicyDocumentException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.MalformedPolicyDocumentException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutResourcePolicy(ctx, input)
 	}, "This resource policy contains an unsupported principal")
 

--- a/internal/service/servicecatalog/principal_portfolio_association.go
+++ b/internal/service/servicecatalog/principal_portfolio_association.go
@@ -94,7 +94,7 @@ func resourcePrincipalPortfolioAssociationCreate(ctx context.Context, d *schema.
 		PrincipalType:  awstypes.PrincipalType(principalType),
 	}
 
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidParametersException](ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidParametersException](ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.AssociatePrincipalWithPortfolio(ctx, input)
 	}, "profile does not exist")
 

--- a/internal/service/servicecatalog/product.go
+++ b/internal/service/servicecatalog/product.go
@@ -204,7 +204,7 @@ func resourceProductCreate(ctx context.Context, d *schema.ResourceData, meta any
 		input.SupportUrl = aws.String(v.(string))
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidParametersException](ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidParametersException](ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.CreateProduct(ctx, input)
 	}, "profile does not exist")
 
@@ -317,7 +317,7 @@ func resourceProductUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 	}
 
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidParametersException](ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidParametersException](ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 		return conn.UpdateProduct(ctx, input)
 	}, "profile does not exist")
 

--- a/internal/service/shield/drt_access_role_arn_association.go
+++ b/internal/service/shield/drt_access_role_arn_association.go
@@ -74,7 +74,7 @@ func (r *drtAccessRoleARNAssociationResource) Create(ctx context.Context, reques
 		RoleArn: aws.String(roleARN),
 	}
 
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidParameterException](ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidParameterException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.AssociateDRTRole(ctx, input)
 	}, "role does not have a valid DRT managed policy")
 
@@ -147,7 +147,7 @@ func (r *drtAccessRoleARNAssociationResource) Update(ctx context.Context, reques
 			RoleArn: aws.String(roleARN),
 		}
 
-		_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidParameterException](ctx, propagationTimeout, func() (any, error) {
+		_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidParameterException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 			return conn.AssociateDRTRole(ctx, input)
 		}, "role does not have a valid DRT managed policy")
 

--- a/internal/service/sns/platform_application.go
+++ b/internal/service/sns/platform_application.go
@@ -137,7 +137,7 @@ func resourcePlatformApplicationCreate(ctx context.Context, d *schema.ResourceDa
 		Platform:   aws.String(d.Get("platform").(string)),
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidParameterException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[any, *types.InvalidParameterException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreatePlatformApplication(ctx, input)
 	}, "is not a valid role to allow SNS to write to Cloudwatch Logs")
 
@@ -229,7 +229,7 @@ func resourcePlatformApplicationUpdate(ctx context.Context, d *schema.ResourceDa
 		PlatformApplicationArn: aws.String(d.Id()),
 	}
 
-	_, err = tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidParameterException](ctx, propagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryWhenIsAErrorMessageContains[any, *types.InvalidParameterException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.SetPlatformApplicationAttributes(ctx, input)
 	}, "is not a valid role to allow SNS to write to Cloudwatch Logs")
 

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -309,7 +309,7 @@ func resourceTopicCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 	// Retry for eventual consistency; if ABAC is in use, this takes some time
 	// usually about 10s, presumably for tags really to be there, and we get a
 	// permissions error.
-	_, err = tfresource.RetryWhenIsAErrorMessageContains[*types.AuthorizationErrorException](ctx, propagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryWhenIsAErrorMessageContains[any, *types.AuthorizationErrorException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return nil, putTopicAttributes(ctx, conn, d.Id(), attributes)
 	}, "no identity-based policy allows")
 

--- a/internal/service/ssm/resource_data_sync.go
+++ b/internal/service/ssm/resource_data_sync.go
@@ -96,7 +96,7 @@ func resourceResourceDataSyncCreate(ctx context.Context, d *schema.ResourceData,
 	const (
 		timeout = 1 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.ResourceDataSyncInvalidConfigurationException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ResourceDataSyncInvalidConfigurationException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.CreateResourceDataSync(ctx, input)
 	}, "S3 write failed for bucket")
 

--- a/internal/service/storagegateway/cached_iscsi_volume.go
+++ b/internal/service/storagegateway/cached_iscsi_volume.go
@@ -220,7 +220,7 @@ func resourceCachediSCSIVolumeDelete(ctx context.Context, d *schema.ResourceData
 	const (
 		timeout = 2 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidGatewayRequestException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidGatewayRequestException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteVolume(ctx, &storagegateway.DeleteVolumeInput{
 			VolumeARN: aws.String(d.Id()),
 		})

--- a/internal/service/storagegateway/stored_iscsi_volume.go
+++ b/internal/service/storagegateway/stored_iscsi_volume.go
@@ -231,7 +231,7 @@ func resourceStorediSCSIVolumeDelete(ctx context.Context, d *schema.ResourceData
 	const (
 		timeout = 2 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidGatewayRequestException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidGatewayRequestException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteVolume(ctx, &storagegateway.DeleteVolumeInput{
 			VolumeARN: aws.String(d.Id()),
 		})

--- a/internal/service/transfer/server.go
+++ b/internal/service/transfer/server.go
@@ -822,8 +822,8 @@ func resourceServerDelete(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	log.Printf("[DEBUG] Deleting Transfer Server: (%s)", d.Id())
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidRequestException](ctx, 1*time.Minute,
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidRequestException](ctx, 1*time.Minute,
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteServer(ctx, &transfer.DeleteServerInput{
 				ServerId: aws.String(d.Id()),
 			})
@@ -884,7 +884,7 @@ func updateServer(ctx context.Context, conn *transfer.Client, input *transfer.Up
 	// To prevent accessing the EC2 API directly to check the VPC Endpoint
 	// state, which can require confusing IAM permissions and have other
 	// eventual consistency consideration, we retry only via the Transfer API.
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.ConflictException](ctx, tfec2.VPCEndpointCreationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ConflictException](ctx, tfec2.VPCEndpointCreationTimeout, func(ctx context.Context) (any, error) {
 		return conn.UpdateServer(ctx, input)
 	}, "VPC Endpoint state is not yet available")
 

--- a/internal/service/vpclattice/resource_configuration.go
+++ b/internal/service/vpclattice/resource_configuration.go
@@ -372,7 +372,7 @@ func (r *resourceConfigurationResource) Delete(ctx context.Context, request reso
 	const (
 		timeout = 1 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.ValidationException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ValidationException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteResourceConfiguration(ctx, &vpclattice.DeleteResourceConfigurationInput{
 			ResourceConfigurationIdentifier: fwflex.StringFromFramework(ctx, data.ID),
 		})

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -189,16 +189,6 @@ func RetryWhenIsAErrorMessageContains[T any, E errs.ErrorWithErrorMessage](ctx c
 	})
 }
 
-func RetryGWhenIsAErrorMessageContains[T any, E errs.ErrorWithErrorMessage](ctx context.Context, timeout time.Duration, f func() (T, error), needle string) (T, error) {
-	return RetryGWhen(ctx, timeout, f, func(err error) (bool, error) {
-		if errs.IsAErrorMessageContains[E](err, needle) {
-			return true, err
-		}
-
-		return false, err
-	})
-}
-
 // RetryUntilEqual retries the specified function until it returns a value equal to `target`.
 func RetryUntilEqual[T comparable](ctx context.Context, timeout time.Duration, target T, f func(context.Context) (T, error), opts ...backoff.Option) (T, error) {
 	t, err := retry.Op(f).If(func(t T, err error) (bool, error) {

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -149,9 +149,9 @@ func RetryWhenIsA[T error](ctx context.Context, timeout time.Duration, f func() 
 	})
 }
 
-func RetryWhenIsOneOf2[T any, T1, T2 error](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error)) (T, error) {
+func RetryWhenIsOneOf2[T any, E1, E2 error](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error)) (T, error) {
 	return retryWhen(ctx, timeout, f, func(err error) (bool, error) {
-		if errs.IsA[T1](err) || errs.IsA[T2](err) {
+		if errs.IsA[E1](err) || errs.IsA[E2](err) {
 			return true, err
 		}
 
@@ -159,9 +159,9 @@ func RetryWhenIsOneOf2[T any, T1, T2 error](ctx context.Context, timeout time.Du
 	})
 }
 
-func RetryWhenIsOneOf3[T any, T1, T2, T3 error](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error)) (T, error) {
+func RetryWhenIsOneOf3[T any, E1, E2, E3 error](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error)) (T, error) {
 	return retryWhen(ctx, timeout, f, func(err error) (bool, error) {
-		if errs.IsA[T1](err) || errs.IsA[T2](err) || errs.IsA[T3](err) {
+		if errs.IsA[E1](err) || errs.IsA[E2](err) || errs.IsA[E3](err) {
 			return true, err
 		}
 
@@ -169,9 +169,9 @@ func RetryWhenIsOneOf3[T any, T1, T2, T3 error](ctx context.Context, timeout tim
 	})
 }
 
-func RetryWhenIsOneOf4[T any, T1, T2, T3, T4 error](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error)) (T, error) {
+func RetryWhenIsOneOf4[T any, E1, E2, E3, E4 error](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error)) (T, error) {
 	return retryWhen(ctx, timeout, f, func(err error) (bool, error) {
-		if errs.IsA[T1](err) || errs.IsA[T2](err) || errs.IsA[T3](err) || errs.IsA[T4](err) {
+		if errs.IsA[E1](err) || errs.IsA[E2](err) || errs.IsA[E3](err) || errs.IsA[E4](err) {
 			return true, err
 		}
 
@@ -179,9 +179,9 @@ func RetryWhenIsOneOf4[T any, T1, T2, T3, T4 error](ctx context.Context, timeout
 	})
 }
 
-func RetryWhenIsAErrorMessageContains[T errs.ErrorWithErrorMessage](ctx context.Context, timeout time.Duration, f func() (any, error), needle string) (any, error) {
+func RetryWhenIsAErrorMessageContains[E errs.ErrorWithErrorMessage](ctx context.Context, timeout time.Duration, f func() (any, error), needle string) (any, error) {
 	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
-		if errs.IsAErrorMessageContains[T](err, needle) {
+		if errs.IsAErrorMessageContains[E](err, needle) {
 			return true, err
 		}
 

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -179,8 +179,8 @@ func RetryWhenIsOneOf4[T any, E1, E2, E3, E4 error](ctx context.Context, timeout
 	})
 }
 
-func RetryWhenIsAErrorMessageContains[E errs.ErrorWithErrorMessage](ctx context.Context, timeout time.Duration, f func() (any, error), needle string) (any, error) {
-	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
+func RetryWhenIsAErrorMessageContains[T any, E errs.ErrorWithErrorMessage](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error), needle string) (T, error) {
+	return retryWhen(ctx, timeout, f, func(err error) (bool, error) {
 		if errs.IsAErrorMessageContains[E](err, needle) {
 			return true, err
 		}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Use the new primitives in `internal/retry` (as a replacement for the SDKv2 `helper/retry` package) for `tfresource.RetryWhenIsAErrorMessageContains`. The new implementation is generic (on the return type), so `tfresource.RetryGWhenIsAErrorMessageContains` is now obsolete and has been removed.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/42554.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43267.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43341.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43412.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43521.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccCodeArtifact_serial/^Domain$$/basic' PKG=codeartifact
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/codeartifact/... -v -count 1 -parallel 20  -run=TestAccCodeArtifact_serial/^Domain$/basic -timeout 360m -vet=off
2025/07/28 07:50:14 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/28 07:50:14 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCodeArtifact_serial
=== PAUSE TestAccCodeArtifact_serial
=== CONT  TestAccCodeArtifact_serial
=== RUN   TestAccCodeArtifact_serial/Domain
=== RUN   TestAccCodeArtifact_serial/Domain/basic
--- PASS: TestAccCodeArtifact_serial (34.96s)
    --- PASS: TestAccCodeArtifact_serial/Domain (34.96s)
        --- PASS: TestAccCodeArtifact_serial/Domain/basic (34.96s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codeartifact	40.285s
```
```console
% make testacc TESTARGS='-run=TestAccLambdaFunction_basic' PKG=lambda
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/lambda/... -v -count 1 -parallel 20  -run=TestAccLambdaFunction_basic -timeout 360m -vet=off
2025/07/28 07:53:27 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/28 07:53:28 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== CONT  TestAccLambdaFunction_basic
--- PASS: TestAccLambdaFunction_basic (40.39s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	45.610s
```
```console
% make testacc TESTARGS='-run=TestAccBedrockAgentAgent_basic' PKG=bedrockagent
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/bedrockagent/... -v -count 1 -parallel 20  -run=TestAccBedrockAgentAgent_basic -timeout 360m -vet=off
2025/07/28 07:59:11 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/28 07:59:11 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockAgentAgent_basic
=== PAUSE TestAccBedrockAgentAgent_basic
=== CONT  TestAccBedrockAgentAgent_basic
--- PASS: TestAccBedrockAgentAgent_basic (23.36s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent	28.268s
```