### PR TITLE
Fix S3 Tables Resource Panic on Maintenance Configuration Read

### DIFF
--- a/internal/service/s3tables/table_bucket.go
+++ b/internal/service/s3tables/table_bucket.go
@@ -255,12 +255,14 @@ func (r *tableBucketResource) Read(ctx context.Context, req resource.ReadRequest
 			err.Error(),
 		)
 	}
-	maintenanceConfiguration, d := flattenTableBucketMaintenanceConfiguration(ctx, awsMaintenanceConfig)
-	resp.Diagnostics.Append(d...)
-	if resp.Diagnostics.HasError() {
-		return
+	if awsMaintenanceConfig != nil {
+		maintenanceConfiguration, d := flattenTableBucketMaintenanceConfiguration(ctx, awsMaintenanceConfig)
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		state.MaintenanceConfiguration = maintenanceConfiguration
 	}
-	state.MaintenanceConfiguration = maintenanceConfiguration
 
 	awsEncryptionConfig, err := findTableBucketEncryptionConfiguration(ctx, conn, state.ARN.ValueString())
 	switch {


### PR DESCRIPTION
## Summary

Fixed a nil pointer dereference panic that occurred when creating S3 Tables resources. 
The panic happened in the `flattenTableBucketMaintenanceConfiguration` function when `GetTableBucketMaintenanceConfiguration` returned an error but the code continued to process the nil response.

## Problem Description

When creating S3 Tables resources, users encountered the following panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1a4d2419]

goroutine 188 [running]:
github.com/hashicorp/terraform-provider-aws/internal/service/s3tables.flattenTableBucketMaintenanceConfiguration({0x2163b918, 0xc001bfb740}, 0x1eab4571?)
    github.com/hashicorp/terraform-provider-aws/internal/service/s3tables/table_bucket.go:495 +0x39
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
