### PR TITLE
[Enhancement] aws_inspector2_enabler: Support resource import

### DIFF
--- a/.changelog/43673.txt
+++ b/.changelog/43673.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_inspector2_enabler: Support resource import
+```

--- a/internal/service/inspector2/enabler.go
+++ b/internal/service/inspector2/enabler.go
@@ -48,6 +48,10 @@ func ResourceEnabler() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"account_ids": {
 				Type:     schema.TypeSet,

--- a/internal/service/inspector2/enabler_test.go
+++ b/internal/service/inspector2/enabler_test.go
@@ -53,6 +53,11 @@ func testAccEnabler_basic(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeEcr)),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -85,6 +90,11 @@ func testAccEnabler_accountID(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeEc2)),
 					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeEcr)),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -248,6 +258,11 @@ func testAccEnabler_lambda(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeLambda)),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -283,6 +298,11 @@ func testAccEnabler_lambdaCode(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeLambdaCode)),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -314,6 +334,11 @@ func testAccEnabler_codeRepository(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeCodeRepository)),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/inspector2_enabler.html.markdown
+++ b/website/docs/r/inspector2_enabler.html.markdown
@@ -47,7 +47,7 @@ This resource supports the following arguments:
 
 ## Attribute Reference
 
-This resource exports no additional attributes.
+* `id` - A unique identifier, formatted as `[account_id1]:[account_id2]:...-[resource_type1]:[resource_type2]:....`, where `account_ids` are sored in ascending order and `resource_types` are sorted in alphabetical order.
 
 ## Timeouts
 
@@ -56,3 +56,20 @@ This resource exports no additional attributes.
 * `create` - (Default `5m`)
 * `update` - (Default `5m`)
 * `delete` - (Default `5m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Inspector Enabler using the `id`. For example:
+
+```terraform
+import {
+  to = aws_inspector2_enabler.example
+  id = "123456789012:234567890123-EC2:ECR"
+}
+```
+
+Using `terraform import`, import Inspector Enabler using the `id`. For example:
+
+```console
+% terraform import aws_inspector2_enabler.example 123456789012:234567890123-EC2:ECR
+```

--- a/website/docs/r/inspector2_enabler.html.markdown
+++ b/website/docs/r/inspector2_enabler.html.markdown
@@ -47,9 +47,7 @@ This resource supports the following arguments:
 
 ## Attribute Reference
 
-This resource exports the following attributes in addition to the arguments above:
-
-* `id` – A unique identifier formatted as `[account_id1]:[account_id2]:...-[resource_type1]:[resource_type2]:...`, where `account_id`s are sorted in ascending order and `resource_type`s are sorted in alphabetical order.
+This resource exports no additional attributes.
 
 ## Timeouts
 
@@ -61,7 +59,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Inspector Enabler using the `id`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Inspector Enabler using `account_ids` and `region_types` formatted as `[account_id1]:[account_id2]:...-[resource_type1]:[resource_type2]:...`, where `account_ids` are sorted in ascending order and `resource_types` are sorted in alphabetical order. For example:
 
 ```terraform
 import {
@@ -70,7 +68,7 @@ import {
 }
 ```
 
-Using `terraform import`, import Inspector Enabler using the `id`. For example:
+Using `terraform import`, import Inspector Enabler using using `account_ids` and `region_types` formatted as `[account_id1]:[account_id2]:...-[resource_type1]:[resource_type2]:...`, where `account_ids` are sorted in ascending order and `resource_types` are sorted in alphabetical order. For example:
 
 ```console
 % terraform import aws_inspector2_enabler.example 123456789012:234567890123-EC2:ECR

--- a/website/docs/r/inspector2_enabler.html.markdown
+++ b/website/docs/r/inspector2_enabler.html.markdown
@@ -47,6 +47,8 @@ This resource supports the following arguments:
 
 ## Attribute Reference
 
+This resource exports the following attributes in addition to the arguments above:
+
 * `id` – A unique identifier formatted as `[account_id1]:[account_id2]:...-[resource_type1]:[resource_type2]:...`, where `account_id`s are sorted in ascending order and `resource_type`s are sorted in alphabetical order.
 
 ## Timeouts

--- a/website/docs/r/inspector2_enabler.html.markdown
+++ b/website/docs/r/inspector2_enabler.html.markdown
@@ -47,7 +47,7 @@ This resource supports the following arguments:
 
 ## Attribute Reference
 
-* `id` - A unique identifier, formatted as `[account_id1]:[account_id2]:...-[resource_type1]:[resource_type2]:....`, where `account_ids` are sored in ascending order and `resource_types` are sorted in alphabetical order.
+* `id` – A unique identifier formatted as `[account_id1]:[account_id2]:...-[resource_type1]:[resource_type2]:...`, where `account_id`s are sorted in ascending order and `resource_type`s are sorted in alphabetical order.
 
 ## Timeouts
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Fix to support resource import for `aws_inspector2_enabler`.

  * A simple `Importer` is added to the schema definition.
  * Instructions for importing, including the complex `id` structure, are added to the documentation.
  * Test cases for resource import are added to some of the existing acceptance tests.

### Relations

Closes #33723

### Output from Acceptance Testing
```console
$ make testacc TESTS=TestAccInspector2_serial/Enabler PKG=inspector2 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/inspector2/... -v -count 1 -parallel 20 -run='TestAccInspector2_serial/Enabler'  -timeout 360m -vet=off
2025/08/02 13:05:31 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/02 13:05:31 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccInspector2_serial
=== PAUSE TestAccInspector2_serial
=== CONT  TestAccInspector2_serial
=== RUN   TestAccInspector2_serial/Enabler
=== RUN   TestAccInspector2_serial/Enabler/memberAccount_basic
    enabler_test.go:361: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
=== RUN   TestAccInspector2_serial/Enabler/memberAccount_multiple
    enabler_test.go:428: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
=== RUN   TestAccInspector2_serial/Enabler/memberAccount_updateMemberAccountsAndScanTypes
    enabler_test.go:536: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
=== RUN   TestAccInspector2_serial/Enabler/basic
=== RUN   TestAccInspector2_serial/Enabler/accountID
=== RUN   TestAccInspector2_serial/Enabler/codeRepository
=== RUN   TestAccInspector2_serial/Enabler/memberAccount_updateMemberAccounts
    enabler_test.go:468: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
=== RUN   TestAccInspector2_serial/Enabler/memberAccount_disappearsMemberAssociation
    enabler_test.go:396: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
=== RUN   TestAccInspector2_serial/Enabler/disappears
=== RUN   TestAccInspector2_serial/Enabler/lambda
=== RUN   TestAccInspector2_serial/Enabler/lambdaCode
=== RUN   TestAccInspector2_serial/Enabler/updateResourceTypes
=== RUN   TestAccInspector2_serial/Enabler/updateResourceTypes_disjoint
--- PASS: TestAccInspector2_serial (723.34s)
    --- PASS: TestAccInspector2_serial/Enabler (723.34s)
        --- SKIP: TestAccInspector2_serial/Enabler/memberAccount_basic (3.24s)
        --- SKIP: TestAccInspector2_serial/Enabler/memberAccount_multiple (0.63s)
        --- SKIP: TestAccInspector2_serial/Enabler/memberAccount_updateMemberAccountsAndScanTypes (0.73s)
        --- PASS: TestAccInspector2_serial/Enabler/basic (41.43s)
        --- PASS: TestAccInspector2_serial/Enabler/accountID (53.61s)
        --- PASS: TestAccInspector2_serial/Enabler/codeRepository (73.56s)
        --- SKIP: TestAccInspector2_serial/Enabler/memberAccount_updateMemberAccounts (1.75s)
        --- SKIP: TestAccInspector2_serial/Enabler/memberAccount_disappearsMemberAssociation (0.64s)
        --- PASS: TestAccInspector2_serial/Enabler/disappears (50.23s)
        --- PASS: TestAccInspector2_serial/Enabler/lambda (45.97s)
        --- PASS: TestAccInspector2_serial/Enabler/lambdaCode (100.61s)
        --- PASS: TestAccInspector2_serial/Enabler/updateResourceTypes (213.94s)
        --- PASS: TestAccInspector2_serial/Enabler/updateResourceTypes_disjoint (137.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/inspector2 727.251s

```
