### PR TITLE
[Enhancement] aws_codebuild_webhook: Support for `pull_request_build_policy` 

### DIFF
--- a/.changelog/43851.txt
+++ b/.changelog/43851.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_codebuild_webhook: Add `pull_request_build_policy` argument
+```

--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -93,6 +93,7 @@ This resource supports the following arguments:
 * `branch_filter` - (Optional) A regular expression used to determine which branches get built. Default is all branches are built. We recommend using `filter_group` over `branch_filter`.
 * `filter_group` - (Optional) Information about the webhook's trigger. Filter group blocks are documented below.
 * `scope_configuration` - (Optional) Scope configuration for global or organization webhooks. Scope configuration blocks are documented below.
+* `pull_request_build_policy` - (Optional) Define a comment-based approval requirements for triggering builds on pull requests. This policy helps control when automated builds are executed based on contributor permissions and approval workflows
 
 `filter_group` supports the following:
 
@@ -109,6 +110,11 @@ This resource supports the following arguments:
 * `name` - (Required) The name of either the enterprise or organization.
 * `scope` - (Required) The type of scope for a GitHub webhook. Valid values for this parameter are: `GITHUB_ORGANIZATION`, `GITHUB_GLOBAL`.
 * `domain` - (Optional) The domain of the GitHub Enterprise organization. Required if your project's source type is GITHUB_ENTERPRISE.
+
+`pull_request_build_policy` supports the following:
+
+* `requires_comment_approval` - (Required) Specifies when comment-based approval is required before triggering a build on pull requests. Valid values: `DISABLED`, `ALL_PULL_REQUESTS`, `FORK_PULL_REQUESTS`.
+* `approver_roles` - (Optional) List of repository roles that have approval privileges for pull request builds when comment approval is required. Only users with these roles can provide valid comment approvals. If a pull request contributor is one of these roles, their pull request builds will trigger automatically.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description


This change adds the new CodeBuild `pull_request_build_policy` webhook resource API parameter. The new parameter helps users control when automated builds are executed based on contributor permissions and approval workflows.

References: 
- https://docs.aws.amazon.com/codebuild/latest/APIReference/API_CreateWebhook.html
- https://docs.aws.amazon.com/codebuild/latest/APIReference/API_PullRequestBuildPolicy.html
- https://docs.aws.amazon.com/codebuild/latest/userguide/pull-request-build-policy.html


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
➜ make testacc TESTS='TestAccCodeBuildWebhook' PKG=codebuild
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/codebuild/... -v -count 1 -parallel 20 -run='TestAccCodeBuildWebhook'  -timeout 360m -vet=off
2025/08/13 01:48:50 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/13 01:48:50 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCodeBuildWebhook_bitbucket
=== PAUSE TestAccCodeBuildWebhook_bitbucket
=== RUN   TestAccCodeBuildWebhook_gitHub
=== PAUSE TestAccCodeBuildWebhook_gitHub
=== RUN   TestAccCodeBuildWebhook_gitHubEnterprise
=== PAUSE TestAccCodeBuildWebhook_gitHubEnterprise
=== RUN   TestAccCodeBuildWebhook_buildType
=== PAUSE TestAccCodeBuildWebhook_buildType
=== RUN   TestAccCodeBuildWebhook_scopeConfiguration
=== PAUSE TestAccCodeBuildWebhook_scopeConfiguration
=== RUN   TestAccCodeBuildWebhook_pullRequestBuildPolicy_basic
=== PAUSE TestAccCodeBuildWebhook_pullRequestBuildPolicy_basic
=== RUN   TestAccCodeBuildWebhook_branchFilter
=== PAUSE TestAccCodeBuildWebhook_branchFilter
=== RUN   TestAccCodeBuildWebhook_filterGroup
=== PAUSE TestAccCodeBuildWebhook_filterGroup
=== RUN   TestAccCodeBuildWebhook_disappears
=== PAUSE TestAccCodeBuildWebhook_disappears
=== RUN   TestAccCodeBuildWebhook_Disappears_project
=== PAUSE TestAccCodeBuildWebhook_Disappears_project
=== RUN   TestAccCodeBuildWebhook_manualCreation
=== PAUSE TestAccCodeBuildWebhook_manualCreation
=== RUN   TestAccCodeBuildWebhook_upgradeV5_94_1
=== PAUSE TestAccCodeBuildWebhook_upgradeV5_94_1
=== CONT  TestAccCodeBuildWebhook_bitbucket
=== CONT  TestAccCodeBuildWebhook_branchFilter
=== CONT  TestAccCodeBuildWebhook_Disappears_project
=== CONT  TestAccCodeBuildWebhook_upgradeV5_94_1
=== CONT  TestAccCodeBuildWebhook_buildType
=== CONT  TestAccCodeBuildWebhook_scopeConfiguration
=== CONT  TestAccCodeBuildWebhook_gitHubEnterprise
=== CONT  TestAccCodeBuildWebhook_disappears
=== CONT  TestAccCodeBuildWebhook_gitHub
=== CONT  TestAccCodeBuildWebhook_filterGroup
=== CONT  TestAccCodeBuildWebhook_manualCreation
=== CONT  TestAccCodeBuildWebhook_pullRequestBuildPolicy_basic
=== NAME  TestAccCodeBuildWebhook_bitbucket
    source_credential_test.go:143: skipping acceptance testing: Source Credentials (BITBUCKET) not found
--- SKIP: TestAccCodeBuildWebhook_bitbucket (1.83s)
=== NAME  TestAccCodeBuildWebhook_gitHubEnterprise
    source_credential_test.go:143: skipping acceptance testing: Source Credentials (GITHUB_ENTERPRISE) not found
--- SKIP: TestAccCodeBuildWebhook_gitHubEnterprise (1.84s)
--- PASS: TestAccCodeBuildWebhook_scopeConfiguration (54.50s)
--- PASS: TestAccCodeBuildWebhook_Disappears_project (56.62s)
--- PASS: TestAccCodeBuildWebhook_filterGroup (57.19s)
--- PASS: TestAccCodeBuildWebhook_disappears (57.31s)
--- PASS: TestAccCodeBuildWebhook_gitHub (57.48s)
--- PASS: TestAccCodeBuildWebhook_pullRequestBuildPolicy_basic (57.95s)
--- PASS: TestAccCodeBuildWebhook_manualCreation (60.67s)
--- PASS: TestAccCodeBuildWebhook_branchFilter (75.30s)
--- PASS: TestAccCodeBuildWebhook_upgradeV5_94_1 (83.41s)
--- PASS: TestAccCodeBuildWebhook_buildType (94.61s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codebuild	101.144s

...
```
