### PR TITLE
`aws-sdk-go-v2` updates (Release 2025-08-11)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -237,7 +237,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/ses v1.32.0
-	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.50.0
+	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.51.0
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/shield v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/signer v1.29.0

--- a/go.mod
+++ b/go.mod
@@ -263,7 +263,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.17.0
 	github.com/aws/aws-sdk-go-v2/service/waf v1.29.0
-	github.com/aws/aws-sdk-go-v2/service/wafregional v1.28.0
+	github.com/aws/aws-sdk-go-v2/service/wafregional v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.65.0
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.60.0

--- a/go.mod
+++ b/go.mod
@@ -213,7 +213,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.20.0
-	github.com/aws/aws-sdk-go-v2/service/route53 v1.55.0
+	github.com/aws/aws-sdk-go-v2/service/route53 v1.56.0
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.7.0
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.29.0

--- a/go.mod
+++ b/go.mod
@@ -262,7 +262,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.64.0
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.17.0
-	github.com/aws/aws-sdk-go-v2/service/waf v1.28.0
+	github.com/aws/aws-sdk-go-v2/service/waf v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.65.0
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.37.0

--- a/go.mod
+++ b/go.mod
@@ -256,7 +256,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/synthetics v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/taxsettings v1.15.0
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.14.0
-	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.33.0
+	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.49.1
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.63.0

--- a/go.mod
+++ b/go.mod
@@ -212,7 +212,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.20.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.28.0
-	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.19.0
+	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.20.0
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.55.0
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -245,7 +245,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.63.0
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.30.0
-	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.37.0
+	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.6.0
 	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.22.0
 	github.com/aws/aws-sdk-go-v2/service/sso v1.28.0

--- a/go.mod
+++ b/go.mod
@@ -224,7 +224,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.64.0
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.9.0
-	github.com/aws/aws-sdk-go-v2/service/s3vectors v1.3.0
+	github.com/aws/aws-sdk-go-v2/service/s3vectors v1.4.0
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.206.0
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.15.0
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.31.0

--- a/go.mod
+++ b/go.mod
@@ -240,7 +240,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.51.0
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/shield v1.33.0
-	github.com/aws/aws-sdk-go-v2/service/signer v1.29.0
+	github.com/aws/aws-sdk-go-v2/service/signer v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/sns v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.62.0

--- a/go.mod
+++ b/go.mod
@@ -239,7 +239,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ses v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.51.0
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.38.0
-	github.com/aws/aws-sdk-go-v2/service/shield v1.32.0
+	github.com/aws/aws-sdk-go-v2/service/shield v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/signer v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/sns v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.40.0

--- a/go.mod
+++ b/go.mod
@@ -226,7 +226,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.9.0
 	github.com/aws/aws-sdk-go-v2/service/s3vectors v1.4.0
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.207.0
-	github.com/aws/aws-sdk-go-v2/service/scheduler v1.15.0
+	github.com/aws/aws-sdk-go-v2/service/scheduler v1.16.0
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.61.0

--- a/go.mod
+++ b/go.mod
@@ -257,7 +257,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/taxsettings v1.15.0
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.14.0
 	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.34.0
-	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.33.0
+	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.49.1
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.63.0
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.26.0

--- a/go.mod
+++ b/go.mod
@@ -260,7 +260,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.50.0
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.64.0
-	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.26.0
+	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.16.0
 	github.com/aws/aws-sdk-go-v2/service/waf v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.28.0

--- a/go.mod
+++ b/go.mod
@@ -214,7 +214,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.20.0
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.56.0
-	github.com/aws/aws-sdk-go-v2/service/route53domains v1.31.0
+	github.com/aws/aws-sdk-go-v2/service/route53domains v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.7.0
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.24.0

--- a/go.mod
+++ b/go.mod
@@ -211,7 +211,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.20.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.32.0
-	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.28.0
+	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.20.0
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.56.0
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.32.0

--- a/go.mod
+++ b/go.mod
@@ -223,7 +223,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.87.0
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.64.0
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.32.0
-	github.com/aws/aws-sdk-go-v2/service/s3tables v1.8.0
+	github.com/aws/aws-sdk-go-v2/service/s3tables v1.9.0
 	github.com/aws/aws-sdk-go-v2/service/s3vectors v1.3.0
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.206.0
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.15.0

--- a/go.mod
+++ b/go.mod
@@ -221,7 +221,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/rum v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.87.0
-	github.com/aws/aws-sdk-go-v2/service/s3control v1.63.0
+	github.com/aws/aws-sdk-go-v2/service/s3control v1.64.0
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.8.0
 	github.com/aws/aws-sdk-go-v2/service/s3vectors v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -230,7 +230,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.62.0
-	github.com/aws/aws-sdk-go-v2/service/securitylake v1.22.0
+	github.com/aws/aws-sdk-go-v2/service/securitylake v1.23.0
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -235,7 +235,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.38.0
-	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.30.0
+	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/ses v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.50.0
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.37.0

--- a/go.mod
+++ b/go.mod
@@ -208,7 +208,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.50.0
-	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.32.0
+	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.19.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.28.0

--- a/go.mod
+++ b/go.mod
@@ -264,7 +264,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.17.0
 	github.com/aws/aws-sdk-go-v2/service/waf v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.29.0
-	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.65.0
+	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.66.0
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.60.0
 	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.30.0

--- a/go.mod
+++ b/go.mod
@@ -267,7 +267,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.66.0
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.61.0
-	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.30.0
+	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/xray v1.33.0
 	github.com/aws/smithy-go v1.22.5
 	github.com/beevik/etree v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -242,7 +242,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/shield v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/signer v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/sns v1.37.0
-	github.com/aws/aws-sdk-go-v2/service/sqs v1.40.0
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.62.0
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.37.0

--- a/go.mod
+++ b/go.mod
@@ -249,7 +249,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.7.0
 	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.23.0
 	github.com/aws/aws-sdk-go-v2/service/sso v1.28.0
-	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.33.0
+	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/swf v1.30.0

--- a/go.mod
+++ b/go.mod
@@ -255,7 +255,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/swf v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/synthetics v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/taxsettings v1.15.0
-	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.13.0
+	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.14.0
 	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.49.1

--- a/go.mod
+++ b/go.mod
@@ -215,7 +215,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.20.0
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.56.0
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.32.0
-	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.7.0
+	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.8.0
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.38.0

--- a/go.mod
+++ b/go.mod
@@ -253,7 +253,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/swf v1.31.0
-	github.com/aws/aws-sdk-go-v2/service/synthetics v1.38.0
+	github.com/aws/aws-sdk-go-v2/service/synthetics v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/taxsettings v1.14.0
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.13.0
 	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -222,7 +222,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rum v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.87.0
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.64.0
-	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.31.0
+	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.8.0
 	github.com/aws/aws-sdk-go-v2/service/s3vectors v1.3.0
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.206.0

--- a/go.mod
+++ b/go.mod
@@ -152,7 +152,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.35.0
-	github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.30.0
+	github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/kms v1.44.0
 	github.com/aws/aws-sdk-go-v2/service/lakeformation v1.44.0
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.76.0

--- a/go.mod
+++ b/go.mod
@@ -210,7 +210,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.50.0
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.20.0
-	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.31.0
+	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.19.0
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.55.0

--- a/go.mod
+++ b/go.mod
@@ -204,7 +204,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ram v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.25.0
 	github.com/aws/aws-sdk-go-v2/service/rds v1.103.0
-	github.com/aws/aws-sdk-go-v2/service/redshift v1.56.0
+	github.com/aws/aws-sdk-go-v2/service/redshift v1.57.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.49.0

--- a/go.mod
+++ b/go.mod
@@ -228,7 +228,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.207.0
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.16.0
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.32.0
-	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.37.0
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.61.0
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.22.0
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.27.0

--- a/go.mod
+++ b/go.mod
@@ -205,7 +205,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.25.0
 	github.com/aws/aws-sdk-go-v2/service/rds v1.103.0
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.57.0
-	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.35.0
+	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.49.0
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.32.0

--- a/go.mod
+++ b/go.mod
@@ -236,7 +236,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.31.0
-	github.com/aws/aws-sdk-go-v2/service/ses v1.32.0
+	github.com/aws/aws-sdk-go-v2/service/ses v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.51.0
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/shield v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -216,7 +216,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.56.0
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.8.0
-	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.29.0
+	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/rum v1.26.0

--- a/go.mod
+++ b/go.mod
@@ -217,7 +217,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.8.0
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.30.0
-	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.24.0
+	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.25.0
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/rum v1.26.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.87.0

--- a/go.mod
+++ b/go.mod
@@ -266,7 +266,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.66.0
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.38.0
-	github.com/aws/aws-sdk-go-v2/service/workspaces v1.60.0
+	github.com/aws/aws-sdk-go-v2/service/workspaces v1.61.0
 	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/xray v1.33.0
 	github.com/aws/smithy-go v1.22.5

--- a/go.mod
+++ b/go.mod
@@ -206,7 +206,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rds v1.103.0
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.57.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.36.0
-	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.29.0
+	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.49.0
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.19.0

--- a/go.mod
+++ b/go.mod
@@ -259,7 +259,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.50.0
-	github.com/aws/aws-sdk-go-v2/service/transfer v1.63.0
+	github.com/aws/aws-sdk-go-v2/service/transfer v1.64.0
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.26.0
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.16.0
 	github.com/aws/aws-sdk-go-v2/service/waf v1.28.0

--- a/go.mod
+++ b/go.mod
@@ -247,7 +247,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.7.0
-	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.22.0
+	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.23.0
 	github.com/aws/aws-sdk-go-v2/service/sso v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.40.0

--- a/go.mod
+++ b/go.mod
@@ -232,7 +232,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.62.0
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.23.0
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.28.0
-	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.36.0
+	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.30.0

--- a/go.mod
+++ b/go.mod
@@ -243,7 +243,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signer v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/sns v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.41.0
-	github.com/aws/aws-sdk-go-v2/service/ssm v1.62.0
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.63.0
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/dax v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/detective v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/devicefarm v1.34.0
-	github.com/aws/aws-sdk-go-v2/service/devopsguru v1.37.0
+	github.com/aws/aws-sdk-go-v2/service/devopsguru v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/directoryservice v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/dlm v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -231,7 +231,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.62.0
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.23.0
-	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.27.0
+	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.37.0

--- a/go.mod
+++ b/go.mod
@@ -233,7 +233,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.23.0
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.37.0
-	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.33.0
+	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/ses v1.32.0

--- a/go.mod
+++ b/go.mod
@@ -250,7 +250,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.23.0
 	github.com/aws/aws-sdk-go-v2/service/sso v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.34.0
-	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.40.0
+	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/swf v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/synthetics v1.38.0

--- a/go.mod
+++ b/go.mod
@@ -238,7 +238,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/ses v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.51.0
-	github.com/aws/aws-sdk-go-v2/service/sfn v1.37.0
+	github.com/aws/aws-sdk-go-v2/service/sfn v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/shield v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/signer v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/sns v1.36.0

--- a/go.mod
+++ b/go.mod
@@ -258,7 +258,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.14.0
 	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.34.0
-	github.com/aws/aws-sdk-go-v2/service/transcribe v1.49.1
+	github.com/aws/aws-sdk-go-v2/service/transcribe v1.50.0
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.63.0
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.26.0
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.16.0

--- a/go.mod
+++ b/go.mod
@@ -241,7 +241,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/shield v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/signer v1.30.0
-	github.com/aws/aws-sdk-go-v2/service/sns v1.36.0
+	github.com/aws/aws-sdk-go-v2/service/sns v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.62.0
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.29.0

--- a/go.mod
+++ b/go.mod
@@ -219,7 +219,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.25.0
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.39.0
-	github.com/aws/aws-sdk-go-v2/service/rum v1.26.0
+	github.com/aws/aws-sdk-go-v2/service/rum v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.87.0
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.63.0
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.31.0

--- a/go.mod
+++ b/go.mod
@@ -229,7 +229,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.16.0
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.38.0
-	github.com/aws/aws-sdk-go-v2/service/securityhub v1.61.0
+	github.com/aws/aws-sdk-go-v2/service/securityhub v1.62.0
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.22.0
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.36.0

--- a/go.mod
+++ b/go.mod
@@ -227,7 +227,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3vectors v1.4.0
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.207.0
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.16.0
-	github.com/aws/aws-sdk-go-v2/service/schemas v1.31.0
+	github.com/aws/aws-sdk-go-v2/service/schemas v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.61.0
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.22.0

--- a/go.mod
+++ b/go.mod
@@ -268,7 +268,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.61.0
 	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.31.0
-	github.com/aws/aws-sdk-go-v2/service/xray v1.33.0
+	github.com/aws/aws-sdk-go-v2/service/xray v1.34.0
 	github.com/aws/smithy-go v1.22.5
 	github.com/beevik/etree v1.5.1
 	github.com/cedar-policy/cedar-go v1.2.6

--- a/go.mod
+++ b/go.mod
@@ -246,7 +246,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.63.0
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.38.0
-	github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.6.0
+	github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.7.0
 	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.22.0
 	github.com/aws/aws-sdk-go-v2/service/sso v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -203,7 +203,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/quicksight v1.92.0
 	github.com/aws/aws-sdk-go-v2/service/ram v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.25.0
-	github.com/aws/aws-sdk-go-v2/service/rds v1.102.0
+	github.com/aws/aws-sdk-go-v2/service/rds v1.103.0
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.56.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.29.0

--- a/go.mod
+++ b/go.mod
@@ -261,7 +261,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.50.0
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.64.0
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.27.0
-	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.16.0
+	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.17.0
 	github.com/aws/aws-sdk-go-v2/service/waf v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.65.0

--- a/go.mod
+++ b/go.mod
@@ -252,7 +252,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.37.0
-	github.com/aws/aws-sdk-go-v2/service/swf v1.30.0
+	github.com/aws/aws-sdk-go-v2/service/swf v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/synthetics v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/taxsettings v1.14.0
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.13.0

--- a/go.mod
+++ b/go.mod
@@ -244,7 +244,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sns v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.63.0
-	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.29.0
+	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.6.0
 	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.22.0

--- a/go.mod
+++ b/go.mod
@@ -218,7 +218,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.8.0
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.25.0
-	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.38.0
+	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/rum v1.26.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.87.0
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.63.0

--- a/go.mod
+++ b/go.mod
@@ -265,7 +265,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/waf v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.66.0
-	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.37.0
+	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.60.0
 	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/xray v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -234,7 +234,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.34.0
-	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.37.0
+	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/ses v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.50.0

--- a/go.mod
+++ b/go.mod
@@ -209,7 +209,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.50.0
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.33.0
-	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.19.0
+	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.20.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.19.0

--- a/go.mod
+++ b/go.mod
@@ -207,7 +207,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.57.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.30.0
-	github.com/aws/aws-sdk-go-v2/service/rekognition v1.49.0
+	github.com/aws/aws-sdk-go-v2/service/rekognition v1.50.0
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.19.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.31.0

--- a/go.mod
+++ b/go.mod
@@ -254,7 +254,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/swf v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/synthetics v1.39.0
-	github.com/aws/aws-sdk-go-v2/service/taxsettings v1.14.0
+	github.com/aws/aws-sdk-go-v2/service/taxsettings v1.15.0
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.13.0
 	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -225,7 +225,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.9.0
 	github.com/aws/aws-sdk-go-v2/service/s3vectors v1.4.0
-	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.206.0
+	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.207.0
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.15.0
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.37.0

--- a/go.sum
+++ b/go.sum
@@ -451,8 +451,8 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.56.0 h1:+8/JB7/ZIk86sDBtcy+md9qq
 github.com/aws/aws-sdk-go-v2/service/route53 v1.56.0/go.mod h1:aSIshIhq15I4lMlrkvvIoH7E4eLTAEW+isWbga9guNg=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.32.0 h1:ZjfNS/AmmzzGbM9Au1219mq3rh7L3HhzgCV04Z5k24M=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.32.0/go.mod h1:v6BvxeZNn9Ys2Fv/6IGmGCcrf5a10guA3YvlpQId/1o=
-github.com/aws/aws-sdk-go-v2/service/route53profiles v1.7.0 h1:JhCFwPOmFja1kndJHeF2wPxGdvft9hqk9rmI+3VYBGg=
-github.com/aws/aws-sdk-go-v2/service/route53profiles v1.7.0/go.mod h1:ZfLB7g4WQPzBcK37APvwX7u0cIz1dKL01MnxRTTkfQo=
+github.com/aws/aws-sdk-go-v2/service/route53profiles v1.8.0 h1:MuXKThC0Lv83LdIiFc5aMjmjYuG7hC49Da3H+dvt6xo=
+github.com/aws/aws-sdk-go-v2/service/route53profiles v1.8.0/go.mod h1:3m2fCUiYfoCDxPMHZGP6u5w9oMOTJnmI8rEc0iKEba0=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.29.0 h1:BSC4rRnApDd4lH2U5dggYS81lyF9v5yG5atDYQlUG4o=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.29.0/go.mod h1:2rt7/1yfNqxIc1+IiwdM2xIA01+FeH+hkkIc6Ui6KYg=
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.24.0 h1:he+LHA/6HCUuFxdM0lUdr+OOTefeEq1G2w/e6yRraQs=

--- a/go.sum
+++ b/go.sum
@@ -497,8 +497,8 @@ github.com/aws/aws-sdk-go-v2/service/ses v1.32.0 h1:hsvll+Vlk63Wh38r5pWcZTGmA8oY
 github.com/aws/aws-sdk-go-v2/service/ses v1.32.0/go.mod h1:w6GEPvRXyzj34dGpgbo5MrRUEFTRoXEVNEvg56TpKhE=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.51.0 h1:EGgXgQlHPLB4AQ2EitqhfkhRkyxHJ+Y1CTFbP6vfS60=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.51.0/go.mod h1:z/Ty4fCI3RR3vFh/z2kYmdv4KgXh6z/ydK5XN/hfCcY=
-github.com/aws/aws-sdk-go-v2/service/sfn v1.37.0 h1:nmo7k4bHzYxK/iH/hdnYAWJ/tfV+ySV3rk029jVgP+c=
-github.com/aws/aws-sdk-go-v2/service/sfn v1.37.0/go.mod h1:+yaDYK9QNsfC2Kp6UpboOqUVp3giQ7GTVBsWoNqtPHY=
+github.com/aws/aws-sdk-go-v2/service/sfn v1.38.0 h1:qDg+pW4hxuM1zlixvZy3EyRxGiy4FknvKwfYHsUGvYw=
+github.com/aws/aws-sdk-go-v2/service/sfn v1.38.0/go.mod h1:UXg+xZNhGCuhG8tg8Qj9XBH3qRA5WgmJkelLEyOassI=
 github.com/aws/aws-sdk-go-v2/service/shield v1.32.0 h1:uekAZy4/sGCQxX+BxWsjMxmKWfavsQyc04NYb6JlIPM=
 github.com/aws/aws-sdk-go-v2/service/shield v1.32.0/go.mod h1:uFSdevNXa2hQFSbvHTrd0/+N4llyjbegPt7T4ij5nIs=
 github.com/aws/aws-sdk-go-v2/service/signer v1.29.0 h1:sF/j2NltXGKx6Tewc7RUwL7fQKxTgXib83qQI/rx5N0=

--- a/go.sum
+++ b/go.sum
@@ -553,8 +553,8 @@ github.com/aws/aws-sdk-go-v2/service/wafregional v1.29.0 h1:gFCxExCqt4/HWMVKmzf+
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.29.0/go.mod h1:brjH7E2LWOtLNsAupQL1Lv803e2xm3v+3wzqlX4BAOk=
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.66.0 h1:zEbaP92GXITM2TrYiw4mNer/ViT4z/Zq8hmrIzSF3Y0=
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.66.0/go.mod h1:EPNcb1lt/lfWkpjINo7eP5AwfvlG8ioVT9frx5w5k9s=
-github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.37.0 h1:Ajd4pP2pftD3pnofQ1+7TEflSaNYevoII49UkI0xatA=
-github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.37.0/go.mod h1:vhARHB5E9NBKpbcLcWo96asxlofoSEXItelnMf4L63Q=
+github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.38.0 h1:5+II3BO8cotBo0VNs3Ix2EakRC+PP//loHRaEKDQUNE=
+github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.38.0/go.mod h1:ObNr9KblAM/kLbDQAhRAqmi8sY5CPdEd9VqeyZxU79Y=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.60.0 h1:l+YQbYWAiupSnKXZ/HOYNOI0XdRexhwnlGY6EYBwZ7g=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.60.0/go.mod h1:wBy3knc+aXjHkaLrHApzc7N8saQha6AaeThgdopPLA8=
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.30.0 h1:Qw3jH5JOp1Yx63HNLd3m/4fuqOmwZoTskrpnoHD8GL0=

--- a/go.sum
+++ b/go.sum
@@ -491,8 +491,8 @@ github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.34.0 h1:kSiJ+K
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.34.0/go.mod h1:6QMbXmJiAJ/+xLTDMZJUq36LdNsMXKj9cH5MeG69a5c=
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.38.0 h1:zQ78zrO5o29Sx+pPK2AYaf6WY2tvmZ2DQcYnX9NfhNE=
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.38.0/go.mod h1:nnG6Pe7Qu1Bv/mE3eL/3gCiQYrAWyXFXDOtOKcC7eh0=
-github.com/aws/aws-sdk-go-v2/service/servicequotas v1.30.0 h1:DkMHQQ1yfoPT57erFe/SJXCZ5Weo5T0/AROuA6hg4VQ=
-github.com/aws/aws-sdk-go-v2/service/servicequotas v1.30.0/go.mod h1:r9XW7P7bOhnjMycQWPVeIEPvmzmW8RqzW65vp4z+IjY=
+github.com/aws/aws-sdk-go-v2/service/servicequotas v1.31.0 h1:IqZZ0dHv/NhExc+8HI6CdgTZLz7Yjn9OaExTmFX4UX8=
+github.com/aws/aws-sdk-go-v2/service/servicequotas v1.31.0/go.mod h1:q+dUus04tyoWH3qZxKzu68bfL4MFs5ahSTSkyFIqmFQ=
 github.com/aws/aws-sdk-go-v2/service/ses v1.32.0 h1:hsvll+Vlk63Wh38r5pWcZTGmA8oYAULQISXguLFc0IA=
 github.com/aws/aws-sdk-go-v2/service/ses v1.32.0/go.mod h1:w6GEPvRXyzj34dGpgbo5MrRUEFTRoXEVNEvg56TpKhE=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.50.0 h1:ahFtnukBJ2pZmZ2lAHXozc0bH/Xid7ceScQXYM4nU6w=

--- a/go.sum
+++ b/go.sum
@@ -439,8 +439,8 @@ github.com/aws/aws-sdk-go-v2/service/rekognition v1.50.0 h1:bn5Y52YaLv5p7sa6TIH3
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.50.0/go.mod h1:5vEhAy+7ycQg3WVq7kp1YWTi43DxOqbUPkDLP8vB1Yk=
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.33.0 h1:DUJziWLjN4tzfLFz+h2DRDItRtrD3NdGWs0xztSZlFU=
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.33.0/go.mod h1:SLrdEDIWvazT0GTFQ6ph3QW2EAYYeizvd7g9CMpoMs0=
-github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.19.0 h1:3VIjZDJSYXEnVuWIRq0oXHISbO+tpya0qIHPPzpp2+A=
-github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.19.0/go.mod h1:bf6/IS5mQoUM4XVKcEaNCF3ghEuOyan7agPlzSheMk4=
+github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.20.0 h1:26bUDFcdGzHxBax1oY+HL/YRmUVfqyvcbgdKHr0FDfE=
+github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.20.0/go.mod h1:eFxDYEcdKWIT77Mrq/fT+6KL9bu3ACn5sDFk7Be8FKg=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.31.0 h1:L9r0qWc6316M37Pb4ce2qAtxAXb2ZJHUIRfqS0yP9eY=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.31.0/go.mod h1:7xr8mm8k3g6gDnYYn3MtEtmSg84Ki/3+exNQe3aLx8Y=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.28.0 h1:UtG7I7N+hYu6X4Yjz8XC7tgRCss5PiEgCW3KXMxz2R4=

--- a/go.sum
+++ b/go.sum
@@ -555,8 +555,8 @@ github.com/aws/aws-sdk-go-v2/service/wafv2 v1.66.0 h1:zEbaP92GXITM2TrYiw4mNer/Vi
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.66.0/go.mod h1:EPNcb1lt/lfWkpjINo7eP5AwfvlG8ioVT9frx5w5k9s=
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.38.0 h1:5+II3BO8cotBo0VNs3Ix2EakRC+PP//loHRaEKDQUNE=
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.38.0/go.mod h1:ObNr9KblAM/kLbDQAhRAqmi8sY5CPdEd9VqeyZxU79Y=
-github.com/aws/aws-sdk-go-v2/service/workspaces v1.60.0 h1:l+YQbYWAiupSnKXZ/HOYNOI0XdRexhwnlGY6EYBwZ7g=
-github.com/aws/aws-sdk-go-v2/service/workspaces v1.60.0/go.mod h1:wBy3knc+aXjHkaLrHApzc7N8saQha6AaeThgdopPLA8=
+github.com/aws/aws-sdk-go-v2/service/workspaces v1.61.0 h1:MzTVNx65GKhj9mLLbC7AIXCEBnucyiDB1jAnp4Vye2A=
+github.com/aws/aws-sdk-go-v2/service/workspaces v1.61.0/go.mod h1:AJ7eKGcsgQ07kXJ4YWAf7PTFOvkoHc0Voh7CkAj9Bqk=
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.30.0 h1:Qw3jH5JOp1Yx63HNLd3m/4fuqOmwZoTskrpnoHD8GL0=
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.30.0/go.mod h1:aOovVVoUFe9mVrtezfjeSHi/AKnZm2JKjI5uf1v6Lhw=
 github.com/aws/aws-sdk-go-v2/service/xray v1.33.0 h1:iHeSWpMxk/qGq5op8qwHw4DGEP+hx7DLEsQbhlF4mW8=

--- a/go.sum
+++ b/go.sum
@@ -515,8 +515,8 @@ github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.38.0 h1:6sjrNE9OXSuF3P2Y+++
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.38.0/go.mod h1:vAUirHmPQmQF5LO19CMdt10p/9Nl4cqqdygIsdPjx4Y=
 github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.7.0 h1:OHfg8SKR3X5AV6/LpinRDBPciw12F4qQjsvf6o0GiGE=
 github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.7.0/go.mod h1:/B5AIPHVKVfZSsofTSfqrvl5QH5r/XK8/qcdHW3jjV4=
-github.com/aws/aws-sdk-go-v2/service/ssmsap v1.22.0 h1:5+fIKFIbA80sYjNf2vccPvmrdp4nb1EbkQdsO9HZA9g=
-github.com/aws/aws-sdk-go-v2/service/ssmsap v1.22.0/go.mod h1:mlTUZlO4rjFmS6ZZ7hJD6Oko4Geto1EMzta8T3R61r4=
+github.com/aws/aws-sdk-go-v2/service/ssmsap v1.23.0 h1:21pRqoiIDamny/57BJYBrGumQKQEAcZ1+7X2xpMkOdc=
+github.com/aws/aws-sdk-go-v2/service/ssmsap v1.23.0/go.mod h1:tLEEa+UsBhm/fZNrnA1O8Vf69/Y94pYuLFP/v1UpB3U=
 github.com/aws/aws-sdk-go-v2/service/sso v1.28.0 h1:Mc/MKBf2m4VynyJkABoVEN+QzkfLqGj0aiJuEe7cMeM=
 github.com/aws/aws-sdk-go-v2/service/sso v1.28.0/go.mod h1:iS5OmxEcN4QIPXARGhavH7S8kETNL11kym6jhoS7IUQ=
 github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.33.0 h1:61baAQJeQS9SdTXJ9MVUiT5hkMf65SUfjVV9j2/W45M=

--- a/go.sum
+++ b/go.sum
@@ -559,8 +559,8 @@ github.com/aws/aws-sdk-go-v2/service/workspaces v1.61.0 h1:MzTVNx65GKhj9mLLbC7AI
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.61.0/go.mod h1:AJ7eKGcsgQ07kXJ4YWAf7PTFOvkoHc0Voh7CkAj9Bqk=
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.31.0 h1:n4HU/6mkGI9nTgt5Q80hvLMWv4HeXwfx51Ux5lVkRTY=
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.31.0/go.mod h1:fCtcQlrmCiCA0BRxpkhrOCFPGDSi7YNw7IV+NS2bKyY=
-github.com/aws/aws-sdk-go-v2/service/xray v1.33.0 h1:iHeSWpMxk/qGq5op8qwHw4DGEP+hx7DLEsQbhlF4mW8=
-github.com/aws/aws-sdk-go-v2/service/xray v1.33.0/go.mod h1:S8Ij3/mKF/976T6WrnozZw2QQBSLs1l2KQTL3SOCwPQ=
+github.com/aws/aws-sdk-go-v2/service/xray v1.34.0 h1:gFPqTmIg8UI0CcW0pk4LXT2BQK2osloIE6xf46p2144=
+github.com/aws/aws-sdk-go-v2/service/xray v1.34.0/go.mod h1:zzWVXnnO820ouM6JAIv2dQa8p5rPTVOCRoEvkljwnnM=
 github.com/aws/smithy-go v1.22.5 h1:P9ATCXPMb2mPjYBgueqJNCA5S9UfktsW0tTxi+a7eqw=
 github.com/aws/smithy-go v1.22.5/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
 github.com/beevik/etree v1.5.1 h1:TC3zyxYp+81wAmbsi8SWUpZCurbxa6S8RITYRSkNRwo=

--- a/go.sum
+++ b/go.sum
@@ -445,8 +445,8 @@ github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.32.0 h1:ZzEJclXVP4woTKwsQ
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.32.0/go.mod h1:uGcWLsjkPjZYRpw67cFbNND8jtLokfgLTvZSGpAT7cs=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.28.0 h1:UtG7I7N+hYu6X4Yjz8XC7tgRCss5PiEgCW3KXMxz2R4=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.28.0/go.mod h1:HEr473Fg94eiVW0HnobYqlkfz5dxw771ZseM6DWJAwg=
-github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.19.0 h1:gDWKqmGdCXpmgQivZtYRH3rBWrZdWytswr4eCQdKCF8=
-github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.19.0/go.mod h1:F6Tg7adKZCu0E2B8Ti4+x3M6HS+Qlgl0C57KbDCgtJw=
+github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.20.0 h1:KBw/bfF87jfAgm0ZcQOCgqJSY7tMLg9x+1f+EdUHQt0=
+github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.20.0/go.mod h1:mWcjTY8epINHRpQmgBLjOTYM5TYUeBOysugdyG128io=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.55.0 h1:uWgREKbrY/+EYuU9u4llSkbsIKLSEPriOSHmLCK3GAY=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.55.0/go.mod h1:6G0V3ndXAxeBFSDbUEZ3VTZgmL/9yoIuWM3s3AAV97E=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.31.0 h1:1FNauE0fGAumFzEpmH+nx3OfvgnfUapdpBq9eCk/7II=

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.29.0 h1:IJkGKIgX2ZCga4A
 github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.29.0/go.mod h1:jYH0HRqYnukQt14eBIgAfnIRjihLy5osnU0BN0G+Do8=
 github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.35.0 h1:eoa+/AK+SVR5cTa/yPiDeupC0EZ8jA496jwjNMhrL+U=
 github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.35.0/go.mod h1:E4piy+DkyYY+2sIOdlI91iLrygWzEfIuldAwgyQmWQs=
-github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.30.0 h1:tv3RAtA6Sy920l3QRvhjnve0hrBG3tDrpOyjVD6fz9s=
-github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.30.0/go.mod h1:RogDtUwHccKseh8E8wGF7THiQFb+IIS170v/d4zBfJ8=
+github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.31.0 h1:wOcpGR9keDoaWcFQOUEQqA9EhRcl2yv2yOWS24sQnpM=
+github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.31.0/go.mod h1:h095RtNvHu1cWmPHWxEitFuK7AcAjO6sKbovcmF+7mw=
 github.com/aws/aws-sdk-go-v2/service/kms v1.44.0 h1:Z95XCqqSnwXr0AY7PgsiOUBhUG2GoDM5getw6RfD1Lg=
 github.com/aws/aws-sdk-go-v2/service/kms v1.44.0/go.mod h1:DqcSngL7jJeU1fOzh5Ll5rSvX/MlMV6OZlE4mVdFAQc=
 github.com/aws/aws-sdk-go-v2/service/lakeformation v1.44.0 h1:L48j3iwTIZPNp1FEnZ3d1L1Fx+9ac3N0Oyca42yY3sQ=

--- a/go.sum
+++ b/go.sum
@@ -427,8 +427,8 @@ github.com/aws/aws-sdk-go-v2/service/ram v1.33.0 h1:S1OWl3a+IRR/GSqzjea0jflabLsH
 github.com/aws/aws-sdk-go-v2/service/ram v1.33.0/go.mod h1:ugO++LtUnJAM+y+SkHc/MnZdgIevyA2Eotn3J0UNluQ=
 github.com/aws/aws-sdk-go-v2/service/rbin v1.25.0 h1:uxZwx9vobWg4IS1dyMoC/5Bqrkt9URYtUvj08SZPDRY=
 github.com/aws/aws-sdk-go-v2/service/rbin v1.25.0/go.mod h1:V9wi+fIOqZV2lNpSeWGEs4FJBNF2ROkPWLhbweCl7NM=
-github.com/aws/aws-sdk-go-v2/service/rds v1.102.0 h1:+gr+tHHyjEcDh6ow7FO8wSnyHIX6HjoMUS0FYmk1U3g=
-github.com/aws/aws-sdk-go-v2/service/rds v1.102.0/go.mod h1:BSg3GYV7zYSk/vUsT77SlTZcYz7JmBprKslzqSuC9Nw=
+github.com/aws/aws-sdk-go-v2/service/rds v1.103.0 h1:OWsmICx9jHtBVrgYwYb+2q0iVSPLIfDZOiKhoQA+gjc=
+github.com/aws/aws-sdk-go-v2/service/rds v1.103.0/go.mod h1:tUKTkGAlJo0Gs4t0Z46vaSGD6H1Z6RvtuF03mZY+tPk=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.56.0 h1:UzGm4pOaR1MQE8kQ0HzuzrIKZvjxfYWmHAhjmkFWrKY=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.56.0/go.mod h1:gPTBFJ7XZEk2thUl1+MS6/kEd0jLuJBIzLz5xuveRvY=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.35.0 h1:2uGuWyvd7uCOEcEMN+SWkJsXlXOPrzfBtElITMnVAp4=

--- a/go.sum
+++ b/go.sum
@@ -477,8 +477,8 @@ github.com/aws/aws-sdk-go-v2/service/scheduler v1.16.0 h1:vlmeLcOZ1PtqEpgRIZOOw4
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.16.0/go.mod h1:2XG5FGAj7Ao8KR3scdaU76/YEsdUG304Qt1dIUfHIGM=
 github.com/aws/aws-sdk-go-v2/service/schemas v1.32.0 h1:37TFUN36cFLnIj32FFanXqD+uuXwASxCEEckhdBjCnE=
 github.com/aws/aws-sdk-go-v2/service/schemas v1.32.0/go.mod h1:kZyD0Nd+qn+NgT7Bc3wWwkgTs+J9ufgH46zvV/aC1x0=
-github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.37.0 h1:fC0s79wxfsbz/4WCvosbHLk2mb9ICjPyB+lWs6a0TGM=
-github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.37.0/go.mod h1:6HxvKCop1trgfFlQGQmlq+WbMM5yPazMN9ClWFWGtDM=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.38.0 h1:r5HePq6z0BEXHOZ5/k6bLZVYMSAplzNbvBxHlb2R31A=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.38.0/go.mod h1:Vjg2dOkHDyjU1GFkMtly8DF0r2hKzddAnotNHN6qovY=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.61.0 h1:aCI2GYfTx4TzzPf2WEzsCqvXee1BRqtgzOcNFf2dFmk=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.61.0/go.mod h1:32eH94E8iekHQ/YdEyJw50SNUiStOjMOZ7l8cEw4pLY=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.22.0 h1:gDD/r2shxWIUj+ewgBoKcESeME6uaTEZWrfp1eyq9Dg=

--- a/go.sum
+++ b/go.sum
@@ -435,8 +435,8 @@ github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.36.0 h1:m900Kua81M38+2mViQR
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.36.0/go.mod h1:fKbyyPpRvNxxd3FC8IllvIVic0l4C/IGKIcU7lb5tfI=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.30.0 h1:jB/wGP9pe9pbXCFqZELx9MxLmkZetN0yK0kc7jFDlIY=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.30.0/go.mod h1:qPNYvgSCnM6m27k766S1vd+QquZYz5efWKbMGjB2cU8=
-github.com/aws/aws-sdk-go-v2/service/rekognition v1.49.0 h1:yJ4TZzihb5umIh54Zryxeh/LGAtNu3zs/V4J90sQR0o=
-github.com/aws/aws-sdk-go-v2/service/rekognition v1.49.0/go.mod h1:2KdIwOeztIPoWhKxA3Jnn1PYzDB45NOYUWkSKfFsHIo=
+github.com/aws/aws-sdk-go-v2/service/rekognition v1.50.0 h1:bn5Y52YaLv5p7sa6TIH3Fr/V+gLpoQkcctNAvYT1YP8=
+github.com/aws/aws-sdk-go-v2/service/rekognition v1.50.0/go.mod h1:5vEhAy+7ycQg3WVq7kp1YWTi43DxOqbUPkDLP8vB1Yk=
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.32.0 h1:W5cFv1nnrXWQIIcP9g0znL9GYrOs2OVxNvWIE+pJjqw=
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.32.0/go.mod h1:Ya5/VbHcg63rRJ10MXtqA5i42LeOuP6edwuhISe6RNM=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.19.0 h1:3VIjZDJSYXEnVuWIRq0oXHISbO+tpya0qIHPPzpp2+A=

--- a/go.sum
+++ b/go.sum
@@ -467,8 +467,8 @@ github.com/aws/aws-sdk-go-v2/service/s3control v1.64.0 h1:vq66S6Ulu9VLBGCuOtENpb
 github.com/aws/aws-sdk-go-v2/service/s3control v1.64.0/go.mod h1:W2e0S97cCup2ME32T3fECFSELYcU71486wsnjMG5GwQ=
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.32.0 h1:mT0D16ojwEPM0/XW1yVAeJYvX1F5B2yMhwf7CDpvIqw=
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.32.0/go.mod h1:CiSms5HhJ3M2Q0sYi27TI7a11rVYW4J92nYKpwRm7qk=
-github.com/aws/aws-sdk-go-v2/service/s3tables v1.8.0 h1:lLiy94CE3tRVKCFM6nsa0ERMBhDBC9EDC6Bx1shhack=
-github.com/aws/aws-sdk-go-v2/service/s3tables v1.8.0/go.mod h1:4W2CAy/TSu6SJ8DlBv5LSz7x58DPN8aiRdlhjvg8WEA=
+github.com/aws/aws-sdk-go-v2/service/s3tables v1.9.0 h1:b+DS5OdH3yZCVMHLs/8aA9Nuw+g/WphnYqWj1lnrZbU=
+github.com/aws/aws-sdk-go-v2/service/s3tables v1.9.0/go.mod h1:jVLVoLsG7vN8XEO7OQ7Bqw6qqHXMqWbSBMZ7tmY8R9Q=
 github.com/aws/aws-sdk-go-v2/service/s3vectors v1.3.0 h1:Edx+W8Px8zDrFnoyxwdOjFUzHPzuxy0IXxIV+T/Z3bI=
 github.com/aws/aws-sdk-go-v2/service/s3vectors v1.3.0/go.mod h1:ionbPTnYOWe9G7OQi/yGz0fDefoTUiAWs2tFAxCQiss=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.206.0 h1:TW3sZpiVEqvSksoVXoniO+4hmJ97E+40pazr3m5EMv8=

--- a/go.sum
+++ b/go.sum
@@ -535,8 +535,8 @@ github.com/aws/aws-sdk-go-v2/service/taxsettings v1.15.0 h1:+LdZx81sNrpT4v1+zr+5
 github.com/aws/aws-sdk-go-v2/service/taxsettings v1.15.0/go.mod h1:VHRAf77eBVojkVkK/6Eh0YyqW474JYo2rkdo0ZSbT9U=
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.14.0 h1:x/RJ5w+RJ7F6DXSqUdRd5oo/L2qq2ziciIep+5G+U7A=
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.14.0/go.mod h1:k9gnnRDj9A3E71aGKvAT6cZTTDQCQ1hHT9mu6ayNjkg=
-github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.33.0 h1:FpXclEjSpDkYeCvLpR6nmURQAZfXD235JFvFI6xkbak=
-github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.33.0/go.mod h1:AOmT9Dn8c674nUD56pQAb9rCkhhrlK1K6ULaz3T6/EM=
+github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.34.0 h1:e2NwGYwvTV2yNa76PRkQ/gtjEmnvCw9h6kRTNCg/PUI=
+github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.34.0/go.mod h1:DwajsOry3HW3LDuBdlkTA2YbZkOXl0lGqf/Tmh52RhU=
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.33.0 h1:Ien1hQnz4TwH27FV3BUZxOnp+OYoamqNG3DrHX7clJ0=
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.33.0/go.mod h1:WquhdpcwQ2IToqTKc9GJSoA4Unm69MhLMXEO6qbhjKU=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.49.1 h1:/ToMjU95u9zM7d5DgePvhgGMfkDJFe9Y+WFbRl7Copw=

--- a/go.sum
+++ b/go.sum
@@ -547,8 +547,8 @@ github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.27.0 h1:eGVvpr1n1sMv
 github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.27.0/go.mod h1:XHTOqO6Iy5JS7BTOT5fg5HvmMTxUJRksaypat8yHexw=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.17.0 h1:l/hNjnFe+0P+0YjVaYghBZDooc5OFJOx4c+hG/YyX5Y=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.17.0/go.mod h1:lVuOOAjNmWYyLy+pHYu0QzZ07u8b+0rfPXrQNJ48N9o=
-github.com/aws/aws-sdk-go-v2/service/waf v1.28.0 h1:OYxdAPcJF5HtA5QtvCBIxCyA5KTNB/CjT0Lw5SsKcUk=
-github.com/aws/aws-sdk-go-v2/service/waf v1.28.0/go.mod h1:sBkZNIMfKDvcVtaNmeNqaBlL+okCb/ZhsYMfpL8fKTI=
+github.com/aws/aws-sdk-go-v2/service/waf v1.29.0 h1:KiJHde7jxo8ppD7jcYopFKZ73of3SSyTbXRPifyCSjc=
+github.com/aws/aws-sdk-go-v2/service/waf v1.29.0/go.mod h1:DVC3u2m55AWSV5tUmODpmG4gojAwO94Osa7YDLw9BCg=
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.28.0 h1:ZF2SFoVktg4N3dZZgTayqmJNoSfsvieI/S9bxFnrau8=
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.28.0/go.mod h1:TWzB6PEp1fYN63oDeiYgl8UzON3M7ygUDPvQOZKnK4A=
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.65.0 h1:uY3OJEiMQuO+RDo0ibtWlU5GTPoMZJoiAiaRPEEZUjQ=

--- a/go.sum
+++ b/go.sum
@@ -527,8 +527,8 @@ github.com/aws/aws-sdk-go-v2/service/storagegateway v1.41.0 h1:IZmMc03E2ay2j+4It
 github.com/aws/aws-sdk-go-v2/service/storagegateway v1.41.0/go.mod h1:WcJG/CyL+W/E19D8G5fV16EBWP/V1mxsZChP1i6HflA=
 github.com/aws/aws-sdk-go-v2/service/sts v1.37.0 h1:MG9VFW43M4A8BYeAfaJJZWrroinxeTi2r3+SnmLQfSA=
 github.com/aws/aws-sdk-go-v2/service/sts v1.37.0/go.mod h1:JdeBDPgpJfuS6rU/hNglmOigKhyEZtBmbraLE4GK1J8=
-github.com/aws/aws-sdk-go-v2/service/swf v1.30.0 h1:isVHS2KcvvQF+K4xm1d8gwn7oblSNrvLGnkgnrklU98=
-github.com/aws/aws-sdk-go-v2/service/swf v1.30.0/go.mod h1:ew3I70Cp5/fov/t/5KR5gnUJKh/oUFaRSXiLhGdNEBQ=
+github.com/aws/aws-sdk-go-v2/service/swf v1.31.0 h1:rH21FB+YB32tQXRRqw5GOXLRlEY6sF0niNUnjIz2K4c=
+github.com/aws/aws-sdk-go-v2/service/swf v1.31.0/go.mod h1:K53Z8VIehp17bkIdte5qQJGIg/TTAnSijG5M3SRVQvo=
 github.com/aws/aws-sdk-go-v2/service/synthetics v1.38.0 h1:bO03M5vd7lbwA2u+AJ5p5lNXDrX95irMpQGnTriIZCs=
 github.com/aws/aws-sdk-go-v2/service/synthetics v1.38.0/go.mod h1:pNBlT8k2dNNduzB6k73U7zZ7yyHV2Kr0YlLfi84+c64=
 github.com/aws/aws-sdk-go-v2/service/taxsettings v1.14.0 h1:1pAiXK1faOGJi8KL/bokC4sqxMBkJePnR56mneSbTN4=

--- a/go.sum
+++ b/go.sum
@@ -449,8 +449,8 @@ github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.20.0 h1:KBw/bfF87jfAgm0ZcQ
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.20.0/go.mod h1:mWcjTY8epINHRpQmgBLjOTYM5TYUeBOysugdyG128io=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.56.0 h1:+8/JB7/ZIk86sDBtcy+md9qqHOjc6rR75NySpsrujDY=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.56.0/go.mod h1:aSIshIhq15I4lMlrkvvIoH7E4eLTAEW+isWbga9guNg=
-github.com/aws/aws-sdk-go-v2/service/route53domains v1.31.0 h1:1FNauE0fGAumFzEpmH+nx3OfvgnfUapdpBq9eCk/7II=
-github.com/aws/aws-sdk-go-v2/service/route53domains v1.31.0/go.mod h1:s9AUhIpEw80em5ERrkUzrvQuDjSP9fKd9/+vi5jCr6w=
+github.com/aws/aws-sdk-go-v2/service/route53domains v1.32.0 h1:ZjfNS/AmmzzGbM9Au1219mq3rh7L3HhzgCV04Z5k24M=
+github.com/aws/aws-sdk-go-v2/service/route53domains v1.32.0/go.mod h1:v6BvxeZNn9Ys2Fv/6IGmGCcrf5a10guA3YvlpQId/1o=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.7.0 h1:JhCFwPOmFja1kndJHeF2wPxGdvft9hqk9rmI+3VYBGg=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.7.0/go.mod h1:ZfLB7g4WQPzBcK37APvwX7u0cIz1dKL01MnxRTTkfQo=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.29.0 h1:BSC4rRnApDd4lH2U5dggYS81lyF9v5yG5atDYQlUG4o=

--- a/go.sum
+++ b/go.sum
@@ -513,8 +513,8 @@ github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.30.0 h1:kr0zUJ5+O+3XOO5k30ZF
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.30.0/go.mod h1:76T1ZqJLS3lBmShTO2230KTCoqjw7Lbxj6U7YwEQv+o=
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.38.0 h1:6sjrNE9OXSuF3P2Y+++303mkGbQlmFweTLvZLUz4Ric=
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.38.0/go.mod h1:vAUirHmPQmQF5LO19CMdt10p/9Nl4cqqdygIsdPjx4Y=
-github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.6.0 h1:ivkaBapgjmE9Put5MJ3Yg7zYw+Fud/ZyLMfmSBgCJTs=
-github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.6.0/go.mod h1:HAdCTJPmPNeZD6mAmPDcU9eK1yVP88JVu0kwp6HmJR0=
+github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.7.0 h1:OHfg8SKR3X5AV6/LpinRDBPciw12F4qQjsvf6o0GiGE=
+github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.7.0/go.mod h1:/B5AIPHVKVfZSsofTSfqrvl5QH5r/XK8/qcdHW3jjV4=
 github.com/aws/aws-sdk-go-v2/service/ssmsap v1.22.0 h1:5+fIKFIbA80sYjNf2vccPvmrdp4nb1EbkQdsO9HZA9g=
 github.com/aws/aws-sdk-go-v2/service/ssmsap v1.22.0/go.mod h1:mlTUZlO4rjFmS6ZZ7hJD6Oko4Geto1EMzta8T3R61r4=
 github.com/aws/aws-sdk-go-v2/service/sso v1.28.0 h1:Mc/MKBf2m4VynyJkABoVEN+QzkfLqGj0aiJuEe7cMeM=

--- a/go.sum
+++ b/go.sum
@@ -545,8 +545,8 @@ github.com/aws/aws-sdk-go-v2/service/transfer v1.64.0 h1:QsCjJRBHeDHhOc0J+GIPxhH
 github.com/aws/aws-sdk-go-v2/service/transfer v1.64.0/go.mod h1:LYJ3Lj45sKL6TmHqQQGGzOBTUWjPvo9rqjYmMzbpIlY=
 github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.27.0 h1:eGVvpr1n1sMvSnvYAQVUKK+JUPNFjUTy2iSR8nutPMc=
 github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.27.0/go.mod h1:XHTOqO6Iy5JS7BTOT5fg5HvmMTxUJRksaypat8yHexw=
-github.com/aws/aws-sdk-go-v2/service/vpclattice v1.16.0 h1:yvmIhQivdW+lkqwWjROA6Ig40WRBlUt1jxzZ8qiiYlk=
-github.com/aws/aws-sdk-go-v2/service/vpclattice v1.16.0/go.mod h1:R3HlHnPqocjz6KcFNEH5eIqzCc8bcI7DyWb2LZGFpxk=
+github.com/aws/aws-sdk-go-v2/service/vpclattice v1.17.0 h1:l/hNjnFe+0P+0YjVaYghBZDooc5OFJOx4c+hG/YyX5Y=
+github.com/aws/aws-sdk-go-v2/service/vpclattice v1.17.0/go.mod h1:lVuOOAjNmWYyLy+pHYu0QzZ07u8b+0rfPXrQNJ48N9o=
 github.com/aws/aws-sdk-go-v2/service/waf v1.28.0 h1:OYxdAPcJF5HtA5QtvCBIxCyA5KTNB/CjT0Lw5SsKcUk=
 github.com/aws/aws-sdk-go-v2/service/waf v1.28.0/go.mod h1:sBkZNIMfKDvcVtaNmeNqaBlL+okCb/ZhsYMfpL8fKTI=
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.28.0 h1:ZF2SFoVktg4N3dZZgTayqmJNoSfsvieI/S9bxFnrau8=

--- a/go.sum
+++ b/go.sum
@@ -533,8 +533,8 @@ github.com/aws/aws-sdk-go-v2/service/synthetics v1.39.0 h1:M7W7qo3OsHzH+zrmoU8gR
 github.com/aws/aws-sdk-go-v2/service/synthetics v1.39.0/go.mod h1:W+FGMMTt/jHWUUM5es5OTFA22E2Ofia4wT9sqs8RmQM=
 github.com/aws/aws-sdk-go-v2/service/taxsettings v1.15.0 h1:+LdZx81sNrpT4v1+zr+5LJa8CBtKjWv9UFE+fLdzWRM=
 github.com/aws/aws-sdk-go-v2/service/taxsettings v1.15.0/go.mod h1:VHRAf77eBVojkVkK/6Eh0YyqW474JYo2rkdo0ZSbT9U=
-github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.13.0 h1:ik+FNIDBN16wpzb2kJExF1FJ7jmyyq77gJAiXmxjsyI=
-github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.13.0/go.mod h1:OOSSPOW5gjnWQfNOtYOnvXqWotSk2TWXW6PqXiM8Dd4=
+github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.14.0 h1:x/RJ5w+RJ7F6DXSqUdRd5oo/L2qq2ziciIep+5G+U7A=
+github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.14.0/go.mod h1:k9gnnRDj9A3E71aGKvAT6cZTTDQCQ1hHT9mu6ayNjkg=
 github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.33.0 h1:FpXclEjSpDkYeCvLpR6nmURQAZfXD235JFvFI6xkbak=
 github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.33.0/go.mod h1:AOmT9Dn8c674nUD56pQAb9rCkhhrlK1K6ULaz3T6/EM=
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.33.0 h1:Ien1hQnz4TwH27FV3BUZxOnp+OYoamqNG3DrHX7clJ0=

--- a/go.sum
+++ b/go.sum
@@ -465,8 +465,8 @@ github.com/aws/aws-sdk-go-v2/service/s3 v1.87.0 h1:egoDf+Geuuntmw79Mz6mk9gGmELCP
 github.com/aws/aws-sdk-go-v2/service/s3 v1.87.0/go.mod h1:t9MDi29H+HDbkolTSQtbI0HP9DemAWQzUjmWC7LGMnE=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.64.0 h1:vq66S6Ulu9VLBGCuOtENpbxBEdpUdn6sBopaoP9/SKY=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.64.0/go.mod h1:W2e0S97cCup2ME32T3fECFSELYcU71486wsnjMG5GwQ=
-github.com/aws/aws-sdk-go-v2/service/s3outposts v1.31.0 h1:M5nUP3UBHZEjw0QS1JfqQupAvUgjDyoHBzk+y0cFIJs=
-github.com/aws/aws-sdk-go-v2/service/s3outposts v1.31.0/go.mod h1:jdBR10G+Lp9mVcEZkbFPVJdSAEq+HJVnQLOIkRylRt8=
+github.com/aws/aws-sdk-go-v2/service/s3outposts v1.32.0 h1:mT0D16ojwEPM0/XW1yVAeJYvX1F5B2yMhwf7CDpvIqw=
+github.com/aws/aws-sdk-go-v2/service/s3outposts v1.32.0/go.mod h1:CiSms5HhJ3M2Q0sYi27TI7a11rVYW4J92nYKpwRm7qk=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.8.0 h1:lLiy94CE3tRVKCFM6nsa0ERMBhDBC9EDC6Bx1shhack=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.8.0/go.mod h1:4W2CAy/TSu6SJ8DlBv5LSz7x58DPN8aiRdlhjvg8WEA=
 github.com/aws/aws-sdk-go-v2/service/s3vectors v1.3.0 h1:Edx+W8Px8zDrFnoyxwdOjFUzHPzuxy0IXxIV+T/Z3bI=

--- a/go.sum
+++ b/go.sum
@@ -505,8 +505,8 @@ github.com/aws/aws-sdk-go-v2/service/signer v1.30.0 h1:iuz8rTwAAVIKp4BL2yafOsZDv
 github.com/aws/aws-sdk-go-v2/service/signer v1.30.0/go.mod h1:9zSvP8LjLc7+ZKNU7wiKFYdtT103jk43rZ8VLh+SxOI=
 github.com/aws/aws-sdk-go-v2/service/sns v1.37.0 h1:+GWmgZ6TeJ12tLw4l981+5nc9FDdzXtdZlnmp6KVHig=
 github.com/aws/aws-sdk-go-v2/service/sns v1.37.0/go.mod h1:O4eFpSa/AodvDLJqarL+0vnRgDP9d/FEKHZmzLnA/1c=
-github.com/aws/aws-sdk-go-v2/service/sqs v1.40.0 h1:sgc/AOL84B6Uc+GYAY8oab8cg0m97JegJ+uVil3yiys=
-github.com/aws/aws-sdk-go-v2/service/sqs v1.40.0/go.mod h1:ll5FUISR9gMMKlo+vgSFVkLCqFBnzHZDJ8IwlRQy0kU=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.41.0 h1:xobvQ4NxlXFUNgVwE6cnMI/ww7K7jtQMWKor2Gi61Xg=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.41.0/go.mod h1:RExz4LhRKY5iogQ1dz7KVa3JyBY0PBotXovrDj850Sc=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.62.0 h1:o/2RGV3LouWdbEFpODWRQTw1VSSNOJ8Bh2StX8BpcFs=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.62.0/go.mod h1:Q42zmnvaj33ibL1cPu7N2hvQx6D19Rf94ScnppcQIlU=
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.29.0 h1:Ognxd7DYQTLnq6HzzMBEPfZUbCLfPK/fijUxI0c7oqY=

--- a/go.sum
+++ b/go.sum
@@ -441,8 +441,8 @@ github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.33.0 h1:DUJziWLjN4tzfLFz+h
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.33.0/go.mod h1:SLrdEDIWvazT0GTFQ6ph3QW2EAYYeizvd7g9CMpoMs0=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.20.0 h1:26bUDFcdGzHxBax1oY+HL/YRmUVfqyvcbgdKHr0FDfE=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.20.0/go.mod h1:eFxDYEcdKWIT77Mrq/fT+6KL9bu3ACn5sDFk7Be8FKg=
-github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.31.0 h1:L9r0qWc6316M37Pb4ce2qAtxAXb2ZJHUIRfqS0yP9eY=
-github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.31.0/go.mod h1:7xr8mm8k3g6gDnYYn3MtEtmSg84Ki/3+exNQe3aLx8Y=
+github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.32.0 h1:ZzEJclXVP4woTKwsQChUKOZuekxc/DBjlHKmfFWpYrg=
+github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.32.0/go.mod h1:uGcWLsjkPjZYRpw67cFbNND8jtLokfgLTvZSGpAT7cs=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.28.0 h1:UtG7I7N+hYu6X4Yjz8XC7tgRCss5PiEgCW3KXMxz2R4=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.28.0/go.mod h1:HEr473Fg94eiVW0HnobYqlkfz5dxw771ZseM6DWJAwg=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.19.0 h1:gDWKqmGdCXpmgQivZtYRH3rBWrZdWytswr4eCQdKCF8=

--- a/go.sum
+++ b/go.sum
@@ -495,8 +495,8 @@ github.com/aws/aws-sdk-go-v2/service/servicequotas v1.31.0 h1:IqZZ0dHv/NhExc+8HI
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.31.0/go.mod h1:q+dUus04tyoWH3qZxKzu68bfL4MFs5ahSTSkyFIqmFQ=
 github.com/aws/aws-sdk-go-v2/service/ses v1.32.0 h1:hsvll+Vlk63Wh38r5pWcZTGmA8oYAULQISXguLFc0IA=
 github.com/aws/aws-sdk-go-v2/service/ses v1.32.0/go.mod h1:w6GEPvRXyzj34dGpgbo5MrRUEFTRoXEVNEvg56TpKhE=
-github.com/aws/aws-sdk-go-v2/service/sesv2 v1.50.0 h1:ahFtnukBJ2pZmZ2lAHXozc0bH/Xid7ceScQXYM4nU6w=
-github.com/aws/aws-sdk-go-v2/service/sesv2 v1.50.0/go.mod h1:BXVAeBjFCdDa+ah9DiaKj16DFXDPkFOYdUagssUsptI=
+github.com/aws/aws-sdk-go-v2/service/sesv2 v1.51.0 h1:EGgXgQlHPLB4AQ2EitqhfkhRkyxHJ+Y1CTFbP6vfS60=
+github.com/aws/aws-sdk-go-v2/service/sesv2 v1.51.0/go.mod h1:z/Ty4fCI3RR3vFh/z2kYmdv4KgXh6z/ydK5XN/hfCcY=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.37.0 h1:nmo7k4bHzYxK/iH/hdnYAWJ/tfV+ySV3rk029jVgP+c=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.37.0/go.mod h1:+yaDYK9QNsfC2Kp6UpboOqUVp3giQ7GTVBsWoNqtPHY=
 github.com/aws/aws-sdk-go-v2/service/shield v1.32.0 h1:uekAZy4/sGCQxX+BxWsjMxmKWfavsQyc04NYb6JlIPM=

--- a/go.sum
+++ b/go.sum
@@ -557,8 +557,8 @@ github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.38.0 h1:5+II3BO8cotBo0VN
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.38.0/go.mod h1:ObNr9KblAM/kLbDQAhRAqmi8sY5CPdEd9VqeyZxU79Y=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.61.0 h1:MzTVNx65GKhj9mLLbC7AIXCEBnucyiDB1jAnp4Vye2A=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.61.0/go.mod h1:AJ7eKGcsgQ07kXJ4YWAf7PTFOvkoHc0Voh7CkAj9Bqk=
-github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.30.0 h1:Qw3jH5JOp1Yx63HNLd3m/4fuqOmwZoTskrpnoHD8GL0=
-github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.30.0/go.mod h1:aOovVVoUFe9mVrtezfjeSHi/AKnZm2JKjI5uf1v6Lhw=
+github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.31.0 h1:n4HU/6mkGI9nTgt5Q80hvLMWv4HeXwfx51Ux5lVkRTY=
+github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.31.0/go.mod h1:fCtcQlrmCiCA0BRxpkhrOCFPGDSi7YNw7IV+NS2bKyY=
 github.com/aws/aws-sdk-go-v2/service/xray v1.33.0 h1:iHeSWpMxk/qGq5op8qwHw4DGEP+hx7DLEsQbhlF4mW8=
 github.com/aws/aws-sdk-go-v2/service/xray v1.33.0/go.mod h1:S8Ij3/mKF/976T6WrnozZw2QQBSLs1l2KQTL3SOCwPQ=
 github.com/aws/smithy-go v1.22.5 h1:P9ATCXPMb2mPjYBgueqJNCA5S9UfktsW0tTxi+a7eqw=

--- a/go.sum
+++ b/go.sum
@@ -447,8 +447,8 @@ github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.28.0 h1:UtG7I7N
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.28.0/go.mod h1:HEr473Fg94eiVW0HnobYqlkfz5dxw771ZseM6DWJAwg=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.20.0 h1:KBw/bfF87jfAgm0ZcQOCgqJSY7tMLg9x+1f+EdUHQt0=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.20.0/go.mod h1:mWcjTY8epINHRpQmgBLjOTYM5TYUeBOysugdyG128io=
-github.com/aws/aws-sdk-go-v2/service/route53 v1.55.0 h1:uWgREKbrY/+EYuU9u4llSkbsIKLSEPriOSHmLCK3GAY=
-github.com/aws/aws-sdk-go-v2/service/route53 v1.55.0/go.mod h1:6G0V3ndXAxeBFSDbUEZ3VTZgmL/9yoIuWM3s3AAV97E=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.56.0 h1:+8/JB7/ZIk86sDBtcy+md9qqHOjc6rR75NySpsrujDY=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.56.0/go.mod h1:aSIshIhq15I4lMlrkvvIoH7E4eLTAEW+isWbga9guNg=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.31.0 h1:1FNauE0fGAumFzEpmH+nx3OfvgnfUapdpBq9eCk/7II=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.31.0/go.mod h1:s9AUhIpEw80em5ERrkUzrvQuDjSP9fKd9/+vi5jCr6w=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.7.0 h1:JhCFwPOmFja1kndJHeF2wPxGdvft9hqk9rmI+3VYBGg=

--- a/go.sum
+++ b/go.sum
@@ -511,8 +511,8 @@ github.com/aws/aws-sdk-go-v2/service/ssm v1.63.0 h1:1T8wFNEtOP4lgLC7v8Fzgbb4kFrM
 github.com/aws/aws-sdk-go-v2/service/ssm v1.63.0/go.mod h1:CDVmu8K5JKdgdJakdZ9gC3K6OJ/+izv/kUncFeGRIj4=
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.30.0 h1:kr0zUJ5+O+3XOO5k30ZFWw6BuW77y1wpYl8QbDxgyuo=
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.30.0/go.mod h1:76T1ZqJLS3lBmShTO2230KTCoqjw7Lbxj6U7YwEQv+o=
-github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.37.0 h1:2I7MLpAwSuZvMQZ7scGuHn0wRqeFYSxFQVn11g8CBUA=
-github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.37.0/go.mod h1:ykpAISEQaGRKPKn9HS/VwH89LQh1zu0qjZY+AMgyQCA=
+github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.38.0 h1:6sjrNE9OXSuF3P2Y+++303mkGbQlmFweTLvZLUz4Ric=
+github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.38.0/go.mod h1:vAUirHmPQmQF5LO19CMdt10p/9Nl4cqqdygIsdPjx4Y=
 github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.6.0 h1:ivkaBapgjmE9Put5MJ3Yg7zYw+Fud/ZyLMfmSBgCJTs=
 github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.6.0/go.mod h1:HAdCTJPmPNeZD6mAmPDcU9eK1yVP88JVu0kwp6HmJR0=
 github.com/aws/aws-sdk-go-v2/service/ssmsap v1.22.0 h1:5+fIKFIbA80sYjNf2vccPvmrdp4nb1EbkQdsO9HZA9g=

--- a/go.sum
+++ b/go.sum
@@ -509,8 +509,8 @@ github.com/aws/aws-sdk-go-v2/service/sqs v1.41.0 h1:xobvQ4NxlXFUNgVwE6cnMI/ww7K7
 github.com/aws/aws-sdk-go-v2/service/sqs v1.41.0/go.mod h1:RExz4LhRKY5iogQ1dz7KVa3JyBY0PBotXovrDj850Sc=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.63.0 h1:1T8wFNEtOP4lgLC7v8Fzgbb4kFrMmnscG7kOqkbA26c=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.63.0/go.mod h1:CDVmu8K5JKdgdJakdZ9gC3K6OJ/+izv/kUncFeGRIj4=
-github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.29.0 h1:Ognxd7DYQTLnq6HzzMBEPfZUbCLfPK/fijUxI0c7oqY=
-github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.29.0/go.mod h1:br4H1KoSMGLTG4PUzzhmp+7CnPqu4XFp1x+WhCsSsV4=
+github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.30.0 h1:kr0zUJ5+O+3XOO5k30ZFWw6BuW77y1wpYl8QbDxgyuo=
+github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.30.0/go.mod h1:76T1ZqJLS3lBmShTO2230KTCoqjw7Lbxj6U7YwEQv+o=
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.37.0 h1:2I7MLpAwSuZvMQZ7scGuHn0wRqeFYSxFQVn11g8CBUA=
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.37.0/go.mod h1:ykpAISEQaGRKPKn9HS/VwH89LQh1zu0qjZY+AMgyQCA=
 github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.6.0 h1:ivkaBapgjmE9Put5MJ3Yg7zYw+Fud/ZyLMfmSBgCJTs=

--- a/go.sum
+++ b/go.sum
@@ -485,8 +485,8 @@ github.com/aws/aws-sdk-go-v2/service/securitylake v1.23.0 h1:bhfdvrLXqdIbe+XixpC
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.23.0/go.mod h1:QV9oXwcwhXmG0epKJcTFu0mfZEwkowRVpkhIteltA5M=
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.28.0 h1:zJ4sLmAK4W6tk1czlTcu0pPMyCEFsZvv/v0NC1CymuE=
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.28.0/go.mod h1:HYxuleUSaHgXo2zG8LX1x//z561i55ilDsrVdLbxt78=
-github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.36.0 h1:zlCZr/65ADvLfmONcKzrbXoVnayipGvR1HyLzAenutA=
-github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.36.0/go.mod h1:7KZX4tCstBrE2P1+VMJLpHOBm+QWOfEh40kcmuYmv4o=
+github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.37.0 h1:c9obaYL+TZzWwZf59bU+F18J89YWxciIiGYf+Sr1NU4=
+github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.37.0/go.mod h1:r7nLneDqXu0JsahY3BLtRYyQhsIBloK9O2KLYbSvHU8=
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.33.0 h1:O4l2ptRmGbSau3W9r71yazynDiCyLcdoegwbKJNzS68=
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.33.0/go.mod h1:Aet4t+BW0xV1hm0lLvWoS+LF++1ahOZn7qdZsNE8tjI=
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.37.0 h1:ANrVQ718sD62ltN18eVQq5bIwEzQuPKXmd/H4eMSfPk=

--- a/go.sum
+++ b/go.sum
@@ -479,8 +479,8 @@ github.com/aws/aws-sdk-go-v2/service/schemas v1.32.0 h1:37TFUN36cFLnIj32FFanXqD+
 github.com/aws/aws-sdk-go-v2/service/schemas v1.32.0/go.mod h1:kZyD0Nd+qn+NgT7Bc3wWwkgTs+J9ufgH46zvV/aC1x0=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.38.0 h1:r5HePq6z0BEXHOZ5/k6bLZVYMSAplzNbvBxHlb2R31A=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.38.0/go.mod h1:Vjg2dOkHDyjU1GFkMtly8DF0r2hKzddAnotNHN6qovY=
-github.com/aws/aws-sdk-go-v2/service/securityhub v1.61.0 h1:aCI2GYfTx4TzzPf2WEzsCqvXee1BRqtgzOcNFf2dFmk=
-github.com/aws/aws-sdk-go-v2/service/securityhub v1.61.0/go.mod h1:32eH94E8iekHQ/YdEyJw50SNUiStOjMOZ7l8cEw4pLY=
+github.com/aws/aws-sdk-go-v2/service/securityhub v1.62.0 h1:sKzvE3fkQNa4iXbS2zhPsWhoYZUuPGeyCx29zWaUAyg=
+github.com/aws/aws-sdk-go-v2/service/securityhub v1.62.0/go.mod h1:O3x2LxaDhY0QmJKHLaw2MGgKeYhDMWvi7zsJ+rcnWQU=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.22.0 h1:gDD/r2shxWIUj+ewgBoKcESeME6uaTEZWrfp1eyq9Dg=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.22.0/go.mod h1:8jHxtowB6qC1v2gsi4B7aWVynHuDTGvDGQdzftRZ+zA=
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.27.0 h1:1r06l2UbLJGUOP1LeQ2ulXm2PtS18joFm9dasYo5NXY=

--- a/go.sum
+++ b/go.sum
@@ -481,8 +481,8 @@ github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.38.0 h1:r5HePq6z0BEXHOZ5/
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.38.0/go.mod h1:Vjg2dOkHDyjU1GFkMtly8DF0r2hKzddAnotNHN6qovY=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.62.0 h1:sKzvE3fkQNa4iXbS2zhPsWhoYZUuPGeyCx29zWaUAyg=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.62.0/go.mod h1:O3x2LxaDhY0QmJKHLaw2MGgKeYhDMWvi7zsJ+rcnWQU=
-github.com/aws/aws-sdk-go-v2/service/securitylake v1.22.0 h1:gDD/r2shxWIUj+ewgBoKcESeME6uaTEZWrfp1eyq9Dg=
-github.com/aws/aws-sdk-go-v2/service/securitylake v1.22.0/go.mod h1:8jHxtowB6qC1v2gsi4B7aWVynHuDTGvDGQdzftRZ+zA=
+github.com/aws/aws-sdk-go-v2/service/securitylake v1.23.0 h1:bhfdvrLXqdIbe+XixpCiW5plHoozqTO7afs+26ovHAk=
+github.com/aws/aws-sdk-go-v2/service/securitylake v1.23.0/go.mod h1:QV9oXwcwhXmG0epKJcTFu0mfZEwkowRVpkhIteltA5M=
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.27.0 h1:1r06l2UbLJGUOP1LeQ2ulXm2PtS18joFm9dasYo5NXY=
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.27.0/go.mod h1:NUStYN0KZE1VG4UVvp7XjZZe1F57Wwyoecq1paMLoiQ=
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.36.0 h1:zlCZr/65ADvLfmONcKzrbXoVnayipGvR1HyLzAenutA=

--- a/go.sum
+++ b/go.sum
@@ -487,8 +487,8 @@ github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.28.0 h1:
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.28.0/go.mod h1:HYxuleUSaHgXo2zG8LX1x//z561i55ilDsrVdLbxt78=
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.37.0 h1:c9obaYL+TZzWwZf59bU+F18J89YWxciIiGYf+Sr1NU4=
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.37.0/go.mod h1:r7nLneDqXu0JsahY3BLtRYyQhsIBloK9O2KLYbSvHU8=
-github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.33.0 h1:O4l2ptRmGbSau3W9r71yazynDiCyLcdoegwbKJNzS68=
-github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.33.0/go.mod h1:Aet4t+BW0xV1hm0lLvWoS+LF++1ahOZn7qdZsNE8tjI=
+github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.34.0 h1:kSiJ+KBflpGStdvVB8osVwzglb9QOcCGeaNeveHUAuo=
+github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.34.0/go.mod h1:6QMbXmJiAJ/+xLTDMZJUq36LdNsMXKj9cH5MeG69a5c=
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.37.0 h1:ANrVQ718sD62ltN18eVQq5bIwEzQuPKXmd/H4eMSfPk=
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.37.0/go.mod h1:0Y5X94ePWp4I/S4/BQ8fqdJni6Ymbnnh0Gyc4lpyY5U=
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.30.0 h1:DkMHQQ1yfoPT57erFe/SJXCZ5Weo5T0/AROuA6hg4VQ=

--- a/go.sum
+++ b/go.sum
@@ -473,8 +473,8 @@ github.com/aws/aws-sdk-go-v2/service/s3vectors v1.4.0 h1:9xIfi7XPNyqbrZBCVsAnxla
 github.com/aws/aws-sdk-go-v2/service/s3vectors v1.4.0/go.mod h1:1ByJ/xRNkPDVddSxcpou91CiBIose3JWIWwFw/QjzD8=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.207.0 h1:TCgHvPhW47af5m6EgGczGFAcY2JTGrjxifok50J+Hek=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.207.0/go.mod h1:sawKpnbUfWJb/Q/i2P3rXiM+vXUosAqJ1KOsuKxPRxU=
-github.com/aws/aws-sdk-go-v2/service/scheduler v1.15.0 h1:peHVUtoH7i9QzmkCMyky/a+b2ysCMJ/M+KOtCVmkg7M=
-github.com/aws/aws-sdk-go-v2/service/scheduler v1.15.0/go.mod h1:cQvpps9Xy75b4TIzRYRMnSYaUneTlECRD6p0Vn9hLew=
+github.com/aws/aws-sdk-go-v2/service/scheduler v1.16.0 h1:vlmeLcOZ1PtqEpgRIZOOw49DABG9EWYkHHmC96IBgBM=
+github.com/aws/aws-sdk-go-v2/service/scheduler v1.16.0/go.mod h1:2XG5FGAj7Ao8KR3scdaU76/YEsdUG304Qt1dIUfHIGM=
 github.com/aws/aws-sdk-go-v2/service/schemas v1.31.0 h1:gpBCY2ekUMIFVyczrg5RZlhfCSfPvq33oo+vAKuz5TI=
 github.com/aws/aws-sdk-go-v2/service/schemas v1.31.0/go.mod h1:rkj4nPmey5KTmwApEwZ4zMBBCQMKam+ATjLvNLz3flQ=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.37.0 h1:fC0s79wxfsbz/4WCvosbHLk2mb9ICjPyB+lWs6a0TGM=

--- a/go.sum
+++ b/go.sum
@@ -429,8 +429,8 @@ github.com/aws/aws-sdk-go-v2/service/rbin v1.25.0 h1:uxZwx9vobWg4IS1dyMoC/5Bqrkt
 github.com/aws/aws-sdk-go-v2/service/rbin v1.25.0/go.mod h1:V9wi+fIOqZV2lNpSeWGEs4FJBNF2ROkPWLhbweCl7NM=
 github.com/aws/aws-sdk-go-v2/service/rds v1.103.0 h1:OWsmICx9jHtBVrgYwYb+2q0iVSPLIfDZOiKhoQA+gjc=
 github.com/aws/aws-sdk-go-v2/service/rds v1.103.0/go.mod h1:tUKTkGAlJo0Gs4t0Z46vaSGD6H1Z6RvtuF03mZY+tPk=
-github.com/aws/aws-sdk-go-v2/service/redshift v1.56.0 h1:UzGm4pOaR1MQE8kQ0HzuzrIKZvjxfYWmHAhjmkFWrKY=
-github.com/aws/aws-sdk-go-v2/service/redshift v1.56.0/go.mod h1:gPTBFJ7XZEk2thUl1+MS6/kEd0jLuJBIzLz5xuveRvY=
+github.com/aws/aws-sdk-go-v2/service/redshift v1.57.0 h1:gFNE53MstNSex5n2AeuqDeO9y6YrAEq5r9ohIo0Q1S4=
+github.com/aws/aws-sdk-go-v2/service/redshift v1.57.0/go.mod h1:royODzFrVBRoek5vd76xF7WnwhMGjDj9ZdYcg7Hj8Es=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.35.0 h1:2uGuWyvd7uCOEcEMN+SWkJsXlXOPrzfBtElITMnVAp4=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.35.0/go.mod h1:6Xy8SN1liN5+zoTMZ1C2UpeUdJURWSqr9u8wkOtSpdE=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.29.0 h1:U6WGIeSwoC0xrSi710RscXbEzLjEXpVWzVV4SsrZyRA=

--- a/go.sum
+++ b/go.sum
@@ -437,8 +437,8 @@ github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.30.0 h1:jB/wGP9pe9pbX
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.30.0/go.mod h1:qPNYvgSCnM6m27k766S1vd+QquZYz5efWKbMGjB2cU8=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.50.0 h1:bn5Y52YaLv5p7sa6TIH3Fr/V+gLpoQkcctNAvYT1YP8=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.50.0/go.mod h1:5vEhAy+7ycQg3WVq7kp1YWTi43DxOqbUPkDLP8vB1Yk=
-github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.32.0 h1:W5cFv1nnrXWQIIcP9g0znL9GYrOs2OVxNvWIE+pJjqw=
-github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.32.0/go.mod h1:Ya5/VbHcg63rRJ10MXtqA5i42LeOuP6edwuhISe6RNM=
+github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.33.0 h1:DUJziWLjN4tzfLFz+h2DRDItRtrD3NdGWs0xztSZlFU=
+github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.33.0/go.mod h1:SLrdEDIWvazT0GTFQ6ph3QW2EAYYeizvd7g9CMpoMs0=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.19.0 h1:3VIjZDJSYXEnVuWIRq0oXHISbO+tpya0qIHPPzpp2+A=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.19.0/go.mod h1:bf6/IS5mQoUM4XVKcEaNCF3ghEuOyan7agPlzSheMk4=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.31.0 h1:L9r0qWc6316M37Pb4ce2qAtxAXb2ZJHUIRfqS0yP9eY=

--- a/go.sum
+++ b/go.sum
@@ -475,8 +475,8 @@ github.com/aws/aws-sdk-go-v2/service/sagemaker v1.207.0 h1:TCgHvPhW47af5m6EgGczG
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.207.0/go.mod h1:sawKpnbUfWJb/Q/i2P3rXiM+vXUosAqJ1KOsuKxPRxU=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.16.0 h1:vlmeLcOZ1PtqEpgRIZOOw49DABG9EWYkHHmC96IBgBM=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.16.0/go.mod h1:2XG5FGAj7Ao8KR3scdaU76/YEsdUG304Qt1dIUfHIGM=
-github.com/aws/aws-sdk-go-v2/service/schemas v1.31.0 h1:gpBCY2ekUMIFVyczrg5RZlhfCSfPvq33oo+vAKuz5TI=
-github.com/aws/aws-sdk-go-v2/service/schemas v1.31.0/go.mod h1:rkj4nPmey5KTmwApEwZ4zMBBCQMKam+ATjLvNLz3flQ=
+github.com/aws/aws-sdk-go-v2/service/schemas v1.32.0 h1:37TFUN36cFLnIj32FFanXqD+uuXwASxCEEckhdBjCnE=
+github.com/aws/aws-sdk-go-v2/service/schemas v1.32.0/go.mod h1:kZyD0Nd+qn+NgT7Bc3wWwkgTs+J9ufgH46zvV/aC1x0=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.37.0 h1:fC0s79wxfsbz/4WCvosbHLk2mb9ICjPyB+lWs6a0TGM=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.37.0/go.mod h1:6HxvKCop1trgfFlQGQmlq+WbMM5yPazMN9ClWFWGtDM=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.61.0 h1:aCI2GYfTx4TzzPf2WEzsCqvXee1BRqtgzOcNFf2dFmk=

--- a/go.sum
+++ b/go.sum
@@ -469,8 +469,8 @@ github.com/aws/aws-sdk-go-v2/service/s3outposts v1.32.0 h1:mT0D16ojwEPM0/XW1yVAe
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.32.0/go.mod h1:CiSms5HhJ3M2Q0sYi27TI7a11rVYW4J92nYKpwRm7qk=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.9.0 h1:b+DS5OdH3yZCVMHLs/8aA9Nuw+g/WphnYqWj1lnrZbU=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.9.0/go.mod h1:jVLVoLsG7vN8XEO7OQ7Bqw6qqHXMqWbSBMZ7tmY8R9Q=
-github.com/aws/aws-sdk-go-v2/service/s3vectors v1.3.0 h1:Edx+W8Px8zDrFnoyxwdOjFUzHPzuxy0IXxIV+T/Z3bI=
-github.com/aws/aws-sdk-go-v2/service/s3vectors v1.3.0/go.mod h1:ionbPTnYOWe9G7OQi/yGz0fDefoTUiAWs2tFAxCQiss=
+github.com/aws/aws-sdk-go-v2/service/s3vectors v1.4.0 h1:9xIfi7XPNyqbrZBCVsAnxlajEsNLP4qZ/T+rw6NYtZ0=
+github.com/aws/aws-sdk-go-v2/service/s3vectors v1.4.0/go.mod h1:1ByJ/xRNkPDVddSxcpou91CiBIose3JWIWwFw/QjzD8=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.206.0 h1:TW3sZpiVEqvSksoVXoniO+4hmJ97E+40pazr3m5EMv8=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.206.0/go.mod h1:QAk+j4WZ3VtD9yJDKqF/sVq0fQCcjjQ5gZLVvoVGmWA=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.15.0 h1:peHVUtoH7i9QzmkCMyky/a+b2ysCMJ/M+KOtCVmkg7M=

--- a/go.sum
+++ b/go.sum
@@ -463,8 +463,8 @@ github.com/aws/aws-sdk-go-v2/service/rum v1.27.0 h1:3r/u8MwfSuEu/PggD/JS+1/p2/g/
 github.com/aws/aws-sdk-go-v2/service/rum v1.27.0/go.mod h1:P7vki/W7C8Yufk6IMf8pZys8ZecwQ9AELEQf2KtRAXA=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.87.0 h1:egoDf+Geuuntmw79Mz6mk9gGmELCPzg5PFEABOHB+6Y=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.87.0/go.mod h1:t9MDi29H+HDbkolTSQtbI0HP9DemAWQzUjmWC7LGMnE=
-github.com/aws/aws-sdk-go-v2/service/s3control v1.63.0 h1:Ke1mqUlAVTdAsd8MUOotJiYkmOIYPHsgsEvGw6GUUkE=
-github.com/aws/aws-sdk-go-v2/service/s3control v1.63.0/go.mod h1:UjBvYLSsE98Zow7RHk2mfbw9QVlX5WNIqDPo1hxrjdY=
+github.com/aws/aws-sdk-go-v2/service/s3control v1.64.0 h1:vq66S6Ulu9VLBGCuOtENpbxBEdpUdn6sBopaoP9/SKY=
+github.com/aws/aws-sdk-go-v2/service/s3control v1.64.0/go.mod h1:W2e0S97cCup2ME32T3fECFSELYcU71486wsnjMG5GwQ=
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.31.0 h1:M5nUP3UBHZEjw0QS1JfqQupAvUgjDyoHBzk+y0cFIJs=
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.31.0/go.mod h1:jdBR10G+Lp9mVcEZkbFPVJdSAEq+HJVnQLOIkRylRt8=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.8.0 h1:lLiy94CE3tRVKCFM6nsa0ERMBhDBC9EDC6Bx1shhack=

--- a/go.sum
+++ b/go.sum
@@ -453,8 +453,8 @@ github.com/aws/aws-sdk-go-v2/service/route53domains v1.32.0 h1:ZjfNS/AmmzzGbM9Au
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.32.0/go.mod h1:v6BvxeZNn9Ys2Fv/6IGmGCcrf5a10guA3YvlpQId/1o=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.8.0 h1:MuXKThC0Lv83LdIiFc5aMjmjYuG7hC49Da3H+dvt6xo=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.8.0/go.mod h1:3m2fCUiYfoCDxPMHZGP6u5w9oMOTJnmI8rEc0iKEba0=
-github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.29.0 h1:BSC4rRnApDd4lH2U5dggYS81lyF9v5yG5atDYQlUG4o=
-github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.29.0/go.mod h1:2rt7/1yfNqxIc1+IiwdM2xIA01+FeH+hkkIc6Ui6KYg=
+github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.30.0 h1:mYSV8Ih3PRx9/uKuMMYRGWnUSDjOKDJAlPLqw/fhxB4=
+github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.30.0/go.mod h1:XTAEe+ed1/YhRZr7IwJOcd7LxwEhdHgXFyAbhW5/0GU=
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.24.0 h1:he+LHA/6HCUuFxdM0lUdr+OOTefeEq1G2w/e6yRraQs=
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.24.0/go.mod h1:LdJD7I50vTaWfAdn1FBydN6r8XpkF6humwUN25hAV+4=
 github.com/aws/aws-sdk-go-v2/service/route53resolver v1.38.0 h1:HRDZKs73kNRsb+5MhAz4+ONvPgiXVmgTfsj4/PoJIWs=

--- a/go.sum
+++ b/go.sum
@@ -433,8 +433,8 @@ github.com/aws/aws-sdk-go-v2/service/redshift v1.57.0 h1:gFNE53MstNSex5n2AeuqDeO
 github.com/aws/aws-sdk-go-v2/service/redshift v1.57.0/go.mod h1:royODzFrVBRoek5vd76xF7WnwhMGjDj9ZdYcg7Hj8Es=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.36.0 h1:m900Kua81M38+2mViQR0WyXuVJHXfHhBMZE2KEOKCxg=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.36.0/go.mod h1:fKbyyPpRvNxxd3FC8IllvIVic0l4C/IGKIcU7lb5tfI=
-github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.29.0 h1:U6WGIeSwoC0xrSi710RscXbEzLjEXpVWzVV4SsrZyRA=
-github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.29.0/go.mod h1:HcZb7L9GmTq1C7RKGBb14VRSTPjnnP9aFJ0xL3KQPco=
+github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.30.0 h1:jB/wGP9pe9pbXCFqZELx9MxLmkZetN0yK0kc7jFDlIY=
+github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.30.0/go.mod h1:qPNYvgSCnM6m27k766S1vd+QquZYz5efWKbMGjB2cU8=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.49.0 h1:yJ4TZzihb5umIh54Zryxeh/LGAtNu3zs/V4J90sQR0o=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.49.0/go.mod h1:2KdIwOeztIPoWhKxA3Jnn1PYzDB45NOYUWkSKfFsHIo=
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.32.0 h1:W5cFv1nnrXWQIIcP9g0znL9GYrOs2OVxNvWIE+pJjqw=

--- a/go.sum
+++ b/go.sum
@@ -523,8 +523,8 @@ github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.34.0 h1:aiGJnlWqp3e81gDzbSX/+67
 github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.34.0/go.mod h1:0PiTFSuC4ripX730Y5aU/E6Nvge5JgVJUR36FAnCFCw=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.33.0 h1:6csaS/aJmqZQbKhi1EyEMM7yBW653Wy/B9hnBofW+sw=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.33.0/go.mod h1:59qHWaY5B+Rs7HGTuVGaC32m0rdpQ68N8QCN3khYiqs=
-github.com/aws/aws-sdk-go-v2/service/storagegateway v1.40.0 h1:eywzm3eHsI6lkM7HpsLuoLUKuW87wINDWM/kpEahPbQ=
-github.com/aws/aws-sdk-go-v2/service/storagegateway v1.40.0/go.mod h1:dpO8VuQCysRhgr+cTRKLjF27aJZ84dDR5mpC3YKSzvI=
+github.com/aws/aws-sdk-go-v2/service/storagegateway v1.41.0 h1:IZmMc03E2ay2j+4It6+XKpWLwdH9RNfLYr31ZjTmlpk=
+github.com/aws/aws-sdk-go-v2/service/storagegateway v1.41.0/go.mod h1:WcJG/CyL+W/E19D8G5fV16EBWP/V1mxsZChP1i6HflA=
 github.com/aws/aws-sdk-go-v2/service/sts v1.37.0 h1:MG9VFW43M4A8BYeAfaJJZWrroinxeTi2r3+SnmLQfSA=
 github.com/aws/aws-sdk-go-v2/service/sts v1.37.0/go.mod h1:JdeBDPgpJfuS6rU/hNglmOigKhyEZtBmbraLE4GK1J8=
 github.com/aws/aws-sdk-go-v2/service/swf v1.30.0 h1:isVHS2KcvvQF+K4xm1d8gwn7oblSNrvLGnkgnrklU98=

--- a/go.sum
+++ b/go.sum
@@ -493,8 +493,8 @@ github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.38.0 h1:zQ78zrO5o29Sx+p
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.38.0/go.mod h1:nnG6Pe7Qu1Bv/mE3eL/3gCiQYrAWyXFXDOtOKcC7eh0=
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.31.0 h1:IqZZ0dHv/NhExc+8HI6CdgTZLz7Yjn9OaExTmFX4UX8=
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.31.0/go.mod h1:q+dUus04tyoWH3qZxKzu68bfL4MFs5ahSTSkyFIqmFQ=
-github.com/aws/aws-sdk-go-v2/service/ses v1.32.0 h1:hsvll+Vlk63Wh38r5pWcZTGmA8oYAULQISXguLFc0IA=
-github.com/aws/aws-sdk-go-v2/service/ses v1.32.0/go.mod h1:w6GEPvRXyzj34dGpgbo5MrRUEFTRoXEVNEvg56TpKhE=
+github.com/aws/aws-sdk-go-v2/service/ses v1.33.0 h1:3BEXxnGZpqGWVFL8lntsAtWjT19EtQp2uUmXS0+wWpA=
+github.com/aws/aws-sdk-go-v2/service/ses v1.33.0/go.mod h1:WvsgG068tbYpznWb1e4z09bo7pdNfKyHK05muGk3JPA=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.51.0 h1:EGgXgQlHPLB4AQ2EitqhfkhRkyxHJ+Y1CTFbP6vfS60=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.51.0/go.mod h1:z/Ty4fCI3RR3vFh/z2kYmdv4KgXh6z/ydK5XN/hfCcY=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.38.0 h1:qDg+pW4hxuM1zlixvZy3EyRxGiy4FknvKwfYHsUGvYw=

--- a/go.sum
+++ b/go.sum
@@ -431,8 +431,8 @@ github.com/aws/aws-sdk-go-v2/service/rds v1.103.0 h1:OWsmICx9jHtBVrgYwYb+2q0iVSP
 github.com/aws/aws-sdk-go-v2/service/rds v1.103.0/go.mod h1:tUKTkGAlJo0Gs4t0Z46vaSGD6H1Z6RvtuF03mZY+tPk=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.57.0 h1:gFNE53MstNSex5n2AeuqDeO9y6YrAEq5r9ohIo0Q1S4=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.57.0/go.mod h1:royODzFrVBRoek5vd76xF7WnwhMGjDj9ZdYcg7Hj8Es=
-github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.35.0 h1:2uGuWyvd7uCOEcEMN+SWkJsXlXOPrzfBtElITMnVAp4=
-github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.35.0/go.mod h1:6Xy8SN1liN5+zoTMZ1C2UpeUdJURWSqr9u8wkOtSpdE=
+github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.36.0 h1:m900Kua81M38+2mViQR0WyXuVJHXfHhBMZE2KEOKCxg=
+github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.36.0/go.mod h1:fKbyyPpRvNxxd3FC8IllvIVic0l4C/IGKIcU7lb5tfI=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.29.0 h1:U6WGIeSwoC0xrSi710RscXbEzLjEXpVWzVV4SsrZyRA=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.29.0/go.mod h1:HcZb7L9GmTq1C7RKGBb14VRSTPjnnP9aFJ0xL3KQPco=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.49.0 h1:yJ4TZzihb5umIh54Zryxeh/LGAtNu3zs/V4J90sQR0o=

--- a/go.sum
+++ b/go.sum
@@ -455,8 +455,8 @@ github.com/aws/aws-sdk-go-v2/service/route53profiles v1.8.0 h1:MuXKThC0Lv83LdIiF
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.8.0/go.mod h1:3m2fCUiYfoCDxPMHZGP6u5w9oMOTJnmI8rEc0iKEba0=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.30.0 h1:mYSV8Ih3PRx9/uKuMMYRGWnUSDjOKDJAlPLqw/fhxB4=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.30.0/go.mod h1:XTAEe+ed1/YhRZr7IwJOcd7LxwEhdHgXFyAbhW5/0GU=
-github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.24.0 h1:he+LHA/6HCUuFxdM0lUdr+OOTefeEq1G2w/e6yRraQs=
-github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.24.0/go.mod h1:LdJD7I50vTaWfAdn1FBydN6r8XpkF6humwUN25hAV+4=
+github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.25.0 h1:M1lJ8nSB8pL5XPIq82UsizGi+t4ZXkmBkW2WpPWczpw=
+github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.25.0/go.mod h1:P9I8vfH8zNEoQNAqKYgpuWRce0tdKZQaCHHs1oF7SV8=
 github.com/aws/aws-sdk-go-v2/service/route53resolver v1.38.0 h1:HRDZKs73kNRsb+5MhAz4+ONvPgiXVmgTfsj4/PoJIWs=
 github.com/aws/aws-sdk-go-v2/service/route53resolver v1.38.0/go.mod h1:b9+yk2umEzWK2xzbsBZDrAeG63ia8B1ess7IyZG+mX4=
 github.com/aws/aws-sdk-go-v2/service/rum v1.26.0 h1:ZqNEWtitFjwaKGPqtPSK8cq0LaTUGKOBbvT/2+n7Zg4=

--- a/go.sum
+++ b/go.sum
@@ -443,8 +443,8 @@ github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.20.0 h1:26bUDFcdGzHxBa
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.20.0/go.mod h1:eFxDYEcdKWIT77Mrq/fT+6KL9bu3ACn5sDFk7Be8FKg=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.32.0 h1:ZzEJclXVP4woTKwsQChUKOZuekxc/DBjlHKmfFWpYrg=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.32.0/go.mod h1:uGcWLsjkPjZYRpw67cFbNND8jtLokfgLTvZSGpAT7cs=
-github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.28.0 h1:UtG7I7N+hYu6X4Yjz8XC7tgRCss5PiEgCW3KXMxz2R4=
-github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.28.0/go.mod h1:HEr473Fg94eiVW0HnobYqlkfz5dxw771ZseM6DWJAwg=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.29.0 h1:jevrLpVG9sOEPsuipO3eGcdDzJyo36Dmme9iSu/8GVE=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.29.0/go.mod h1:t/zZb99l0WrcNYbDIF3tgj0rJNklhiVa6B1x/Rz4rHc=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.20.0 h1:KBw/bfF87jfAgm0ZcQOCgqJSY7tMLg9x+1f+EdUHQt0=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.20.0/go.mod h1:mWcjTY8epINHRpQmgBLjOTYM5TYUeBOysugdyG128io=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.56.0 h1:+8/JB7/ZIk86sDBtcy+md9qqHOjc6rR75NySpsrujDY=

--- a/go.sum
+++ b/go.sum
@@ -459,8 +459,8 @@ github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.25.0 h1:M1lJ8nS
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.25.0/go.mod h1:P9I8vfH8zNEoQNAqKYgpuWRce0tdKZQaCHHs1oF7SV8=
 github.com/aws/aws-sdk-go-v2/service/route53resolver v1.39.0 h1:JCUZSQ0pCqqihKLmicNKzvKt0JpXzwyWr4izSjyKxbg=
 github.com/aws/aws-sdk-go-v2/service/route53resolver v1.39.0/go.mod h1:gF2Hv8YowjskA+/IKprIj9QroaE0HdD7H0Ay39K4y2s=
-github.com/aws/aws-sdk-go-v2/service/rum v1.26.0 h1:ZqNEWtitFjwaKGPqtPSK8cq0LaTUGKOBbvT/2+n7Zg4=
-github.com/aws/aws-sdk-go-v2/service/rum v1.26.0/go.mod h1:PLpZddWg0SWhlNl442cRfa5zeWV7NCECrE/naqMhzl8=
+github.com/aws/aws-sdk-go-v2/service/rum v1.27.0 h1:3r/u8MwfSuEu/PggD/JS+1/p2/g/a3mz+bjg1uTSyys=
+github.com/aws/aws-sdk-go-v2/service/rum v1.27.0/go.mod h1:P7vki/W7C8Yufk6IMf8pZys8ZecwQ9AELEQf2KtRAXA=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.87.0 h1:egoDf+Geuuntmw79Mz6mk9gGmELCPzg5PFEABOHB+6Y=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.87.0/go.mod h1:t9MDi29H+HDbkolTSQtbI0HP9DemAWQzUjmWC7LGMnE=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.63.0 h1:Ke1mqUlAVTdAsd8MUOotJiYkmOIYPHsgsEvGw6GUUkE=

--- a/go.sum
+++ b/go.sum
@@ -541,8 +541,8 @@ github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.34.0 h1:/Ec93n7oXPhZvalY
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.34.0/go.mod h1:zR+5dzF2qJz6WneebK+JkFEheDRa8CbRKYs//5XycJU=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.50.0 h1:otdXZIcJvXCaOpXvZnydfshPQJVtM3s6A5KozVtmkbc=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.50.0/go.mod h1:zKZY1p5qYRYG/NMOMv8GVeUJLliaK+EpgD9Q2q4v7O4=
-github.com/aws/aws-sdk-go-v2/service/transfer v1.63.0 h1:ccfREMOY7VoLlSuSEH/wvXr1Ex+AbmKSKf1iTYvsyYI=
-github.com/aws/aws-sdk-go-v2/service/transfer v1.63.0/go.mod h1:zZCkAJeuF8Pfs9vOShUWoL7cXqANEbYaycWjiPeHzJo=
+github.com/aws/aws-sdk-go-v2/service/transfer v1.64.0 h1:QsCjJRBHeDHhOc0J+GIPxhHesz5yTSYXR1jyMWzXcNQ=
+github.com/aws/aws-sdk-go-v2/service/transfer v1.64.0/go.mod h1:LYJ3Lj45sKL6TmHqQQGGzOBTUWjPvo9rqjYmMzbpIlY=
 github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.26.0 h1:PpHbbpQ2q02tM40tzUGwRpuTDHc36TtujWkKgcUZhJs=
 github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.26.0/go.mod h1:hmDaQDyTtzWXZ9dImqrLz33w5W1zwq5Vl+ek1ocUEiU=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.16.0 h1:yvmIhQivdW+lkqwWjROA6Ig40WRBlUt1jxzZ8qiiYlk=

--- a/go.sum
+++ b/go.sum
@@ -507,8 +507,8 @@ github.com/aws/aws-sdk-go-v2/service/sns v1.37.0 h1:+GWmgZ6TeJ12tLw4l981+5nc9FDd
 github.com/aws/aws-sdk-go-v2/service/sns v1.37.0/go.mod h1:O4eFpSa/AodvDLJqarL+0vnRgDP9d/FEKHZmzLnA/1c=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.41.0 h1:xobvQ4NxlXFUNgVwE6cnMI/ww7K7jtQMWKor2Gi61Xg=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.41.0/go.mod h1:RExz4LhRKY5iogQ1dz7KVa3JyBY0PBotXovrDj850Sc=
-github.com/aws/aws-sdk-go-v2/service/ssm v1.62.0 h1:o/2RGV3LouWdbEFpODWRQTw1VSSNOJ8Bh2StX8BpcFs=
-github.com/aws/aws-sdk-go-v2/service/ssm v1.62.0/go.mod h1:Q42zmnvaj33ibL1cPu7N2hvQx6D19Rf94ScnppcQIlU=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.63.0 h1:1T8wFNEtOP4lgLC7v8Fzgbb4kFrMmnscG7kOqkbA26c=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.63.0/go.mod h1:CDVmu8K5JKdgdJakdZ9gC3K6OJ/+izv/kUncFeGRIj4=
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.29.0 h1:Ognxd7DYQTLnq6HzzMBEPfZUbCLfPK/fijUxI0c7oqY=
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.29.0/go.mod h1:br4H1KoSMGLTG4PUzzhmp+7CnPqu4XFp1x+WhCsSsV4=
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.37.0 h1:2I7MLpAwSuZvMQZ7scGuHn0wRqeFYSxFQVn11g8CBUA=

--- a/go.sum
+++ b/go.sum
@@ -489,8 +489,8 @@ github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.37.0 h1:c9obaYL+TZzWwZf59
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.37.0/go.mod h1:r7nLneDqXu0JsahY3BLtRYyQhsIBloK9O2KLYbSvHU8=
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.34.0 h1:kSiJ+KBflpGStdvVB8osVwzglb9QOcCGeaNeveHUAuo=
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.34.0/go.mod h1:6QMbXmJiAJ/+xLTDMZJUq36LdNsMXKj9cH5MeG69a5c=
-github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.37.0 h1:ANrVQ718sD62ltN18eVQq5bIwEzQuPKXmd/H4eMSfPk=
-github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.37.0/go.mod h1:0Y5X94ePWp4I/S4/BQ8fqdJni6Ymbnnh0Gyc4lpyY5U=
+github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.38.0 h1:zQ78zrO5o29Sx+pPK2AYaf6WY2tvmZ2DQcYnX9NfhNE=
+github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.38.0/go.mod h1:nnG6Pe7Qu1Bv/mE3eL/3gCiQYrAWyXFXDOtOKcC7eh0=
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.30.0 h1:DkMHQQ1yfoPT57erFe/SJXCZ5Weo5T0/AROuA6hg4VQ=
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.30.0/go.mod h1:r9XW7P7bOhnjMycQWPVeIEPvmzmW8RqzW65vp4z+IjY=
 github.com/aws/aws-sdk-go-v2/service/ses v1.32.0 h1:hsvll+Vlk63Wh38r5pWcZTGmA8oYAULQISXguLFc0IA=

--- a/go.sum
+++ b/go.sum
@@ -539,8 +539,8 @@ github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.34.0 h1:e2NwGYwvTV2yNa76
 github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.34.0/go.mod h1:DwajsOry3HW3LDuBdlkTA2YbZkOXl0lGqf/Tmh52RhU=
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.34.0 h1:/Ec93n7oXPhZvalYxFphWMSNjaAy/A2dWkKhqCAePEg=
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.34.0/go.mod h1:zR+5dzF2qJz6WneebK+JkFEheDRa8CbRKYs//5XycJU=
-github.com/aws/aws-sdk-go-v2/service/transcribe v1.49.1 h1:/ToMjU95u9zM7d5DgePvhgGMfkDJFe9Y+WFbRl7Copw=
-github.com/aws/aws-sdk-go-v2/service/transcribe v1.49.1/go.mod h1:C4HQjEMMSrwJQKQsFslNNOeP3dICpXktxWJ6MjRCyq8=
+github.com/aws/aws-sdk-go-v2/service/transcribe v1.50.0 h1:otdXZIcJvXCaOpXvZnydfshPQJVtM3s6A5KozVtmkbc=
+github.com/aws/aws-sdk-go-v2/service/transcribe v1.50.0/go.mod h1:zKZY1p5qYRYG/NMOMv8GVeUJLliaK+EpgD9Q2q4v7O4=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.63.0 h1:ccfREMOY7VoLlSuSEH/wvXr1Ex+AbmKSKf1iTYvsyYI=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.63.0/go.mod h1:zZCkAJeuF8Pfs9vOShUWoL7cXqANEbYaycWjiPeHzJo=
 github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.26.0 h1:PpHbbpQ2q02tM40tzUGwRpuTDHc36TtujWkKgcUZhJs=

--- a/go.sum
+++ b/go.sum
@@ -503,8 +503,8 @@ github.com/aws/aws-sdk-go-v2/service/shield v1.33.0 h1:vIp1dRkvVu4oKSl41ds/Y/rBR
 github.com/aws/aws-sdk-go-v2/service/shield v1.33.0/go.mod h1:oT7arIE6sZstDjgtKfXZtLqpnsJuX261eFPfp7+0LR8=
 github.com/aws/aws-sdk-go-v2/service/signer v1.30.0 h1:iuz8rTwAAVIKp4BL2yafOsZDvuW5tkkPsOmxRcytPhw=
 github.com/aws/aws-sdk-go-v2/service/signer v1.30.0/go.mod h1:9zSvP8LjLc7+ZKNU7wiKFYdtT103jk43rZ8VLh+SxOI=
-github.com/aws/aws-sdk-go-v2/service/sns v1.36.0 h1:Jal42fPojaJRvXps8yN7ZGyIJRAbgE8jBqxMIv10hEg=
-github.com/aws/aws-sdk-go-v2/service/sns v1.36.0/go.mod h1:SyCtWzjWA5aLNfchfyuWTtwO0AXRg9rPwfCkOB7fUPA=
+github.com/aws/aws-sdk-go-v2/service/sns v1.37.0 h1:+GWmgZ6TeJ12tLw4l981+5nc9FDdzXtdZlnmp6KVHig=
+github.com/aws/aws-sdk-go-v2/service/sns v1.37.0/go.mod h1:O4eFpSa/AodvDLJqarL+0vnRgDP9d/FEKHZmzLnA/1c=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.40.0 h1:sgc/AOL84B6Uc+GYAY8oab8cg0m97JegJ+uVil3yiys=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.40.0/go.mod h1:ll5FUISR9gMMKlo+vgSFVkLCqFBnzHZDJ8IwlRQy0kU=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.62.0 h1:o/2RGV3LouWdbEFpODWRQTw1VSSNOJ8Bh2StX8BpcFs=

--- a/go.sum
+++ b/go.sum
@@ -529,8 +529,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.37.0 h1:MG9VFW43M4A8BYeAfaJJZWrroinx
 github.com/aws/aws-sdk-go-v2/service/sts v1.37.0/go.mod h1:JdeBDPgpJfuS6rU/hNglmOigKhyEZtBmbraLE4GK1J8=
 github.com/aws/aws-sdk-go-v2/service/swf v1.31.0 h1:rH21FB+YB32tQXRRqw5GOXLRlEY6sF0niNUnjIz2K4c=
 github.com/aws/aws-sdk-go-v2/service/swf v1.31.0/go.mod h1:K53Z8VIehp17bkIdte5qQJGIg/TTAnSijG5M3SRVQvo=
-github.com/aws/aws-sdk-go-v2/service/synthetics v1.38.0 h1:bO03M5vd7lbwA2u+AJ5p5lNXDrX95irMpQGnTriIZCs=
-github.com/aws/aws-sdk-go-v2/service/synthetics v1.38.0/go.mod h1:pNBlT8k2dNNduzB6k73U7zZ7yyHV2Kr0YlLfi84+c64=
+github.com/aws/aws-sdk-go-v2/service/synthetics v1.39.0 h1:M7W7qo3OsHzH+zrmoU8gR4Or+WB2aV32kJ6H5qSYgEs=
+github.com/aws/aws-sdk-go-v2/service/synthetics v1.39.0/go.mod h1:W+FGMMTt/jHWUUM5es5OTFA22E2Ofia4wT9sqs8RmQM=
 github.com/aws/aws-sdk-go-v2/service/taxsettings v1.14.0 h1:1pAiXK1faOGJi8KL/bokC4sqxMBkJePnR56mneSbTN4=
 github.com/aws/aws-sdk-go-v2/service/taxsettings v1.14.0/go.mod h1:RdzWkdzuoaM98wctumapBmD2r3WImPXw6g7rICPLvyY=
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.13.0 h1:ik+FNIDBN16wpzb2kJExF1FJ7jmyyq77gJAiXmxjsyI=

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/aws/aws-sdk-go-v2/service/detective v1.36.0 h1:0av6yvy0lYUtlgDnZoinqI
 github.com/aws/aws-sdk-go-v2/service/detective v1.36.0/go.mod h1:mS/k1sKOFKsE7Jr34gvsnX52nLSjAWfnjvvoUJwhkTU=
 github.com/aws/aws-sdk-go-v2/service/devicefarm v1.34.0 h1:zvhsIkUZOol3DwpcvFl/y14uSSs1JNcGsbu7cMdSxqU=
 github.com/aws/aws-sdk-go-v2/service/devicefarm v1.34.0/go.mod h1:3QfEUV+KuDYX+oOpu86CUe1/m9yVBO8Z+72OLmPGsWA=
-github.com/aws/aws-sdk-go-v2/service/devopsguru v1.37.0 h1:SUJxgNXb9Gl+gm9p5Q0M5M9G3E8AjV6ELnmgMwt2MTM=
-github.com/aws/aws-sdk-go-v2/service/devopsguru v1.37.0/go.mod h1:Uttl2g1mxh8OO3Nn6L/O5RyMW96Q9NCQ9v95NH7AAIs=
+github.com/aws/aws-sdk-go-v2/service/devopsguru v1.38.0 h1:+yQPtAOwzsA/4eIT1oGcZu30dljvlCNec2pGOPUsw4A=
+github.com/aws/aws-sdk-go-v2/service/devopsguru v1.38.0/go.mod h1:yfBgovuMZJiyeD7iv6LNn45JYSLLWoNjALM0OPPf23I=
 github.com/aws/aws-sdk-go-v2/service/directconnect v1.35.0 h1:6FJwZjdnKtDCPb5oH0DY2NMIOiMlw/srC7H0P5TZWbE=
 github.com/aws/aws-sdk-go-v2/service/directconnect v1.35.0/go.mod h1:nfTthF0vgdEKFt79wWB4mdX8YuLq2slQxG+mv3U+rmA=
 github.com/aws/aws-sdk-go-v2/service/directoryservice v1.35.0 h1:raC54NZ3nBlLL8AJgcH4jcI6tM0bPm2gxVk5svtN1hw=

--- a/go.sum
+++ b/go.sum
@@ -519,8 +519,8 @@ github.com/aws/aws-sdk-go-v2/service/ssmsap v1.23.0 h1:21pRqoiIDamny/57BJYBrGumQ
 github.com/aws/aws-sdk-go-v2/service/ssmsap v1.23.0/go.mod h1:tLEEa+UsBhm/fZNrnA1O8Vf69/Y94pYuLFP/v1UpB3U=
 github.com/aws/aws-sdk-go-v2/service/sso v1.28.0 h1:Mc/MKBf2m4VynyJkABoVEN+QzkfLqGj0aiJuEe7cMeM=
 github.com/aws/aws-sdk-go-v2/service/sso v1.28.0/go.mod h1:iS5OmxEcN4QIPXARGhavH7S8kETNL11kym6jhoS7IUQ=
-github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.33.0 h1:61baAQJeQS9SdTXJ9MVUiT5hkMf65SUfjVV9j2/W45M=
-github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.33.0/go.mod h1:nnlw3wIldhDvFLfpv/yH9j31xoz0EdczpuYu95M/Mm0=
+github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.34.0 h1:aiGJnlWqp3e81gDzbSX/+67LqbnW9ppW/Md2CqLVCrQ=
+github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.34.0/go.mod h1:0PiTFSuC4ripX730Y5aU/E6Nvge5JgVJUR36FAnCFCw=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.33.0 h1:6csaS/aJmqZQbKhi1EyEMM7yBW653Wy/B9hnBofW+sw=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.33.0/go.mod h1:59qHWaY5B+Rs7HGTuVGaC32m0rdpQ68N8QCN3khYiqs=
 github.com/aws/aws-sdk-go-v2/service/storagegateway v1.40.0 h1:eywzm3eHsI6lkM7HpsLuoLUKuW87wINDWM/kpEahPbQ=

--- a/go.sum
+++ b/go.sum
@@ -537,8 +537,8 @@ github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.14.0 h1:x/RJ5w+RJ7F6D
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.14.0/go.mod h1:k9gnnRDj9A3E71aGKvAT6cZTTDQCQ1hHT9mu6ayNjkg=
 github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.34.0 h1:e2NwGYwvTV2yNa76PRkQ/gtjEmnvCw9h6kRTNCg/PUI=
 github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.34.0/go.mod h1:DwajsOry3HW3LDuBdlkTA2YbZkOXl0lGqf/Tmh52RhU=
-github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.33.0 h1:Ien1hQnz4TwH27FV3BUZxOnp+OYoamqNG3DrHX7clJ0=
-github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.33.0/go.mod h1:WquhdpcwQ2IToqTKc9GJSoA4Unm69MhLMXEO6qbhjKU=
+github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.34.0 h1:/Ec93n7oXPhZvalYxFphWMSNjaAy/A2dWkKhqCAePEg=
+github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.34.0/go.mod h1:zR+5dzF2qJz6WneebK+JkFEheDRa8CbRKYs//5XycJU=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.49.1 h1:/ToMjU95u9zM7d5DgePvhgGMfkDJFe9Y+WFbRl7Copw=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.49.1/go.mod h1:C4HQjEMMSrwJQKQsFslNNOeP3dICpXktxWJ6MjRCyq8=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.63.0 h1:ccfREMOY7VoLlSuSEH/wvXr1Ex+AbmKSKf1iTYvsyYI=

--- a/go.sum
+++ b/go.sum
@@ -549,8 +549,8 @@ github.com/aws/aws-sdk-go-v2/service/vpclattice v1.17.0 h1:l/hNjnFe+0P+0YjVaYghB
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.17.0/go.mod h1:lVuOOAjNmWYyLy+pHYu0QzZ07u8b+0rfPXrQNJ48N9o=
 github.com/aws/aws-sdk-go-v2/service/waf v1.29.0 h1:KiJHde7jxo8ppD7jcYopFKZ73of3SSyTbXRPifyCSjc=
 github.com/aws/aws-sdk-go-v2/service/waf v1.29.0/go.mod h1:DVC3u2m55AWSV5tUmODpmG4gojAwO94Osa7YDLw9BCg=
-github.com/aws/aws-sdk-go-v2/service/wafregional v1.28.0 h1:ZF2SFoVktg4N3dZZgTayqmJNoSfsvieI/S9bxFnrau8=
-github.com/aws/aws-sdk-go-v2/service/wafregional v1.28.0/go.mod h1:TWzB6PEp1fYN63oDeiYgl8UzON3M7ygUDPvQOZKnK4A=
+github.com/aws/aws-sdk-go-v2/service/wafregional v1.29.0 h1:gFCxExCqt4/HWMVKmzf+Mxt3i1gyovNNL8xlfVaN0a4=
+github.com/aws/aws-sdk-go-v2/service/wafregional v1.29.0/go.mod h1:brjH7E2LWOtLNsAupQL1Lv803e2xm3v+3wzqlX4BAOk=
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.65.0 h1:uY3OJEiMQuO+RDo0ibtWlU5GTPoMZJoiAiaRPEEZUjQ=
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.65.0/go.mod h1:2y/+a6X3qVfn8T1s3ZT7+OAdyFNVfnG6GRa6EMf69u0=
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.37.0 h1:Ajd4pP2pftD3pnofQ1+7TEflSaNYevoII49UkI0xatA=

--- a/go.sum
+++ b/go.sum
@@ -543,8 +543,8 @@ github.com/aws/aws-sdk-go-v2/service/transcribe v1.50.0 h1:otdXZIcJvXCaOpXvZnydf
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.50.0/go.mod h1:zKZY1p5qYRYG/NMOMv8GVeUJLliaK+EpgD9Q2q4v7O4=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.64.0 h1:QsCjJRBHeDHhOc0J+GIPxhHesz5yTSYXR1jyMWzXcNQ=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.64.0/go.mod h1:LYJ3Lj45sKL6TmHqQQGGzOBTUWjPvo9rqjYmMzbpIlY=
-github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.26.0 h1:PpHbbpQ2q02tM40tzUGwRpuTDHc36TtujWkKgcUZhJs=
-github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.26.0/go.mod h1:hmDaQDyTtzWXZ9dImqrLz33w5W1zwq5Vl+ek1ocUEiU=
+github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.27.0 h1:eGVvpr1n1sMvSnvYAQVUKK+JUPNFjUTy2iSR8nutPMc=
+github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.27.0/go.mod h1:XHTOqO6Iy5JS7BTOT5fg5HvmMTxUJRksaypat8yHexw=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.16.0 h1:yvmIhQivdW+lkqwWjROA6Ig40WRBlUt1jxzZ8qiiYlk=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.16.0/go.mod h1:R3HlHnPqocjz6KcFNEH5eIqzCc8bcI7DyWb2LZGFpxk=
 github.com/aws/aws-sdk-go-v2/service/waf v1.28.0 h1:OYxdAPcJF5HtA5QtvCBIxCyA5KTNB/CjT0Lw5SsKcUk=

--- a/go.sum
+++ b/go.sum
@@ -531,8 +531,8 @@ github.com/aws/aws-sdk-go-v2/service/swf v1.31.0 h1:rH21FB+YB32tQXRRqw5GOXLRlEY6
 github.com/aws/aws-sdk-go-v2/service/swf v1.31.0/go.mod h1:K53Z8VIehp17bkIdte5qQJGIg/TTAnSijG5M3SRVQvo=
 github.com/aws/aws-sdk-go-v2/service/synthetics v1.39.0 h1:M7W7qo3OsHzH+zrmoU8gR4Or+WB2aV32kJ6H5qSYgEs=
 github.com/aws/aws-sdk-go-v2/service/synthetics v1.39.0/go.mod h1:W+FGMMTt/jHWUUM5es5OTFA22E2Ofia4wT9sqs8RmQM=
-github.com/aws/aws-sdk-go-v2/service/taxsettings v1.14.0 h1:1pAiXK1faOGJi8KL/bokC4sqxMBkJePnR56mneSbTN4=
-github.com/aws/aws-sdk-go-v2/service/taxsettings v1.14.0/go.mod h1:RdzWkdzuoaM98wctumapBmD2r3WImPXw6g7rICPLvyY=
+github.com/aws/aws-sdk-go-v2/service/taxsettings v1.15.0 h1:+LdZx81sNrpT4v1+zr+5LJa8CBtKjWv9UFE+fLdzWRM=
+github.com/aws/aws-sdk-go-v2/service/taxsettings v1.15.0/go.mod h1:VHRAf77eBVojkVkK/6Eh0YyqW474JYo2rkdo0ZSbT9U=
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.13.0 h1:ik+FNIDBN16wpzb2kJExF1FJ7jmyyq77gJAiXmxjsyI=
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.13.0/go.mod h1:OOSSPOW5gjnWQfNOtYOnvXqWotSk2TWXW6PqXiM8Dd4=
 github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.33.0 h1:FpXclEjSpDkYeCvLpR6nmURQAZfXD235JFvFI6xkbak=

--- a/go.sum
+++ b/go.sum
@@ -483,8 +483,8 @@ github.com/aws/aws-sdk-go-v2/service/securityhub v1.62.0 h1:sKzvE3fkQNa4iXbS2zhP
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.62.0/go.mod h1:O3x2LxaDhY0QmJKHLaw2MGgKeYhDMWvi7zsJ+rcnWQU=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.23.0 h1:bhfdvrLXqdIbe+XixpCiW5plHoozqTO7afs+26ovHAk=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.23.0/go.mod h1:QV9oXwcwhXmG0epKJcTFu0mfZEwkowRVpkhIteltA5M=
-github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.27.0 h1:1r06l2UbLJGUOP1LeQ2ulXm2PtS18joFm9dasYo5NXY=
-github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.27.0/go.mod h1:NUStYN0KZE1VG4UVvp7XjZZe1F57Wwyoecq1paMLoiQ=
+github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.28.0 h1:zJ4sLmAK4W6tk1czlTcu0pPMyCEFsZvv/v0NC1CymuE=
+github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.28.0/go.mod h1:HYxuleUSaHgXo2zG8LX1x//z561i55ilDsrVdLbxt78=
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.36.0 h1:zlCZr/65ADvLfmONcKzrbXoVnayipGvR1HyLzAenutA=
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.36.0/go.mod h1:7KZX4tCstBrE2P1+VMJLpHOBm+QWOfEh40kcmuYmv4o=
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.33.0 h1:O4l2ptRmGbSau3W9r71yazynDiCyLcdoegwbKJNzS68=

--- a/go.sum
+++ b/go.sum
@@ -551,8 +551,8 @@ github.com/aws/aws-sdk-go-v2/service/waf v1.29.0 h1:KiJHde7jxo8ppD7jcYopFKZ73of3
 github.com/aws/aws-sdk-go-v2/service/waf v1.29.0/go.mod h1:DVC3u2m55AWSV5tUmODpmG4gojAwO94Osa7YDLw9BCg=
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.29.0 h1:gFCxExCqt4/HWMVKmzf+Mxt3i1gyovNNL8xlfVaN0a4=
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.29.0/go.mod h1:brjH7E2LWOtLNsAupQL1Lv803e2xm3v+3wzqlX4BAOk=
-github.com/aws/aws-sdk-go-v2/service/wafv2 v1.65.0 h1:uY3OJEiMQuO+RDo0ibtWlU5GTPoMZJoiAiaRPEEZUjQ=
-github.com/aws/aws-sdk-go-v2/service/wafv2 v1.65.0/go.mod h1:2y/+a6X3qVfn8T1s3ZT7+OAdyFNVfnG6GRa6EMf69u0=
+github.com/aws/aws-sdk-go-v2/service/wafv2 v1.66.0 h1:zEbaP92GXITM2TrYiw4mNer/ViT4z/Zq8hmrIzSF3Y0=
+github.com/aws/aws-sdk-go-v2/service/wafv2 v1.66.0/go.mod h1:EPNcb1lt/lfWkpjINo7eP5AwfvlG8ioVT9frx5w5k9s=
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.37.0 h1:Ajd4pP2pftD3pnofQ1+7TEflSaNYevoII49UkI0xatA=
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.37.0/go.mod h1:vhARHB5E9NBKpbcLcWo96asxlofoSEXItelnMf4L63Q=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.60.0 h1:l+YQbYWAiupSnKXZ/HOYNOI0XdRexhwnlGY6EYBwZ7g=

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ github.com/aws/aws-sdk-go-v2/service/s3tables v1.9.0 h1:b+DS5OdH3yZCVMHLs/8aA9Nu
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.9.0/go.mod h1:jVLVoLsG7vN8XEO7OQ7Bqw6qqHXMqWbSBMZ7tmY8R9Q=
 github.com/aws/aws-sdk-go-v2/service/s3vectors v1.4.0 h1:9xIfi7XPNyqbrZBCVsAnxlajEsNLP4qZ/T+rw6NYtZ0=
 github.com/aws/aws-sdk-go-v2/service/s3vectors v1.4.0/go.mod h1:1ByJ/xRNkPDVddSxcpou91CiBIose3JWIWwFw/QjzD8=
-github.com/aws/aws-sdk-go-v2/service/sagemaker v1.206.0 h1:TW3sZpiVEqvSksoVXoniO+4hmJ97E+40pazr3m5EMv8=
-github.com/aws/aws-sdk-go-v2/service/sagemaker v1.206.0/go.mod h1:QAk+j4WZ3VtD9yJDKqF/sVq0fQCcjjQ5gZLVvoVGmWA=
+github.com/aws/aws-sdk-go-v2/service/sagemaker v1.207.0 h1:TCgHvPhW47af5m6EgGczGFAcY2JTGrjxifok50J+Hek=
+github.com/aws/aws-sdk-go-v2/service/sagemaker v1.207.0/go.mod h1:sawKpnbUfWJb/Q/i2P3rXiM+vXUosAqJ1KOsuKxPRxU=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.15.0 h1:peHVUtoH7i9QzmkCMyky/a+b2ysCMJ/M+KOtCVmkg7M=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.15.0/go.mod h1:cQvpps9Xy75b4TIzRYRMnSYaUneTlECRD6p0Vn9hLew=
 github.com/aws/aws-sdk-go-v2/service/schemas v1.31.0 h1:gpBCY2ekUMIFVyczrg5RZlhfCSfPvq33oo+vAKuz5TI=

--- a/go.sum
+++ b/go.sum
@@ -499,8 +499,8 @@ github.com/aws/aws-sdk-go-v2/service/sesv2 v1.51.0 h1:EGgXgQlHPLB4AQ2EitqhfkhRky
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.51.0/go.mod h1:z/Ty4fCI3RR3vFh/z2kYmdv4KgXh6z/ydK5XN/hfCcY=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.38.0 h1:qDg+pW4hxuM1zlixvZy3EyRxGiy4FknvKwfYHsUGvYw=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.38.0/go.mod h1:UXg+xZNhGCuhG8tg8Qj9XBH3qRA5WgmJkelLEyOassI=
-github.com/aws/aws-sdk-go-v2/service/shield v1.32.0 h1:uekAZy4/sGCQxX+BxWsjMxmKWfavsQyc04NYb6JlIPM=
-github.com/aws/aws-sdk-go-v2/service/shield v1.32.0/go.mod h1:uFSdevNXa2hQFSbvHTrd0/+N4llyjbegPt7T4ij5nIs=
+github.com/aws/aws-sdk-go-v2/service/shield v1.33.0 h1:vIp1dRkvVu4oKSl41ds/Y/rBRfw9tyUAOMS1E0FRdG8=
+github.com/aws/aws-sdk-go-v2/service/shield v1.33.0/go.mod h1:oT7arIE6sZstDjgtKfXZtLqpnsJuX261eFPfp7+0LR8=
 github.com/aws/aws-sdk-go-v2/service/signer v1.29.0 h1:sF/j2NltXGKx6Tewc7RUwL7fQKxTgXib83qQI/rx5N0=
 github.com/aws/aws-sdk-go-v2/service/signer v1.29.0/go.mod h1:kiL4+PJKl6UCNmJORt8IS/k/ydl31sI4WQJnqJQfQi8=
 github.com/aws/aws-sdk-go-v2/service/sns v1.36.0 h1:Jal42fPojaJRvXps8yN7ZGyIJRAbgE8jBqxMIv10hEg=

--- a/go.sum
+++ b/go.sum
@@ -501,8 +501,8 @@ github.com/aws/aws-sdk-go-v2/service/sfn v1.38.0 h1:qDg+pW4hxuM1zlixvZy3EyRxGiy4
 github.com/aws/aws-sdk-go-v2/service/sfn v1.38.0/go.mod h1:UXg+xZNhGCuhG8tg8Qj9XBH3qRA5WgmJkelLEyOassI=
 github.com/aws/aws-sdk-go-v2/service/shield v1.33.0 h1:vIp1dRkvVu4oKSl41ds/Y/rBRfw9tyUAOMS1E0FRdG8=
 github.com/aws/aws-sdk-go-v2/service/shield v1.33.0/go.mod h1:oT7arIE6sZstDjgtKfXZtLqpnsJuX261eFPfp7+0LR8=
-github.com/aws/aws-sdk-go-v2/service/signer v1.29.0 h1:sF/j2NltXGKx6Tewc7RUwL7fQKxTgXib83qQI/rx5N0=
-github.com/aws/aws-sdk-go-v2/service/signer v1.29.0/go.mod h1:kiL4+PJKl6UCNmJORt8IS/k/ydl31sI4WQJnqJQfQi8=
+github.com/aws/aws-sdk-go-v2/service/signer v1.30.0 h1:iuz8rTwAAVIKp4BL2yafOsZDvuW5tkkPsOmxRcytPhw=
+github.com/aws/aws-sdk-go-v2/service/signer v1.30.0/go.mod h1:9zSvP8LjLc7+ZKNU7wiKFYdtT103jk43rZ8VLh+SxOI=
 github.com/aws/aws-sdk-go-v2/service/sns v1.36.0 h1:Jal42fPojaJRvXps8yN7ZGyIJRAbgE8jBqxMIv10hEg=
 github.com/aws/aws-sdk-go-v2/service/sns v1.36.0/go.mod h1:SyCtWzjWA5aLNfchfyuWTtwO0AXRg9rPwfCkOB7fUPA=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.40.0 h1:sgc/AOL84B6Uc+GYAY8oab8cg0m97JegJ+uVil3yiys=

--- a/go.sum
+++ b/go.sum
@@ -457,8 +457,8 @@ github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.30.0 h1:mYS
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.30.0/go.mod h1:XTAEe+ed1/YhRZr7IwJOcd7LxwEhdHgXFyAbhW5/0GU=
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.25.0 h1:M1lJ8nSB8pL5XPIq82UsizGi+t4ZXkmBkW2WpPWczpw=
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.25.0/go.mod h1:P9I8vfH8zNEoQNAqKYgpuWRce0tdKZQaCHHs1oF7SV8=
-github.com/aws/aws-sdk-go-v2/service/route53resolver v1.38.0 h1:HRDZKs73kNRsb+5MhAz4+ONvPgiXVmgTfsj4/PoJIWs=
-github.com/aws/aws-sdk-go-v2/service/route53resolver v1.38.0/go.mod h1:b9+yk2umEzWK2xzbsBZDrAeG63ia8B1ess7IyZG+mX4=
+github.com/aws/aws-sdk-go-v2/service/route53resolver v1.39.0 h1:JCUZSQ0pCqqihKLmicNKzvKt0JpXzwyWr4izSjyKxbg=
+github.com/aws/aws-sdk-go-v2/service/route53resolver v1.39.0/go.mod h1:gF2Hv8YowjskA+/IKprIj9QroaE0HdD7H0Ay39K4y2s=
 github.com/aws/aws-sdk-go-v2/service/rum v1.26.0 h1:ZqNEWtitFjwaKGPqtPSK8cq0LaTUGKOBbvT/2+n7Zg4=
 github.com/aws/aws-sdk-go-v2/service/rum v1.26.0/go.mod h1:PLpZddWg0SWhlNl442cRfa5zeWV7NCECrE/naqMhzl8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.87.0 h1:egoDf+Geuuntmw79Mz6mk9gGmELCPzg5PFEABOHB+6Y=


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Manual update of `github.com/aws/aws-sdk-go-v2/aws` dependencies to [Release 2025-08-11](https://github.com/aws/aws-sdk-go-v2/commit/0ab2d66f8e3df0b6850a13986c7d8c2d23cbd822) due to dependabot failures.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/39287.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43585.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43619.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43709.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
