### PR TITLE
Fix SageMaker user profile regex

### DIFF
--- a/.changelog/43807.txt
+++ b/.changelog/43807.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sagemaker_user_profile: Fix incomplete regex for `user_profile_name`
+```

--- a/internal/service/sagemaker/user_profile.go
+++ b/internal/service/sagemaker/user_profile.go
@@ -78,7 +78,7 @@ func resourceUserProfile() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 63),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z](-*[0-9A-Za-z]){0,62}`), "Valid characters are a-z, A-Z, 0-9, and - (hyphen)."),
+					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z](-*[0-9A-Za-z]){0,62}$`), "Valid characters are a-z, A-Z, 0-9, and - (hyphen)."),
 				),
 			},
 			"user_settings": {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

n/a

### Description

This is a minor change to the regex matching pattern for SageMaker user profiles, as it had not caught many failure cases until an apply

### Relations
 
n/a

### References

I'm not entirely sure how to make sure this gets properly tested. The testing cases are a little over my head.

### Output from Acceptance Testing

I have not yet run any acceptance testing, but will update when I have, just wanted to get the PR open

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
