### PR TITLE
[Enhancement] r/aws_opensearch_domain: Support the write-only variant of `master_user_password`

### DIFF
--- a/.changelog/43621.txt
+++ b/.changelog/43621.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_opensearch_domain: Add `advanced_security_options.master_user_options.master_user_password_wo` argument to support the write-only variant of `master_user_password`
+```

--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/opensearch"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/opensearch/types"
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -130,7 +131,6 @@ func resourceDomain() *schema.Resource {
 			"advanced_security_options": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -199,6 +199,19 @@ func resourceDomain() *schema.Resource {
 										Type:      schema.TypeString,
 										Optional:  true,
 										Sensitive: true,
+									},
+									"master_user_password_wo": {
+										Type:          schema.TypeString,
+										Optional:      true,
+										Sensitive:     true,
+										WriteOnly:     true,
+										ConflictsWith: []string{"advanced_security_options.0.master_user_options.0.master_user_password"},
+										RequiredWith:  []string{"advanced_security_options.0.master_user_options.0.master_user_password_wo_version"},
+									},
+									"master_user_password_wo_version": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										RequiredWith: []string{"advanced_security_options.0.master_user_options.0.master_user_password_wo"},
 									},
 								},
 							},
@@ -845,7 +858,13 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	if v, ok := d.GetOk("advanced_security_options"); ok {
-		input.AdvancedSecurityOptions = expandAdvancedSecurityOptions(v.([]any))
+		// get write-only value from configuration
+		masterUserPasswordWO, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath("advanced_security_options").IndexInt(0).GetAttr("master_user_options").IndexInt(0).GetAttr("master_user_password_wo"))
+		diags = append(diags, di...)
+		if diags.HasError() {
+			return diags
+		}
+		input.AdvancedSecurityOptions = expandAdvancedSecurityOptions(v.([]any), masterUserPasswordWO)
 	}
 
 	if v, ok := d.GetOk("aiml_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
@@ -1208,7 +1227,20 @@ func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 		}
 
 		if d.HasChange("advanced_security_options") {
-			input.AdvancedSecurityOptions = expandAdvancedSecurityOptions(d.Get("advanced_security_options").([]any))
+			masterUserPasswordWO := ""
+			if v, ok := d.Get("advanced_security_options").([]any); ok && len(v) > 0 && v[0] != nil {
+				if v, ok := v[0].(map[string]any)["master_user_options"].([]any); ok && len(v) > 0 && v[0] != nil {
+					if d.HasChange("advanced_security_options.0.master_user_options.0.master_user_password_wo_version") {
+						var di diag.Diagnostics
+						masterUserPasswordWO, di = flex.GetWriteOnlyStringValue(d, cty.GetAttrPath("advanced_security_options").IndexInt(0).GetAttr("master_user_options").IndexInt(0).GetAttr("master_user_password_wo"))
+						diags = append(diags, di...)
+						if diags.HasError() {
+							return diags
+						}
+					}
+				}
+			}
+			input.AdvancedSecurityOptions = expandAdvancedSecurityOptions(d.Get("advanced_security_options").([]any), masterUserPasswordWO)
 
 			// When jwt_options block is removed from config, explicitly disable JWT authentication
 			if input.AdvancedSecurityOptions.JWTOptions == nil {

--- a/internal/service/opensearch/domain_structure.go
+++ b/internal/service/opensearch/domain_structure.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func expandAdvancedSecurityOptions(m []any) *awstypes.AdvancedSecurityOptionsInput {
+func expandAdvancedSecurityOptions(m []any, masterUserPasswordWO string) *awstypes.AdvancedSecurityOptionsInput {
 	config := awstypes.AdvancedSecurityOptionsInput{}
 	group := m[0].(map[string]any)
 
@@ -48,6 +48,10 @@ func expandAdvancedSecurityOptions(m []any) *awstypes.AdvancedSecurityOptionsInp
 
 					if v, ok := masterUserOptions["master_user_password"].(string); ok && v != "" {
 						muo.MasterUserPassword = aws.String(v)
+					}
+
+					if masterUserPasswordWO != "" {
+						muo.MasterUserPassword = aws.String(masterUserPasswordWO)
 					}
 
 					config.MasterUserOptions = &muo

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -4391,7 +4391,7 @@ resource "aws_opensearch_domain" "test" {
     master_user_options {
       master_user_name                = "testmasteruser"
       master_user_password_wo         = %[2]q
-	  master_user_password_wo_version = %[3]q
+      master_user_password_wo_version = %[3]q
     }
   }
 

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -1112,7 +1112,7 @@ func TestAccOpenSearchDomain_AdvancedSecurityOptions_userDBWithMasterUserPasswor
 	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -1116,7 +1116,7 @@ func TestAccOpenSearchDomain_AdvancedSecurityOptions_userDBWithMasterUserPasswor
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainConfig_advancedSecurityOptionsUserDBWithMasterUserPasswordWO(rName, "Testpassword1!", "1"),
@@ -1130,7 +1130,7 @@ func TestAccOpenSearchDomain_AdvancedSecurityOptions_userDBWithMasterUserPasswor
 					},
 				},
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainExists(ctx, resourceName, &domain),
+					testAccCheckDomainExists(ctx, t, resourceName, &domain),
 					testAccCheckAdvancedSecurityOptions(true, true, false, &domain),
 				),
 			},
@@ -1165,7 +1165,7 @@ func TestAccOpenSearchDomain_AdvancedSecurityOptions_userDBWithMasterUserPasswor
 					},
 				},
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainExists(ctx, resourceName, &domain),
+					testAccCheckDomainExists(ctx, t, resourceName, &domain),
 					testAccCheckAdvancedSecurityOptions(true, true, false, &domain),
 				),
 			},

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -1102,6 +1102,77 @@ func TestAccOpenSearchDomain_AdvancedSecurityOptions_userDB(t *testing.T) {
 	})
 }
 
+func TestAccOpenSearchDomain_AdvancedSecurityOptions_userDBWithMasterUserPasswordWO(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var domain awstypes.DomainStatus
+	rName := testAccRandomDomainName()
+	resourceName := "aws_opensearch_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_advancedSecurityOptionsUserDBWithMasterUserPasswordWO(rName, "Testpassword1!", "1"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectSensitiveValue(
+							resourceName,
+							tfjsonpath.New("advanced_security_options").AtSliceIndex(0).AtMapKey("master_user_options").AtSliceIndex(0).AtMapKey("master_user_password_wo"),
+						),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					testAccCheckAdvancedSecurityOptions(true, true, false, &domain),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     rName,
+				ImportStateVerify: true,
+				// MasterUserOptions are not returned from DescribeDomainConfig
+				ImportStateVerifyIgnore: []string{
+					"advanced_security_options.0.internal_user_database_enabled",
+					"advanced_security_options.0.master_user_options",
+				},
+			},
+			{
+				Config: testAccDomainConfig_advancedSecurityOptionsUserDBWithMasterUserPasswordWO(rName, "Testpassword2!", "1"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: testAccDomainConfig_advancedSecurityOptionsUserDBWithMasterUserPasswordWO(rName, "Testpassword2!", "2"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectSensitiveValue(
+							resourceName,
+							tfjsonpath.New("advanced_security_options").AtSliceIndex(0).AtMapKey("master_user_options").AtSliceIndex(0).AtMapKey("master_user_password_wo"),
+						),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					testAccCheckAdvancedSecurityOptions(true, true, false, &domain),
+				),
+			},
+		},
+	})
+}
+
 func TestAccOpenSearchDomain_AdvancedSecurityOptions_anonymousAuth(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -4302,6 +4373,47 @@ resource "aws_opensearch_domain" "test" {
   }
 }
 `, rName)
+}
+
+func testAccDomainConfig_advancedSecurityOptionsUserDBWithMasterUserPasswordWO(rName, password, passwordVersion string) string {
+	return fmt.Sprintf(`
+resource "aws_opensearch_domain" "test" {
+  domain_name    = %[1]q
+  engine_version = "Elasticsearch_7.1"
+
+  cluster_config {
+    instance_type = "r5.large.search"
+  }
+
+  advanced_security_options {
+    enabled                        = true
+    internal_user_database_enabled = true
+    master_user_options {
+      master_user_name                = "testmasteruser"
+      master_user_password_wo         = %[2]q
+	  master_user_password_wo_version = %[3]q
+    }
+  }
+
+  encrypt_at_rest {
+    enabled = true
+  }
+
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
+
+  node_to_node_encryption {
+    enabled = true
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+  }
+}
+`, rName, password, passwordVersion)
 }
 
 func testAccDomainConfig_advancedSecurityOptionsAnonymousAuth(rName string, enabled bool) string {

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -363,7 +363,9 @@ The following arguments are optional:
 
 * `master_user_arn` - (Optional) ARN for the main user. Only specify if `internal_user_database_enabled` is not set or set to `false`.
 * `master_user_name` - (Optional) Main user's username, which is stored in the Amazon OpenSearch Service domain's internal database. Only specify if `internal_user_database_enabled` is set to `true`.
-* `master_user_password` - (Optional) Main user's password, which is stored in the Amazon OpenSearch Service domain's internal database. Only specify if `internal_user_database_enabled` is set to `true`.
+* `master_user_password` - (Optional) Main user's password, which is stored in the Amazon OpenSearch Service domain's internal database. Only specify if `internal_user_database_enabled` is set to `true`. Conflict with `master_user_password_wo`.
+* `master_user_password_wo` - (Optional, Write-Only) Main user's password, which is stored in the Amazon OpenSearch Service domain's internal database. It will not be stored in the state file. Only specify if `internal_user_database_enabled` is set to `true`. Conflict with `master_user_password`.
+* `master_user_password_wo_version` - (Optional, required when `master_user_password_wo` is specified) Used together with `master_user_password_wo` to trigger an update. Increment this value when an update to the `master_user_password_wo` is required.
 
 ### aiml_options
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

**Description**

* Added `master_user_password_wo` and `master_user_password_wo_version` to `advanced_security_options.master_user_options` to support the write-only variant of `master_user_password`.

### Relations

Closes #43509


### Output from Acceptance Testing
Rebased on the latest main branch and reran tests on Mar. 3, 2026

```console
$ make testacc TESTS='TestAccOpenSearchDomain_(basic|AdvancedSecurityOptions_)' PKG=opensearch
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_opensearch_domain-support_master_user_password_wo 🌿...
TF_ACC=1 go1.25.7 test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchDomain_(basic|AdvancedSecurityOptions_)'  -timeout 360m -vet=off
2026/03/03 23:34:04 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/03 23:34:04 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccOpenSearchDomain_basic
=== PAUSE TestAccOpenSearchDomain_basic
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_userDB
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_userDB
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_userDBWithMasterUserPasswordWO
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_userDBWithMasterUserPasswordWO
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_anonymousAuth
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_anonymousAuth
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_iam
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_iam
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_disabled
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_disabled
=== CONT  TestAccOpenSearchDomain_basic
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_iam
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_userDB
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_disabled
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_userDBWithMasterUserPasswordWO
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_anonymousAuth
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/elasticsearch_7.10
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/elasticsearch_7.10
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.11
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.11
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.13
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.13
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.9
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.9
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.10
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.10
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/elasticsearch_7.10
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.9
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.10
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.11
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.13
--- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation (0.00s)
    --- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/elasticsearch_7.10 (8.36s)
    --- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.10 (8.44s)
    --- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.9 (8.56s)
    --- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.13 (14.76s)
    --- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.11 (14.78s)
--- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_userDB (1540.42s)
--- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_disabled (1570.86s)
--- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_iam (1573.87s)
--- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_userDBWithMasterUserPasswordWO (1644.68s)
--- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions (1679.07s)
--- PASS: TestAccOpenSearchDomain_basic (1887.82s)
--- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_anonymousAuth (3783.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 3788.320s
```
