### PR TITLE
Add skip_os_shutdown attribute to ec2_instance_state resource.

### DIFF
--- a/.changelog/43761.txt
+++ b/.changelog/43761.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/ec2_instance_state: Add `skip_os_shutdown` attribute.
+```

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1913,7 +1913,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta an
 	if d.HasChange("capacity_reservation_specification") && !d.IsNewResource() {
 		if v, ok := d.GetOk("capacity_reservation_specification"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 			if v := expandCapacityReservationSpecification(v.([]any)[0].(map[string]any)); v != nil && (v.CapacityReservationPreference != "" || v.CapacityReservationTarget != nil) {
-				if err := stopInstance(ctx, conn, d.Id(), false, instanceStopTimeout); err != nil {
+				if err := stopInstance(ctx, conn, d.Id(), false, false, instanceStopTimeout); err != nil {
 					return sdkdiag.AppendFromErr(diags, err)
 				}
 
@@ -2053,7 +2053,7 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta an
 		}
 	}
 
-	if err := terminateInstance(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+	if err := terminateInstance(ctx, conn, d.Id(), false, d.Timeout(schema.TimeoutDelete)); err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
@@ -2111,7 +2111,7 @@ func disableInstanceAPITermination(ctx context.Context, conn *ec2.Client, id str
 func modifyInstanceAttributeWithStopStart(ctx context.Context, conn *ec2.Client, input *ec2.ModifyInstanceAttributeInput, attrName string) error {
 	id := aws.ToString(input.InstanceId)
 
-	if err := stopInstance(ctx, conn, id, false, instanceStopTimeout); err != nil {
+	if err := stopInstance(ctx, conn, id, false, false, instanceStopTimeout); err != nil {
 		return err
 	}
 
@@ -3074,14 +3074,15 @@ func startInstance(ctx context.Context, conn *ec2.Client, id string, retry bool,
 }
 
 // stopInstance stops an EC2 instance and waits for the instance to stop.
-func stopInstance(ctx context.Context, conn *ec2.Client, id string, force bool, timeout time.Duration) error {
+func stopInstance(ctx context.Context, conn *ec2.Client, id string, force bool, skipOsShutdown bool, timeout time.Duration) error {
 	tflog.Info(ctx, "Stopping EC2 Instance", map[string]any{
 		"ec2_instance_id": id,
 		"force":           force,
 	})
 	input := ec2.StopInstancesInput{
-		Force:       aws.Bool(force),
-		InstanceIds: []string{id},
+		Force:          aws.Bool(force),
+		SkipOsShutdown: aws.Bool(skipOsShutdown),
+		InstanceIds:    []string{id},
 	}
 	_, err := conn.StopInstances(ctx, &input)
 
@@ -3097,10 +3098,11 @@ func stopInstance(ctx context.Context, conn *ec2.Client, id string, force bool, 
 }
 
 // terminateInstance shuts down an EC2 instance and waits for the instance to be deleted.
-func terminateInstance(ctx context.Context, conn *ec2.Client, id string, timeout time.Duration) error {
+func terminateInstance(ctx context.Context, conn *ec2.Client, id string, skipOsShutdown bool, timeout time.Duration) error {
 	log.Printf("[DEBUG] Terminating EC2 Instance: %s", id)
 	input := ec2.TerminateInstancesInput{
-		InstanceIds: []string{id},
+		SkipOsShutdown: aws.Bool(skipOsShutdown),
+		InstanceIds:    []string{id},
 	}
 	_, err := conn.TerminateInstances(ctx, &input)
 

--- a/internal/service/ec2/ec2_instance_state.go
+++ b/internal/service/ec2/ec2_instance_state.go
@@ -47,10 +47,9 @@ func resourceInstanceState() *schema.Resource {
 				Default:  false,
 			},
 			"skip_os_shutdown": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: "Skip graceful OS shutdown. Ignored for 'start' states.",
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
 			},
 			names.AttrInstanceID: {
 				Type:     schema.TypeString,

--- a/internal/service/ec2/ec2_instance_state.go
+++ b/internal/service/ec2/ec2_instance_state.go
@@ -46,6 +46,12 @@ func resourceInstanceState() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"skip_os_shutdown": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Skip graceful OS shutdown. Ignored for 'start' states.",
+			},
 			names.AttrInstanceID: {
 				Type:     schema.TypeString,
 				ForceNew: true,
@@ -71,7 +77,7 @@ func resourceInstanceStateCreate(ctx context.Context, d *schema.ResourceData, me
 		return sdkdiag.AppendErrorf(diags, "waiting for EC2 Instance (%s) ready: %s", instanceID, err)
 	}
 
-	if err := updateInstanceState(ctx, conn, instanceID, string(instance.State.Name), d.Get(names.AttrState).(string), d.Get("force").(bool)); err != nil {
+	if err := updateInstanceState(ctx, conn, instanceID, string(instance.State.Name), d.Get(names.AttrState).(string), d.Get("force").(bool), d.Get("skip_os_shutdown").(bool)); err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
@@ -97,6 +103,7 @@ func resourceInstanceStateRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	d.Set("force", d.Get("force").(bool))
+	d.Set("skip_os_shutdown", d.Get("skip_os_shutdown").(bool))
 	d.Set(names.AttrInstanceID, d.Id())
 	d.Set(names.AttrState, state.Name)
 
@@ -114,7 +121,7 @@ func resourceInstanceStateUpdate(ctx context.Context, d *schema.ResourceData, me
 	if d.HasChange(names.AttrState) {
 		o, n := d.GetChange(names.AttrState)
 
-		if err := updateInstanceState(ctx, conn, d.Id(), o.(string), n.(string), d.Get("force").(bool)); err != nil {
+		if err := updateInstanceState(ctx, conn, d.Id(), o.(string), n.(string), d.Get("force").(bool), d.Get("skip_os_shutdown").(bool)); err != nil {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
@@ -122,13 +129,13 @@ func resourceInstanceStateUpdate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceInstanceStateRead(ctx, d, meta)...)
 }
 
-func updateInstanceState(ctx context.Context, conn *ec2.Client, id string, currentState string, configuredState string, force bool) error {
+func updateInstanceState(ctx context.Context, conn *ec2.Client, id string, currentState string, configuredState string, force bool, skipOsShutdown bool) error {
 	if currentState == configuredState {
 		return nil
 	}
 
 	if configuredState == "stopped" {
-		if err := stopInstance(ctx, conn, id, force, instanceStopTimeout); err != nil {
+		if err := stopInstance(ctx, conn, id, force, skipOsShutdown, instanceStopTimeout); err != nil {
 			return err
 		}
 	}

--- a/internal/service/ec2/ec2_instance_state_test.go
+++ b/internal/service/ec2/ec2_instance_state_test.go
@@ -28,7 +28,7 @@ func TestAccEC2InstanceState_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckInstanceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceStateConfig_basic(state, false),
+				Config: testAccInstanceStateConfig_basic(state, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceStateExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrInstanceID),
@@ -52,7 +52,7 @@ func TestAccEC2InstanceState_state(t *testing.T) {
 		CheckDestroy:             testAccCheckInstanceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceStateConfig_basic(stateStopped, false),
+				Config: testAccInstanceStateConfig_basic(stateStopped, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceStateExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrInstanceID),
@@ -65,7 +65,7 @@ func TestAccEC2InstanceState_state(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInstanceStateConfig_basic(stateRunning, false),
+				Config: testAccInstanceStateConfig_basic(stateRunning, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceStateExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrInstanceID),
@@ -89,7 +89,7 @@ func TestAccEC2InstanceState_disappears_Instance(t *testing.T) {
 		CheckDestroy:             testAccCheckInstanceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceStateConfig_basic(state, false),
+				Config: testAccInstanceStateConfig_basic(state, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceStateExists(ctx, t, resourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfec2.ResourceInstance(), parentResourceName),
@@ -127,7 +127,7 @@ func testAccCheckInstanceStateExists(ctx context.Context, t *testing.T, n string
 	}
 }
 
-func testAccInstanceStateConfig_basic(state string, force bool) string {
+func testAccInstanceStateConfig_basic(state string, force bool, skipOsShutdown bool) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro", "t1.micro", "m1.small"),
@@ -138,9 +138,10 @@ resource "aws_instance" "test" {
 }
 
 resource "aws_ec2_instance_state" "test" {
-  instance_id = aws_instance.test.id
-  state       = %[1]q
-  force       = %[2]t
+  instance_id      = aws_instance.test.id
+  state            = %[1]q
+  force            = %[2]t
+  skip_os_shutdown = %[3]t
 }
-`, state, force))
+`, state, force, skipOsShutdown))
 }

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -6993,7 +6993,7 @@ func testAccCheckStopInstance(ctx context.Context, t *testing.T, v *awstypes.Ins
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).EC2Client(ctx)
 
-		return tfec2.StopInstance(ctx, conn, aws.ToString(v.InstanceId), false, 10*time.Minute)
+		return tfec2.StopInstance(ctx, conn, aws.ToString(v.InstanceId), false, false, 10*time.Minute)
 	}
 }
 

--- a/internal/service/ec2/ec2_spot_instance_request.go
+++ b/internal/service/ec2/ec2_spot_instance_request.go
@@ -325,7 +325,7 @@ func resourceSpotInstanceRequestDelete(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if instanceID := d.Get("spot_instance_id").(string); instanceID != "" {
-		if err := terminateInstance(ctx, conn, instanceID, d.Timeout(schema.TimeoutDelete)); err != nil {
+		if err := terminateInstance(ctx, conn, instanceID, false, d.Timeout(schema.TimeoutDelete)); err != nil {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}

--- a/website/docs/r/ec2_instance_state.html.markdown
+++ b/website/docs/r/ec2_instance_state.html.markdown
@@ -56,7 +56,8 @@ The following arguments are required:
 The following arguments are optional:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `force` - (Optional) Whether to request a forced stop when `state` is `stopped`. Otherwise (_i.e._, `state` is `running`), ignored. When an instance is forced to stop, it does not flush file system caches or file system metadata, and you must subsequently perform file system check and repair. Not recommended for Windows instances. Defaults to `false`.
+* `force` - (Optional) Whether to request a forced stop when `state` is `stopped`. Otherwise (_i.e._, `state` is `running`), ignored. When an instance is forced to stop, it does not flush file system caches or file system metadata, and you must subsequently perform file system check and repair. Not recommended for Windows instances. Defaults to `false`. See [methods for terminating an instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-terminate-methods.html)
+* `skip_os_shutdown` - (Optional) Whether to skip the graceful OS shutdown when `state` is `stopped`.  Otherwise (_i.e._, `state` is `running`), ignored. Bypassing the graceful OS shutdown might result in data loss or corruption (for example, memory contents not flushed to disk or loss of in-flight IOs) or skipped shutdown scripts. Defaults to `false`. See [methods for terminating an instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-terminate-methods.html)
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No. 

### Description
Recently AWS added an option to skip the graceful OS shutdown when stopping or terminating EC2 instances. 

This PR adds a `skip_os_shutdown` argument/attribute to the `service/ec2/ec2_instance_state` resource to support this. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.
For Example:

Relates #0000
or 
Closes #0000
--->

Closes #43726 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
User Guide: [terminate](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-terminate-methods.html), [stop](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-stop-methods.html)

API Reference: [StopInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_StopInstances.html), [TerminateInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TerminateInstances.html)). 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ec2 TESTS="TestAccEC2InstanceState*"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2InstanceState*'  -timeout 360m -vet=off
2025/08/08 00:08:30 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/08 00:08:30 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEC2InstanceState_basic
=== PAUSE TestAccEC2InstanceState_basic
=== RUN   TestAccEC2InstanceState_state
=== PAUSE TestAccEC2InstanceState_state
=== RUN   TestAccEC2InstanceState_disappears_Instance
=== PAUSE TestAccEC2InstanceState_disappears_Instance
=== CONT  TestAccEC2InstanceState_basic
=== CONT  TestAccEC2InstanceState_disappears_Instance
=== CONT  TestAccEC2InstanceState_state
--- PASS: TestAccEC2InstanceState_disappears_Instance (85.67s)
--- PASS: TestAccEC2InstanceState_basic (103.24s)
--- PASS: TestAccEC2InstanceState_state (182.06s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        182.213s
```
