### PR TITLE
chore: Remove aws.StringSlice usages from aws_ec2_client_vpn_endpoint

### DIFF
--- a/internal/service/ec2/vpnclient_endpoint.go
+++ b/internal/service/ec2/vpnclient_endpoint.go
@@ -373,8 +373,8 @@ func resourceClientVPNEndpointRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set(names.AttrDescription, ep.Description)
 	d.Set("disconnect_on_session_timeout", ep.DisconnectOnSessionTimeout)
 	d.Set(names.AttrDNSName, ep.DnsName)
-	d.Set("dns_servers", aws.StringSlice(ep.DnsServers))
-	d.Set(names.AttrSecurityGroupIDs, aws.StringSlice(ep.SecurityGroupIds))
+	d.Set("dns_servers", ep.DnsServers)
+	d.Set(names.AttrSecurityGroupIDs, ep.SecurityGroupIds)
 	if aws.ToString(ep.SelfServicePortalUrl) != "" {
 		d.Set("self_service_portal", awstypes.SelfServicePortalEnabled)
 	} else {

--- a/internal/service/ec2/vpnclient_endpoint_data_source.go
+++ b/internal/service/ec2/vpnclient_endpoint_data_source.go
@@ -258,8 +258,8 @@ func dataSourceClientVPNEndpointRead(ctx context.Context, d *schema.ResourceData
 	}
 	d.Set(names.AttrDescription, ep.Description)
 	d.Set(names.AttrDNSName, ep.DnsName)
-	d.Set("dns_servers", aws.StringSlice(ep.DnsServers))
-	d.Set(names.AttrSecurityGroupIDs, aws.StringSlice(ep.SecurityGroupIds))
+	d.Set("dns_servers", ep.DnsServers)
+	d.Set(names.AttrSecurityGroupIDs, ep.SecurityGroupIds)
 	if aws.ToString(ep.SelfServicePortalUrl) != "" {
 		d.Set("self_service_portal", awstypes.SelfServicePortalEnabled)
 	} else {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to remove `aws.StringSlice` usage from the `aws_ec2_client_vpn_endpoint` resource and data source, specifically for the `dns_servers` and `security_group_ids` arguments.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41800

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccClientVPNEndpoint_serial/Endpoint PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccClientVPNEndpoint_serial/Endpoint'  -timeout 360m -vet=off
2025/08/10 03:16:07 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/10 03:16:07 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccClientVPNEndpoint_serial
=== PAUSE TestAccClientVPNEndpoint_serial
=== CONT  TestAccClientVPNEndpoint_serial
=== RUN   TestAccClientVPNEndpoint_serial/AuthorizationRule_disappearsEndpoint       
=== PAUSE TestAccClientVPNEndpoint_serial/AuthorizationRule_disappearsEndpoint
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_vpcNoSecurityGroups
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_vpcNoSecurityGroups
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_disappears
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_disappears
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_msADAuthAndMutualAuth
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_msADAuthAndMutualAuth
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_simpleAttributesUpdate
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_simpleAttributesUpdate
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_vpcSecurityGroups
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_vpcSecurityGroups
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_withLogGroup
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_withLogGroup
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_withDNSServers
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_withDNSServers
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_tags
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_tags
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_basicDataSource
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_basicDataSource
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_withClientRouteEnforcement
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_withClientRouteEnforcement
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_basic
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_basic
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_msADAuth
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_msADAuth
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_federatedAuth
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_federatedAuth
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_federatedAuthWithSelfService
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_federatedAuthWithSelfService
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_withClientConnect
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_withClientConnect
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_withClientLoginBanner
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_withClientLoginBanner
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_selfServicePortal
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_selfServicePortal
=== CONT  TestAccClientVPNEndpoint_serial/AuthorizationRule_disappearsEndpoint
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_basicDataSource
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_federatedAuthWithSelfService      
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_vpcSecurityGroups
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_federatedAuth
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_selfServicePortal
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_disappears
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_withDNSServers
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_tags
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_basic
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_withClientLoginBanner
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_withClientRouteEnforcement        
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_withClientConnect
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_msADAuthAndMutualAuth
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_withLogGroup
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_simpleAttributesUpdate
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_vpcNoSecurityGroups
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_msADAuth
--- PASS: TestAccClientVPNEndpoint_serial (5.13s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_federatedAuth (36.20s)        
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_basicDataSource (36.45s)      
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_federatedAuthWithSelfService (37.95s)
    --- PASS: TestAccClientVPNEndpoint_serial/AuthorizationRule_disappearsEndpoint (56.74s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_vpcSecurityGroups (57.24s)    
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_disappears (60.09s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_selfServicePortal (78.74s)    
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_basic (83.16s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_tags (95.25s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_withClientRouteEnforcement (99.35s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_withDNSServers (109.89s)      
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_withClientLoginBanner (128.38s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_simpleAttributesUpdate (147.63s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_vpcNoSecurityGroups (158.48s) 
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_withLogGroup (165.25s)        
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_withClientConnect (184.51s)   
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_msADAuthAndMutualAuth (1853.03s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_msADAuth (1879.72s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        1885.096s

$
```
