### PR TITLE
[bugfix] aws_ecs_service: Fix tagging failure after upgrading to v6 due to missing refreshing process for `arn` in the Read function

### DIFF
--- a/.changelog/43816.txt
+++ b/.changelog/43816.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_service: Fix tagging failure after upgrading to v6 provider
+```

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -1471,6 +1471,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta any) 
 		return sdkdiag.AppendErrorf(diags, "reading ECS Service (%s): %s", d.Id(), err)
 	}
 
+	d.Set(names.AttrARN, service.ServiceArn)
 	d.Set("availability_zone_rebalancing", service.AvailabilityZoneRebalancing)
 	if err := d.Set(names.AttrCapacityProviderStrategy, flattenCapacityProviderStrategyItems(service.CapacityProviderStrategy)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting capacity_provider_strategy: %s", err)

--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -2334,6 +2334,64 @@ func TestAccECSService_Tags_managed(t *testing.T) {
 	})
 }
 
+func TestAccECSService_Tags_UpgradeFromV5_100_0(t *testing.T) {
+	ctx := acctest.Context(t)
+	var service awstypes.Service
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ecs_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.ECSServiceID),
+		CheckDestroy: testAccCheckServiceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.100.0",
+					},
+				},
+				Config: testAccServiceConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
+				),
+			},
+			{
+				// Just only upgrading to the latest provider version
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccServiceConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccServiceConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccServiceConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
+				),
+			},
+		},
+	})
+}
+
 func TestAccECSService_Tags_propagate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var first, second, third awstypes.Service


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR fixes the issue reported in #43570.

* It was reported that after upgrading the provider to v6, the tagging process no longer works.

  * The issue does not occur when an ECS Service is created using the v6 provider.
  * The newly added acceptance test reproduces the issue: when `aws_ecs_service` is created with the v5.100.0 provider and its tags are modified using the latest provider, the expected results are not obtained.

    * The acceptance test fails without the changes in this PR:

      ```console
      $ make testacc TESTS=TestAccECSService_Tags_UpgradeFromV5_100_0 PKG=ecs
      make: Verifying source code with gofmt...
      ==> Checking that code complies with gofmt requirements...
      TF_ACC=1 go1.24.5 test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSService_Tags_UpgradeFromV5_100_0'  -timeout 360m -vet=off
      2025/08/11 23:29:11 Creating Terraform AWS Provider (SDKv2-style)...
      2025/08/11 23:29:11 Initializing Terraform AWS Provider (SDKv2-style)...
      === RUN   TestAccECSService_Tags_UpgradeFromV5_100_0
      === PAUSE TestAccECSService_Tags_UpgradeFromV5_100_0
      === CONT  TestAccECSService_Tags_UpgradeFromV5_100_0
          service_test.go:2343: Step 3/4 error: Check failed: Check 2/4 error: aws_ecs_service.test: Attribute 'tags.%' expected "2", got "1"
      --- FAIL: TestAccECSService_Tags_UpgradeFromV5_100_0 (89.96s)
      FAIL
      FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/ecs        93.917s
      FAIL
      make: *** [testacc] Error 1
      ```

* In v6.0.0, the following changes were made:

  * The identifier for `@Tag` was changed from ID to ARN:
    [https://github.com/hashicorp/terraform-provider-aws/commit/2c020a817e96d14773be1b26b649f607960581cc](https://github.com/hashicorp/terraform-provider-aws/commit/2c020a817e96d14773be1b26b649f607960581cc)
  * The `arn` attribute was added to the schema:
    [https://github.com/hashicorp/terraform-provider-aws/commit/cc129e68ae484df4031a7613dbf3b033384e1c94](https://github.com/hashicorp/terraform-provider-aws/commit/cc129e68ae484df4031a7613dbf3b033384e1c94)

* In the v6 provider, the `arn` attribute is referenced when processing tags. However, `d.Set()` for `arn` is missing in the Read function, even though it is called in the Create function.

  * As a result, when a service is created using the v6 provider, `arn` is set and tagging works properly. However, if a service is created using the v5 provider and then upgraded to v6, `arn` remains `null`. Since `arn` is `null`, tagging does not work because it is referenced during the tagging process.


* This PR resolves the issue by:

  * `d.Set()` for `arn` (purely `Computed` attribute) has been added to the Read function.

<!---
#### Note on CI failure

*  One of the CI jobs (`terraform provider schema`) failed. This appears to be an issue with GitHub Actions, rather than a result of the changes in this PR.

  * In the preceding step of this job (`go-build`), saving to the cache failed, even though the build itself succeeded.
    https://github.com/hashicorp/terraform-provider-aws/actions/runs/16886102492/job/47834160830?pr=43816
     ```console
        Failed to save: Unable to reserve cache with key Linux-terraform-plugin-dir-b29fbb5ab9edeb48dc0e768fd79a8dae8010e966448f29dec83f70de07e5dc8b-c79bb01b4dae72f19b963b7df5c02677a8e432205981334c3222297683f8e8ad, another job may be creating this cache.
     ```
    * The current cache size exceeds 30 GB, while the limit is 10 GB. This might have caused the cache save to fail.

  * The `terraform provider schema` job expects the directory (terraform-plugin-dir) to be stored in the cache in `go-build`  job and loaded from it in `terraform provider schema` job. Since the cache was not saved, the job likely failed.

* By retrying later (after some of the cache has been removed), I believe the failed job is expected to succeed.
--->

### Relations

Closes #43570



### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccECSService_ PKG=ecs                                      
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSService_'  -timeout 360m -vet=off
2025/08/12 04:40:38 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/12 04:40:38 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSService_Identity_Basic
=== PAUSE TestAccECSService_Identity_Basic
=== RUN   TestAccECSService_Identity_RegionOverride
=== PAUSE TestAccECSService_Identity_RegionOverride
=== RUN   TestAccECSService_disappears
=== PAUSE TestAccECSService_disappears
=== RUN   TestAccECSService_LatticeConfigurations
=== PAUSE TestAccECSService_LatticeConfigurations
=== RUN   TestAccECSService_PlacementStrategy_unnormalized
=== PAUSE TestAccECSService_PlacementStrategy_unnormalized
=== RUN   TestAccECSService_CapacityProviderStrategy_basic
=== PAUSE TestAccECSService_CapacityProviderStrategy_basic
=== RUN   TestAccECSService_CapacityProviderStrategy_forceNewDeployment
=== PAUSE TestAccECSService_CapacityProviderStrategy_forceNewDeployment
=== RUN   TestAccECSService_CapacityProviderStrategy_update
=== PAUSE TestAccECSService_CapacityProviderStrategy_update
=== RUN   TestAccECSService_VolumeConfiguration_basic
=== PAUSE TestAccECSService_VolumeConfiguration_basic
=== RUN   TestAccECSService_VolumeConfiguration_volumeInitializationRate
=== PAUSE TestAccECSService_VolumeConfiguration_volumeInitializationRate
=== RUN   TestAccECSService_VolumeConfiguration_tagSpecifications
=== PAUSE TestAccECSService_VolumeConfiguration_tagSpecifications
=== RUN   TestAccECSService_VolumeConfiguration_update
=== PAUSE TestAccECSService_VolumeConfiguration_update
=== RUN   TestAccECSService_VolumeConfiguration_throughputTypeChange
=== PAUSE TestAccECSService_VolumeConfiguration_throughputTypeChange
=== RUN   TestAccECSService_familyAndRevision
=== PAUSE TestAccECSService_familyAndRevision
=== RUN   TestAccECSService_healthCheckGracePeriodSeconds
=== PAUSE TestAccECSService_healthCheckGracePeriodSeconds
=== RUN   TestAccECSService_iamRole
=== PAUSE TestAccECSService_iamRole
=== RUN   TestAccECSService_DeploymentControllerType_codeDeploy
=== PAUSE TestAccECSService_DeploymentControllerType_codeDeploy
=== RUN   TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
=== PAUSE TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
=== RUN   TestAccECSService_DeploymentControllerType_external
=== PAUSE TestAccECSService_DeploymentControllerType_external
=== RUN   TestAccECSService_DeploymentControllerMutability_codeDeployToECS
=== PAUSE TestAccECSService_DeploymentControllerMutability_codeDeployToECS
=== RUN   TestAccECSService_alarmsAdd
=== PAUSE TestAccECSService_alarmsAdd
=== RUN   TestAccECSService_alarmsUpdate
=== PAUSE TestAccECSService_alarmsUpdate
=== RUN   TestAccECSService_BlueGreenDeployment_basic
=== PAUSE TestAccECSService_BlueGreenDeployment_basic
=== RUN   TestAccECSService_BlueGreenDeployment_circuitBreakerRollback
=== PAUSE TestAccECSService_BlueGreenDeployment_circuitBreakerRollback
=== RUN   TestAccECSService_BlueGreenDeployment_createFailure
=== PAUSE TestAccECSService_BlueGreenDeployment_createFailure
=== RUN   TestAccECSService_BlueGreenDeployment_changeStrategy
=== PAUSE TestAccECSService_BlueGreenDeployment_changeStrategy
=== RUN   TestAccECSService_BlueGreenDeployment_updateFailure
=== PAUSE TestAccECSService_BlueGreenDeployment_updateFailure
=== RUN   TestAccECSService_BlueGreenDeployment_updateInPlace
=== PAUSE TestAccECSService_BlueGreenDeployment_updateInPlace
=== RUN   TestAccECSService_BlueGreenDeployment_waitServiceActive
=== PAUSE TestAccECSService_BlueGreenDeployment_waitServiceActive
=== RUN   TestAccECSService_BlueGreenDeployment_withoutTestListenerRule
=== PAUSE TestAccECSService_BlueGreenDeployment_withoutTestListenerRule
=== RUN   TestAccECSService_DeploymentConfiguration_strategy
=== PAUSE TestAccECSService_DeploymentConfiguration_strategy
=== RUN   TestAccECSService_DeploymentValues_basic
=== PAUSE TestAccECSService_DeploymentValues_basic
=== RUN   TestAccECSService_DeploymentValues_minZeroMaxOneHundred
=== PAUSE TestAccECSService_DeploymentValues_minZeroMaxOneHundred
=== RUN   TestAccECSService_deploymentCircuitBreaker
=== PAUSE TestAccECSService_deploymentCircuitBreaker
=== RUN   TestAccECSService_loadBalancerChanges
=== PAUSE TestAccECSService_loadBalancerChanges
=== RUN   TestAccECSService_clusterName
=== PAUSE TestAccECSService_clusterName
=== RUN   TestAccECSService_alb
=== PAUSE TestAccECSService_alb
=== RUN   TestAccECSService_multipleTargetGroups
=== PAUSE TestAccECSService_multipleTargetGroups
=== RUN   TestAccECSService_forceNewDeployment
=== PAUSE TestAccECSService_forceNewDeployment
=== RUN   TestAccECSService_forceNewDeploymentTriggers
=== PAUSE TestAccECSService_forceNewDeploymentTriggers
=== RUN   TestAccECSService_PlacementStrategy_basic
=== PAUSE TestAccECSService_PlacementStrategy_basic
=== RUN   TestAccECSService_PlacementStrategy_missing
=== PAUSE TestAccECSService_PlacementStrategy_missing
=== RUN   TestAccECSService_PlacementConstraints_basic
=== PAUSE TestAccECSService_PlacementConstraints_basic
=== RUN   TestAccECSService_PlacementConstraints_emptyExpression
=== PAUSE TestAccECSService_PlacementConstraints_emptyExpression
=== RUN   TestAccECSService_LaunchTypeFargate_basic
=== PAUSE TestAccECSService_LaunchTypeFargate_basic
=== RUN   TestAccECSService_LaunchTypeFargate_platformVersion
=== PAUSE TestAccECSService_LaunchTypeFargate_platformVersion
=== RUN   TestAccECSService_LaunchTypeFargate_waitForSteadyState
=== PAUSE TestAccECSService_LaunchTypeFargate_waitForSteadyState
=== RUN   TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
=== PAUSE TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
=== RUN   TestAccECSService_LaunchTypeEC2_network
=== PAUSE TestAccECSService_LaunchTypeEC2_network
=== RUN   TestAccECSService_DaemonSchedulingStrategy_basic
=== PAUSE TestAccECSService_DaemonSchedulingStrategy_basic
=== RUN   TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
=== PAUSE TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
=== RUN   TestAccECSService_replicaSchedulingStrategy
=== PAUSE TestAccECSService_replicaSchedulingStrategy
=== RUN   TestAccECSService_ServiceRegistries_basic
=== PAUSE TestAccECSService_ServiceRegistries_basic
=== RUN   TestAccECSService_ServiceRegistries_container
=== PAUSE TestAccECSService_ServiceRegistries_container
=== RUN   TestAccECSService_ServiceRegistries_changes
=== PAUSE TestAccECSService_ServiceRegistries_changes
=== RUN   TestAccECSService_ServiceRegistries_removal
=== PAUSE TestAccECSService_ServiceRegistries_removal
=== RUN   TestAccECSService_ServiceConnect_basic
=== PAUSE TestAccECSService_ServiceConnect_basic
=== RUN   TestAccECSService_ServiceConnect_full
=== PAUSE TestAccECSService_ServiceConnect_full
=== RUN   TestAccECSService_ServiceConnect_tls_with_empty_timeout
=== PAUSE TestAccECSService_ServiceConnect_tls_with_empty_timeout
=== RUN   TestAccECSService_ServiceConnect_ingressPortOverride
=== PAUSE TestAccECSService_ServiceConnect_ingressPortOverride
=== RUN   TestAccECSService_ServiceConnect_remove
=== PAUSE TestAccECSService_ServiceConnect_remove
=== RUN   TestAccECSService_Tags_basic
=== PAUSE TestAccECSService_Tags_basic
=== RUN   TestAccECSService_Tags_managed
=== PAUSE TestAccECSService_Tags_managed
=== RUN   TestAccECSService_Tags_UpgradeFromV5_100_0
=== PAUSE TestAccECSService_Tags_UpgradeFromV5_100_0
=== RUN   TestAccECSService_Tags_UpgradeFromV5_100_0ThroughV6_08_0
=== PAUSE TestAccECSService_Tags_UpgradeFromV5_100_0ThroughV6_08_0
=== RUN   TestAccECSService_Tags_propagate
=== PAUSE TestAccECSService_Tags_propagate
=== RUN   TestAccECSService_executeCommand
=== PAUSE TestAccECSService_executeCommand
=== RUN   TestAccECSService_AvailabilityZoneRebalancing
=== PAUSE TestAccECSService_AvailabilityZoneRebalancing
=== CONT  TestAccECSService_basic
=== CONT  TestAccECSService_loadBalancerChanges
=== CONT  TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
=== CONT  TestAccECSService_AvailabilityZoneRebalancing
=== CONT  TestAccECSService_executeCommand
=== CONT  TestAccECSService_Tags_propagate
=== CONT  TestAccECSService_Tags_UpgradeFromV5_100_0ThroughV6_08_0
=== CONT  TestAccECSService_Tags_UpgradeFromV5_100_0
=== CONT  TestAccECSService_Tags_managed
=== CONT  TestAccECSService_Tags_basic
=== CONT  TestAccECSService_ServiceRegistries_removal
=== CONT  TestAccECSService_ServiceRegistries_changes
=== CONT  TestAccECSService_ServiceRegistries_container
=== CONT  TestAccECSService_ServiceRegistries_basic
=== CONT  TestAccECSService_ServiceConnect_ingressPortOverride
=== CONT  TestAccECSService_ServiceConnect_basic
=== CONT  TestAccECSService_ServiceConnect_remove
=== CONT  TestAccECSService_ServiceConnect_tls_with_empty_timeout
=== CONT  TestAccECSService_BlueGreenDeployment_updateFailure
=== CONT  TestAccECSService_replicaSchedulingStrategy
--- PASS: TestAccECSService_Tags_managed (87.12s)
=== CONT  TestAccECSService_ServiceConnect_full
--- PASS: TestAccECSService_replicaSchedulingStrategy (87.30s)
=== CONT  TestAccECSService_deploymentCircuitBreaker
--- PASS: TestAccECSService_executeCommand (91.73s)
=== CONT  TestAccECSService_PlacementConstraints_emptyExpression
--- PASS: TestAccECSService_Tags_propagate (116.36s)
=== CONT  TestAccECSService_DeploymentValues_minZeroMaxOneHundred
--- PASS: TestAccECSService_basic (117.38s)
=== CONT  TestAccECSService_DeploymentValues_basic
--- PASS: TestAccECSService_Tags_basic (125.00s)
=== CONT  TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum
--- PASS: TestAccECSService_AvailabilityZoneRebalancing (134.90s)
=== CONT  TestAccECSService_DeploymentConfiguration_strategy
--- PASS: TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum (41.04s)
=== CONT  TestAccECSService_DaemonSchedulingStrategy_basic
--- PASS: TestAccECSService_deploymentCircuitBreaker (81.35s)
=== CONT  TestAccECSService_BlueGreenDeployment_withoutTestListenerRule
--- PASS: TestAccECSService_Tags_UpgradeFromV5_100_0 (171.26s)
=== CONT  TestAccECSService_LaunchTypeEC2_network
--- PASS: TestAccECSService_PlacementConstraints_emptyExpression (79.72s)
=== CONT  TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState
--- PASS: TestAccECSService_ServiceRegistries_container (178.90s)
=== CONT  TestAccECSService_LaunchTypeFargate_waitForSteadyState
--- PASS: TestAccECSService_ServiceRegistries_basic (181.99s)
=== CONT  TestAccECSService_LaunchTypeFargate_platformVersion
--- PASS: TestAccECSService_DeploymentValues_minZeroMaxOneHundred (76.78s)
=== CONT  TestAccECSService_LaunchTypeFargate_basic
--- PASS: TestAccECSService_ServiceConnect_basic (193.42s)
=== CONT  TestAccECSService_PlacementStrategy_missing
--- PASS: TestAccECSService_DeploymentValues_basic (76.54s)
=== CONT  TestAccECSService_PlacementConstraints_basic
--- PASS: TestAccECSService_PlacementStrategy_missing (1.82s)
=== CONT  TestAccECSService_VolumeConfiguration_basic
--- PASS: TestAccECSService_ServiceRegistries_removal (197.55s)
=== CONT  TestAccECSService_DeploymentControllerType_codeDeploy
--- PASS: TestAccECSService_ServiceConnect_tls_with_empty_timeout (200.53s)
=== CONT  TestAccECSService_iamRole
--- PASS: TestAccECSService_ServiceConnect_ingressPortOverride (200.71s)
=== CONT  TestAccECSService_healthCheckGracePeriodSeconds
--- PASS: TestAccECSService_DaemonSchedulingStrategy_basic (37.64s)
=== CONT  TestAccECSService_familyAndRevision
--- PASS: TestAccECSService_Tags_UpgradeFromV5_100_0ThroughV6_08_0 (206.35s)
=== CONT  TestAccECSService_VolumeConfiguration_throughputTypeChange
--- PASS: TestAccECSService_DeploymentConfiguration_strategy (101.33s)
=== CONT  TestAccECSService_VolumeConfiguration_update
--- PASS: TestAccECSService_ServiceConnect_remove (244.98s)
=== CONT  TestAccECSService_VolumeConfiguration_tagSpecifications
--- PASS: TestAccECSService_iamRole (65.55s)
=== CONT  TestAccECSService_VolumeConfiguration_volumeInitializationRate
--- PASS: TestAccECSService_ServiceConnect_full (185.74s)
=== CONT  TestAccECSService_BlueGreenDeployment_basic
--- PASS: TestAccECSService_VolumeConfiguration_basic (82.18s)
=== CONT  TestAccECSService_BlueGreenDeployment_waitServiceActive
--- PASS: TestAccECSService_PlacementConstraints_basic (102.07s)
=== CONT  TestAccECSService_BlueGreenDeployment_changeStrategy
--- PASS: TestAccECSService_familyAndRevision (99.54s)
=== CONT  TestAccECSService_BlueGreenDeployment_createFailure
--- PASS: TestAccECSService_LaunchTypeEC2_network (138.04s)
=== CONT  TestAccECSService_BlueGreenDeployment_updateInPlace
--- PASS: TestAccECSService_loadBalancerChanges (317.05s)
=== CONT  TestAccECSService_BlueGreenDeployment_circuitBreakerRollback
--- PASS: TestAccECSService_VolumeConfiguration_throughputTypeChange (123.80s)
=== CONT  TestAccECSService_PlacementStrategy_basic
--- PASS: TestAccECSService_LaunchTypeFargate_waitForSteadyState (154.65s)
=== CONT  TestAccECSService_alarmsAdd
--- PASS: TestAccECSService_VolumeConfiguration_tagSpecifications (91.20s)
=== CONT  TestAccECSService_DeploymentControllerMutability_codeDeployToECS
--- PASS: TestAccECSService_ServiceRegistries_changes (339.01s)
=== CONT  TestAccECSService_alarmsUpdate
--- PASS: TestAccECSService_VolumeConfiguration_update (111.75s)
=== CONT  TestAccECSService_forceNewDeploymentTriggers
--- PASS: TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState (186.60s)
=== CONT  TestAccECSService_PlacementStrategy_unnormalized
--- PASS: TestAccECSService_LaunchTypeFargate_platformVersion (207.97s)
=== CONT  TestAccECSService_CapacityProviderStrategy_update
--- PASS: TestAccECSService_LaunchTypeFargate_basic (207.12s)
=== CONT  TestAccECSService_multipleTargetGroups
--- PASS: TestAccECSService_VolumeConfiguration_volumeInitializationRate (134.44s)
=== CONT  TestAccECSService_CapacityProviderStrategy_forceNewDeployment
--- PASS: TestAccECSService_alarmsAdd (78.19s)
=== CONT  TestAccECSService_forceNewDeployment
--- PASS: TestAccECSService_forceNewDeploymentTriggers (69.91s)
=== CONT  TestAccECSService_CapacityProviderStrategy_basic
--- PASS: TestAccECSService_alarmsUpdate (90.58s)
=== CONT  TestAccECSService_alb
--- PASS: TestAccECSService_PlacementStrategy_unnormalized (76.61s)
=== CONT  TestAccECSService_disappears
--- PASS: TestAccECSService_PlacementStrategy_basic (116.20s)
=== CONT  TestAccECSService_clusterName
--- PASS: TestAccECSService_forceNewDeployment (71.60s)
=== CONT  TestAccECSService_LatticeConfigurations
--- PASS: TestAccECSService_CapacityProviderStrategy_forceNewDeployment (84.95s)
=== CONT  TestAccECSService_Identity_RegionOverride
--- PASS: TestAccECSService_DeploymentControllerType_codeDeploy (293.44s)
=== CONT  TestAccECSService_Identity_Basic
--- PASS: TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod (492.19s)
=== CONT  TestAccECSService_DeploymentControllerType_external
--- PASS: TestAccECSService_clusterName (66.11s)
--- PASS: TestAccECSService_healthCheckGracePeriodSeconds (335.18s)
--- PASS: TestAccECSService_DeploymentControllerType_external (51.22s)
--- PASS: TestAccECSService_Identity_RegionOverride (74.08s)
--- PASS: TestAccECSService_Identity_Basic (73.24s)
--- PASS: TestAccECSService_CapacityProviderStrategy_basic (160.68s)
--- PASS: TestAccECSService_disappears (198.00s)
--- PASS: TestAccECSService_DeploymentControllerMutability_codeDeployToECS (296.92s)
--- PASS: TestAccECSService_BlueGreenDeployment_createFailure (342.64s)
--- PASS: TestAccECSService_CapacityProviderStrategy_update (262.57s)
--- PASS: TestAccECSService_alb (236.92s)
--- PASS: TestAccECSService_multipleTargetGroups (290.49s)
--- PASS: TestAccECSService_LatticeConfigurations (588.68s)
--- PASS: TestAccECSService_BlueGreenDeployment_updateFailure (1182.70s)
--- PASS: TestAccECSService_BlueGreenDeployment_waitServiceActive (985.09s)
--- PASS: TestAccECSService_BlueGreenDeployment_updateInPlace (1079.49s)
--- PASS: TestAccECSService_BlueGreenDeployment_basic (1467.49s)
--- PASS: TestAccECSService_BlueGreenDeployment_withoutTestListenerRule (1860.27s)
--- PASS: TestAccECSService_BlueGreenDeployment_changeStrategy (1960.63s)
--- PASS: TestAccECSService_BlueGreenDeployment_circuitBreakerRollback (3446.88s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        3768.543s
```
