### PR TITLE
[bugfix] aws_cognito_log_delivery_configuration: Fix inconsistent result when multiple `log_configurations` are specified

### DIFF
--- a/internal/service/cognitoidp/log_delivery_configuration.go
+++ b/internal/service/cognitoidp/log_delivery_configuration.go
@@ -4,13 +4,16 @@
 package cognitoidp
 
 import (
+	"cmp"
 	"context"
 	"errors"
+	"slices"
 
 	"github.com/YakDriver/smarterr"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
+	gocmp "github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -153,6 +156,16 @@ func (r *logDeliveryConfigurationResource) Create(ctx context.Context, req resou
 		return
 	}
 
+	// If the LogConfigurations in the plan are equal to the config except order,
+	// replace LogConfiguration in the plan with the config
+	var config resourceLogDeliveryConfigurationModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if logConfigurationsEqualIgnoreOrder(ctx, plan.LogConfigurations, config.LogConfigurations) {
+		plan.LogConfigurations = config.LogConfigurations
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
@@ -176,11 +189,19 @@ func (r *logDeliveryConfigurationResource) Read(ctx context.Context, req resourc
 		return
 	}
 
+	// Save the current LogConfigurations before flex.Flatten overwrites it
+	originalLogConfigurations := state.LogConfigurations
+
 	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	// If the LogConfigurations in the state are equal to the pre-refreshed one except order,
+	// replace LogConfiguration in the state with the pre-refreshed one
+	if logConfigurationsEqualIgnoreOrder(ctx, state.LogConfigurations, originalLogConfigurations) {
+		state.LogConfigurations = originalLogConfigurations
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -220,6 +241,17 @@ func (r *logDeliveryConfigurationResource) Update(ctx context.Context, req resou
 		resp.Diagnostics.Append(flex.Flatten(ctx, out.LogDeliveryConfiguration, &plan)...)
 		if resp.Diagnostics.HasError() {
 			return
+		}
+
+		// If the LogConfigurations in the plan are equal to the ones in the config except order,
+		// replace LogConfiguration in the plan with the config
+		var config resourceLogDeliveryConfigurationModel
+		resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if logConfigurationsEqualIgnoreOrder(ctx, plan.LogConfigurations, config.LogConfigurations) {
+			plan.LogConfigurations = config.LogConfigurations
 		}
 	}
 
@@ -300,4 +332,55 @@ type firehoseConfigurationModel struct {
 
 type s3ConfigurationModel struct {
 	BucketArn fwtypes.ARN `tfsdk:"bucket_arn"`
+}
+
+func compareLogConfigurations(x, y logConfigurationModel) int {
+	// Compare LogLevel first
+	if c := cmp.Compare(x.LogLevel.ValueString(), y.LogLevel.ValueString()); c != 0 {
+		return c
+	}
+	// Then EventSource
+	if c := cmp.Compare(x.EventSource.ValueString(), y.EventSource.ValueString()); c != 0 {
+		return c
+	}
+	// Then CloudWatchLogsConfiguration
+	if c := cmp.Compare(x.CloudWatchLogsConfiguration.String(), y.CloudWatchLogsConfiguration.String()); c != 0 {
+		return c
+	}
+	// Then FirehoseConfiguration
+	if c := cmp.Compare(x.FirehoseConfiguration.String(), y.FirehoseConfiguration.String()); c != 0 {
+		return c
+	}
+	// Finally S3Configuration
+	return cmp.Compare(x.S3Configuration.String(), y.S3Configuration.String())
+}
+
+func logConfigurationsEqualIgnoreOrder(ctx context.Context, a, b fwtypes.ListNestedObjectValueOf[logConfigurationModel]) bool {
+	// Check if both are null/empty
+	if a.IsNull() && b.IsNull() {
+		return true
+	}
+	if a.IsNull() || b.IsNull() {
+		return false
+	}
+
+	// Extract elements to slices
+	var aSlice, bSlice []logConfigurationModel
+	a.ElementsAs(ctx, &aSlice, false)
+	b.ElementsAs(ctx, &bSlice, false)
+
+	// Check lengths
+	if len(aSlice) != len(bSlice) {
+		return false
+	}
+
+	// Sort both slices for comparison
+	sortLogConfigurations := func(slice []logConfigurationModel) {
+		slices.SortFunc(slice, compareLogConfigurations)
+	}
+	sortLogConfigurations(aSlice)
+	sortLogConfigurations(bSlice)
+
+	// Compare sorted slices using go-cmp
+	return gocmp.Equal(aSlice, bSlice)
 }

--- a/internal/service/cognitoidp/log_delivery_configuration.go
+++ b/internal/service/cognitoidp/log_delivery_configuration.go
@@ -156,7 +156,7 @@ func (r *logDeliveryConfigurationResource) Create(ctx context.Context, req resou
 		return
 	}
 
-	// Preserve original configuration order if content is equivalent
+	// Preserve original log_configurations order if content is equivalent
 	var config resourceLogDeliveryConfigurationModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
@@ -196,7 +196,7 @@ func (r *logDeliveryConfigurationResource) Read(ctx context.Context, req resourc
 		return
 	}
 
-	// Preserve original configuration order if content is equivalent
+	// Preserve original log_configurations order if content is equivalent
 	r.preserveConfigurationOrder(ctx, &state, originalState)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -239,7 +239,7 @@ func (r *logDeliveryConfigurationResource) Update(ctx context.Context, req resou
 			return
 		}
 
-		// Preserve original configuration order if content is equivalent
+		// Preserve original log_configurations order if content is equivalent
 		var config resourceLogDeliveryConfigurationModel
 		resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 		if resp.Diagnostics.HasError() {
@@ -335,23 +335,18 @@ func (r *logDeliveryConfigurationResource) preserveConfigurationOrder(ctx contex
 }
 
 func compareLogConfigurations(x, y logConfigurationModel) int {
-	// Compare LogLevel first
 	if c := cmp.Compare(x.LogLevel.ValueString(), y.LogLevel.ValueString()); c != 0 {
 		return c
 	}
-	// Then EventSource
 	if c := cmp.Compare(x.EventSource.ValueString(), y.EventSource.ValueString()); c != 0 {
 		return c
 	}
-	// Then CloudWatchLogsConfiguration
 	if c := cmp.Compare(x.CloudWatchLogsConfiguration.String(), y.CloudWatchLogsConfiguration.String()); c != 0 {
 		return c
 	}
-	// Then FirehoseConfiguration
 	if c := cmp.Compare(x.FirehoseConfiguration.String(), y.FirehoseConfiguration.String()); c != 0 {
 		return c
 	}
-	// Finally S3Configuration
 	return cmp.Compare(x.S3Configuration.String(), y.S3Configuration.String())
 }
 
@@ -373,20 +368,16 @@ func logConfigurationsEqualIgnoreOrder(ctx context.Context, a, b fwtypes.ListNes
 		return false
 	}
 
-	// Early length check before expensive operations
 	if len(aSlice) != len(bSlice) {
 		return false
 	}
 
-	// For small slices, avoid sorting overhead
 	if len(aSlice) <= 1 {
 		return gocmp.Equal(aSlice, bSlice)
 	}
 
-	// Sort and compare for larger slices
 	slices.SortFunc(aSlice, compareLogConfigurations)
 	slices.SortFunc(bSlice, compareLogConfigurations)
 
-	// Compare sorted slices using go-cmp
 	return gocmp.Equal(aSlice, bSlice)
 }

--- a/internal/service/cognitoidp/log_delivery_configuration.go
+++ b/internal/service/cognitoidp/log_delivery_configuration.go
@@ -156,16 +156,13 @@ func (r *logDeliveryConfigurationResource) Create(ctx context.Context, req resou
 		return
 	}
 
-	// If the LogConfigurations in the plan are equal to the config except order,
-	// replace LogConfiguration in the plan with the config
+	// Preserve original configuration order if content is equivalent
 	var config resourceLogDeliveryConfigurationModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if logConfigurationsEqualIgnoreOrder(ctx, plan.LogConfigurations, config.LogConfigurations) {
-		plan.LogConfigurations = config.LogConfigurations
-	}
+	r.preserveConfigurationOrder(ctx, &plan, config)
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
@@ -190,18 +187,17 @@ func (r *logDeliveryConfigurationResource) Read(ctx context.Context, req resourc
 	}
 
 	// Save the current LogConfigurations before flex.Flatten overwrites it
-	originalLogConfigurations := state.LogConfigurations
+	originalState := resourceLogDeliveryConfigurationModel{
+		LogConfigurations: state.LogConfigurations,
+	}
 
 	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// If the LogConfigurations in the state are equal to the pre-refreshed one except order,
-	// replace LogConfiguration in the state with the pre-refreshed one
-	if logConfigurationsEqualIgnoreOrder(ctx, state.LogConfigurations, originalLogConfigurations) {
-		state.LogConfigurations = originalLogConfigurations
-	}
+	// Preserve original configuration order if content is equivalent
+	r.preserveConfigurationOrder(ctx, &state, originalState)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -243,16 +239,13 @@ func (r *logDeliveryConfigurationResource) Update(ctx context.Context, req resou
 			return
 		}
 
-		// If the LogConfigurations in the plan are equal to the ones in the config except order,
-		// replace LogConfiguration in the plan with the config
+		// Preserve original configuration order if content is equivalent
 		var config resourceLogDeliveryConfigurationModel
 		resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		if logConfigurationsEqualIgnoreOrder(ctx, plan.LogConfigurations, config.LogConfigurations) {
-			plan.LogConfigurations = config.LogConfigurations
-		}
+		r.preserveConfigurationOrder(ctx, &plan, config)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -334,6 +327,13 @@ type s3ConfigurationModel struct {
 	BucketArn fwtypes.ARN `tfsdk:"bucket_arn"`
 }
 
+// preserveConfigurationOrder replaces plan's LogConfigurations with config's if they are equal ignoring order
+func (r *logDeliveryConfigurationResource) preserveConfigurationOrder(ctx context.Context, plan *resourceLogDeliveryConfigurationModel, config resourceLogDeliveryConfigurationModel) {
+	if logConfigurationsEqualIgnoreOrder(ctx, plan.LogConfigurations, config.LogConfigurations) {
+		plan.LogConfigurations = config.LogConfigurations
+	}
+}
+
 func compareLogConfigurations(x, y logConfigurationModel) int {
 	// Compare LogLevel first
 	if c := cmp.Compare(x.LogLevel.ValueString(), y.LogLevel.ValueString()); c != 0 {
@@ -364,22 +364,28 @@ func logConfigurationsEqualIgnoreOrder(ctx context.Context, a, b fwtypes.ListNes
 		return false
 	}
 
-	// Extract elements to slices
+	// Extract elements to slices with proper error handling
 	var aSlice, bSlice []logConfigurationModel
-	a.ElementsAs(ctx, &aSlice, false)
-	b.ElementsAs(ctx, &bSlice, false)
+	if diag := a.ElementsAs(ctx, &aSlice, false); diag.HasError() {
+		return false
+	}
+	if diag := b.ElementsAs(ctx, &bSlice, false); diag.HasError() {
+		return false
+	}
 
-	// Check lengths
+	// Early length check before expensive operations
 	if len(aSlice) != len(bSlice) {
 		return false
 	}
 
-	// Sort both slices for comparison
-	sortLogConfigurations := func(slice []logConfigurationModel) {
-		slices.SortFunc(slice, compareLogConfigurations)
+	// For small slices, avoid sorting overhead
+	if len(aSlice) <= 1 {
+		return gocmp.Equal(aSlice, bSlice)
 	}
-	sortLogConfigurations(aSlice)
-	sortLogConfigurations(bSlice)
+
+	// Sort and compare for larger slices
+	slices.SortFunc(aSlice, compareLogConfigurations)
+	slices.SortFunc(bSlice, compareLogConfigurations)
 
 	// Compare sorted slices using go-cmp
 	return gocmp.Equal(aSlice, bSlice)

--- a/internal/service/cognitoidp/log_delivery_configuration_test.go
+++ b/internal/service/cognitoidp/log_delivery_configuration_test.go
@@ -4,9 +4,11 @@
 package cognitoidp_test
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
@@ -159,6 +161,54 @@ func TestAccCognitoIDPLogDeliveryConfiguration_multipleLogConfigurationsOrder(t 
 				),
 			},
 			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    testAccLogDeliveryConfigurationImportStateIdFunc(resourceName),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrUserPoolID,
+				ImportStateVerifyIgnore:              []string{"log_configuration"},
+				ImportStateCheck: acctest.ComposeAggregateImportStateCheckFunc(
+					acctest.ImportCheckResourceAttr("log_configurations.#", "2"),
+					func(states []*terraform.InstanceState) error {
+						type logConfiguration struct {
+							eventSource string
+							logLevel    string
+						}
+						got := make([]logConfiguration, 2)
+						expected := []logConfiguration{
+							{eventSource: "userNotification", logLevel: "INFO"},
+							{eventSource: "userAuthEvents", logLevel: "INFO"},
+						}
+						for _, rs := range states {
+							if v, ok := rs.Attributes["log_configurations.0.event_source"]; ok && v != "" {
+								got[0].eventSource = v
+							}
+							if v, ok := rs.Attributes["log_configurations.0.log_level"]; ok && v != "" {
+								got[0].logLevel = v
+							}
+							if v, ok := rs.Attributes["log_configurations.1.event_source"]; ok && v != "" {
+								got[1].eventSource = v
+							}
+							if v, ok := rs.Attributes["log_configurations.1.log_level"]; ok && v != "" {
+								got[1].logLevel = v
+							}
+						}
+						compareFunc := func(a, b logConfiguration) int {
+							return cmp.Compare(a.eventSource, b.eventSource)
+						}
+						slices.SortFunc(got, compareFunc)
+						slices.SortFunc(expected, compareFunc)
+
+						for i := range got {
+							if got[i].eventSource != expected[i].eventSource || got[i].logLevel != expected[i].logLevel {
+								return fmt.Errorf("ImportStateCheck failed: log_configurations did not match expected values. expected: %v, got %v", expected, got)
+							}
+						}
+						return nil
+					},
+				),
+			},
+			{
 				Config: testAccLogDeliveryConfigurationConfig_multipleLogConfigurationsOrder(rName, "ERROR", "INFO"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLogDeliveryConfigurationExists(ctx, resourceName, &logDeliveryConfiguration),
@@ -167,6 +217,15 @@ func TestAccCognitoIDPLogDeliveryConfiguration_multipleLogConfigurationsOrder(t 
 					resource.TestCheckResourceAttr(resourceName, "log_configurations.0.log_level", "ERROR"),
 					resource.TestCheckResourceAttr(resourceName, "log_configurations.1.event_source", "userAuthEvents"),
 					resource.TestCheckResourceAttr(resourceName, "log_configurations.1.log_level", "INFO"),
+				),
+			},
+			{
+				Config: testAccLogDeliveryConfigurationConfig_multipleLogConfigurationsOrderUpdated(rName, "ERROR"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLogDeliveryConfigurationExists(ctx, resourceName, &logDeliveryConfiguration),
+					resource.TestCheckResourceAttr(resourceName, "log_configurations.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_configurations.0.event_source", "userNotification"),
+					resource.TestCheckResourceAttr(resourceName, "log_configurations.0.log_level", "ERROR"),
 				),
 			},
 		},
@@ -472,4 +531,30 @@ resource "aws_cognito_log_delivery_configuration" "test" {
   }
 }
 `, rName, logLevel1, logLevel2)
+}
+
+func testAccLogDeliveryConfigurationConfig_multipleLogConfigurationsOrderUpdated(rName, logLevel1 string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name           = %[1]q
+  user_pool_tier = "PLUS"
+}
+
+resource "aws_cloudwatch_log_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_cognito_log_delivery_configuration" "test" {
+  user_pool_id = aws_cognito_user_pool.test.id
+
+  log_configurations {
+    event_source = "userNotification"
+    log_level    = %[2]q
+
+    cloud_watch_logs_configuration {
+      log_group_arn = aws_cloudwatch_log_group.test.arn
+    }
+  }
+}
+`, rName, logLevel1)
 }

--- a/internal/service/cognitoidp/log_delivery_configuration_test.go
+++ b/internal/service/cognitoidp/log_delivery_configuration_test.go
@@ -133,6 +133,46 @@ func TestAccCognitoIDPLogDeliveryConfiguration_logLevelUpdate(t *testing.T) {
 	})
 }
 
+func TestAccCognitoIDPLogDeliveryConfiguration_multipleLogConfigurationsOrder(t *testing.T) {
+	ctx := acctest.Context(t)
+	var logDeliveryConfiguration awstypes.LogDeliveryConfigurationType
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cognito_log_delivery_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLogDeliveryConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLogDeliveryConfigurationConfig_multipleLogConfigurationsOrder(rName, "INFO", "INFO"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLogDeliveryConfigurationExists(ctx, resourceName, &logDeliveryConfiguration),
+					resource.TestCheckResourceAttr(resourceName, "log_configurations.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "log_configurations.0.event_source", "userNotification"),
+					resource.TestCheckResourceAttr(resourceName, "log_configurations.0.log_level", "INFO"),
+					resource.TestCheckResourceAttr(resourceName, "log_configurations.1.event_source", "userAuthEvents"),
+					resource.TestCheckResourceAttr(resourceName, "log_configurations.1.log_level", "INFO"),
+				),
+			},
+			{
+				Config: testAccLogDeliveryConfigurationConfig_multipleLogConfigurationsOrder(rName, "ERROR", "INFO"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLogDeliveryConfigurationExists(ctx, resourceName, &logDeliveryConfiguration),
+					resource.TestCheckResourceAttr(resourceName, "log_configurations.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "log_configurations.0.event_source", "userNotification"),
+					resource.TestCheckResourceAttr(resourceName, "log_configurations.0.log_level", "ERROR"),
+					resource.TestCheckResourceAttr(resourceName, "log_configurations.1.event_source", "userAuthEvents"),
+					resource.TestCheckResourceAttr(resourceName, "log_configurations.1.log_level", "INFO"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCognitoIDPLogDeliveryConfiguration_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var logDeliveryConfiguration awstypes.LogDeliveryConfigurationType
@@ -398,4 +438,38 @@ resource "aws_cognito_log_delivery_configuration" "test" {
   }
 }
 `, rName, logLevel)
+}
+
+func testAccLogDeliveryConfigurationConfig_multipleLogConfigurationsOrder(rName, logLevel1, logLevel2 string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name           = %[1]q
+  user_pool_tier = "PLUS"
+}
+
+resource "aws_cloudwatch_log_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_cognito_log_delivery_configuration" "test" {
+  user_pool_id = aws_cognito_user_pool.test.id
+
+  log_configurations {
+    event_source = "userNotification"
+    log_level    = %[2]q
+
+    cloud_watch_logs_configuration {
+      log_group_arn = aws_cloudwatch_log_group.test.arn
+    }
+  }
+  log_configurations {
+    event_source = "userAuthEvents"
+    log_level    = %[3]q
+
+    cloud_watch_logs_configuration {
+      log_group_arn = aws_cloudwatch_log_group.test.arn
+    }
+  }
+}
+`, rName, logLevel1, logLevel2)
 }

--- a/internal/service/cognitoidp/log_delivery_configuration_test.go
+++ b/internal/service/cognitoidp/log_delivery_configuration_test.go
@@ -4,11 +4,9 @@
 package cognitoidp_test
 
 import (
-	"cmp"
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"testing"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
@@ -170,38 +168,27 @@ func TestAccCognitoIDPLogDeliveryConfiguration_multipleLogConfigurationsOrder(t 
 				ImportStateCheck: acctest.ComposeAggregateImportStateCheckFunc(
 					acctest.ImportCheckResourceAttr("log_configurations.#", "2"),
 					func(states []*terraform.InstanceState) error {
-						type logConfiguration struct {
-							eventSource string
-							logLevel    string
+						expected := []struct{ eventSource, logLevel string }{
+							{"userNotification", "INFO"},
+							{"userAuthEvents", "INFO"},
 						}
-						got := make([]logConfiguration, 2)
-						expected := []logConfiguration{
-							{eventSource: "userNotification", logLevel: "INFO"},
-							{eventSource: "userAuthEvents", logLevel: "INFO"},
-						}
-						for _, rs := range states {
-							if v, ok := rs.Attributes["log_configurations.0.event_source"]; ok && v != "" {
-								got[0].eventSource = v
-							}
-							if v, ok := rs.Attributes["log_configurations.0.log_level"]; ok && v != "" {
-								got[0].logLevel = v
-							}
-							if v, ok := rs.Attributes["log_configurations.1.event_source"]; ok && v != "" {
-								got[1].eventSource = v
-							}
-							if v, ok := rs.Attributes["log_configurations.1.log_level"]; ok && v != "" {
-								got[1].logLevel = v
-							}
-						}
-						compareFunc := func(a, b logConfiguration) int {
-							return cmp.Compare(a.eventSource, b.eventSource)
-						}
-						slices.SortFunc(got, compareFunc)
-						slices.SortFunc(expected, compareFunc)
 
-						for i := range got {
-							if got[i].eventSource != expected[i].eventSource || got[i].logLevel != expected[i].logLevel {
-								return fmt.Errorf("ImportStateCheck failed: log_configurations did not match expected values. expected: %v, got %v", expected, got)
+						found := make(map[string]string)
+						for _, rs := range states {
+							for i := 0; i < 2; i++ {
+								eventSource := rs.Attributes[fmt.Sprintf("log_configurations.%d.event_source", i)]
+								logLevel := rs.Attributes[fmt.Sprintf("log_configurations.%d.log_level", i)]
+								if eventSource != "" && logLevel != "" {
+									found[eventSource] = logLevel
+								}
+							}
+						}
+
+						for _, exp := range expected {
+							if foundLevel, ok := found[exp.eventSource]; !ok {
+								return fmt.Errorf("expected event_source %s not found", exp.eventSource)
+							} else if foundLevel != exp.logLevel {
+								return fmt.Errorf("expected %s=%s, got %s", exp.eventSource, exp.logLevel, foundLevel)
 							}
 						}
 						return nil


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description


### Relations

Closes #43550


### Output from Acceptance Testing
```console


```
