### PR TITLE
docs: add missing standards for aws_securityhub_standards_subscription

### DIFF
--- a/website/docs/r/securityhub_standards_subscription.html.markdown
+++ b/website/docs/r/securityhub_standards_subscription.html.markdown
@@ -45,7 +45,9 @@ Currently available standards (remember to replace `${var.partition}` and `${var
 | CIS AWS Foundations Benchmark v1.4.0     | `arn:${var.partition}:securityhub:${var.region}::standards/cis-aws-foundations-benchmark/v/1.4.0`            |
 | CIS AWS Foundations Benchmark v3.0.0     | `arn:${var.partition}:securityhub:${var.region}::standards/cis-aws-foundations-benchmark/v/3.0.0`            |
 | NIST SP 800-53 Rev. 5                    | `arn:${var.partition}:securityhub:${var.region}::standards/nist-800-53/v/5.0.0`                              |
-| PCI DSS                                  | `arn:${var.partition}:securityhub:${var.region}::standards/pci-dss/v/3.2.1`                                  |
+| NIST SP 800-171 Rev. 2                   | `arn:${var.partition}:securityhub:${var.region}::standards/nist-800-171/v/2.0.0`                             |
+| PCI DSS  v3.2.1                          | `arn:${var.partition}:securityhub:${var.region}::standards/pci-dss/v/3.2.1`                                  |
+| PCI DSS  v4.0.1                          | `arn:${var.partition}:securityhub:${var.region}::standards/pci-dss/v/4.0.1`                                  |
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls are applied.

### Description

The [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_standards_subscription) for the resource `aws_securityhub_standards_subscription` contains the list of currently available standards. As mentioned in #43658 there are two standards that are missing in the list. This pull request adds both.

### Relations

Closes #43658 

### References
- In  #43658 I added Terraform config and output of `terraform apply` showing that both standards can be used already.
- [AWS Docs for NIST 800-171 Rev. 2](https://docs.aws.amazon.com/securityhub/latest/userguide/standards-reference-nist-800-171.html)
- [AWS Docs for PCI DSS v4.0.1](https://docs.aws.amazon.com/securityhub/latest/userguide/pci-standard.html#pci4-controls)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.