### PR TITLE
chore: Remove aws.StringSlice usage from r/aws_imagebuilder_image_pipeline

### DIFF
--- a/internal/service/imagebuilder/image_pipeline.go
+++ b/internal/service/imagebuilder/image_pipeline.go
@@ -590,7 +590,7 @@ func flattenECRConfiguration(apiObject *awstypes.EcrConfiguration) map[string]an
 	}
 
 	if v := apiObject.ContainerTags; v != nil {
-		tfMap["container_tags"] = aws.StringSlice(v)
+		tfMap["container_tags"] = v
 	}
 
 	return tfMap


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to remove `aws.StringSlice` usage from the `aws_imagebuilder_image_pipeline` resource, specifically for the `container_tags` argument.

Note that the acceptance test case `TestAccImageBuilderImagePipeline_Identity_ExistingResource` but it is failing for the usual reason, that it doesn't seem to be using the old provider. It's not related to this change so I'll ignore it for now.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41800

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS="TestAccImageBuilderImagePipeline_" PKG=imagebuilder
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderImagePipeline_'  -timeout 360m -vet=off
2025/08/10 22:51:34 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/10 22:51:34 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccImageBuilderImagePipeline_Identity_Basic
=== PAUSE TestAccImageBuilderImagePipeline_Identity_Basic
=== RUN   TestAccImageBuilderImagePipeline_Identity_RegionOverride
=== PAUSE TestAccImageBuilderImagePipeline_Identity_RegionOverride
=== RUN   TestAccImageBuilderImagePipeline_Identity_ExistingResource
=== PAUSE TestAccImageBuilderImagePipeline_Identity_ExistingResource
=== RUN   TestAccImageBuilderImagePipeline_basic
=== PAUSE TestAccImageBuilderImagePipeline_basic
=== RUN   TestAccImageBuilderImagePipeline_disappears
=== PAUSE TestAccImageBuilderImagePipeline_disappears
=== RUN   TestAccImageBuilderImagePipeline_description
=== PAUSE TestAccImageBuilderImagePipeline_description
=== RUN   TestAccImageBuilderImagePipeline_distributionARN
=== PAUSE TestAccImageBuilderImagePipeline_distributionARN
=== RUN   TestAccImageBuilderImagePipeline_enhancedImageMetadataEnabled
=== PAUSE TestAccImageBuilderImagePipeline_enhancedImageMetadataEnabled
=== RUN   TestAccImageBuilderImagePipeline_imageRecipeARN
=== PAUSE TestAccImageBuilderImagePipeline_imageRecipeARN
=== RUN   TestAccImageBuilderImagePipeline_containerRecipeARN
=== PAUSE TestAccImageBuilderImagePipeline_containerRecipeARN
=== RUN   TestAccImageBuilderImagePipeline_ImageScanning_imageScanningEnabled
=== PAUSE TestAccImageBuilderImagePipeline_ImageScanning_imageScanningEnabled
=== RUN   TestAccImageBuilderImagePipeline_ImageScanning_imageScanningEnabledAdvanced
=== PAUSE TestAccImageBuilderImagePipeline_ImageScanning_imageScanningEnabledAdvanced
=== RUN   TestAccImageBuilderImagePipeline_ImageTests_imageTestsEnabled
=== PAUSE TestAccImageBuilderImagePipeline_ImageTests_imageTestsEnabled
=== RUN   TestAccImageBuilderImagePipeline_ImageTests_timeoutMinutes
=== PAUSE TestAccImageBuilderImagePipeline_ImageTests_timeoutMinutes
=== RUN   TestAccImageBuilderImagePipeline_infrastructureARN
=== PAUSE TestAccImageBuilderImagePipeline_infrastructureARN
=== RUN   TestAccImageBuilderImagePipeline_Schedule_pipelineExecutionStartCondition
=== PAUSE TestAccImageBuilderImagePipeline_Schedule_pipelineExecutionStartCondition
=== RUN   TestAccImageBuilderImagePipeline_Schedule_scheduleExpression
=== PAUSE TestAccImageBuilderImagePipeline_Schedule_scheduleExpression
=== RUN   TestAccImageBuilderImagePipeline_Schedule_timezone
=== PAUSE TestAccImageBuilderImagePipeline_Schedule_timezone
=== RUN   TestAccImageBuilderImagePipeline_status
=== PAUSE TestAccImageBuilderImagePipeline_status
=== RUN   TestAccImageBuilderImagePipeline_tags
=== PAUSE TestAccImageBuilderImagePipeline_tags
=== RUN   TestAccImageBuilderImagePipeline_workflow
=== PAUSE TestAccImageBuilderImagePipeline_workflow
=== RUN   TestAccImageBuilderImagePipeline_workflowParameter
=== PAUSE TestAccImageBuilderImagePipeline_workflowParameter
=== CONT  TestAccImageBuilderImagePipeline_Identity_Basic
=== CONT  TestAccImageBuilderImagePipeline_ImageScanning_imageScanningEnabledAdvanced
=== CONT  TestAccImageBuilderImagePipeline_distributionARN
=== CONT  TestAccImageBuilderImagePipeline_status
=== CONT  TestAccImageBuilderImagePipeline_basic
=== CONT  TestAccImageBuilderImagePipeline_description
=== CONT  TestAccImageBuilderImagePipeline_infrastructureARN
=== CONT  TestAccImageBuilderImagePipeline_containerRecipeARN
=== CONT  TestAccImageBuilderImagePipeline_ImageScanning_imageScanningEnabled
=== CONT  TestAccImageBuilderImagePipeline_disappears
=== CONT  TestAccImageBuilderImagePipeline_imageRecipeARN
=== CONT  TestAccImageBuilderImagePipeline_workflowParameter
=== CONT  TestAccImageBuilderImagePipeline_workflow
=== CONT  TestAccImageBuilderImagePipeline_tags
=== CONT  TestAccImageBuilderImagePipeline_enhancedImageMetadataEnabled
=== CONT  TestAccImageBuilderImagePipeline_Identity_ExistingResource
=== CONT  TestAccImageBuilderImagePipeline_Schedule_scheduleExpression
=== CONT  TestAccImageBuilderImagePipeline_Schedule_timezone
=== CONT  TestAccImageBuilderImagePipeline_ImageTests_timeoutMinutes
=== CONT  TestAccImageBuilderImagePipeline_Identity_RegionOverride
=== NAME  TestAccImageBuilderImagePipeline_Identity_ExistingResource
    image_pipeline_identity_gen_test.go:234: Step 1/2 error: Post-apply refresh state check(s) failed:
        aws_imagebuilder_image_pipeline.test - Identity found in state, and was not expected.
--- PASS: TestAccImageBuilderImagePipeline_disappears (57.29s)
=== CONT  TestAccImageBuilderImagePipeline_ImageTests_imageTestsEnabled
--- PASS: TestAccImageBuilderImagePipeline_basic (58.79s)
=== CONT  TestAccImageBuilderImagePipeline_Schedule_pipelineExecutionStartCondition
--- FAIL: TestAccImageBuilderImagePipeline_Identity_ExistingResource (63.59s)
--- PASS: TestAccImageBuilderImagePipeline_ImageScanning_imageScanningEnabled (90.11s)
--- PASS: TestAccImageBuilderImagePipeline_status (91.72s)
--- PASS: TestAccImageBuilderImagePipeline_description (92.24s)
--- PASS: TestAccImageBuilderImagePipeline_workflowParameter (94.78s)
--- PASS: TestAccImageBuilderImagePipeline_enhancedImageMetadataEnabled (95.74s)
--- PASS: TestAccImageBuilderImagePipeline_imageRecipeARN (95.81s)
--- PASS: TestAccImageBuilderImagePipeline_containerRecipeARN (97.23s)
--- PASS: TestAccImageBuilderImagePipeline_infrastructureARN (97.36s)
--- PASS: TestAccImageBuilderImagePipeline_ImageScanning_imageScanningEnabledAdvanced (97.36s)
--- PASS: TestAccImageBuilderImagePipeline_Schedule_timezone (97.40s)
--- PASS: TestAccImageBuilderImagePipeline_ImageTests_timeoutMinutes (97.52s)
--- PASS: TestAccImageBuilderImagePipeline_Identity_Basic (98.19s)
--- PASS: TestAccImageBuilderImagePipeline_distributionARN (98.68s)
--- PASS: TestAccImageBuilderImagePipeline_workflow (101.38s)
--- PASS: TestAccImageBuilderImagePipeline_Schedule_scheduleExpression (102.28s)
--- PASS: TestAccImageBuilderImagePipeline_Identity_RegionOverride (108.34s)
--- PASS: TestAccImageBuilderImagePipeline_tags (111.83s)
--- PASS: TestAccImageBuilderImagePipeline_ImageTests_imageTestsEnabled (61.14s)
--- PASS: TestAccImageBuilderImagePipeline_Schedule_pipelineExecutionStartCondition (61.86s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       120.984s
FAIL
make: *** [GNUmakefile:645: testacc] Error 1

$
```
