### PR TITLE
Fix error unmarshalling Redshift policy

### DIFF
--- a/.changelog/43623.txt
+++ b/.changelog/43623.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_redshiftserverless_resource_policy: Fix unmarshalling error on import or apply
+```

--- a/internal/service/redshiftserverless/resource_policy.go
+++ b/internal/service/redshiftserverless/resource_policy.go
@@ -109,13 +109,15 @@ func resourceResourcePolicyRead(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "unmarshaling policy: %s", err)
 	}
 
-	doc.Statement.Resources = nil
+	for _, stmt := range doc.Statement {
+		stmt.Resources = nil
+	}
 
 	policyDoc := tfiam.IAMPolicyDoc{}
 
 	policyDoc.Id = doc.Id
 	policyDoc.Version = doc.Version
-	policyDoc.Statements = []*tfiam.IAMPolicyStatement{doc.Statement}
+	policyDoc.Statements = doc.Statement
 
 	formattedPolicy, err := json.Marshal(policyDoc)
 	if err != nil {
@@ -185,7 +187,7 @@ func findResourcePolicyByARN(ctx context.Context, conn *redshiftserverless.Clien
 }
 
 type resourcePolicyDoc struct {
-	Version   string                    `json:",omitempty"`
-	Id        string                    `json:",omitempty"`
-	Statement *tfiam.IAMPolicyStatement `json:"Statement,omitempty"`
+	Version   string                      `json:",omitempty"`
+	Id        string                      `json:",omitempty"`
+	Statement []*tfiam.IAMPolicyStatement `json:"Statement,omitempty"`
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

N/A

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes an unmarshalling error in importing or applying `aws_redshiftserverless_resource_policy` described in #42859.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42859

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccRedshiftServerlessResourcePolicy PKG=redshiftserverless

...
```

[I don't really have an account convenient to do this with, if it's really necessary for such a small change & not done in CI then I'll try to sort it.]
