### PR TITLE
docs: add detail on TagFilter usage

### DIFF
--- a/website/docs/d/ram_resource_share.html.markdown
+++ b/website/docs/d/ram_resource_share.html.markdown
@@ -39,7 +39,7 @@ This data source supports the following arguments:
 * `name` - (Optional) Name of the resource share to retrieve.
 * `resource_owner` (Required) Owner of the resource share. Valid values are `SELF` or `OTHER-ACCOUNTS`.
 * `resource_share_status` (Optional) Specifies that you want to retrieve details of only those resource shares that have this status. Valid values are `PENDING`, `ACTIVE`, `FAILED`, `DELETING`, and `DELETED`.
-* `filter` - (Optional) Filter used to scope the list e.g., by tags. See [related docs] (https://docs.aws.amazon.com/ram/latest/APIReference/API_TagFilter.html).
+* `filter` - (Optional) Filter used to scope the list of owned shares e.g., by tags. See [related docs] (https://docs.aws.amazon.com/ram/latest/APIReference/API_TagFilter.html).
     * `name` - (Required) Name of the tag key to filter on.
     * `values` - (Required) Value of the tag key.
 


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls are made.

### Description

As mentioned in #40970 the [`filter`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ram_resource_share#filter-1) in the data source [`aws_ram_resource_share`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ram_resource_share) only works with resources that are owned (`resource_owner = "SELF"`).

The documentation is updated to reflect this detail.


Example code for showing the issue  when combining `resource_owner = "OTHER-ACCOUNTS"` and `filter`

```hcl
terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "6.8.0"
    }
  }
  required_version = "~> 1.12.2"
}

provider "aws" {
  region = "eu-central-1"
}

data "aws_ram_resource_share" "tag_filter" {
  resource_owner = "OTHER-ACCOUNTS"
  filter {
    name   = "NameOfTag"
    values = ["exampleNameTagValue"]
  }
}
```

Output of `terraform plan`

```shell
❯ terraform init -upgrade
Initializing the backend...
Initializing provider plugins...
- Finding hashicorp/aws versions matching "6.8.0"...
- Installing hashicorp/aws v6.8.0...
- Installed hashicorp/aws v6.8.0 (signed by HashiCorp)
Terraform has made some changes to the provider dependency selections recorded
in the .terraform.lock.hcl file. Review those changes and commit them to your
version control system if they represent changes you intended to make.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
❯ terraform plan
data.aws_ram_resource_share.tag_filter: Reading...

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: reading RAM Resource Share: operation error RAM: GetResourceShares, https response error StatusCode: 400, RequestID: 40ccbac4-590d-4666-b369-f14dbdf0ee31, InvalidParameterException: You cannot use resourceOwner set to OTHER-ACCOUNTS and tagFilters in one request. Specify one parameter and try again.
│ 
│   with data.aws_ram_resource_share.tag_filter,
│   on main.tf line 16, in data "aws_ram_resource_share" "tag_filter":
│   16: data "aws_ram_resource_share" "tag_filter" {
│ 
```

### Relations

Closes #40970 

### References

- [GetResourceShares API](https://docs.aws.amazon.com/ram/latest/APIReference/API_GetResourceShares.html)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.