### PR TITLE
chore: aws_security_group Fix the validation logic for description to be more strict

### DIFF
--- a/internal/service/ec2/vpc_security_group.go
+++ b/internal/service/ec2/vpc_security_group.go
@@ -68,7 +68,7 @@ func resourceSecurityGroup() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Default:      "Managed by Terraform",
-				ValidateFunc: validation.StringLenBetween(0, 255),
+				ValidateFunc: validSecurityGroupRuleDescription,
 			},
 			"egress":  securityGroupRuleSetNestedBlock,
 			"ingress": securityGroupRuleSetNestedBlock,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Changed the validation logic for security group descriptions to be more strict.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

n/a

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

```tf
resource "aws_security_group" "sample" {
  name = "sample-sg"
  description = "セキュリティグループ"
}

│ Error: creating Security Group (microsof-entra-private-access-connector-server-sg): operation error EC2: CreateSecurityGroup, https response error StatusCode: 400, RequestID: 0436c17d-0ab1-4d6e-a28b-b87a46b54644, api error InvalidParameterValue: Value (セキュリティグループ) for parameter GroupDescription is invalid. Character sets beyond ASCII are not supported.
│ 
│   with aws_security_group.sample,
│   on sg.tf line 3, in resource "aws_security_group" "sample":
│    3: resource "aws_security_group" "sample" {
│ 
```

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccVPCSecurityGroup_ruleDescription PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCSecurityGroup_ruleDescription'  -timeout 360m -vet=off
2025/08/13 14:15:59 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/13 14:15:59 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCSecurityGroup_ruleDescription
=== PAUSE TestAccVPCSecurityGroup_ruleDescription
=== CONT  TestAccVPCSecurityGroup_ruleDescription
--- PASS: TestAccVPCSecurityGroup_ruleDescription (63.46s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	68.564s
...
```
