### PR TITLE
r/aws_servicequotas_service_quota: fix error when updating pending quota increase

### DIFF
--- a/.changelog/43606.txt
+++ b/.changelog/43606.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_servicequotas_service_quota: Fix error when updating a pending service quota request
+```

--- a/internal/service/servicequotas/service_quota.go
+++ b/internal/service/servicequotas/service_quota.go
@@ -278,7 +278,7 @@ func resourceServiceQuotaUpdate(ctx context.Context, d *schema.ResourceData, met
 
 	if errs.IsAErrorMessageContains[*awstypes.ResourceAlreadyExistsException](err, "Only one open service quota increase request is allowed per quota") {
 		tflog.Info(ctx, "request for Service Quota already exists", map[string]any{
-			"id": d.Id(),
+			names.AttrID: d.Id(),
 		})
 		return diags
 	}

--- a/internal/service/servicequotas/service_quota.go
+++ b/internal/service/servicequotas/service_quota.go
@@ -276,6 +276,13 @@ func resourceServiceQuotaUpdate(ctx context.Context, d *schema.ResourceData, met
 
 	output, err := conn.RequestServiceQuotaIncrease(ctx, &input)
 
+	if errs.IsAErrorMessageContains[*awstypes.ResourceAlreadyExistsException](err, "Only one open service quota increase request is allowed per quota") {
+		tflog.Info(ctx, "request for Service Quota already exists", map[string]any{
+			"id": d.Id(),
+		})
+		return diags
+	}
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "requesting Service Quotas Service Quota (%s) increase: %s", d.Id(), err)
 	}

--- a/internal/service/servicequotas/service_quota.go
+++ b/internal/service/servicequotas/service_quota.go
@@ -277,10 +277,7 @@ func resourceServiceQuotaUpdate(ctx context.Context, d *schema.ResourceData, met
 	output, err := conn.RequestServiceQuotaIncrease(ctx, &input)
 
 	if errs.IsAErrorMessageContains[*awstypes.ResourceAlreadyExistsException](err, "Only one open service quota increase request is allowed per quota") {
-		tflog.Info(ctx, "request for Service Quota already exists", map[string]any{
-			names.AttrID: d.Id(),
-		})
-		return diags
+		return sdkdiag.AppendWarningf(diags, "resource service quota %s already exists", d.Id())
 	}
 
 	if err != nil {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When a service quota increase is still pending, subsequent updates can produce the following error:

```console
 ResourceAlreadyExistsException: Only one open service quota increase request is allowed per qu
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccServiceQuotasServiceQuota_' PKG=servicequotas

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/servicequotas/... -v -count 1 -parallel 20  -run=TestAccServiceQuotasServiceQuota_ -timeout 360m -vet=off
2025/07/30 09:34:21 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/30 09:34:21 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccServiceQuotasServiceQuota_basic
=== PAUSE TestAccServiceQuotasServiceQuota_basic
=== RUN   TestAccServiceQuotasServiceQuota_basic_Unset
=== PAUSE TestAccServiceQuotasServiceQuota_basic_Unset
=== RUN   TestAccServiceQuotasServiceQuota_basic_hasUsageMetric
=== PAUSE TestAccServiceQuotasServiceQuota_basic_hasUsageMetric
=== RUN   TestAccServiceQuotasServiceQuota_Value_increaseOnCreate
    service_quota_test.go:146: Environment variable SERVICEQUOTAS_INCREASE_ON_CREATE_QUOTA_CODE is not set. WARNING: This test will submit a real service quota increase!
--- SKIP: TestAccServiceQuotasServiceQuota_Value_increaseOnCreate (0.00s)
=== RUN   TestAccServiceQuotasServiceQuota_Value_increaseOnUpdate
    service_quota_test.go:190: Environment variable SERVICEQUOTAS_INCREASE_ON_UPDATE_QUOTA_CODE is not set. WARNING: This test will submit a real service quota increase!
--- SKIP: TestAccServiceQuotasServiceQuota_Value_increaseOnUpdate (0.00s)
=== RUN   TestAccServiceQuotasServiceQuota_permissionError
=== PAUSE TestAccServiceQuotasServiceQuota_permissionError
=== CONT  TestAccServiceQuotasServiceQuota_basic
=== CONT  TestAccServiceQuotasServiceQuota_basic_hasUsageMetric
=== CONT  TestAccServiceQuotasServiceQuota_permissionError
=== CONT  TestAccServiceQuotasServiceQuota_basic_Unset
=== NAME  TestAccServiceQuotasServiceQuota_permissionError
    service_quota_test.go:243: skipping test; environment variable TF_ACC_ASSUME_ROLE_ARN must be set. Usage: Amazon Resource Name (ARN) of existing IAM Role to assume for testing restricted permissions
--- SKIP: TestAccServiceQuotasServiceQuota_permissionError (0.74s)
--- PASS: TestAccServiceQuotasServiceQuota_basic_hasUsageMetric (16.37s)
--- PASS: TestAccServiceQuotasServiceQuota_basic_Unset (16.47s)
--- PASS: TestAccServiceQuotasServiceQuota_basic (16.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas	22.746s
```
