### PR TITLE
chore: Remove aws.StringSlice usages from r/aws_iot_topic_rule_destination

### DIFF
--- a/internal/service/iot/topic_rule_destination.go
+++ b/internal/service/iot/topic_rule_destination.go
@@ -405,11 +405,11 @@ func flattenVPCDestinationProperties(apiObject *awstypes.VpcDestinationPropertie
 	}
 
 	if v := apiObject.SecurityGroups; v != nil {
-		tfMap[names.AttrSecurityGroups] = aws.StringSlice(v)
+		tfMap[names.AttrSecurityGroups] = v
 	}
 
 	if v := apiObject.SubnetIds; v != nil {
-		tfMap[names.AttrSubnetIDs] = aws.StringSlice(v)
+		tfMap[names.AttrSubnetIDs] = v
 	}
 
 	if v := apiObject.VpcId; v != nil {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR is to remove `aws.StringSlice` usages from the `aws_iot_topic_rule_destination` resource, specifically for the `security_groups` and `subnet_ids` arguments.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41800 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccIoTTopicRuleDestination_ PKG=iot
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/iot/... -v -count 1 -parallel 20 -run='TestAccIoTTopicRuleDestination_'  -timeout 360m -vet=off
2025/08/10 04:19:04 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/10 04:19:04 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIoTTopicRuleDestination_basic
=== PAUSE TestAccIoTTopicRuleDestination_basic
=== RUN   TestAccIoTTopicRuleDestination_disappears
=== PAUSE TestAccIoTTopicRuleDestination_disappears
=== RUN   TestAccIoTTopicRuleDestination_enabled
=== PAUSE TestAccIoTTopicRuleDestination_enabled
=== CONT  TestAccIoTTopicRuleDestination_basic
=== CONT  TestAccIoTTopicRuleDestination_enabled
=== CONT  TestAccIoTTopicRuleDestination_disappears
--- PASS: TestAccIoTTopicRuleDestination_basic (652.16s)
--- PASS: TestAccIoTTopicRuleDestination_disappears (652.83s)
--- PASS: TestAccIoTTopicRuleDestination_enabled (1759.90s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iot        1760.198s

$
```
