### PR TITLE
 chore: Remove aws.StringSlice usage from r/aws_finspace_kx_volume

### DIFF
--- a/internal/service/finspace/kx_volume.go
+++ b/internal/service/finspace/kx_volume.go
@@ -243,7 +243,7 @@ func resourceKxVolumeRead(ctx context.Context, d *schema.ResourceData, meta any)
 	d.Set(names.AttrDescription, out.Description)
 	d.Set("created_timestamp", out.CreatedTimestamp.String())
 	d.Set("last_modified_timestamp", out.LastModifiedTimestamp.String())
-	d.Set(names.AttrAvailabilityZones, aws.StringSlice(out.AvailabilityZoneIds))
+	d.Set(names.AttrAvailabilityZones, out.AvailabilityZoneIds)
 
 	if err := d.Set("nas1_configuration", flattenNas1Configuration(out.Nas1Configuration)); err != nil {
 		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionSetting, ResNameKxVolume, d.Id(), err)

--- a/website/docs/r/finspace_kx_volume.html.markdown
+++ b/website/docs/r/finspace_kx_volume.html.markdown
@@ -18,7 +18,7 @@ Terraform resource for managing an AWS FinSpace Kx Volume.
 resource "aws_finspace_kx_volume" "example" {
   name               = "my-tf-kx-volume"
   environment_id     = aws_finspace_kx_environment.example.id
-  availability_zones = "use1-az2"
+  availability_zones = ["use1-az2"]
   az_mode            = "SINGLE"
   type               = "NAS_1"
   nas1_configuration {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to remove `aws.StringSlice` usages from the `aws_finspace_kx_volume` resource, specifically for the `availability_zones` argument.

I noticed that `availability_zones` in the example usage is incorrectly set as a value instead of a list, so I fixed that in this PR too.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41800

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Note that `TestAccFinSpaceKxVolume_basic` failed because of the account quota limit of 2 environments. I reran the test case individually afterwards and it's fine.

```console
$ make testacc TESTS=TestAccFinSpaceKxVolume_ PKG=finspace
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/finspace/... -v -count 1 -parallel 20 -run='TestAccFinSpaceKxVolume_'  -timeout 360m -vet=off
2025/08/12 23:34:36 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/12 23:34:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccFinSpaceKxVolume_basic
=== PAUSE TestAccFinSpaceKxVolume_basic
=== RUN   TestAccFinSpaceKxVolume_disappears
=== PAUSE TestAccFinSpaceKxVolume_disappears
=== RUN   TestAccFinSpaceKxVolume_tags
=== PAUSE TestAccFinSpaceKxVolume_tags
=== CONT  TestAccFinSpaceKxVolume_basic
=== CONT  TestAccFinSpaceKxVolume_tags
=== CONT  TestAccFinSpaceKxVolume_disappears
=== NAME  TestAccFinSpaceKxVolume_basic
    kx_volume_test.go:34: Step 1/2 error: Error running apply: exit status 1

        Error: waiting for creation AWS FinSpace Kx Volume (2lgfbp24hqbei7rtgfe45o,tf-acc-test-5097556728037647913): unexpected state 'CREATE_FAILED', wanted target 'ACTIVE'. last error: %!s(<nil>)

          with aws_finspace_kx_volume.test,
          on terraform_plugin_test.tf line 119, in resource "aws_finspace_kx_volume" "test":
         119: resource "aws_finspace_kx_volume" "test" {

--- PASS: TestAccFinSpaceKxVolume_disappears (2604.53s)
--- PASS: TestAccFinSpaceKxVolume_tags (3753.43s)
=== NAME  TestAccFinSpaceKxVolume_basic
    panic.go:636: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: waiting for delete AWS FinSpace Kx Environment (2lgfbp24hqbei7rtgfe45o): timeout while waiting for resource to be gone (last state: 'DELETING', timeout: 1h15m0s)

--- FAIL: TestAccFinSpaceKxVolume_basic (5643.94s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/finspace   5644.275s
FAIL
make: *** [GNUmakefile:645: testacc] Error 1

$
```

```console
$ make testacc TESTS=TestAccFinSpaceKxVolume_basic PKG=finspace
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/finspace/... -v -count 1 -parallel 20 -run='TestAccFinSpaceKxVolume_basic'  -timeout 360m -vet=off
2025/08/13 01:09:57 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/13 01:09:57 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccFinSpaceKxVolume_basic
=== PAUSE TestAccFinSpaceKxVolume_basic
=== CONT  TestAccFinSpaceKxVolume_basic
--- PASS: TestAccFinSpaceKxVolume_basic (1424.79s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/finspace   1425.086s

$
```