### PR TITLE
feat(ecr): Add support for IMMUTABLE_WITH_EXCLUSION image tag mutability

### DIFF
--- a/internal/service/ecr/repository.go
+++ b/internal/service/ecr/repository.go
@@ -5,15 +5,20 @@ package ecr
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"strings"
 	"time"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -40,6 +45,8 @@ func resourceRepository() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
+
+		CustomizeDiff: validateImageTagMutabilityExclusionFilterUsage,
 
 		Schema: map[string]*schema.Schema{
 			names.AttrARN: {
@@ -93,6 +100,32 @@ func resourceRepository() *schema.Resource {
 				Default:          types.ImageTagMutabilityMutable,
 				ValidateDiagFunc: enum.Validate[types.ImageTagMutability](),
 			},
+			"image_tag_mutability_exclusion_filter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 5,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						names.AttrFilter: {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateDiagFunc: validation.AllDiag(
+								validation.ToDiagFunc(validation.StringLenBetween(1, 128)),
+								validation.ToDiagFunc(validation.StringMatch(
+									regexache.MustCompile(`^[a-zA-Z0-9._*-]+$`),
+									"must contain only letters, numbers, and special characters (._*-)",
+								)),
+								validateImageTagMutabilityExclusionFilter(),
+							),
+						},
+						"filter_type": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: enum.Validate[types.ImageTagMutabilityExclusionFilterType](),
+						},
+					},
+				},
+			},
 			names.AttrName: {
 				Type:     schema.TypeString,
 				Required: true,
@@ -129,6 +162,10 @@ func resourceRepositoryCreate(ctx context.Context, d *schema.ResourceData, meta 
 		input.ImageScanningConfiguration = &types.ImageScanningConfiguration{
 			ScanOnPush: tfMap["scan_on_push"].(bool),
 		}
+	}
+
+	if v, ok := d.GetOk("image_tag_mutability_exclusion_filter"); ok && len(v.([]any)) > 0 {
+		input.ImageTagMutabilityExclusionFilters = expandImageTagMutabilityExclusionFilters(v.([]any))
 	}
 
 	output, err := conn.CreateRepository(ctx, input)
@@ -189,6 +226,9 @@ func resourceRepositoryRead(ctx context.Context, d *schema.ResourceData, meta an
 		return sdkdiag.AppendErrorf(diags, "setting image_scanning_configuration: %s", err)
 	}
 	d.Set("image_tag_mutability", repository.ImageTagMutability)
+	if err := d.Set("image_tag_mutability_exclusion_filter", flattenImageTagMutabilityExclusionFilters(repository.ImageTagMutabilityExclusionFilters)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting image_tag_mutability_exclusion_filter: %s", err)
+	}
 	d.Set(names.AttrName, repository.RepositoryName)
 	d.Set("registry_id", repository.RegistryId)
 	d.Set("repository_url", repository.RepositoryUri)
@@ -200,11 +240,15 @@ func resourceRepositoryUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECRClient(ctx)
 
-	if d.HasChange("image_tag_mutability") {
+	if d.HasChanges("image_tag_mutability", "image_tag_mutability_exclusion_filter") {
 		input := &ecr.PutImageTagMutabilityInput{
 			ImageTagMutability: types.ImageTagMutability((d.Get("image_tag_mutability").(string))),
 			RegistryId:         aws.String(d.Get("registry_id").(string)),
 			RepositoryName:     aws.String(d.Id()),
+		}
+
+		if v, ok := d.GetOk("image_tag_mutability_exclusion_filter"); ok && len(v.([]any)) > 0 {
+			input.ImageTagMutabilityExclusionFilters = expandImageTagMutabilityExclusionFilters(v.([]any))
 		}
 
 		_, err := conn.PutImageTagMutability(ctx, input)
@@ -342,4 +386,68 @@ func flattenRepositoryEncryptionConfiguration(ec *types.EncryptionConfiguration)
 	return []map[string]any{
 		config,
 	}
+}
+
+func expandImageTagMutabilityExclusionFilters(data []any) []types.ImageTagMutabilityExclusionFilter {
+	if len(data) == 0 {
+		return nil
+	}
+
+	var filters []types.ImageTagMutabilityExclusionFilter
+	for _, v := range data {
+		tfMap := v.(map[string]any)
+		filter := types.ImageTagMutabilityExclusionFilter{
+			Filter:     aws.String(tfMap[names.AttrFilter].(string)),
+			FilterType: types.ImageTagMutabilityExclusionFilterType(tfMap["filter_type"].(string)),
+		}
+		filters = append(filters, filter)
+	}
+
+	return filters
+}
+
+func flattenImageTagMutabilityExclusionFilters(filters []types.ImageTagMutabilityExclusionFilter) []any {
+	if len(filters) == 0 {
+		return nil
+	}
+
+	var tfList []any
+	for _, filter := range filters {
+		tfMap := map[string]any{
+			names.AttrFilter: aws.ToString(filter.Filter),
+			"filter_type":    string(filter.FilterType),
+		}
+		tfList = append(tfList, tfMap)
+	}
+
+	return tfList
+}
+
+func validateImageTagMutabilityExclusionFilter() schema.SchemaValidateDiagFunc {
+	return func(v any, path cty.Path) diag.Diagnostics {
+		var diags diag.Diagnostics
+		value := v.(string)
+
+		wildcardCount := strings.Count(value, "*")
+		if wildcardCount > 2 {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Invalid filter pattern",
+				Detail:   "Image tag mutability exclusion filter can contain a maximum of 2 wildcards (*)",
+			})
+		}
+
+		return diags
+	}
+}
+
+func validateImageTagMutabilityExclusionFilterUsage(_ context.Context, d *schema.ResourceDiff, meta any) error {
+	mutability := d.Get("image_tag_mutability").(string)
+	filters := d.Get("image_tag_mutability_exclusion_filter").([]any)
+
+	if len(filters) > 0 && mutability != string(types.ImageTagMutabilityImmutableWithExclusion) && mutability != string(types.ImageTagMutabilityMutableWithExclusion) {
+		return fmt.Errorf("image_tag_mutability_exclusion_filter can only be used when image_tag_mutability is set to IMMUTABLE_WITH_EXCLUSION or MUTABLE_WITH_EXCLUSION")
+	}
+
+	return nil
 }

--- a/internal/service/ecr/repository_test.go
+++ b/internal/service/ecr/repository_test.go
@@ -6,6 +6,7 @@ package ecr_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/YakDriver/regexache"
@@ -151,6 +152,89 @@ func TestAccECRRepository_immutability(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccECRRepository_immutabilityWithExclusion(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.Repository
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ecr_repository.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRepositoryDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRepositoryConfig_immutabilityWithExclusion(rName, "latest*"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRepositoryExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability", string(types.ImageTagMutabilityImmutableWithExclusion)),
+					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability_exclusion_filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability_exclusion_filter.0.filter", "latest*"),
+					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability_exclusion_filter.0.filter_type", string(types.ImageTagMutabilityExclusionFilterTypeWildcard)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRepositoryConfig_immutabilityWithExclusion(rName, "dev-*"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRepositoryExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability_exclusion_filter.0.filter", "dev-*"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccECRRepository_immutabilityWithExclusion_validation(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRepositoryDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccRepositoryConfig_immutabilityWithExclusion(rName, "invalid!@#$"),
+				ExpectError: regexache.MustCompile(`must contain only letters, numbers, and special characters`),
+			},
+			{
+				Config:      testAccRepositoryConfig_immutabilityWithExclusion(rName, "a*b*c*d"),
+				ExpectError: regexache.MustCompile(`Image tag mutability exclusion filter can contain a maximum of 2 wildcards`),
+			},
+			{
+				Config:      testAccRepositoryConfig_immutabilityWithExclusion(rName, strings.Repeat("a", 129)),
+				ExpectError: regexache.MustCompile(`expected length of.*to be in the range.*128`),
+			},
+		},
+	})
+}
+
+func TestAccECRRepository_immutabilityWithExclusion_crossValidation(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRepositoryDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccRepositoryConfig_immutabilityWithExclusionInvalid(rName),
+				ExpectError: regexache.MustCompile(`image_tag_mutability_exclusion_filter can only be used when image_tag_mutability is set to IMMUTABLE_WITH_EXCLUSION`),
 			},
 		},
 	})
@@ -444,6 +528,34 @@ func testAccRepositoryConfig_immutability(rName string) string {
 resource "aws_ecr_repository" "test" {
   name                 = %[1]q
   image_tag_mutability = "IMMUTABLE"
+}
+`, rName)
+}
+
+func testAccRepositoryConfig_immutabilityWithExclusion(rName, filter string) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_repository" "test" {
+  name                 = %[1]q
+  image_tag_mutability = "IMMUTABLE_WITH_EXCLUSION"
+
+  image_tag_mutability_exclusion_filter {
+    filter      = %[2]q
+    filter_type = "WILDCARD"
+  }
+}
+`, rName, filter)
+}
+
+func testAccRepositoryConfig_immutabilityWithExclusionInvalid(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_repository" "test" {
+  name                 = %[1]q
+  image_tag_mutability = "MUTABLE"
+
+  image_tag_mutability_exclusion_filter {
+    filter      = "latest*"
+    filter_type = "WILDCARD"
+  }
 }
 `, rName)
 }

--- a/website/docs/r/ecr_repository.html.markdown
+++ b/website/docs/r/ecr_repository.html.markdown
@@ -23,6 +23,25 @@ resource "aws_ecr_repository" "foo" {
 }
 ```
 
+### With Image Tag Mutability Exclusion
+
+```terraform
+resource "aws_ecr_repository" "example" {
+  name                 = "example-repo"
+  image_tag_mutability = "IMMUTABLE_WITH_EXCLUSION"
+
+  image_tag_mutability_exclusion_filter {
+    filter      = "latest*"
+    filter_type = "WILDCARD"
+  }
+
+  image_tag_mutability_exclusion_filter {
+    filter      = "dev-*"
+    filter_type = "WILDCARD"
+  }
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
@@ -32,7 +51,8 @@ This resource supports the following arguments:
 * `encryption_configuration` - (Optional) Encryption configuration for the repository. See [below for schema](#encryption_configuration).
 * `force_delete` - (Optional) If `true`, will delete the repository even if it contains images.
   Defaults to `false`.
-* `image_tag_mutability` - (Optional) The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE`. Defaults to `MUTABLE`.
+* `image_tag_mutability` - (Optional) The tag mutability setting for the repository. Must be one of: `MUTABLE`, `IMMUTABLE`, or `IMMUTABLE_WITH_EXCLUSION`. Defaults to `MUTABLE`.
+* `image_tag_mutability_exclusion_filter` - (Optional) Configuration block that defines filters to specify which image tags can override the default tag mutability setting. Only applicable when `image_tag_mutability` is set to `IMMUTABLE_WITH_EXCLUSION`. See [below for schema](#image_tag_mutability_exclusion_filter).
 * `image_scanning_configuration` - (Optional) Configuration block that defines image scanning configuration for the repository. By default, image scanning must be manually triggered. See the [ECR User Guide](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html) for more information about image scanning.
     * `scan_on_push` - (Required) Indicates whether images are scanned after being pushed to the repository (true) or not scanned (false).
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
@@ -41,6 +61,11 @@ This resource supports the following arguments:
 
 * `encryption_type` - (Optional) The encryption type to use for the repository. Valid values are `AES256` or `KMS`. Defaults to `AES256`.
 * `kms_key` - (Optional) The ARN of the KMS key to use when `encryption_type` is `KMS`. If not specified, uses the default AWS managed key for ECR.
+
+### image_tag_mutability_exclusion_filter
+
+* `filter` - (Required) The filter pattern to use for excluding image tags from the mutability setting. Must contain only letters, numbers, and special characters (._*-). Each filter can be up to 128 characters long and can contain a maximum of 2 wildcards (*).
+* `filter_type` - (Required) The type of filter to use. Must be `WILDCARD`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Rollback Plan

  If a change needs to be reverted, we will publish an updated version of the library.

  ## Changes to Security Controls

  Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

  no

  ### Description

  This PR adds support for the `IMMUTABLE_WITH_EXCLUSION` image tag mutability mode for ECR repositories, allowing users to specify exclusion filters for tags that should remain mutable while enforcing immutability for all others.

  Changes:
  - Add `image_tag_mutability_exclusion_filter` configuration block
  - Support `IMMUTABLE_WITH_EXCLUSION` as a valid `image_tag_mutability` value
  - Add validation for exclusion filters (max 5 filters, max 128 chars, max 2 wildcards)
  - Add cross-field validation to ensure filters are only used with appropriate mutability modes
  - Add comprehensive acceptance tests including cross-field validation test
  - Update documentation with examples and constraints

  ### Relations

  Closes #43569

  ### References
  <!---
  Optionally, provide any helpful references that may help the reviewer(s).
  --->

  ### Output from Acceptance Testing
  <!--
  Replace TestAccXXX with a pattern that matches the tests affected by this PR.

  Replace ec2 with the service package corresponding to your tests.

  For more information on the `-run` flag, see the `go test` documentation at
  https://tip.golang.org/cmd/go/#hdr-Testing_flags.
  -->

  ```console
  $ make testacc TESTS=TestAccECRRepository_ PKG=ecr
  ==> Checking that code complies with gofmt requirements...
  TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRRepository_' -timeout
   360m

  --- PASS: TestAccECRRepository_basic (31.43s)
  --- PASS: TestAccECRRepository_disappears (24.93s)
  --- PASS: TestAccECRRepository_tags (50.47s)
  --- PASS: TestAccECRRepository_immutability (29.31s)
  --- PASS: TestAccECRRepository_immutabilityWithExclusion (39.86s)
  --- PASS: TestAccECRRepository_immutabilityWithExclusion_validation (16.63s)
  --- PASS: TestAccECRRepository_immutabilityWithExclusion_crossValidation (13.79s)
  --- PASS: TestAccECRRepository_Image_scanning (55.66s)
  --- PASS: TestAccECRRepository_Encryption_kms (60.19s)
  --- PASS: TestAccECRRepository_Encryption_aes256 (42.97s)
  PASS
  ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr       63.755s
```