### PR TITLE
[Docs/Test] aws_route53_resolver_endpoint:  Update the documentation to add `INBOUND_DELEGATION` as a valid value for `direction`

### DIFF
--- a/internal/service/route53resolver/endpoint_test.go
+++ b/internal/service/route53resolver/endpoint_test.go
@@ -203,6 +203,37 @@ func TestAccRoute53ResolverEndpoint_updateOutbound(t *testing.T) {
 	})
 }
 
+func TestAccRoute53ResolverEndpoint_directionInboundDelegation(t *testing.T) {
+	ctx := acctest.Context(t)
+	var ep awstypes.ResolverEndpoint
+	resourceName := "aws_route53_resolver_endpoint.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ResolverServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfig_directionInboundDelegation(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(ctx, resourceName, &ep),
+					resource.TestCheckResourceAttr(resourceName, "direction", "INBOUND_DELEGATION"),
+					resource.TestCheckResourceAttr(resourceName, "ip_address.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "resolver_endpoint_type", "IPV4"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccRoute53ResolverEndpoint_resolverEndpointType(t *testing.T) {
 	ctx := acctest.Context(t)
 	var ep awstypes.ResolverEndpoint
@@ -531,6 +562,31 @@ resource "aws_route53_resolver_endpoint" "test" {
   protocols = ["Do53", "DoH"]
 }
 `, name))
+}
+
+func testAccEndpointConfig_directionInboundDelegation(rName string) string {
+	return acctest.ConfigCompose(testAccEndpointConfig_base(rName), fmt.Sprintf(`
+resource "aws_route53_resolver_endpoint" "test" {
+  direction = "INBOUND_DELEGATION"
+  name      = %[1]q
+
+  resolver_endpoint_type = "IPV4"
+
+  security_group_ids = aws_security_group.test[*].id
+
+  ip_address {
+    subnet_id = aws_subnet.test[0].id
+  }
+
+  ip_address {
+    subnet_id = aws_subnet.test[1].id
+  }
+
+  ip_address {
+    subnet_id = aws_subnet.test[2].id
+  }
+}
+`, rName))
 }
 
 func testAccEndpointConfig_resolverEndpointType(rName, resolverEndpointType string) string {

--- a/website/docs/r/route53_resolver_endpoint.html.markdown
+++ b/website/docs/r/route53_resolver_endpoint.html.markdown
@@ -46,8 +46,7 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `direction` - (Required) Direction of DNS queries to or from the Route 53 Resolver endpoint.
-Valid values are `INBOUND` (resolver forwards DNS queries to the DNS service for a VPC from your network or another VPC)
-or `OUTBOUND` (resolver forwards DNS queries from the DNS service for a VPC to your network or another VPC).
+Valid values are `INBOUND` (resolver forwards DNS queries to the DNS service for a VPC from your network or another VPC), `OUTBOUND` (resolver forwards DNS queries from the DNS service for a VPC to your network or another VPC) or `INBOUND_DELEGATION` (resolver delegates queries to Route 53 private hosted zones from your network).
 * `ip_address` - (Required) Subnets and IP addresses in your VPC that you want DNS queries to pass through on the way from your VPCs
 to your network (for outbound endpoints) or on the way from your network to your VPCs (for inbound endpoints). Described below.
 * `name` - (Optional) Friendly name of the Route 53 Resolver endpoint.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Due to updates in AWS SDK for Go v2, `INBOUND_DELEGATION` is now supported as a valid value for `direction` in the `aws_route53_resolver_endpoint` resource.
* The documentation has been updated to include `INBOUND_DELEGATION` as a valid value for `direction`.
* An acceptance test has been added to confirm that `INBOUND_DELEGATION` is supported.

### Relations

Relates #43745 

### References
https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53resolver_CreateResolverEndpoint.html#Route53Resolver-route53resolver_CreateResolverEndpoint-request-Direction

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccRoute53ResolverEndpoint_directionInboundDelegation PKG=route53resolver
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/route53resolver/... -v -count 1 -parallel 20 -run='TestAccRoute53ResolverEndpoint_directionInboundDelegation'  -timeout 360m -vet=off
2025/08/09 02:35:35 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/09 02:35:35 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRoute53ResolverEndpoint_directionInboundDelegation
=== PAUSE TestAccRoute53ResolverEndpoint_directionInboundDelegation
=== CONT  TestAccRoute53ResolverEndpoint_directionInboundDelegation
--- PASS: TestAccRoute53ResolverEndpoint_directionInboundDelegation (122.64s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53resolver    126.570s


```
