### PR TITLE
security: replace math/rand with crypto/rand in WithDelayRand function

### DIFF
--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -5,8 +5,9 @@ package tfresource
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"sync"
 	"time"
 
@@ -256,7 +257,21 @@ func WithDelay(delay time.Duration) OptionsFunc {
 // WithDelayRand sets the delay to a value between 0s and the passed duration
 func WithDelayRand(delayRand time.Duration) OptionsFunc {
 	return func(o *Options) {
-		o.Delay = time.Duration(rand.Int63n(delayRand.Milliseconds())) * time.Millisecond
+		maxMs := delayRand.Milliseconds()
+		if maxMs <= 0 {
+			o.Delay = 0
+			return
+		}
+		
+		// Use crypto/rand for cryptographically secure random number generation
+		randomMs, err := rand.Int(rand.Reader, big.NewInt(maxMs))
+		if err != nil {
+			// Fallback to no delay if random generation fails
+			o.Delay = 0
+			return
+		}
+		
+		o.Delay = time.Duration(randomMs.Int64()) * time.Millisecond
 	}
 }
 

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -262,7 +262,7 @@ func WithDelayRand(delayRand time.Duration) OptionsFunc {
 			o.Delay = 0
 			return
 		}
-		
+
 		// Use crypto/rand for cryptographically secure random number generation
 		randomMs, err := rand.Int(rand.Reader, big.NewInt(maxMs))
 		if err != nil {
@@ -270,7 +270,7 @@ func WithDelayRand(delayRand time.Duration) OptionsFunc {
 			o.Delay = 0
 			return
 		}
-		
+
 		o.Delay = time.Duration(randomMs.Int64()) * time.Millisecond
 	}
 }


### PR DESCRIPTION
## Summary

This PR fixes a security vulnerability identified by a code scanning alert by replacing the use of cryptographically weak `math/rand` with secure `crypto/rand` in the `WithDelayRand` function.

## Issue

The current implementation uses `math/rand.Int63n()` which generates predictable pseudo-random numbers. This was flagged as:
- **CWE-338**: Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
- **OWASP-A02:2021**: Cryptographic Failures
- **Severity**: Warning

## Changes

- **Imports**: Replaced `math/rand` with `crypto/rand` and added `math/big`
- **WithDelayRand function**: 
  - Now uses `crypto/rand.Int()` for cryptographically secure random generation
  - Added proper error handling with fallback to zero delay
  - Added bounds checking for edge cases (`maxMs <= 0`)
  - Maintains the same functional behavior (random delay between 0 and delayRand)

## Security Benefits

- ✅ Uses cryptographically secure random number generation
- ✅ Eliminates predictable timing patterns in retry logic
- ✅ Follows OWASP security guidelines
- ✅ Resolves CWE-338 vulnerability

## Testing

The change maintains backward compatibility and the same functional behavior. The function still generates random delays between 0 and the specified duration, but now uses secure randomness.

## Risk Assessment

**Low Risk**: This change only affects the randomness quality of retry delays. The fallback behavior (zero delay on error) ensures the retry mechanism continues to work even if secure random generation fails.
