### PR TITLE
internal/sweep: Additional skippable errors

### DIFF
--- a/internal/sweep/awsv2/skip.go
+++ b/internal/sweep/awsv2/skip.go
@@ -45,6 +45,10 @@ func SkipSweepError(err error) bool {
 	if tfawserr.ErrMessageContains(err, "HttpConnectionTimeoutException", "Failed to connect to") {
 		return true
 	}
+	// Example (amp): InternalServerErrorException: Internal server error
+	if tfawserr.ErrMessageContains(err, "InternalServerErrorException", "Internal server error") {
+		return true
+	}
 	// Example (GovCloud): InvalidAction: DescribeDBProxies is not available in this region
 	if tfawserr.ErrMessageContains(err, "InvalidAction", "is not available") {
 		return true


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Additional skippable errors for the `amp` and `fsx` services.


```
2025/07/29 17:03:08   - aws_fsx_s3_access_point_attachment: listing "aws_fsx_s3_access_point_attachment" (us-west-1): operation error FSx: DescribeS3AccessPointAttachments, https response error StatusCode: 400, RequestID: 14c7a9f4-d964-4736-a908-b93366371f56, UnsupportedOperation: This operation is unsupported.
```


```
2025/07/29 17:03:08   - aws_prometheus_scraper: listing "aws_prometheus_scraper" (us-west-1): operation error amp: ListScrapers, exceeded maximum number of attempts, 5, https response error StatusCode: 500, RequestID: 7fcd350e-6973-48a1-8c10-9d3458fc856c, api error InternalServerErrorException: Internal server error
```
