### PR TITLE
skaff: Use `names` package attr consts in older TF Plugin SDK V2 templates

### DIFF
--- a/skaff/datasource/datasource.gtpl
+++ b/skaff/datasource/datasource.gtpl
@@ -112,7 +112,7 @@ func DataSource{{ .DataSource }}() *schema.Resource {
 		// https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#Schema
 		{{- end }}
 		Schema: map[string]*schema.Schema{
-			"arn": { {{- if .IncludeComments }} // TIP: Many, but not all, data sources have an `arn` attribute.{{- end }}
+			names.AttrARN: { {{- if .IncludeComments }} // TIP: Many, but not all, data sources have an `arn` attribute.{{- end }}
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -139,7 +139,7 @@ func DataSource{{ .DataSource }}() *schema.Resource {
 				},
 			},
 			{{- if .IncludeTags }}
-			"tags":         tftags.TagsSchemaComputed(), {{- if .IncludeComments }} // TIP: Many, but not all, data sources have `tags` attributes.{{- end }}
+			names.AttrTags: tftags.TagsSchemaComputed(), {{- if .IncludeComments }} // TIP: Many, but not all, data sources have `tags` attributes.{{- end }}
 			{{- end }}
 		},
 	}
@@ -175,7 +175,7 @@ func dataSource{{ .DataSource }}Read(ctx context.Context, d *schema.ResourceData
 	// elements. However, a data source will have perhaps one or a few arguments
 	// that are key to finding the relevant information, such as 'name' below.
 	{{- end }}
-	name := d.Get("name").(string)
+	name := d.Get(names.AttrName).(string)
 
 	out, err := find{{ .DataSource }}ByName(ctx, conn, name)
 	if err != nil {
@@ -198,7 +198,7 @@ func dataSource{{ .DataSource }}Read(ctx context.Context, d *schema.ResourceData
 	//
 	// For simple data types (i.e., schema.TypeString, schema.TypeBool,
 	// schema.TypeInt, and schema.TypeFloat), a simple Set call (e.g.,
-	// d.Set("arn", out.Arn) is sufficient. No error or nil checking is
+	// d.Set(names.AttrARN, out.Arn) is sufficient. No error or nil checking is
 	// necessary.
 	//
 	// However, there are some situations where more handling is needed.
@@ -208,8 +208,8 @@ func dataSource{{ .DataSource }}Read(ctx context.Context, d *schema.ResourceData
 	//    is equivalent to what is already set. In that case, you may check if
 	//    it is equivalent before setting the different JSON.
 	{{- end }}
-	d.Set("arn", out.ARN)
-	d.Set("name", out.Name)
+	d.Set(names.AttrARN, out.ARN)
+	d.Set(names.AttrName, out.Name)
 	{{ if .IncludeComments }}
 	// TIP: Setting a complex type.
 	// For more information, see:
@@ -246,7 +246,7 @@ func dataSource{{ .DataSource }}Read(ctx context.Context, d *schema.ResourceData
 	{{- if .IncludeTags }}
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)
 
-	if err := d.Set("tags", KeyValueTags(out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+	if err := d.Set(names.AttrTags, KeyValueTags(out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		smerr.Append(ctx, diags, err, smerr.ID, d.Id())
 		return diags
 	}

--- a/skaff/resource/resource.gtpl
+++ b/skaff/resource/resource.gtpl
@@ -165,7 +165,7 @@ func Resource{{ .Resource }}() *schema.Resource {
 		// https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#Schema
 		{{- end }}
 		Schema: map[string]*schema.Schema{
-			"arn": { {{- if .IncludeComments }} // TIP: Many, but not all, resources have an `arn` attribute.{{- end }}
+			names.AttrARN: { {{- if .IncludeComments }} // TIP: Many, but not all, resources have an `arn` attribute.{{- end }}
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -232,8 +232,8 @@ func resource{{ .Resource }}Create(ctx context.Context, d *schema.ResourceData, 
 		// TIP: Mandatory or fields that will always be present can be set when
 		// you create the Input structure. (Replace these with real fields.)
 		{{- end }}
-		{{ .Resource }}Name: aws.String(d.Get("name").(string)),
-		{{ .Resource }}Type: aws.String(d.Get("type").(string)),
+		{{ .Resource }}Name: aws.String(d.Get(names.AttrName).(string)),
+		{{ .Resource }}Type: aws.String(d.Get(names.AttrType).(string)),
 		{{ if .IncludeComments }}
 		// TIP: Not all resources support tags and tags don't always make sense. If
 		// your resource doesn't need tags, you can remove the tags lines here and
@@ -269,11 +269,11 @@ func resource{{ .Resource }}Create(ctx context.Context, d *schema.ResourceData, 
 		// TIP: Since d.SetId() has not been called yet, you cannot use d.Id()
 		// in error messages at this point.
 		{{- end }}
-		return smerr.Append(ctx, diags, err, smerr.ID, d.Get("name").(string))
+		return smerr.Append(ctx, diags, err, smerr.ID, d.Get(names.AttrName).(string))
 	}
 
 	if out == nil || out.{{ .Resource }} == nil {
-		return smerr.Append(ctx, diags, errors.New("empty output"), smerr.ID, d.Get("name").(string))
+		return smerr.Append(ctx, diags, errors.New("empty output"), smerr.ID, d.Get(names.AttrName).(string))
 	}
 	{{ if .IncludeComments }}
 	// TIP: -- 4. Set the minimum arguments and/or attributes for the Read function to
@@ -333,7 +333,7 @@ func resource{{ .Resource }}Read(ctx context.Context, d *schema.ResourceData, me
 	//
 	// For simple data types (i.e., schema.TypeString, schema.TypeBool,
 	// schema.TypeInt, and schema.TypeFloat), a simple Set call (e.g.,
-	// d.Set("arn", out.Arn) is sufficient. No error or nil checking is
+	// d.Set(names.AttrARN, out.Arn) is sufficient. No error or nil checking is
 	// necessary.
 	//
 	// However, there are some situations where more handling is needed.
@@ -343,8 +343,8 @@ func resource{{ .Resource }}Read(ctx context.Context, d *schema.ResourceData, me
 	//    is equivalent to what is already set. In that case, you may check if
 	//    it is equivalent before setting the different JSON.
 	{{- end }}
-	d.Set("arn", out.Arn)
-	d.Set("name", out.Name)
+	d.Set(names.AttrARN, out.Arn)
+	d.Set(names.AttrName, out.Name)
 	{{ if .IncludeComments }}
 	// TIP: Setting a complex type.
 	// For more information, see:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
For completeness, this PR is to update the skaff resource and data source templates to use the common attribute constants in the  `github.com/hashicorp/terraform-provider-aws/names` package

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41583

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a
