### PR TITLE
[Docs] d/aws_eks_cluster_versions: Fix the documentation to reflect the current implementation

### DIFF
--- a/website/docs/d/eks_cluster_versions.html.markdown
+++ b/website/docs/d/eks_cluster_versions.html.markdown
@@ -16,6 +16,18 @@ Terraform data source for managing AWS EKS (Elastic Kubernetes) Cluster Versions
 
 ```terraform
 data "aws_eks_cluster_versions" "example" {}
+
+output "eks_cluster_versions" {
+  value = data.aws_eks_cluster_versions.example.cluster_versions
+}
+
+output "eks_cluster_version_filtered" {
+  value = [for version in data.aws_eks_cluster_versions.example.cluster_versions : version if version.cluster_version == "1.33"]
+}
+
+output "eks_cluster_version_list" {
+  value = [for version in data.aws_eks_cluster_versions.example.cluster_versions : version.cluster_version]
+}
 ```
 
 ### Filter by Cluster Type
@@ -41,7 +53,6 @@ The following arguments are optional:
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `cluster_type` - (Optional) Type of clusters to filter by.
 Currently, the only valid value is `eks`.
-* `cluster_versions` - (Optional) A list of Kubernetes versions that you can use to check if EKS supports it.
 * `default_only` - (Optional) Whether to show only the default versions of Kubernetes supported by EKS.
 * `include_all` - (Optional) Whether to include all kubernetes versions in the response.
 * `version_status` - (Optional) Status of the EKS cluster versions to list.
@@ -51,12 +62,14 @@ Valid values are `STANDARD_SUPPORT` or `UNSUPPORTED` or `EXTENDED_SUPPORT`.
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `cluster_type` - Type of cluster that the version belongs to.
-* `cluster_version` - Kubernetes version supported by EKS.
-* `default_platform_version` - Default eks platform version for the cluster version.
-* `default_version` - Default Kubernetes version for the cluster version.
-* `end_of_extended_support_date` - End of extended support date for the cluster version.
-* `end_of_standard_support_date` - End of standard support date for the cluster version.
-* `kubernetes_patch_version` - Kubernetes patch version for the cluster version.
-* `release_date` - Release date of the cluster version.
-* `version_status` - Status of the EKS cluster version.
+* `cluster_versions` - A list of Kubernetes version information.
+
+    * `cluster_type` - Type of cluster that the version belongs to.
+    * `cluster_version` - Kubernetes version supported by EKS.
+    * `default_platform_version` - Default eks platform version for the cluster version.
+    * `default_version` - Default Kubernetes version for the cluster version.
+    * `end_of_extended_support_date` - End of extended support date for the cluster version.
+    * `end_of_standard_support_date` - End of standard support date for the cluster version.
+    * `kubernetes_patch_version` - Kubernetes patch version for the cluster version.
+    * `release_date` - Release date of the cluster version.
+    * `version_status` - Status of the EKS cluster version.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Fix the documentation of `aws_eks_cluster_versions` to reflect the current implementation.

  * According to the [source code](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/eks/cluster_data_source.go) and [acceptance tests](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/eks/cluster_versions_data_source_test.go), the [Attribute Reference](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_versions#attribute-reference) section refers to the attributes within the `cluster_versions` block.
  * `cluster_versions` is not an input argument but an output attribute.
  * Add examples to show how to access these attributes.

**Note**

* The schema currently defines both `cluster_versions` and `cluster_versions_only`, but `cluster_versions_only` does not function (I confirmed) and is not documented.
  [https://github.com/hashicorp/terraform-provider-aws/blob/c60cb7778a012ae9952d2f46ee19926bb9f5d55e/internal/service/eks/cluster\_versions\_data\_source.go#L41-L45](https://github.com/hashicorp/terraform-provider-aws/blob/c60cb7778a012ae9952d2f46ee19926bb9f5d55e/internal/service/eks/cluster_versions_data_source.go#L41-L45)

  * In the AWS API [`DescribeClusterVersions`](https://docs.aws.amazon.com/eks/latest/APIReference/API_DescribeClusterVersions.html), the `ClusterVersions` field serves as both an input string and an output object.
  * In the initial implementation of this data source, `cluster_version_only` was used to populate the `ClusterVersion` input field in the API. However, this implementation was removed when autoflex was introduced: [https://github.com/hashicorp/terraform-provider-aws/commit/28521b83a48a7fd71b08252f9bc8a1a5757460f9](https://github.com/hashicorp/terraform-provider-aws/commit/28521b83a48a7fd71b08252f9bc8a1a5757460f9)
    * Autoflex does not apply here because the API field name (`ClusterVersion`) and the model name (`ClusterVersionOnly`) do not match.
    * Since the initial implementation, `cluster_version_only` has neither been documented nor tested in acceptance tests.
  * As it stands undocumented, it is not currently a critical issue. However, to prevent confusion, I suggest that `cluster_version_only` should either be properly implemented as an enhancement or fully removed from the codebase.



### Relations

Closes #43634

### References
https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/eks/cluster_data_source.go
https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/eks/cluster_versions_data_source_test.go
https://docs.aws.amazon.com/eks/latest/APIReference/API_DescribeClusterVersions.html


