### PR TITLE
[bugfix] aws_lambda_function: Fix missing concurrency information when published version exists

### DIFF
--- a/.changelog/43753.txt
+++ b/.changelog/43753.txt
@@ -1,7 +1,7 @@
 ```release-note:bug
-resource/aws_lambda_function: Fix missing value for `reserved_concurrent_executions` attribute when a published version exists
+resource/aws_lambda_function: Fix missing value for `reserved_concurrent_executions` attribute when a published version exists. This functionality requires the `lambda:GetFunctionConcurrency` IAM permission
 ```
 
 ```release-note:bug
-data-source/aws_lambda_function: Fix missing value for `reserved_concurrent_executions` attribute when a published version exists
+data-source/aws_lambda_function: Fix missing value for `reserved_concurrent_executions` attribute when a published version exists. This functionality requires the `lambda:GetFunctionConcurrency` IAM permission
 ```

--- a/.changelog/43753.txt
+++ b/.changelog/43753.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_lambda_function: Fix missing value for `reserved_concurrent_executions` attribute when a published version exists
+```
+
+```release-note:bug
+data-source/aws_lambda_function: Fix missing value for `reserved_concurrent_executions` attribute when a published version exists
+```

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -1104,6 +1104,21 @@ func findFunction(ctx context.Context, conn *lambda.Client, input *lambda.GetFun
 		return nil, tfresource.NewEmptyResultError(input)
 	}
 
+	// If Qualifier is specified, GetFunction will return nil for Concurrency.
+	// Need to fetch it separately using GetFunctionConcurrency.
+	if output.Concurrency == nil && input.Qualifier != nil {
+		input := lambda.GetFunctionConcurrencyInput{
+			FunctionName: aws.String(aws.ToString(input.FunctionName)),
+		}
+		concurrencyOutput, err := conn.GetFunctionConcurrency(ctx, &input)
+		if err != nil {
+			return nil, err
+		}
+		output.Concurrency = &awstypes.Concurrency{
+			ReservedConcurrentExecutions: concurrencyOutput.ReservedConcurrentExecutions,
+		}
+	}
+
 	return output, nil
 }
 

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -645,6 +645,20 @@ func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta any)
 		return sdkdiag.AppendErrorf(diags, "reading Lambda Function (%s): %s", d.Id(), err)
 	}
 
+	// If Qualifier is specified, GetFunction will return nil for Concurrency.
+	// Need to fetch it separately using GetFunctionConcurrency.
+	if output.Concurrency == nil && input.Qualifier != nil {
+		outputGFC, err := findFunctionConcurrencyByName(ctx, conn, d.Id())
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "reading Lambda Function (%s) concurrency: %s", d.Id(), err)
+		}
+
+		output.Concurrency = &awstypes.Concurrency{
+			ReservedConcurrentExecutions: outputGFC.ReservedConcurrentExecutions,
+		}
+	}
+
 	function := output.Configuration
 	d.Set("architectures", function.Architectures)
 	functionARN := aws.ToString(function.FunctionArn)
@@ -1079,11 +1093,11 @@ func resourceFunctionDelete(ctx context.Context, d *schema.ResourceData, meta an
 }
 
 func findFunctionByName(ctx context.Context, conn *lambda.Client, name string) (*lambda.GetFunctionOutput, error) {
-	input := &lambda.GetFunctionInput{
+	input := lambda.GetFunctionInput{
 		FunctionName: aws.String(name),
 	}
 
-	return findFunction(ctx, conn, input)
+	return findFunction(ctx, conn, &input)
 }
 
 func findFunction(ctx context.Context, conn *lambda.Client, input *lambda.GetFunctionInput) (*lambda.GetFunctionOutput, error) {
@@ -1102,21 +1116,6 @@ func findFunction(ctx context.Context, conn *lambda.Client, input *lambda.GetFun
 
 	if output == nil || output.Code == nil || output.Configuration == nil {
 		return nil, tfresource.NewEmptyResultError(input)
-	}
-
-	// If Qualifier is specified, GetFunction will return nil for Concurrency.
-	// Need to fetch it separately using GetFunctionConcurrency.
-	if output.Concurrency == nil && input.Qualifier != nil {
-		input := lambda.GetFunctionConcurrencyInput{
-			FunctionName: aws.String(aws.ToString(input.FunctionName)),
-		}
-		concurrencyOutput, err := conn.GetFunctionConcurrency(ctx, &input)
-		if err != nil {
-			return nil, err
-		}
-		output.Concurrency = &awstypes.Concurrency{
-			ReservedConcurrentExecutions: concurrencyOutput.ReservedConcurrentExecutions,
-		}
 	}
 
 	return output, nil
@@ -1155,13 +1154,13 @@ func findFunctionConfiguration(ctx context.Context, conn *lambda.Client, input *
 }
 
 func findLatestFunctionVersionByName(ctx context.Context, conn *lambda.Client, name string) (*awstypes.FunctionConfiguration, error) {
-	input := &lambda.ListVersionsByFunctionInput{
+	input := lambda.ListVersionsByFunctionInput{
 		FunctionName: aws.String(name),
 		MaxItems:     aws.Int32(listVersionsMaxItems),
 	}
 	var output *awstypes.FunctionConfiguration
 
-	pages := lambda.NewListVersionsByFunctionPaginator(conn, input)
+	pages := lambda.NewListVersionsByFunctionPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
@@ -1173,6 +1172,35 @@ func findLatestFunctionVersionByName(ctx context.Context, conn *lambda.Client, n
 			// List is sorted from oldest to latest.
 			output = &page.Versions[len(page.Versions)-1]
 		}
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
+}
+
+func findFunctionConcurrencyByName(ctx context.Context, conn *lambda.Client, name string) (*lambda.GetFunctionConcurrencyOutput, error) {
+	input := lambda.GetFunctionConcurrencyInput{
+		FunctionName: aws.String(name),
+	}
+
+	return findFunctionConcurrency(ctx, conn, &input)
+}
+
+func findFunctionConcurrency(ctx context.Context, conn *lambda.Client, input *lambda.GetFunctionConcurrencyInput) (*lambda.GetFunctionConcurrencyOutput, error) {
+	output, err := conn.GetFunctionConcurrency(ctx, input)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	if output == nil {

--- a/internal/service/lambda/function_data_source_test.go
+++ b/internal/service/lambda/function_data_source_test.go
@@ -91,6 +91,33 @@ func TestAccLambdaFunctionDataSource_version(t *testing.T) {
 	})
 }
 
+func TestAccLambdaFunctionDataSource_versionWithReservedConcurrency(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_lambda_function.test"
+	resourceName := "aws_lambda_function.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionDataSourceConfig_versionWithReservedConcurrency(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, "invoke_arn", resourceName, "invoke_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "qualified_arn", resourceName, "qualified_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "qualified_invoke_arn", resourceName, "qualified_invoke_arn"),
+					resource.TestCheckResourceAttr(dataSourceName, "qualifier", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "reserved_concurrent_executions", resourceName, "reserved_concurrent_executions"),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrVersion, "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccLambdaFunctionDataSource_latestVersion(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -460,6 +487,25 @@ resource "aws_lambda_function" "test" {
   publish       = true
   role          = aws_iam_role.lambda.arn
   runtime       = "nodejs20.x"
+}
+
+data "aws_lambda_function" "test" {
+  function_name = aws_lambda_function.test.function_name
+  qualifier     = 1
+}
+`, rName))
+}
+
+func testAccFunctionDataSourceConfig_versionWithReservedConcurrency(rName string) string {
+	return acctest.ConfigCompose(testAccFunctionDataSourceConfig_base(rName), fmt.Sprintf(`
+resource "aws_lambda_function" "test" {
+  filename                       = "test-fixtures/lambdatest.zip"
+  function_name                  = %[1]q
+  handler                        = "exports.example"
+  publish                        = true
+  role                           = aws_iam_role.lambda.arn
+  runtime                        = "nodejs20.x"
+  reserved_concurrent_executions = 10
 }
 
 data "aws_lambda_function" "test" {

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -273,6 +273,13 @@ func TestAccLambdaFunction_concurrency(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "reserved_concurrent_executions", "222"),
 				),
 			},
+			{
+				Config: testAccFunctionConfig_concurrencyPublished(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFunctionExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "reserved_concurrent_executions", "222"),
+				),
+			},
 		},
 	})
 }
@@ -2832,6 +2839,22 @@ resource "aws_lambda_function" "test" {
   function_name                  = %[1]q
   role                           = aws_iam_role.iam_for_lambda.arn
   handler                        = "exports.example"
+  runtime                        = "nodejs20.x"
+  reserved_concurrent_executions = 222
+}
+`, rName))
+}
+
+func testAccFunctionConfig_concurrencyPublished(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLambdaBase(rName, rName, rName),
+		fmt.Sprintf(`
+resource "aws_lambda_function" "test" {
+  filename                       = "test-fixtures/lambdatest.zip"
+  function_name                  = %[1]q
+  role                           = aws_iam_role.iam_for_lambda.arn
+  handler                        = "exports.example"
+  publish                        = true
   runtime                        = "nodejs20.x"
   reserved_concurrent_executions = 222
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* As reported in #43711, the `aws_lambda_function` data source returns `null` for `reserved_concurrent_executions` when a published version exists.

  * The `GetFunction` API returns `null` for `Concurrency` when a `Qualifier` is specified. The data source reflects this `null` value.
  * `Concurrency` appears to be version-agnostic. The other APIs, `GetFunctionConcurrency` and `PutFunctionConcurrency`, accept only a `FunctionName` and do not support a `Qualifier`.
  * To return the correct value for `reserved_concurrent_executions`, `GetFunctionConcurrency` is called when the `Concurrency` field in the `GetFunction` response is `null` and the version is published. The returned value is then merged into the `GetFunction` output.
  * An acceptance test has been added to the data source to verify that the correct value for `reserved_concurrent_executions` is returned.

    * A corresponding test case has also been added to the resource to confirm this behavior.


### Relations

Closes #43711

### References
https://docs.aws.amazon.com/lambda/latest/api/API_GetFunctionConcurrency.html
https://docs.aws.amazon.com/lambda/latest/api/API_PutFunctionConcurrency.html

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccLambdaFunctionDataSource_ PKG=lambda 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunctionDataSource_'  -timeout 360m -vet=off
2025/08/08 00:08:02 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/08 00:08:02 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaFunctionDataSource_tags
=== PAUSE TestAccLambdaFunctionDataSource_tags
=== RUN   TestAccLambdaFunctionDataSource_tags_NullMap
=== PAUSE TestAccLambdaFunctionDataSource_tags_NullMap
=== RUN   TestAccLambdaFunctionDataSource_tags_EmptyMap
=== PAUSE TestAccLambdaFunctionDataSource_tags_EmptyMap
=== RUN   TestAccLambdaFunctionDataSource_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccLambdaFunctionDataSource_tags_DefaultTags_nonOverlapping
=== RUN   TestAccLambdaFunctionDataSource_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccLambdaFunctionDataSource_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccLambdaFunctionDataSource_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccLambdaFunctionDataSource_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccLambdaFunctionDataSource_basic
=== PAUSE TestAccLambdaFunctionDataSource_basic
=== RUN   TestAccLambdaFunctionDataSource_version
=== PAUSE TestAccLambdaFunctionDataSource_version
=== RUN   TestAccLambdaFunctionDataSource_versionWithReservedConcurrency
=== PAUSE TestAccLambdaFunctionDataSource_versionWithReservedConcurrency
=== RUN   TestAccLambdaFunctionDataSource_latestVersion
=== PAUSE TestAccLambdaFunctionDataSource_latestVersion
=== RUN   TestAccLambdaFunctionDataSource_unpublishedVersion
=== PAUSE TestAccLambdaFunctionDataSource_unpublishedVersion
=== RUN   TestAccLambdaFunctionDataSource_alias
=== PAUSE TestAccLambdaFunctionDataSource_alias
=== RUN   TestAccLambdaFunctionDataSource_layers
=== PAUSE TestAccLambdaFunctionDataSource_layers
=== RUN   TestAccLambdaFunctionDataSource_vpc
=== PAUSE TestAccLambdaFunctionDataSource_vpc
=== RUN   TestAccLambdaFunctionDataSource_environment
=== PAUSE TestAccLambdaFunctionDataSource_environment
=== RUN   TestAccLambdaFunctionDataSource_fileSystem
=== PAUSE TestAccLambdaFunctionDataSource_fileSystem
=== RUN   TestAccLambdaFunctionDataSource_image
=== PAUSE TestAccLambdaFunctionDataSource_image
=== RUN   TestAccLambdaFunctionDataSource_architectures
=== PAUSE TestAccLambdaFunctionDataSource_architectures
=== RUN   TestAccLambdaFunctionDataSource_ephemeralStorage
=== PAUSE TestAccLambdaFunctionDataSource_ephemeralStorage
=== RUN   TestAccLambdaFunctionDataSource_loggingConfig
=== PAUSE TestAccLambdaFunctionDataSource_loggingConfig
=== CONT  TestAccLambdaFunctionDataSource_tags
=== CONT  TestAccLambdaFunctionDataSource_unpublishedVersion
=== CONT  TestAccLambdaFunctionDataSource_fileSystem
=== CONT  TestAccLambdaFunctionDataSource_loggingConfig
=== CONT  TestAccLambdaFunctionDataSource_ephemeralStorage
=== CONT  TestAccLambdaFunctionDataSource_architectures
=== CONT  TestAccLambdaFunctionDataSource_image
=== CONT  TestAccLambdaFunctionDataSource_environment
=== CONT  TestAccLambdaFunctionDataSource_layers
=== CONT  TestAccLambdaFunctionDataSource_alias
=== CONT  TestAccLambdaFunctionDataSource_tags_IgnoreTags_Overlap_ResourceTag
=== CONT  TestAccLambdaFunctionDataSource_latestVersion
=== CONT  TestAccLambdaFunctionDataSource_versionWithReservedConcurrency
=== CONT  TestAccLambdaFunctionDataSource_version
=== CONT  TestAccLambdaFunctionDataSource_vpc
=== CONT  TestAccLambdaFunctionDataSource_basic
=== CONT  TestAccLambdaFunctionDataSource_tags_DefaultTags_nonOverlapping
=== CONT  TestAccLambdaFunctionDataSource_tags_IgnoreTags_Overlap_DefaultTag
=== CONT  TestAccLambdaFunctionDataSource_tags_EmptyMap
=== CONT  TestAccLambdaFunctionDataSource_tags_NullMap
=== NAME  TestAccLambdaFunctionDataSource_image
    function_data_source_test.go:402: AWS_LAMBDA_IMAGE_LATEST_ID env var must be set for Lambda Function Data Source Image Support acceptance tests.
--- SKIP: TestAccLambdaFunctionDataSource_image (4.70s)
--- PASS: TestAccLambdaFunctionDataSource_environment (43.69s)
--- PASS: TestAccLambdaFunctionDataSource_tags_NullMap (50.08s)
--- PASS: TestAccLambdaFunctionDataSource_ephemeralStorage (56.80s)
--- PASS: TestAccLambdaFunctionDataSource_version (63.49s)
--- PASS: TestAccLambdaFunctionDataSource_unpublishedVersion (70.33s)
--- PASS: TestAccLambdaFunctionDataSource_tags_IgnoreTags_Overlap_DefaultTag (77.54s)
--- PASS: TestAccLambdaFunctionDataSource_basic (83.36s)
--- PASS: TestAccLambdaFunctionDataSource_architectures (96.51s)
--- PASS: TestAccLambdaFunctionDataSource_tags_DefaultTags_nonOverlapping (103.42s)
--- PASS: TestAccLambdaFunctionDataSource_tags (110.06s)
--- PASS: TestAccLambdaFunctionDataSource_loggingConfig (111.21s)
--- PASS: TestAccLambdaFunctionDataSource_tags_IgnoreTags_Overlap_ResourceTag (116.80s)
--- PASS: TestAccLambdaFunctionDataSource_versionWithReservedConcurrency (123.46s)
--- PASS: TestAccLambdaFunctionDataSource_tags_EmptyMap (130.17s)
--- PASS: TestAccLambdaFunctionDataSource_alias (137.60s)
--- PASS: TestAccLambdaFunctionDataSource_latestVersion (144.09s)
--- PASS: TestAccLambdaFunctionDataSource_layers (150.23s)
--- PASS: TestAccLambdaFunctionDataSource_fileSystem (894.16s)
--- PASS: TestAccLambdaFunctionDataSource_vpc (1734.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     1738.002s

```

```console
$ make testacc TESTS=TestAccLambdaFunction_ PKG=lambda 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunction_'  -timeout 360m -vet=off
2025/08/08 00:38:10 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/08 00:38:10 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaFunction_tags
=== PAUSE TestAccLambdaFunction_tags
=== RUN   TestAccLambdaFunction_tags_null
=== PAUSE TestAccLambdaFunction_tags_null
=== RUN   TestAccLambdaFunction_tags_EmptyMap
=== PAUSE TestAccLambdaFunction_tags_EmptyMap
=== RUN   TestAccLambdaFunction_tags_AddOnUpdate
=== PAUSE TestAccLambdaFunction_tags_AddOnUpdate
=== RUN   TestAccLambdaFunction_tags_EmptyTag_OnCreate
=== PAUSE TestAccLambdaFunction_tags_EmptyTag_OnCreate
=== RUN   TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccLambdaFunction_tags_DefaultTags_providerOnly
=== PAUSE TestAccLambdaFunction_tags_DefaultTags_providerOnly
=== RUN   TestAccLambdaFunction_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccLambdaFunction_tags_DefaultTags_nonOverlapping
=== RUN   TestAccLambdaFunction_tags_DefaultTags_overlapping
=== PAUSE TestAccLambdaFunction_tags_DefaultTags_overlapping
=== RUN   TestAccLambdaFunction_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccLambdaFunction_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccLambdaFunction_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccLambdaFunction_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccLambdaFunction_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccLambdaFunction_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccLambdaFunction_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccLambdaFunction_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccLambdaFunction_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccLambdaFunction_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccLambdaFunction_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccLambdaFunction_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccLambdaFunction_tags_ComputedTag_OnCreate
=== PAUSE TestAccLambdaFunction_tags_ComputedTag_OnCreate
=== RUN   TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccLambdaFunction_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccLambdaFunction_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccLambdaFunction_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccLambdaFunction_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== RUN   TestAccLambdaFunction_disappears
=== PAUSE TestAccLambdaFunction_disappears
=== RUN   TestAccLambdaFunction_unpublishedCodeUpdate
=== PAUSE TestAccLambdaFunction_unpublishedCodeUpdate
=== RUN   TestAccLambdaFunction_codeSigning
=== PAUSE TestAccLambdaFunction_codeSigning
=== RUN   TestAccLambdaFunction_concurrency
=== PAUSE TestAccLambdaFunction_concurrency
=== RUN   TestAccLambdaFunction_concurrencyCycle
=== PAUSE TestAccLambdaFunction_concurrencyCycle
=== RUN   TestAccLambdaFunction_expectFilenameAndS3Attributes
=== PAUSE TestAccLambdaFunction_expectFilenameAndS3Attributes
=== RUN   TestAccLambdaFunction_envVariables
=== PAUSE TestAccLambdaFunction_envVariables
=== RUN   TestAccLambdaFunction_EnvironmentVariables_noValue
=== PAUSE TestAccLambdaFunction_EnvironmentVariables_noValue
=== RUN   TestAccLambdaFunction_encryptedEnvVariables
=== PAUSE TestAccLambdaFunction_encryptedEnvVariables
=== RUN   TestAccLambdaFunction_nameValidation
=== PAUSE TestAccLambdaFunction_nameValidation
=== RUN   TestAccLambdaFunction_versioned
=== PAUSE TestAccLambdaFunction_versioned
=== RUN   TestAccLambdaFunction_versionedUpdate
=== PAUSE TestAccLambdaFunction_versionedUpdate
=== RUN   TestAccLambdaFunction_enablePublish
=== PAUSE TestAccLambdaFunction_enablePublish
=== RUN   TestAccLambdaFunction_disablePublish
=== PAUSE TestAccLambdaFunction_disablePublish
=== RUN   TestAccLambdaFunction_deadLetter
=== PAUSE TestAccLambdaFunction_deadLetter
=== RUN   TestAccLambdaFunction_deadLetterUpdated
=== PAUSE TestAccLambdaFunction_deadLetterUpdated
=== RUN   TestAccLambdaFunction_nilDeadLetter
=== PAUSE TestAccLambdaFunction_nilDeadLetter
=== RUN   TestAccLambdaFunction_fileSystem
=== PAUSE TestAccLambdaFunction_fileSystem
=== RUN   TestAccLambdaFunction_image
    function_test.go:903: Environment variable AWS_LAMBDA_IMAGE_LATEST_ID is not set
--- SKIP: TestAccLambdaFunction_image (0.00s)
=== RUN   TestAccLambdaFunction_architectures
=== PAUSE TestAccLambdaFunction_architectures
=== RUN   TestAccLambdaFunction_architecturesUpdate
=== PAUSE TestAccLambdaFunction_architecturesUpdate
=== RUN   TestAccLambdaFunction_architecturesWithLayer
=== PAUSE TestAccLambdaFunction_architecturesWithLayer
=== RUN   TestAccLambdaFunction_ephemeralStorage
=== PAUSE TestAccLambdaFunction_ephemeralStorage
=== RUN   TestAccLambdaFunction_loggingConfig
=== PAUSE TestAccLambdaFunction_loggingConfig
=== RUN   TestAccLambdaFunction_loggingConfigWithPublish
=== PAUSE TestAccLambdaFunction_loggingConfigWithPublish
=== RUN   TestAccLambdaFunction_tracing
=== PAUSE TestAccLambdaFunction_tracing
=== RUN   TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables
=== PAUSE TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables
=== RUN   TestAccLambdaFunction_layers
=== PAUSE TestAccLambdaFunction_layers
=== RUN   TestAccLambdaFunction_layersUpdate
=== PAUSE TestAccLambdaFunction_layersUpdate
=== RUN   TestAccLambdaFunction_vpc
=== PAUSE TestAccLambdaFunction_vpc
=== RUN   TestAccLambdaFunction_vpcRemoval
=== PAUSE TestAccLambdaFunction_vpcRemoval
=== RUN   TestAccLambdaFunction_vpcUpdate
=== PAUSE TestAccLambdaFunction_vpcUpdate
=== RUN   TestAccLambdaFunction_VPC_withInvocation
=== PAUSE TestAccLambdaFunction_VPC_withInvocation
=== RUN   TestAccLambdaFunction_VPCPublishNo_changes
=== PAUSE TestAccLambdaFunction_VPCPublishNo_changes
=== RUN   TestAccLambdaFunction_VPCPublishHas_changes
=== PAUSE TestAccLambdaFunction_VPCPublishHas_changes
=== RUN   TestAccLambdaFunction_VPC_properIAMDependencies
=== PAUSE TestAccLambdaFunction_VPC_properIAMDependencies
=== RUN   TestAccLambdaFunction_VPC_replaceSGWithDefault
=== PAUSE TestAccLambdaFunction_VPC_replaceSGWithDefault
=== RUN   TestAccLambdaFunction_VPC_replaceSGWithCustom
=== PAUSE TestAccLambdaFunction_VPC_replaceSGWithCustom
=== RUN   TestAccLambdaFunction_emptyVPC
=== PAUSE TestAccLambdaFunction_emptyVPC
=== RUN   TestAccLambdaFunction_s3
=== PAUSE TestAccLambdaFunction_s3
=== RUN   TestAccLambdaFunction_localUpdate
=== PAUSE TestAccLambdaFunction_localUpdate
=== RUN   TestAccLambdaFunction_LocalUpdate_nameOnly
=== PAUSE TestAccLambdaFunction_LocalUpdate_nameOnly
=== RUN   TestAccLambdaFunction_LocalUpdate_publish
=== PAUSE TestAccLambdaFunction_LocalUpdate_publish
=== RUN   TestAccLambdaFunction_S3Update_basic
=== PAUSE TestAccLambdaFunction_S3Update_basic
=== RUN   TestAccLambdaFunction_S3Update_unversioned
=== PAUSE TestAccLambdaFunction_S3Update_unversioned
=== RUN   TestAccLambdaFunction_snapStart
=== PAUSE TestAccLambdaFunction_snapStart
=== RUN   TestAccLambdaFunction_runtimes
=== PAUSE TestAccLambdaFunction_runtimes
=== RUN   TestAccLambdaFunction_Zip_validation
=== PAUSE TestAccLambdaFunction_Zip_validation
=== RUN   TestAccLambdaFunction_ipv6AllowedForDualStack
=== PAUSE TestAccLambdaFunction_ipv6AllowedForDualStack
=== RUN   TestAccLambdaFunction_skipDestroy
=== PAUSE TestAccLambdaFunction_skipDestroy
=== CONT  TestAccLambdaFunction_tags
=== CONT  TestAccLambdaFunction_deadLetter
=== CONT  TestAccLambdaFunction_tags_DefaultTags_overlapping
=== CONT  TestAccLambdaFunction_tags_IgnoreTags_Overlap_ResourceTag
=== CONT  TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Replace
=== CONT  TestAccLambdaFunction_disablePublish
=== CONT  TestAccLambdaFunction_enablePublish
=== CONT  TestAccLambdaFunction_versionedUpdate
=== CONT  TestAccLambdaFunction_versioned
=== CONT  TestAccLambdaFunction_nameValidation
=== CONT  TestAccLambdaFunction_encryptedEnvVariables
=== CONT  TestAccLambdaFunction_EnvironmentVariables_noValue
=== CONT  TestAccLambdaFunction_envVariables
=== CONT  TestAccLambdaFunction_expectFilenameAndS3Attributes
=== CONT  TestAccLambdaFunction_concurrencyCycle
=== CONT  TestAccLambdaFunction_concurrency
=== CONT  TestAccLambdaFunction_codeSigning
=== CONT  TestAccLambdaFunction_unpublishedCodeUpdate
=== CONT  TestAccLambdaFunction_disappears
=== CONT  TestAccLambdaFunction_basic
--- PASS: TestAccLambdaFunction_expectFilenameAndS3Attributes (5.71s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccLambdaFunction_nameValidation (7.29s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccLambdaFunction_versioned (61.01s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccLambdaFunction_basic (74.49s)
=== CONT  TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccLambdaFunction_codeSigning (75.91s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_nonOverlapping
--- PASS: TestAccLambdaFunction_disappears (85.59s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_providerOnly
--- PASS: TestAccLambdaFunction_concurrency (92.82s)
=== CONT  TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccLambdaFunction_disablePublish (97.40s)
=== CONT  TestAccLambdaFunction_tags_AddOnUpdate
--- PASS: TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Replace (114.99s)
=== CONT  TestAccLambdaFunction_tags_EmptyTag_OnCreate
--- PASS: TestAccLambdaFunction_tags_DefaultTags_emptyProviderOnlyTag (115.43s)
=== CONT  TestAccLambdaFunction_tags_EmptyMap
--- PASS: TestAccLambdaFunction_envVariables (132.01s)
=== CONT  TestAccLambdaFunction_tags_null
--- PASS: TestAccLambdaFunction_concurrencyCycle (134.11s)
=== CONT  TestAccLambdaFunction_VPCPublishNo_changes
--- PASS: TestAccLambdaFunction_tags_IgnoreTags_Overlap_ResourceTag (142.15s)
=== CONT  TestAccLambdaFunction_skipDestroy
--- PASS: TestAccLambdaFunction_EnvironmentVariables_noValue (149.21s)
=== CONT  TestAccLambdaFunction_ipv6AllowedForDualStack
--- PASS: TestAccLambdaFunction_tags_DefaultTags_overlapping (180.84s)
=== CONT  TestAccLambdaFunction_Zip_validation
--- PASS: TestAccLambdaFunction_Zip_validation (5.30s)
=== CONT  TestAccLambdaFunction_runtimes
--- PASS: TestAccLambdaFunction_deadLetter (188.27s)
=== CONT  TestAccLambdaFunction_snapStart
--- PASS: TestAccLambdaFunction_tags_DefaultTags_updateToResourceOnly (181.98s)
=== CONT  TestAccLambdaFunction_S3Update_unversioned
--- PASS: TestAccLambdaFunction_tags (192.38s)
=== CONT  TestAccLambdaFunction_S3Update_basic
--- PASS: TestAccLambdaFunction_enablePublish (194.65s)
=== CONT  TestAccLambdaFunction_LocalUpdate_publish
--- PASS: TestAccLambdaFunction_tags_DefaultTags_updateToProviderOnly (141.92s)
=== CONT  TestAccLambdaFunction_LocalUpdate_nameOnly
--- PASS: TestAccLambdaFunction_unpublishedCodeUpdate (225.99s)
=== CONT  TestAccLambdaFunction_localUpdate
--- PASS: TestAccLambdaFunction_encryptedEnvVariables (228.45s)
=== CONT  TestAccLambdaFunction_s3
--- PASS: TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Replace (139.27s)
=== CONT  TestAccLambdaFunction_emptyVPC
--- PASS: TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Add (160.10s)
=== CONT  TestAccLambdaFunction_VPC_replaceSGWithCustom
--- PASS: TestAccLambdaFunction_tags_AddOnUpdate (141.36s)
=== CONT  TestAccLambdaFunction_VPC_replaceSGWithDefault
--- PASS: TestAccLambdaFunction_tags_DefaultTags_nonOverlapping (173.92s)
=== CONT  TestAccLambdaFunction_VPC_properIAMDependencies
--- PASS: TestAccLambdaFunction_tags_EmptyMap (134.05s)
=== CONT  TestAccLambdaFunction_VPCPublishHas_changes
--- PASS: TestAccLambdaFunction_tags_EmptyTag_OnCreate (142.74s)
=== CONT  TestAccLambdaFunction_loggingConfigWithPublish
--- PASS: TestAccLambdaFunction_S3Update_unversioned (69.41s)
=== CONT  TestAccLambdaFunction_VPC_withInvocation
--- PASS: TestAccLambdaFunction_tags_null (127.79s)
=== CONT  TestAccLambdaFunction_vpcUpdate
--- PASS: TestAccLambdaFunction_skipDestroy (117.67s)
=== CONT  TestAccLambdaFunction_vpcRemoval
--- PASS: TestAccLambdaFunction_S3Update_basic (74.23s)
=== CONT  TestAccLambdaFunction_vpc
--- PASS: TestAccLambdaFunction_s3 (40.77s)
=== CONT  TestAccLambdaFunction_layersUpdate
--- PASS: TestAccLambdaFunction_tags_DefaultTags_providerOnly (193.59s)
=== CONT  TestAccLambdaFunction_layers
--- PASS: TestAccLambdaFunction_versionedUpdate (283.05s)
=== CONT  TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables
--- PASS: TestAccLambdaFunction_snapStart (475.44s)
=== CONT  TestAccLambdaFunction_tracing
--- PASS: TestAccLambdaFunction_emptyVPC (437.82s)
=== CONT  TestAccLambdaFunction_architecturesUpdate
--- PASS: TestAccLambdaFunction_VPC_replaceSGWithCustom (883.73s)
=== CONT  TestAccLambdaFunction_loggingConfig
--- PASS: TestAccLambdaFunction_runtimes (961.50s)
=== CONT  TestAccLambdaFunction_ephemeralStorage
--- PASS: TestAccLambdaFunction_layersUpdate (998.92s)
=== CONT  TestAccLambdaFunction_architecturesWithLayer
--- PASS: TestAccLambdaFunction_loggingConfigWithPublish (1125.96s)
=== CONT  TestAccLambdaFunction_fileSystem
--- PASS: TestAccLambdaFunction_VPC_properIAMDependencies (1155.76s)
=== CONT  TestAccLambdaFunction_architectures
--- PASS: TestAccLambdaFunction_VPCPublishHas_changes (1531.73s)
=== CONT  TestAccLambdaFunction_nilDeadLetter
--- PASS: TestAccLambdaFunction_VPCPublishNo_changes (1826.78s)
=== CONT  TestAccLambdaFunction_deadLetterUpdated
--- PASS: TestAccLambdaFunction_VPC_withInvocation (1709.82s)
=== CONT  TestAccLambdaFunction_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccLambdaFunction_layers (1713.18s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccLambdaFunction_ipv6AllowedForDualStack (1995.06s)
=== CONT  TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables (1901.02s)
=== CONT  TestAccLambdaFunction_tags_ComputedTag_OnCreate
--- PASS: TestAccLambdaFunction_LocalUpdate_publish (2071.16s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccLambdaFunction_LocalUpdate_nameOnly (2069.02s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccLambdaFunction_localUpdate (2052.38s)
--- PASS: TestAccLambdaFunction_tracing (1646.63s)
--- PASS: TestAccLambdaFunction_vpcUpdate (2065.79s)
--- PASS: TestAccLambdaFunction_vpcRemoval (2066.13s)
--- PASS: TestAccLambdaFunction_VPC_replaceSGWithDefault (2089.17s)
--- PASS: TestAccLambdaFunction_ephemeralStorage (1183.15s)
--- PASS: TestAccLambdaFunction_architectures (931.52s)
--- PASS: TestAccLambdaFunction_loggingConfig (1239.38s)
--- PASS: TestAccLambdaFunction_vpc (2220.46s)
--- PASS: TestAccLambdaFunction_nilDeadLetter (709.43s)
--- PASS: TestAccLambdaFunction_tags_DefaultTags_nullOverlappingResourceTag (535.12s)
--- PASS: TestAccLambdaFunction_deadLetterUpdated (576.19s)
--- PASS: TestAccLambdaFunction_tags_ComputedTag_OnCreate (359.05s)
--- PASS: TestAccLambdaFunction_tags_DefaultTags_nullNonOverlappingResourceTag (283.79s)
--- PASS: TestAccLambdaFunction_tags_IgnoreTags_Overlap_DefaultTag (581.96s)
--- PASS: TestAccLambdaFunction_tags_DefaultTags_emptyResourceTag (282.01s)
--- PASS: TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Add (410.95s)
--- PASS: TestAccLambdaFunction_architecturesUpdate (1888.12s)
--- PASS: TestAccLambdaFunction_architecturesWithLayer (1295.42s)
--- PASS: TestAccLambdaFunction_fileSystem (1830.45s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     3218.048s


```