### PR TITLE
r/aws_sagemaker_image: correct `image_name` validation

### DIFF
--- a/.changelog/43751.txt
+++ b/.changelog/43751.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sagemaker_image: Fix `image_name` regular expression validation
+```

--- a/internal/service/sagemaker/image.go
+++ b/internal/service/sagemaker/image.go
@@ -49,7 +49,7 @@ func resourceImage() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 63),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z](-*[0-9A-Za-z])*$`), "Valid characters are a-z, A-Z, 0-9, and - (hyphen)."),
+					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z]([-.]?[0-9A-Za-z])*$`), "Valid characters are a-z, A-Z, 0-9, - (hyphen), and . (dot)."),
 				),
 			},
 			names.AttrRoleARN: {


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously the regex was more restrictive than the AWS API in that dots (`.`) were not allowed. The expression has been updated to match the AWS constraints.


- https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateImage.html#sagemaker-CreateImage-request-ImageName


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #43750


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=sagemaker TESTS="TestAccSageMakerImage_"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerImage_'  -timeout 360m -vet=off
2025/08/07 11:04:32 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/07 11:04:32 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccSageMakerImage_disappears (76.20s)
--- PASS: TestAccSageMakerImage_basic (78.81s)
--- PASS: TestAccSageMakerImage_tags (98.60s)
--- PASS: TestAccSageMakerImage_displayName (100.57s)
--- PASS: TestAccSageMakerImage_description (103.91s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  110.808s
```
