### PR TITLE
fix: compilation errors in "resource not found" code in Read method

### DIFF
--- a/skaff/resource/resourcefw.gtpl
+++ b/skaff/resource/resourcefw.gtpl
@@ -359,7 +359,7 @@ func (r *resource{{ .Resource }}) Read(ctx context.Context, req resource.ReadReq
 	// TIP: -- 4. Remove resource from state if it is not found
 	{{- end }}
 	if tfresource.NotFound(err) {
-		smerr.append(ctx, &resp.Diagnostics, fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		resp.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
 		resp.State.RemoveResource(ctx)
 		return
 	}


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No

### Description

Line 363 of resourcefw.gtpl template contains following line:

```go
smerr.append(ctx, &resp.Diagnostics, fwdiag.NewResourceNotFoundWarningDiagnostic(err))
```

which does not compile.

The most suitable fix seems to be:

```go
smerr.EnrichAppend(ctx, &resp.Diagnostics, diag.Diagnostics{fwdiag.NewResourceNotFoundWarningDiagnostic(err)})
```

however, because smerr.EnrichAppend for passed in `WarningDiagnostic` still outputs `ErrorDiagnostic` it is not a valid solution because disappeared resources would cause error on plan.
The most suitable solution currently seems to be:

```go
resp.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
```

which preserves `WarningDiagnostic ` nature of the diagnostic output. This PR implements this solution.


### Relations

Closes #43662

### Output from Acceptance Testing

It was not possible to delivery any outputs from automated testing. The fix was tested by execution of `skaff resource --xxx` using fixed template