### PR TITLE
Technical debt: Use `internal/retry` for `tfresource.RetryWhenAWSErrCodeEquals`

### DIFF
--- a/internal/service/applicationinsights/application.go
+++ b/internal/service/applicationinsights/application.go
@@ -104,7 +104,7 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 		input.OpsItemSNSTopicArn = aws.String(v.(string))
 	}
 
-	output, err := tfresource.RetryGWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (*applicationinsights.CreateApplicationOutput, error) {
+	output, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func(ctx context.Context) (*applicationinsights.CreateApplicationOutput, error) {
 		return conn.CreateApplication(ctx, input)
 	})
 	if err != nil {

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -1562,7 +1562,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 		}
 
 		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate),
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.UpdateAutoScalingGroup(ctx, &input)
 			},
 			errCodeOperationError, errCodeUpdateASG, errCodeValidationError)
@@ -1895,7 +1895,7 @@ func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) 
 		ForceDelete:          aws.Bool(forceDeleteGroup),
 	}
 	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete),
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteAutoScalingGroup(ctx, &input)
 		},
 		errCodeResourceInUseFault, errCodeScalingActivityInProgressFault)
@@ -1989,7 +1989,7 @@ func deleteWarmPool(ctx context.Context, conn *autoscaling.Client, name string, 
 		ForceDelete:          aws.Bool(force),
 	}
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteWarmPool(ctx, &input)
 		},
 		errCodeResourceInUseFault, errCodeScalingActivityInProgressFault)

--- a/internal/service/chatbot/slack_channel_configuration.go
+++ b/internal/service/chatbot/slack_channel_configuration.go
@@ -276,7 +276,7 @@ func (r *slackChannelConfigurationResource) Delete(ctx context.Context, request 
 		ChatConfigurationArn: data.ChatConfigurationARN.ValueStringPointer(),
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, r.DeleteTimeout(ctx, data.Timeouts), func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, r.DeleteTimeout(ctx, data.Timeouts), func(ctx context.Context) (any, error) {
 		return conn.DeleteSlackChannelConfiguration(ctx, input)
 	}, "DependencyViolation")
 

--- a/internal/service/chatbot/teams_channel_configuration.go
+++ b/internal/service/chatbot/teams_channel_configuration.go
@@ -280,7 +280,7 @@ func (r *teamsChannelConfigurationResource) Delete(ctx context.Context, request 
 		ChatConfigurationArn: data.ChatConfigurationARN.ValueStringPointer(),
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, r.DeleteTimeout(ctx, data.Timeouts), func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, r.DeleteTimeout(ctx, data.Timeouts), func(ctx context.Context) (any, error) {
 		return conn.DeleteMicrosoftTeamsChannelConfiguration(ctx, input)
 	}, "DependencyViolation")
 

--- a/internal/service/drs/replication_configuration_template.go
+++ b/internal/service/drs/replication_configuration_template.go
@@ -282,7 +282,7 @@ func (r *replicationConfigurationTemplateResource) Delete(ctx context.Context, r
 		ReplicationConfigurationTemplateID: data.ID.ValueStringPointer(),
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute, func(ctx context.Context) (any, error) {
 		return conn.DeleteReplicationConfigurationTemplate(ctx, input)
 	}, "DependencyViolation")
 

--- a/internal/service/ec2/ebs_snapshot.go
+++ b/internal/service/ec2/ebs_snapshot.go
@@ -139,7 +139,7 @@ func resourceEBSSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta
 	d.SetId(aws.ToString(outputRaw.(*ec2.CreateSnapshotOutput).SnapshotId))
 
 	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate),
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return waitSnapshotCompleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate))
 		},
 		errCodeResourceNotReady)
@@ -253,7 +253,7 @@ func resourceEBSSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta
 	input := ec2.DeleteSnapshotInput{
 		SnapshotId: aws.String(d.Id()),
 	}
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteSnapshot(ctx, &input)
 	}, errCodeInvalidSnapshotInUse)
 

--- a/internal/service/ec2/ebs_snapshot_copy.go
+++ b/internal/service/ec2/ebs_snapshot_copy.go
@@ -151,7 +151,7 @@ func resourceEBSSnapshotCopyCreate(ctx context.Context, d *schema.ResourceData, 
 	d.SetId(aws.ToString(output.SnapshotId))
 
 	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate),
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return waitSnapshotCompleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate))
 		},
 		errCodeResourceNotReady)

--- a/internal/service/ec2/ebs_volume.go
+++ b/internal/service/ec2/ebs_volume.go
@@ -304,7 +304,7 @@ func resourceEBSVolumeDelete(ctx context.Context, d *schema.ResourceData, meta a
 		snapshotID := aws.ToString(outputRaw.(*ec2.CreateSnapshotOutput).SnapshotId)
 
 		_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete),
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return waitSnapshotCompleted(ctx, conn, snapshotID, d.Timeout(schema.TimeoutDelete))
 			},
 			errCodeResourceNotReady)
@@ -319,7 +319,7 @@ func resourceEBSVolumeDelete(ctx context.Context, d *schema.ResourceData, meta a
 		VolumeId: aws.String(d.Id()),
 	}
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete),
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteVolume(ctx, &input)
 		},
 		errCodeVolumeInUse)

--- a/internal/service/ec2/ec2_eip.go
+++ b/internal/service/ec2/ec2_eip.go
@@ -192,7 +192,7 @@ func resourceEIPCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 
 	if instanceID, eniID := d.Get("instance").(string), d.Get("network_interface").(string); instanceID != "" || eniID != "" {
 		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate),
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return nil, associateEIP(ctx, conn, d.Id(), instanceID, eniID, d.Get("associate_with_private_ip").(string))
 			}, errCodeInvalidAllocationIDNotFound)
 

--- a/internal/service/ec2/transitgateway_.go
+++ b/internal/service/ec2/transitgateway_.go
@@ -305,7 +305,7 @@ func resourceTransitGatewayDelete(ctx context.Context, d *schema.ResourceData, m
 	const (
 		timeout = 5 * time.Minute
 	)
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteTransitGateway(ctx, &ec2.DeleteTransitGatewayInput{
 			TransitGatewayId: aws.String(d.Id()),
 		})

--- a/internal/service/ec2/vpc_.go
+++ b/internal/service/ec2/vpc_.go
@@ -449,7 +449,7 @@ func resourceVPCDelete(ctx context.Context, d *schema.ResourceData, meta any) di
 	}
 
 	log.Printf("[INFO] Deleting EC2 VPC: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteVpc(ctx, input)
 	}, errCodeDependencyViolation)
 

--- a/internal/service/ec2/vpc_dhcp_options.go
+++ b/internal/service/ec2/vpc_dhcp_options.go
@@ -208,7 +208,7 @@ func resourceVPCDHCPOptionsDelete(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	log.Printf("[INFO] Deleting EC2 DHCP Options Set: %s", d.Id())
-	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteDhcpOptions(ctx, input)
 	}, errCodeDependencyViolation)
 

--- a/internal/service/ec2/vpc_internet_gateway.go
+++ b/internal/service/ec2/vpc_internet_gateway.go
@@ -164,7 +164,7 @@ func resourceInternetGatewayDelete(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	log.Printf("[INFO] Deleting Internet Gateway: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteInternetGateway(ctx, input)
 	}, errCodeDependencyViolation)
 
@@ -186,7 +186,7 @@ func attachInternetGateway(ctx context.Context, conn *ec2.Client, internetGatewa
 	}
 
 	log.Printf("[INFO] Attaching EC2 Internet Gateway: %#v", input)
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.AttachInternetGateway(ctx, input)
 	}, errCodeInvalidInternetGatewayIDNotFound)
 
@@ -210,7 +210,7 @@ func detachInternetGateway(ctx context.Context, conn *ec2.Client, internetGatewa
 	}
 
 	log.Printf("[INFO] Detaching EC2 Internet Gateway: %#v", input)
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DetachInternetGateway(ctx, input)
 	}, errCodeDependencyViolation)
 

--- a/internal/service/ec2/vpc_managed_prefix_list_entry.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_entry.go
@@ -71,7 +71,7 @@ func resourceManagedPrefixListEntryCreate(ctx context.Context, d *schema.Resourc
 		addPrefixListEntry.Description = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		mutexKey := fmt.Sprintf("vpc-managed-prefix-list-%s", plID)
 		conns.GlobalMutexKV.Lock(mutexKey)
 		defer conns.GlobalMutexKV.Unlock(mutexKey)
@@ -146,7 +146,7 @@ func resourceManagedPrefixListEntryDelete(ctx context.Context, d *schema.Resourc
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		mutexKey := fmt.Sprintf("vpc-managed-prefix-list-%s", plID)
 		conns.GlobalMutexKV.Lock(mutexKey)
 		defer conns.GlobalMutexKV.Unlock(mutexKey)

--- a/internal/service/ec2/vpc_network_acl.go
+++ b/internal/service/ec2/vpc_network_acl.go
@@ -288,7 +288,7 @@ func resourceNetworkACLDelete(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	log.Printf("[INFO] Deleting EC2 Network ACL: %s", d.Id())
-	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteNetworkAcl(ctx, input)
 	}, errCodeDependencyViolation)
 

--- a/internal/service/ec2/vpc_network_acl_association.go
+++ b/internal/service/ec2/vpc_network_acl_association.go
@@ -133,7 +133,7 @@ func networkACLAssociationCreate(ctx context.Context, conn *ec2.Client, naclID, 
 	}
 
 	log.Printf("[DEBUG] Creating EC2 Network ACL Association: %#v", input)
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.ReplaceNetworkAclAssociation(ctx, input)
 	}, errCodeInvalidAssociationIDNotFound)
 

--- a/internal/service/ec2/vpc_network_insights_path.go
+++ b/internal/service/ec2/vpc_network_insights_path.go
@@ -265,7 +265,7 @@ func resourceNetworkInsightsPathDelete(ctx context.Context, d *schema.ResourceDa
 	input := ec2.DeleteNetworkInsightsPathInput{
 		NetworkInsightsPathId: aws.String(d.Id()),
 	}
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteNetworkInsightsPath(ctx, &input)
 	}, errCodeAnalysisExistsForNetworkInsightsPath)
 

--- a/internal/service/ec2/vpc_route.go
+++ b/internal/service/ec2/vpc_route.go
@@ -254,7 +254,7 @@ func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate),
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateRoute(ctx, input)
 		},
 		errCodeInvalidParameterException,
@@ -457,7 +457,7 @@ func resourceRouteDelete(ctx context.Context, d *schema.ResourceData, meta any) 
 
 	log.Printf("[DEBUG] Deleting Route: %v", input)
 	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete),
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteRoute(ctx, input)
 		},
 		errCodeInvalidParameterException,

--- a/internal/service/ec2/vpc_route_table.go
+++ b/internal/service/ec2/vpc_route_table.go
@@ -487,7 +487,7 @@ func routeTableAddRoute(ctx context.Context, conn *ec2.Client, routeTableID stri
 		// created by AWS so probably doesn't need a retry but just to be sure
 		// we provide a small one
 		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, time.Second*15,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return routeFinder(ctx, conn, routeTableID, destination)
 			},
 			errCodeInvalidRouteNotFound,
@@ -505,7 +505,7 @@ func routeTableAddRoute(ctx context.Context, conn *ec2.Client, routeTableID stri
 	}
 
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateRoute(ctx, input)
 		},
 		errCodeInvalidParameterException,
@@ -636,7 +636,7 @@ func routeTableEnableVGWRoutePropagation(ctx context.Context, conn *ec2.Client, 
 	}
 
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.EnableVgwRoutePropagation(ctx, input)
 		},
 		errCodeGatewayNotAttached,

--- a/internal/service/ec2/vpc_route_table_association.go
+++ b/internal/service/ec2/vpc_route_table_association.go
@@ -78,7 +78,7 @@ func resourceRouteTableAssociationCreate(ctx context.Context, d *schema.Resource
 	}
 
 	output, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.AssociateRouteTable(ctx, input)
 		},
 		errCodeInvalidRouteTableIDNotFound,

--- a/internal/service/ec2/vpc_security_group.go
+++ b/internal/service/ec2/vpc_security_group.go
@@ -368,7 +368,7 @@ func resourceSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, me
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(
 		ctx,
 		firstShortRetry, // short initial attempt followed by full length attempt
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteSecurityGroup(ctx, &ec2.DeleteSecurityGroupInput{
 				GroupId: aws.String(d.Id()),
 			})
@@ -388,7 +388,7 @@ func resourceSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, me
 		_, err = tfresource.RetryWhenAWSErrCodeEquals(
 			ctx,
 			remainingRetry,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.DeleteSecurityGroup(ctx, &ec2.DeleteSecurityGroupInput{
 					GroupId: aws.String(d.Id()),
 				})

--- a/internal/service/ec2/vpc_subnet.go
+++ b/internal/service/ec2/vpc_subnet.go
@@ -373,7 +373,7 @@ func resourceSubnetDelete(ctx context.Context, d *schema.ResourceData, meta any)
 		return sdkdiag.AppendErrorf(diags, "deleting ENIs for EC2 Subnet (%s): %s", d.Id(), err)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteSubnet(ctx, &ec2.DeleteSubnetInput{
 			SubnetId: aws.String(d.Id()),
 		})

--- a/internal/service/ec2/vpnclient_route.go
+++ b/internal/service/ec2/vpnclient_route.go
@@ -92,7 +92,7 @@ func resourceClientVPNRouteCreate(ctx context.Context, d *schema.ResourceData, m
 		input.Description = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateClientVpnRoute(ctx, input)
 	}, errCodeInvalidClientVPNActiveAssociationNotFound)
 

--- a/internal/service/ec2/vpnsite_gateway.go
+++ b/internal/service/ec2/vpnsite_gateway.go
@@ -174,7 +174,7 @@ func resourceVPNGatewayDelete(ctx context.Context, d *schema.ResourceData, meta 
 	const (
 		timeout = 5 * time.Minute
 	)
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteVpnGateway(ctx, &ec2.DeleteVpnGatewayInput{
 			VpnGatewayId: aws.String(d.Id()),
 		})
@@ -201,7 +201,7 @@ func attachVPNGatewayToVPC(ctx context.Context, conn *ec2.Client, vpnGatewayID, 
 		VpnGatewayId: aws.String(vpnGatewayID),
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.AttachVpnGateway(ctx, &input)
 	}, errCodeInvalidVPNGatewayIDNotFound)
 

--- a/internal/service/elasticache/serverless_cache.go
+++ b/internal/service/elasticache/serverless_cache.go
@@ -405,7 +405,7 @@ func (r *serverlessCacheResource) Delete(ctx context.Context, request resource.D
 		FinalSnapshotName:   nil,
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute, func(ctx context.Context) (any, error) {
 		return conn.DeleteServerlessCache(ctx, input)
 	}, errCodeDependencyViolation)
 

--- a/internal/service/elasticache/subnet_group.go
+++ b/internal/service/elasticache/subnet_group.go
@@ -178,7 +178,7 @@ func resourceSubnetGroupDelete(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
 	log.Printf("[DEBUG] Deleting ElastiCache Subnet Group: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute, func(ctx context.Context) (any, error) {
 		return conn.DeleteCacheSubnetGroup(ctx, &elasticache.DeleteCacheSubnetGroupInput{
 			CacheSubnetGroupName: aws.String(d.Id()),
 		})

--- a/internal/service/elb/attachment.go
+++ b/internal/service/elb/attachment.go
@@ -58,7 +58,7 @@ func resourceAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta 
 	const (
 		timeout = 10 * time.Minute
 	)
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.RegisterInstancesWithLoadBalancer(ctx, input)
 	}, errCodeInvalidTarget)
 

--- a/internal/service/iam/group_policy_attachment.go
+++ b/internal/service/iam/group_policy_attachment.go
@@ -124,7 +124,7 @@ func resourceGroupPolicyAttachmentImport(ctx context.Context, d *schema.Resource
 
 func attachPolicyToGroup(ctx context.Context, conn *iam.Client, group, policyARN string) error {
 	var errConcurrentModificationException *awstypes.ConcurrentModificationException
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.AttachGroupPolicy(ctx, &iam.AttachGroupPolicyInput{
 			GroupName: aws.String(group),
 			PolicyArn: aws.String(policyARN),
@@ -140,7 +140,7 @@ func attachPolicyToGroup(ctx context.Context, conn *iam.Client, group, policyARN
 
 func detachPolicyFromGroup(ctx context.Context, conn *iam.Client, group, policyARN string) error {
 	var errConcurrentModificationException *awstypes.ConcurrentModificationException
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.DetachGroupPolicy(ctx, &iam.DetachGroupPolicyInput{
 			GroupName: aws.String(group),
 			PolicyArn: aws.String(policyARN),

--- a/internal/service/iam/role_policy_attachment.go
+++ b/internal/service/iam/role_policy_attachment.go
@@ -107,7 +107,7 @@ func resourceRolePolicyAttachmentDelete(ctx context.Context, d *schema.ResourceD
 
 func attachPolicyToRole(ctx context.Context, conn *iam.Client, role, policyARN string) error {
 	var errConcurrentModificationException *awstypes.ConcurrentModificationException
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.AttachRolePolicy(ctx, &iam.AttachRolePolicyInput{
 			PolicyArn: aws.String(policyARN),
 			RoleName:  aws.String(role),
@@ -123,7 +123,7 @@ func attachPolicyToRole(ctx context.Context, conn *iam.Client, role, policyARN s
 
 func detachPolicyFromRole(ctx context.Context, conn *iam.Client, role, policyARN string) error {
 	var errConcurrentModificationException *awstypes.ConcurrentModificationException
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.DetachRolePolicy(ctx, &iam.DetachRolePolicyInput{
 			PolicyArn: aws.String(policyARN),
 			RoleName:  aws.String(role),

--- a/internal/service/iam/service_linked_role.go
+++ b/internal/service/iam/service_linked_role.go
@@ -105,7 +105,7 @@ func resourceServiceLinkedRoleCreate(ctx context.Context, d *schema.ResourceData
 		input.Description = aws.String(v.(string))
 	}
 
-	output, err := tfresource.RetryGWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (*iam.CreateServiceLinkedRoleOutput, error) {
+	output, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func(ctx context.Context) (*iam.CreateServiceLinkedRoleOutput, error) {
 		return conn.CreateServiceLinkedRole(ctx, input)
 	}, "AccessDenied")
 	if err != nil {

--- a/internal/service/macie2/classification_job.go
+++ b/internal/service/macie2/classification_job.go
@@ -677,7 +677,7 @@ func resourceClassificationJobCreate(ctx context.Context, d *schema.ResourceData
 		input.ScheduleFrequency = expandScheduleFrequency(v.([]any))
 	}
 
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.CreateClassificationJob(ctx, &input)
 	}, errCodeClientError)
 

--- a/internal/service/macie2/custom_data_identifier.go
+++ b/internal/service/macie2/custom_data_identifier.go
@@ -146,7 +146,7 @@ func resourceCustomDataIdentifierCreate(ctx context.Context, d *schema.ResourceD
 		input.Regex = aws.String(v.(string))
 	}
 
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.CreateCustomDataIdentifier(ctx, &input)
 	}, errCodeClientError)
 

--- a/internal/service/macie2/findings_filter.go
+++ b/internal/service/macie2/findings_filter.go
@@ -169,7 +169,7 @@ func resourceFindingsFilterCreate(ctx context.Context, d *schema.ResourceData, m
 		input.Position = aws.Int32(int32(v.(int)))
 	}
 
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.CreateFindingsFilter(ctx, &input)
 	}, errCodeClientError)
 

--- a/internal/service/macie2/member.go
+++ b/internal/service/macie2/member.go
@@ -117,7 +117,7 @@ func resourceMemberCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		Tags: getTagsIn(ctx),
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.CreateMember(ctx, &input)
 	}, errCodeClientError)
 
@@ -250,7 +250,7 @@ func inviteMember(ctx context.Context, conn *macie2.Client, d *schema.ResourceDa
 		input.Message = aws.String(v.(string))
 	}
 
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.CreateInvitations(ctx, &input)
 	}, errCodeClientError)
 

--- a/internal/service/mwaa/environment.go
+++ b/internal/service/mwaa/environment.go
@@ -418,7 +418,7 @@ func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta
 	*/
 
 	var validationException, internalServerException = &awstypes.ValidationException{}, &awstypes.InternalServerException{}
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateEnvironment(ctx, input)
 	}, validationException.ErrorCode(), internalServerException.ErrorCode())
 

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -768,7 +768,7 @@ func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		input.ObjectLockEnabledForBucket = aws.Bool(true)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.CreateBucket(ctx, input)
 	}, errCodeOperationAborted)
 
@@ -1173,7 +1173,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 		}
 
 		if policy == "" {
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 				return conn.DeleteBucketPolicy(ctx, &s3.DeleteBucketPolicyInput{
 					Bucket: aws.String(d.Id()),
 				})
@@ -1188,7 +1188,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 				Policy: aws.String(policy),
 			}
 
-			_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+			_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 				return conn.PutBucketPolicy(ctx, input)
 			}, errCodeMalformedPolicy, errCodeNoSuchBucket)
 
@@ -1203,7 +1203,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 	//
 	if d.HasChange("cors_rule") {
 		if v, ok := d.GetOk("cors_rule"); !ok || len(v.([]any)) == 0 {
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 				return conn.DeleteBucketCors(ctx, &s3.DeleteBucketCorsInput{
 					Bucket: aws.String(d.Id()),
 				})
@@ -1220,7 +1220,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 				},
 			}
 
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 				return conn.PutBucketCors(ctx, input)
 			}, errCodeNoSuchBucket)
 
@@ -1235,7 +1235,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 	//
 	if d.HasChange("website") {
 		if v, ok := d.GetOk("website"); !ok || len(v.([]any)) == 0 || v.([]any)[0] == nil {
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 				return conn.DeleteBucketWebsite(ctx, &s3.DeleteBucketWebsiteInput{
 					Bucket: aws.String(d.Id()),
 				})
@@ -1255,7 +1255,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 				WebsiteConfiguration: websiteConfig,
 			}
 
-			_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+			_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 				return conn.PutBucketWebsite(ctx, input)
 			}, errCodeNoSuchBucket)
 
@@ -1284,7 +1284,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 				VersioningConfiguration: versioningConfig,
 			}
 
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 				return conn.PutBucketVersioning(ctx, input)
 			}, errCodeNoSuchBucket)
 
@@ -1308,7 +1308,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 			Bucket: aws.String(d.Id()),
 		}
 
-		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 			return conn.PutBucketAcl(ctx, input)
 		}, errCodeNoSuchBucket)
 
@@ -1334,7 +1334,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 			Bucket: aws.String(d.Id()),
 		}
 
-		_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+		_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 			return conn.PutBucketAcl(ctx, input)
 		}, errCodeNoSuchBucket)
 
@@ -1366,7 +1366,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 			}
 		}
 
-		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 			return conn.PutBucketLogging(ctx, input)
 		}, errCodeNoSuchBucket)
 
@@ -1380,7 +1380,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 	//
 	if d.HasChange("lifecycle_rule") {
 		if v, ok := d.GetOk("lifecycle_rule"); !ok || len(v.([]any)) == 0 {
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 				return conn.DeleteBucketLifecycle(ctx, &s3.DeleteBucketLifecycleInput{
 					Bucket: aws.String(d.Id()),
 				})
@@ -1397,7 +1397,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 				},
 			}
 
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 				return conn.PutBucketLifecycleConfiguration(ctx, input)
 			}, errCodeNoSuchBucket)
 
@@ -1418,7 +1418,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 			Bucket: aws.String(d.Id()),
 		}
 
-		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 			return conn.PutBucketAccelerateConfiguration(ctx, input)
 		}, errCodeNoSuchBucket)
 
@@ -1438,7 +1438,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 			},
 		}
 
-		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 			return conn.PutBucketRequestPayment(ctx, input)
 		}, errCodeNoSuchBucket)
 
@@ -1452,7 +1452,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 	//
 	if d.HasChange("replication_configuration") {
 		if v, ok := d.GetOk("replication_configuration"); !ok || len(v.([]any)) == 0 || v.([]any)[0] == nil {
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 				return conn.DeleteBucketReplication(ctx, &s3.DeleteBucketReplicationInput{
 					Bucket: aws.String(d.Id()),
 				})
@@ -1506,7 +1506,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 	//
 	if d.HasChange("server_side_encryption_configuration") {
 		if v, ok := d.GetOk("server_side_encryption_configuration"); !ok || len(v.([]any)) == 0 {
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 				return conn.DeleteBucketEncryption(ctx, &s3.DeleteBucketEncryptionInput{
 					Bucket: aws.String(d.Id()),
 				})
@@ -1523,7 +1523,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 				},
 			}
 
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 				return conn.PutBucketEncryption(ctx, input)
 			}, errCodeNoSuchBucket, errCodeOperationAborted)
 
@@ -1543,7 +1543,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 			ObjectLockConfiguration: expandBucketObjectLockConfiguration(d.Get("object_lock_configuration").([]any)),
 		}
 
-		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 			return conn.PutObjectLockConfiguration(ctx, input)
 		}, errCodeNoSuchBucket)
 
@@ -1660,7 +1660,7 @@ func findBucketRegion(ctx context.Context, c *conns.AWSClient, bucket string, op
 }
 
 func retryWhenNoSuchBucketError[T any](ctx context.Context, timeout time.Duration, f func() (T, error)) (T, error) {
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func(ctx context.Context) (any, error) {
 		return f()
 	}, errCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_accelerate_configuration.go
+++ b/internal/service/s3/bucket_accelerate_configuration.go
@@ -76,7 +76,7 @@ func resourceBucketAccelerateConfigurationCreate(ctx context.Context, d *schema.
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutBucketAccelerateConfiguration(ctx, input)
 	}, errCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_acl.go
+++ b/internal/service/s3/bucket_acl.go
@@ -172,7 +172,7 @@ func resourceBucketACLCreate(ctx context.Context, d *schema.ResourceData, meta a
 		input.AccessControlPolicy = expandAccessControlPolicy(v.([]any))
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutBucketAcl(ctx, input)
 	}, errCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_analytics_configuration.go
+++ b/internal/service/s3/bucket_analytics_configuration.go
@@ -158,7 +158,7 @@ func resourceBucketAnalyticsConfigurationPut(ctx context.Context, d *schema.Reso
 		AnalyticsConfiguration: analyticsConfiguration,
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutBucketAnalyticsConfiguration(ctx, input)
 	}, errCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_cors_configuration.go
+++ b/internal/service/s3/bucket_cors_configuration.go
@@ -109,7 +109,7 @@ func resourceBucketCorsConfigurationCreate(ctx context.Context, d *schema.Resour
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutBucketCors(ctx, input)
 	}, errCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_intelligent_tiering_configuration.go
+++ b/internal/service/s3/bucket_intelligent_tiering_configuration.go
@@ -123,7 +123,7 @@ func resourceBucketIntelligentTieringConfigurationPut(ctx context.Context, d *sc
 		IntelligentTieringConfiguration: intelligentTieringConfiguration,
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutBucketIntelligentTieringConfiguration(ctx, input)
 	}, errCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_inventory.go
+++ b/internal/service/s3/bucket_inventory.go
@@ -219,7 +219,7 @@ func resourceBucketInventoryPut(ctx context.Context, d *schema.ResourceData, met
 		InventoryConfiguration: inventoryConfiguration,
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutBucketInventoryConfiguration(ctx, input)
 	}, errCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -423,7 +423,7 @@ func (r *bucketLifecycleConfigurationResource) Create(ctx context.Context, reque
 
 	input.LifecycleConfiguration = &lifecycleConfiguraton
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutBucketLifecycleConfiguration(ctx, &input)
 	}, errCodeNoSuchBucket)
 	if tfawserr.ErrMessageContains(err, errCodeInvalidArgument, "LifecycleConfiguration is not valid, expected CreateBucketConfiguration") {
@@ -542,7 +542,7 @@ func (r *bucketLifecycleConfigurationResource) Update(ctx context.Context, reque
 
 	input.LifecycleConfiguration = &lifecycleConfiguraton
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutBucketLifecycleConfiguration(ctx, &input)
 	}, errCodeNoSuchBucket)
 	if err != nil {

--- a/internal/service/s3/bucket_logging.go
+++ b/internal/service/s3/bucket_logging.go
@@ -166,7 +166,7 @@ func resourceBucketLoggingCreate(ctx context.Context, d *schema.ResourceData, me
 		input.BucketLoggingStatus.LoggingEnabled.TargetObjectKeyFormat = expandTargetObjectKeyFormat(v.([]any)[0].(map[string]any))
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutBucketLogging(ctx, input)
 	}, errCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_metric.go
+++ b/internal/service/s3/bucket_metric.go
@@ -104,7 +104,7 @@ func resourceBucketMetricPut(ctx context.Context, d *schema.ResourceData, meta a
 		MetricsConfiguration: metricsConfiguration,
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutBucketMetricsConfiguration(ctx, input)
 	}, errCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_notification.go
+++ b/internal/service/s3/bucket_notification.go
@@ -309,7 +309,7 @@ func resourceBucketNotificationPut(ctx context.Context, d *schema.ResourceData, 
 		NotificationConfiguration: notificationConfiguration,
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutBucketNotificationConfiguration(ctx, input)
 	}, errCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_object_lock_configuration.go
+++ b/internal/service/s3/bucket_object_lock_configuration.go
@@ -128,7 +128,7 @@ func resourceBucketObjectLockConfigurationCreate(ctx context.Context, d *schema.
 		input.Token = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutObjectLockConfiguration(ctx, input)
 	}, errCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_ownership_controls.go
+++ b/internal/service/s3/bucket_ownership_controls.go
@@ -163,7 +163,7 @@ func resourceBucketOwnershipControlsDelete(ctx context.Context, d *schema.Resour
 	}
 
 	log.Printf("[DEBUG] Deleting S3 Bucket Ownership Controls: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute, func(ctx context.Context) (any, error) {
 		return conn.DeleteBucketOwnershipControls(ctx, &s3.DeleteBucketOwnershipControlsInput{
 			Bucket: aws.String(bucket),
 		})

--- a/internal/service/s3/bucket_policy.go
+++ b/internal/service/s3/bucket_policy.go
@@ -63,7 +63,7 @@ func resourceBucketPolicyPut(ctx context.Context, d *schema.ResourceData, meta a
 		Policy: aws.String(policy),
 	}
 
-	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutBucketPolicy(ctx, input)
 	}, errCodeMalformedPolicy, errCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_public_access_block.go
+++ b/internal/service/s3/bucket_public_access_block.go
@@ -84,7 +84,7 @@ func resourceBucketPublicAccessBlockCreate(ctx context.Context, d *schema.Resour
 		},
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutPublicAccessBlock(ctx, input)
 	}, errCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_request_payment_configuration.go
+++ b/internal/service/s3/bucket_request_payment_configuration.go
@@ -76,7 +76,7 @@ func resourceBucketRequestPaymentConfigurationCreate(ctx context.Context, d *sch
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutBucketRequestPayment(ctx, input)
 	}, errCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_server_side_encryption_configuration.go
+++ b/internal/service/s3/bucket_server_side_encryption_configuration.go
@@ -101,7 +101,7 @@ func resourceBucketServerSideEncryptionConfigurationCreate(ctx context.Context, 
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutBucketEncryption(ctx, input)
 	}, errCodeNoSuchBucket, errCodeOperationAborted)
 
@@ -179,7 +179,7 @@ func resourceBucketServerSideEncryptionConfigurationUpdate(ctx context.Context, 
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutBucketEncryption(ctx, input)
 	}, errCodeNoSuchBucket, errCodeOperationAborted)
 

--- a/internal/service/s3/bucket_versioning.go
+++ b/internal/service/s3/bucket_versioning.go
@@ -129,7 +129,7 @@ func resourceBucketVersioningCreate(ctx context.Context, d *schema.ResourceData,
 			input.MFA = aws.String(v.(string))
 		}
 
-		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 			return conn.PutBucketVersioning(ctx, input)
 		}, errCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_website_configuration.go
+++ b/internal/service/s3/bucket_website_configuration.go
@@ -223,7 +223,7 @@ func resourceBucketWebsiteConfigurationCreate(ctx context.Context, d *schema.Res
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutBucketWebsite(ctx, input)
 	}, errCodeNoSuchBucket)
 

--- a/internal/service/s3control/access_grants_location.go
+++ b/internal/service/s3control/access_grants_location.go
@@ -105,7 +105,7 @@ func (r *accessGrantsLocationResource) Create(ctx context.Context, request resou
 	// Additional fields.
 	input.Tags = getTagsIn(ctx)
 
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, s3PropagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, s3PropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateAccessGrantsLocation(ctx, &input)
 	}, errCodeInvalidIAMRole)
 
@@ -190,7 +190,7 @@ func (r *accessGrantsLocationResource) Update(ctx context.Context, request resou
 			return
 		}
 
-		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, s3PropagationTimeout, func() (any, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, s3PropagationTimeout, func(ctx context.Context) (any, error) {
 			return conn.UpdateAccessGrantsLocation(ctx, &input)
 		}, errCodeInvalidIAMRole)
 
@@ -218,7 +218,7 @@ func (r *accessGrantsLocationResource) Delete(ctx context.Context, request resou
 		AccountId:              fwflex.StringFromFramework(ctx, data.AccountID),
 	}
 	// "AccessGrantsLocationNotEmptyError: Please delete access grants before deleting access grants location".
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, s3PropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, s3PropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteAccessGrantsLocation(ctx, &input)
 	}, errCodeAccessGrantsLocationNotEmptyError)
 

--- a/internal/service/s3control/bucket.go
+++ b/internal/service/s3control/bucket.go
@@ -186,7 +186,7 @@ func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta any)
 	// can occur on deletion:
 	//   InvalidBucketState: Bucket is in an invalid state
 	log.Printf("[DEBUG] Deleting S3 Control Bucket: %s", d.Id())
-	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketStatePropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketStatePropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteBucket(ctx, input)
 	}, errCodeInvalidBucketState)
 

--- a/internal/service/sagemaker/device_fleet.go
+++ b/internal/service/sagemaker/device_fleet.go
@@ -114,7 +114,7 @@ func resourceDeviceFleetCreate(ctx context.Context, d *schema.ResourceData, meta
 		input.Description = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func(ctx context.Context) (any, error) {
 		return conn.CreateDeviceFleet(ctx, input)
 	}, ErrCodeValidationException)
 	if err != nil {

--- a/internal/service/sagemaker/flow_definition.go
+++ b/internal/service/sagemaker/flow_definition.go
@@ -274,7 +274,7 @@ func resourceFlowDefinitionCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	log.Printf("[DEBUG] Creating SageMaker AI Flow Definition: %#v", input)
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateFlowDefinition(ctx, input)
 	}, ErrCodeValidationException)
 

--- a/internal/service/sagemaker/model.go
+++ b/internal/service/sagemaker/model.go
@@ -445,7 +445,7 @@ func resourceModelCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	log.Printf("[DEBUG] SageMaker AI model create config: %#v", *createOpts)
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func(ctx context.Context) (any, error) {
 		return conn.CreateModel(ctx, createOpts)
 	}, ErrCodeValidationException)
 

--- a/internal/service/sagemaker/project.go
+++ b/internal/service/sagemaker/project.go
@@ -121,7 +121,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta any
 		input.ProjectDescription = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func(ctx context.Context) (any, error) {
 		return conn.CreateProject(ctx, input)
 	}, ErrCodeValidationException)
 	if err != nil {

--- a/internal/service/sagemaker/workteam.go
+++ b/internal/service/sagemaker/workteam.go
@@ -206,7 +206,7 @@ func resourceWorkteamCreate(ctx context.Context, d *schema.ResourceData, meta an
 		input.WorkforceName = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func(ctx context.Context) (any, error) {
 		return conn.CreateWorkteam(ctx, input)
 	}, ErrCodeValidationException)
 

--- a/internal/service/secretsmanager/secret_rotation.go
+++ b/internal/service/secretsmanager/secret_rotation.go
@@ -113,7 +113,7 @@ func resourceSecretRotationCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	// AccessDeniedException: Secrets Manager cannot invoke the specified Lambda function.
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 1*time.Minute, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 1*time.Minute, func(ctx context.Context) (any, error) {
 		return conn.RotateSecret(ctx, input)
 	}, "AccessDeniedException")
 
@@ -176,7 +176,7 @@ func resourceSecretRotationUpdate(ctx context.Context, d *schema.ResourceData, m
 		}
 
 		// AccessDeniedException: Secrets Manager cannot invoke the specified Lambda function.
-		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 1*time.Minute, func() (any, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 1*time.Minute, func(ctx context.Context) (any, error) {
 			return conn.RotateSecret(ctx, input)
 		}, "AccessDeniedException", "InvalidRequestException")
 

--- a/internal/service/securityhub/organization_admin_account.go
+++ b/internal/service/securityhub/organization_admin_account.go
@@ -57,7 +57,7 @@ func resourceOrganizationAdminAccountCreate(ctx context.Context, d *schema.Resou
 	const (
 		timeout = 2 * time.Minute
 	)
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.EnableOrganizationAdminAccount(ctx, input)
 	}, errCodeResourceConflictException)
 

--- a/internal/service/sfn/state_machine.go
+++ b/internal/service/sfn/state_machine.go
@@ -230,7 +230,7 @@ func resourceStateMachineCreate(ctx context.Context, d *schema.ResourceData, met
 	// Note: the instance may be in a deleting mode, hence the retry
 	// when creating the step function. This can happen when we are
 	// updating the resource (since there is no update API call).
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.CreateStateMachine(ctx, input)
 	}, "StateMachineDeleting", "AccessDeniedException")
 

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -238,7 +238,7 @@ func resourceQueueCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 	// create is 2 phase: 1. create, 2. wait for propagation
 	deadline := inttypes.NewDeadline(d.Timeout(schema.TimeoutCreate))
 
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate)/2, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate)/2, func(ctx context.Context) (any, error) {
 		return conn.CreateQueue(ctx, input)
 	}, errCodeQueueDeletedRecently)
 
@@ -246,7 +246,7 @@ func resourceQueueCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 	if input.Tags != nil && errs.IsUnsupportedOperationInPartitionError(meta.(*conns.AWSClient).Partition(ctx), err) {
 		input.Tags = nil
 
-		outputRaw, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate)/2, func() (any, error) {
+		outputRaw, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate)/2, func(ctx context.Context) (any, error) {
 			return conn.CreateQueue(ctx, input)
 		}, errCodeQueueDeletedRecently)
 	}

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -96,8 +96,8 @@ func RetryGWhen[T any](ctx context.Context, timeout time.Duration, f func() (T, 
 }
 
 // RetryWhenAWSErrCodeEquals retries the specified function when it returns one of the specified AWS error codes.
-func RetryWhenAWSErrCodeEquals(ctx context.Context, timeout time.Duration, f func() (any, error), codes ...string) (any, error) { // nosemgrep:ci.aws-in-func-name
-	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
+func RetryWhenAWSErrCodeEquals[T any](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error), codes ...string) (T, error) { // nosemgrep:ci.aws-in-func-name
+	return retryWhen(ctx, timeout, f, func(err error) (bool, error) {
 		if tfawserr.ErrCodeEquals(err, codes...) {
 			return true, err
 		}

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -106,17 +106,6 @@ func RetryWhenAWSErrCodeEquals[T any](ctx context.Context, timeout time.Duration
 	})
 }
 
-// RetryGWhenAWSErrCodeEquals retries the specified function when it returns one of the specified AWS error codes.
-func RetryGWhenAWSErrCodeEquals[T any](ctx context.Context, timeout time.Duration, f func() (T, error), codes ...string) (T, error) { // nosemgrep:ci.aws-in-func-name
-	return RetryGWhen(ctx, timeout, f, func(err error) (bool, error) {
-		if tfawserr.ErrCodeEquals(err, codes...) {
-			return true, err
-		}
-
-		return false, err
-	})
-}
-
 // RetryWhenAWSErrCodeContains retries the specified function when it returns an AWS error containing the specified code.
 func RetryWhenAWSErrCodeContains[T any](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error), code string) (T, error) { // nosemgrep:ci.aws-in-func-name
 	return retryWhen(ctx, timeout, f, func(err error) (bool, error) {

--- a/internal/tfresource/retry_test.go
+++ b/internal/tfresource/retry_test.go
@@ -22,18 +22,18 @@ func TestRetryWhenAWSErrCodeEquals(t *testing.T) { // nosemgrep:ci.aws-in-func-n
 	ctx := t.Context()
 	testCases := []struct {
 		Name        string
-		F           func() (any, error)
+		F           func(context.Context) (any, error)
 		ExpectError bool
 	}{
 		{
 			Name: "no error",
-			F: func() (any, error) {
+			F: func(context.Context) (any, error) {
 				return nil, nil
 			},
 		},
 		{
 			Name: "non-retryable other error",
-			F: func() (any, error) {
+			F: func(context.Context) (any, error) {
 				return nil, errors.New("TestCode")
 			},
 			ExpectError: true,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Use the new primitives in `internal/retry` (as a replacement for the SDKv2 `helper/retry` package) for `tfresource.RetryWhenAWSErrCodeEquals`. The new implementation is generic (on the return type), so `tfresource.RetryGWhenAWSErrCodeEquals` is now obsolete and has been removed.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/42554.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43267.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43341.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43412.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43521.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43573.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccApplicationInsightsApplication_basic' PKG=applicationinsights
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/applicationinsights/... -v -count 1 -parallel 20  -run=TestAccApplicationInsightsApplication_basic -timeout 360m -vet=off
2025/08/01 16:21:57 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/01 16:21:57 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccApplicationInsightsApplication_basic
=== PAUSE TestAccApplicationInsightsApplication_basic
=== CONT  TestAccApplicationInsightsApplication_basic
--- PASS: TestAccApplicationInsightsApplication_basic (34.08s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/applicationinsights	39.537s
```
```console
% make testacc TESTARGS='-run=TestAccVPC_basic' PKG=ec2                 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPC_basic -timeout 360m -vet=off
2025/08/01 16:24:26 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/01 16:24:26 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPC_basic
=== PAUSE TestAccVPC_basic
=== CONT  TestAccVPC_basic
--- PASS: TestAccVPC_basic (17.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	22.736s
```
```console
% make testacc TESTARGS='-run=TestAccS3Bucket_' PKG=s3 ACCTEST_PARALLELISM=3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/s3/... -v -count 1 -parallel 3  -run=TestAccS3Bucket_ -timeout 360m -vet=off
2025/08/01 16:26:16 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/01 16:26:16 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3Bucket_Identity_Basic
=== PAUSE TestAccS3Bucket_Identity_Basic
=== RUN   TestAccS3Bucket_Identity_RegionOverride
=== PAUSE TestAccS3Bucket_Identity_RegionOverride
=== RUN   TestAccS3Bucket_Identity_ExistingResource
=== PAUSE TestAccS3Bucket_Identity_ExistingResource
=== RUN   TestAccS3Bucket_tags
=== PAUSE TestAccS3Bucket_tags
=== RUN   TestAccS3Bucket_tags_null
=== PAUSE TestAccS3Bucket_tags_null
=== RUN   TestAccS3Bucket_tags_EmptyMap
=== PAUSE TestAccS3Bucket_tags_EmptyMap
=== RUN   TestAccS3Bucket_tags_AddOnUpdate
=== PAUSE TestAccS3Bucket_tags_AddOnUpdate
=== RUN   TestAccS3Bucket_tags_EmptyTag_OnCreate
=== PAUSE TestAccS3Bucket_tags_EmptyTag_OnCreate
=== RUN   TestAccS3Bucket_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccS3Bucket_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccS3Bucket_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccS3Bucket_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccS3Bucket_tags_DefaultTags_providerOnly
=== PAUSE TestAccS3Bucket_tags_DefaultTags_providerOnly
=== RUN   TestAccS3Bucket_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccS3Bucket_tags_DefaultTags_nonOverlapping
=== RUN   TestAccS3Bucket_tags_DefaultTags_overlapping
=== PAUSE TestAccS3Bucket_tags_DefaultTags_overlapping
=== RUN   TestAccS3Bucket_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccS3Bucket_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccS3Bucket_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccS3Bucket_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccS3Bucket_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccS3Bucket_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccS3Bucket_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccS3Bucket_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccS3Bucket_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccS3Bucket_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccS3Bucket_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccS3Bucket_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccS3Bucket_tags_ComputedTag_OnCreate
=== PAUSE TestAccS3Bucket_tags_ComputedTag_OnCreate
=== RUN   TestAccS3Bucket_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccS3Bucket_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccS3Bucket_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccS3Bucket_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccS3Bucket_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccS3Bucket_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccS3Bucket_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccS3Bucket_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Basic_emptyString
=== PAUSE TestAccS3Bucket_Basic_emptyString
=== RUN   TestAccS3Bucket_Basic_nameGenerated
=== PAUSE TestAccS3Bucket_Basic_nameGenerated
=== RUN   TestAccS3Bucket_Basic_namePrefix
=== PAUSE TestAccS3Bucket_Basic_namePrefix
=== RUN   TestAccS3Bucket_Basic_forceDestroy
=== PAUSE TestAccS3Bucket_Basic_forceDestroy
=== RUN   TestAccS3Bucket_Basic_forceDestroyWithUnusualKeyBytes
=== PAUSE TestAccS3Bucket_Basic_forceDestroyWithUnusualKeyBytes
=== RUN   TestAccS3Bucket_Basic_forceDestroyWithObjectVersions
=== PAUSE TestAccS3Bucket_Basic_forceDestroyWithObjectVersions
=== RUN   TestAccS3Bucket_Basic_forceDestroyWithObjectVersionsUnusualKeyBytes
=== PAUSE TestAccS3Bucket_Basic_forceDestroyWithObjectVersionsUnusualKeyBytes
=== RUN   TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
=== PAUSE TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
=== RUN   TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
=== PAUSE TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
=== RUN   TestAccS3Bucket_Basic_acceleration
=== PAUSE TestAccS3Bucket_Basic_acceleration
=== RUN   TestAccS3Bucket_Basic_keyEnabled
=== PAUSE TestAccS3Bucket_Basic_keyEnabled
=== RUN   TestAccS3Bucket_Basic_requestPayer
=== PAUSE TestAccS3Bucket_Basic_requestPayer
=== RUN   TestAccS3Bucket_Basic_upgradeFromV5
=== PAUSE TestAccS3Bucket_Basic_upgradeFromV5
=== RUN   TestAccS3Bucket_disappears
=== PAUSE TestAccS3Bucket_disappears
=== RUN   TestAccS3Bucket_Duplicate_basic
=== PAUSE TestAccS3Bucket_Duplicate_basic
=== RUN   TestAccS3Bucket_Duplicate_UsEast1
=== PAUSE TestAccS3Bucket_Duplicate_UsEast1
=== RUN   TestAccS3Bucket_Duplicate_UsEast1AltAccount
=== PAUSE TestAccS3Bucket_Duplicate_UsEast1AltAccount
=== RUN   TestAccS3Bucket_tags_withSystemTags
=== PAUSE TestAccS3Bucket_tags_withSystemTags
=== RUN   TestAccS3Bucket_tags_ignoreTags
=== PAUSE TestAccS3Bucket_tags_ignoreTags
=== RUN   TestAccS3Bucket_Manage_lifecycleBasic
=== PAUSE TestAccS3Bucket_Manage_lifecycleBasic
=== RUN   TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly
=== PAUSE TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly
=== RUN   TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock
=== PAUSE TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock
=== RUN   TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration
=== PAUSE TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration
=== RUN   TestAccS3Bucket_Manage_lifecycleRemove
=== PAUSE TestAccS3Bucket_Manage_lifecycleRemove
=== RUN   TestAccS3Bucket_Manage_objectLock
=== PAUSE TestAccS3Bucket_Manage_objectLock
=== RUN   TestAccS3Bucket_Manage_objectLock_deprecatedEnabled
=== PAUSE TestAccS3Bucket_Manage_objectLock_deprecatedEnabled
=== RUN   TestAccS3Bucket_Manage_objectLock_migrate
=== PAUSE TestAccS3Bucket_Manage_objectLock_migrate
=== RUN   TestAccS3Bucket_Manage_objectLockWithVersioning
=== PAUSE TestAccS3Bucket_Manage_objectLockWithVersioning
=== RUN   TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled
=== PAUSE TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled
=== RUN   TestAccS3Bucket_Manage_versioning
=== PAUSE TestAccS3Bucket_Manage_versioning
=== RUN   TestAccS3Bucket_Manage_versioningDisabled
=== PAUSE TestAccS3Bucket_Manage_versioningDisabled
=== RUN   TestAccS3Bucket_Manage_MFADeleteDisabled
=== PAUSE TestAccS3Bucket_Manage_MFADeleteDisabled
=== RUN   TestAccS3Bucket_Manage_versioningAndMFADeleteDisabled
=== PAUSE TestAccS3Bucket_Manage_versioningAndMFADeleteDisabled
=== RUN   TestAccS3Bucket_Replication_basic
=== PAUSE TestAccS3Bucket_Replication_basic
=== RUN   TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter
=== PAUSE TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter
=== RUN   TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter
=== PAUSE TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter
=== RUN   TestAccS3Bucket_Replication_twoDestination
=== PAUSE TestAccS3Bucket_Replication_twoDestination
=== RUN   TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation
=== PAUSE TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation
=== RUN   TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation
=== PAUSE TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation
=== RUN   TestAccS3Bucket_Replication_withoutStorageClass
=== PAUSE TestAccS3Bucket_Replication_withoutStorageClass
=== RUN   TestAccS3Bucket_Replication_expectVersioningValidationError
=== PAUSE TestAccS3Bucket_Replication_expectVersioningValidationError
=== RUN   TestAccS3Bucket_Replication_withoutPrefix
=== PAUSE TestAccS3Bucket_Replication_withoutPrefix
=== RUN   TestAccS3Bucket_Replication_schemaV2
=== PAUSE TestAccS3Bucket_Replication_schemaV2
=== RUN   TestAccS3Bucket_Replication_schemaV2SameRegion
=== PAUSE TestAccS3Bucket_Replication_schemaV2SameRegion
=== RUN   TestAccS3Bucket_Replication_RTC_valid
=== PAUSE TestAccS3Bucket_Replication_RTC_valid
=== RUN   TestAccS3Bucket_Security_corsUpdate
=== PAUSE TestAccS3Bucket_Security_corsUpdate
=== RUN   TestAccS3Bucket_Security_corsDelete
=== PAUSE TestAccS3Bucket_Security_corsDelete
=== RUN   TestAccS3Bucket_Security_corsEmptyOrigin
=== PAUSE TestAccS3Bucket_Security_corsEmptyOrigin
=== RUN   TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin
=== PAUSE TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin
=== RUN   TestAccS3Bucket_Security_logging
=== PAUSE TestAccS3Bucket_Security_logging
=== RUN   TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical
=== PAUSE TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical
=== RUN   TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed
=== PAUSE TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed
=== RUN   TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled
=== PAUSE TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled
=== RUN   TestAccS3Bucket_Web_simple
=== PAUSE TestAccS3Bucket_Web_simple
=== RUN   TestAccS3Bucket_Web_redirect
=== PAUSE TestAccS3Bucket_Web_redirect
=== RUN   TestAccS3Bucket_Web_routingRules
=== PAUSE TestAccS3Bucket_Web_routingRules
=== CONT  TestAccS3Bucket_Identity_Basic
=== CONT  TestAccS3Bucket_Manage_lifecycleBasic
=== CONT  TestAccS3Bucket_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (27.90s)
=== CONT  TestAccS3Bucket_tags_DefaultTags_nonOverlapping
--- PASS: TestAccS3Bucket_Identity_Basic (27.92s)
=== CONT  TestAccS3Bucket_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccS3Bucket_tags_IgnoreTags_Overlap_DefaultTag (39.58s)
=== CONT  TestAccS3Bucket_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccS3Bucket_tags_ComputedTag_OnUpdate_Replace (35.73s)
=== CONT  TestAccS3Bucket_tags_ComputedTag_OnCreate
--- PASS: TestAccS3Bucket_tags_ComputedTag_OnUpdate_Add (34.68s)
=== CONT  TestAccS3Bucket_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccS3Bucket_tags_DefaultTags_nonOverlapping (53.18s)
=== CONT  TestAccS3Bucket_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccS3Bucket_tags_ComputedTag_OnCreate (22.07s)
=== CONT  TestAccS3Bucket_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccS3Bucket_tags_DefaultTags_nullNonOverlappingResourceTag (19.37s)
=== CONT  TestAccS3Bucket_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccS3Bucket_tags_DefaultTags_nullOverlappingResourceTag (19.45s)
=== CONT  TestAccS3Bucket_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccS3Bucket_tags_DefaultTags_emptyProviderOnlyTag (19.41s)
=== CONT  TestAccS3Bucket_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccS3Bucket_tags_DefaultTags_emptyResourceTag (19.08s)
=== CONT  TestAccS3Bucket_tags_DefaultTags_overlapping
--- PASS: TestAccS3Bucket_tags_DefaultTags_updateToResourceOnly (29.23s)
=== CONT  TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation
--- PASS: TestAccS3Bucket_tags_DefaultTags_updateToProviderOnly (31.72s)
=== CONT  TestAccS3Bucket_Web_routingRules
--- PASS: TestAccS3Bucket_Web_routingRules (26.59s)
=== CONT  TestAccS3Bucket_Web_redirect
--- PASS: TestAccS3Bucket_tags_DefaultTags_overlapping (52.96s)
=== CONT  TestAccS3Bucket_Web_simple
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (42.81s)
=== CONT  TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (27.01s)
=== CONT  TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed
--- PASS: TestAccS3Bucket_Web_redirect (38.06s)
=== CONT  TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical
--- PASS: TestAccS3Bucket_Web_simple (37.74s)
=== CONT  TestAccS3Bucket_Security_logging
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (17.42s)
=== CONT  TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin
--- PASS: TestAccS3Bucket_Security_logging (22.84s)
=== CONT  TestAccS3Bucket_Security_corsEmptyOrigin
--- PASS: TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin (17.75s)
=== CONT  TestAccS3Bucket_Security_corsDelete
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (35.33s)
=== CONT  TestAccS3Bucket_tags_AddOnUpdate
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (18.13s)
=== CONT  TestAccS3Bucket_Security_corsUpdate
--- PASS: TestAccS3Bucket_Security_corsDelete (15.60s)
=== CONT  TestAccS3Bucket_Replication_RTC_valid
--- PASS: TestAccS3Bucket_tags_AddOnUpdate (31.75s)
=== CONT  TestAccS3Bucket_tags_DefaultTags_providerOnly
--- PASS: TestAccS3Bucket_Security_corsUpdate (30.92s)
=== CONT  TestAccS3Bucket_Replication_schemaV2SameRegion
--- PASS: TestAccS3Bucket_Replication_schemaV2SameRegion (23.80s)
=== CONT  TestAccS3Bucket_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccS3Bucket_Replication_RTC_valid (70.36s)
=== CONT  TestAccS3Bucket_Replication_schemaV2
--- PASS: TestAccS3Bucket_tags_EmptyTag_OnUpdate_Replace (32.47s)
=== CONT  TestAccS3Bucket_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccS3Bucket_tags_DefaultTags_providerOnly (70.80s)
=== CONT  TestAccS3Bucket_Replication_withoutPrefix
--- PASS: TestAccS3Bucket_Replication_withoutPrefix (26.20s)
=== CONT  TestAccS3Bucket_tags_EmptyTag_OnCreate
--- PASS: TestAccS3Bucket_tags_EmptyTag_OnUpdate_Add (49.45s)
=== CONT  TestAccS3Bucket_Replication_expectVersioningValidationError
--- PASS: TestAccS3Bucket_Replication_expectVersioningValidationError (10.80s)
=== CONT  TestAccS3Bucket_Replication_withoutStorageClass
--- PASS: TestAccS3Bucket_tags_EmptyTag_OnCreate (38.48s)
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
--- PASS: TestAccS3Bucket_Replication_schemaV2 (95.08s)
=== CONT  TestAccS3Bucket_Duplicate_basic
--- PASS: TestAccS3Bucket_Replication_withoutStorageClass (27.70s)
=== CONT  TestAccS3Bucket_disappears
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (19.35s)
=== CONT  TestAccS3Bucket_tags_ignoreTags
--- PASS: TestAccS3Bucket_Duplicate_basic (8.58s)
=== CONT  TestAccS3Bucket_Basic_upgradeFromV5
--- PASS: TestAccS3Bucket_disappears (14.07s)
=== CONT  TestAccS3Bucket_tags_withSystemTags
--- PASS: TestAccS3Bucket_tags_ignoreTags (28.49s)
=== CONT  TestAccS3Bucket_Basic_requestPayer
--- PASS: TestAccS3Bucket_Basic_upgradeFromV5 (53.92s)
=== CONT  TestAccS3Bucket_Duplicate_UsEast1AltAccount
    bucket_test.go:589: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccS3Bucket_Duplicate_UsEast1AltAccount (0.00s)
=== CONT  TestAccS3Bucket_Basic_keyEnabled
--- PASS: TestAccS3Bucket_Basic_requestPayer (29.27s)
=== CONT  TestAccS3Bucket_Duplicate_UsEast1
--- PASS: TestAccS3Bucket_Duplicate_UsEast1 (5.62s)
=== CONT  TestAccS3Bucket_Basic_acceleration
--- PASS: TestAccS3Bucket_Basic_keyEnabled (34.98s)
=== CONT  TestAccS3Bucket_Basic_forceDestroy
--- PASS: TestAccS3Bucket_tags_withSystemTags (83.04s)
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithObjectVersionsUnusualKeyBytes
--- PASS: TestAccS3Bucket_Basic_acceleration (32.37s)
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithObjectVersions
--- PASS: TestAccS3Bucket_Basic_forceDestroy (14.35s)
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectVersionsUnusualKeyBytes (17.87s)
=== CONT  TestAccS3Bucket_tags
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectVersions (18.53s)
=== CONT  TestAccS3Bucket_tags_EmptyMap
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (14.19s)
=== CONT  TestAccS3Bucket_tags_null
--- PASS: TestAccS3Bucket_tags_EmptyMap (27.37s)
=== CONT  TestAccS3Bucket_Manage_versioning
--- PASS: TestAccS3Bucket_tags_null (27.73s)
=== CONT  TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation
--- PASS: TestAccS3Bucket_Manage_versioning (33.47s)
=== CONT  TestAccS3Bucket_Replication_twoDestination
--- PASS: TestAccS3Bucket_tags (68.56s)
=== CONT  TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter
--- PASS: TestAccS3Bucket_Replication_twoDestination (26.77s)
=== CONT  TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter (26.70s)
=== CONT  TestAccS3Bucket_Replication_basic
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation (69.37s)
=== CONT  TestAccS3Bucket_Manage_versioningAndMFADeleteDisabled
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter (26.82s)
=== CONT  TestAccS3Bucket_Manage_MFADeleteDisabled
--- PASS: TestAccS3Bucket_Manage_versioningAndMFADeleteDisabled (17.33s)
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithUnusualKeyBytes
--- PASS: TestAccS3Bucket_Manage_MFADeleteDisabled (17.31s)
=== CONT  TestAccS3Bucket_Manage_versioningDisabled
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithUnusualKeyBytes (14.36s)
=== CONT  TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration
--- PASS: TestAccS3Bucket_Manage_versioningDisabled (17.47s)
=== CONT  TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (17.49s)
=== CONT  TestAccS3Bucket_Manage_lifecycleRemove
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (14.34s)
=== CONT  TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly
--- PASS: TestAccS3Bucket_Replication_basic (78.59s)
=== CONT  TestAccS3Bucket_Identity_ExistingResource
--- PASS: TestAccS3Bucket_Manage_lifecycleRemove (24.20s)
=== CONT  TestAccS3Bucket_Basic_emptyString
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (33.12s)
=== CONT  TestAccS3Bucket_Manage_objectLock
--- PASS: TestAccS3Bucket_Basic_emptyString (22.39s)
=== CONT  TestAccS3Bucket_Basic_namePrefix
--- PASS: TestAccS3Bucket_Basic_namePrefix (17.58s)
=== CONT  TestAccS3Bucket_Basic_nameGenerated
--- PASS: TestAccS3Bucket_Manage_objectLock (30.82s)
=== CONT  TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled
--- PASS: TestAccS3Bucket_Basic_nameGenerated (20.36s)
=== CONT  TestAccS3Bucket_Basic_basic
--- PASS: TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled (22.24s)
=== CONT  TestAccS3Bucket_Manage_objectLock_migrate
--- PASS: TestAccS3Bucket_Basic_basic (19.13s)
=== CONT  TestAccS3Bucket_Identity_RegionOverride
--- PASS: TestAccS3Bucket_Identity_ExistingResource (99.90s)
=== CONT  TestAccS3Bucket_Manage_objectLockWithVersioning
--- PASS: TestAccS3Bucket_Manage_objectLock_migrate (24.12s)
=== CONT  TestAccS3Bucket_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccS3Bucket_Identity_RegionOverride (20.09s)
=== CONT  TestAccS3Bucket_Manage_objectLock_deprecatedEnabled
--- PASS: TestAccS3Bucket_Manage_objectLockWithVersioning (20.96s)
--- PASS: TestAccS3Bucket_Manage_objectLock_deprecatedEnabled (17.85s)
--- PASS: TestAccS3Bucket_tags_IgnoreTags_Overlap_ResourceTag (45.82s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	863.032s
```