### PR TITLE
custom key store: mark credentials as sensitive

### DIFF
--- a/.changelog/43788.txt
+++ b/.changelog/43788.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/custom_key_store: Make `xks_proxy_authentication_credential` sensitive input values
+```

--- a/internal/service/kms/custom_key_store.go
+++ b/internal/service/kms/custom_key_store.go
@@ -75,12 +75,14 @@ func resourceCustomKeyStore() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"access_key_id": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:      schema.TypeString,
+							Required:  true,
+							Sensitive: true,
 						},
 						"raw_secret_access_key": {
 							Type:     schema.TypeString,
-							Required: true,
+							Required:  true,
+							Sensitive: true,
 						},
 					},
 				},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No, other than redacting sensitive values in `xks_proxy_authentication_credential ` in  custom key store resource.

### Description

Mark `xks_proxy_authentication_credential` fields `access_key_id` and `raw_secret_access_key ` as sensitive in CustomKeyStore.

As per https://developer.hashicorp.com/terraform/tutorials/configuration-language/sensitive-variables and the existing usages of `Sensitive` on secret string fields in this repository.

