### PR TITLE
fix: avoid PrefixListVersionMismatch when changing description of entries

### DIFF
--- a/internal/service/ec2/vpc_managed_prefix_list.go
+++ b/internal/service/ec2/vpc_managed_prefix_list.go
@@ -248,12 +248,12 @@ func resourceManagedPrefixListUpdate(ctx context.Context, d *schema.ResourceData
 			}
 
 			if len(descriptionOnlyRemovals) > 0 {
-				input := ec2.ModifyManagedPrefixListInput{
+				removeInput := ec2.ModifyManagedPrefixListInput{
 					CurrentVersion: input.CurrentVersion,
 					PrefixListId:   aws.String(d.Id()),
 					RemoveEntries:  descriptionOnlyRemovals,
 				}
-				_, err := conn.ModifyManagedPrefixList(ctx, &input)
+				_, err := conn.ModifyManagedPrefixList(ctx, &removeInput)
 
 				if err != nil {
 					return sdkdiag.AppendErrorf(diags, "updating EC2 Managed Prefix List (%s): %s", d.Id(), err)

--- a/internal/service/ec2/vpc_managed_prefix_list_test.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_test.go
@@ -358,6 +358,41 @@ func TestAccVPCManagedPrefixList_tags(t *testing.T) {
 	})
 }
 
+func TestAccVPCManagedPrefixList_descriptionOnlyChange(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_ec2_managed_prefix_list.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckManagedPrefixList(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckManagedPrefixListDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCManagedPrefixListConfig_simpleDescriptionChange(rName, "old description"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccManagedPrefixListExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "entry.#", "1"),
+				),
+			},
+			{
+				// This reproduces the bug: change ONLY the description
+				// Before the fix, this would fail with "PrefixListVersionMismatch"
+				Config: testAccVPCManagedPrefixListConfig_simpleDescriptionChange(rName, "new description"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccManagedPrefixListExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "entry.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "entry.*", map[string]string{
+						"cidr":                "1.0.0.0/8",
+						names.AttrDescription: "new description",
+					}),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckManagedPrefixListDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
@@ -555,4 +590,19 @@ resource "aws_ec2_managed_prefix_list" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccVPCManagedPrefixListConfig_simpleDescriptionChange(rName string, description string) string {
+	return fmt.Sprintf(`
+resource "aws_ec2_managed_prefix_list" "test" {
+  address_family = "IPv4"
+  max_entries    = 1
+  name           = %[1]q
+
+  entry {
+    cidr        = "1.0.0.0/8"
+    description = %[2]q
+  }
+}
+`, rName, description)
 }


### PR DESCRIPTION
## Description

Fixes a variable shadowing bug in `aws_ec2_managed_prefix_list` that caused `PrefixListVersionMismatch` errors when updating entry descriptions.

**Problem:**
When updating only the description of prefix list entries (same CIDR, different description), the resource would fail on the first apply with:
```
Error: updating EC2 Managed Prefix List (pl-xxx): operation error EC2: ModifyManagedPrefixList,
https response error StatusCode: 400, RequestID: xxx,
api error PrefixListVersionMismatch: The prefix list has the incorrect version number.
```
The second apply would succeed without any configuration changes.

**Root Cause:**
Variable shadowing in the description-only update logic. When entries had description changes, the code would:
1. Make first API call to remove old entries (version incremented)
2. Update the wrong `input` variable's version due to shadowing
3. Make second API call with stale version number → AWS rejects with version mismatch

**Solution:**
- Renamed inner `input` variable to `removeInput` to eliminate shadowing
- Added regression test `TestAccVPCManagedPrefixList_descriptionOnlyChange`

**Testing:**
The new test reproduces the exact bug scenario - updating only the description of a single entry. Before the fix, this test would fail with the version mismatch error. After the fix, it passes successfully.

## Rollback Plan
If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls
No changes to security controls (access controls, encryption, logging) in this pull request.

## Relations
Closes #43528

## References
- AWS API Documentation: [ModifyManagedPrefixList](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyManagedPrefixList.html)
- Related to description-only updates requiring two separate API calls due to AWS API limitations