### PR TITLE
Td test gen acctest test

### DIFF
--- a/internal/generate/identitytests/resource_test.go.gtpl
+++ b/internal/generate/identitytests/resource_test.go.gtpl
@@ -15,10 +15,6 @@
 	{{ template "commonInit" . }}
 {{ end }}
 
-{{ define "Test" -}}
-resource.{{ if and .Serialize (not .SerializeParallelTests) }}Test{{ else }}ParallelTest{{ end }}
-{{- end }}
-
 {{ define "TestCaseSetupNoProviders" -}}
 	TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 		tfversion.SkipBelow(tfversion.Version1_12_0),
@@ -253,7 +249,7 @@ func {{ template "testname" . }}_IdentitySerial(t *testing.T) {
 func {{ template "testname" . }}_Identity_Basic(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetup" . }}
 		Steps: []resource.TestStep{
 			{{ $step := 1 -}}
@@ -382,7 +378,7 @@ func {{ template "testname" . }}_Identity_Basic(t *testing.T) {
 func {{ template "testname" . }}_Identity_RegionOverride(t *testing.T) {
 	{{- template "InitRegionOverride" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetupRegionOverride" . }}
 		Steps: []resource.TestStep{
 			{{ $step := 1 -}}
@@ -545,7 +541,7 @@ func {{ template "testname" . }}_Identity_RegionOverride(t *testing.T) {
 	func {{ template "testname" . }}_Identity_ExistingResource_fromV5(t *testing.T) {
 		{{- template "Init" . }}
 
-		{{ template "Test" . }}(t, resource.TestCase{
+		{{ template "Test" . }}(ctx, t, resource.TestCase{
 			{{ template "TestCaseSetupNoProviders" . }}
 			Steps: []resource.TestStep{
 				{{ $step := 1 -}}
@@ -630,7 +626,7 @@ func {{ template "testname" . }}_Identity_RegionOverride(t *testing.T) {
 	func {{ template "testname" . }}_Identity_ExistingResource_fromV6(t *testing.T) {
 		{{- template "Init" . }}
 
-		{{ template "Test" . }}(t, resource.TestCase{
+		{{ template "Test" . }}(ctx, t, resource.TestCase{
 			{{ template "TestCaseSetupNoProviders" . }}
 			Steps: []resource.TestStep{
 				{{ $step := 1 -}}
@@ -747,7 +743,7 @@ func {{ template "testname" . }}_Identity_RegionOverride(t *testing.T) {
 	func {{ template "testname" . }}_Identity_ExistingResource(t *testing.T) {
 		{{- template "Init" . }}
 
-		{{ template "Test" . }}(t, resource.TestCase{
+		{{ template "Test" . }}(ctx, t, resource.TestCase{
 			{{ template "TestCaseSetupNoProviders" . }}
 			Steps: []resource.TestStep{
 				{{ $step := 1 -}}
@@ -880,7 +876,7 @@ func {{ template "testname" . }}_Identity_RegionOverride(t *testing.T) {
 		func {{ template "testname" . }}_Identity_ExistingResource(t *testing.T) {
 			{{- template "Init" . }}
 
-			{{ template "Test" . }}(t, resource.TestCase{
+			{{ template "Test" . }}(ctx, t, resource.TestCase{
 				{{ template "TestCaseSetupNoProviders" . }}
 				Steps: []resource.TestStep{
 					{{ $step := 1 -}}
@@ -967,7 +963,7 @@ func {{ template "testname" . }}_Identity_RegionOverride(t *testing.T) {
 		func {{ template "testname" . }}_Identity_ExistingResource(t *testing.T) {
 			{{- template "Init" . }}
 
-			{{ template "Test" . }}(t, resource.TestCase{
+			{{ template "Test" . }}(ctx, t, resource.TestCase{
 				{{ template "TestCaseSetupNoProviders" . }}
 				Steps: []resource.TestStep{
 					{{ $step := 1 -}}

--- a/internal/service/acm/certificate_identity_gen_test.go
+++ b/internal/service/acm/certificate_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccACMCertificate_Identity_Basic(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -124,7 +124,7 @@ func TestAccACMCertificate_Identity_RegionOverride(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -264,7 +264,7 @@ func TestAccACMCertificate_Identity_ExistingResource(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/acmpca/certificate_authority_certificate_identity_gen_test.go
+++ b/internal/service/acmpca/certificate_authority_certificate_identity_gen_test.go
@@ -26,7 +26,7 @@ func TestAccACMPCACertificateAuthorityCertificate_Identity_Basic(t *testing.T) {
 	resourceName := "aws_acmpca_certificate_authority_certificate.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -111,7 +111,7 @@ func TestAccACMPCACertificateAuthorityCertificate_Identity_RegionOverride(t *tes
 	resourceName := "aws_acmpca_certificate_authority_certificate.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -232,7 +232,7 @@ func TestAccACMPCACertificateAuthorityCertificate_Identity_ExistingResource(t *t
 	resourceName := "aws_acmpca_certificate_authority_certificate.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/acmpca/certificate_authority_identity_gen_test.go
+++ b/internal/service/acmpca/certificate_authority_identity_gen_test.go
@@ -26,7 +26,7 @@ func TestAccACMPCACertificateAuthority_Identity_Basic(t *testing.T) {
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -118,7 +118,7 @@ func TestAccACMPCACertificateAuthority_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -251,7 +251,7 @@ func TestAccACMPCACertificateAuthority_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/acmpca/certificate_identity_gen_test.go
+++ b/internal/service/acmpca/certificate_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccACMPCACertificate_Identity_Basic(t *testing.T) {
 	resourceName := "aws_acmpca_certificate.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -116,7 +116,7 @@ func TestAccACMPCACertificate_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_acmpca_certificate.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -247,7 +247,7 @@ func TestAccACMPCACertificate_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_acmpca_certificate.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/acmpca/policy_identity_gen_test.go
+++ b/internal/service/acmpca/policy_identity_gen_test.go
@@ -22,7 +22,7 @@ func TestAccACMPCAPolicy_Identity_Basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acmpca_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -98,7 +98,7 @@ func TestAccACMPCAPolicy_Identity_RegionOverride(t *testing.T) {
 
 	resourceName := "aws_acmpca_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -210,7 +210,7 @@ func TestAccACMPCAPolicy_Identity_ExistingResource(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acmpca_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/amp/rule_group_namespace_identity_gen_test.go
+++ b/internal/service/amp/rule_group_namespace_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccAMPRuleGroupNamespace_Identity_Basic(t *testing.T) {
 	resourceName := "aws_prometheus_rule_group_namespace.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccAMPRuleGroupNamespace_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_prometheus_rule_group_namespace.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -233,7 +233,7 @@ func TestAccAMPRuleGroupNamespace_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_prometheus_rule_group_namespace.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/apigateway/domain_name_access_association_identity_gen_test.go
+++ b/internal/service/apigateway/domain_name_access_association_identity_gen_test.go
@@ -28,7 +28,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Identity_Basic(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -123,7 +123,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Identity_RegionOverride(t *tes
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -258,7 +258,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Identity_ExistingResource(t *t
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/appfabric/app_bundle_identity_gen_test.go
+++ b/internal/service/appfabric/app_bundle_identity_gen_test.go
@@ -38,7 +38,7 @@ func testAccAppFabricAppBundle_Identity_Basic(t *testing.T) {
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -117,7 +117,7 @@ func testAccAppFabricAppBundle_Identity_RegionOverride(t *testing.T) {
 
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -234,7 +234,7 @@ func testAccAppFabricAppBundle_Identity_ExistingResource(t *testing.T) {
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/appflow/connector_profile_identity_gen_test.go
+++ b/internal/service/appflow/connector_profile_identity_gen_test.go
@@ -28,7 +28,7 @@ func TestAccAppFlowConnectorProfile_Identity_Basic(t *testing.T) {
 	resourceName := "aws_appflow_connector_profile.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -123,7 +123,7 @@ func TestAccAppFlowConnectorProfile_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_appflow_connector_profile.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -220,7 +220,7 @@ func TestAccAppFlowConnectorProfile_Identity_ExistingResource_fromV5(t *testing.
 	resourceName := "aws_appflow_connector_profile.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -280,7 +280,7 @@ func TestAccAppFlowConnectorProfile_Identity_ExistingResource_fromV6(t *testing.
 	resourceName := "aws_appflow_connector_profile.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/appflow/flow_identity_gen_test.go
+++ b/internal/service/appflow/flow_identity_gen_test.go
@@ -28,7 +28,7 @@ func TestAccAppFlowFlow_Identity_Basic(t *testing.T) {
 	resourceName := "aws_appflow_flow.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -116,7 +116,7 @@ func TestAccAppFlowFlow_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_appflow_flow.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -206,7 +206,7 @@ func TestAccAppFlowFlow_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_appflow_flow.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/apprunner/auto_scaling_configuration_version_identity_gen_test.go
+++ b/internal/service/apprunner/auto_scaling_configuration_version_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_Identity_Basic(t *testing.T
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -109,7 +109,7 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_Identity_RegionOverride(t *
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -228,7 +228,7 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_Identity_ExistingResource(t
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/apprunner/observability_configuration_identity_gen_test.go
+++ b/internal/service/apprunner/observability_configuration_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccAppRunnerObservabilityConfiguration_Identity_Basic(t *testing.T) {
 	resourceName := "aws_apprunner_observability_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -109,7 +109,7 @@ func TestAccAppRunnerObservabilityConfiguration_Identity_RegionOverride(t *testi
 	resourceName := "aws_apprunner_observability_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -228,7 +228,7 @@ func TestAccAppRunnerObservabilityConfiguration_Identity_ExistingResource(t *tes
 	resourceName := "aws_apprunner_observability_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/apprunner/service_identity_gen_test.go
+++ b/internal/service/apprunner/service_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccAppRunnerService_Identity_Basic(t *testing.T) {
 	resourceName := "aws_apprunner_service.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -109,7 +109,7 @@ func TestAccAppRunnerService_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_apprunner_service.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -228,7 +228,7 @@ func TestAccAppRunnerService_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_apprunner_service.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/apprunner/vpc_connector_identity_gen_test.go
+++ b/internal/service/apprunner/vpc_connector_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccAppRunnerVPCConnector_Identity_Basic(t *testing.T) {
 	resourceName := "aws_apprunner_vpc_connector.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -109,7 +109,7 @@ func TestAccAppRunnerVPCConnector_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_apprunner_vpc_connector.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -228,7 +228,7 @@ func TestAccAppRunnerVPCConnector_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_apprunner_vpc_connector.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/apprunner/vpc_ingress_connection_identity_gen_test.go
+++ b/internal/service/apprunner/vpc_ingress_connection_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccAppRunnerVPCIngressConnection_Identity_Basic(t *testing.T) {
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -109,7 +109,7 @@ func TestAccAppRunnerVPCIngressConnection_Identity_RegionOverride(t *testing.T) 
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -228,7 +228,7 @@ func TestAccAppRunnerVPCIngressConnection_Identity_ExistingResource(t *testing.T
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/auditmanager/account_registration_identity_gen_test.go
+++ b/internal/service/auditmanager/account_registration_identity_gen_test.go
@@ -35,7 +35,7 @@ func testAccAuditManagerAccountRegistration_Identity_Basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_auditmanager_account_registration.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -106,7 +106,7 @@ func testAccAuditManagerAccountRegistration_Identity_RegionOverride(t *testing.T
 
 	resourceName := "aws_auditmanager_account_registration.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -215,7 +215,7 @@ func testAccAuditManagerAccountRegistration_Identity_ExistingResource(t *testing
 	ctx := acctest.Context(t)
 	resourceName := "aws_auditmanager_account_registration.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/backup/region_settings_identity_gen_test.go
+++ b/internal/service/backup/region_settings_identity_gen_test.go
@@ -38,7 +38,7 @@ func testAccBackupRegionSettings_Identity_Basic(t *testing.T) {
 	var v backup.DescribeRegionSettingsOutput
 	resourceName := "aws_backup_region_settings.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -115,7 +115,7 @@ func testAccBackupRegionSettings_Identity_RegionOverride(t *testing.T) {
 
 	resourceName := "aws_backup_region_settings.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -229,7 +229,7 @@ func testAccBackupRegionSettings_Identity_ExistingResource(t *testing.T) {
 	var v backup.DescribeRegionSettingsOutput
 	resourceName := "aws_backup_region_settings.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/batch/job_definition_identity_gen_test.go
+++ b/internal/service/batch/job_definition_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccBatchJobDefinition_Identity_Basic(t *testing.T) {
 	resourceName := "aws_batch_job_definition.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -113,7 +113,7 @@ func TestAccBatchJobDefinition_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_batch_job_definition.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -236,7 +236,7 @@ func TestAccBatchJobDefinition_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_batch_job_definition.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/batch/job_queue_identity_gen_test.go
+++ b/internal/service/batch/job_queue_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccBatchJobQueue_Identity_Basic(t *testing.T) {
 	resourceName := "aws_batch_job_queue.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -113,7 +113,7 @@ func TestAccBatchJobQueue_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_batch_job_queue.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -235,7 +235,7 @@ func TestAccBatchJobQueue_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_batch_job_queue.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/bcmdataexports/export_identity_gen_test.go
+++ b/internal/service/bcmdataexports/export_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccBCMDataExportsExport_Identity_Basic(t *testing.T) {
 	resourceName := "aws_bcmdataexports_export.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -110,7 +110,7 @@ func TestAccBCMDataExportsExport_Identity_ExistingResource_fromV5(t *testing.T) 
 	resourceName := "aws_bcmdataexports_export.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -168,7 +168,7 @@ func TestAccBCMDataExportsExport_Identity_ExistingResource_fromV6(t *testing.T) 
 	resourceName := "aws_bcmdataexports_export.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/bedrock/custom_model_identity_gen_test.go
+++ b/internal/service/bedrock/custom_model_identity_gen_test.go
@@ -39,7 +39,7 @@ func testAccBedrockCustomModel_Identity_Basic(t *testing.T) {
 	resourceName := "aws_bedrock_custom_model.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -131,7 +131,7 @@ func testAccBedrockCustomModel_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_bedrock_custom_model.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -264,7 +264,7 @@ func testAccBedrockCustomModel_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_bedrock_custom_model.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/bedrock/model_invocation_logging_configuration_identity_gen_test.go
+++ b/internal/service/bedrock/model_invocation_logging_configuration_identity_gen_test.go
@@ -37,7 +37,7 @@ func testAccBedrockModelInvocationLoggingConfiguration_Identity_Basic(t *testing
 	resourceName := "aws_bedrock_model_invocation_logging_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -120,7 +120,7 @@ func testAccBedrockModelInvocationLoggingConfiguration_Identity_RegionOverride(t
 	resourceName := "aws_bedrock_model_invocation_logging_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -236,7 +236,7 @@ func testAccBedrockModelInvocationLoggingConfiguration_Identity_ExistingResource
 	resourceName := "aws_bedrock_model_invocation_logging_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/ce/anomaly_monitor_identity_gen_test.go
+++ b/internal/service/ce/anomaly_monitor_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccCEAnomalyMonitor_Identity_Basic(t *testing.T) {
 	resourceName := "aws_ce_anomaly_monitor.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -110,7 +110,7 @@ func TestAccCEAnomalyMonitor_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_ce_anomaly_monitor.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/ce/anomaly_subscription_identity_gen_test.go
+++ b/internal/service/ce/anomaly_subscription_identity_gen_test.go
@@ -29,7 +29,7 @@ func TestAccCEAnomalySubscription_Identity_Basic(t *testing.T) {
 	domain := acctest.RandomDomainName()
 	email_address := acctest.RandomEmailAddress(domain)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -118,7 +118,7 @@ func TestAccCEAnomalySubscription_Identity_ExistingResource(t *testing.T) {
 	domain := acctest.RandomDomainName()
 	email_address := acctest.RandomEmailAddress(domain)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/ce/cost_category_identity_gen_test.go
+++ b/internal/service/ce/cost_category_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccCECostCategory_Identity_Basic(t *testing.T) {
 	resourceName := "aws_ce_cost_category.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -110,7 +110,7 @@ func TestAccCECostCategory_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_ce_cost_category.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/chimesdkmediapipelines/media_insights_pipeline_configuration_identity_gen_test.go
+++ b/internal/service/chimesdkmediapipelines/media_insights_pipeline_configuration_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccChimeSDKMediaPipelinesMediaInsightsPipelineConfiguration_Identity_Ba
 	resourceName := "aws_chimesdkmediapipelines_media_insights_pipeline_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccChimeSDKMediaPipelinesMediaInsightsPipelineConfiguration_Identity_Re
 	resourceName := "aws_chimesdkmediapipelines_media_insights_pipeline_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -233,7 +233,7 @@ func TestAccChimeSDKMediaPipelinesMediaInsightsPipelineConfiguration_Identity_Ex
 	resourceName := "aws_chimesdkmediapipelines_media_insights_pipeline_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/cloudfront/key_value_store_identity_gen_test.go
+++ b/internal/service/cloudfront/key_value_store_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccCloudFrontKeyValueStore_Identity_Basic(t *testing.T) {
 	resourceName := "aws_cloudfront_key_value_store.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccCloudFrontKeyValueStore_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_cloudfront_key_value_store.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/cloudfront/realtime_log_config_identity_gen_test.go
+++ b/internal/service/cloudfront/realtime_log_config_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccCloudFrontRealtimeLogConfig_Identity_Basic(t *testing.T) {
 	resourceName := "aws_cloudfront_realtime_log_config.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -111,7 +111,7 @@ func TestAccCloudFrontRealtimeLogConfig_Identity_ExistingResource(t *testing.T) 
 	resourceName := "aws_cloudfront_realtime_log_config.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/cloudfrontkeyvaluestore/key_identity_gen_test.go
+++ b/internal/service/cloudfrontkeyvaluestore/key_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccCloudFrontKeyValueStoreKey_Identity_Basic(t *testing.T) {
 	resourceName := "aws_cloudfrontkeyvaluestore_key.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -108,7 +108,7 @@ func TestAccCloudFrontKeyValueStoreKey_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_cloudfrontkeyvaluestore_key.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/cloudtrail/event_data_store_identity_gen_test.go
+++ b/internal/service/cloudtrail/event_data_store_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccCloudTrailEventDataStore_Identity_Basic(t *testing.T) {
 	resourceName := "aws_cloudtrail_event_data_store.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -109,7 +109,7 @@ func TestAccCloudTrailEventDataStore_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_cloudtrail_event_data_store.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -228,7 +228,7 @@ func TestAccCloudTrailEventDataStore_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_cloudtrail_event_data_store.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/cloudtrail/trail_identity_gen_test.go
+++ b/internal/service/cloudtrail/trail_identity_gen_test.go
@@ -39,7 +39,7 @@ func testAccCloudTrailTrail_Identity_Basic(t *testing.T) {
 	resourceName := "aws_cloudtrail.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -124,7 +124,7 @@ func testAccCloudTrailTrail_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_cloudtrail.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -245,7 +245,7 @@ func testAccCloudTrailTrail_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_cloudtrail.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/codeartifact/domain_identity_gen_test.go
+++ b/internal/service/codeartifact/domain_identity_gen_test.go
@@ -36,7 +36,7 @@ func testAccCodeArtifactDomain_Identity_Basic(t *testing.T) {
 	resourceName := "aws_codeartifact_domain.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -122,7 +122,7 @@ func testAccCodeArtifactDomain_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_codeartifact_domain.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -242,7 +242,7 @@ func testAccCodeArtifactDomain_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_codeartifact_domain.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/codeartifact/domain_permissions_policy_identity_gen_test.go
+++ b/internal/service/codeartifact/domain_permissions_policy_identity_gen_test.go
@@ -36,7 +36,7 @@ func testAccCodeArtifactDomainPermissionsPolicy_Identity_Basic(t *testing.T) {
 	resourceName := "aws_codeartifact_domain_permissions_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -121,7 +121,7 @@ func testAccCodeArtifactDomainPermissionsPolicy_Identity_RegionOverride(t *testi
 	resourceName := "aws_codeartifact_domain_permissions_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -240,7 +240,7 @@ func testAccCodeArtifactDomainPermissionsPolicy_Identity_ExistingResource(t *tes
 	resourceName := "aws_codeartifact_domain_permissions_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/codeartifact/repository_identity_gen_test.go
+++ b/internal/service/codeartifact/repository_identity_gen_test.go
@@ -36,7 +36,7 @@ func testAccCodeArtifactRepository_Identity_Basic(t *testing.T) {
 	resourceName := "aws_codeartifact_repository.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -122,7 +122,7 @@ func testAccCodeArtifactRepository_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_codeartifact_repository.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -242,7 +242,7 @@ func testAccCodeArtifactRepository_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_codeartifact_repository.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/codeartifact/repository_permissions_policy_identity_gen_test.go
+++ b/internal/service/codeartifact/repository_permissions_policy_identity_gen_test.go
@@ -36,7 +36,7 @@ func testAccCodeArtifactRepositoryPermissionsPolicy_Identity_Basic(t *testing.T)
 	resourceName := "aws_codeartifact_repository_permissions_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -121,7 +121,7 @@ func testAccCodeArtifactRepositoryPermissionsPolicy_Identity_RegionOverride(t *t
 	resourceName := "aws_codeartifact_repository_permissions_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -240,7 +240,7 @@ func testAccCodeArtifactRepositoryPermissionsPolicy_Identity_ExistingResource(t 
 	resourceName := "aws_codeartifact_repository_permissions_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/codebuild/fleet_identity_gen_test.go
+++ b/internal/service/codebuild/fleet_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccCodeBuildFleet_Identity_Basic(t *testing.T) {
 	resourceName := "aws_codebuild_fleet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -109,7 +109,7 @@ func TestAccCodeBuildFleet_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_codebuild_fleet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -228,7 +228,7 @@ func TestAccCodeBuildFleet_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_codebuild_fleet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/codebuild/project_identity_gen_test.go
+++ b/internal/service/codebuild/project_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccCodeBuildProject_Identity_Basic(t *testing.T) {
 	resourceName := "aws_codebuild_project.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -117,7 +117,7 @@ func TestAccCodeBuildProject_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_codebuild_project.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -244,7 +244,7 @@ func TestAccCodeBuildProject_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_codebuild_project.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/codebuild/report_group_identity_gen_test.go
+++ b/internal/service/codebuild/report_group_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccCodeBuildReportGroup_Identity_Basic(t *testing.T) {
 	resourceName := "aws_codebuild_report_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -116,7 +116,7 @@ func TestAccCodeBuildReportGroup_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_codebuild_report_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -244,7 +244,7 @@ func TestAccCodeBuildReportGroup_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_codebuild_report_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/codebuild/resource_policy_identity_gen_test.go
+++ b/internal/service/codebuild/resource_policy_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccCodeBuildResourcePolicy_Identity_Basic(t *testing.T) {
 	resourceName := "aws_codebuild_resource_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccCodeBuildResourcePolicy_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_codebuild_resource_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -233,7 +233,7 @@ func TestAccCodeBuildResourcePolicy_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_codebuild_resource_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/codebuild/source_credential_identity_gen_test.go
+++ b/internal/service/codebuild/source_credential_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccCodeBuildSourceCredential_Identity_Basic(t *testing.T) {
 	resourceName := "aws_codebuild_source_credential.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -119,7 +119,7 @@ func TestAccCodeBuildSourceCredential_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_codebuild_source_credential.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -252,7 +252,7 @@ func TestAccCodeBuildSourceCredential_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_codebuild_source_credential.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/codeconnections/connection_identity_gen_test.go
+++ b/internal/service/codeconnections/connection_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccCodeConnectionsConnection_Identity_Basic(t *testing.T) {
 	resourceName := "aws_codeconnections_connection.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccCodeConnectionsConnection_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_codeconnections_connection.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -233,7 +233,7 @@ func TestAccCodeConnectionsConnection_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_codeconnections_connection.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/codeconnections/host_identity_gen_test.go
+++ b/internal/service/codeconnections/host_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccCodeConnectionsHost_Identity_Basic(t *testing.T) {
 	resourceName := "aws_codeconnections_host.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccCodeConnectionsHost_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_codeconnections_host.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -233,7 +233,7 @@ func TestAccCodeConnectionsHost_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_codeconnections_host.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/codegurureviewer/repository_association_identity_gen_test.go
+++ b/internal/service/codegurureviewer/repository_association_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccCodeGuruReviewerRepositoryAssociation_Identity_Basic(t *testing.T) {
 	resourceName := "aws_codegurureviewer_repository_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -119,7 +119,7 @@ func TestAccCodeGuruReviewerRepositoryAssociation_Identity_RegionOverride(t *tes
 	resourceName := "aws_codegurureviewer_repository_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -252,7 +252,7 @@ func TestAccCodeGuruReviewerRepositoryAssociation_Identity_ExistingResource(t *t
 	resourceName := "aws_codegurureviewer_repository_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/codepipeline/webhook_identity_gen_test.go
+++ b/internal/service/codepipeline/webhook_identity_gen_test.go
@@ -28,7 +28,7 @@ func TestAccCodePipelineWebhook_Identity_Basic(t *testing.T) {
 	resourceName := "aws_codepipeline_webhook.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -118,7 +118,7 @@ func TestAccCodePipelineWebhook_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_codepipeline_webhook.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -244,7 +244,7 @@ func TestAccCodePipelineWebhook_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_codepipeline_webhook.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/codestarconnections/connection_identity_gen_test.go
+++ b/internal/service/codestarconnections/connection_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccCodeStarConnectionsConnection_Identity_Basic(t *testing.T) {
 	resourceName := "aws_codestarconnections_connection.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccCodeStarConnectionsConnection_Identity_RegionOverride(t *testing.T) 
 	resourceName := "aws_codestarconnections_connection.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -233,7 +233,7 @@ func TestAccCodeStarConnectionsConnection_Identity_ExistingResource(t *testing.T
 	resourceName := "aws_codestarconnections_connection.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/codestarconnections/host_identity_gen_test.go
+++ b/internal/service/codestarconnections/host_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccCodeStarConnectionsHost_Identity_Basic(t *testing.T) {
 	resourceName := "aws_codestarconnections_host.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccCodeStarConnectionsHost_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_codestarconnections_host.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -233,7 +233,7 @@ func TestAccCodeStarConnectionsHost_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_codestarconnections_host.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/codestarnotifications/notification_rule_identity_gen_test.go
+++ b/internal/service/codestarnotifications/notification_rule_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccCodeStarNotificationsNotificationRule_Identity_Basic(t *testing.T) {
 	resourceName := "aws_codestarnotifications_notification_rule.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -109,7 +109,7 @@ func TestAccCodeStarNotificationsNotificationRule_Identity_RegionOverride(t *tes
 	resourceName := "aws_codestarnotifications_notification_rule.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -228,7 +228,7 @@ func TestAccCodeStarNotificationsNotificationRule_Identity_ExistingResource(t *t
 	resourceName := "aws_codestarnotifications_notification_rule.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/cognitoidp/log_delivery_configuration_identity_gen_test.go
+++ b/internal/service/cognitoidp/log_delivery_configuration_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccCognitoIDPLogDeliveryConfiguration_Identity_Basic(t *testing.T) {
 	resourceName := "aws_cognito_log_delivery_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -114,7 +114,7 @@ func TestAccCognitoIDPLogDeliveryConfiguration_Identity_RegionOverride(t *testin
 	resourceName := "aws_cognito_log_delivery_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -204,7 +204,7 @@ func TestAccCognitoIDPLogDeliveryConfiguration_Identity_ExistingResource(t *test
 	resourceName := "aws_cognito_log_delivery_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/comprehend/document_classifier_identity_gen_test.go
+++ b/internal/service/comprehend/document_classifier_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccComprehendDocumentClassifier_Identity_Basic(t *testing.T) {
 	resourceName := "aws_comprehend_document_classifier.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -115,7 +115,7 @@ func TestAccComprehendDocumentClassifier_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_comprehend_document_classifier.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -239,7 +239,7 @@ func TestAccComprehendDocumentClassifier_Identity_ExistingResource(t *testing.T)
 	resourceName := "aws_comprehend_document_classifier.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/comprehend/entity_recognizer_identity_gen_test.go
+++ b/internal/service/comprehend/entity_recognizer_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccComprehendEntityRecognizer_Identity_Basic(t *testing.T) {
 	resourceName := "aws_comprehend_entity_recognizer.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -115,7 +115,7 @@ func TestAccComprehendEntityRecognizer_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_comprehend_entity_recognizer.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -239,7 +239,7 @@ func TestAccComprehendEntityRecognizer_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_comprehend_entity_recognizer.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/datasync/agent_identity_gen_test.go
+++ b/internal/service/datasync/agent_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccDataSyncAgent_Identity_Basic(t *testing.T) {
 	resourceName := "aws_datasync_agent.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -122,7 +122,7 @@ func TestAccDataSyncAgent_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_datasync_agent.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -258,7 +258,7 @@ func TestAccDataSyncAgent_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_datasync_agent.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/datasync/location_azure_blob_identity_gen_test.go
+++ b/internal/service/datasync/location_azure_blob_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccDataSyncLocationAzureBlob_Identity_Basic(t *testing.T) {
 	resourceName := "aws_datasync_location_azure_blob.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -122,7 +122,7 @@ func TestAccDataSyncLocationAzureBlob_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_datasync_location_azure_blob.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -258,7 +258,7 @@ func TestAccDataSyncLocationAzureBlob_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_datasync_location_azure_blob.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/datasync/location_efs_identity_gen_test.go
+++ b/internal/service/datasync/location_efs_identity_gen_test.go
@@ -25,7 +25,7 @@ func TestAccDataSyncLocationEFS_Identity_Basic(t *testing.T) {
 	var v datasync.DescribeLocationEfsOutput
 	resourceName := "aws_datasync_location_efs.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -104,7 +104,7 @@ func TestAccDataSyncLocationEFS_Identity_RegionOverride(t *testing.T) {
 
 	resourceName := "aws_datasync_location_efs.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -221,7 +221,7 @@ func TestAccDataSyncLocationEFS_Identity_ExistingResource(t *testing.T) {
 	var v datasync.DescribeLocationEfsOutput
 	resourceName := "aws_datasync_location_efs.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/datasync/location_hdfs_identity_gen_test.go
+++ b/internal/service/datasync/location_hdfs_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccDataSyncLocationHDFS_Identity_Basic(t *testing.T) {
 	resourceName := "aws_datasync_location_hdfs.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -115,7 +115,7 @@ func TestAccDataSyncLocationHDFS_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_datasync_location_hdfs.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -239,7 +239,7 @@ func TestAccDataSyncLocationHDFS_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_datasync_location_hdfs.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/datasync/location_nfs_identity_gen_test.go
+++ b/internal/service/datasync/location_nfs_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccDataSyncLocationNFS_Identity_Basic(t *testing.T) {
 	resourceName := "aws_datasync_location_nfs.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -115,7 +115,7 @@ func TestAccDataSyncLocationNFS_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_datasync_location_nfs.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -239,7 +239,7 @@ func TestAccDataSyncLocationNFS_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_datasync_location_nfs.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/datasync/location_object_storage_identity_gen_test.go
+++ b/internal/service/datasync/location_object_storage_identity_gen_test.go
@@ -28,7 +28,7 @@ func TestAccDataSyncLocationObjectStorage_Identity_Basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	domain := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -121,7 +121,7 @@ func TestAccDataSyncLocationObjectStorage_Identity_RegionOverride(t *testing.T) 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	domain := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -252,7 +252,7 @@ func TestAccDataSyncLocationObjectStorage_Identity_ExistingResource(t *testing.T
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	domain := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/datasync/location_s3_identity_gen_test.go
+++ b/internal/service/datasync/location_s3_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccDataSyncLocationS3_Identity_Basic(t *testing.T) {
 	resourceName := "aws_datasync_location_s3.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -115,7 +115,7 @@ func TestAccDataSyncLocationS3_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_datasync_location_s3.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -239,7 +239,7 @@ func TestAccDataSyncLocationS3_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_datasync_location_s3.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/datasync/location_smb_identity_gen_test.go
+++ b/internal/service/datasync/location_smb_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccDataSyncLocationSMB_Identity_Basic(t *testing.T) {
 	resourceName := "aws_datasync_location_smb.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -122,7 +122,7 @@ func TestAccDataSyncLocationSMB_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_datasync_location_smb.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -258,7 +258,7 @@ func TestAccDataSyncLocationSMB_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_datasync_location_smb.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/datasync/task_identity_gen_test.go
+++ b/internal/service/datasync/task_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccDataSyncTask_Identity_Basic(t *testing.T) {
 	resourceName := "aws_datasync_task.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -115,7 +115,7 @@ func TestAccDataSyncTask_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_datasync_task.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -239,7 +239,7 @@ func TestAccDataSyncTask_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_datasync_task.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/devicefarm/device_pool_identity_gen_test.go
+++ b/internal/service/devicefarm/device_pool_identity_gen_test.go
@@ -28,7 +28,7 @@ func TestAccDeviceFarmDevicePool_Identity_Basic(t *testing.T) {
 	resourceName := "aws_devicefarm_device_pool.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -117,7 +117,7 @@ func TestAccDeviceFarmDevicePool_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_devicefarm_device_pool.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/devicefarm/instance_profile_identity_gen_test.go
+++ b/internal/service/devicefarm/instance_profile_identity_gen_test.go
@@ -28,7 +28,7 @@ func TestAccDeviceFarmInstanceProfile_Identity_Basic(t *testing.T) {
 	resourceName := "aws_devicefarm_instance_profile.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -117,7 +117,7 @@ func TestAccDeviceFarmInstanceProfile_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_devicefarm_instance_profile.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/devicefarm/network_profile_identity_gen_test.go
+++ b/internal/service/devicefarm/network_profile_identity_gen_test.go
@@ -28,7 +28,7 @@ func TestAccDeviceFarmNetworkProfile_Identity_Basic(t *testing.T) {
 	resourceName := "aws_devicefarm_network_profile.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -117,7 +117,7 @@ func TestAccDeviceFarmNetworkProfile_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_devicefarm_network_profile.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/devicefarm/project_identity_gen_test.go
+++ b/internal/service/devicefarm/project_identity_gen_test.go
@@ -28,7 +28,7 @@ func TestAccDeviceFarmProject_Identity_Basic(t *testing.T) {
 	resourceName := "aws_devicefarm_project.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -117,7 +117,7 @@ func TestAccDeviceFarmProject_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_devicefarm_project.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/devicefarm/test_grid_project_identity_gen_test.go
+++ b/internal/service/devicefarm/test_grid_project_identity_gen_test.go
@@ -28,7 +28,7 @@ func TestAccDeviceFarmTestGridProject_Identity_Basic(t *testing.T) {
 	resourceName := "aws_devicefarm_test_grid_project.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -117,7 +117,7 @@ func TestAccDeviceFarmTestGridProject_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_devicefarm_test_grid_project.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/devicefarm/upload_identity_gen_test.go
+++ b/internal/service/devicefarm/upload_identity_gen_test.go
@@ -28,7 +28,7 @@ func TestAccDeviceFarmUpload_Identity_Basic(t *testing.T) {
 	resourceName := "aws_devicefarm_upload.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -120,7 +120,7 @@ func TestAccDeviceFarmUpload_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_devicefarm_upload.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/devopsguru/event_sources_config_identity_gen_test.go
+++ b/internal/service/devopsguru/event_sources_config_identity_gen_test.go
@@ -38,7 +38,7 @@ func testAccDevOpsGuruEventSourcesConfig_Identity_Basic(t *testing.T) {
 	var v devopsguru.DescribeEventSourcesConfigOutput
 	resourceName := "aws_devopsguru_event_sources_config.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -115,7 +115,7 @@ func testAccDevOpsGuruEventSourcesConfig_Identity_RegionOverride(t *testing.T) {
 
 	resourceName := "aws_devopsguru_event_sources_config.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -229,7 +229,7 @@ func testAccDevOpsGuruEventSourcesConfig_Identity_ExistingResource(t *testing.T)
 	var v devopsguru.DescribeEventSourcesConfigOutput
 	resourceName := "aws_devopsguru_event_sources_config.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/devopsguru/service_integration_identity_gen_test.go
+++ b/internal/service/devopsguru/service_integration_identity_gen_test.go
@@ -35,7 +35,7 @@ func testAccDevOpsGuruServiceIntegration_Identity_Basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_devopsguru_service_integration.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func testAccDevOpsGuruServiceIntegration_Identity_RegionOverride(t *testing.T) {
 
 	resourceName := "aws_devopsguru_service_integration.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -224,7 +224,7 @@ func testAccDevOpsGuruServiceIntegration_Identity_ExistingResource(t *testing.T)
 	ctx := acctest.Context(t)
 	resourceName := "aws_devopsguru_service_integration.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/dms/replication_config_identity_gen_test.go
+++ b/internal/service/dms/replication_config_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccDMSReplicationConfig_Identity_Basic(t *testing.T) {
 	resourceName := "aws_dms_replication_config.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -115,7 +115,7 @@ func TestAccDMSReplicationConfig_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_dms_replication_config.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -242,7 +242,7 @@ func TestAccDMSReplicationConfig_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_dms_replication_config.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/docdbelastic/cluster_identity_gen_test.go
+++ b/internal/service/docdbelastic/cluster_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccDocDBElasticCluster_Identity_Basic(t *testing.T) {
 	resourceName := "aws_docdbelastic_cluster.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -119,7 +119,7 @@ func TestAccDocDBElasticCluster_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_docdbelastic_cluster.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -252,7 +252,7 @@ func TestAccDocDBElasticCluster_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_docdbelastic_cluster.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/dynamodb/resource_policy_identity_gen_test.go
+++ b/internal/service/dynamodb/resource_policy_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccDynamoDBResourcePolicy_Identity_Basic(t *testing.T) {
 	resourceName := "aws_dynamodb_resource_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -119,7 +119,7 @@ func TestAccDynamoDBResourcePolicy_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_dynamodb_resource_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -252,7 +252,7 @@ func TestAccDynamoDBResourcePolicy_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_dynamodb_resource_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/dynamodb/table_export_identity_gen_test.go
+++ b/internal/service/dynamodb/table_export_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccDynamoDBTableExport_Identity_Basic(t *testing.T) {
 	resourceName := "aws_dynamodb_table_export.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccDynamoDBTableExport_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_dynamodb_table_export.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -233,7 +233,7 @@ func TestAccDynamoDBTableExport_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_dynamodb_table_export.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/ec2/ebs_snapshot_block_public_access_identity_gen_test.go
+++ b/internal/service/ec2/ebs_snapshot_block_public_access_identity_gen_test.go
@@ -35,7 +35,7 @@ func testAccEC2EBSEBSSnapshotBlockPublicAccess_Identity_Basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ebs_snapshot_block_public_access.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -106,7 +106,7 @@ func testAccEC2EBSEBSSnapshotBlockPublicAccess_Identity_RegionOverride(t *testin
 
 	resourceName := "aws_ebs_snapshot_block_public_access.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -215,7 +215,7 @@ func testAccEC2EBSEBSSnapshotBlockPublicAccess_Identity_ExistingResource(t *test
 	ctx := acctest.Context(t)
 	resourceName := "aws_ebs_snapshot_block_public_access.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/ec2/ec2_image_block_public_access_identity_gen_test.go
+++ b/internal/service/ec2/ec2_image_block_public_access_identity_gen_test.go
@@ -33,7 +33,7 @@ func testAccEC2ImageBlockPublicAccess_Identity_Basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ec2_image_block_public_access.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -61,7 +61,7 @@ func testAccEC2ImageBlockPublicAccess_Identity_ExistingResource(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ec2_image_block_public_access.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/ec2/ec2_serial_console_access_identity_gen_test.go
+++ b/internal/service/ec2/ec2_serial_console_access_identity_gen_test.go
@@ -33,7 +33,7 @@ func testAccEC2SerialConsoleAccess_Identity_Basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ec2_serial_console_access.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -99,7 +99,7 @@ func testAccEC2SerialConsoleAccess_Identity_ExistingResource(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ec2_serial_console_access.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/ec2/vpc_security_group_vpc_association_identity_gen_test.go
+++ b/internal/service/ec2/vpc_security_group_vpc_association_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccVPCSecurityGroupVPCAssociation_Identity_Basic(t *testing.T) {
 	resourceName := "aws_vpc_security_group_vpc_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -118,7 +118,7 @@ func TestAccVPCSecurityGroupVPCAssociation_Identity_RegionOverride(t *testing.T)
 	resourceName := "aws_vpc_security_group_vpc_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -212,7 +212,7 @@ func TestAccVPCSecurityGroupVPCAssociation_Identity_ExistingResource(t *testing.
 	resourceName := "aws_vpc_security_group_vpc_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/ecs/capacity_provider_identity_gen_test.go
+++ b/internal/service/ecs/capacity_provider_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccECSCapacityProvider_Identity_Basic(t *testing.T) {
 	resourceName := "aws_ecs_capacity_provider.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -113,7 +113,7 @@ func TestAccECSCapacityProvider_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_ecs_capacity_provider.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -235,7 +235,7 @@ func TestAccECSCapacityProvider_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_ecs_capacity_provider.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/elbv2/listener_identity_gen_test.go
+++ b/internal/service/elbv2/listener_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccELBV2Listener_Identity_Basic(t *testing.T) {
 	resourceName := "aws_lb_listener.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -119,7 +119,7 @@ func TestAccELBV2Listener_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_lb_listener.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -253,7 +253,7 @@ func TestAccELBV2Listener_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_lb_listener.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/elbv2/listener_rule_identity_gen_test.go
+++ b/internal/service/elbv2/listener_rule_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccELBV2ListenerRule_Identity_Basic(t *testing.T) {
 	resourceName := "aws_lb_listener_rule.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -115,7 +115,7 @@ func TestAccELBV2ListenerRule_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_lb_listener_rule.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -243,7 +243,7 @@ func TestAccELBV2ListenerRule_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_lb_listener_rule.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/elbv2/load_balancer_identity_gen_test.go
+++ b/internal/service/elbv2/load_balancer_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccELBV2LoadBalancer_Identity_Basic(t *testing.T) {
 	resourceName := "aws_lb.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccELBV2LoadBalancer_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_lb.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -233,7 +233,7 @@ func TestAccELBV2LoadBalancer_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_lb.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/elbv2/target_group_identity_gen_test.go
+++ b/internal/service/elbv2/target_group_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccELBV2TargetGroup_Identity_Basic(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -115,7 +115,7 @@ func TestAccELBV2TargetGroup_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -243,7 +243,7 @@ func TestAccELBV2TargetGroup_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/elbv2/trust_store_identity_gen_test.go
+++ b/internal/service/elbv2/trust_store_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccELBV2TrustStore_Identity_Basic(t *testing.T) {
 	resourceName := "aws_lb_trust_store.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -119,7 +119,7 @@ func TestAccELBV2TrustStore_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_lb_trust_store.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -253,7 +253,7 @@ func TestAccELBV2TrustStore_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_lb_trust_store.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/globalaccelerator/accelerator_identity_gen_test.go
+++ b/internal/service/globalaccelerator/accelerator_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccGlobalAcceleratorAccelerator_Identity_Basic(t *testing.T) {
 	resourceName := "aws_globalaccelerator_accelerator.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -106,7 +106,7 @@ func TestAccGlobalAcceleratorAccelerator_Identity_ExistingResource(t *testing.T)
 	resourceName := "aws_globalaccelerator_accelerator.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/globalaccelerator/cross_account_attachment_identity_gen_test.go
+++ b/internal/service/globalaccelerator/cross_account_attachment_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccGlobalAcceleratorCrossAccountAttachment_Identity_Basic(t *testing.T)
 	resourceName := "aws_globalaccelerator_cross_account_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -110,7 +110,7 @@ func TestAccGlobalAcceleratorCrossAccountAttachment_Identity_ExistingResource(t 
 	resourceName := "aws_globalaccelerator_cross_account_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/globalaccelerator/custom_routing_accelerator_identity_gen_test.go
+++ b/internal/service/globalaccelerator/custom_routing_accelerator_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccGlobalAcceleratorCustomRoutingAccelerator_Identity_Basic(t *testing.
 	resourceName := "aws_globalaccelerator_custom_routing_accelerator.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -106,7 +106,7 @@ func TestAccGlobalAcceleratorCustomRoutingAccelerator_Identity_ExistingResource(
 	resourceName := "aws_globalaccelerator_custom_routing_accelerator.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/globalaccelerator/custom_routing_endpoint_group_identity_gen_test.go
+++ b/internal/service/globalaccelerator/custom_routing_endpoint_group_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccGlobalAcceleratorCustomRoutingEndpointGroup_Identity_Basic(t *testin
 	resourceName := "aws_globalaccelerator_custom_routing_endpoint_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -111,7 +111,7 @@ func TestAccGlobalAcceleratorCustomRoutingEndpointGroup_Identity_ExistingResourc
 	resourceName := "aws_globalaccelerator_custom_routing_endpoint_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/globalaccelerator/custom_routing_listener_identity_gen_test.go
+++ b/internal/service/globalaccelerator/custom_routing_listener_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccGlobalAcceleratorCustomRoutingListener_Identity_Basic(t *testing.T) 
 	resourceName := "aws_globalaccelerator_custom_routing_listener.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -111,7 +111,7 @@ func TestAccGlobalAcceleratorCustomRoutingListener_Identity_ExistingResource(t *
 	resourceName := "aws_globalaccelerator_custom_routing_listener.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/globalaccelerator/endpoint_group_identity_gen_test.go
+++ b/internal/service/globalaccelerator/endpoint_group_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccGlobalAcceleratorEndpointGroup_Identity_Basic(t *testing.T) {
 	resourceName := "aws_globalaccelerator_endpoint_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -111,7 +111,7 @@ func TestAccGlobalAcceleratorEndpointGroup_Identity_ExistingResource(t *testing.
 	resourceName := "aws_globalaccelerator_endpoint_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/globalaccelerator/listener_identity_gen_test.go
+++ b/internal/service/globalaccelerator/listener_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccGlobalAcceleratorListener_Identity_Basic(t *testing.T) {
 	resourceName := "aws_globalaccelerator_listener.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -106,7 +106,7 @@ func TestAccGlobalAcceleratorListener_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_globalaccelerator_listener.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/glue/registry_identity_gen_test.go
+++ b/internal/service/glue/registry_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccGlueRegistry_Identity_Basic(t *testing.T) {
 	resourceName := "aws_glue_registry.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccGlueRegistry_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_glue_registry.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -234,7 +234,7 @@ func TestAccGlueRegistry_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_glue_registry.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/glue/resource_policy_identity_gen_test.go
+++ b/internal/service/glue/resource_policy_identity_gen_test.go
@@ -35,7 +35,7 @@ func testAccGlueResourcePolicy_Identity_Basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_glue_resource_policy.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -106,7 +106,7 @@ func testAccGlueResourcePolicy_Identity_RegionOverride(t *testing.T) {
 
 	resourceName := "aws_glue_resource_policy.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -215,7 +215,7 @@ func testAccGlueResourcePolicy_Identity_ExistingResource(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_glue_resource_policy.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/glue/schema_identity_gen_test.go
+++ b/internal/service/glue/schema_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccGlueSchema_Identity_Basic(t *testing.T) {
 	resourceName := "aws_glue_schema.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccGlueSchema_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_glue_schema.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -234,7 +234,7 @@ func TestAccGlueSchema_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_glue_schema.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/iam/openid_connect_provider_identity_gen_test.go
+++ b/internal/service/iam/openid_connect_provider_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccIAMOpenIDConnectProvider_Identity_Basic(t *testing.T) {
 	resourceName := "aws_iam_openid_connect_provider.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -106,7 +106,7 @@ func TestAccIAMOpenIDConnectProvider_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_iam_openid_connect_provider.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/iam/policy_identity_gen_test.go
+++ b/internal/service/iam/policy_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccIAMPolicy_Identity_Basic(t *testing.T) {
 	resourceName := "aws_iam_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -111,7 +111,7 @@ func TestAccIAMPolicy_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_iam_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/iam/role_identity_gen_test.go
+++ b/internal/service/iam/role_identity_gen_test.go
@@ -28,7 +28,7 @@ func TestAccIAMRole_Identity_Basic(t *testing.T) {
 	resourceName := "aws_iam_role.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccIAMRole_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_iam_role.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/iam/role_policy_attachment_identity_gen_test.go
+++ b/internal/service/iam/role_policy_attachment_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccIAMRolePolicyAttachment_Identity_Basic(t *testing.T) {
 	resourceName := "aws_iam_role_policy_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -109,7 +109,7 @@ func TestAccIAMRolePolicyAttachment_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_iam_role_policy_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/iam/role_policy_identity_gen_test.go
+++ b/internal/service/iam/role_policy_identity_gen_test.go
@@ -26,7 +26,7 @@ func TestAccIAMRolePolicy_Identity_Basic(t *testing.T) {
 	resourceName := "aws_iam_role_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -113,7 +113,7 @@ func TestAccIAMRolePolicy_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_iam_role_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/iam/saml_provider_identity_gen_test.go
+++ b/internal/service/iam/saml_provider_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccIAMSAMLProvider_Identity_Basic(t *testing.T) {
 	resourceName := "aws_iam_saml_provider.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -106,7 +106,7 @@ func TestAccIAMSAMLProvider_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_iam_saml_provider.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/iam/service_linked_role_identity_gen_test.go
+++ b/internal/service/iam/service_linked_role_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccIAMServiceLinkedRole_Identity_Basic(t *testing.T) {
 	resourceName := "aws_iam_service_linked_role.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -106,7 +106,7 @@ func TestAccIAMServiceLinkedRole_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_iam_service_linked_role.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/imagebuilder/container_recipe_identity_gen_test.go
+++ b/internal/service/imagebuilder/container_recipe_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccImageBuilderContainerRecipe_Identity_Basic(t *testing.T) {
 	resourceName := "aws_imagebuilder_container_recipe.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -109,7 +109,7 @@ func TestAccImageBuilderContainerRecipe_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_imagebuilder_container_recipe.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -229,7 +229,7 @@ func TestAccImageBuilderContainerRecipe_Identity_ExistingResource(t *testing.T) 
 	resourceName := "aws_imagebuilder_container_recipe.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/imagebuilder/distribution_configuration_identity_gen_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccImageBuilderDistributionConfiguration_Identity_Basic(t *testing.T) {
 	resourceName := "aws_imagebuilder_distribution_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -109,7 +109,7 @@ func TestAccImageBuilderDistributionConfiguration_Identity_RegionOverride(t *tes
 	resourceName := "aws_imagebuilder_distribution_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -229,7 +229,7 @@ func TestAccImageBuilderDistributionConfiguration_Identity_ExistingResource(t *t
 	resourceName := "aws_imagebuilder_distribution_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/imagebuilder/image_identity_gen_test.go
+++ b/internal/service/imagebuilder/image_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccImageBuilderImage_Identity_Basic(t *testing.T) {
 	resourceName := "aws_imagebuilder_image.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -109,7 +109,7 @@ func TestAccImageBuilderImage_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_imagebuilder_image.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -229,7 +229,7 @@ func TestAccImageBuilderImage_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_imagebuilder_image.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/imagebuilder/image_pipeline_identity_gen_test.go
+++ b/internal/service/imagebuilder/image_pipeline_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccImageBuilderImagePipeline_Identity_Basic(t *testing.T) {
 	resourceName := "aws_imagebuilder_image_pipeline.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -109,7 +109,7 @@ func TestAccImageBuilderImagePipeline_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_imagebuilder_image_pipeline.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -229,7 +229,7 @@ func TestAccImageBuilderImagePipeline_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_imagebuilder_image_pipeline.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/imagebuilder/image_recipe_identity_gen_test.go
+++ b/internal/service/imagebuilder/image_recipe_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccImageBuilderImageRecipe_Identity_Basic(t *testing.T) {
 	resourceName := "aws_imagebuilder_image_recipe.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -109,7 +109,7 @@ func TestAccImageBuilderImageRecipe_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_imagebuilder_image_recipe.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -229,7 +229,7 @@ func TestAccImageBuilderImageRecipe_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_imagebuilder_image_recipe.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/imagebuilder/infrastructure_configuration_identity_gen_test.go
+++ b/internal/service/imagebuilder/infrastructure_configuration_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccImageBuilderInfrastructureConfiguration_Identity_Basic(t *testing.T)
 	resourceName := "aws_imagebuilder_infrastructure_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -109,7 +109,7 @@ func TestAccImageBuilderInfrastructureConfiguration_Identity_RegionOverride(t *t
 	resourceName := "aws_imagebuilder_infrastructure_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -229,7 +229,7 @@ func TestAccImageBuilderInfrastructureConfiguration_Identity_ExistingResource(t 
 	resourceName := "aws_imagebuilder_infrastructure_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/imagebuilder/lifecycle_policy_identity_gen_test.go
+++ b/internal/service/imagebuilder/lifecycle_policy_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccImageBuilderLifecyclePolicy_Identity_Basic(t *testing.T) {
 	resourceName := "aws_imagebuilder_lifecycle_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -110,7 +110,7 @@ func TestAccImageBuilderLifecyclePolicy_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_imagebuilder_lifecycle_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -230,7 +230,7 @@ func TestAccImageBuilderLifecyclePolicy_Identity_ExistingResource(t *testing.T) 
 	resourceName := "aws_imagebuilder_lifecycle_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/imagebuilder/workflow_identity_gen_test.go
+++ b/internal/service/imagebuilder/workflow_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccImageBuilderWorkflow_Identity_Basic(t *testing.T) {
 	resourceName := "aws_imagebuilder_workflow.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -109,7 +109,7 @@ func TestAccImageBuilderWorkflow_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_imagebuilder_workflow.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -229,7 +229,7 @@ func TestAccImageBuilderWorkflow_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_imagebuilder_workflow.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/inspector/assessment_target_identity_gen_test.go
+++ b/internal/service/inspector/assessment_target_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccInspectorAssessmentTarget_Identity_Basic(t *testing.T) {
 	resourceName := "aws_inspector_assessment_target.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccInspectorAssessmentTarget_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_inspector_assessment_target.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -234,7 +234,7 @@ func TestAccInspectorAssessmentTarget_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_inspector_assessment_target.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/inspector/assessment_template_identity_gen_test.go
+++ b/internal/service/inspector/assessment_template_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccInspectorAssessmentTemplate_Identity_Basic(t *testing.T) {
 	resourceName := "aws_inspector_assessment_template.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccInspectorAssessmentTemplate_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_inspector_assessment_template.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -234,7 +234,7 @@ func TestAccInspectorAssessmentTemplate_Identity_ExistingResource(t *testing.T) 
 	resourceName := "aws_inspector_assessment_template.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/inspector/resource_group_identity_gen_test.go
+++ b/internal/service/inspector/resource_group_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccInspectorResourceGroup_Identity_Basic(t *testing.T) {
 	resourceName := "aws_inspector_resource_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccInspectorResourceGroup_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_inspector_resource_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -234,7 +234,7 @@ func TestAccInspectorResourceGroup_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_inspector_resource_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/iot/event_configurations_identity_gen_test.go
+++ b/internal/service/iot/event_configurations_identity_gen_test.go
@@ -35,7 +35,7 @@ func testAccIoTEventConfigurations_Identity_Basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iot_event_configurations.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -106,7 +106,7 @@ func testAccIoTEventConfigurations_Identity_RegionOverride(t *testing.T) {
 
 	resourceName := "aws_iot_event_configurations.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -215,7 +215,7 @@ func testAccIoTEventConfigurations_Identity_ExistingResource(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iot_event_configurations.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/iot/indexing_configuration_identity_gen_test.go
+++ b/internal/service/iot/indexing_configuration_identity_gen_test.go
@@ -35,7 +35,7 @@ func testAccIoTIndexingConfiguration_Identity_Basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iot_indexing_configuration.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -106,7 +106,7 @@ func testAccIoTIndexingConfiguration_Identity_RegionOverride(t *testing.T) {
 
 	resourceName := "aws_iot_indexing_configuration.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -215,7 +215,7 @@ func testAccIoTIndexingConfiguration_Identity_ExistingResource(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iot_indexing_configuration.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/iot/logging_options_identity_gen_test.go
+++ b/internal/service/iot/logging_options_identity_gen_test.go
@@ -37,7 +37,7 @@ func testAccIoTLoggingOptions_Identity_Basic(t *testing.T) {
 	resourceName := "aws_iot_logging_options.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -71,7 +71,7 @@ func testAccIoTLoggingOptions_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_iot_logging_options.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -105,7 +105,7 @@ func testAccIoTLoggingOptions_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_iot_logging_options.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/kinesis/resource_policy_identity_gen_test.go
+++ b/internal/service/kinesis/resource_policy_identity_gen_test.go
@@ -26,7 +26,7 @@ func TestAccKinesisResourcePolicy_Identity_Basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	providers := make(map[string]*schema.Provider)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -125,7 +125,7 @@ func TestAccKinesisResourcePolicy_Identity_RegionOverride(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	providers := make(map[string]*schema.Provider)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -265,7 +265,7 @@ func TestAccKinesisResourcePolicy_Identity_ExistingResource(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	providers := make(map[string]*schema.Provider)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/macie2/classification_export_configuration_identity_gen_test.go
+++ b/internal/service/macie2/classification_export_configuration_identity_gen_test.go
@@ -38,7 +38,7 @@ func testAccMacie2ClassificationExportConfiguration_Identity_Basic(t *testing.T)
 	var v macie2.GetClassificationExportConfigurationOutput
 	resourceName := "aws_macie2_classification_export_configuration.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func testAccMacie2ClassificationExportConfiguration_Identity_RegionOverride(t *t
 
 	resourceName := "aws_macie2_classification_export_configuration.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -223,7 +223,7 @@ func testAccMacie2ClassificationExportConfiguration_Identity_ExistingResource(t 
 	var v macie2.GetClassificationExportConfigurationOutput
 	resourceName := "aws_macie2_classification_export_configuration.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/networkfirewall/tls_inspection_configuration_identity_gen_test.go
+++ b/internal/service/networkfirewall/tls_inspection_configuration_identity_gen_test.go
@@ -29,7 +29,7 @@ func TestAccNetworkFirewallTLSInspectionConfiguration_Identity_Basic(t *testing.
 	common_name := acctest.RandomDomain()
 	certificate_domain := common_name.RandomSubdomain()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -128,7 +128,7 @@ func TestAccNetworkFirewallTLSInspectionConfiguration_Identity_RegionOverride(t 
 	common_name := acctest.RandomDomain()
 	certificate_domain := common_name.RandomSubdomain()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -270,7 +270,7 @@ func TestAccNetworkFirewallTLSInspectionConfiguration_Identity_ExistingResource(
 	common_name := acctest.RandomDomain()
 	certificate_domain := common_name.RandomSubdomain()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/organizations/organization_identity_gen_test.go
+++ b/internal/service/organizations/organization_identity_gen_test.go
@@ -36,7 +36,7 @@ func testAccOrganizationsOrganization_Identity_Basic(t *testing.T) {
 	var v awstypes.Organization
 	resourceName := "aws_organizations_organization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func testAccOrganizationsOrganization_Identity_ExistingResource(t *testing.T) {
 	var v awstypes.Organization
 	resourceName := "aws_organizations_organization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/organizations/organizational_unit_identity_gen_test.go
+++ b/internal/service/organizations/organizational_unit_identity_gen_test.go
@@ -38,7 +38,7 @@ func testAccOrganizationsOrganizationalUnit_Identity_Basic(t *testing.T) {
 	resourceName := "aws_organizations_organizational_unit.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -123,7 +123,7 @@ func testAccOrganizationsOrganizationalUnit_Identity_ExistingResource(t *testing
 	resourceName := "aws_organizations_organizational_unit.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/organizations/policy_attachment_identity_gen_test.go
+++ b/internal/service/organizations/policy_attachment_identity_gen_test.go
@@ -35,7 +35,7 @@ func testAccOrganizationsPolicyAttachment_Identity_Basic(t *testing.T) {
 	resourceName := "aws_organizations_policy_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -122,7 +122,7 @@ func testAccOrganizationsPolicyAttachment_Identity_ExistingResource(t *testing.T
 	resourceName := "aws_organizations_policy_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/organizations/policy_identity_gen_test.go
+++ b/internal/service/organizations/policy_identity_gen_test.go
@@ -38,7 +38,7 @@ func testAccOrganizationsPolicy_Identity_Basic(t *testing.T) {
 	resourceName := "aws_organizations_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -123,7 +123,7 @@ func testAccOrganizationsPolicy_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_organizations_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/organizations/resource_policy_identity_gen_test.go
+++ b/internal/service/organizations/resource_policy_identity_gen_test.go
@@ -38,7 +38,7 @@ func testAccOrganizationsResourcePolicy_Identity_Basic(t *testing.T) {
 	resourceName := "aws_organizations_resource_policy.test"
 	providers := make(map[string]*schema.Provider)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -119,7 +119,7 @@ func testAccOrganizationsResourcePolicy_Identity_ExistingResource(t *testing.T) 
 	resourceName := "aws_organizations_resource_policy.test"
 	providers := make(map[string]*schema.Provider)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/paymentcryptography/key_identity_gen_test.go
+++ b/internal/service/paymentcryptography/key_identity_gen_test.go
@@ -25,7 +25,7 @@ func TestAccPaymentCryptographyKey_Identity_Basic(t *testing.T) {
 	var v paymentcryptography.GetKeyOutput
 	resourceName := "aws_paymentcryptography_key.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -108,7 +108,7 @@ func TestAccPaymentCryptographyKey_Identity_RegionOverride(t *testing.T) {
 
 	resourceName := "aws_paymentcryptography_key.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -234,7 +234,7 @@ func TestAccPaymentCryptographyKey_Identity_ExistingResource(t *testing.T) {
 	var v paymentcryptography.GetKeyOutput
 	resourceName := "aws_paymentcryptography_key.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/rds/certificate_identity_gen_test.go
+++ b/internal/service/rds/certificate_identity_gen_test.go
@@ -38,7 +38,7 @@ func testAccRDSCertificate_Identity_Basic(t *testing.T) {
 	var v awstypes.Certificate
 	resourceName := "aws_rds_certificate.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func testAccRDSCertificate_Identity_RegionOverride(t *testing.T) {
 
 	resourceName := "aws_rds_certificate.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -223,7 +223,7 @@ func testAccRDSCertificate_Identity_ExistingResource(t *testing.T) {
 	var v awstypes.Certificate
 	resourceName := "aws_rds_certificate.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/rds/integration_identity_gen_test.go
+++ b/internal/service/rds/integration_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccRDSIntegration_Identity_Basic(t *testing.T) {
 	resourceName := "aws_rds_integration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccRDSIntegration_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_rds_integration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -233,7 +233,7 @@ func TestAccRDSIntegration_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_rds_integration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/resourceexplorer2/index_identity_gen_test.go
+++ b/internal/service/resourceexplorer2/index_identity_gen_test.go
@@ -34,7 +34,7 @@ func testAccResourceExplorer2Index_Identity_Basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_resourceexplorer2_index.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -110,7 +110,7 @@ func testAccResourceExplorer2Index_Identity_RegionOverride(t *testing.T) {
 
 	resourceName := "aws_resourceexplorer2_index.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -222,7 +222,7 @@ func testAccResourceExplorer2Index_Identity_ExistingResource(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_resourceexplorer2_index.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/resourceexplorer2/view_identity_gen_test.go
+++ b/internal/service/resourceexplorer2/view_identity_gen_test.go
@@ -39,7 +39,7 @@ func testAccResourceExplorer2View_Identity_Basic(t *testing.T) {
 	resourceName := "aws_resourceexplorer2_view.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -124,7 +124,7 @@ func testAccResourceExplorer2View_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_resourceexplorer2_view.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -245,7 +245,7 @@ func testAccResourceExplorer2View_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_resourceexplorer2_view.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/route53/record_identity_gen_test.go
+++ b/internal/service/route53/record_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccRoute53Record_Identity_Basic(t *testing.T) {
 	zoneName := acctest.RandomDomain()
 	recordName := zoneName.RandomSubdomain()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -125,7 +125,7 @@ func TestAccRoute53Record_Identity_ExistingResource(t *testing.T) {
 	zoneName := acctest.RandomDomain()
 	recordName := zoneName.RandomSubdomain()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/s3/bucket_identity_gen_test.go
+++ b/internal/service/s3/bucket_identity_gen_test.go
@@ -25,7 +25,7 @@ func TestAccS3Bucket_Identity_Basic(t *testing.T) {
 	resourceName := "aws_s3_bucket.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccS3Bucket_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_s3_bucket.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -199,7 +199,7 @@ func TestAccS3Bucket_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_s3_bucket.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/s3/bucket_object_identity_gen_test.go
+++ b/internal/service/s3/bucket_object_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccS3BucketObject_Identity_Basic(t *testing.T) {
 	resourceName := "aws_s3_bucket_object.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -123,7 +123,7 @@ func TestAccS3BucketObject_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_s3_bucket_object.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -224,7 +224,7 @@ func TestAccS3BucketObject_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_s3_bucket_object.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/s3/object_identity_gen_test.go
+++ b/internal/service/s3/object_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccS3Object_Identity_Basic(t *testing.T) {
 	resourceName := "aws_s3_object.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -119,7 +119,7 @@ func TestAccS3Object_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_s3_object.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -216,7 +216,7 @@ func TestAccS3Object_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_s3_object.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/s3control/account_public_access_block_identity_gen_test.go
+++ b/internal/service/s3control/account_public_access_block_identity_gen_test.go
@@ -36,7 +36,7 @@ func testAccS3ControlAccountPublicAccessBlock_Identity_Basic(t *testing.T) {
 	var v awstypes.PublicAccessBlockConfiguration
 	resourceName := "aws_s3_account_public_access_block.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -107,7 +107,7 @@ func testAccS3ControlAccountPublicAccessBlock_Identity_ExistingResource(t *testi
 	var v awstypes.PublicAccessBlockConfiguration
 	resourceName := "aws_s3_account_public_access_block.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/sagemaker/servicecatalog_portfolio_status_identity_gen_test.go
+++ b/internal/service/sagemaker/servicecatalog_portfolio_status_identity_gen_test.go
@@ -38,7 +38,7 @@ func testAccSageMakerServicecatalogPortfolioStatus_Identity_Basic(t *testing.T) 
 	var v sagemaker.GetSagemakerServicecatalogPortfolioStatusOutput
 	resourceName := "aws_sagemaker_servicecatalog_portfolio_status.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func testAccSageMakerServicecatalogPortfolioStatus_Identity_RegionOverride(t *te
 
 	resourceName := "aws_sagemaker_servicecatalog_portfolio_status.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -223,7 +223,7 @@ func testAccSageMakerServicecatalogPortfolioStatus_Identity_ExistingResource(t *
 	var v sagemaker.GetSagemakerServicecatalogPortfolioStatusOutput
 	resourceName := "aws_sagemaker_servicecatalog_portfolio_status.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/sagemaker/user_profile_identity_gen_test.go
+++ b/internal/service/sagemaker/user_profile_identity_gen_test.go
@@ -39,7 +39,7 @@ func testAccSageMakerUserProfile_Identity_Basic(t *testing.T) {
 	resourceName := "aws_sagemaker_user_profile.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -128,7 +128,7 @@ func testAccSageMakerUserProfile_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_sagemaker_user_profile.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -222,7 +222,7 @@ func testAccSageMakerUserProfile_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_sagemaker_user_profile.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/securityhub/automation_rule_identity_gen_test.go
+++ b/internal/service/securityhub/automation_rule_identity_gen_test.go
@@ -39,7 +39,7 @@ func testAccSecurityHubAutomationRule_Identity_Basic(t *testing.T) {
 	resourceName := "aws_securityhub_automation_rule.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -124,7 +124,7 @@ func testAccSecurityHubAutomationRule_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_securityhub_automation_rule.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -245,7 +245,7 @@ func testAccSecurityHubAutomationRule_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_securityhub_automation_rule.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/shield/application_layer_automatic_response_identity_gen_test.go
+++ b/internal/service/shield/application_layer_automatic_response_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccShieldApplicationLayerAutomaticResponse_Identity_Basic(t *testing.T)
 	resourceName := "aws_shield_application_layer_automatic_response.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -114,7 +114,7 @@ func TestAccShieldApplicationLayerAutomaticResponse_Identity_ExistingResource(t 
 	resourceName := "aws_shield_application_layer_automatic_response.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/sns/topic_identity_gen_test.go
+++ b/internal/service/sns/topic_identity_gen_test.go
@@ -26,7 +26,7 @@ func TestAccSNSTopic_Identity_Basic(t *testing.T) {
 	resourceName := "aws_sns_topic.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -111,7 +111,7 @@ func TestAccSNSTopic_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_sns_topic.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -233,7 +233,7 @@ func TestAccSNSTopic_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_sns_topic.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/ssmcontacts/rotation_identity_gen_test.go
+++ b/internal/service/ssmcontacts/rotation_identity_gen_test.go
@@ -35,7 +35,7 @@ func testAccSSMContactsRotation_Identity_Basic(t *testing.T) {
 	resourceName := "aws_ssmcontacts_rotation.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -119,7 +119,7 @@ func testAccSSMContactsRotation_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_ssmcontacts_rotation.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/ssoadmin/application_assignment_configuration_identity_gen_test.go
+++ b/internal/service/ssoadmin/application_assignment_configuration_identity_gen_test.go
@@ -24,7 +24,7 @@ func TestAccSSOAdminApplicationAssignmentConfiguration_Identity_Basic(t *testing
 	resourceName := "aws_ssoadmin_application_assignment_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -113,7 +113,7 @@ func TestAccSSOAdminApplicationAssignmentConfiguration_Identity_RegionOverride(t
 	resourceName := "aws_ssoadmin_application_assignment_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -236,7 +236,7 @@ func TestAccSSOAdminApplicationAssignmentConfiguration_Identity_ExistingResource
 	resourceName := "aws_ssoadmin_application_assignment_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -296,7 +296,7 @@ func TestAccSSOAdminApplicationAssignmentConfiguration_Identity_ExistingResource
 	resourceName := "aws_ssoadmin_application_assignment_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/ssoadmin/application_identity_gen_test.go
+++ b/internal/service/ssoadmin/application_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccSSOAdminApplication_Identity_Basic(t *testing.T) {
 	resourceName := "aws_ssoadmin_application.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -119,7 +119,7 @@ func TestAccSSOAdminApplication_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_ssoadmin_application.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -248,7 +248,7 @@ func TestAccSSOAdminApplication_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_ssoadmin_application.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/ssoadmin/trusted_token_issuer_identity_gen_test.go
+++ b/internal/service/ssoadmin/trusted_token_issuer_identity_gen_test.go
@@ -39,7 +39,7 @@ func testAccSSOAdminTrustedTokenIssuer_Identity_Basic(t *testing.T) {
 	resourceName := "aws_ssoadmin_trusted_token_issuer.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -128,7 +128,7 @@ func testAccSSOAdminTrustedTokenIssuer_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_ssoadmin_trusted_token_issuer.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -253,7 +253,7 @@ func testAccSSOAdminTrustedTokenIssuer_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_ssoadmin_trusted_token_issuer.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/xray/encryption_config_identity_gen_test.go
+++ b/internal/service/xray/encryption_config_identity_gen_test.go
@@ -38,7 +38,7 @@ func testAccXRayEncryptionConfig_Identity_Basic(t *testing.T) {
 	var v awstypes.EncryptionConfig
 	resourceName := "aws_xray_encryption_config.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func testAccXRayEncryptionConfig_Identity_RegionOverride(t *testing.T) {
 
 	resourceName := "aws_xray_encryption_config.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -223,7 +223,7 @@ func testAccXRayEncryptionConfig_Identity_ExistingResource(t *testing.T) {
 	var v awstypes.EncryptionConfig
 	resourceName := "aws_xray_encryption_config.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/xray/group_identity_gen_test.go
+++ b/internal/service/xray/group_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccXRayGroup_Identity_Basic(t *testing.T) {
 	resourceName := "aws_xray_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccXRayGroup_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_xray_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -233,7 +233,7 @@ func TestAccXRayGroup_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_xray_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Uses `acctest.ParallelTest` or `acctest.Test` instead of equivalents from `resource`

Relates #25602 