### PR TITLE
[Enhancement] r/aws_computeoptimizer_recommendation_preferences: Add `AuroraDBClusterStorage` as a valid `resource_type`

### DIFF
--- a/internal/service/computeoptimizer/recommendation_preferences.go
+++ b/internal/service/computeoptimizer/recommendation_preferences.go
@@ -71,7 +71,7 @@ func (r *recommendationPreferencesResource) Schema(ctx context.Context, request 
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.OneOf(enum.Slice(awstypes.ResourceTypeAutoScalingGroup, awstypes.ResourceTypeEc2Instance, awstypes.ResourceTypeRdsDbInstance)...),
+					stringvalidator.OneOf(enum.Slice(awstypes.ResourceTypeAutoScalingGroup, awstypes.ResourceTypeEc2Instance, awstypes.ResourceTypeRdsDbInstance, awstypes.ResourceTypeAuroraDbClusterStorage)...),
 				},
 			},
 			"savings_estimation_mode": schema.StringAttribute{

--- a/website/docs/r/computeoptimizer_recommendation_preferences.html.markdown
+++ b/website/docs/r/computeoptimizer_recommendation_preferences.html.markdown
@@ -59,7 +59,7 @@ This resource supports the following arguments:
 * `inferred_workload_types` - (Optional) The status of the inferred workload types recommendation preference. Valid values: `Active`, `Inactive`.
 * `look_back_period` - (Optional) The preference to control the number of days the utilization metrics of the AWS resource are analyzed. Valid values: `DAYS_14`, `DAYS_32`, `DAYS_93`.
 * `preferred_resource` - (Optional) The preference to control which resource type values are considered when generating rightsizing recommendations. See [Preferred Resources](#preferred-resources) below.
-* `resource_type` - (Required) The target resource type of the recommendation preferences. Valid values: `Ec2Instance`, `AutoScalingGroup`, `RdsDBInstance`.
+* `resource_type` - (Required) The target resource type of the recommendation preferences. Valid values: `Ec2Instance`, `AutoScalingGroup`, `RdsDBInstance`, `AuroraDBClusterStorage`.
 * `savings_estimation_mode` - (Optional) The status of the savings estimation mode preference. Valid values: `AfterDiscounts`, `BeforeDiscounts`.
 * `scope` - (Required) The scope of the recommendation preferences. See [Scope](#scope) below.
 * `utilization_preference` - (Optional) The preference to control the resource’s CPU utilization threshold, CPU utilization headroom, and memory utilization headroom. See [Utilization Preferences](#utilization-preferences) below.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* Add `AuroraDBClusterStorage` as a valid `resource_type`
  * Also see discussion in #43618 with @roynesholen

### Relations

Closes #43618

### References
https://docs.aws.amazon.com/compute-optimizer/latest/APIReference/API_PutRecommendationPreferences.html#computeoptimizer-PutRecommendationPreferences-request-resourceType

https://github.com/hashicorp/terraform-provider-aws/issues/43618#issuecomment-3146557743

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccComputeOptimizer_serial/RecommendationPreferences PKG=computeoptimizer
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/computeoptimizer/... -v -count 1 -parallel 20 -run='TestAccComputeOptimizer_serial/RecommendationPreferences'  -timeout 360m -vet=off
2025/08/03 00:55:01 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/03 00:55:01 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccComputeOptimizer_serial
=== PAUSE TestAccComputeOptimizer_serial
=== CONT  TestAccComputeOptimizer_serial
=== RUN   TestAccComputeOptimizer_serial/RecommendationPreferences
=== RUN   TestAccComputeOptimizer_serial/RecommendationPreferences/basic
=== RUN   TestAccComputeOptimizer_serial/RecommendationPreferences/disappears
=== RUN   TestAccComputeOptimizer_serial/RecommendationPreferences/preferredResources
=== RUN   TestAccComputeOptimizer_serial/RecommendationPreferences/utilizationPreferences
--- PASS: TestAccComputeOptimizer_serial (85.59s)
    --- PASS: TestAccComputeOptimizer_serial/RecommendationPreferences (85.59s)
        --- PASS: TestAccComputeOptimizer_serial/RecommendationPreferences/basic (21.61s)
        --- PASS: TestAccComputeOptimizer_serial/RecommendationPreferences/disappears (15.52s)
        --- PASS: TestAccComputeOptimizer_serial/RecommendationPreferences/preferredResources (18.01s)
        --- PASS: TestAccComputeOptimizer_serial/RecommendationPreferences/utilizationPreferences (30.45s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/computeoptimizer   89.590s


```
