### PR TITLE
Update autoscaling_lifecycle_hook target docs

### DIFF
--- a/website/docs/r/autoscaling_lifecycle_hook.html.markdown
+++ b/website/docs/r/autoscaling_lifecycle_hook.html.markdown
@@ -65,7 +65,7 @@ This resource supports the following arguments:
 * `heartbeat_timeout` - (Optional) Defines the amount of time, in seconds, that can elapse before the lifecycle hook times out. When the lifecycle hook times out, Auto Scaling performs the action defined in the DefaultResult parameter
 * `lifecycle_transition` - (Required) Instance state to which you want to attach the lifecycle hook. For a list of lifecycle hook types, see [describe-lifecycle-hook-types](https://docs.aws.amazon.com/cli/latest/reference/autoscaling/describe-lifecycle-hook-types.html#examples)
 * `notification_metadata` - (Optional) Contains additional information that you want to include any time Auto Scaling sends a message to the notification target.
-* `notification_target_arn` - (Optional) ARN of the notification target that Auto Scaling will use to notify you when an instance is in the transition state for the lifecycle hook. This ARN target can be either an SQS queue or an SNS topic.
+* `notification_target_arn` - (Optional) ARN of the notification target that Auto Scaling will use to notify you when an instance is in the transition state for the lifecycle hook. This ARN target can be either an SQS queue, an SNS topic, or a Lambda function.
 * `role_arn` - (Optional) ARN of the IAM role that allows the Auto Scaling group to publish to the specified notification target.
 
 ## Attribute Reference


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
This PR updates the documentation for the `notification_target_arn` argument of the `aws_autoscaling_lifecycle_hook` resource to include support for Lambda functions as notification targets.

Previously, the documentation only mentioned SQS queues and SNS topics. This PR brings the docs in line with [recent provider updates](https://aws.amazon.com/about-aws/whats-new/2025/07/amazon-ec2-auto-scaling-aws-lambda-functions/) and closes issue #43620.


### Relations
Closes #43620


### References
AWS Documentation: https://aws.amazon.com/about-aws/whats-new/2025/07/amazon-ec2-auto-scaling-aws-lambda-functions/

