### PR TITLE
[Enhancement] r/aws_opensearch_domain_policy: Support resource import

### DIFF
--- a/internal/service/opensearch/domain_policy.go
+++ b/internal/service/opensearch/domain_policy.go
@@ -6,6 +6,7 @@ package opensearch
 import (
 	"context"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -35,6 +36,10 @@ func resourceDomainPolicy() *schema.Resource {
 			Delete: schema.DefaultTimeout(90 * time.Minute),
 		},
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			names.AttrDomainName: {
 				Type:     schema.TypeString,
@@ -58,7 +63,8 @@ func resourceDomainPolicyRead(ctx context.Context, d *schema.ResourceData, meta 
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OpenSearchClient(ctx)
 
-	ds, err := findDomainByName(ctx, conn, d.Get(names.AttrDomainName).(string))
+	domainName := strings.Replace(d.Id(), "esd-policy-", "", 1)
+	ds, err := findDomainByName(ctx, conn, domainName)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] OpenSearch Domain Policy (%s) not found, removing from state", d.Id())
@@ -77,6 +83,7 @@ func resourceDomainPolicyRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	d.Set("access_policies", policies)
+	d.Set(names.AttrDomainName, ds.DomainName)
 
 	return diags
 }

--- a/internal/service/opensearch/domain_policy_test.go
+++ b/internal/service/opensearch/domain_policy_test.go
@@ -21,6 +21,7 @@ func TestAccOpenSearchDomainPolicy_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var domain awstypes.DomainStatus
 	ri := sdkacctest.RandInt()
+	resourceName := "aws_opensearch_domain_policy.test"
 	policy := `{
     "Version": "2012-10-17",
     "Statement": [
@@ -69,9 +70,14 @@ func TestAccOpenSearchDomainPolicy_basic(t *testing.T) {
 						}
 						expectedPolicy := fmt.Sprintf(expectedPolicyTpl, expectedArn)
 
-						return testAccCheckPolicyMatch("aws_opensearch_domain_policy.test", "access_policies", expectedPolicy)(s)
+						return testAccCheckPolicyMatch(resourceName, "access_policies", expectedPolicy)(s)
 					},
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/opensearch_domain_policy.html.markdown
+++ b/website/docs/r/opensearch_domain_policy.html.markdown
@@ -62,3 +62,20 @@ This resource exports no additional attributes.
 
 * `update` - (Default `180m`)
 * `delete` - (Default `90m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import OpenSearch Domain Policy using `domain_name` prefixed with `esd-policy-`. For example:
+
+```terraform
+import {
+  to = aws_opensearch_domain_policy.example
+  id = "esd-policy-tf-test"
+}
+```
+
+Using `terraform import`, import OpenSearch Domain Policy using `domain_name` prefixed with `esd-policy-`. For example:
+
+```console
+% terraform import aws_opensearch_domain_policy.example esd-policy-tf-test
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Fix to support resource import for `aws_opensearch_domain_policy`.

  * Adds an `Importer` to the schema.
  * In the `Read` function:

    * Uses `d.Id()` to obtain the domain name instead of `d.Get("domain_name")`, since only the ID is known during import.
    * Adds `d.Set("domain_name", ...)` to populate the `domain_name` when importing.
  * Adds an import test case to the acceptance tests.
  * Adds import instructions to the documentation.


### Relations

Closes #42289

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccOpenSearchDomainPolicy_basic PKG=opensearch
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchDomainPolicy_basic'  -timeout 360m -vet=off
2025/08/02 14:43:51 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/02 14:43:51 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccOpenSearchDomainPolicy_basic
=== PAUSE TestAccOpenSearchDomainPolicy_basic
=== CONT  TestAccOpenSearchDomainPolicy_basic
--- PASS: TestAccOpenSearchDomainPolicy_basic (2301.30s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 2305.722s

```
