### PR TITLE
[Docs]r/aws_flow_log: Add an example for cross-account Data Firehose logging for VPC flow logs

### DIFF
--- a/website/docs/r/flow_log.html.markdown
+++ b/website/docs/r/flow_log.html.markdown
@@ -247,6 +247,7 @@ data "aws_iam_policy_document" "src_role_policy" {
     resources = [aws_iam_role.dst.arn]
   }
 }
+
 resource "aws_iam_role_policy" "src_policy" {
   name   = "tf-example-mySourceRolePolicy"
   role   = aws_iam_role.src.name


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Add an (almost) complete example configuration for cross-account Data Firehose logging for a VPC flow log.

  * Confirmed to work as expected in my environment.
* Improve descriptions of several arguments related to IAM roles.

### Relations

Closes #43747

### References
https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-firehose.html
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFlowLogs.html

