### PR TITLE
Add validation and update docs for aws_route53_resolver_firewall_rule_group_association priority

### DIFF
--- a/internal/service/route53resolver/firewall_rule_group_association.go
+++ b/internal/service/route53resolver/firewall_rule_group_association.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -60,8 +61,9 @@ func resourceFirewallRuleGroupAssociation() *schema.Resource {
 				ValidateFunc: validResolverName,
 			},
 			names.AttrPriority: {
-				Type:     schema.TypeInt,
-				Required: true,
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntBetween(101, 9899),
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),

--- a/website/docs/r/route53_resolver_firewall_rule_group_association.html.markdown
+++ b/website/docs/r/route53_resolver_firewall_rule_group_association.html.markdown
@@ -20,7 +20,7 @@ resource "aws_route53_resolver_firewall_rule_group" "example" {
 resource "aws_route53_resolver_firewall_rule_group_association" "example" {
   name                   = "example"
   firewall_rule_group_id = aws_route53_resolver_firewall_rule_group.example.id
-  priority               = 100
+  priority               = 101
   vpc_id                 = aws_vpc.example.id
 }
 ```
@@ -33,7 +33,7 @@ This resource supports the following arguments:
 * `name` - (Required) A name that lets you identify the rule group association, to manage and use it.
 * `firewall_rule_group_id` - (Required) The unique identifier of the firewall rule group.
 * `mutation_protection` - (Optional) If enabled, this setting disallows modification or removal of the association, to help prevent against accidentally altering DNS firewall protections. Valid values: `ENABLED`, `DISABLED`.
-* `priority` - (Required) The setting that determines the processing order of the rule group among the rule groups that you associate with the specified VPC. DNS Firewall filters VPC traffic starting from the rule group with the lowest numeric priority setting.
+* `priority` - (Required) The setting that determines the processing order of the rule group among the rule groups that you associate with the specified VPC. DNS Firewall filters VPC traffic starting from the rule group with the lowest numeric priority setting. Valid values: `101` to `9899`.
 * `vpc_id` - (Required) The unique identifier of the VPC that you want to associate with the rule group.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No

### Description

100 actually fails with error. Value must be _properly_ contained in the 100 to 9900 range referenced by AWS

```
 Error: creating Route53 Resolver Firewall Rule Group Association (<omitted>): operation error Route53Resolver: AssociateFirewallRuleGroup, https response error StatusCode: 400, RequestID:<omitted>, ValidationException: [RSLVR-00000] The priority value you provided is reserved. Provide a number between "100" and "9900". Trace Id: "..."
```

### Relations

Closes #43694

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53resolver_AssociateFirewallRuleGroup.html#API_route53resolver_AssociateFirewallRuleGroup_RequestSyntax


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

N/A
