### PR TITLE
chore: Remove aws.StringSlice usage from r/aws_iot_indexing_configuration

### DIFF
--- a/internal/service/iot/indexing_configuration.go
+++ b/internal/service/iot/indexing_configuration.go
@@ -292,7 +292,7 @@ func flattenIndexingFilter(apiObject *awstypes.IndexingFilter) map[string]any {
 	tfMap := map[string]any{}
 
 	if v := apiObject.NamedShadowNames; v != nil {
-		tfMap["named_shadow_names"] = aws.StringSlice(v)
+		tfMap["named_shadow_names"] = v
 	}
 
 	return tfMap


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
his PR is to remove `aws.StringSlice` usage from the `aws_iot_indexing_configuration` resource, specifically for the `named_shadow_names` argument.

**Note:** The test case `TestAccIoTIndexingConfiguration_serial/Identity/ExistingResource` is failing for an unrelated reason.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41800

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccIoTIndexingConfiguration_serial PKG=iot
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/iot/... -v -count 1 -parallel 20 -run='TestAccIoTIndexingConfiguration_serial'  -timeout 360m -vet=off
2025/08/10 03:59:36 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/10 03:59:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIoTIndexingConfiguration_serial
=== PAUSE TestAccIoTIndexingConfiguration_serial
=== CONT  TestAccIoTIndexingConfiguration_serial
=== RUN   TestAccIoTIndexingConfiguration_serial/basic
=== RUN   TestAccIoTIndexingConfiguration_serial/allAttributes
=== RUN   TestAccIoTIndexingConfiguration_serial/Identity
=== RUN   TestAccIoTIndexingConfiguration_serial/Identity/basic
=== RUN   TestAccIoTIndexingConfiguration_serial/Identity/ExistingResource
    indexing_configuration_identity_gen_test.go:220: Step 1/3 error: Post-apply refresh state check(s) failed:
        aws_iot_indexing_configuration.test - Identity found in state, and was not expected.
=== RUN   TestAccIoTIndexingConfiguration_serial/Identity/RegionOverride
--- FAIL: TestAccIoTIndexingConfiguration_serial (126.52s)
    --- PASS: TestAccIoTIndexingConfiguration_serial/basic (16.75s)
    --- PASS: TestAccIoTIndexingConfiguration_serial/allAttributes (17.35s)
    --- FAIL: TestAccIoTIndexingConfiguration_serial/Identity (92.43s)
        --- PASS: TestAccIoTIndexingConfiguration_serial/Identity/basic (25.24s)     
        --- FAIL: TestAccIoTIndexingConfiguration_serial/Identity/ExistingResource (34.78s)
        --- PASS: TestAccIoTIndexingConfiguration_serial/Identity/RegionOverride (32.41s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/iot        126.857s
FAIL
make: *** [GNUmakefile:645: testacc] Error 1

$
```
