### PR TITLE
[bugfix] aws_cloudwatch_log_delivery_destination: fix update failure of `destination_resource_arn` when tags are set

### DIFF
--- a/internal/service/logs/delivery_destination.go
+++ b/internal/service/logs/delivery_destination.go
@@ -185,9 +185,6 @@ func (r *deliveryDestinationResource) Update(ctx context.Context, request resour
 			return
 		}
 
-		// Additional fields.
-		input.Tags = getTagsIn(ctx)
-
 		output, err := conn.PutDeliveryDestination(ctx, &input)
 
 		if err != nil {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* The issue reported in #43572 is reproduced when updating the `destination_resource_arn` while tags are set.
* In the current implementation, `getTagsIn(ctx)` is invoked not only in the `create` function but also in the `update` function.

  * Tags are handled automatically via the Transparent Tagging mechanism, so no explicit tagging logic is necessary.
  * This PR removes the call to `getTagsIn(ctx)` in the `update` function.

### Verification

* Without this modification, the newly added acceptance test fails, reproducing the reported error:
  **"ConflictException: Tags can only be provided when a resource is being created, not updated."**

```console
$ make testacc TESTS=TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationWithTag PKG=logs
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/logs/... -v -count 1 -parallel 20 -run='TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationWithTag'  -timeout 360m -vet=off
2025/07/28 23:35:50 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/28 23:35:50 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationWithTag
=== PAUSE TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationWithTag
=== CONT  TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationWithTag
    delivery_destination_test.go:332: Step 3/3 error: Error running apply: exit status 1
        
        Error: updating CloudWatch Logs Delivery Destination (tf-acc-test-1572113506661276345)
        
          with aws_cloudwatch_log_delivery_destination.test,
          on terraform_plugin_test.tf line 25, in resource "aws_cloudwatch_log_delivery_destination" "test":
          25: resource "aws_cloudwatch_log_delivery_destination" "test" {
        
        operation error CloudWatch Logs: PutDeliveryDestination, https response error
        StatusCode: 400, RequestID: 87b47954-549a-4b16-af55-37fe3a142706,
        ConflictException: Tags can only be provided when a resource is being
        created, not updated.
--- FAIL: TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationWithTag (41.00s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/logs       44.763s
FAIL
make: *** [testacc] Error 1
```


* With this modification, the acceptance test passes, along with all other existing tests.


### Relations

Closes #43572

### References
https://hashicorp.github.io/terraform-provider-aws/resource-tagging/#resource-update-operation

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccLogsDeliveryDestination_ PKG=logs
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/logs/... -v -count 1 -parallel 20 -run='TestAccLogsDeliveryDestination_'  -timeout 360m -vet=off
2025/07/28 23:39:11 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/28 23:39:11 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLogsDeliveryDestination_basic
=== PAUSE TestAccLogsDeliveryDestination_basic
=== RUN   TestAccLogsDeliveryDestination_disappears
=== PAUSE TestAccLogsDeliveryDestination_disappears
=== RUN   TestAccLogsDeliveryDestination_tags
=== PAUSE TestAccLogsDeliveryDestination_tags
=== RUN   TestAccLogsDeliveryDestination_outputFormat
=== PAUSE TestAccLogsDeliveryDestination_outputFormat
=== RUN   TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationSameType
=== PAUSE TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationSameType
=== RUN   TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationDifferentType
=== PAUSE TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationDifferentType
=== RUN   TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationWithTag
=== PAUSE TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationWithTag
=== CONT  TestAccLogsDeliveryDestination_basic
=== CONT  TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationSameType
=== CONT  TestAccLogsDeliveryDestination_tags
=== CONT  TestAccLogsDeliveryDestination_outputFormat
=== CONT  TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationDifferentType
=== CONT  TestAccLogsDeliveryDestination_disappears
=== CONT  TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationWithTag
--- PASS: TestAccLogsDeliveryDestination_disappears (25.83s)
--- PASS: TestAccLogsDeliveryDestination_basic (30.53s)
--- PASS: TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationSameType (50.53s)
--- PASS: TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationDifferentType (53.35s)
--- PASS: TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationWithTag (53.53s)
--- PASS: TestAccLogsDeliveryDestination_outputFormat (54.27s)
--- PASS: TestAccLogsDeliveryDestination_tags (57.63s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       61.858s

```
