### PR TITLE
Resource Identity: Test generation Existing Resource tests

### DIFF
--- a/internal/generate/identitytests/main.go
+++ b/internal/generate/identitytests/main.go
@@ -213,52 +213,54 @@ func main() {
 
 			generateTestConfig(g, testDirPath, "basic", tfTemplates, common)
 
-			if resource.PreIdentityVersion.Equal(v5_100_0) {
-				tfTemplatesV5, err := tfTemplates.Clone()
-				if err != nil {
-					g.Fatalf("cloning Terraform config template: %s", err)
-				}
-				ext := filepath.Ext(configTmplFile)
-				name := strings.TrimSuffix(configTmplFile, ext)
-				configTmplV5File := name + "_v5.100.0" + ext
-				configTmplV5Path := path.Join("testdata", "tmpl", configTmplV5File)
-				if _, err := os.Stat(configTmplV5Path); err == nil {
-					b, err := os.ReadFile(configTmplV5Path)
+			if resource.PreIdentityVersion != nil {
+				if resource.PreIdentityVersion.Equal(v5_100_0) {
+					tfTemplatesV5, err := tfTemplates.Clone()
 					if err != nil {
-						g.Fatalf("reading config template %q: %s", configTmplV5Path, err)
+						g.Fatalf("cloning Terraform config template: %s", err)
 					}
-					configTmplV5 := string(b)
-					_, err = tfTemplatesV5.New("body").Parse(configTmplV5)
-					if err != nil {
-						g.Fatalf("parsing config template %q: %s", configTmplV5Path, err)
+					ext := filepath.Ext(configTmplFile)
+					name := strings.TrimSuffix(configTmplFile, ext)
+					configTmplV5File := name + "_v5.100.0" + ext
+					configTmplV5Path := path.Join("testdata", "tmpl", configTmplV5File)
+					if _, err := os.Stat(configTmplV5Path); err == nil {
+						b, err := os.ReadFile(configTmplV5Path)
+						if err != nil {
+							g.Fatalf("reading config template %q: %s", configTmplV5Path, err)
+						}
+						configTmplV5 := string(b)
+						_, err = tfTemplatesV5.New("body").Parse(configTmplV5)
+						if err != nil {
+							g.Fatalf("parsing config template %q: %s", configTmplV5Path, err)
+						}
 					}
-				}
-				commonV5 := common
-				commonV5.ExternalProviders = map[string]requiredProvider{
-					"aws": {
-						Source:  "hashicorp/aws",
-						Version: "5.100.0",
-					},
-				}
-				generateTestConfig(g, testDirPath, "basic_v5.100.0", tfTemplatesV5, commonV5)
+					commonV5 := common
+					commonV5.ExternalProviders = map[string]requiredProvider{
+						"aws": {
+							Source:  "hashicorp/aws",
+							Version: "5.100.0",
+						},
+					}
+					generateTestConfig(g, testDirPath, "basic_v5.100.0", tfTemplatesV5, commonV5)
 
-				commonV6 := common
-				commonV6.ExternalProviders = map[string]requiredProvider{
-					"aws": {
-						Source:  "hashicorp/aws",
-						Version: "6.0.0",
-					},
+					commonV6 := common
+					commonV6.ExternalProviders = map[string]requiredProvider{
+						"aws": {
+							Source:  "hashicorp/aws",
+							Version: "6.0.0",
+						},
+					}
+					generateTestConfig(g, testDirPath, "basic_v6.0.0", tfTemplates, commonV6)
+				} else {
+					commonPreIdentity := common
+					commonPreIdentity.ExternalProviders = map[string]requiredProvider{
+						"aws": {
+							Source:  "hashicorp/aws",
+							Version: resource.PreIdentityVersion.String(),
+						},
+					}
+					generateTestConfig(g, testDirPath, fmt.Sprintf("basic_v%s", resource.PreIdentityVersion.String()), tfTemplates, commonPreIdentity)
 				}
-				generateTestConfig(g, testDirPath, "basic_v6.0.0", tfTemplates, commonV6)
-			} else {
-				commonPreIdentity := common
-				commonPreIdentity.ExternalProviders = map[string]requiredProvider{
-					"aws": {
-						Source:  "hashicorp/aws",
-						Version: resource.PreIdentityVersion.String(),
-					},
-				}
-				generateTestConfig(g, testDirPath, fmt.Sprintf("basic_v%s", resource.PreIdentityVersion.String()), tfTemplates, commonPreIdentity)
 			}
 
 			_, err = tfTemplates.New("region").Parse("\n  region = var.region\n")
@@ -362,25 +364,26 @@ const (
 )
 
 type ResourceDatum struct {
-	service                *serviceRecords
-	FileName               string
-	idAttrDuplicates       string // TODO: Remove. Still needed for Parameterized Identity
-	GenerateConfig         bool
-	ARNFormat              string
-	arnAttribute           string
-	isARNFormatGlobal      triBoolean
-	ArnIdentity            bool
-	MutableIdentity        bool
-	IsGlobal               bool
-	isSingleton            bool
-	HasRegionOverrideTest  bool
-	identityAttributes     []identityAttribute
-	identityAttribute      string
-	IdentityDuplicateAttrs []string
-	IDAttrFormat           string
-	HasV6_0NullValuesError bool
-	HasV6_0RefreshError    bool
-	PreIdentityVersion     *version.Version
+	service                  *serviceRecords
+	FileName                 string
+	idAttrDuplicates         string // TODO: Remove. Still needed for Parameterized Identity
+	GenerateConfig           bool
+	ARNFormat                string
+	arnAttribute             string
+	isARNFormatGlobal        triBoolean
+	ArnIdentity              bool
+	MutableIdentity          bool
+	IsGlobal                 bool
+	isSingleton              bool
+	HasRegionOverrideTest    bool
+	identityAttributes       []identityAttribute
+	identityAttribute        string
+	IdentityDuplicateAttrs   []string
+	IDAttrFormat             string
+	HasV6_0NullValuesError   bool
+	HasV6_0RefreshError      bool
+	HasNoPreExistingResource bool
+	PreIdentityVersion       *version.Version
 	tests.CommonArgs
 }
 
@@ -548,7 +551,6 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 		CommonArgs:            tests.InitCommonArgs(),
 		IsGlobal:              false,
 		HasRegionOverrideTest: true,
-		PreIdentityVersion:    version.Must(version.NewVersion("5.100.0")),
 	}
 	hasIdentity := false
 	skip := false
@@ -696,6 +698,7 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 			// TODO: allow underscore?
 			case "V60SDKv2Fix":
 				d.HasV6_0NullValuesError = true
+				d.PreIdentityVersion = v5_100_0
 
 				args := common.ParseArgs(m[3])
 				if attr, ok := args.Keyword["v60RefreshError"]; ok {
@@ -758,6 +761,9 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 						v.errs = append(v.errs, err)
 					} else {
 						d.HasV6_0NullValuesError = b
+						if b {
+							d.PreIdentityVersion = v5_100_0
+						}
 					}
 				}
 				if attr, ok := args.Keyword["v60RefreshError"]; ok {
@@ -765,6 +771,9 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 						v.errs = append(v.errs, err)
 					} else {
 						d.HasV6_0RefreshError = b
+						if b {
+							d.PreIdentityVersion = v5_100_0
+						}
 					}
 				}
 				if attr, ok := args.Keyword["preIdentityVersion"]; ok {
@@ -774,6 +783,13 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 						continue
 					}
 					d.PreIdentityVersion = version
+				}
+				if attr, ok := args.Keyword["hasNoPreExistingResource"]; ok {
+					if b, err := tests.ParseBoolAttr("hasNoPreExistingResource", attr); err != nil {
+						v.errs = append(v.errs, err)
+					} else {
+						d.HasNoPreExistingResource = b
+					}
 				}
 				if attr, ok := args.Keyword["tlsKey"]; ok {
 					if b, err := tests.ParseBoolAttr("tlsKey", attr); err != nil {
@@ -839,6 +855,10 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 			}
 			if d.Name == "" {
 				v.errs = append(v.errs, fmt.Errorf("no name parameter set: %s", fmt.Sprintf("%s.%s", v.packageName, v.functionName)))
+				return
+			}
+			if !d.HasNoPreExistingResource && d.PreIdentityVersion == nil {
+				v.errs = append(v.errs, fmt.Errorf("preIdentityVersion is required when hasNoPreExistingResource is false: %s", fmt.Sprintf("%s.%s", v.packageName, v.functionName)))
 				return
 			}
 			if !generatorSeen {

--- a/internal/generate/identitytests/resource_test.go.gtpl
+++ b/internal/generate/identitytests/resource_test.go.gtpl
@@ -862,7 +862,7 @@ func {{ template "testname" . }}_Identity_RegionOverride(t *testing.T) {
 			},
 		})
 	}
-{{ else }}
+{{ else if .PreIdentityVersion }}
 	{{ if .PreIdentityVersion.GreaterThanOrEqual (NewVersion "6.0.0") }}
 		// Resource Identity was added after v{{ .PreIdentityVersion }}
 		func {{ template "testname" . }}_Identity_ExistingResource(t *testing.T) {

--- a/internal/service/apigateway/domain_name_access_association.go
+++ b/internal/service/apigateway/domain_name_access_association.go
@@ -34,6 +34,7 @@ import (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigateway/types;awstypes;awstypes.DomainNameAccessAssociation")
 // @Testing(generator="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.RandomSubdomain()")
 // @Testing(tlsKey=true, tlsKeyDomain="rName")
+// @Testing(preIdentityVersion="v5.100.0")
 func newDomainNameAccessAssociationResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &domainNameAccessAssociationResource{}
 

--- a/internal/service/appfabric/app_bundle.go
+++ b/internal/service/appfabric/app_bundle.go
@@ -34,6 +34,7 @@ import (
 // @Testing(generator=false)
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/appfabric/types;awstypes;awstypes.AppBundle")
 // @Testing(preCheckRegion="us-east-1;ap-northeast-1;eu-west-1")
+// @Testing(preIdentityVersion="v5.100.0")
 func newAppBundleResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &appBundleResource{}
 

--- a/internal/service/auditmanager/account_registration.go
+++ b/internal/service/auditmanager/account_registration.go
@@ -28,6 +28,7 @@ import (
 // @SingletonIdentity(identityDuplicateAttributes="id")
 // @Testing(generator=false)
 // @Testing(hasExistsFunction=false, checkDestroyNoop=true)
+// @Testing(preIdentityVersion="v5.100.0")
 func newAccountRegistrationResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	return &accountRegistrationResource{}, nil
 }

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -40,6 +40,7 @@ import (
 // @ArnIdentity(identityDuplicateAttributes="id")
 // @ArnFormat("job-queue/{name}")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/batch/types;types.JobQueueDetail")
+// @Testing(preIdentityVersion="v5.100.0")
 func newJobQueueResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := jobQueueResource{}
 

--- a/internal/service/bedrock/custom_model.go
+++ b/internal/service/bedrock/custom_model.go
@@ -48,6 +48,7 @@ import (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/bedrock;bedrock.GetModelCustomizationJobOutput")
 // @Testing(serialize=true)
 // @Testing(importIgnore="base_model_identifier", plannableImportAction="Replace")
+// @Testing(preIdentityVersion="v5.100.0")
 func newCustomModelResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &customModelResource{}
 

--- a/internal/service/bedrock/model_invocation_logging_configuration.go
+++ b/internal/service/bedrock/model_invocation_logging_configuration.go
@@ -27,6 +27,7 @@ import (
 
 // @FrameworkResource("aws_bedrock_model_invocation_logging_configuration", name="Model Invocation Logging Configuration")
 // @SingletonIdentity(identityDuplicateAttributes="id")
+// @Testing(preIdentityVersion="v5.100.0")
 func newModelInvocationLoggingConfigurationResource(context.Context) (resource.ResourceWithConfigure, error) {
 	return &modelInvocationLoggingConfigurationResource{}, nil
 }

--- a/internal/service/cloudfront/key_value_store.go
+++ b/internal/service/cloudfront/key_value_store.go
@@ -36,6 +36,7 @@ import (
 // @ArnFormat("key-value-store/{id}", attribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/cloudfront/types;awstypes;awstypes.KeyValueStore")
 // @Testing(importStateIdAttribute="name")
+// @Testing(preIdentityVersion="v5.100.0")
 func newKeyValueStoreResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &keyValueStoreResource{}
 

--- a/internal/service/codeconnections/connection.go
+++ b/internal/service/codeconnections/connection.go
@@ -37,6 +37,7 @@ import (
 // @Tags(identifierAttribute="arn")
 // @ArnIdentity(identityDuplicateAttributes="id")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/codeconnections/types;types.Connection")
+// @Testing(preIdentityVersion="v5.100.0")
 func newConnectionResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &connectionResource{}
 

--- a/internal/service/codeconnections/host.go
+++ b/internal/service/codeconnections/host.go
@@ -36,6 +36,7 @@ import (
 // @Tags(identifierAttribute="arn")
 // @ArnIdentity(identityDuplicateAttributes="id")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/codeconnections/types;types.Host")
+// @Testing(preIdentityVersion="v5.100.0")
 func newHostResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &hostResource{}
 

--- a/internal/service/devopsguru/event_sources_config.go
+++ b/internal/service/devopsguru/event_sources_config.go
@@ -29,6 +29,7 @@ import (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/devopsguru;devopsguru.DescribeEventSourcesConfigOutput")
 // @Testing(preCheck="testAccPreCheck")
 // @Testing(generator=false)
+// @Testing(preIdentityVersion="v5.100.0")
 func newEventSourcesConfigResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	return &eventSourcesConfigResource{}, nil
 }

--- a/internal/service/devopsguru/service_integration.go
+++ b/internal/service/devopsguru/service_integration.go
@@ -29,6 +29,7 @@ import (
 // @SingletonIdentity(identityDuplicateAttributes="id")
 // @Testing(preCheck="testAccPreCheck")
 // @Testing(generator=false)
+// @Testing(preIdentityVersion="v5.100.0")
 func newServiceIntegrationResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	return &serviceIntegrationResource{}, nil
 }

--- a/internal/service/docdbelastic/cluster.go
+++ b/internal/service/docdbelastic/cluster.go
@@ -42,6 +42,7 @@ import (
 // @ArnIdentity(identityDuplicateAttributes="id")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/docdbelastic/types;awstypes;awstypes.Cluster")
 // @Testing(importIgnore="admin_user_password")
+// @Testing(preIdentityVersion="v5.100.0")
 func newClusterResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &clusterResource{}
 

--- a/internal/service/dynamodb/resource_policy.go
+++ b/internal/service/dynamodb/resource_policy.go
@@ -31,6 +31,7 @@ import (
 // @ArnIdentity("resource_arn", identityDuplicateAttributes="id")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/dynamodb;dynamodb.GetResourcePolicyOutput")
 // @Testing(importIgnore="policy")
+// @Testing(preIdentityVersion="v5.100.0")
 func newResourcePolicyResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resourcePolicyResource{}
 

--- a/internal/service/globalaccelerator/cross_account_attachment.go
+++ b/internal/service/globalaccelerator/cross_account_attachment.go
@@ -34,6 +34,7 @@ import (
 // @Tags(identifierAttribute="arn")
 // @ArnIdentity(identityDuplicateAttributes="id")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/globalaccelerator/types;awstypes;awstypes.Attachment")
+// @Testing(preIdentityVersion="v5.100.0")
 func newCrossAccountAttachmentResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &crossAccountAttachmentResource{}
 

--- a/internal/service/imagebuilder/lifecycle_policy.go
+++ b/internal/service/imagebuilder/lifecycle_policy.go
@@ -38,6 +38,7 @@ import (
 // @Tags(identifierAttribute="arn")
 // @ArnIdentity(identityDuplicateAttributes="id")
 // @ArnFormat("lifecycle-policy/{name}")
+// @Testing(preIdentityVersion="v5.100.0")
 func newLifecyclePolicyResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	return &lifecyclePolicyResource{}, nil
 }

--- a/internal/service/ivschat/logging_configuration_identity_gen_test.go
+++ b/internal/service/ivschat/logging_configuration_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccIVSChatLoggingConfiguration_Identity_Basic(t *testing.T) {
 	resourceName := "aws_ivschat_logging_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -112,7 +112,7 @@ func TestAccIVSChatLoggingConfiguration_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_ivschat_logging_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -234,7 +234,7 @@ func TestAccIVSChatLoggingConfiguration_Identity_ExistingResource(t *testing.T) 
 	resourceName := "aws_ivschat_logging_configuration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/ivschat/room_identity_gen_test.go
+++ b/internal/service/ivschat/room_identity_gen_test.go
@@ -25,7 +25,7 @@ func TestAccIVSChatRoom_Identity_Basic(t *testing.T) {
 	var v ivschat.GetRoomOutput
 	resourceName := "aws_ivschat_room.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -101,7 +101,7 @@ func TestAccIVSChatRoom_Identity_RegionOverride(t *testing.T) {
 
 	resourceName := "aws_ivschat_room.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -216,7 +216,7 @@ func TestAccIVSChatRoom_Identity_ExistingResource(t *testing.T) {
 	var v ivschat.GetRoomOutput
 	resourceName := "aws_ivschat_room.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/kinesis/resource_policy.go
+++ b/internal/service/kinesis/resource_policy.go
@@ -30,6 +30,7 @@ import (
 // @Testing(useAlternateAccount=true)
 // We need to ignore `policy` because the JSON body is not normalized
 // @Testing(importIgnore="policy")
+// @Testing(preIdentityVersion="v5.100.0")
 func newResourcePolicyResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resourcePolicyResource{}
 

--- a/internal/service/logs/group_identity_gen_test.go
+++ b/internal/service/logs/group_identity_gen_test.go
@@ -28,7 +28,7 @@ func TestAccLogsLogGroup_Identity_Basic(t *testing.T) {
 	resourceName := "aws_cloudwatch_log_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -115,7 +115,7 @@ func TestAccLogsLogGroup_Identity_RegionOverride(t *testing.T) {
 	resourceName := "aws_cloudwatch_log_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
@@ -205,7 +205,7 @@ func TestAccLogsLogGroup_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_cloudwatch_log_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/networkfirewall/tls_inspection_configuration.go
+++ b/internal/service/networkfirewall/tls_inspection_configuration.go
@@ -47,6 +47,7 @@ import (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/networkfirewall;networkfirewall.DescribeTLSInspectionConfigurationOutput")
 // @Testing(subdomainTfVar="common_name;certificate_domain")
 // @Testing(importIgnore="update_token", plannableImportAction="NoOp")
+// @Testing(preIdentityVersion="v5.100.0")
 func newTLSInspectionConfigurationResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &tlsInspectionConfigurationResource{}
 

--- a/internal/service/paymentcryptography/key.go
+++ b/internal/service/paymentcryptography/key.go
@@ -39,6 +39,7 @@ import (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/paymentcryptography;paymentcryptography.GetKeyOutput")
 // @Testing(generator=false)
 // @Testing(importIgnore="deletion_window_in_days")
+// @Testing(preIdentityVersion="v5.100.0")
 func newKeyResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &keyResource{}
 

--- a/internal/service/quicksight/custom_permissions_tags_gen_test.go
+++ b/internal/service/quicksight/custom_permissions_tags_gen_test.go
@@ -18,6 +18,7 @@ import (
 
 func TestAccQuickSightCustomPermissions_tags(t *testing.T) {
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -210,6 +211,7 @@ func TestAccQuickSightCustomPermissions_tags_null(t *testing.T) {
 	t.Skip("Resource CustomPermissions does not support null tags")
 
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -274,6 +276,7 @@ func TestAccQuickSightCustomPermissions_tags_null(t *testing.T) {
 
 func TestAccQuickSightCustomPermissions_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -326,6 +329,7 @@ func TestAccQuickSightCustomPermissions_tags_EmptyMap(t *testing.T) {
 
 func TestAccQuickSightCustomPermissions_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -410,6 +414,7 @@ func TestAccQuickSightCustomPermissions_tags_EmptyTag_OnCreate(t *testing.T) {
 	t.Skip("Resource CustomPermissions does not support empty tags")
 
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -506,6 +511,7 @@ func TestAccQuickSightCustomPermissions_tags_EmptyTag_OnUpdate_Add(t *testing.T)
 	t.Skip("Resource CustomPermissions does not support empty tags")
 
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -651,6 +657,7 @@ func TestAccQuickSightCustomPermissions_tags_EmptyTag_OnUpdate_Replace(t *testin
 	t.Skip("Resource CustomPermissions does not support empty tags")
 
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -743,6 +750,7 @@ func TestAccQuickSightCustomPermissions_tags_EmptyTag_OnUpdate_Replace(t *testin
 
 func TestAccQuickSightCustomPermissions_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -932,6 +940,7 @@ func TestAccQuickSightCustomPermissions_tags_DefaultTags_providerOnly(t *testing
 
 func TestAccQuickSightCustomPermissions_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -1098,6 +1107,7 @@ func TestAccQuickSightCustomPermissions_tags_DefaultTags_nonOverlapping(t *testi
 
 func TestAccQuickSightCustomPermissions_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -1280,6 +1290,7 @@ func TestAccQuickSightCustomPermissions_tags_DefaultTags_overlapping(t *testing.
 
 func TestAccQuickSightCustomPermissions_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -1372,6 +1383,7 @@ func TestAccQuickSightCustomPermissions_tags_DefaultTags_updateToProviderOnly(t 
 
 func TestAccQuickSightCustomPermissions_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -1465,6 +1477,7 @@ func TestAccQuickSightCustomPermissions_tags_DefaultTags_emptyResourceTag(t *tes
 	t.Skip("Resource CustomPermissions does not support empty tags")
 
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -1535,6 +1548,7 @@ func TestAccQuickSightCustomPermissions_tags_DefaultTags_emptyProviderOnlyTag(t 
 	t.Skip("Resource CustomPermissions does not support empty tags")
 
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -1597,6 +1611,7 @@ func TestAccQuickSightCustomPermissions_tags_DefaultTags_nullOverlappingResource
 	t.Skip("Resource CustomPermissions does not support null tags")
 
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -1670,6 +1685,7 @@ func TestAccQuickSightCustomPermissions_tags_DefaultTags_nullNonOverlappingResou
 	t.Skip("Resource CustomPermissions does not support null tags")
 
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -1743,6 +1759,7 @@ func TestAccQuickSightCustomPermissions_tags_DefaultTags_nullNonOverlappingResou
 
 func TestAccQuickSightCustomPermissions_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -1800,6 +1817,7 @@ func TestAccQuickSightCustomPermissions_tags_ComputedTag_OnCreate(t *testing.T) 
 
 func TestAccQuickSightCustomPermissions_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -1899,6 +1917,7 @@ func TestAccQuickSightCustomPermissions_tags_ComputedTag_OnUpdate_Add(t *testing
 
 func TestAccQuickSightCustomPermissions_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -1988,6 +2007,7 @@ func TestAccQuickSightCustomPermissions_tags_ComputedTag_OnUpdate_Replace(t *tes
 
 func TestAccQuickSightCustomPermissions_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -2150,6 +2170,7 @@ func TestAccQuickSightCustomPermissions_tags_IgnoreTags_Overlap_DefaultTag(t *te
 
 func TestAccQuickSightCustomPermissions_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
+
 	var v awstypes.CustomPermissions
 	resourceName := "aws_quicksight_custom_permissions.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)

--- a/internal/service/rds/integration.go
+++ b/internal/service/rds/integration.go
@@ -37,6 +37,7 @@ import (
 // @ArnIdentity(identityDuplicateAttributes="id")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/rds/types;awstypes;awstypes.Integration")
 // @Testing(tagsTest=false)
+// @Testing(preIdentityVersion="v5.100.0")
 func newIntegrationResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &integrationResource{}
 

--- a/internal/service/resourceexplorer2/index.go
+++ b/internal/service/resourceexplorer2/index.go
@@ -35,6 +35,7 @@ import (
 // @ArnIdentity(identityDuplicateAttributes="id")
 // @Testing(serialize=true)
 // @Testing(generator=false)
+// @Testing(preIdentityVersion="v5.100.0")
 func newIndexResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &indexResource{}
 

--- a/internal/service/resourceexplorer2/view.go
+++ b/internal/service/resourceexplorer2/view.go
@@ -41,6 +41,7 @@ import (
 // @ArnIdentity(identityDuplicateAttributes="id")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/resourceexplorer2;resourceexplorer2.GetViewOutput")
 // @Testing(serialize=true)
+// @Testing(preIdentityVersion="v5.100.0")
 func newViewResource(context.Context) (resource.ResourceWithConfigure, error) {
 	return &viewResource{}, nil
 }

--- a/internal/service/securityhub/automation_rule.go
+++ b/internal/service/securityhub/automation_rule.go
@@ -37,6 +37,7 @@ import (
 // @ArnIdentity(identityDuplicateAttributes="id")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/securityhub/types;awstypes;awstypes.AutomationRulesConfig")
 // @Testing(serialize=true)
+// @Testing(preIdentityVersion="v5.100.0")
 func newAutomationRuleResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	return &automationRuleResource{}, nil
 }

--- a/internal/service/shield/application_layer_automatic_response.go
+++ b/internal/service/shield/application_layer_automatic_response.go
@@ -47,6 +47,7 @@ func (applicationLayerAutomaticResponseAction) Values() []applicationLayerAutoma
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/shield/types;awstypes;awstypes.ApplicationLayerAutomaticResponseConfiguration")
 // @Testing(preCheck="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.PreCheckWAFV2CloudFrontScope")
 // @Testing(preCheck="testAccPreCheck")
+// @Testing(preIdentityVersion="v5.100.0")
 func newApplicationLayerAutomaticResponseResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &applicationLayerAutomaticResponseResource{}
 

--- a/internal/service/ssmcontacts/rotation.go
+++ b/internal/service/ssmcontacts/rotation.go
@@ -42,6 +42,7 @@ const (
 // @Testing(serialize=true)
 // Region override test requires `aws_ssmincidents_replication_set`, which doesn't support region override
 // @Testing(identityRegionOverrideTest=false)
+// @Testing(preIdentityVersion="v5.100.0")
 func newRotationResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &rotationResource{}
 

--- a/internal/service/ssoadmin/trusted_token_issuer.go
+++ b/internal/service/ssoadmin/trusted_token_issuer.go
@@ -39,6 +39,7 @@ import (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/ssoadmin;ssoadmin.DescribeTrustedTokenIssuerOutput")
 // @Testing(preCheckWithRegion="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.PreCheckSSOAdminInstancesWithRegion")
 // @Testing(serialize=true)
+// @Testing(preIdentityVersion="v5.100.0")
 func newTrustedTokenIssuerResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	return &trustedTokenIssuerResource{}, nil
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Now requires either `@Testing(preIdentityVersion=<version>)` or new `@Testing(hasNoPreExistingResource=true)` to be set. `hasNoPreExistingResource` is used when adding a net-new resource type with Resource Identity support.
