### PR TITLE
[Enhancement] r/aws_lightsail_static_ip: Support resource import

### DIFF
--- a/internal/service/lightsail/static_ip.go
+++ b/internal/service/lightsail/static_ip.go
@@ -25,6 +25,10 @@ func ResourceStaticIP() *schema.Resource {
 		ReadWithoutTimeout:   resourceStaticIPRead,
 		DeleteWithoutTimeout: resourceStaticIPDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			names.AttrName: {
 				Type:     schema.TypeString,
@@ -69,7 +73,7 @@ func resourceStaticIPRead(ctx context.Context, d *schema.ResourceData, meta any)
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
-	name := d.Get(names.AttrName).(string)
+	name := d.Id()
 	log.Printf("[INFO] Reading Lightsail Static IP: %q", name)
 	out, err := conn.GetStaticIp(ctx, &lightsail.GetStaticIpInput{
 		StaticIpName: aws.String(name),
@@ -85,6 +89,7 @@ func resourceStaticIPRead(ctx context.Context, d *schema.ResourceData, meta any)
 
 	d.Set(names.AttrARN, out.StaticIp.Arn)
 	d.Set(names.AttrIPAddress, out.StaticIp.IpAddress)
+	d.Set(names.AttrName, out.StaticIp.Name)
 	d.Set("support_code", out.StaticIp.SupportCode)
 
 	return diags

--- a/internal/service/lightsail/static_ip_test.go
+++ b/internal/service/lightsail/static_ip_test.go
@@ -23,6 +23,7 @@ import (
 func TestAccLightsailStaticIP_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	staticIpName := fmt.Sprintf("tf-test-lightsail-%s", sdkacctest.RandString(5))
+	resourceName := "aws_lightsail_static_ip.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
@@ -33,8 +34,13 @@ func TestAccLightsailStaticIP_basic(t *testing.T) {
 			{
 				Config: testAccStaticIPConfig_basic(staticIpName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStaticIPExists(ctx, "aws_lightsail_static_ip.test"),
+					testAccCheckStaticIPExists(ctx, resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Fix to support the import operation for `aws_lightsail_static_ip`.

  * In the `Read` function:

    * `d.Id()` is used to obtain the static IP name instead of `d.Get("name")`, because the `name` attribute is unknown and only `id` is known during import.
    * `d.Set("name", ...)` is called to populate the `name` attribute in the import process.
  * The `Importer` is defined in the schema.
  * A test case is added to verify the import functionality.
  * Although import was previously unsupported, instructions for import were included in the documentation. This PR does not update the documentation.

### Relations

Closes #43617


### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccLightsailStaticIP_basic PKG=lightsail
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/lightsail/... -v -count 1 -parallel 20 -run='TestAccLightsailStaticIP_basic'  -timeout 360m -vet=off
2025/08/02 12:29:41 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/02 12:29:41 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLightsailStaticIP_basic
=== PAUSE TestAccLightsailStaticIP_basic
=== CONT  TestAccLightsailStaticIP_basic
--- PASS: TestAccLightsailStaticIP_basic (22.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  26.642s

```
