### PR TITLE
Re-add support for NoSuchTagSetError

### DIFF
--- a/internal/service/s3/errors.go
+++ b/internal/service/s3/errors.go
@@ -30,6 +30,7 @@ const (
 	errCodeNoSuchKey                            = "NoSuchKey"
 	errCodeNoSuchPublicAccessBlockConfiguration = "NoSuchPublicAccessBlockConfiguration"
 	errCodeNoSuchTagSet                         = "NoSuchTagSet"
+	errCodeNoSuchTagSetError                    = "NoSuchTagSetError"
 	errCodeNoSuchWebsiteConfiguration           = "NoSuchWebsiteConfiguration"
 	errCodeNotImplemented                       = "NotImplemented"
 	// errCodeObjectLockConfigurationNotFound should be used with tfawserr.ErrCodeContains, not tfawserr.ErrCodeEquals.

--- a/internal/service/s3/tags.go
+++ b/internal/service/s3/tags.go
@@ -42,7 +42,7 @@ func bucketListTags(ctx context.Context, conn *s3.Client, identifier string, opt
 
 	output, err := conn.GetBucketTagging(ctx, input, optFns...)
 
-	if tfawserr.ErrCodeEquals(err, errCodeNoSuchTagSet, errCodeMethodNotAllowed, errCodeNotImplemented, errCodeXNotImplemented, errCodeUnsupportedOperation) {
+	if tfawserr.ErrCodeEquals(err, errCodeNoSuchTagSet, errCodeNoSuchTagSetError, errCodeMethodNotAllowed, errCodeNotImplemented, errCodeXNotImplemented, errCodeUnsupportedOperation) {
 		return tftags.New(ctx, nil), nil
 	}
 	if err != nil {
@@ -104,7 +104,7 @@ func objectListTags(ctx context.Context, conn *s3.Client, bucket, key string, op
 
 	output, err := conn.GetObjectTagging(ctx, input, optFns...)
 
-	if tfawserr.ErrCodeEquals(err, errCodeNoSuchTagSet) {
+	if tfawserr.ErrCodeEquals(err, errCodeNoSuchTagSet, errCodeNoSuchTagSetError) {
 		return tftags.New(ctx, nil), nil
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR addresses a regression of compatibility with S3 like interfaces such as Ceph. Specifically this PR will fix #40831 where the issue aptly describes the scenario where the error condition for `NoSuchTagSetError` is removed from listing object and bucket tags. Ceph RGW normally returns the error `NoSuchTagSetError` during the bucket creation process and this scenario should not result in a fatal error to maintain compatibility with Ceph and similiar S3 like interfaces.

Issue #40831 goes into better detail into the history of this particular incompatibility regression and makes a good argument that the regression was a simple mistake made in a larger feature change.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Again this PR resolves #40831 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->



```console
% make testacc TESTS='TestAccS3Bucket_tags_.*' PKG=s3        
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3Bucket_tags_.*'  -timeout 360m -vet=off
2025/07/29 11:06:29 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/29 11:06:29 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3Bucket_tags_null
=== PAUSE TestAccS3Bucket_tags_null
=== RUN   TestAccS3Bucket_tags_EmptyMap
=== PAUSE TestAccS3Bucket_tags_EmptyMap
=== RUN   TestAccS3Bucket_tags_AddOnUpdate
=== PAUSE TestAccS3Bucket_tags_AddOnUpdate
=== RUN   TestAccS3Bucket_tags_EmptyTag_OnCreate
=== PAUSE TestAccS3Bucket_tags_EmptyTag_OnCreate
=== RUN   TestAccS3Bucket_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccS3Bucket_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccS3Bucket_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccS3Bucket_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccS3Bucket_tags_DefaultTags_providerOnly
=== PAUSE TestAccS3Bucket_tags_DefaultTags_providerOnly
=== RUN   TestAccS3Bucket_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccS3Bucket_tags_DefaultTags_nonOverlapping
=== RUN   TestAccS3Bucket_tags_DefaultTags_overlapping
=== PAUSE TestAccS3Bucket_tags_DefaultTags_overlapping
=== RUN   TestAccS3Bucket_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccS3Bucket_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccS3Bucket_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccS3Bucket_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccS3Bucket_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccS3Bucket_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccS3Bucket_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccS3Bucket_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccS3Bucket_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccS3Bucket_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccS3Bucket_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccS3Bucket_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccS3Bucket_tags_ComputedTag_OnCreate
=== PAUSE TestAccS3Bucket_tags_ComputedTag_OnCreate
=== RUN   TestAccS3Bucket_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccS3Bucket_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccS3Bucket_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccS3Bucket_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccS3Bucket_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccS3Bucket_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccS3Bucket_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccS3Bucket_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccS3Bucket_tags_withSystemTags
=== PAUSE TestAccS3Bucket_tags_withSystemTags
=== RUN   TestAccS3Bucket_tags_ignoreTags
=== PAUSE TestAccS3Bucket_tags_ignoreTags
=== CONT  TestAccS3Bucket_tags_null
=== CONT  TestAccS3Bucket_tags_DefaultTags_emptyResourceTag
=== CONT  TestAccS3Bucket_tags_IgnoreTags_Overlap_DefaultTag
=== CONT  TestAccS3Bucket_tags_DefaultTags_providerOnly
=== CONT  TestAccS3Bucket_tags_ComputedTag_OnUpdate_Replace
=== CONT  TestAccS3Bucket_tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccS3Bucket_tags_ignoreTags
=== CONT  TestAccS3Bucket_tags_withSystemTags
=== CONT  TestAccS3Bucket_tags_IgnoreTags_Overlap_ResourceTag
=== CONT  TestAccS3Bucket_tags_ComputedTag_OnCreate
=== CONT  TestAccS3Bucket_tags_DefaultTags_updateToProviderOnly
=== CONT  TestAccS3Bucket_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccS3Bucket_tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccS3Bucket_tags_EmptyTag_OnCreate
=== CONT  TestAccS3Bucket_tags_EmptyTag_OnUpdate_Replace
=== CONT  TestAccS3Bucket_tags_EmptyTag_OnUpdate_Add
=== CONT  TestAccS3Bucket_tags_EmptyMap
=== CONT  TestAccS3Bucket_tags_DefaultTags_emptyProviderOnlyTag
=== CONT  TestAccS3Bucket_tags_DefaultTags_overlapping
=== CONT  TestAccS3Bucket_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccS3Bucket_tags_DefaultTags_nullNonOverlappingResourceTag (29.48s)
=== CONT  TestAccS3Bucket_tags_DefaultTags_nonOverlapping
--- PASS: TestAccS3Bucket_tags_DefaultTags_nullOverlappingResourceTag (32.74s)
=== CONT  TestAccS3Bucket_tags_AddOnUpdate
--- PASS: TestAccS3Bucket_tags_DefaultTags_emptyProviderOnlyTag (34.13s)
--- PASS: TestAccS3Bucket_tags_ComputedTag_OnCreate (34.47s)
--- PASS: TestAccS3Bucket_tags_DefaultTags_emptyResourceTag (35.76s)
--- PASS: TestAccS3Bucket_tags_ignoreTags (38.03s)
--- PASS: TestAccS3Bucket_tags_EmptyMap (42.60s)
--- PASS: TestAccS3Bucket_tags_null (43.60s)
--- PASS: TestAccS3Bucket_tags_EmptyTag_OnUpdate_Replace (46.94s)
--- PASS: TestAccS3Bucket_tags_DefaultTags_updateToProviderOnly (47.06s)
--- PASS: TestAccS3Bucket_tags_ComputedTag_OnUpdate_Add (48.43s)
--- PASS: TestAccS3Bucket_tags_DefaultTags_updateToResourceOnly (48.64s)
--- PASS: TestAccS3Bucket_tags_ComputedTag_OnUpdate_Replace (51.26s)
--- PASS: TestAccS3Bucket_tags_EmptyTag_OnCreate (51.36s)
--- PASS: TestAccS3Bucket_tags_IgnoreTags_Overlap_DefaultTag (54.96s)
--- PASS: TestAccS3Bucket_tags_IgnoreTags_Overlap_ResourceTag (60.77s)
--- PASS: TestAccS3Bucket_tags_EmptyTag_OnUpdate_Add (62.03s)
--- PASS: TestAccS3Bucket_tags_AddOnUpdate (31.64s)
--- PASS: TestAccS3Bucket_tags_DefaultTags_overlapping (66.53s)
--- PASS: TestAccS3Bucket_tags_DefaultTags_providerOnly (75.64s)
--- PASS: TestAccS3Bucket_tags_DefaultTags_nonOverlapping (48.70s)
--- PASS: TestAccS3Bucket_tags_withSystemTags (98.05s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 101.810s
...
```
