### PR TITLE
[bugfix] aws_fsx_lustre_file_system: Fix validation of SSD read cache size for file systems using the Intelligent-Tiering storage class

### DIFF
--- a/.changelog/43605.txt
+++ b/.changelog/43605.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_fsx_lustre_file_system: Fix validation of SSD read cache size for file systems using the Intelligent-Tiering storage class
+```

--- a/internal/service/fsx/lustre_file_system.go
+++ b/internal/service/fsx/lustre_file_system.go
@@ -406,7 +406,7 @@ func resourceLustreFileSystemMetadataConfigCustomizeDiff(_ context.Context, d *s
 }
 
 func resourceLustreFileSystemDataReadCacheConfigurationCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta any) error {
-	if v, ok := d.Get("storage_type").(string); ok && v == string(awstypes.StorageTypeIntelligentTiering) {
+	if v, ok := d.Get(names.AttrStorageType).(string); ok && v == string(awstypes.StorageTypeIntelligentTiering) {
 		var throughputCapacity int
 		if v, ok := d.Get("throughput_capacity").(int); ok && v != 0 {
 			throughputCapacity = v

--- a/internal/service/fsx/lustre_file_system.go
+++ b/internal/service/fsx/lustre_file_system.go
@@ -108,9 +108,8 @@ func resourceLustreFileSystem() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						names.AttrSize: {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ValidateFunc: validation.IntBetween(32, 131072),
+							Type:     schema.TypeInt,
+							Optional: true,
 						},
 						"sizing_mode": {
 							Type:             schema.TypeString,
@@ -343,6 +342,7 @@ func resourceLustreFileSystem() *schema.Resource {
 		CustomizeDiff: customdiff.Sequence(
 			resourceLustreFileSystemStorageCapacityCustomizeDiff,
 			resourceLustreFileSystemMetadataConfigCustomizeDiff,
+			resourceLustreFileSystemDataReadCacheConfigurationCustomizeDiff,
 		),
 	}
 }
@@ -396,6 +396,34 @@ func resourceLustreFileSystemMetadataConfigCustomizeDiff(_ context.Context, d *s
 						if err := d.ForceNew("metadata_configuration.0.iops"); err != nil {
 							return err
 						}
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func resourceLustreFileSystemDataReadCacheConfigurationCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta any) error {
+	if v, ok := d.Get("storage_type").(string); ok && v == string(awstypes.StorageTypeIntelligentTiering) {
+		var throughputCapacity int
+		if v, ok := d.Get("throughput_capacity").(int); ok && v != 0 {
+			throughputCapacity = v
+		} else {
+			return fmt.Errorf("Validation Error: ThroughputCapacity is a required parameter for Lustre file systems with StorageType  %s", awstypes.StorageTypeIntelligentTiering)
+		}
+
+		if v, ok := d.Get("data_read_cache_configuration").([]any); ok && len(v) > 0 && v[0] != nil {
+			config := v[0].(map[string]any)
+
+			if sizingMode, ok := config["sizing_mode"].(string); ok && sizingMode == string(awstypes.LustreReadCacheSizingModeUserProvisioned) {
+				if size, ok := config[names.AttrSize].(int); ok && size > 0 {
+					factor := throughputCapacity / 4000
+					minSize := 32 * factor
+					maxSize := 131072 * factor
+					if size < minSize || size > maxSize {
+						return fmt.Errorf("File systems with throughput capacity of %d MB/s support a minimum read cache size of %d GiB and maximum read cache size of %d GiB", throughputCapacity, minSize, maxSize)
 					}
 				}
 			}

--- a/internal/service/fsx/lustre_file_system_test.go
+++ b/internal/service/fsx/lustre_file_system_test.go
@@ -883,7 +883,15 @@ func TestAccFSxLustreFileSystem_intelligentTiering(t *testing.T) {
 		CheckDestroy:             testAccCheckLustreFileSystemDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLustreFileSystemConfig_intelligentTiering(rName),
+				Config:      testAccLustreFileSystemConfig_intelligentTiering(rName, 4000, 31),
+				ExpectError: regexache.MustCompile("File systems with throughput capacity of 4000 MB/s support a minimum read cache size of 32 GiB and maximum read cache size of 131072 GiB"),
+			},
+			{
+				Config:      testAccLustreFileSystemConfig_intelligentTiering(rName, 8000, 32),
+				ExpectError: regexache.MustCompile("File systems with throughput capacity of 8000 MB/s support a minimum read cache size of 64 GiB and maximum read cache size of 262144 GiB"),
+			},
+			{
+				Config: testAccLustreFileSystemConfig_intelligentTiering(rName, 4000, 32),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "fsx", regexache.MustCompile(`file-system/fs-.+`)),
@@ -2089,17 +2097,17 @@ resource "aws_fsx_lustre_file_system" "test" {
 `, rName, efaEnabled))
 }
 
-func testAccLustreFileSystemConfig_intelligentTiering(rName string) string {
-	return acctest.ConfigCompose(testAccLustreFileSystemConfig_base(rName), `
+func testAccLustreFileSystemConfig_intelligentTiering(rName string, throughputCapacity, cacheSize int) string {
+	return acctest.ConfigCompose(testAccLustreFileSystemConfig_base(rName), fmt.Sprintf(`
 resource "aws_fsx_lustre_file_system" "test" {
   subnet_ids          = aws_subnet.test[*].id
   deployment_type     = "PERSISTENT_2"
   storage_type        = "INTELLIGENT_TIERING"
-  throughput_capacity = 4000
+  throughput_capacity = %[1]d
 
   data_read_cache_configuration {
     sizing_mode = "USER_PROVISIONED"
-    size        = 32
+    size        = %[2]d
   }
 
   metadata_configuration {
@@ -2108,5 +2116,5 @@ resource "aws_fsx_lustre_file_system" "test" {
   }
 
 }
-`)
+`, throughputCapacity, cacheSize))
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Fix validation logic for the read cache size `data_read_cache_configuration.size`.

  * As explained in #43599, the valid range of `data_read_cache_configuration.size` depends on the value of `throughput_capacity`, and is calculated as follows:

    ```
    N = throughput_capacity / 4000
    32 * N <= SSD Read Cache <= 131072 * N
    ```
  * However, [the current validation](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/fsx/lustre_file_system.go#L113) is implemented as:

    ```go
    validation.IntBetween(32, 131072),
    ```

    which does not take `throughput_capacity` into account.
  * Instead of using `ValidateFunc` in the schema, the revised validation is implemented using a `customDiff` function to allow for dynamic validation based on `throughput_capacity`.

* Additional test cases that trigger validation failures have been added to the acceptance tests.
It is confirmed that the cases which fail this validation would also result in errors from the AWS API if the validation logic were commented out.

### Relations
Closes #43599

### References
https://docs.aws.amazon.com/fsx/latest/LustreGuide/managing-ssd-read-cache.html

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccFSxLustreFileSystem_ PKG=fsx                  
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/fsx/... -v -count 1 -parallel 20 -run='TestAccFSxLustreFileSystem_'  -timeout 360m -vet=off
2025/07/30 22:08:02 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/30 22:08:03 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccFSxLustreFileSystem_basic
=== PAUSE TestAccFSxLustreFileSystem_basic
=== RUN   TestAccFSxLustreFileSystem_disappears
=== PAUSE TestAccFSxLustreFileSystem_disappears
=== RUN   TestAccFSxLustreFileSystem_dataCompression
=== PAUSE TestAccFSxLustreFileSystem_dataCompression
=== RUN   TestAccFSxLustreFileSystem_deleteConfig
    lustre_file_system_test.go:162: Environment variable AWS_FSX_CREATE_FINAL_BACKUP is not set, skipping test
--- SKIP: TestAccFSxLustreFileSystem_deleteConfig (0.00s)
=== RUN   TestAccFSxLustreFileSystem_exportPath
=== PAUSE TestAccFSxLustreFileSystem_exportPath
=== RUN   TestAccFSxLustreFileSystem_importPath
=== PAUSE TestAccFSxLustreFileSystem_importPath
=== RUN   TestAccFSxLustreFileSystem_importedFileChunkSize
=== PAUSE TestAccFSxLustreFileSystem_importedFileChunkSize
=== RUN   TestAccFSxLustreFileSystem_securityGroupIDs
=== PAUSE TestAccFSxLustreFileSystem_securityGroupIDs
=== RUN   TestAccFSxLustreFileSystem_storageCapacity
=== PAUSE TestAccFSxLustreFileSystem_storageCapacity
=== RUN   TestAccFSxLustreFileSystem_storageCapacityUpdate
=== PAUSE TestAccFSxLustreFileSystem_storageCapacityUpdate
=== RUN   TestAccFSxLustreFileSystem_fileSystemTypeVersion
=== PAUSE TestAccFSxLustreFileSystem_fileSystemTypeVersion
=== RUN   TestAccFSxLustreFileSystem_tags
=== PAUSE TestAccFSxLustreFileSystem_tags
=== RUN   TestAccFSxLustreFileSystem_weeklyMaintenanceStartTime
=== PAUSE TestAccFSxLustreFileSystem_weeklyMaintenanceStartTime
=== RUN   TestAccFSxLustreFileSystem_automaticBackupRetentionDays
=== PAUSE TestAccFSxLustreFileSystem_automaticBackupRetentionDays
=== RUN   TestAccFSxLustreFileSystem_dailyAutomaticBackupStartTime
=== PAUSE TestAccFSxLustreFileSystem_dailyAutomaticBackupStartTime
=== RUN   TestAccFSxLustreFileSystem_deploymentTypePersistent1
=== PAUSE TestAccFSxLustreFileSystem_deploymentTypePersistent1
=== RUN   TestAccFSxLustreFileSystem_deploymentTypePersistent1_perUnitStorageThroughput
=== PAUSE TestAccFSxLustreFileSystem_deploymentTypePersistent1_perUnitStorageThroughput
=== RUN   TestAccFSxLustreFileSystem_deploymentTypePersistent2
=== PAUSE TestAccFSxLustreFileSystem_deploymentTypePersistent2
=== RUN   TestAccFSxLustreFileSystem_deploymentTypePersistent2_perUnitStorageThroughput
=== PAUSE TestAccFSxLustreFileSystem_deploymentTypePersistent2_perUnitStorageThroughput
=== RUN   TestAccFSxLustreFileSystem_efaEnabled
=== PAUSE TestAccFSxLustreFileSystem_efaEnabled
=== RUN   TestAccFSxLustreFileSystem_intelligentTiering
=== PAUSE TestAccFSxLustreFileSystem_intelligentTiering
=== RUN   TestAccFSxLustreFileSystem_logConfig
=== PAUSE TestAccFSxLustreFileSystem_logConfig
=== RUN   TestAccFSxLustreFileSystem_metadataConfig
=== PAUSE TestAccFSxLustreFileSystem_metadataConfig
=== RUN   TestAccFSxLustreFileSystem_metadataConfig_increase
=== PAUSE TestAccFSxLustreFileSystem_metadataConfig_increase
=== RUN   TestAccFSxLustreFileSystem_metadataConfig_decrease
=== PAUSE TestAccFSxLustreFileSystem_metadataConfig_decrease
=== RUN   TestAccFSxLustreFileSystem_rootSquashConfig
=== PAUSE TestAccFSxLustreFileSystem_rootSquashConfig
=== RUN   TestAccFSxLustreFileSystem_fromBackup
=== PAUSE TestAccFSxLustreFileSystem_fromBackup
=== RUN   TestAccFSxLustreFileSystem_kmsKeyID
=== PAUSE TestAccFSxLustreFileSystem_kmsKeyID
=== RUN   TestAccFSxLustreFileSystem_deploymentTypeScratch2
=== PAUSE TestAccFSxLustreFileSystem_deploymentTypeScratch2
=== RUN   TestAccFSxLustreFileSystem_storageTypeHddDriveCacheRead
=== PAUSE TestAccFSxLustreFileSystem_storageTypeHddDriveCacheRead
=== RUN   TestAccFSxLustreFileSystem_storageTypeHddDriveCacheNone
=== PAUSE TestAccFSxLustreFileSystem_storageTypeHddDriveCacheNone
=== RUN   TestAccFSxLustreFileSystem_copyTagsToBackups
=== PAUSE TestAccFSxLustreFileSystem_copyTagsToBackups
=== RUN   TestAccFSxLustreFileSystem_autoImportPolicy
=== PAUSE TestAccFSxLustreFileSystem_autoImportPolicy
=== CONT  TestAccFSxLustreFileSystem_basic
=== CONT  TestAccFSxLustreFileSystem_deploymentTypePersistent2
=== CONT  TestAccFSxLustreFileSystem_storageTypeHddDriveCacheNone
=== CONT  TestAccFSxLustreFileSystem_logConfig
=== CONT  TestAccFSxLustreFileSystem_storageCapacityUpdate
=== CONT  TestAccFSxLustreFileSystem_rootSquashConfig
=== CONT  TestAccFSxLustreFileSystem_deploymentTypeScratch2
=== CONT  TestAccFSxLustreFileSystem_copyTagsToBackups
=== CONT  TestAccFSxLustreFileSystem_storageTypeHddDriveCacheRead
=== CONT  TestAccFSxLustreFileSystem_kmsKeyID
=== CONT  TestAccFSxLustreFileSystem_importPath
=== CONT  TestAccFSxLustreFileSystem_storageCapacity
=== CONT  TestAccFSxLustreFileSystem_securityGroupIDs
=== CONT  TestAccFSxLustreFileSystem_importedFileChunkSize
=== CONT  TestAccFSxLustreFileSystem_efaEnabled
=== CONT  TestAccFSxLustreFileSystem_intelligentTiering
=== CONT  TestAccFSxLustreFileSystem_deploymentTypePersistent2_perUnitStorageThroughput
=== CONT  TestAccFSxLustreFileSystem_metadataConfig_increase
=== CONT  TestAccFSxLustreFileSystem_metadataConfig_decrease
=== CONT  TestAccFSxLustreFileSystem_autoImportPolicy
--- PASS: TestAccFSxLustreFileSystem_copyTagsToBackups (1048.48s)
=== CONT  TestAccFSxLustreFileSystem_dataCompression
--- PASS: TestAccFSxLustreFileSystem_deploymentTypePersistent2 (1053.74s)
=== CONT  TestAccFSxLustreFileSystem_exportPath
--- PASS: TestAccFSxLustreFileSystem_basic (1065.18s)
=== CONT  TestAccFSxLustreFileSystem_automaticBackupRetentionDays
--- PASS: TestAccFSxLustreFileSystem_deploymentTypeScratch2 (1095.20s)
=== CONT  TestAccFSxLustreFileSystem_deploymentTypePersistent1_perUnitStorageThroughput
--- PASS: TestAccFSxLustreFileSystem_storageTypeHddDriveCacheNone (1162.63s)
=== CONT  TestAccFSxLustreFileSystem_deploymentTypePersistent1
--- PASS: TestAccFSxLustreFileSystem_storageTypeHddDriveCacheRead (1180.01s)
=== CONT  TestAccFSxLustreFileSystem_dailyAutomaticBackupStartTime
--- PASS: TestAccFSxLustreFileSystem_intelligentTiering (1193.09s)
=== CONT  TestAccFSxLustreFileSystem_metadataConfig
--- PASS: TestAccFSxLustreFileSystem_rootSquashConfig (1303.12s)
=== CONT  TestAccFSxLustreFileSystem_tags
--- PASS: TestAccFSxLustreFileSystem_efaEnabled (1327.35s)
=== CONT  TestAccFSxLustreFileSystem_weeklyMaintenanceStartTime
--- PASS: TestAccFSxLustreFileSystem_logConfig (1472.09s)
=== CONT  TestAccFSxLustreFileSystem_fileSystemTypeVersion
--- PASS: TestAccFSxLustreFileSystem_autoImportPolicy (1643.95s)
=== CONT  TestAccFSxLustreFileSystem_fromBackup
--- PASS: TestAccFSxLustreFileSystem_deploymentTypePersistent2_perUnitStorageThroughput (1757.14s)
=== CONT  TestAccFSxLustreFileSystem_disappears
--- PASS: TestAccFSxLustreFileSystem_metadataConfig_increase (2042.56s)
--- PASS: TestAccFSxLustreFileSystem_metadataConfig_decrease (2143.58s)
--- PASS: TestAccFSxLustreFileSystem_kmsKeyID (2167.18s)
--- PASS: TestAccFSxLustreFileSystem_securityGroupIDs (2184.10s)
--- PASS: TestAccFSxLustreFileSystem_deploymentTypePersistent1 (1069.83s)
--- PASS: TestAccFSxLustreFileSystem_storageCapacity (2249.38s)
--- PASS: TestAccFSxLustreFileSystem_automaticBackupRetentionDays (1224.91s)
--- PASS: TestAccFSxLustreFileSystem_dailyAutomaticBackupStartTime (1126.89s)
--- PASS: TestAccFSxLustreFileSystem_importedFileChunkSize (2312.81s)
--- PASS: TestAccFSxLustreFileSystem_metadataConfig (1169.44s)
--- PASS: TestAccFSxLustreFileSystem_dataCompression (1348.97s)
--- PASS: TestAccFSxLustreFileSystem_tags (1104.52s)
--- PASS: TestAccFSxLustreFileSystem_importPath (2447.98s)
--- PASS: TestAccFSxLustreFileSystem_weeklyMaintenanceStartTime (1157.97s)
--- PASS: TestAccFSxLustreFileSystem_disappears (995.97s)
--- PASS: TestAccFSxLustreFileSystem_deploymentTypePersistent1_perUnitStorageThroughput (1797.29s)
--- PASS: TestAccFSxLustreFileSystem_storageCapacityUpdate (3306.09s)
--- PASS: TestAccFSxLustreFileSystem_exportPath (2276.74s)
--- PASS: TestAccFSxLustreFileSystem_fileSystemTypeVersion (2225.11s)
--- PASS: TestAccFSxLustreFileSystem_fromBackup (2559.03s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fsx        4207.571s

```
