### PR TITLE
chore: Remove aws.StringSlice usages from r/aws_wafv2_web_acl

### DIFF
--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -2539,8 +2539,8 @@ func flattenCookiesMatchPattern(c *awstypes.CookieMatchPattern) any {
 	}
 
 	m := map[string]any{
-		"included_cookies": aws.StringSlice(c.IncludedCookies),
-		"excluded_cookies": aws.StringSlice(c.ExcludedCookies),
+		"included_cookies": c.IncludedCookies,
+		"excluded_cookies": c.ExcludedCookies,
 	}
 
 	if c.All != nil {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to remove `aws.StringSlice` usages from the `aws_wafv2_web_acl` resource, specifically for the `included_cookies` and `excluded_cookies` arguments.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41800

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccWAFV2WebACL_ PKG=wafv2
make: go1.24.6 not found
make: installing go1.24.6...
make: if you get an error, see https://go.dev/doc/manage-install to locally install various Go versions
go: downloading golang.org/dl v0.0.0-20250812204734-236a62c85c37
Downloaded   0.0% (   16384 / 87261212 bytes) ...
Downloaded   0.2% (  212992 / 87261212 bytes) ...
Downloaded  15.0% (13123488 / 87261212 bytes) ...
Downloaded  31.0% (27082560 / 87261212 bytes) ...
Downloaded  45.0% (39288544 / 87261212 bytes) ...
Downloaded  60.3% (52657776 / 87261212 bytes) ...
Downloaded  74.1% (64618016 / 87261212 bytes) ...
Downloaded  86.9% (75824576 / 87261212 bytes) ...
Downloaded 100.0% (87261212 / 87261212 bytes)
Unpacking C:\Users\Anthony\sdk\go1.24.6\go1.24.6.windows-amd64.zip ...
Success. You may now run 'go1.24.6'
make: go1.24.6 ready
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACL_'  -timeout 360m -vet=off
2025/08/13 01:57:35 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/13 01:57:35 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccWAFV2WebACL_basic
=== PAUSE TestAccWAFV2WebACL_basic
=== RUN   TestAccWAFV2WebACL_nameGenerated
=== PAUSE TestAccWAFV2WebACL_nameGenerated
=== RUN   TestAccWAFV2WebACL_namePrefix
=== PAUSE TestAccWAFV2WebACL_namePrefix
=== RUN   TestAccWAFV2WebACL_Update_rule
=== PAUSE TestAccWAFV2WebACL_Update_rule
=== RUN   TestAccWAFV2WebACL_Update_ruleProperties
=== PAUSE TestAccWAFV2WebACL_Update_ruleProperties
=== RUN   TestAccWAFV2WebACL_Update_nameForceNew
=== PAUSE TestAccWAFV2WebACL_Update_nameForceNew
=== RUN   TestAccWAFV2WebACL_disappears
=== PAUSE TestAccWAFV2WebACL_disappears
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_antiDDosRuleSet
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_antiDDosRuleSet
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== RUN   TestAccWAFV2WebACL_minimal
=== PAUSE TestAccWAFV2WebACL_minimal
=== RUN   TestAccWAFV2WebACL_RateBased_basic
=== PAUSE TestAccWAFV2WebACL_RateBased_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_basic
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_body
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_body
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_urlFragment
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_urlFragment
=== RUN   TestAccWAFV2WebACL_GeoMatch_basic
=== PAUSE TestAccWAFV2WebACL_GeoMatch_basic
=== RUN   TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== PAUSE TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== RUN   TestAccWAFV2WebACL_LabelMatchStatement
=== PAUSE TestAccWAFV2WebACL_LabelMatchStatement
=== RUN   TestAccWAFV2WebACL_RuleLabels
=== PAUSE TestAccWAFV2WebACL_RuleLabels
=== RUN   TestAccWAFV2WebACL_IPSetReference_basic
=== PAUSE TestAccWAFV2WebACL_IPSetReference_basic
=== RUN   TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== PAUSE TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== RUN   TestAccWAFV2WebACL_RateBased_customKeys
=== PAUSE TestAccWAFV2WebACL_RateBased_customKeys
=== RUN   TestAccWAFV2WebACL_RateBased_forwardedIP
=== PAUSE TestAccWAFV2WebACL_RateBased_forwardedIP
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_basic
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_basic
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== RUN   TestAccWAFV2WebACL_Custom_requestHandling
=== PAUSE TestAccWAFV2WebACL_Custom_requestHandling
=== RUN   TestAccWAFV2WebACL_Custom_response
=== PAUSE TestAccWAFV2WebACL_Custom_response
=== RUN   TestAccWAFV2WebACL_tags
=== PAUSE TestAccWAFV2WebACL_tags
=== RUN   TestAccWAFV2WebACL_RateBased_maxNested
=== PAUSE TestAccWAFV2WebACL_RateBased_maxNested
=== RUN   TestAccWAFV2WebACL_Operators_maxNested
=== PAUSE TestAccWAFV2WebACL_Operators_maxNested
=== RUN   TestAccWAFV2WebACL_tokenDomains
=== PAUSE TestAccWAFV2WebACL_tokenDomains
=== RUN   TestAccWAFV2WebACL_associationConfigCloudFront
=== PAUSE TestAccWAFV2WebACL_associationConfigCloudFront
=== RUN   TestAccWAFV2WebACL_associationConfigRegional
=== PAUSE TestAccWAFV2WebACL_associationConfigRegional
=== RUN   TestAccWAFV2WebACL_CloudFrontScope
=== PAUSE TestAccWAFV2WebACL_CloudFrontScope
=== RUN   TestAccWAFV2WebACL_ruleJSON
=== PAUSE TestAccWAFV2WebACL_ruleJSON
=== RUN   TestAccWAFV2WebACL_ruleJSONToRule
=== PAUSE TestAccWAFV2WebACL_ruleJSONToRule
=== RUN   TestAccWAFV2WebACL_dataProtectionConfig
=== PAUSE TestAccWAFV2WebACL_dataProtectionConfig
=== RUN   TestAccWAFV2WebACL_dataProtectionConfigMultiple
=== PAUSE TestAccWAFV2WebACL_dataProtectionConfigMultiple
=== RUN   TestAccWAFV2WebACL_ASNMatchStatement
=== PAUSE TestAccWAFV2WebACL_ASNMatchStatement
=== RUN   TestAccWAFV2WebACL_RateBased_ASNMatchStatement
=== PAUSE TestAccWAFV2WebACL_RateBased_ASNMatchStatement
=== CONT  TestAccWAFV2WebACL_RateBased_ASNMatchStatement
=== CONT  TestAccWAFV2WebACL_basic
=== CONT  TestAccWAFV2WebACL_ASNMatchStatement
=== CONT  TestAccWAFV2WebACL_dataProtectionConfigMultiple
=== CONT  TestAccWAFV2WebACL_dataProtectionConfig
=== CONT  TestAccWAFV2WebACL_ruleJSONToRule
=== CONT  TestAccWAFV2WebACL_ruleJSON
=== CONT  TestAccWAFV2WebACL_CloudFrontScope
=== CONT  TestAccWAFV2WebACL_associationConfigRegional
=== CONT  TestAccWAFV2WebACL_associationConfigCloudFront
=== CONT  TestAccWAFV2WebACL_tokenDomains
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_basic
=== CONT  TestAccWAFV2WebACL_RateBased_basic
=== CONT  TestAccWAFV2WebACL_minimal
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_body
=== NAME  TestAccWAFV2WebACL_associationConfigCloudFront
    web_acl_test.go:3302: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
=== NAME  TestAccWAFV2WebACL_CloudFrontScope
    web_acl_test.go:3399: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_antiDDosRuleSet
--- SKIP: TestAccWAFV2WebACL_associationConfigCloudFront (0.46s)
--- SKIP: TestAccWAFV2WebACL_CloudFrontScope (0.46s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
--- PASS: TestAccWAFV2WebACL_minimal (52.17s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
--- PASS: TestAccWAFV2WebACL_associationConfigRegional (69.04s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
--- PASS: TestAccWAFV2WebACL_dataProtectionConfigMultiple (73.49s)
=== CONT  TestAccWAFV2WebACL_Update_rule
--- PASS: TestAccWAFV2WebACL_basic (79.20s)
=== CONT  TestAccWAFV2WebACL_namePrefix
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl (79.85s)
=== CONT  TestAccWAFV2WebACL_Operators_maxNested
--- PASS: TestAccWAFV2WebACL_tokenDomains (82.01s)
=== CONT  TestAccWAFV2WebACL_nameGenerated
--- PASS: TestAccWAFV2WebACL_ASNMatchStatement (90.53s)
=== CONT  TestAccWAFV2WebACL_RateBased_maxNested
--- PASS: TestAccWAFV2WebACL_RateBased_ASNMatchStatement (95.63s)
=== CONT  TestAccWAFV2WebACL_tags
--- PASS: TestAccWAFV2WebACL_ruleJSON (121.28s)
=== CONT  TestAccWAFV2WebACL_Custom_response
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_body (132.13s)
=== CONT  TestAccWAFV2WebACL_Custom_requestHandling
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint (132.42s)
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
--- PASS: TestAccWAFV2WebACL_ruleJSONToRule (136.71s)
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_jsonBody (137.12s)
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_basic
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion (139.86s)
=== CONT  TestAccWAFV2WebACL_RateBased_forwardedIP
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint (146.03s)
=== CONT  TestAccWAFV2WebACL_RateBased_customKeys
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet (151.32s)
=== CONT  TestAccWAFV2WebACL_IPSetReference_forwardedIP
--- PASS: TestAccWAFV2WebACL_namePrefix (81.01s)
=== CONT  TestAccWAFV2WebACL_IPSetReference_basic
--- PASS: TestAccWAFV2WebACL_nameGenerated (81.38s)
=== CONT  TestAccWAFV2WebACL_RuleLabels
--- PASS: TestAccWAFV2WebACL_Operators_maxNested (89.84s)
=== CONT  TestAccWAFV2WebACL_LabelMatchStatement
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_antiDDosRuleSet (170.53s)
=== CONT  TestAccWAFV2WebACL_GeoMatch_forwardedIP
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_basic (172.23s)
=== CONT  TestAccWAFV2WebACL_GeoMatch_basic
--- PASS: TestAccWAFV2WebACL_RateBased_basic (173.45s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_urlFragment
--- PASS: TestAccWAFV2WebACL_RateBased_maxNested (89.34s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet (142.15s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_basic
--- PASS: TestAccWAFV2WebACL_dataProtectionConfig (212.30s)
=== CONT  TestAccWAFV2WebACL_Update_nameForceNew
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig (145.18s)
=== CONT  TestAccWAFV2WebACL_disappears
--- PASS: TestAccWAFV2WebACL_Update_rule (154.57s)
=== CONT  TestAccWAFV2WebACL_Update_ruleProperties
--- PASS: TestAccWAFV2WebACL_IPSetReference_basic (89.11s)
--- PASS: TestAccWAFV2WebACL_disappears (69.24s)
--- PASS: TestAccWAFV2WebACL_RateBased_forwardedIP (146.24s)
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule (158.33s)
--- PASS: TestAccWAFV2WebACL_tags (196.02s)
--- PASS: TestAccWAFV2WebACL_RuleLabels (140.16s)
--- PASS: TestAccWAFV2WebACL_LabelMatchStatement (136.58s)
--- PASS: TestAccWAFV2WebACL_GeoMatch_basic (138.84s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_urlFragment (138.10s)
--- PASS: TestAccWAFV2WebACL_GeoMatch_forwardedIP (141.00s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_headerOrder (134.27s)
--- PASS: TestAccWAFV2WebACL_Custom_response (194.44s)
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_basic (181.70s)
--- PASS: TestAccWAFV2WebACL_Update_nameForceNew (108.69s)
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation (185.79s)
--- PASS: TestAccWAFV2WebACL_Custom_requestHandling (209.82s)
--- PASS: TestAccWAFV2WebACL_IPSetReference_forwardedIP (202.39s)
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_basic (169.27s)
--- PASS: TestAccWAFV2WebACL_Update_ruleProperties (137.70s)
--- PASS: TestAccWAFV2WebACL_RateBased_customKeys (405.33s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      551.703s

$
```