### PR TITLE
chore: Remove aws.StringSlice usages from r/aws_storagegateway_smb_file_share

### DIFF
--- a/internal/service/storagegateway/smb_file_share.go
+++ b/internal/service/storagegateway/smb_file_share.go
@@ -319,7 +319,7 @@ func resourceSMBFileShareRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	d.Set("access_based_enumeration", fileshare.AccessBasedEnumeration)
-	d.Set("admin_user_list", aws.StringSlice(fileshare.AdminUserList))
+	d.Set("admin_user_list", fileshare.AdminUserList)
 	d.Set(names.AttrARN, fileshare.FileShareARN)
 	d.Set("audit_destination_arn", fileshare.AuditDestinationARN)
 	d.Set("authentication", fileshare.Authentication)
@@ -337,7 +337,7 @@ func resourceSMBFileShareRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("file_share_name", fileshare.FileShareName)
 	d.Set("gateway_arn", fileshare.GatewayARN)
 	d.Set("guess_mime_type_enabled", fileshare.GuessMIMETypeEnabled)
-	d.Set("invalid_user_list", aws.StringSlice(fileshare.InvalidUserList))
+	d.Set("invalid_user_list", fileshare.InvalidUserList)
 	d.Set("kms_encrypted", fileshare.KMSEncrypted) //nolint:staticcheck // deprecated by AWS, but must remain for backward compatibility
 	d.Set(names.AttrKMSKeyARN, fileshare.KMSKey)
 	d.Set("location_arn", fileshare.LocationARN)
@@ -349,7 +349,7 @@ func resourceSMBFileShareRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("requester_pays", fileshare.RequesterPays)
 	d.Set(names.AttrRoleARN, fileshare.Role)
 	d.Set("smb_acl_enabled", fileshare.SMBACLEnabled)
-	d.Set("valid_user_list", aws.StringSlice(fileshare.ValidUserList))
+	d.Set("valid_user_list", fileshare.ValidUserList)
 	d.Set("vpc_endpoint_dns_name", fileshare.VPCEndpointDNSName)
 
 	setTagsOut(ctx, fileshare.Tags)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to remove `aws.StringSlice` usages from the `aws_storagegateway_smb_file_share` resource, specifically for the security_groups and `admin_user_list`, `invalid_user_list`, and `valid_user_list` arguments.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41800

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccStorageGatewaySMBFileShare_ PKG=storagegateway
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/storagegateway/... -v -count 1 -parallel 8 -run='TestAccStorageGatewaySMBFileShare_'  -timeout 360m -vet=off
2025/08/10 12:58:29 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/10 12:58:29 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccStorageGatewaySMBFileShare_Authentication_activeDirectory
=== PAUSE TestAccStorageGatewaySMBFileShare_Authentication_activeDirectory
=== RUN   TestAccStorageGatewaySMBFileShare_Authentication_guestAccess
=== PAUSE TestAccStorageGatewaySMBFileShare_Authentication_guestAccess
=== RUN   TestAccStorageGatewaySMBFileShare_accessBasedEnumeration
=== PAUSE TestAccStorageGatewaySMBFileShare_accessBasedEnumeration
=== RUN   TestAccStorageGatewaySMBFileShare_notificationPolicy
=== PAUSE TestAccStorageGatewaySMBFileShare_notificationPolicy
=== RUN   TestAccStorageGatewaySMBFileShare_defaultStorageClass
=== PAUSE TestAccStorageGatewaySMBFileShare_defaultStorageClass
=== RUN   TestAccStorageGatewaySMBFileShare_encryptedUpdate
=== PAUSE TestAccStorageGatewaySMBFileShare_encryptedUpdate
=== RUN   TestAccStorageGatewaySMBFileShare_fileShareName
=== PAUSE TestAccStorageGatewaySMBFileShare_fileShareName
=== RUN   TestAccStorageGatewaySMBFileShare_tags
=== PAUSE TestAccStorageGatewaySMBFileShare_tags
=== RUN   TestAccStorageGatewaySMBFileShare_guessMIMETypeEnabled
=== PAUSE TestAccStorageGatewaySMBFileShare_guessMIMETypeEnabled
=== RUN   TestAccStorageGatewaySMBFileShare_invalidUserList
=== PAUSE TestAccStorageGatewaySMBFileShare_invalidUserList
=== RUN   TestAccStorageGatewaySMBFileShare_kmsEncrypted
=== PAUSE TestAccStorageGatewaySMBFileShare_kmsEncrypted
=== RUN   TestAccStorageGatewaySMBFileShare_kmsKeyARN
=== PAUSE TestAccStorageGatewaySMBFileShare_kmsKeyARN
=== RUN   TestAccStorageGatewaySMBFileShare_objectACL
=== PAUSE TestAccStorageGatewaySMBFileShare_objectACL
=== RUN   TestAccStorageGatewaySMBFileShare_readOnly
=== PAUSE TestAccStorageGatewaySMBFileShare_readOnly
=== RUN   TestAccStorageGatewaySMBFileShare_requesterPays
=== PAUSE TestAccStorageGatewaySMBFileShare_requesterPays
=== RUN   TestAccStorageGatewaySMBFileShare_validUserList
=== PAUSE TestAccStorageGatewaySMBFileShare_validUserList
=== RUN   TestAccStorageGatewaySMBFileShare_SMB_acl
=== PAUSE TestAccStorageGatewaySMBFileShare_SMB_acl
=== RUN   TestAccStorageGatewaySMBFileShare_audit
=== PAUSE TestAccStorageGatewaySMBFileShare_audit
=== RUN   TestAccStorageGatewaySMBFileShare_cacheAttributes
=== PAUSE TestAccStorageGatewaySMBFileShare_cacheAttributes
=== RUN   TestAccStorageGatewaySMBFileShare_caseSensitivity
=== PAUSE TestAccStorageGatewaySMBFileShare_caseSensitivity
=== RUN   TestAccStorageGatewaySMBFileShare_disappears
=== PAUSE TestAccStorageGatewaySMBFileShare_disappears
=== RUN   TestAccStorageGatewaySMBFileShare_adminUserList
=== PAUSE TestAccStorageGatewaySMBFileShare_adminUserList
=== CONT  TestAccStorageGatewaySMBFileShare_Authentication_activeDirectory
=== CONT  TestAccStorageGatewaySMBFileShare_kmsKeyARN
=== CONT  TestAccStorageGatewaySMBFileShare_fileShareName
=== CONT  TestAccStorageGatewaySMBFileShare_invalidUserList
=== CONT  TestAccStorageGatewaySMBFileShare_defaultStorageClass
=== CONT  TestAccStorageGatewaySMBFileShare_notificationPolicy
=== CONT  TestAccStorageGatewaySMBFileShare_encryptedUpdate
=== CONT  TestAccStorageGatewaySMBFileShare_guessMIMETypeEnabled
--- PASS: TestAccStorageGatewaySMBFileShare_guessMIMETypeEnabled (250.24s)
=== CONT  TestAccStorageGatewaySMBFileShare_kmsEncrypted
--- PASS: TestAccStorageGatewaySMBFileShare_defaultStorageClass (262.62s)
=== CONT  TestAccStorageGatewaySMBFileShare_audit
--- PASS: TestAccStorageGatewaySMBFileShare_encryptedUpdate (266.27s)
=== CONT  TestAccStorageGatewaySMBFileShare_adminUserList
--- PASS: TestAccStorageGatewaySMBFileShare_fileShareName (283.45s)
=== CONT  TestAccStorageGatewaySMBFileShare_disappears
--- PASS: TestAccStorageGatewaySMBFileShare_notificationPolicy (322.01s)
=== CONT  TestAccStorageGatewaySMBFileShare_caseSensitivity
--- PASS: TestAccStorageGatewaySMBFileShare_kmsKeyARN (323.89s)
=== CONT  TestAccStorageGatewaySMBFileShare_cacheAttributes
--- PASS: TestAccStorageGatewaySMBFileShare_kmsEncrypted (229.81s)
=== CONT  TestAccStorageGatewaySMBFileShare_tags
--- PASS: TestAccStorageGatewaySMBFileShare_disappears (215.11s)
=== CONT  TestAccStorageGatewaySMBFileShare_accessBasedEnumeration
--- PASS: TestAccStorageGatewaySMBFileShare_audit (278.34s)
=== CONT  TestAccStorageGatewaySMBFileShare_requesterPays
--- PASS: TestAccStorageGatewaySMBFileShare_caseSensitivity (319.99s)
=== CONT  TestAccStorageGatewaySMBFileShare_SMB_acl
--- PASS: TestAccStorageGatewaySMBFileShare_cacheAttributes (325.89s)
=== CONT  TestAccStorageGatewaySMBFileShare_validUserList
--- PASS: TestAccStorageGatewaySMBFileShare_tags (275.00s)
=== CONT  TestAccStorageGatewaySMBFileShare_readOnly
--- PASS: TestAccStorageGatewaySMBFileShare_requesterPays (267.58s)
=== CONT  TestAccStorageGatewaySMBFileShare_objectACL
--- PASS: TestAccStorageGatewaySMBFileShare_accessBasedEnumeration (317.92s)
=== CONT  TestAccStorageGatewaySMBFileShare_Authentication_guestAccess
--- PASS: TestAccStorageGatewaySMBFileShare_invalidUserList (887.94s)
--- PASS: TestAccStorageGatewaySMBFileShare_Authentication_guestAccess (204.92s)
--- PASS: TestAccStorageGatewaySMBFileShare_Authentication_activeDirectory (1035.74s)
--- PASS: TestAccStorageGatewaySMBFileShare_readOnly (281.99s)
--- PASS: TestAccStorageGatewaySMBFileShare_objectACL (259.54s)
--- PASS: TestAccStorageGatewaySMBFileShare_adminUserList (1074.27s)
--- PASS: TestAccStorageGatewaySMBFileShare_SMB_acl (887.48s)
--- PASS: TestAccStorageGatewaySMBFileShare_validUserList (897.06s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway     1547.189s

$
```
