### PR TITLE
remove max limit from regular expression argument

### DIFF
--- a/.changelog/43693.txt
+++ b/.changelog/43693.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_wafv2_regex_pattern_set: Remove maximum items limit on the `regular_expression` argument
+```

--- a/internal/service/wafv2/regex_pattern_set.go
+++ b/internal/service/wafv2/regex_pattern_set.go
@@ -94,7 +94,6 @@ func resourceRegexPatternSet() *schema.Resource {
 				"regular_expression": {
 					Type:     schema.TypeSet,
 					Optional: true,
-					MaxItems: 10,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"regex_string": {

--- a/website/docs/r/wafv2_regex_pattern_set.html.markdown
+++ b/website/docs/r/wafv2_regex_pattern_set.html.markdown
@@ -42,7 +42,7 @@ This resource supports the following arguments:
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `description` - (Optional) A friendly description of the regular expression pattern set.
 * `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the region `us-east-1` (N. Virginia) on the AWS provider.
-* `regular_expression` - (Optional) One or more blocks of regular expression patterns that you want AWS WAF to search for, such as `B[a@]dB[o0]t`. See [Regular Expression](#regular-expression) below for details. A maximum of 10 `regular_expression` blocks may be specified.
+* `regular_expression` - (Optional) One or more blocks of regular expression patterns that you want AWS WAF to search for, such as `B[a@]dB[o0]t`. See [Regular Expression](#regular-expression) below for details.
 * `tags` - (Optional) An array of key:value pairs to associate with the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Regular Expression


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls are implemented.

### Description

The OP in #43615 is hitting a limit of maximum 10 `regular_expression`s in [`aws_wafv2_regex_pattern_set`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_regex_pattern_set).

The [provider code](https://github.com/hashicorp/terraform-provider-aws/blob/4adef3e358624a9fe8eaa80b237789f556035781/internal/service/wafv2/regex_pattern_set.go#L94) is

```golang
"regular_expression": {
	Type:     schema.TypeSet,
	Optional: true,
	MaxItems: 10,
	Elem: &schema.Resource{
       ...
	},
},
```
The value 10 is the default quota in an AWS account and can be raised via support request.

This pull request removes the limitation `MaxItems: 10`. I linked a similar PR in the References section for comparison.


### Relations

Closes #43615 

### References

- [PR for similar issue in CodeBuild resource](https://github.com/hashicorp/terraform-provider-aws/pull/39971)
- [AWS Service Quotas for WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/limits.html)
  
### Output from Acceptance Testing

```console
❯ make testacc TESTS=TestAccWAFV2RegexPatternSet_  PKG=wafv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2RegexPatternSet_'  -timeout 360m -vet=off
2025/08/04 20:55:53 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/04 20:55:53 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccWAFV2RegexPatternSet_basic
=== PAUSE TestAccWAFV2RegexPatternSet_basic
=== RUN   TestAccWAFV2RegexPatternSet_nameGenerated
=== PAUSE TestAccWAFV2RegexPatternSet_nameGenerated
=== RUN   TestAccWAFV2RegexPatternSet_namePrefix
=== PAUSE TestAccWAFV2RegexPatternSet_namePrefix
=== RUN   TestAccWAFV2RegexPatternSet_disappears
=== PAUSE TestAccWAFV2RegexPatternSet_disappears
=== RUN   TestAccWAFV2RegexPatternSet_minimal
=== PAUSE TestAccWAFV2RegexPatternSet_minimal
=== RUN   TestAccWAFV2RegexPatternSet_changeNameForceNew
=== PAUSE TestAccWAFV2RegexPatternSet_changeNameForceNew
=== RUN   TestAccWAFV2RegexPatternSet_tags
=== PAUSE TestAccWAFV2RegexPatternSet_tags
=== CONT  TestAccWAFV2RegexPatternSet_basic
=== CONT  TestAccWAFV2RegexPatternSet_minimal
=== CONT  TestAccWAFV2RegexPatternSet_tags
=== CONT  TestAccWAFV2RegexPatternSet_changeNameForceNew
=== CONT  TestAccWAFV2RegexPatternSet_namePrefix
=== CONT  TestAccWAFV2RegexPatternSet_disappears
=== CONT  TestAccWAFV2RegexPatternSet_nameGenerated
--- PASS: TestAccWAFV2RegexPatternSet_minimal (33.50s)
--- PASS: TestAccWAFV2RegexPatternSet_disappears (40.79s)
--- PASS: TestAccWAFV2RegexPatternSet_namePrefix (40.92s)
--- PASS: TestAccWAFV2RegexPatternSet_changeNameForceNew (58.98s)
--- PASS: TestAccWAFV2RegexPatternSet_nameGenerated (59.32s)
--- PASS: TestAccWAFV2RegexPatternSet_basic (71.40s)
--- PASS: TestAccWAFV2RegexPatternSet_tags (86.46s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      86.706s
```
