### PR TITLE
fix: setting the region after resource has been removed from state due resource disappearance

### DIFF
--- a/.changelog/43659.txt
+++ b/.changelog/43659.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+provider: Fix failure to detect resources deleted outside of Terraform as missing for numerous resource types
+```

--- a/internal/provider/framework/region.go
+++ b/internal/provider/framework/region.go
@@ -332,7 +332,10 @@ func (r resourceSetRegionInStateInterceptor) read(ctx context.Context, opts inte
 
 	switch response, when := opts.response, opts.when; when {
 	case After:
-		// Set region in state after R.
+		// Set region in state after R but skip if the provider just called RemoveResource(ctx) due to disappearance.
+		if response.State.Raw.IsNull() {
+			return diags
+		}
 		diags.Append(response.State.SetAttribute(ctx, path.Root(names.AttrRegion), c.Region(ctx))...)
 		if diags.HasError() {
 			return diags

--- a/internal/provider/framework/region.go
+++ b/internal/provider/framework/region.go
@@ -332,10 +332,12 @@ func (r resourceSetRegionInStateInterceptor) read(ctx context.Context, opts inte
 
 	switch response, when := opts.response, opts.when; when {
 	case After:
-		// Set region in state after R but skip if the provider just called RemoveResource(ctx) due to disappearance.
+		// Will occur on a refresh when the resource does not exist in AWS and needs to be recreated, e.g. "_disappears" tests.
 		if response.State.Raw.IsNull() {
 			return diags
 		}
+
+		// Set region in state after R.
 		diags.Append(response.State.SetAttribute(ctx, path.Root(names.AttrRegion), c.Region(ctx))...)
 		if diags.HasError() {
 			return diags

--- a/internal/provider/framework/region_test.go
+++ b/internal/provider/framework/region_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package framework
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/provider/framework/resourceattribute"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestResourceSetRegionInStateInterceptor_Read(t *testing.T) {
+	t.Parallel()
+
+	const name = "example"
+
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		t.Skip("AWS_DEFAULT_REGION env var must be set for ResourceSetRegionInStateInterceptor test.")
+	}
+
+	ctx := context.Background()
+	client := mockClient{region: region}
+	icpt := resourceSetRegionInStateInterceptor{}
+
+	s := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrName:   schema.StringAttribute{Required: true},
+			names.AttrRegion: resourceattribute.Region(),
+		},
+	}
+
+	tests := map[string]struct {
+		startState tfsdk.State
+		expectSet  bool
+	}{
+		"when state is present then region is set": {
+			startState: stateFromSchema(ctx, s, map[string]string{"name": name}),
+			expectSet:  true,
+		},
+		"when state is null then it remains null": {
+			startState: tfsdk.State{
+				Raw:    tftypes.NewValue(s.Type().TerraformType(ctx), nil),
+				Schema: s,
+			},
+			expectSet: false,
+		},
+	}
+
+	for tn, tc := range tests {
+		t.Run(tn, func(t *testing.T) {
+			t.Parallel()
+
+			req := resource.ReadRequest{State: tc.startState}
+			resp := resource.ReadResponse{State: tc.startState}
+
+			if diags := icpt.read(ctx, interceptorOptions[resource.ReadRequest, resource.ReadResponse]{
+				c:        client,
+				request:  &req,
+				response: &resp,
+				when:     After,
+			}); diags.HasError() {
+				t.Fatalf("unexpected diags: %s", diags)
+			}
+
+			if tc.expectSet {
+				got := getStateAttributeValue(ctx, t, resp.State, path.Root("region"))
+				if got != region {
+					t.Errorf("expected region %q, got %q", region, got)
+				}
+			} else {
+				if !resp.State.Raw.IsNull() {
+					t.Errorf("expected State.Raw to stay null, got %#v", resp.State.Raw)
+				}
+			}
+		})
+	}
+}
+
+func getStateAttributeValue(ctx context.Context, t *testing.T, st tfsdk.State, p path.Path) string {
+	t.Helper()
+
+	var v types.String
+	if diags := st.GetAttribute(ctx, p, &v); diags.HasError() {
+		t.Fatalf("unexpected error getting State attribute %q: %s", p, fwdiag.DiagnosticsError(diags))
+	}
+	return v.ValueString()
+}

--- a/internal/provider/sdkv2/region.go
+++ b/internal/provider/sdkv2/region.go
@@ -78,6 +78,11 @@ func setRegionInState() crudInterceptor {
 			// Set region in state after R.
 			switch why {
 			case Read:
+				// Will occur on a refresh when the resource does not exist in AWS and needs to be recreated, e.g. "_disappears" tests.
+				if d.Id() == "" {
+					return diags
+				}
+
 				if err := d.Set(names.AttrRegion, c.Region(ctx)); err != nil {
 					return sdkdiag.AppendErrorf(diags, "setting %s: %s", names.AttrRegion, err)
 				}

--- a/internal/service/appfabric/app_bundle_test.go
+++ b/internal/service/appfabric/app_bundle_test.go
@@ -89,6 +89,11 @@ func testAccAppBundle_disappears(t *testing.T) {
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfappfabric.ResourceAppBundle, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 		},
 	})

--- a/internal/service/ec2/vpc_test.go
+++ b/internal/service/ec2/vpc_test.go
@@ -94,6 +94,11 @@ func TestAccVPC_disappears(t *testing.T) {
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfec2.ResourceVPC(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 		},
 	})

--- a/internal/service/s3control/access_point_test.go
+++ b/internal/service/s3control/access_point_test.go
@@ -14,6 +14,7 @@ import (
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
@@ -92,6 +93,11 @@ func TestAccS3ControlAccessPoint_disappears(t *testing.T) {
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfs3control.ResourceAccessPoint(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 		},
 	})

--- a/internal/service/s3tables/table_test.go
+++ b/internal/service/s3tables/table_test.go
@@ -129,6 +129,11 @@ func TestAccS3TablesTable_disappears(t *testing.T) {
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfs3tables.NewResourceTable, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
## Rollback Plan
If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls
No changes to security controls (access controls, encryption, logging) in this pull request.

### Description
Fixes `resourceSetRegionInStateInterceptor` preventing proper resource removal detection for Framework resources. The interceptor was setting region attributes on null state after
`RemoveResource()` was called, preventing Terraform from detecting disappeared resources correctly.

### Relations

Closes #43655.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/43537.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/43323.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/43530.

### References
- Related to #42261 (improving "_disappears" test coverage) - this fix is a prerequisite
- Follows existing patterns for handling disappeared resources throughout the codebase

### Output from Acceptance Testing
This change affects internal provider framework functionality and is covered by unit tests. No acceptance tests are required as this is a low-level interceptor fix that doesn't change
  resource behavior.

```console
% AWS_DEFAULT_REGION=us-west-2 go test -run TestResourceSetRegionInStateInterceptor_Read -v

=== RUN   TestResourceSetRegionInStateInterceptor_Read
=== RUN   TestResourceSetRegionInStateInterceptor_Read/when_state_is_present_then_region_is_set
=== RUN   TestResourceSetRegionInStateInterceptor_Read/when_state_is_null_then_it_remains_null
--- PASS: TestResourceSetRegionInStateInterceptor_Read (0.00s)
    --- PASS: TestResourceSetRegionInStateInterceptor_Read/when_state_is_present_then_region_is_set (0.00s)
    --- PASS: TestResourceSetRegionInStateInterceptor_Read/when_state_is_null_then_it_remains_null (0.00s)
PASS