### PR TITLE
[Enhancement] r/aws_kms_ciphertext: Support write-only argument `plaintext_wo`

### DIFF
--- a/internal/service/kms/ciphertext.go
+++ b/internal/service/kms/ciphertext.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -42,10 +43,27 @@ func resourceCiphertext() *schema.Resource {
 				ForceNew: true,
 			},
 			"plaintext": {
-				Type:      schema.TypeString,
-				Required:  true,
-				ForceNew:  true,
-				Sensitive: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Sensitive:     true,
+				ConflictsWith: []string{"plaintext_wo"},
+				ExactlyOneOf:  []string{"plaintext", "plaintext_wo"},
+			},
+			"plaintext_wo": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Sensitive:     true,
+				WriteOnly:     true,
+				ConflictsWith: []string{"plaintext"},
+				ExactlyOneOf:  []string{"plaintext", "plaintext_wo"},
+				RequiredWith:  []string{"plaintext_wo_version"},
+			},
+			"plaintext_wo_version": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"plaintext_wo"},
 			},
 		},
 	}
@@ -55,10 +73,21 @@ func resourceCiphertextCreate(ctx context.Context, d *schema.ResourceData, meta 
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KMSClient(ctx)
 
+	plaintextWO, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath("plaintext_wo"))
+	diags = append(diags, di...)
+	if diags.HasError() {
+		return diags
+	}
+
+	plaintext := d.Get("plaintext").(string)
+	if plaintextWO != "" {
+		plaintext = plaintextWO
+	}
+
 	keyID := d.Get(names.AttrKeyID).(string)
 	input := &kms.EncryptInput{
 		KeyId:     aws.String(d.Get(names.AttrKeyID).(string)),
-		Plaintext: []byte(d.Get("plaintext").(string)),
+		Plaintext: []byte(plaintext),
 	}
 
 	if v, ok := d.GetOk("context"); ok && len(v.(map[string]any)) > 0 {

--- a/internal/service/kms/ciphertext_test.go
+++ b/internal/service/kms/ciphertext_test.go
@@ -4,9 +4,12 @@
 package kms_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -69,6 +72,47 @@ func TestAccKMSCiphertext_Validate_withContext(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "ciphertext_blob"),
 					resource.TestCheckResourceAttrPair(resourceName, "plaintext", kmsSecretsDataSource, "plaintext.plaintext"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKMSCiphertext_plaintextWO(t *testing.T) {
+	ctx := acctest.Context(t)
+	kmsSecretsDataSource := "data.aws_kms_secrets.test"
+	resourceName := "aws_kms_ciphertext.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KMSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCiphertextConfig_plaintextWO("Secret1", "1"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectSensitiveValue(resourceName, tfjsonpath.New("plaintext_wo")),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "ciphertext_blob"),
+					resource.TestCheckResourceAttr(kmsSecretsDataSource, "plaintext.plaintext", "Secret1"),
+				),
+			},
+			{
+				Config: testAccCiphertextConfig_plaintextWO("Secret2", "2"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+						plancheck.ExpectSensitiveValue(resourceName, tfjsonpath.New("plaintext_wo")),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "ciphertext_blob"),
+					resource.TestCheckResourceAttr(kmsSecretsDataSource, "plaintext.plaintext", "Secret2"),
 				),
 			},
 		},
@@ -141,3 +185,29 @@ data "aws_kms_secrets" "test" {
   }
 }
 `
+
+func testAccCiphertextConfig_plaintextWO(plaintextWO, plaintextWOVersion string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = "tf-test-acc-data-source-aws-kms-ciphertext-plaintext-wo"
+  is_enabled              = true
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
+
+resource "aws_kms_ciphertext" "test" {
+  key_id = aws_kms_key.test.key_id
+
+  plaintext_wo         = %[1]q
+  plaintext_wo_version = %[2]q
+}
+
+data "aws_kms_secrets" "test" {
+  secret {
+    name    = "plaintext"
+    payload = aws_kms_ciphertext.test.ciphertext_blob
+  }
+}
+
+`, plaintextWO, plaintextWOVersion)
+}

--- a/website/docs/r/kms_ciphertext.html.markdown
+++ b/website/docs/r/kms_ciphertext.html.markdown
@@ -41,7 +41,9 @@ EOF
 This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `plaintext` - (Required) Data to be encrypted. Note that this may show up in logs, and it will be stored in the state file.
+* `plaintext` - (Exactly one of `plaintext` or `plaintext_wo` must be set) Data to be encrypted. Note that this may show up in logs, and it will be stored in the state file.
+* `plaintext_wo` - (Write-Only, Exactly one of `plaintext` or `plaintext_wo` must be set) Data to be encrypted. Note that this may show up in logs. It will not be stored in the state file.
+* `plaintext_wo_version` - (Required when `plaintext_wo` is set) Used together with `plaintext_wo` to trigger a replacement. Modify this value when a replacement is required.
 * `key_id` - (Required) Globally unique key ID for the customer master key.
 * `context` - (Optional) An optional mapping that makes up the encryption context.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* Add `plaintext_wo` along with `plaintext_wo_version` to support write-only `plaintext` argument

### Relations

Closes #43290



### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccKMSCiphertext_ PKG=kms           
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/kms/... -v -count 1 -parallel 20 -run='TestAccKMSCiphertext_'  -timeout 360m -vet=off
2025/07/30 01:16:46 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/30 01:16:46 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKMSCiphertext_basic
=== PAUSE TestAccKMSCiphertext_basic
=== RUN   TestAccKMSCiphertext_validate
=== PAUSE TestAccKMSCiphertext_validate
=== RUN   TestAccKMSCiphertext_Validate_withContext
=== PAUSE TestAccKMSCiphertext_Validate_withContext
=== RUN   TestAccKMSCiphertext_plaintextWO
=== PAUSE TestAccKMSCiphertext_plaintextWO
=== CONT  TestAccKMSCiphertext_basic
=== CONT  TestAccKMSCiphertext_Validate_withContext
=== CONT  TestAccKMSCiphertext_plaintextWO
=== CONT  TestAccKMSCiphertext_validate
--- PASS: TestAccKMSCiphertext_basic (37.81s)
--- PASS: TestAccKMSCiphertext_Validate_withContext (38.36s)
--- PASS: TestAccKMSCiphertext_validate (38.44s)
--- PASS: TestAccKMSCiphertext_plaintextWO (50.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kms        54.951s

```
