### PR TITLE
Use correct field name for Bedrock Flow prompt ARN

### DIFF
--- a/internal/service/bedrockagent/flow.go
+++ b/internal/service/bedrockagent/flow.go
@@ -806,7 +806,7 @@ func (r *flowResource) Schema(ctx context.Context, request resource.SchemaReques
 																			},
 																			NestedObject: schema.NestedBlockObject{
 																				Attributes: map[string]schema.Attribute{
-																					names.AttrResourceARN: schema.StringAttribute{
+																					"prompt_arn": schema.StringAttribute{
 																						CustomType: fwtypes.ARNType,
 																						Required:   true,
 																					},
@@ -1775,7 +1775,7 @@ type promptFlowNodeInlineConfigurationModel struct {
 }
 
 type promptFlowNodeResourceConfigurationModel struct {
-	ResourceARN fwtypes.ARN `tfsdk:"resource_arn"`
+	PromptARN fwtypes.ARN `tfsdk:"prompt_arn"`
 }
 
 type retrievalFlowNodeConfigurationModel struct {

--- a/internal/service/bedrockagent/flow_test.go
+++ b/internal/service/bedrockagent/flow_test.go
@@ -330,6 +330,68 @@ func TestAccBedrockAgentFlow_withDefinition(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentFlow_withPromptResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var flow bedrockagent.GetFlowOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_bedrockagent_flow.test"
+	foundationModel := "amazon.titan-text-express-v1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckFlow(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFlowDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFlowConfig_withPromptResource(rName, foundationModel),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckFlowExists(ctx, resourceName, &flow),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "bedrock", regexache.MustCompile(`flow/.+$`)),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreatedAt),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrVersion),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrStatus),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrExecutionRoleARN, "aws_iam_role.test", names.AttrARN),
+					resource.TestCheckNoResourceAttr(resourceName, "customer_encryption_key_arn"),
+					resource.TestCheckNoResourceAttr(resourceName, names.AttrDescription),
+
+					resource.TestCheckResourceAttr(resourceName, "definition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.connection.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.node.#", "1"),
+
+					resource.TestCheckResourceAttr(resourceName, "definition.0.node.0.name", "Prompt_1"),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.node.0.type", "Prompt"),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.node.0.configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.node.0.configuration.0.prompt.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.node.0.configuration.0.prompt.0.source_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.node.0.configuration.0.prompt.0.source_configuration.0.resource.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "definition.0.node.0.configuration.0.prompt.0.source_configuration.0.resource.0.prompt_arn", "aws_bedrockagent_prompt.test", names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.node.0.input.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.node.0.input.0.expression", "$.data"),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.node.0.input.0.name", "topic"),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.node.0.input.0.type", "String"),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.node.0.output.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.node.0.output.0.name", "modelCompletion"),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.node.0.output.0.type", "String"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckFlowDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).BedrockAgentClient(ctx)
@@ -590,6 +652,48 @@ resource "aws_bedrockagent_flow" "test" {
         expression = "$.data"
         name       = "document"
         type       = "String"
+      }
+    }
+  }
+}
+`, rName, model))
+}
+
+func testAccFlowConfig_withPromptResource(rName, model string) string {
+	return acctest.ConfigCompose(testAccFlowConfig_base(model), fmt.Sprintf(`
+resource "aws_bedrockagent_prompt" "test" {
+  name        = "MyPrompt"
+  description = "My prompt description."
+}
+
+resource "aws_bedrockagent_flow" "test" {
+  name               = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  definition {
+    node {
+      name = "Prompt_1"
+      type = "Prompt"
+
+      configuration {
+        prompt {
+          source_configuration {
+            resource {
+              prompt_arn = aws_bedrockagent_prompt.test.arn
+            }
+          }
+        }
+      }
+
+      input {
+        expression = "$.data"
+        name       = "topic"
+        type       = "String"
+      }
+
+      output {
+        name = "modelCompletion"
+        type = "String"
       }
     }
   }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This corrects the field name for the prompt resource node ARN

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #43594

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://github.com/aws/aws-sdk-go-v2/blob/main/service/bedrockagent/types/types.go#L4262

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccBedrockAgentFlow PKG=bedrockagent
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/bedrockagent/... -v -count 1 -parallel 20 -run='TestAccBedrockAgentFlow'  -timeout 360m -vet=off
2025/07/29 19:15:58 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/29 19:15:59 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockAgentFlow_basic
=== PAUSE TestAccBedrockAgentFlow_basic
=== RUN   TestAccBedrockAgentFlow_disappears
=== PAUSE TestAccBedrockAgentFlow_disappears
=== RUN   TestAccBedrockAgentFlow_withEncryptionKey
=== PAUSE TestAccBedrockAgentFlow_withEncryptionKey
=== RUN   TestAccBedrockAgentFlow_tags
=== PAUSE TestAccBedrockAgentFlow_tags
=== RUN   TestAccBedrockAgentFlow_withDefinition
=== PAUSE TestAccBedrockAgentFlow_withDefinition
=== RUN   TestAccBedrockAgentFlow_withPromptResource
=== PAUSE TestAccBedrockAgentFlow_withPromptResource
=== CONT  TestAccBedrockAgentFlow_basic
=== CONT  TestAccBedrockAgentFlow_tags
=== CONT  TestAccBedrockAgentFlow_withPromptResource
=== CONT  TestAccBedrockAgentFlow_withEncryptionKey
=== CONT  TestAccBedrockAgentFlow_disappears
=== CONT  TestAccBedrockAgentFlow_withDefinition
--- PASS: TestAccBedrockAgentFlow_disappears (10.34s)
--- PASS: TestAccBedrockAgentFlow_withPromptResource (12.13s)
--- PASS: TestAccBedrockAgentFlow_basic (12.29s)
--- PASS: TestAccBedrockAgentFlow_withEncryptionKey (12.38s)
--- PASS: TestAccBedrockAgentFlow_withDefinition (12.42s)
--- PASS: TestAccBedrockAgentFlow_tags (26.76s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       29.806s
...
```
