### PR TITLE
chore: Remove aws.StringSlice usages from r/aws_imagebuilder_distribution_configuration

### DIFF
--- a/internal/service/imagebuilder/distribution_configuration.go
+++ b/internal/service/imagebuilder/distribution_configuration.go
@@ -896,7 +896,7 @@ func flattenAMIDistributionConfiguration(apiObject *awstypes.AmiDistributionConf
 	}
 
 	if v := apiObject.TargetAccountIds; v != nil {
-		tfMap["target_account_ids"] = aws.StringSlice(v)
+		tfMap["target_account_ids"] = v
 	}
 
 	return tfMap
@@ -910,7 +910,7 @@ func flattenContainerDistributionConfiguration(apiObject *awstypes.ContainerDist
 	tfMap := map[string]any{}
 
 	if v := apiObject.ContainerTags; v != nil {
-		tfMap["container_tags"] = aws.StringSlice(v)
+		tfMap["container_tags"] = v
 	}
 
 	if v := apiObject.Description; v != nil {
@@ -958,7 +958,7 @@ func flattenDistribution(apiObject awstypes.Distribution) map[string]any {
 	}
 
 	if v := apiObject.LicenseConfigurationArns; v != nil {
-		tfMap["license_configuration_arns"] = aws.StringSlice(v)
+		tfMap["license_configuration_arns"] = v
 	}
 
 	if v := apiObject.Region; v != nil {
@@ -998,19 +998,19 @@ func flattenLaunchPermissionConfiguration(apiObject *awstypes.LaunchPermissionCo
 	tfMap := map[string]any{}
 
 	if v := apiObject.OrganizationArns; v != nil {
-		tfMap["organization_arns"] = aws.StringSlice(v)
+		tfMap["organization_arns"] = v
 	}
 
 	if v := apiObject.OrganizationalUnitArns; v != nil {
-		tfMap["organizational_unit_arns"] = aws.StringSlice(v)
+		tfMap["organizational_unit_arns"] = v
 	}
 
 	if v := apiObject.UserGroups; v != nil {
-		tfMap["user_groups"] = aws.StringSlice(v)
+		tfMap["user_groups"] = v
 	}
 
 	if v := apiObject.UserIds; v != nil {
-		tfMap["user_ids"] = aws.StringSlice(v)
+		tfMap["user_ids"] = v
 	}
 
 	return tfMap


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to remove `aws.StringSlice` usage from the `aws_imagebuilder_distribution_configuration` resource, specifically for the following arguments:

- `target_account_ids`
- `container_tags`
- `license_configuration_arns`
- `organization_arns`
- `organizational_unit_arns`
- `user_groups`
- `user_ids`

Note that the acceptance test case `TestAccImageBuilderDistributionConfiguration_Identity_ExistingResource ` but it is failing for the usual reason, that it doesn't seem to be using the old provider. It's not related to this change so I'll ignore it for now.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41800

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccImageBuilderDistributionConfiguration_ PKG=imagebuilder
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderDistributionConfiguration_'  -timeout 360m -vet=off
2025/08/10 23:54:49 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/10 23:54:49 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccImageBuilderDistributionConfiguration_Identity_Basic
=== PAUSE TestAccImageBuilderDistributionConfiguration_Identity_Basic
=== RUN   TestAccImageBuilderDistributionConfiguration_Identity_RegionOverride
=== PAUSE TestAccImageBuilderDistributionConfiguration_Identity_RegionOverride
=== RUN   TestAccImageBuilderDistributionConfiguration_Identity_ExistingResource
=== PAUSE TestAccImageBuilderDistributionConfiguration_Identity_ExistingResource
=== RUN   TestAccImageBuilderDistributionConfiguration_basic
=== PAUSE TestAccImageBuilderDistributionConfiguration_basic
=== RUN   TestAccImageBuilderDistributionConfiguration_disappears
=== PAUSE TestAccImageBuilderDistributionConfiguration_disappears
=== RUN   TestAccImageBuilderDistributionConfiguration_description
=== PAUSE TestAccImageBuilderDistributionConfiguration_description
=== RUN   TestAccImageBuilderDistributionConfiguration_distribution
=== PAUSE TestAccImageBuilderDistributionConfiguration_distribution
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_amiTags
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_amiTags
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_description
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_description
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_kmsKeyID
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_kmsKeyID
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_userGroups
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_userGroups
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_userIDs
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_userIDs
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_organizationARNs
    distribution_configuration_test.go:354: skipping tests; this AWS account must not be an existing member of an AWS Organization
--- SKIP: TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_organizationARNs (0.80s)
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_ouARNs
    distribution_configuration_test.go:387: skipping tests; this AWS account must not be an existing member of an AWS Organization
--- SKIP: TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_ouARNs (0.14s)
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_name
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_name
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_targetAccountIDs
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_targetAccountIDs
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_containerTags
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_containerTags
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_description
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_description
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_targetRepository
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_targetRepository
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_enabled
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_enabled
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_launchTemplate
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_launchTemplate
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_maxParallelLaunches
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_maxParallelLaunches
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_snapshotConfiguration
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_snapshotConfiguration
=== RUN   TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateConfiguration
=== PAUSE TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateConfiguration
=== RUN   TestAccImageBuilderDistributionConfiguration_Distribution_licenseARNs
=== PAUSE TestAccImageBuilderDistributionConfiguration_Distribution_licenseARNs
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionS3Export_diskImageFormatRaw
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionS3Export_diskImageFormatRaw
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionS3Export_diskImageFormatVhd
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionS3Export_diskImageFormatVhd
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionS3Export_diskImageFormatVmdk
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionS3Export_diskImageFormatVmdk
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionS3Export_roleName
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionS3Export_roleName
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionS3Export_s3Bucket
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionS3Export_s3Bucket
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionS3Export_s3Prefix
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionS3Export_s3Prefix
=== RUN   TestAccImageBuilderDistributionConfiguration_ssmParameterConfiguration
=== PAUSE TestAccImageBuilderDistributionConfiguration_ssmParameterConfiguration
=== RUN   TestAccImageBuilderDistributionConfiguration_tags
=== PAUSE TestAccImageBuilderDistributionConfiguration_tags
=== CONT  TestAccImageBuilderDistributionConfiguration_Identity_Basic
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_targetRepository
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_description
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionS3Export_diskImageFormatVhd
=== CONT  TestAccImageBuilderDistributionConfiguration_distribution
=== CONT  TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateConfiguration
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_targetAccountIDs
=== CONT  TestAccImageBuilderDistributionConfiguration_ssmParameterConfiguration
=== CONT  TestAccImageBuilderDistributionConfiguration_Identity_ExistingResource
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_amiTags
=== CONT  TestAccImageBuilderDistributionConfiguration_basic
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_snapshotConfiguration
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionS3Export_diskImageFormatRaw
=== CONT  TestAccImageBuilderDistributionConfiguration_Distribution_licenseARNs
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_name
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_description
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_containerTags
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionS3Export_s3Prefix
=== CONT  TestAccImageBuilderDistributionConfiguration_tags
=== CONT  TestAccImageBuilderDistributionConfiguration_disappears
--- PASS: TestAccImageBuilderDistributionConfiguration_disappears (46.66s)
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_userIDs
--- PASS: TestAccImageBuilderDistributionConfiguration_ssmParameterConfiguration (54.05s)
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_userGroups
=== NAME  TestAccImageBuilderDistributionConfiguration_Identity_ExistingResource
    distribution_configuration_identity_gen_test.go:234: Step 1/2 error: Post-apply refresh state check(s) failed:
        aws_imagebuilder_distribution_configuration.test - Identity found in state, and was not expected.
--- PASS: TestAccImageBuilderDistributionConfiguration_basic (56.65s)
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_launchTemplate
--- FAIL: TestAccImageBuilderDistributionConfiguration_Identity_ExistingResource (75.04s)
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_kmsKeyID
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_description (86.47s)
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_maxParallelLaunches
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_amiTags (86.73s)
=== CONT  TestAccImageBuilderDistributionConfiguration_Identity_RegionOverride
--- PASS: TestAccImageBuilderDistributionConfiguration_distribution (86.85s)
=== CONT  TestAccImageBuilderDistributionConfiguration_description
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_containerTags (87.20s)
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionS3Export_roleName
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_snapshotConfiguration (87.54s)
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionS3Export_diskImageFormatVmdk
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_targetRepository (87.60s)
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionS3Export_s3Bucket
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_targetAccountIDs (88.12s)
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_enabled
--- PASS: TestAccImageBuilderDistributionConfiguration_Identity_Basic (89.97s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionS3Export_diskImageFormatRaw (90.58s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_description (91.10s)
--- PASS: TestAccImageBuilderDistributionConfiguration_Distribution_licenseARNs (92.98s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionS3Export_s3Prefix (94.70s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionS3Export_diskImageFormatVhd (94.98s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_userGroups (48.68s)
--- PASS: TestAccImageBuilderDistributionConfiguration_tags (111.74s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_name (112.90s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_userIDs (72.35s)
--- PASS: TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateConfiguration (119.29s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_launchTemplate (80.67s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_maxParallelLaunches (52.58s)
--- PASS: TestAccImageBuilderDistributionConfiguration_description (52.30s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionFastLaunchConfiguration_enabled (51.34s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_kmsKeyID (66.88s)
--- PASS: TestAccImageBuilderDistributionConfiguration_Identity_RegionOverride (59.18s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionS3Export_diskImageFormatVmdk (58.64s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionS3Export_roleName (59.05s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionS3Export_s3Bucket (61.46s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       150.331s
FAIL
make: *** [GNUmakefile:645: testacc] Error 1
```

Results from org-related test cases in another stand-alone AWS account:

```console
$ make testacc TESTS="TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_organizationARNs|TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_organizationARNs" PKG=imagebuilder ACCTEST_PARALLELISM=1
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/imagebuilder/... -v -count 1 -parallel 1 -run='TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_organizationARNs|TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_organizationARNs'  -timeout 360m -vet=off
2025/08/11 00:02:04 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/11 00:02:04 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_organizationARNs
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_organizationARNs (21.83s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       22.101s

$
```