### PR TITLE
Technical debt: Allow S3 Access Grants resources to use full transparent tagging

### DIFF
--- a/internal/errs/fwdiag/diags.go
+++ b/internal/errs/fwdiag/diags.go
@@ -38,6 +38,13 @@ func DiagnosticString(d diag.Diagnostic) string {
 	return buf.String()
 }
 
+func NewCreatingResourceIDErrorDiagnostic(err error) diag.Diagnostic {
+	return diag.NewErrorDiagnostic(
+		"Creating Resource ID",
+		err.Error(),
+	)
+}
+
 func NewParsingResourceIDErrorDiagnostic(err error) diag.Diagnostic {
 	return diag.NewErrorDiagnostic(
 		"Parsing Resource ID",

--- a/internal/generate/tags/main.go
+++ b/internal/generate/tags/main.go
@@ -87,6 +87,7 @@ var (
 	tagOpBatchSize        = flag.Int("TagOpBatchSize", 0, "tagOpBatchSize")
 	tagResTypeElem        = flag.String("TagResTypeElem", "", "tagResTypeElem")
 	tagResTypeElemType    = flag.String("TagResTypeElemType", "", "tagResTypeElemType")
+	tagResTypeIsAccountID = flag.Bool("TagResTypeIsAccountID", false, "tagResTypeIsAccountID")
 	tagType               = flag.String("TagType", "Tag", "tagType")
 	tagType2              = flag.String("TagType2", "", "tagType")
 	tagTypeAddBoolElem    = flag.String("TagTypeAddBoolElem", "", "TagTypeAddBoolElem")
@@ -182,6 +183,7 @@ type TemplateData struct {
 	TagOpBatchSize             int
 	TagResTypeElem             string
 	TagResTypeElemType         string
+	TagResTypeIsAccountID      bool
 	TagType                    string
 	TagType2                   string
 	TagTypeAddBoolElem         string
@@ -242,6 +244,10 @@ func main() {
 		createTagsFunc = ""
 	}
 
+	if *tagResTypeIsAccountID && *tagResTypeElem == "" {
+		g.Errorf("TagResTypeIsAccountID requires TagResTypeElem")
+	}
+
 	clientType := fmt.Sprintf("*%s.Client", awsPkg)
 	providerNameUpper := service.ProviderNameUpper()
 	templateData := TemplateData{
@@ -281,6 +287,7 @@ func main() {
 		TagOpBatchSize:             *tagOpBatchSize,
 		TagResTypeElem:             *tagResTypeElem,
 		TagResTypeElemType:         *tagResTypeElemType,
+		TagResTypeIsAccountID:      *tagResTypeIsAccountID,
 		TagType:                    *tagType,
 		TagType2:                   *tagType2,
 		TagTypeAddBoolElem:         *tagTypeAddBoolElem,

--- a/internal/generate/tags/templates/list_tags_body.gtpl
+++ b/internal/generate/tags/templates/list_tags_body.gtpl
@@ -176,8 +176,19 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 {{- if .IsDefaultListTags }}
 // {{ .ListTagsFunc | Title }} lists {{ .ServicePackage }} service tags and set them in Context.
 // It is called from outside this package.
-func (p *servicePackage) {{ .ListTagsFunc | Title }}(ctx context.Context, meta any, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string) error {
-	tags, err :=  {{ .ListTagsFunc }}(ctx, meta.(*conns.AWSClient).{{ .ProviderNameUpper }}Client(ctx), identifier{{ if .TagResTypeElem }}, resourceType{{ end }})
+{{- if .TagResTypeElem }}
+{{- if .TagResTypeIsAccountID }}
+func (p *servicePackage) {{ .ListTagsFunc | Title }}(ctx context.Context, meta any, identifier string) error {
+	c := meta.(*conns.AWSClient)
+	tags, err :=  {{ .ListTagsFunc }}(ctx, c.{{ .ProviderNameUpper }}Client(ctx), identifier, c.AccountID(ctx))
+{{- else }}
+func (p *servicePackage) {{ .ListTagsFunc | Title }}(ctx context.Context, meta any, identifier, resourceType string) error {
+	tags, err :=  {{ .ListTagsFunc }}(ctx, meta.(*conns.AWSClient).{{ .ProviderNameUpper }}Client(ctx), identifier, resourceType)
+{{- end }}
+{{- else }}
+func (p *servicePackage) {{ .ListTagsFunc | Title }}(ctx context.Context, meta any, identifier string) error {
+	tags, err :=  {{ .ListTagsFunc }}(ctx, meta.(*conns.AWSClient).{{ .ProviderNameUpper }}Client(ctx), identifier)
+{{- end }}
 
 	if err != nil {
 		return smarterr.NewError(err)

--- a/internal/generate/tags/templates/update_tags_body.gtpl
+++ b/internal/generate/tags/templates/update_tags_body.gtpl
@@ -195,7 +195,20 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 {{- if .IsDefaultUpdateTags }}
 // {{ .UpdateTagsFunc | Title }} updates {{ .ServicePackage }} service tags.
 // It is called from outside this package.
-func (p *servicePackage) {{ .UpdateTagsFunc | Title }}(ctx context.Context, meta any, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string, oldTags, newTags any) error {
-	return  {{ .UpdateTagsFunc }}(ctx, meta.(*conns.AWSClient).{{ .ProviderNameUpper }}Client(ctx), identifier{{ if .TagResTypeElem }}, resourceType{{ end }}, oldTags, newTags)
+{{- if .TagResTypeElem }}
+{{- if .TagResTypeIsAccountID }}
+func (p *servicePackage) {{ .UpdateTagsFunc | Title }}(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
+	c := meta.(*conns.AWSClient)
+	return  {{ .UpdateTagsFunc }}(ctx, c.{{ .ProviderNameUpper }}Client(ctx), identifier, c.AccountID(ctx), oldTags, newTags)
 }
+{{- else }}
+func (p *servicePackage) {{ .UpdateTagsFunc | Title }}(ctx context.Context, meta any, identifier, resourceType string, oldTags, newTags any) error {
+	return  {{ .UpdateTagsFunc }}(ctx, meta.(*conns.AWSClient).{{ .ProviderNameUpper }}Client(ctx), identifier, resourceType, oldTags, newTags)
+}
+{{- end }}
+{{- else }}
+func (p *servicePackage) {{ .UpdateTagsFunc | Title }}(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
+	return  {{ .UpdateTagsFunc }}(ctx, meta.(*conns.AWSClient).{{ .ProviderNameUpper }}Client(ctx), identifier, oldTags, newTags)
+}
+{{- end }}
 {{- end }}

--- a/internal/service/s3/tags.go
+++ b/internal/service/s3/tags.go
@@ -36,11 +36,11 @@ func bucketCreateTags(ctx context.Context, conn *s3.Client, identifier string, t
 // bucketListTags lists S3 bucket tags.
 // The identifier is the bucket name.
 func bucketListTags(ctx context.Context, conn *s3.Client, identifier string, optFns ...func(*s3.Options)) (tftags.KeyValueTags, error) {
-	input := &s3.GetBucketTaggingInput{
+	input := s3.GetBucketTaggingInput{
 		Bucket: aws.String(identifier),
 	}
 
-	output, err := conn.GetBucketTagging(ctx, input, optFns...)
+	output, err := conn.GetBucketTagging(ctx, &input, optFns...)
 
 	if tfawserr.ErrCodeEquals(err, errCodeNoSuchTagSet, errCodeNoSuchTagSetError, errCodeMethodNotAllowed, errCodeNotImplemented, errCodeXNotImplemented, errCodeUnsupportedOperation) {
 		return tftags.New(ctx, nil), nil
@@ -68,24 +68,24 @@ func bucketUpdateTags(ctx context.Context, conn *s3.Client, identifier string, o
 	ignoredTags := allTags.Ignore(oldTags).Ignore(newTags)
 
 	if len(newTags)+len(ignoredTags) > 0 {
-		input := &s3.PutBucketTaggingInput{
+		input := s3.PutBucketTaggingInput{
 			Bucket: aws.String(identifier),
 			Tagging: &awstypes.Tagging{
 				TagSet: svcTags(newTags.Merge(ignoredTags)),
 			},
 		}
 
-		_, err := conn.PutBucketTagging(ctx, input, optFns...)
+		_, err := conn.PutBucketTagging(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("setting resource tags (%s): %w", identifier, err)
 		}
 	} else if len(oldTags) > 0 && len(ignoredTags) == 0 {
-		input := &s3.DeleteBucketTaggingInput{
+		input := s3.DeleteBucketTaggingInput{
 			Bucket: aws.String(identifier),
 		}
 
-		_, err := conn.DeleteBucketTagging(ctx, input, optFns...)
+		_, err := conn.DeleteBucketTagging(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("deleting resource tags (%s): %w", identifier, err)
@@ -97,12 +97,12 @@ func bucketUpdateTags(ctx context.Context, conn *s3.Client, identifier string, o
 
 // objectListTags lists S3 object tags.
 func objectListTags(ctx context.Context, conn *s3.Client, bucket, key string, optFns ...func(*s3.Options)) (tftags.KeyValueTags, error) {
-	input := &s3.GetObjectTaggingInput{
+	input := s3.GetObjectTaggingInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
 	}
 
-	output, err := conn.GetObjectTagging(ctx, input, optFns...)
+	output, err := conn.GetObjectTagging(ctx, &input, optFns...)
 
 	if tfawserr.ErrCodeEquals(err, errCodeNoSuchTagSet, errCodeNoSuchTagSetError) {
 		return tftags.New(ctx, nil), nil
@@ -134,7 +134,7 @@ func objectUpdateTags(ctx context.Context, conn *s3.Client, bucket, key string, 
 	ignoredTags := allTags.Ignore(oldTags).Ignore(newTags)
 
 	if len(newTags)+len(ignoredTags) > 0 {
-		input := &s3.PutObjectTaggingInput{
+		input := s3.PutObjectTaggingInput{
 			Bucket: aws.String(bucket),
 			Key:    aws.String(key),
 			Tagging: &awstypes.Tagging{
@@ -142,18 +142,18 @@ func objectUpdateTags(ctx context.Context, conn *s3.Client, bucket, key string, 
 			},
 		}
 
-		_, err := conn.PutObjectTagging(ctx, input, optFns...)
+		_, err := conn.PutObjectTagging(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("setting resource tags (%s/%s): %w", bucket, key, err)
 		}
 	} else if len(oldTags) > 0 && len(ignoredTags) == 0 {
-		input := &s3.DeleteObjectTaggingInput{
+		input := s3.DeleteObjectTaggingInput{
 			Bucket: aws.String(bucket),
 			Key:    aws.String(key),
 		}
 
-		_, err := conn.DeleteObjectTagging(ctx, input, optFns...)
+		_, err := conn.DeleteObjectTagging(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("deleting resource tags (%s/%s): %w", bucket, key, err)

--- a/internal/service/s3control/access_grant.go
+++ b/internal/service/s3control/access_grant.go
@@ -33,7 +33,7 @@ import (
 )
 
 // @FrameworkResource("aws_s3control_access_grant", name="Access Grant")
-// @Tags
+// @Tags(identifierAttribute="access_grant_arn")
 func newAccessGrantResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &accessGrantResource{}
 
@@ -82,6 +82,7 @@ func (r *accessGrantResource) Schema(ctx context.Context, request resource.Schem
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
+			names.AttrID: framework.IDAttribute(),
 			"permission": schema.StringAttribute{
 				CustomType: fwtypes.StringEnumType[awstypes.Permission](),
 				Required:   true,
@@ -89,7 +90,6 @@ func (r *accessGrantResource) Schema(ctx context.Context, request resource.Schem
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			names.AttrID: framework.IDAttribute(),
 			"s3_prefix_type": schema.StringAttribute{
 				CustomType: fwtypes.StringEnumType[awstypes.S3PrefixType](),
 				Optional:   true,
@@ -153,29 +153,28 @@ func (r *accessGrantResource) Schema(ctx context.Context, request resource.Schem
 
 func (r *accessGrantResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
 	var data accessGrantResourceModel
-
 	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
-
 	if response.Diagnostics.HasError() {
 		return
+	}
+	if data.AccountID.IsUnknown() {
+		data.AccountID = fwflex.StringValueToFramework(ctx, r.Meta().AccountID(ctx))
 	}
 
 	conn := r.Meta().S3ControlClient(ctx)
 
-	if data.AccountID.ValueString() == "" {
-		data.AccountID = types.StringValue(r.Meta().AccountID(ctx))
-	}
-	input := &s3control.CreateAccessGrantInput{}
-	response.Diagnostics.Append(fwflex.Expand(ctx, data, input)...)
+	var input s3control.CreateAccessGrantInput
+	response.Diagnostics.Append(fwflex.Expand(ctx, data, &input)...)
 	if response.Diagnostics.HasError() {
 		return
 	}
 
+	// Additional fields.
 	input.Tags = getTagsIn(ctx)
 
 	// "InvalidRequest: Invalid Grantee in the request".
 	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, s3PropagationTimeout, func() (any, error) {
-		return conn.CreateAccessGrant(ctx, input)
+		return conn.CreateAccessGrant(ctx, &input)
 	}, errCodeInvalidRequest, "Invalid Grantee in the request")
 
 	if err != nil {
@@ -186,30 +185,29 @@ func (r *accessGrantResource) Create(ctx context.Context, request resource.Creat
 
 	// Set values for unknowns.
 	output := outputRaw.(*s3control.CreateAccessGrantOutput)
-	data.AccessGrantARN = fwflex.StringToFramework(ctx, output.AccessGrantArn)
-	data.AccessGrantID = fwflex.StringToFramework(ctx, output.AccessGrantId)
-	data.GrantScope = fwflex.StringToFramework(ctx, output.GrantScope)
-	id, err := data.setID()
-	if err != nil {
-		response.Diagnostics.AddError("creating S3 Access Grant", err.Error())
+	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &data)...)
+	if response.Diagnostics.HasError() {
 		return
 	}
-	data.ID = types.StringValue(id)
+	id, err := data.setID()
+	if err != nil {
+		response.Diagnostics.Append(fwdiag.NewCreatingResourceIDErrorDiagnostic(err))
+		return
+	}
+	data.ID = fwflex.StringValueToFramework(ctx, id)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
 func (r *accessGrantResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
 	var data accessGrantResourceModel
-
 	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
-
 	if response.Diagnostics.HasError() {
 		return
 	}
 
 	if err := data.InitFromID(); err != nil {
-		response.Diagnostics.AddError("parsing resource ID", err.Error())
+		response.Diagnostics.Append(fwdiag.NewParsingResourceIDErrorDiagnostic(err))
 
 		return
 	}
@@ -241,62 +239,23 @@ func (r *accessGrantResource) Read(ctx context.Context, request resource.ReadReq
 		return
 	}
 
-	tags, err := listTags(ctx, conn, data.AccessGrantARN.ValueString(), data.AccountID.ValueString())
-
-	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("listing tags for S3 Access Grant (%s)", data.ID.ValueString()), err.Error())
-
-		return
-	}
-
-	setTagsOut(ctx, svcTags(tags))
-
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
-}
-
-func (r *accessGrantResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
-	var old, new accessGrantResourceModel
-
-	response.Diagnostics.Append(request.State.Get(ctx, &old)...)
-
-	if response.Diagnostics.HasError() {
-		return
-	}
-
-	response.Diagnostics.Append(request.Plan.Get(ctx, &new)...)
-
-	if response.Diagnostics.HasError() {
-		return
-	}
-
-	conn := r.Meta().S3ControlClient(ctx)
-
-	if oldTagsAll, newTagsAll := old.TagsAll, new.TagsAll; !newTagsAll.Equal(oldTagsAll) {
-		if err := updateTags(ctx, conn, new.AccessGrantARN.ValueString(), new.AccountID.ValueString(), oldTagsAll, newTagsAll); err != nil {
-			response.Diagnostics.AddError(fmt.Sprintf("updating tags for S3 Access Grant (%s)", new.ID.ValueString()), err.Error())
-
-			return
-		}
-	}
-
-	response.Diagnostics.Append(response.State.Set(ctx, &new)...)
 }
 
 func (r *accessGrantResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
 	var data accessGrantResourceModel
-
 	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
-
 	if response.Diagnostics.HasError() {
 		return
 	}
 
 	conn := r.Meta().S3ControlClient(ctx)
 
-	_, err := conn.DeleteAccessGrant(ctx, &s3control.DeleteAccessGrantInput{
+	input := s3control.DeleteAccessGrantInput{
 		AccessGrantId: fwflex.StringFromFramework(ctx, data.AccessGrantID),
 		AccountId:     fwflex.StringFromFramework(ctx, data.AccountID),
-	})
+	}
+	_, err := conn.DeleteAccessGrant(ctx, &input)
 
 	if tfawserr.ErrHTTPStatusCodeEquals(err, http.StatusNotFound) {
 		return
@@ -310,11 +269,15 @@ func (r *accessGrantResource) Delete(ctx context.Context, request resource.Delet
 }
 
 func findAccessGrantByTwoPartKey(ctx context.Context, conn *s3control.Client, accountID, grantID string) (*s3control.GetAccessGrantOutput, error) {
-	input := &s3control.GetAccessGrantInput{
+	input := s3control.GetAccessGrantInput{
 		AccessGrantId: aws.String(grantID),
 		AccountId:     aws.String(accountID),
 	}
 
+	return findAccessGrant(ctx, conn, &input)
+}
+
+func findAccessGrant(ctx context.Context, conn *s3control.Client, input *s3control.GetAccessGrantInput) (*s3control.GetAccessGrantOutput, error) {
 	output, err := conn.GetAccessGrant(ctx, input)
 
 	if tfawserr.ErrHTTPStatusCodeEquals(err, http.StatusNotFound) {

--- a/internal/service/s3control/access_grants_instance.go
+++ b/internal/service/s3control/access_grants_instance.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
-	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -29,7 +29,7 @@ import (
 )
 
 // @FrameworkResource("aws_s3control_access_grants_instance", name="Access Grants Instance")
-// @Tags
+// @Tags(identifierAttribute="access_grants_instance_arn")
 func newAccessGrantsInstanceResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &accessGrantsInstanceResource{}
 
@@ -85,59 +85,56 @@ func (r *accessGrantsInstanceResource) Schema(ctx context.Context, request resou
 
 func (r *accessGrantsInstanceResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
 	var data accessGrantsInstanceResourceModel
-
 	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
-
 	if response.Diagnostics.HasError() {
 		return
+	}
+	if data.AccountID.IsUnknown() {
+		data.AccountID = fwflex.StringValueToFramework(ctx, r.Meta().AccountID(ctx))
 	}
 
 	conn := r.Meta().S3ControlClient(ctx)
 
-	if data.AccountID.ValueString() == "" {
-		data.AccountID = types.StringValue(r.Meta().AccountID(ctx))
-	}
-	input := &s3control.CreateAccessGrantsInstanceInput{
-		AccountId:         flex.StringFromFramework(ctx, data.AccountID),
-		IdentityCenterArn: flex.StringFromFramework(ctx, data.IdentityCenterARN),
-		Tags:              getTagsIn(ctx),
+	accountID := fwflex.StringValueFromFramework(ctx, data.AccountID)
+	var input s3control.CreateAccessGrantsInstanceInput
+	response.Diagnostics.Append(fwflex.Expand(ctx, data, &input)...)
+	if response.Diagnostics.HasError() {
+		return
 	}
 
-	output, err := conn.CreateAccessGrantsInstance(ctx, input)
+	// Additional fields.
+	input.Tags = getTagsIn(ctx)
+
+	output, err := conn.CreateAccessGrantsInstance(ctx, &input)
 
 	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("creating S3 Access Grants Instance (%s)", data.AccountID.ValueString()), err.Error())
+		response.Diagnostics.AddError(fmt.Sprintf("creating S3 Access Grants Instance (%s)", accountID), err.Error())
 
 		return
 	}
 
 	// Set values for unknowns.
-	data.AccessGrantsInstanceARN = flex.StringToFramework(ctx, output.AccessGrantsInstanceArn)
-	data.AccessGrantsInstanceID = flex.StringToFramework(ctx, output.AccessGrantsInstanceId)
-	data.IdentityCenterApplicationARN = flex.StringToFramework(ctx, output.IdentityCenterArn)
-	data.setID()
+	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	data.ID = fwflex.StringValueToFramework(ctx, accountID)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
 func (r *accessGrantsInstanceResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
 	var data accessGrantsInstanceResourceModel
-
 	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
-
 	if response.Diagnostics.HasError() {
 		return
 	}
-
-	if err := data.InitFromID(); err != nil {
-		response.Diagnostics.AddError("parsing resource ID", err.Error())
-
-		return
-	}
+	data.AccountID = data.ID // From import.
 
 	conn := r.Meta().S3ControlClient(ctx)
 
-	output, err := findAccessGrantsInstance(ctx, conn, data.AccountID.ValueString())
+	accountID := fwflex.StringValueFromFramework(ctx, data.AccountID)
+	output, err := findAccessGrantsInstanceByID(ctx, conn, accountID)
 
 	if tfresource.NotFound(err) {
 		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
@@ -147,69 +144,48 @@ func (r *accessGrantsInstanceResource) Read(ctx context.Context, request resourc
 	}
 
 	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("reading S3 Access Grants Instance (%s)", data.ID.ValueString()), err.Error())
+		response.Diagnostics.AddError(fmt.Sprintf("reading S3 Access Grants Instance (%s)", accountID), err.Error())
 
 		return
 	}
 
 	// Set attributes for import.
-	data.AccessGrantsInstanceARN = flex.StringToFramework(ctx, output.AccessGrantsInstanceArn)
-	data.AccessGrantsInstanceID = flex.StringToFramework(ctx, output.AccessGrantsInstanceId)
-	data.IdentityCenterApplicationARN = flex.StringToFramework(ctx, output.IdentityCenterArn)
-
-	tags, err := listTags(ctx, conn, data.AccessGrantsInstanceARN.ValueString(), data.AccountID.ValueString())
-
-	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("listing tags for S3 Access Grants Instance (%s)", data.ID.ValueString()), err.Error())
-
+	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &data)...)
+	if response.Diagnostics.HasError() {
 		return
 	}
-
-	setTagsOut(ctx, svcTags(tags))
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
 func (r *accessGrantsInstanceResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
 	var old, new accessGrantsInstanceResourceModel
-
 	response.Diagnostics.Append(request.State.Get(ctx, &old)...)
-
 	if response.Diagnostics.HasError() {
 		return
 	}
-
 	response.Diagnostics.Append(request.Plan.Get(ctx, &new)...)
-
 	if response.Diagnostics.HasError() {
 		return
 	}
 
 	conn := r.Meta().S3ControlClient(ctx)
 
-	if oldARN, newARN := old.IdentityCenterARN, new.IdentityCenterARN; !newARN.Equal(oldARN) {
+	if accountID, oldARN, newARN := fwflex.StringValueFromFramework(ctx, new.AccountID), old.IdentityCenterARN, new.IdentityCenterARN; !newARN.Equal(oldARN) {
 		if !oldARN.IsNull() {
-			if err := disassociateAccessGrantsInstanceIdentityCenterInstance(ctx, conn, old.ID.ValueString()); err != nil {
-				response.Diagnostics.AddError(fmt.Sprintf("dissociating S3 Access Grants Instance (%s) IAM Identity Center instance", old.ID.ValueString()), err.Error())
+			if err := disassociateAccessGrantsInstanceIdentityCenterInstance(ctx, conn, accountID); err != nil {
+				response.Diagnostics.AddError(fmt.Sprintf("dissociating S3 Access Grants Instance (%s) IAM Identity Center instance", accountID), err.Error())
 
 				return
 			}
 		}
 
 		if !newARN.IsNull() {
-			if err := associateAccessGrantsInstanceIdentityCenterInstance(ctx, conn, new.ID.ValueString(), newARN.ValueString()); err != nil {
-				response.Diagnostics.AddError(fmt.Sprintf("associating S3 Access Grants Instance (%s) IAM Identity Center instance (%s)", new.ID.ValueString(), newARN.ValueString()), err.Error())
+			if err := associateAccessGrantsInstanceIdentityCenterInstance(ctx, conn, accountID, newARN.ValueString()); err != nil {
+				response.Diagnostics.AddError(fmt.Sprintf("associating S3 Access Grants Instance (%s) IAM Identity Center instance (%s)", accountID, newARN.ValueString()), err.Error())
 
 				return
 			}
-		}
-	}
-
-	if oldTagsAll, newTagsAll := old.TagsAll, new.TagsAll; !newTagsAll.Equal(oldTagsAll) {
-		if err := updateTags(ctx, conn, new.AccessGrantsInstanceARN.ValueString(), new.AccountID.ValueString(), oldTagsAll, newTagsAll); err != nil {
-			response.Diagnostics.AddError(fmt.Sprintf("updating tags for S3 Access Grants Instance (%s)", new.ID.ValueString()), err.Error())
-
-			return
 		}
 	}
 
@@ -218,64 +194,68 @@ func (r *accessGrantsInstanceResource) Update(ctx context.Context, request resou
 
 func (r *accessGrantsInstanceResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
 	var data accessGrantsInstanceResourceModel
-
 	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
-
 	if response.Diagnostics.HasError() {
 		return
 	}
 
 	conn := r.Meta().S3ControlClient(ctx)
 
+	accountID := fwflex.StringValueFromFramework(ctx, data.AccountID)
 	if !data.IdentityCenterARN.IsNull() {
-		if err := disassociateAccessGrantsInstanceIdentityCenterInstance(ctx, conn, data.ID.ValueString()); err != nil {
-			response.Diagnostics.AddError(fmt.Sprintf("dissociating S3 Access Grants Instance (%s) IAM Identity Center instance", data.ID.ValueString()), err.Error())
+		if err := disassociateAccessGrantsInstanceIdentityCenterInstance(ctx, conn, accountID); err != nil {
+			response.Diagnostics.AddError(fmt.Sprintf("dissociating S3 Access Grants Instance (%s) IAM Identity Center instance", accountID), err.Error())
 
 			return
 		}
 	}
 
-	_, err := conn.DeleteAccessGrantsInstance(ctx, &s3control.DeleteAccessGrantsInstanceInput{
-		AccountId: flex.StringFromFramework(ctx, data.AccountID),
-	})
+	input := s3control.DeleteAccessGrantsInstanceInput{
+		AccountId: aws.String(accountID),
+	}
+	_, err := conn.DeleteAccessGrantsInstance(ctx, &input)
 
 	if tfawserr.ErrHTTPStatusCodeEquals(err, http.StatusNotFound) {
 		return
 	}
 
 	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("deleting S3 Access Grants Instance (%s)", data.ID.ValueString()), err.Error())
+		response.Diagnostics.AddError(fmt.Sprintf("deleting S3 Access Grants Instance (%s)", accountID), err.Error())
 
 		return
 	}
 }
 
 func associateAccessGrantsInstanceIdentityCenterInstance(ctx context.Context, conn *s3control.Client, accountID, identityCenterARN string) error {
-	input := &s3control.AssociateAccessGrantsIdentityCenterInput{
+	input := s3control.AssociateAccessGrantsIdentityCenterInput{
 		AccountId:         aws.String(accountID),
 		IdentityCenterArn: aws.String(identityCenterARN),
 	}
 
-	_, err := conn.AssociateAccessGrantsIdentityCenter(ctx, input)
+	_, err := conn.AssociateAccessGrantsIdentityCenter(ctx, &input)
 
 	return err
 }
 
 func disassociateAccessGrantsInstanceIdentityCenterInstance(ctx context.Context, conn *s3control.Client, accountID string) error {
-	input := &s3control.DissociateAccessGrantsIdentityCenterInput{
+	input := s3control.DissociateAccessGrantsIdentityCenterInput{
 		AccountId: aws.String(accountID),
 	}
 
-	_, err := conn.DissociateAccessGrantsIdentityCenter(ctx, input)
+	_, err := conn.DissociateAccessGrantsIdentityCenter(ctx, &input)
 
 	return err
 }
 
-func findAccessGrantsInstance(ctx context.Context, conn *s3control.Client, accountID string) (*s3control.GetAccessGrantsInstanceOutput, error) {
-	input := &s3control.GetAccessGrantsInstanceInput{
+func findAccessGrantsInstanceByID(ctx context.Context, conn *s3control.Client, accountID string) (*s3control.GetAccessGrantsInstanceOutput, error) {
+	input := s3control.GetAccessGrantsInstanceInput{
 		AccountId: aws.String(accountID),
 	}
 
+	return findAccessGrantsInstance(ctx, conn, &input)
+}
+
+func findAccessGrantsInstance(ctx context.Context, conn *s3control.Client, input *s3control.GetAccessGrantsInstanceInput) (*s3control.GetAccessGrantsInstanceOutput, error) {
 	output, err := conn.GetAccessGrantsInstance(ctx, input)
 
 	if tfawserr.ErrHTTPStatusCodeEquals(err, http.StatusNotFound) {
@@ -306,14 +286,4 @@ type accessGrantsInstanceResourceModel struct {
 	IdentityCenterARN            fwtypes.ARN  `tfsdk:"identity_center_arn"`
 	Tags                         tftags.Map   `tfsdk:"tags"`
 	TagsAll                      tftags.Map   `tfsdk:"tags_all"`
-}
-
-func (data *accessGrantsInstanceResourceModel) InitFromID() error {
-	data.AccountID = data.ID
-
-	return nil
-}
-
-func (data *accessGrantsInstanceResourceModel) setID() {
-	data.ID = data.AccountID
 }

--- a/internal/service/s3control/access_grants_instance_test.go
+++ b/internal/service/s3control/access_grants_instance_test.go
@@ -167,7 +167,7 @@ func testAccCheckAccessGrantsInstanceDestroy(ctx context.Context) resource.TestC
 				continue
 			}
 
-			_, err := tfs3control.FindAccessGrantsInstance(ctx, conn, rs.Primary.ID)
+			_, err := tfs3control.FindAccessGrantsInstanceByID(ctx, conn, rs.Primary.ID)
 
 			if tfresource.NotFound(err) {
 				continue
@@ -193,7 +193,7 @@ func testAccCheckAccessGrantsInstanceExists(ctx context.Context, n string) resou
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).S3ControlClient(ctx)
 
-		_, err := tfs3control.FindAccessGrantsInstance(ctx, conn, rs.Primary.ID)
+		_, err := tfs3control.FindAccessGrantsInstanceByID(ctx, conn, rs.Primary.ID)
 
 		return err
 	}

--- a/internal/service/s3control/access_grants_location.go
+++ b/internal/service/s3control/access_grants_location.go
@@ -30,7 +30,7 @@ import (
 )
 
 // @FrameworkResource("aws_s3control_access_grants_location", name="Access Grants Location")
-// @Tags
+// @Tags(identifierAttribute="access_grants_location_arn")
 func newAccessGrantsLocationResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &accessGrantsLocationResource{}
 
@@ -71,13 +71,13 @@ func (r *accessGrantsLocationResource) Schema(ctx context.Context, request resou
 				CustomType: fwtypes.ARNType,
 				Required:   true,
 			},
+			names.AttrID: framework.IDAttribute(),
 			"location_scope": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			names.AttrID:      framework.IDAttribute(),
 			names.AttrTags:    tftags.TagsAttribute(),
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 		},
@@ -86,28 +86,27 @@ func (r *accessGrantsLocationResource) Schema(ctx context.Context, request resou
 
 func (r *accessGrantsLocationResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
 	var data accessGrantsLocationResourceModel
-
 	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
-
 	if response.Diagnostics.HasError() {
 		return
+	}
+	if data.AccountID.IsUnknown() {
+		data.AccountID = fwflex.StringValueToFramework(ctx, r.Meta().AccountID(ctx))
 	}
 
 	conn := r.Meta().S3ControlClient(ctx)
 
-	if data.AccountID.ValueString() == "" {
-		data.AccountID = types.StringValue(r.Meta().AccountID(ctx))
-	}
-	input := &s3control.CreateAccessGrantsLocationInput{}
-	response.Diagnostics.Append(fwflex.Expand(ctx, data, input)...)
+	var input s3control.CreateAccessGrantsLocationInput
+	response.Diagnostics.Append(fwflex.Expand(ctx, data, &input)...)
 	if response.Diagnostics.HasError() {
 		return
 	}
 
+	// Additional fields.
 	input.Tags = getTagsIn(ctx)
 
 	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, s3PropagationTimeout, func() (any, error) {
-		return conn.CreateAccessGrantsLocation(ctx, input)
+		return conn.CreateAccessGrantsLocation(ctx, &input)
 	}, errCodeInvalidIAMRole)
 
 	if err != nil {
@@ -118,29 +117,29 @@ func (r *accessGrantsLocationResource) Create(ctx context.Context, request resou
 
 	// Set values for unknowns.
 	output := outputRaw.(*s3control.CreateAccessGrantsLocationOutput)
-	data.AccessGrantsLocationARN = fwflex.StringToFramework(ctx, output.AccessGrantsLocationArn)
-	data.AccessGrantsLocationID = fwflex.StringToFramework(ctx, output.AccessGrantsLocationId)
-	id, err := data.setID()
-	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("creating S3 Access Grants Location (%s)", data.LocationScope.ValueString()), err.Error())
+	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &data)...)
+	if response.Diagnostics.HasError() {
 		return
 	}
-	data.ID = types.StringValue(id)
+	id, err := data.setID()
+	if err != nil {
+		response.Diagnostics.Append(fwdiag.NewCreatingResourceIDErrorDiagnostic(err))
+		return
+	}
+	data.ID = fwflex.StringValueToFramework(ctx, id)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
 func (r *accessGrantsLocationResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
 	var data accessGrantsLocationResourceModel
-
 	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
-
 	if response.Diagnostics.HasError() {
 		return
 	}
 
 	if err := data.InitFromID(); err != nil {
-		response.Diagnostics.AddError("parsing resource ID", err.Error())
+		response.Diagnostics.Append(fwdiag.NewParsingResourceIDErrorDiagnostic(err))
 
 		return
 	}
@@ -168,30 +167,16 @@ func (r *accessGrantsLocationResource) Read(ctx context.Context, request resourc
 		return
 	}
 
-	tags, err := listTags(ctx, conn, data.AccessGrantsLocationARN.ValueString(), data.AccountID.ValueString())
-
-	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("listing tags for S3 Access Grants Location (%s)", data.ID.ValueString()), err.Error())
-
-		return
-	}
-
-	setTagsOut(ctx, svcTags(tags))
-
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
 func (r *accessGrantsLocationResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
 	var old, new accessGrantsLocationResourceModel
-
 	response.Diagnostics.Append(request.State.Get(ctx, &old)...)
-
 	if response.Diagnostics.HasError() {
 		return
 	}
-
 	response.Diagnostics.Append(request.Plan.Get(ctx, &new)...)
-
 	if response.Diagnostics.HasError() {
 		return
 	}
@@ -199,26 +184,18 @@ func (r *accessGrantsLocationResource) Update(ctx context.Context, request resou
 	conn := r.Meta().S3ControlClient(ctx)
 
 	if !new.IAMRoleARN.Equal(old.IAMRoleARN) {
-		input := &s3control.UpdateAccessGrantsLocationInput{}
-		response.Diagnostics.Append(fwflex.Expand(ctx, new, input)...)
+		var input s3control.UpdateAccessGrantsLocationInput
+		response.Diagnostics.Append(fwflex.Expand(ctx, new, &input)...)
 		if response.Diagnostics.HasError() {
 			return
 		}
 
 		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, s3PropagationTimeout, func() (any, error) {
-			return conn.UpdateAccessGrantsLocation(ctx, input)
+			return conn.UpdateAccessGrantsLocation(ctx, &input)
 		}, errCodeInvalidIAMRole)
 
 		if err != nil {
 			response.Diagnostics.AddError(fmt.Sprintf("updating S3 Access Grants Location (%s)", new.ID.ValueString()), err.Error())
-
-			return
-		}
-	}
-
-	if oldTagsAll, newTagsAll := old.TagsAll, new.TagsAll; !newTagsAll.Equal(oldTagsAll) {
-		if err := updateTags(ctx, conn, new.AccessGrantsLocationARN.ValueString(), new.AccountID.ValueString(), oldTagsAll, newTagsAll); err != nil {
-			response.Diagnostics.AddError(fmt.Sprintf("updating tags for S3 Access Grants Location (%s)", new.ID.ValueString()), err.Error())
 
 			return
 		}
@@ -229,23 +206,20 @@ func (r *accessGrantsLocationResource) Update(ctx context.Context, request resou
 
 func (r *accessGrantsLocationResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
 	var data accessGrantsLocationResourceModel
-
 	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
-
 	if response.Diagnostics.HasError() {
 		return
 	}
 
 	conn := r.Meta().S3ControlClient(ctx)
 
-	input := &s3control.DeleteAccessGrantsLocationInput{
+	input := s3control.DeleteAccessGrantsLocationInput{
 		AccessGrantsLocationId: fwflex.StringFromFramework(ctx, data.AccessGrantsLocationID),
 		AccountId:              fwflex.StringFromFramework(ctx, data.AccountID),
 	}
-
 	// "AccessGrantsLocationNotEmptyError: Please delete access grants before deleting access grants location".
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, s3PropagationTimeout, func() (any, error) {
-		return conn.DeleteAccessGrantsLocation(ctx, input)
+		return conn.DeleteAccessGrantsLocation(ctx, &input)
 	}, errCodeAccessGrantsLocationNotEmptyError)
 
 	if tfawserr.ErrHTTPStatusCodeEquals(err, http.StatusNotFound) {
@@ -260,11 +234,15 @@ func (r *accessGrantsLocationResource) Delete(ctx context.Context, request resou
 }
 
 func findAccessGrantsLocationByTwoPartKey(ctx context.Context, conn *s3control.Client, accountID, locationID string) (*s3control.GetAccessGrantsLocationOutput, error) {
-	input := &s3control.GetAccessGrantsLocationInput{
+	input := s3control.GetAccessGrantsLocationInput{
 		AccessGrantsLocationId: aws.String(locationID),
 		AccountId:              aws.String(accountID),
 	}
 
+	return findAccessGrantsLocation(ctx, conn, &input)
+}
+
+func findAccessGrantsLocation(ctx context.Context, conn *s3control.Client, input *s3control.GetAccessGrantsLocationInput) (*s3control.GetAccessGrantsLocationOutput, error) {
 	output, err := conn.GetAccessGrantsLocation(ctx, input)
 
 	if tfawserr.ErrHTTPStatusCodeEquals(err, http.StatusNotFound) {

--- a/internal/service/s3control/bucket.go
+++ b/internal/service/s3control/bucket.go
@@ -5,7 +5,6 @@ package s3control
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -14,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/s3control"
-	"github.com/aws/aws-sdk-go-v2/service/s3control/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -99,10 +97,8 @@ func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta any)
 
 	d.SetId(aws.ToString(output.BucketArn))
 
-	if tags := keyValueTagsFromS3Tags(ctx, getS3TagsIn(ctx)); len(tags) > 0 {
-		if err := bucketUpdateTags(ctx, conn, d.Id(), nil, tags); err != nil {
-			return sdkdiag.AppendErrorf(diags, "adding S3 Control Bucket (%s) tags: %s", d.Id(), err)
-		}
+	if err := bucketCreateTags(ctx, conn, d.Id(), getS3TagsIn(ctx)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting S3 Control Bucket (%s) tags: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceBucketRead(ctx, d, meta)...)
@@ -229,84 +225,4 @@ func findBucketByTwoPartKey(ctx context.Context, conn *s3control.Client, account
 	}
 
 	return output, nil
-}
-
-// Custom S3control tagging functions using similar formatting as other service generated code.
-
-// bucketListTags lists S3control bucket tags.
-// The identifier is the bucket ARN.
-func bucketListTags(ctx context.Context, conn *s3control.Client, identifier string) (tftags.KeyValueTags, error) {
-	parsedArn, err := arn.Parse(identifier)
-
-	if err != nil {
-		return tftags.New(ctx, nil), err
-	}
-
-	input := &s3control.GetBucketTaggingInput{
-		AccountId: aws.String(parsedArn.AccountID),
-		Bucket:    aws.String(identifier),
-	}
-
-	output, err := conn.GetBucketTagging(ctx, input)
-
-	if tfawserr.ErrCodeEquals(err, errCodeNoSuchTagSet) {
-		return tftags.New(ctx, nil), nil
-	}
-
-	if err != nil {
-		return tftags.New(ctx, nil), err
-	}
-
-	return keyValueTagsFromS3Tags(ctx, output.TagSet), nil
-}
-
-// bucketUpdateTags updates S3control bucket tags.
-// The identifier is the bucket ARN.
-func bucketUpdateTags(ctx context.Context, conn *s3control.Client, identifier string, oldTagsMap, newTagsMap any) error {
-	parsedArn, err := arn.Parse(identifier)
-
-	if err != nil {
-		return err
-	}
-
-	oldTags := tftags.New(ctx, oldTagsMap)
-	newTags := tftags.New(ctx, newTagsMap)
-
-	// We need to also consider any existing ignored tags.
-	allTags, err := bucketListTags(ctx, conn, identifier)
-
-	if err != nil {
-		return fmt.Errorf("listing resource tags (%s): %w", identifier, err)
-	}
-
-	ignoredTags := allTags.Ignore(oldTags).Ignore(newTags)
-
-	if len(newTags)+len(ignoredTags) > 0 {
-		input := &s3control.PutBucketTaggingInput{
-			AccountId: aws.String(parsedArn.AccountID),
-			Bucket:    aws.String(identifier),
-			Tagging: &types.Tagging{
-				TagSet: svcS3Tags(newTags.Merge(ignoredTags)),
-			},
-		}
-
-		_, err := conn.PutBucketTagging(ctx, input)
-
-		if err != nil {
-			return fmt.Errorf("setting resource tags (%s): %s", identifier, err)
-		}
-	} else if len(oldTags) > 0 && len(ignoredTags) == 0 {
-		input := &s3control.DeleteBucketTaggingInput{
-			AccountId: aws.String(parsedArn.AccountID),
-			Bucket:    aws.String(identifier),
-		}
-
-		_, err := conn.DeleteBucketTagging(ctx, input)
-
-		if err != nil {
-			return fmt.Errorf("deleting resource tags (%s): %s", identifier, err)
-		}
-	}
-
-	return nil
 }

--- a/internal/service/s3control/exports_test.go
+++ b/internal/service/s3control/exports_test.go
@@ -23,7 +23,7 @@ var (
 	ResourceStorageLensConfiguration           = resourceStorageLensConfiguration
 
 	FindAccessGrantByTwoPartKey                            = findAccessGrantByTwoPartKey
-	FindAccessGrantsInstance                               = findAccessGrantsInstance
+	FindAccessGrantsInstanceByID                           = findAccessGrantsInstanceByID
 	FindAccessGrantsInstanceResourcePolicy                 = findAccessGrantsInstanceResourcePolicy
 	FindAccessGrantsLocationByTwoPartKey                   = findAccessGrantsLocationByTwoPartKey
 	FindAccessPointByTwoPartKey                            = findAccessPointByTwoPartKey

--- a/internal/service/s3control/generate.go
+++ b/internal/service/s3control/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsSlice -TagResTypeElem=AccountId -UpdateTags
+//go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsSlice -TagResTypeIsAccountID -TagResTypeElem=AccountId -UpdateTags
 //go:generate go run ../../generate/tags/main.go -ServiceTagsSlice -TagsFunc=svcS3Tags -KeyValueTagsFunc=keyValueTagsFromS3Tags -GetTagsInFunc=getS3TagsIn -SetTagsOutFunc=setS3TagsOut -TagType=S3Tag -- s3_tags_gen.go
 //go:generate go run ../../generate/servicepackage/main.go
 //go:generate go run ../../generate/identitytests/main.go

--- a/internal/service/s3control/s3_tags.go
+++ b/internal/service/s3control/s3_tags.go
@@ -1,0 +1,104 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package s3control
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/s3control"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/s3control/types"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+)
+
+// Custom S3 tag functions using the same format as generated code.
+
+func bucketCreateTags(ctx context.Context, conn *s3control.Client, identifier string, tags []awstypes.S3Tag) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return bucketUpdateTags(ctx, conn, identifier, nil, keyValueTagsFromS3Tags(ctx, tags))
+}
+
+// bucketListTags lists S3control bucket tags.
+// The identifier is the bucket ARN.
+func bucketListTags(ctx context.Context, conn *s3control.Client, identifier string, optFns ...func(*s3control.Options)) (tftags.KeyValueTags, error) {
+	parsedArn, err := arn.Parse(identifier)
+
+	if err != nil {
+		return tftags.New(ctx, nil), err
+	}
+
+	input := s3control.GetBucketTaggingInput{
+		AccountId: aws.String(parsedArn.AccountID),
+		Bucket:    aws.String(identifier),
+	}
+
+	output, err := conn.GetBucketTagging(ctx, &input, optFns...)
+
+	if tfawserr.ErrCodeEquals(err, errCodeNoSuchTagSet) {
+		return tftags.New(ctx, nil), nil
+	}
+
+	if err != nil {
+		return tftags.New(ctx, nil), err
+	}
+
+	return keyValueTagsFromS3Tags(ctx, output.TagSet), nil
+}
+
+// bucketUpdateTags updates S3control bucket tags.
+// The identifier is the bucket ARN.
+func bucketUpdateTags(ctx context.Context, conn *s3control.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*s3control.Options)) error {
+	parsedArn, err := arn.Parse(identifier)
+
+	if err != nil {
+		return err
+	}
+
+	oldTags := tftags.New(ctx, oldTagsMap)
+	newTags := tftags.New(ctx, newTagsMap)
+
+	// We need to also consider any existing ignored tags.
+	allTags, err := bucketListTags(ctx, conn, identifier)
+
+	if err != nil {
+		return fmt.Errorf("listing resource tags (%s): %w", identifier, err)
+	}
+
+	ignoredTags := allTags.Ignore(oldTags).Ignore(newTags)
+
+	if len(newTags)+len(ignoredTags) > 0 {
+		input := s3control.PutBucketTaggingInput{
+			AccountId: aws.String(parsedArn.AccountID),
+			Bucket:    aws.String(identifier),
+			Tagging: &awstypes.Tagging{
+				TagSet: svcS3Tags(newTags.Merge(ignoredTags)),
+			},
+		}
+
+		_, err := conn.PutBucketTagging(ctx, &input, optFns...)
+
+		if err != nil {
+			return fmt.Errorf("setting resource tags (%s): %s", identifier, err)
+		}
+	} else if len(oldTags) > 0 && len(ignoredTags) == 0 {
+		input := s3control.DeleteBucketTaggingInput{
+			AccountId: aws.String(parsedArn.AccountID),
+			Bucket:    aws.String(identifier),
+		}
+
+		_, err := conn.DeleteBucketTagging(ctx, &input, optFns...)
+
+		if err != nil {
+			return fmt.Errorf("deleting resource tags (%s): %s", identifier, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/s3control/service_package_gen.go
+++ b/internal/service/s3control/service_package_gen.go
@@ -57,8 +57,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			Factory:  newAccessGrantsLocationResource,
 			TypeName: "aws_s3control_access_grants_location",
 			Name:     "Access Grants Location",
-			Tags:     unique.Make(inttypes.ServicePackageResourceTags{}),
-			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: "access_grants_location_arn",
+			}),
+			Region: unique.Make(inttypes.ResourceRegionDefault()),
 		},
 		{
 			Factory:  newDirectoryBucketAccessPointScopeResource,

--- a/internal/service/s3control/service_package_gen.go
+++ b/internal/service/s3control/service_package_gen.go
@@ -35,8 +35,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			Factory:  newAccessGrantResource,
 			TypeName: "aws_s3control_access_grant",
 			Name:     "Access Grant",
-			Tags:     unique.Make(inttypes.ServicePackageResourceTags{}),
-			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: "access_grant_arn",
+			}),
+			Region: unique.Make(inttypes.ResourceRegionDefault()),
 		},
 		{
 			Factory:  newAccessGrantsInstanceResource,

--- a/internal/service/s3control/service_package_gen.go
+++ b/internal/service/s3control/service_package_gen.go
@@ -42,8 +42,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			Factory:  newAccessGrantsInstanceResource,
 			TypeName: "aws_s3control_access_grants_instance",
 			Name:     "Access Grants Instance",
-			Tags:     unique.Make(inttypes.ServicePackageResourceTags{}),
-			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: "access_grants_instance_arn",
+			}),
+			Region: unique.Make(inttypes.ResourceRegionDefault()),
 		},
 		{
 			Factory:  newAccessGrantsInstanceResourcePolicyResource,

--- a/internal/service/s3control/tags_gen.go
+++ b/internal/service/s3control/tags_gen.go
@@ -36,8 +36,9 @@ func listTags(ctx context.Context, conn *s3control.Client, identifier, resourceT
 
 // ListTags lists s3control service tags and set them in Context.
 // It is called from outside this package.
-func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier, resourceType string) error {
-	tags, err := listTags(ctx, meta.(*conns.AWSClient).S3ControlClient(ctx), identifier, resourceType)
+func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier string) error {
+	c := meta.(*conns.AWSClient)
+	tags, err := listTags(ctx, c.S3ControlClient(ctx), identifier, c.AccountID(ctx))
 
 	if err != nil {
 		return smarterr.NewError(err)
@@ -144,6 +145,7 @@ func updateTags(ctx context.Context, conn *s3control.Client, identifier, resourc
 
 // UpdateTags updates s3control service tags.
 // It is called from outside this package.
-func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier, resourceType string, oldTags, newTags any) error {
-	return updateTags(ctx, meta.(*conns.AWSClient).S3ControlClient(ctx), identifier, resourceType, oldTags, newTags)
+func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
+	c := meta.(*conns.AWSClient)
+	return updateTags(ctx, c.S3ControlClient(ctx), identifier, c.AccountID(ctx), oldTags, newTags)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds a flag to the tagging code generator to allow AWS account ID to be passed into generate tagging functions.
This allows the S3 Access Grants resources to use full transparent tagging.
The other `s3control` resources with tag support requires some more thinking...

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
