### PR TITLE
Tech debt: Use `%w` in generated call to `fmt.Errorf()`

### DIFF
--- a/.ci/tools/go.mod
+++ b/.ci/tools/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pavius/impi v0.0.3
 	github.com/rhysd/actionlint v1.7.7
 	github.com/terraform-linters/tflint v0.58.1
+	golang.org/x/tools v0.35.0
 	mvdan.cc/gofumpt v0.8.0
 )
 
@@ -381,7 +382,6 @@ require (
 	golang.org/x/term v0.33.0 // indirect
 	golang.org/x/text v0.27.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
-	golang.org/x/tools v0.35.0 // indirect
 	google.golang.org/api v0.242.0 // indirect
 	google.golang.org/genproto v0.0.0-20250505200425-f936aa4a68b2 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250603155806-513f23925822 // indirect

--- a/.ci/tools/main.go
+++ b/.ci/tools/main.go
@@ -13,5 +13,6 @@ import (
 	_ "github.com/pavius/impi/cmd/impi"
 	_ "github.com/rhysd/actionlint/cmd/actionlint"
 	_ "github.com/terraform-linters/tflint"
+	_ "golang.org/x/tools/cmd/stringer"
 	_ "mvdan.cc/gofumpt"
 )

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -730,6 +730,7 @@ tools: prereq-go ## Install tools
 	cd .ci/tools && $(GO_VER) install github.com/pavius/impi/cmd/impi
 	cd .ci/tools && $(GO_VER) install github.com/rhysd/actionlint/cmd/actionlint
 	cd .ci/tools && $(GO_VER) install github.com/terraform-linters/tflint
+	cd .ci/tools && $(GO_VER) install golang.org/x/tools/cmd/stringer
 	cd .ci/tools && $(GO_VER) install mvdan.cc/gofumpt
 
 ts: testacc-short ## Alias to testacc-short

--- a/internal/generate/serviceendpointtests/file.gtpl
+++ b/internal/generate/serviceendpointtests/file.gtpl
@@ -831,7 +831,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/generate/servicepackage/endpoint_resolver.go.gtpl
+++ b/internal/generate/servicepackage/endpoint_resolver.go.gtpl
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params {{ .GoV2Package 
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up {{ .GoV2Package }} endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up {{ .GoV2Package }} endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/accessanalyzer/service_endpoint_resolver_gen.go
+++ b/internal/service/accessanalyzer/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params accessanalyzer.E
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up accessanalyzer endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up accessanalyzer endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/accessanalyzer/service_endpoints_gen_test.go
+++ b/internal/service/accessanalyzer/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/account/service_endpoint_resolver_gen.go
+++ b/internal/service/account/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params account.Endpoint
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up account endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up account endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/account/service_endpoints_gen_test.go
+++ b/internal/service/account/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/acm/service_endpoint_resolver_gen.go
+++ b/internal/service/acm/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params acm.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up acm endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up acm endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/acm/service_endpoints_gen_test.go
+++ b/internal/service/acm/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/acmpca/service_endpoint_resolver_gen.go
+++ b/internal/service/acmpca/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params acmpca.EndpointP
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up acmpca endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up acmpca endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/acmpca/service_endpoints_gen_test.go
+++ b/internal/service/acmpca/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/amp/service_endpoint_resolver_gen.go
+++ b/internal/service/amp/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params amp.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up amp endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up amp endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/amp/service_endpoints_gen_test.go
+++ b/internal/service/amp/service_endpoints_gen_test.go
@@ -678,7 +678,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/amplify/service_endpoint_resolver_gen.go
+++ b/internal/service/amplify/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params amplify.Endpoint
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up amplify endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up amplify endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/amplify/service_endpoints_gen_test.go
+++ b/internal/service/amplify/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/apigateway/service_endpoint_resolver_gen.go
+++ b/internal/service/apigateway/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params apigateway.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up apigateway endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up apigateway endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/apigateway/service_endpoints_gen_test.go
+++ b/internal/service/apigateway/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/apigatewayv2/service_endpoint_resolver_gen.go
+++ b/internal/service/apigatewayv2/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params apigatewayv2.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up apigatewayv2 endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up apigatewayv2 endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/apigatewayv2/service_endpoints_gen_test.go
+++ b/internal/service/apigatewayv2/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/appautoscaling/service_endpoint_resolver_gen.go
+++ b/internal/service/appautoscaling/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params applicationautos
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up applicationautoscaling endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up applicationautoscaling endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/appautoscaling/service_endpoints_gen_test.go
+++ b/internal/service/appautoscaling/service_endpoints_gen_test.go
@@ -604,7 +604,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/appconfig/service_endpoint_resolver_gen.go
+++ b/internal/service/appconfig/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params appconfig.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up appconfig endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up appconfig endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/appconfig/service_endpoints_gen_test.go
+++ b/internal/service/appconfig/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/appfabric/service_endpoint_resolver_gen.go
+++ b/internal/service/appfabric/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params appfabric.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up appfabric endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up appfabric endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/appfabric/service_endpoints_gen_test.go
+++ b/internal/service/appfabric/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/appflow/service_endpoint_resolver_gen.go
+++ b/internal/service/appflow/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params appflow.Endpoint
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up appflow endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up appflow endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/appflow/service_endpoints_gen_test.go
+++ b/internal/service/appflow/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/appintegrations/service_endpoint_resolver_gen.go
+++ b/internal/service/appintegrations/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params appintegrations.
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up appintegrations endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up appintegrations endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/appintegrations/service_endpoints_gen_test.go
+++ b/internal/service/appintegrations/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/applicationinsights/service_endpoint_resolver_gen.go
+++ b/internal/service/applicationinsights/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params applicationinsig
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up applicationinsights endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up applicationinsights endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/applicationinsights/service_endpoints_gen_test.go
+++ b/internal/service/applicationinsights/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/applicationsignals/service_endpoint_resolver_gen.go
+++ b/internal/service/applicationsignals/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params applicationsigna
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up applicationsignals endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up applicationsignals endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/applicationsignals/service_endpoints_gen_test.go
+++ b/internal/service/applicationsignals/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/appmesh/service_endpoint_resolver_gen.go
+++ b/internal/service/appmesh/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params appmesh.Endpoint
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up appmesh endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up appmesh endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/appmesh/service_endpoints_gen_test.go
+++ b/internal/service/appmesh/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/apprunner/service_endpoint_resolver_gen.go
+++ b/internal/service/apprunner/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params apprunner.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up apprunner endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up apprunner endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/apprunner/service_endpoints_gen_test.go
+++ b/internal/service/apprunner/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/appstream/service_endpoint_resolver_gen.go
+++ b/internal/service/appstream/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params appstream.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up appstream endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up appstream endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/appstream/service_endpoints_gen_test.go
+++ b/internal/service/appstream/service_endpoints_gen_test.go
@@ -523,7 +523,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/appsync/service_endpoint_resolver_gen.go
+++ b/internal/service/appsync/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params appsync.Endpoint
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up appsync endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up appsync endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/appsync/service_endpoints_gen_test.go
+++ b/internal/service/appsync/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/athena/service_endpoint_resolver_gen.go
+++ b/internal/service/athena/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params athena.EndpointP
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up athena endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up athena endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/athena/service_endpoints_gen_test.go
+++ b/internal/service/athena/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/auditmanager/service_endpoint_resolver_gen.go
+++ b/internal/service/auditmanager/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params auditmanager.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up auditmanager endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up auditmanager endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/auditmanager/service_endpoints_gen_test.go
+++ b/internal/service/auditmanager/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/autoscaling/service_endpoint_resolver_gen.go
+++ b/internal/service/autoscaling/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params autoscaling.Endp
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up autoscaling endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up autoscaling endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/autoscaling/service_endpoints_gen_test.go
+++ b/internal/service/autoscaling/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/autoscalingplans/service_endpoint_resolver_gen.go
+++ b/internal/service/autoscalingplans/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params autoscalingplans
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up autoscalingplans endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up autoscalingplans endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/autoscalingplans/service_endpoints_gen_test.go
+++ b/internal/service/autoscalingplans/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/backup/service_endpoint_resolver_gen.go
+++ b/internal/service/backup/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params backup.EndpointP
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up backup endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up backup endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/backup/service_endpoints_gen_test.go
+++ b/internal/service/backup/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/batch/service_endpoint_resolver_gen.go
+++ b/internal/service/batch/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params batch.EndpointPa
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up batch endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up batch endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/batch/service_endpoints_gen_test.go
+++ b/internal/service/batch/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/bcmdataexports/service_endpoint_resolver_gen.go
+++ b/internal/service/bcmdataexports/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params bcmdataexports.E
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up bcmdataexports endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up bcmdataexports endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/bcmdataexports/service_endpoints_gen_test.go
+++ b/internal/service/bcmdataexports/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/bedrock/service_endpoint_resolver_gen.go
+++ b/internal/service/bedrock/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params bedrock.Endpoint
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up bedrock endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up bedrock endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/bedrock/service_endpoints_gen_test.go
+++ b/internal/service/bedrock/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/bedrockagent/service_endpoint_resolver_gen.go
+++ b/internal/service/bedrockagent/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params bedrockagent.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up bedrockagent endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up bedrockagent endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/bedrockagent/service_endpoints_gen_test.go
+++ b/internal/service/bedrockagent/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/bedrockagentcore/service_endpoint_resolver_gen.go
+++ b/internal/service/bedrockagentcore/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params bedrockagentcore
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up bedrockagentcorecontrol endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up bedrockagentcorecontrol endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/bedrockagentcore/service_endpoints_gen_test.go
+++ b/internal/service/bedrockagentcore/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/billing/service_endpoint_resolver_gen.go
+++ b/internal/service/billing/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params billing.Endpoint
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up billing endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up billing endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/billing/service_endpoints_gen_test.go
+++ b/internal/service/billing/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/budgets/service_endpoint_resolver_gen.go
+++ b/internal/service/budgets/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params budgets.Endpoint
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up budgets endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up budgets endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/budgets/service_endpoints_gen_test.go
+++ b/internal/service/budgets/service_endpoints_gen_test.go
@@ -524,7 +524,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/ce/service_endpoint_resolver_gen.go
+++ b/internal/service/ce/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params costexplorer.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up costexplorer endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up costexplorer endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/ce/service_endpoints_gen_test.go
+++ b/internal/service/ce/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/chatbot/service_endpoint_resolver_gen.go
+++ b/internal/service/chatbot/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params chatbot.Endpoint
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up chatbot endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up chatbot endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/chatbot/service_endpoints_gen_test.go
+++ b/internal/service/chatbot/service_endpoints_gen_test.go
@@ -523,7 +523,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/chime/service_endpoint_resolver_gen.go
+++ b/internal/service/chime/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params chime.EndpointPa
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up chime endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up chime endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/chime/service_endpoints_gen_test.go
+++ b/internal/service/chime/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/chimesdkmediapipelines/service_endpoint_resolver_gen.go
+++ b/internal/service/chimesdkmediapipelines/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params chimesdkmediapip
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up chimesdkmediapipelines endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up chimesdkmediapipelines endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/chimesdkmediapipelines/service_endpoints_gen_test.go
+++ b/internal/service/chimesdkmediapipelines/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/chimesdkvoice/service_endpoint_resolver_gen.go
+++ b/internal/service/chimesdkvoice/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params chimesdkvoice.En
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up chimesdkvoice endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up chimesdkvoice endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/chimesdkvoice/service_endpoints_gen_test.go
+++ b/internal/service/chimesdkvoice/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/cleanrooms/service_endpoint_resolver_gen.go
+++ b/internal/service/cleanrooms/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params cleanrooms.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up cleanrooms endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up cleanrooms endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/cleanrooms/service_endpoints_gen_test.go
+++ b/internal/service/cleanrooms/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/cloud9/service_endpoint_resolver_gen.go
+++ b/internal/service/cloud9/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params cloud9.EndpointP
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up cloud9 endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up cloud9 endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/cloud9/service_endpoints_gen_test.go
+++ b/internal/service/cloud9/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/cloudcontrol/service_endpoint_resolver_gen.go
+++ b/internal/service/cloudcontrol/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params cloudcontrol.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up cloudcontrol endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up cloudcontrol endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/cloudcontrol/service_endpoints_gen_test.go
+++ b/internal/service/cloudcontrol/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/cloudformation/service_endpoint_resolver_gen.go
+++ b/internal/service/cloudformation/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params cloudformation.E
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up cloudformation endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up cloudformation endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/cloudformation/service_endpoints_gen_test.go
+++ b/internal/service/cloudformation/service_endpoints_gen_test.go
@@ -523,7 +523,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/cloudfront/service_endpoint_resolver_gen.go
+++ b/internal/service/cloudfront/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params cloudfront.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up cloudfront endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up cloudfront endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/cloudfront/service_endpoints_gen_test.go
+++ b/internal/service/cloudfront/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/cloudfrontkeyvaluestore/service_endpoint_resolver_gen.go
+++ b/internal/service/cloudfrontkeyvaluestore/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params cloudfrontkeyval
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up cloudfrontkeyvaluestore endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up cloudfrontkeyvaluestore endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/cloudhsmv2/service_endpoint_resolver_gen.go
+++ b/internal/service/cloudhsmv2/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params cloudhsmv2.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up cloudhsmv2 endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up cloudhsmv2 endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/cloudhsmv2/service_endpoints_gen_test.go
+++ b/internal/service/cloudhsmv2/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/cloudsearch/service_endpoint_resolver_gen.go
+++ b/internal/service/cloudsearch/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params cloudsearch.Endp
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up cloudsearch endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up cloudsearch endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/cloudsearch/service_endpoints_gen_test.go
+++ b/internal/service/cloudsearch/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/cloudtrail/service_endpoint_resolver_gen.go
+++ b/internal/service/cloudtrail/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params cloudtrail.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up cloudtrail endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up cloudtrail endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/cloudtrail/service_endpoints_gen_test.go
+++ b/internal/service/cloudtrail/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/cloudwatch/service_endpoint_resolver_gen.go
+++ b/internal/service/cloudwatch/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params cloudwatch.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up cloudwatch endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up cloudwatch endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/cloudwatch/service_endpoints_gen_test.go
+++ b/internal/service/cloudwatch/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/codeartifact/service_endpoint_resolver_gen.go
+++ b/internal/service/codeartifact/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params codeartifact.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up codeartifact endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up codeartifact endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/codeartifact/service_endpoints_gen_test.go
+++ b/internal/service/codeartifact/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/codebuild/service_endpoint_resolver_gen.go
+++ b/internal/service/codebuild/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params codebuild.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up codebuild endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up codebuild endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/codebuild/service_endpoints_gen_test.go
+++ b/internal/service/codebuild/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/codecatalyst/service_endpoint_resolver_gen.go
+++ b/internal/service/codecatalyst/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params codecatalyst.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up codecatalyst endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up codecatalyst endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/codecommit/service_endpoint_resolver_gen.go
+++ b/internal/service/codecommit/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params codecommit.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up codecommit endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up codecommit endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/codecommit/service_endpoints_gen_test.go
+++ b/internal/service/codecommit/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/codeconnections/service_endpoint_resolver_gen.go
+++ b/internal/service/codeconnections/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params codeconnections.
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up codeconnections endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up codeconnections endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/codeconnections/service_endpoints_gen_test.go
+++ b/internal/service/codeconnections/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/codeguruprofiler/service_endpoint_resolver_gen.go
+++ b/internal/service/codeguruprofiler/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params codeguruprofiler
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up codeguruprofiler endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up codeguruprofiler endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/codeguruprofiler/service_endpoints_gen_test.go
+++ b/internal/service/codeguruprofiler/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/codegurureviewer/service_endpoint_resolver_gen.go
+++ b/internal/service/codegurureviewer/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params codegurureviewer
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up codegurureviewer endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up codegurureviewer endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/codegurureviewer/service_endpoints_gen_test.go
+++ b/internal/service/codegurureviewer/service_endpoints_gen_test.go
@@ -524,7 +524,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/codepipeline/service_endpoint_resolver_gen.go
+++ b/internal/service/codepipeline/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params codepipeline.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up codepipeline endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up codepipeline endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/codepipeline/service_endpoints_gen_test.go
+++ b/internal/service/codepipeline/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/codestarconnections/service_endpoint_resolver_gen.go
+++ b/internal/service/codestarconnections/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params codestarconnecti
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up codestarconnections endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up codestarconnections endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/codestarconnections/service_endpoints_gen_test.go
+++ b/internal/service/codestarconnections/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/codestarnotifications/service_endpoint_resolver_gen.go
+++ b/internal/service/codestarnotifications/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params codestarnotifica
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up codestarnotifications endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up codestarnotifications endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/codestarnotifications/service_endpoints_gen_test.go
+++ b/internal/service/codestarnotifications/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/cognitoidentity/service_endpoint_resolver_gen.go
+++ b/internal/service/cognitoidentity/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params cognitoidentity.
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up cognitoidentity endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up cognitoidentity endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/cognitoidentity/service_endpoints_gen_test.go
+++ b/internal/service/cognitoidentity/service_endpoints_gen_test.go
@@ -523,7 +523,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/cognitoidp/service_endpoint_resolver_gen.go
+++ b/internal/service/cognitoidp/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params cognitoidentityp
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up cognitoidentityprovider endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up cognitoidentityprovider endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/cognitoidp/service_endpoints_gen_test.go
+++ b/internal/service/cognitoidp/service_endpoints_gen_test.go
@@ -603,7 +603,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/comprehend/service_endpoint_resolver_gen.go
+++ b/internal/service/comprehend/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params comprehend.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up comprehend endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up comprehend endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/comprehend/service_endpoints_gen_test.go
+++ b/internal/service/comprehend/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/computeoptimizer/service_endpoint_resolver_gen.go
+++ b/internal/service/computeoptimizer/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params computeoptimizer
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up computeoptimizer endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up computeoptimizer endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/computeoptimizer/service_endpoints_gen_test.go
+++ b/internal/service/computeoptimizer/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/configservice/service_endpoint_resolver_gen.go
+++ b/internal/service/configservice/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params configservice.En
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up configservice endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up configservice endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/configservice/service_endpoints_gen_test.go
+++ b/internal/service/configservice/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/connect/service_endpoint_resolver_gen.go
+++ b/internal/service/connect/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params connect.Endpoint
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up connect endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up connect endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/connect/service_endpoints_gen_test.go
+++ b/internal/service/connect/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/connectcases/service_endpoint_resolver_gen.go
+++ b/internal/service/connectcases/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params connectcases.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up connectcases endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up connectcases endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/connectcases/service_endpoints_gen_test.go
+++ b/internal/service/connectcases/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/controltower/service_endpoint_resolver_gen.go
+++ b/internal/service/controltower/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params controltower.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up controltower endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up controltower endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/controltower/service_endpoints_gen_test.go
+++ b/internal/service/controltower/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/costoptimizationhub/service_endpoint_resolver_gen.go
+++ b/internal/service/costoptimizationhub/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params costoptimization
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up costoptimizationhub endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up costoptimizationhub endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/costoptimizationhub/service_endpoints_gen_test.go
+++ b/internal/service/costoptimizationhub/service_endpoints_gen_test.go
@@ -523,7 +523,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/cur/service_endpoint_resolver_gen.go
+++ b/internal/service/cur/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params costandusagerepo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up costandusagereportservice endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up costandusagereportservice endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/cur/service_endpoints_gen_test.go
+++ b/internal/service/cur/service_endpoints_gen_test.go
@@ -603,7 +603,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/customerprofiles/service_endpoint_resolver_gen.go
+++ b/internal/service/customerprofiles/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params customerprofiles
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up customerprofiles endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up customerprofiles endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/customerprofiles/service_endpoints_gen_test.go
+++ b/internal/service/customerprofiles/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/databrew/service_endpoint_resolver_gen.go
+++ b/internal/service/databrew/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params databrew.Endpoin
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up databrew endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up databrew endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/databrew/service_endpoints_gen_test.go
+++ b/internal/service/databrew/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/dataexchange/service_endpoint_resolver_gen.go
+++ b/internal/service/dataexchange/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params dataexchange.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up dataexchange endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up dataexchange endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/dataexchange/service_endpoints_gen_test.go
+++ b/internal/service/dataexchange/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/datapipeline/service_endpoint_resolver_gen.go
+++ b/internal/service/datapipeline/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params datapipeline.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up datapipeline endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up datapipeline endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/datapipeline/service_endpoints_gen_test.go
+++ b/internal/service/datapipeline/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/datasync/service_endpoint_resolver_gen.go
+++ b/internal/service/datasync/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params datasync.Endpoin
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up datasync endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up datasync endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/datasync/service_endpoints_gen_test.go
+++ b/internal/service/datasync/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/datazone/service_endpoint_resolver_gen.go
+++ b/internal/service/datazone/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params datazone.Endpoin
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up datazone endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up datazone endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/datazone/service_endpoints_gen_test.go
+++ b/internal/service/datazone/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/dax/service_endpoint_resolver_gen.go
+++ b/internal/service/dax/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params dax.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up dax endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up dax endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/dax/service_endpoints_gen_test.go
+++ b/internal/service/dax/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/deploy/service_endpoint_resolver_gen.go
+++ b/internal/service/deploy/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params codedeploy.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up codedeploy endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up codedeploy endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/deploy/service_endpoints_gen_test.go
+++ b/internal/service/deploy/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/detective/service_endpoint_resolver_gen.go
+++ b/internal/service/detective/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params detective.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up detective endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up detective endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/detective/service_endpoints_gen_test.go
+++ b/internal/service/detective/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/devicefarm/service_endpoint_resolver_gen.go
+++ b/internal/service/devicefarm/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params devicefarm.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up devicefarm endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up devicefarm endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/devicefarm/service_endpoints_gen_test.go
+++ b/internal/service/devicefarm/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/devopsguru/service_endpoint_resolver_gen.go
+++ b/internal/service/devopsguru/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params devopsguru.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up devopsguru endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up devopsguru endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/devopsguru/service_endpoints_gen_test.go
+++ b/internal/service/devopsguru/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/directconnect/service_endpoint_resolver_gen.go
+++ b/internal/service/directconnect/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params directconnect.En
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up directconnect endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up directconnect endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/directconnect/service_endpoints_gen_test.go
+++ b/internal/service/directconnect/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/dlm/service_endpoint_resolver_gen.go
+++ b/internal/service/dlm/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params dlm.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up dlm endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up dlm endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/dlm/service_endpoints_gen_test.go
+++ b/internal/service/dlm/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/dms/service_endpoint_resolver_gen.go
+++ b/internal/service/dms/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params databasemigratio
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up databasemigrationservice endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up databasemigrationservice endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/dms/service_endpoints_gen_test.go
+++ b/internal/service/dms/service_endpoints_gen_test.go
@@ -678,7 +678,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/docdb/service_endpoint_resolver_gen.go
+++ b/internal/service/docdb/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params docdb.EndpointPa
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up docdb endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up docdb endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/docdb/service_endpoints_gen_test.go
+++ b/internal/service/docdb/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/docdbelastic/service_endpoint_resolver_gen.go
+++ b/internal/service/docdbelastic/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params docdbelastic.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up docdbelastic endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up docdbelastic endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/docdbelastic/service_endpoints_gen_test.go
+++ b/internal/service/docdbelastic/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/drs/service_endpoint_resolver_gen.go
+++ b/internal/service/drs/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params drs.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up drs endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up drs endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/drs/service_endpoints_gen_test.go
+++ b/internal/service/drs/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/ds/service_endpoint_resolver_gen.go
+++ b/internal/service/ds/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params directoryservice
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up directoryservice endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up directoryservice endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/ds/service_endpoints_gen_test.go
+++ b/internal/service/ds/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/dsql/service_endpoint_resolver_gen.go
+++ b/internal/service/dsql/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params dsql.EndpointPar
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up dsql endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up dsql endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/dsql/service_endpoints_gen_test.go
+++ b/internal/service/dsql/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/dynamodb/service_endpoint_resolver_gen.go
+++ b/internal/service/dynamodb/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params dynamodb.Endpoin
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up dynamodb endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up dynamodb endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/dynamodb/service_endpoints_gen_test.go
+++ b/internal/service/dynamodb/service_endpoints_gen_test.go
@@ -659,7 +659,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/ec2/service_endpoint_resolver_gen.go
+++ b/internal/service/ec2/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params ec2.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up ec2 endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up ec2 endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/ec2/service_endpoints_gen_test.go
+++ b/internal/service/ec2/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/ecr/service_endpoint_resolver_gen.go
+++ b/internal/service/ecr/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params ecr.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up ecr endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up ecr endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/ecr/service_endpoints_gen_test.go
+++ b/internal/service/ecr/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/ecrpublic/service_endpoint_resolver_gen.go
+++ b/internal/service/ecrpublic/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params ecrpublic.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up ecrpublic endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up ecrpublic endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/ecrpublic/service_endpoints_gen_test.go
+++ b/internal/service/ecrpublic/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/ecs/service_endpoint_resolver_gen.go
+++ b/internal/service/ecs/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params ecs.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up ecs endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up ecs endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/ecs/service_endpoints_gen_test.go
+++ b/internal/service/ecs/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/efs/service_endpoint_resolver_gen.go
+++ b/internal/service/efs/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params efs.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up efs endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up efs endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/efs/service_endpoints_gen_test.go
+++ b/internal/service/efs/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/eks/service_endpoint_resolver_gen.go
+++ b/internal/service/eks/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params eks.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up eks endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up eks endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/eks/service_endpoints_gen_test.go
+++ b/internal/service/eks/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/elasticache/service_endpoint_resolver_gen.go
+++ b/internal/service/elasticache/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params elasticache.Endp
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up elasticache endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up elasticache endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/elasticache/service_endpoints_gen_test.go
+++ b/internal/service/elasticache/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/elasticbeanstalk/service_endpoint_resolver_gen.go
+++ b/internal/service/elasticbeanstalk/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params elasticbeanstalk
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up elasticbeanstalk endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up elasticbeanstalk endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/elasticbeanstalk/service_endpoints_gen_test.go
+++ b/internal/service/elasticbeanstalk/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/elasticsearch/service_endpoint_resolver_gen.go
+++ b/internal/service/elasticsearch/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params elasticsearchser
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up elasticsearchservice endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up elasticsearchservice endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/elasticsearch/service_endpoints_gen_test.go
+++ b/internal/service/elasticsearch/service_endpoints_gen_test.go
@@ -678,7 +678,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/elastictranscoder/service_endpoint_resolver_gen.go
+++ b/internal/service/elastictranscoder/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params elastictranscode
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up elastictranscoder endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up elastictranscoder endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/elastictranscoder/service_endpoints_gen_test.go
+++ b/internal/service/elastictranscoder/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/elb/service_endpoint_resolver_gen.go
+++ b/internal/service/elb/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params elasticloadbalan
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up elasticloadbalancing endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up elasticloadbalancing endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/elb/service_endpoints_gen_test.go
+++ b/internal/service/elb/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/elbv2/service_endpoint_resolver_gen.go
+++ b/internal/service/elbv2/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params elasticloadbalan
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up elasticloadbalancingv2 endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up elasticloadbalancingv2 endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/elbv2/service_endpoints_gen_test.go
+++ b/internal/service/elbv2/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/emr/service_endpoint_resolver_gen.go
+++ b/internal/service/emr/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params emr.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up emr endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up emr endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/emr/service_endpoints_gen_test.go
+++ b/internal/service/emr/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/emrcontainers/service_endpoint_resolver_gen.go
+++ b/internal/service/emrcontainers/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params emrcontainers.En
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up emrcontainers endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up emrcontainers endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/emrcontainers/service_endpoints_gen_test.go
+++ b/internal/service/emrcontainers/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/emrserverless/service_endpoint_resolver_gen.go
+++ b/internal/service/emrserverless/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params emrserverless.En
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up emrserverless endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up emrserverless endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/emrserverless/service_endpoints_gen_test.go
+++ b/internal/service/emrserverless/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/events/service_endpoint_resolver_gen.go
+++ b/internal/service/events/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params eventbridge.Endp
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up eventbridge endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up eventbridge endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/events/service_endpoints_gen_test.go
+++ b/internal/service/events/service_endpoints_gen_test.go
@@ -678,7 +678,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/evidently/service_endpoint_resolver_gen.go
+++ b/internal/service/evidently/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params evidently.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up evidently endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up evidently endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/evidently/service_endpoints_gen_test.go
+++ b/internal/service/evidently/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/evs/service_endpoint_resolver_gen.go
+++ b/internal/service/evs/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params evs.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up evs endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up evs endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/evs/service_endpoints_gen_test.go
+++ b/internal/service/evs/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/finspace/service_endpoint_resolver_gen.go
+++ b/internal/service/finspace/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params finspace.Endpoin
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up finspace endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up finspace endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/finspace/service_endpoints_gen_test.go
+++ b/internal/service/finspace/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/firehose/service_endpoint_resolver_gen.go
+++ b/internal/service/firehose/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params firehose.Endpoin
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up firehose endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up firehose endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/firehose/service_endpoints_gen_test.go
+++ b/internal/service/firehose/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/fis/service_endpoint_resolver_gen.go
+++ b/internal/service/fis/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params fis.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up fis endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up fis endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/fis/service_endpoints_gen_test.go
+++ b/internal/service/fis/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/fms/service_endpoint_resolver_gen.go
+++ b/internal/service/fms/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params fms.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up fms endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up fms endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/fms/service_endpoints_gen_test.go
+++ b/internal/service/fms/service_endpoints_gen_test.go
@@ -523,7 +523,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/fsx/service_endpoint_resolver_gen.go
+++ b/internal/service/fsx/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params fsx.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up fsx endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up fsx endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/fsx/service_endpoints_gen_test.go
+++ b/internal/service/fsx/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/gamelift/service_endpoint_resolver_gen.go
+++ b/internal/service/gamelift/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params gamelift.Endpoin
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up gamelift endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up gamelift endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/gamelift/service_endpoints_gen_test.go
+++ b/internal/service/gamelift/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/glacier/service_endpoint_resolver_gen.go
+++ b/internal/service/glacier/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params glacier.Endpoint
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up glacier endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up glacier endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/glacier/service_endpoints_gen_test.go
+++ b/internal/service/glacier/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/globalaccelerator/service_endpoint_resolver_gen.go
+++ b/internal/service/globalaccelerator/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params globalaccelerato
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up globalaccelerator endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up globalaccelerator endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/globalaccelerator/service_endpoints_gen_test.go
+++ b/internal/service/globalaccelerator/service_endpoints_gen_test.go
@@ -523,7 +523,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/glue/service_endpoint_resolver_gen.go
+++ b/internal/service/glue/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params glue.EndpointPar
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up glue endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up glue endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/glue/service_endpoints_gen_test.go
+++ b/internal/service/glue/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/grafana/service_endpoint_resolver_gen.go
+++ b/internal/service/grafana/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params grafana.Endpoint
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up grafana endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up grafana endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/grafana/service_endpoints_gen_test.go
+++ b/internal/service/grafana/service_endpoints_gen_test.go
@@ -678,7 +678,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/greengrass/service_endpoint_resolver_gen.go
+++ b/internal/service/greengrass/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params greengrass.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up greengrass endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up greengrass endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/greengrass/service_endpoints_gen_test.go
+++ b/internal/service/greengrass/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/groundstation/service_endpoint_resolver_gen.go
+++ b/internal/service/groundstation/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params groundstation.En
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up groundstation endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up groundstation endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/groundstation/service_endpoints_gen_test.go
+++ b/internal/service/groundstation/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/guardduty/service_endpoint_resolver_gen.go
+++ b/internal/service/guardduty/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params guardduty.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up guardduty endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up guardduty endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/guardduty/service_endpoints_gen_test.go
+++ b/internal/service/guardduty/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/healthlake/service_endpoint_resolver_gen.go
+++ b/internal/service/healthlake/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params healthlake.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up healthlake endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up healthlake endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/healthlake/service_endpoints_gen_test.go
+++ b/internal/service/healthlake/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/iam/service_endpoint_resolver_gen.go
+++ b/internal/service/iam/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params iam.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up iam endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up iam endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/iam/service_endpoints_gen_test.go
+++ b/internal/service/iam/service_endpoints_gen_test.go
@@ -659,7 +659,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/identitystore/service_endpoint_resolver_gen.go
+++ b/internal/service/identitystore/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params identitystore.En
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up identitystore endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up identitystore endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/identitystore/service_endpoints_gen_test.go
+++ b/internal/service/identitystore/service_endpoints_gen_test.go
@@ -523,7 +523,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/imagebuilder/service_endpoint_resolver_gen.go
+++ b/internal/service/imagebuilder/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params imagebuilder.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up imagebuilder endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up imagebuilder endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/imagebuilder/service_endpoints_gen_test.go
+++ b/internal/service/imagebuilder/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/inspector/service_endpoint_resolver_gen.go
+++ b/internal/service/inspector/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params inspector.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up inspector endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up inspector endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/inspector/service_endpoints_gen_test.go
+++ b/internal/service/inspector/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/inspector2/service_endpoint_resolver_gen.go
+++ b/internal/service/inspector2/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params inspector2.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up inspector2 endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up inspector2 endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/inspector2/service_endpoints_gen_test.go
+++ b/internal/service/inspector2/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/internetmonitor/service_endpoint_resolver_gen.go
+++ b/internal/service/internetmonitor/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params internetmonitor.
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up internetmonitor endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up internetmonitor endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/internetmonitor/service_endpoints_gen_test.go
+++ b/internal/service/internetmonitor/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/invoicing/service_endpoint_resolver_gen.go
+++ b/internal/service/invoicing/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params invoicing.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up invoicing endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up invoicing endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/invoicing/service_endpoints_gen_test.go
+++ b/internal/service/invoicing/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/iot/service_endpoint_resolver_gen.go
+++ b/internal/service/iot/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params iot.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up iot endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up iot endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/iot/service_endpoints_gen_test.go
+++ b/internal/service/iot/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/ivs/service_endpoint_resolver_gen.go
+++ b/internal/service/ivs/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params ivs.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up ivs endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up ivs endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/ivs/service_endpoints_gen_test.go
+++ b/internal/service/ivs/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/ivschat/service_endpoint_resolver_gen.go
+++ b/internal/service/ivschat/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params ivschat.Endpoint
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up ivschat endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up ivschat endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/ivschat/service_endpoints_gen_test.go
+++ b/internal/service/ivschat/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/kafka/service_endpoint_resolver_gen.go
+++ b/internal/service/kafka/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params kafka.EndpointPa
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up kafka endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up kafka endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/kafka/service_endpoints_gen_test.go
+++ b/internal/service/kafka/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/kafkaconnect/service_endpoint_resolver_gen.go
+++ b/internal/service/kafkaconnect/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params kafkaconnect.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up kafkaconnect endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up kafkaconnect endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/kafkaconnect/service_endpoints_gen_test.go
+++ b/internal/service/kafkaconnect/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/kendra/service_endpoint_resolver_gen.go
+++ b/internal/service/kendra/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params kendra.EndpointP
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up kendra endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up kendra endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/kendra/service_endpoints_gen_test.go
+++ b/internal/service/kendra/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/keyspaces/service_endpoint_resolver_gen.go
+++ b/internal/service/keyspaces/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params keyspaces.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up keyspaces endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up keyspaces endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/keyspaces/service_endpoints_gen_test.go
+++ b/internal/service/keyspaces/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/kinesis/service_endpoint_resolver_gen.go
+++ b/internal/service/kinesis/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params kinesis.Endpoint
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up kinesis endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up kinesis endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/kinesis/service_endpoints_gen_test.go
+++ b/internal/service/kinesis/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/kinesisanalytics/service_endpoint_resolver_gen.go
+++ b/internal/service/kinesisanalytics/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params kinesisanalytics
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up kinesisanalytics endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up kinesisanalytics endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/kinesisanalytics/service_endpoints_gen_test.go
+++ b/internal/service/kinesisanalytics/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/kinesisanalyticsv2/service_endpoint_resolver_gen.go
+++ b/internal/service/kinesisanalyticsv2/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params kinesisanalytics
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up kinesisanalyticsv2 endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up kinesisanalyticsv2 endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/kinesisanalyticsv2/service_endpoints_gen_test.go
+++ b/internal/service/kinesisanalyticsv2/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/kinesisvideo/service_endpoint_resolver_gen.go
+++ b/internal/service/kinesisvideo/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params kinesisvideo.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up kinesisvideo endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up kinesisvideo endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/kinesisvideo/service_endpoints_gen_test.go
+++ b/internal/service/kinesisvideo/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/kms/service_endpoint_resolver_gen.go
+++ b/internal/service/kms/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params kms.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up kms endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up kms endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/kms/service_endpoints_gen_test.go
+++ b/internal/service/kms/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/lakeformation/service_endpoint_resolver_gen.go
+++ b/internal/service/lakeformation/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params lakeformation.En
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up lakeformation endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up lakeformation endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/lakeformation/service_endpoints_gen_test.go
+++ b/internal/service/lakeformation/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/lambda/service_endpoint_resolver_gen.go
+++ b/internal/service/lambda/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params lambda.EndpointP
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up lambda endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up lambda endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/lambda/service_endpoints_gen_test.go
+++ b/internal/service/lambda/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/launchwizard/service_endpoint_resolver_gen.go
+++ b/internal/service/launchwizard/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params launchwizard.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up launchwizard endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up launchwizard endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/launchwizard/service_endpoints_gen_test.go
+++ b/internal/service/launchwizard/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/lexmodels/service_endpoint_resolver_gen.go
+++ b/internal/service/lexmodels/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params lexmodelbuilding
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up lexmodelbuildingservice endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up lexmodelbuildingservice endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/lexmodels/service_endpoints_gen_test.go
+++ b/internal/service/lexmodels/service_endpoints_gen_test.go
@@ -763,7 +763,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/lexv2models/service_endpoint_resolver_gen.go
+++ b/internal/service/lexv2models/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params lexmodelsv2.Endp
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up lexmodelsv2 endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up lexmodelsv2 endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/lexv2models/service_endpoints_gen_test.go
+++ b/internal/service/lexv2models/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/licensemanager/service_endpoint_resolver_gen.go
+++ b/internal/service/licensemanager/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params licensemanager.E
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up licensemanager endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up licensemanager endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/licensemanager/service_endpoints_gen_test.go
+++ b/internal/service/licensemanager/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/lightsail/service_endpoint_resolver_gen.go
+++ b/internal/service/lightsail/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params lightsail.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up lightsail endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up lightsail endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/lightsail/service_endpoints_gen_test.go
+++ b/internal/service/lightsail/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/location/service_endpoint_resolver_gen.go
+++ b/internal/service/location/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params location.Endpoin
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up location endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up location endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/logs/service_endpoint_resolver_gen.go
+++ b/internal/service/logs/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params cloudwatchlogs.E
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up cloudwatchlogs endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up cloudwatchlogs endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/logs/service_endpoints_gen_test.go
+++ b/internal/service/logs/service_endpoints_gen_test.go
@@ -678,7 +678,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/lookoutmetrics/service_endpoint_resolver_gen.go
+++ b/internal/service/lookoutmetrics/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params lookoutmetrics.E
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up lookoutmetrics endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up lookoutmetrics endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/lookoutmetrics/service_endpoints_gen_test.go
+++ b/internal/service/lookoutmetrics/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/m2/service_endpoint_resolver_gen.go
+++ b/internal/service/m2/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params m2.EndpointParam
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up m2 endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up m2 endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/m2/service_endpoints_gen_test.go
+++ b/internal/service/m2/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/macie2/service_endpoint_resolver_gen.go
+++ b/internal/service/macie2/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params macie2.EndpointP
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up macie2 endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up macie2 endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/macie2/service_endpoints_gen_test.go
+++ b/internal/service/macie2/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/mediaconnect/service_endpoint_resolver_gen.go
+++ b/internal/service/mediaconnect/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params mediaconnect.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up mediaconnect endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up mediaconnect endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/mediaconnect/service_endpoints_gen_test.go
+++ b/internal/service/mediaconnect/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/mediaconvert/service_endpoint_resolver_gen.go
+++ b/internal/service/mediaconvert/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params mediaconvert.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up mediaconvert endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up mediaconvert endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/mediaconvert/service_endpoints_gen_test.go
+++ b/internal/service/mediaconvert/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/medialive/service_endpoint_resolver_gen.go
+++ b/internal/service/medialive/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params medialive.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up medialive endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up medialive endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/medialive/service_endpoints_gen_test.go
+++ b/internal/service/medialive/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/mediapackage/service_endpoint_resolver_gen.go
+++ b/internal/service/mediapackage/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params mediapackage.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up mediapackage endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up mediapackage endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/mediapackage/service_endpoints_gen_test.go
+++ b/internal/service/mediapackage/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/mediapackagev2/service_endpoint_resolver_gen.go
+++ b/internal/service/mediapackagev2/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params mediapackagev2.E
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up mediapackagev2 endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up mediapackagev2 endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/mediapackagev2/service_endpoints_gen_test.go
+++ b/internal/service/mediapackagev2/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/mediapackagevod/service_endpoint_resolver_gen.go
+++ b/internal/service/mediapackagevod/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params mediapackagevod.
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up mediapackagevod endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up mediapackagevod endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/mediapackagevod/service_endpoints_gen_test.go
+++ b/internal/service/mediapackagevod/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/mediastore/service_endpoint_resolver_gen.go
+++ b/internal/service/mediastore/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params mediastore.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up mediastore endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up mediastore endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/mediastore/service_endpoints_gen_test.go
+++ b/internal/service/mediastore/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/memorydb/service_endpoint_resolver_gen.go
+++ b/internal/service/memorydb/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params memorydb.Endpoin
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up memorydb endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up memorydb endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/memorydb/service_endpoints_gen_test.go
+++ b/internal/service/memorydb/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/mgn/service_endpoint_resolver_gen.go
+++ b/internal/service/mgn/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params mgn.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up mgn endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up mgn endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/mgn/service_endpoints_gen_test.go
+++ b/internal/service/mgn/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/mq/service_endpoint_resolver_gen.go
+++ b/internal/service/mq/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params mq.EndpointParam
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up mq endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up mq endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/mq/service_endpoints_gen_test.go
+++ b/internal/service/mq/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/mwaa/service_endpoint_resolver_gen.go
+++ b/internal/service/mwaa/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params mwaa.EndpointPar
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up mwaa endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up mwaa endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/neptune/service_endpoint_resolver_gen.go
+++ b/internal/service/neptune/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params neptune.Endpoint
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up neptune endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up neptune endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/neptune/service_endpoints_gen_test.go
+++ b/internal/service/neptune/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/neptunegraph/service_endpoint_resolver_gen.go
+++ b/internal/service/neptunegraph/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params neptunegraph.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up neptunegraph endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up neptunegraph endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/networkfirewall/service_endpoint_resolver_gen.go
+++ b/internal/service/networkfirewall/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params networkfirewall.
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up networkfirewall endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up networkfirewall endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/networkfirewall/service_endpoints_gen_test.go
+++ b/internal/service/networkfirewall/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/networkmanager/service_endpoint_resolver_gen.go
+++ b/internal/service/networkmanager/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params networkmanager.E
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up networkmanager endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up networkmanager endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/networkmanager/service_endpoints_gen_test.go
+++ b/internal/service/networkmanager/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/networkmonitor/service_endpoint_resolver_gen.go
+++ b/internal/service/networkmonitor/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params networkmonitor.E
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up networkmonitor endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up networkmonitor endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/networkmonitor/service_endpoints_gen_test.go
+++ b/internal/service/networkmonitor/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/notifications/service_endpoint_resolver_gen.go
+++ b/internal/service/notifications/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params notifications.En
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up notifications endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up notifications endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/notifications/service_endpoints_gen_test.go
+++ b/internal/service/notifications/service_endpoints_gen_test.go
@@ -523,7 +523,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/notificationscontacts/service_endpoint_resolver_gen.go
+++ b/internal/service/notificationscontacts/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params notificationscon
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up notificationscontacts endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up notificationscontacts endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/notificationscontacts/service_endpoints_gen_test.go
+++ b/internal/service/notificationscontacts/service_endpoints_gen_test.go
@@ -523,7 +523,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/oam/service_endpoint_resolver_gen.go
+++ b/internal/service/oam/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params oam.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up oam endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up oam endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/oam/service_endpoints_gen_test.go
+++ b/internal/service/oam/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/odb/service_endpoint_resolver_gen.go
+++ b/internal/service/odb/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params odb.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up odb endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up odb endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/odb/service_endpoints_gen_test.go
+++ b/internal/service/odb/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/opensearch/service_endpoint_resolver_gen.go
+++ b/internal/service/opensearch/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params opensearch.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up opensearch endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up opensearch endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/opensearch/service_endpoints_gen_test.go
+++ b/internal/service/opensearch/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/opensearchserverless/service_endpoint_resolver_gen.go
+++ b/internal/service/opensearchserverless/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params opensearchserver
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up opensearchserverless endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up opensearchserverless endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/opensearchserverless/service_endpoints_gen_test.go
+++ b/internal/service/opensearchserverless/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/organizations/service_endpoint_resolver_gen.go
+++ b/internal/service/organizations/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params organizations.En
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up organizations endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up organizations endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/organizations/service_endpoints_gen_test.go
+++ b/internal/service/organizations/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/osis/service_endpoint_resolver_gen.go
+++ b/internal/service/osis/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params osis.EndpointPar
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up osis endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up osis endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/osis/service_endpoints_gen_test.go
+++ b/internal/service/osis/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/outposts/service_endpoint_resolver_gen.go
+++ b/internal/service/outposts/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params outposts.Endpoin
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up outposts endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up outposts endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/outposts/service_endpoints_gen_test.go
+++ b/internal/service/outposts/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/paymentcryptography/service_endpoint_resolver_gen.go
+++ b/internal/service/paymentcryptography/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params paymentcryptogra
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up paymentcryptography endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up paymentcryptography endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/pcaconnectorad/service_endpoint_resolver_gen.go
+++ b/internal/service/pcaconnectorad/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params pcaconnectorad.E
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up pcaconnectorad endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up pcaconnectorad endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/pcaconnectorad/service_endpoints_gen_test.go
+++ b/internal/service/pcaconnectorad/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/pcs/service_endpoint_resolver_gen.go
+++ b/internal/service/pcs/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params pcs.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up pcs endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up pcs endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/pcs/service_endpoints_gen_test.go
+++ b/internal/service/pcs/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/pinpoint/service_endpoint_resolver_gen.go
+++ b/internal/service/pinpoint/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params pinpoint.Endpoin
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up pinpoint endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up pinpoint endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/pinpoint/service_endpoints_gen_test.go
+++ b/internal/service/pinpoint/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/pinpointsmsvoicev2/service_endpoint_resolver_gen.go
+++ b/internal/service/pinpointsmsvoicev2/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params pinpointsmsvoice
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up pinpointsmsvoicev2 endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up pinpointsmsvoicev2 endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/pinpointsmsvoicev2/service_endpoints_gen_test.go
+++ b/internal/service/pinpointsmsvoicev2/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/pipes/service_endpoint_resolver_gen.go
+++ b/internal/service/pipes/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params pipes.EndpointPa
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up pipes endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up pipes endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/pipes/service_endpoints_gen_test.go
+++ b/internal/service/pipes/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/polly/service_endpoint_resolver_gen.go
+++ b/internal/service/polly/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params polly.EndpointPa
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up polly endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up polly endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/polly/service_endpoints_gen_test.go
+++ b/internal/service/polly/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/pricing/service_endpoint_resolver_gen.go
+++ b/internal/service/pricing/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params pricing.Endpoint
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up pricing endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up pricing endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/pricing/service_endpoints_gen_test.go
+++ b/internal/service/pricing/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/qbusiness/service_endpoint_resolver_gen.go
+++ b/internal/service/qbusiness/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params qbusiness.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up qbusiness endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up qbusiness endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/qbusiness/service_endpoints_gen_test.go
+++ b/internal/service/qbusiness/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/qldb/service_endpoint_resolver_gen.go
+++ b/internal/service/qldb/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params qldb.EndpointPar
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up qldb endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up qldb endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/qldb/service_endpoints_gen_test.go
+++ b/internal/service/qldb/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/quicksight/service_endpoint_resolver_gen.go
+++ b/internal/service/quicksight/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params quicksight.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up quicksight endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up quicksight endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/quicksight/service_endpoints_gen_test.go
+++ b/internal/service/quicksight/service_endpoints_gen_test.go
@@ -524,7 +524,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/ram/service_endpoint_resolver_gen.go
+++ b/internal/service/ram/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params ram.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up ram endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up ram endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/ram/service_endpoints_gen_test.go
+++ b/internal/service/ram/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/rbin/service_endpoint_resolver_gen.go
+++ b/internal/service/rbin/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params rbin.EndpointPar
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up rbin endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up rbin endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/rbin/service_endpoints_gen_test.go
+++ b/internal/service/rbin/service_endpoints_gen_test.go
@@ -604,7 +604,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/rds/service_endpoint_resolver_gen.go
+++ b/internal/service/rds/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params rds.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up rds endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up rds endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/rds/service_endpoints_gen_test.go
+++ b/internal/service/rds/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/redshift/service_endpoint_resolver_gen.go
+++ b/internal/service/redshift/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params redshift.Endpoin
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up redshift endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up redshift endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/redshift/service_endpoints_gen_test.go
+++ b/internal/service/redshift/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/redshiftdata/service_endpoint_resolver_gen.go
+++ b/internal/service/redshiftdata/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params redshiftdata.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up redshiftdata endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up redshiftdata endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/redshiftdata/service_endpoints_gen_test.go
+++ b/internal/service/redshiftdata/service_endpoints_gen_test.go
@@ -603,7 +603,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/redshiftserverless/service_endpoint_resolver_gen.go
+++ b/internal/service/redshiftserverless/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params redshiftserverle
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up redshiftserverless endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up redshiftserverless endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/redshiftserverless/service_endpoints_gen_test.go
+++ b/internal/service/redshiftserverless/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/rekognition/service_endpoint_resolver_gen.go
+++ b/internal/service/rekognition/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params rekognition.Endp
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up rekognition endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up rekognition endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/rekognition/service_endpoints_gen_test.go
+++ b/internal/service/rekognition/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/resiliencehub/service_endpoint_resolver_gen.go
+++ b/internal/service/resiliencehub/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params resiliencehub.En
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up resiliencehub endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up resiliencehub endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/resiliencehub/service_endpoints_gen_test.go
+++ b/internal/service/resiliencehub/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/resourceexplorer2/service_endpoint_resolver_gen.go
+++ b/internal/service/resourceexplorer2/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params resourceexplorer
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up resourceexplorer2 endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up resourceexplorer2 endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/resourceexplorer2/service_endpoints_gen_test.go
+++ b/internal/service/resourceexplorer2/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/resourcegroups/service_endpoint_resolver_gen.go
+++ b/internal/service/resourcegroups/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params resourcegroups.E
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up resourcegroups endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up resourcegroups endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/resourcegroups/service_endpoints_gen_test.go
+++ b/internal/service/resourcegroups/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/resourcegroupstaggingapi/service_endpoint_resolver_gen.go
+++ b/internal/service/resourcegroupstaggingapi/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params resourcegroupsta
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up resourcegroupstaggingapi endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up resourcegroupstaggingapi endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/resourcegroupstaggingapi/service_endpoints_gen_test.go
+++ b/internal/service/resourcegroupstaggingapi/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/rolesanywhere/service_endpoint_resolver_gen.go
+++ b/internal/service/rolesanywhere/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params rolesanywhere.En
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up rolesanywhere endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up rolesanywhere endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/rolesanywhere/service_endpoints_gen_test.go
+++ b/internal/service/rolesanywhere/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/route53/service_endpoint_resolver_gen.go
+++ b/internal/service/route53/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params route53.Endpoint
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up route53 endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up route53 endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/route53/service_endpoints_gen_test.go
+++ b/internal/service/route53/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/route53domains/service_endpoint_resolver_gen.go
+++ b/internal/service/route53domains/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params route53domains.E
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up route53domains endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up route53domains endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/route53domains/service_endpoints_gen_test.go
+++ b/internal/service/route53domains/service_endpoints_gen_test.go
@@ -523,7 +523,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/route53profiles/service_endpoint_resolver_gen.go
+++ b/internal/service/route53profiles/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params route53profiles.
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up route53profiles endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up route53profiles endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/route53recoverycontrolconfig/service_endpoint_resolver_gen.go
+++ b/internal/service/route53recoverycontrolconfig/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params route53recoveryc
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up route53recoverycontrolconfig endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up route53recoverycontrolconfig endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/route53recoverycontrolconfig/service_endpoints_gen_test.go
+++ b/internal/service/route53recoverycontrolconfig/service_endpoints_gen_test.go
@@ -523,7 +523,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/route53recoveryreadiness/service_endpoint_resolver_gen.go
+++ b/internal/service/route53recoveryreadiness/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params route53recoveryr
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up route53recoveryreadiness endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up route53recoveryreadiness endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/route53recoveryreadiness/service_endpoints_gen_test.go
+++ b/internal/service/route53recoveryreadiness/service_endpoints_gen_test.go
@@ -523,7 +523,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/route53resolver/service_endpoint_resolver_gen.go
+++ b/internal/service/route53resolver/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params route53resolver.
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up route53resolver endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up route53resolver endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/route53resolver/service_endpoints_gen_test.go
+++ b/internal/service/route53resolver/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/rum/service_endpoint_resolver_gen.go
+++ b/internal/service/rum/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params rum.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up rum endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up rum endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/rum/service_endpoints_gen_test.go
+++ b/internal/service/rum/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/s3/service_endpoint_resolver_gen.go
+++ b/internal/service/s3/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params s3.EndpointParam
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up s3 endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up s3 endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/s3/service_endpoints_gen_test.go
+++ b/internal/service/s3/service_endpoints_gen_test.go
@@ -753,7 +753,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/s3control/service_endpoint_resolver_gen.go
+++ b/internal/service/s3control/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params s3control.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up s3control endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up s3control endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/s3outposts/service_endpoint_resolver_gen.go
+++ b/internal/service/s3outposts/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params s3outposts.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up s3outposts endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up s3outposts endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/s3outposts/service_endpoints_gen_test.go
+++ b/internal/service/s3outposts/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/s3tables/service_endpoint_resolver_gen.go
+++ b/internal/service/s3tables/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params s3tables.Endpoin
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up s3tables endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up s3tables endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/s3tables/service_endpoints_gen_test.go
+++ b/internal/service/s3tables/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/s3vectors/service_endpoint_resolver_gen.go
+++ b/internal/service/s3vectors/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params s3vectors.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up s3vectors endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up s3vectors endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/s3vectors/service_endpoints_gen_test.go
+++ b/internal/service/s3vectors/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/sagemaker/service_endpoint_resolver_gen.go
+++ b/internal/service/sagemaker/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params sagemaker.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up sagemaker endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up sagemaker endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/sagemaker/service_endpoints_gen_test.go
+++ b/internal/service/sagemaker/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/scheduler/service_endpoint_resolver_gen.go
+++ b/internal/service/scheduler/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params scheduler.Endpoi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up scheduler endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up scheduler endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/scheduler/service_endpoints_gen_test.go
+++ b/internal/service/scheduler/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/schemas/service_endpoint_resolver_gen.go
+++ b/internal/service/schemas/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params schemas.Endpoint
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up schemas endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up schemas endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/schemas/service_endpoints_gen_test.go
+++ b/internal/service/schemas/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/secretsmanager/service_endpoint_resolver_gen.go
+++ b/internal/service/secretsmanager/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params secretsmanager.E
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up secretsmanager endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up secretsmanager endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/secretsmanager/service_endpoints_gen_test.go
+++ b/internal/service/secretsmanager/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/securityhub/service_endpoint_resolver_gen.go
+++ b/internal/service/securityhub/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params securityhub.Endp
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up securityhub endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up securityhub endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/securityhub/service_endpoints_gen_test.go
+++ b/internal/service/securityhub/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/securitylake/service_endpoint_resolver_gen.go
+++ b/internal/service/securitylake/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params securitylake.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up securitylake endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up securitylake endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/securitylake/service_endpoints_gen_test.go
+++ b/internal/service/securitylake/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/serverlessrepo/service_endpoint_resolver_gen.go
+++ b/internal/service/serverlessrepo/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params serverlessapplic
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up serverlessapplicationrepository endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up serverlessapplicationrepository endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/serverlessrepo/service_endpoints_gen_test.go
+++ b/internal/service/serverlessrepo/service_endpoints_gen_test.go
@@ -678,7 +678,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/servicecatalog/service_endpoint_resolver_gen.go
+++ b/internal/service/servicecatalog/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params servicecatalog.E
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up servicecatalog endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up servicecatalog endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/servicecatalog/service_endpoints_gen_test.go
+++ b/internal/service/servicecatalog/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/servicecatalogappregistry/service_endpoint_resolver_gen.go
+++ b/internal/service/servicecatalogappregistry/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params servicecatalogap
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up servicecatalogappregistry endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up servicecatalogappregistry endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/servicecatalogappregistry/service_endpoints_gen_test.go
+++ b/internal/service/servicecatalogappregistry/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/servicediscovery/service_endpoint_resolver_gen.go
+++ b/internal/service/servicediscovery/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params servicediscovery
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up servicediscovery endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up servicediscovery endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/servicediscovery/service_endpoints_gen_test.go
+++ b/internal/service/servicediscovery/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/servicequotas/service_endpoint_resolver_gen.go
+++ b/internal/service/servicequotas/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params servicequotas.En
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up servicequotas endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up servicequotas endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/servicequotas/service_endpoints_gen_test.go
+++ b/internal/service/servicequotas/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/ses/service_endpoint_resolver_gen.go
+++ b/internal/service/ses/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params ses.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up ses endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up ses endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/ses/service_endpoints_gen_test.go
+++ b/internal/service/ses/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/sesv2/service_endpoint_resolver_gen.go
+++ b/internal/service/sesv2/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params sesv2.EndpointPa
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up sesv2 endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up sesv2 endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/sesv2/service_endpoints_gen_test.go
+++ b/internal/service/sesv2/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/sfn/service_endpoint_resolver_gen.go
+++ b/internal/service/sfn/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params sfn.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up sfn endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up sfn endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/sfn/service_endpoints_gen_test.go
+++ b/internal/service/sfn/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/shield/service_endpoint_resolver_gen.go
+++ b/internal/service/shield/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params shield.EndpointP
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up shield endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up shield endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/shield/service_endpoints_gen_test.go
+++ b/internal/service/shield/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/signer/service_endpoint_resolver_gen.go
+++ b/internal/service/signer/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params signer.EndpointP
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up signer endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up signer endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/signer/service_endpoints_gen_test.go
+++ b/internal/service/signer/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/sns/service_endpoint_resolver_gen.go
+++ b/internal/service/sns/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params sns.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up sns endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up sns endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/sns/service_endpoints_gen_test.go
+++ b/internal/service/sns/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/sqs/service_endpoint_resolver_gen.go
+++ b/internal/service/sqs/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params sqs.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up sqs endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up sqs endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/sqs/service_endpoints_gen_test.go
+++ b/internal/service/sqs/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/ssm/service_endpoint_resolver_gen.go
+++ b/internal/service/ssm/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params ssm.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up ssm endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up ssm endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/ssm/service_endpoints_gen_test.go
+++ b/internal/service/ssm/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/ssmcontacts/service_endpoint_resolver_gen.go
+++ b/internal/service/ssmcontacts/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params ssmcontacts.Endp
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up ssmcontacts endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up ssmcontacts endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/ssmcontacts/service_endpoints_gen_test.go
+++ b/internal/service/ssmcontacts/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/ssmincidents/service_endpoint_resolver_gen.go
+++ b/internal/service/ssmincidents/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params ssmincidents.End
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up ssmincidents endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up ssmincidents endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/ssmincidents/service_endpoints_gen_test.go
+++ b/internal/service/ssmincidents/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/ssmquicksetup/service_endpoint_resolver_gen.go
+++ b/internal/service/ssmquicksetup/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params ssmquicksetup.En
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up ssmquicksetup endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up ssmquicksetup endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/ssmquicksetup/service_endpoints_gen_test.go
+++ b/internal/service/ssmquicksetup/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/ssmsap/service_endpoint_resolver_gen.go
+++ b/internal/service/ssmsap/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params ssmsap.EndpointP
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up ssmsap endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up ssmsap endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/ssmsap/service_endpoints_gen_test.go
+++ b/internal/service/ssmsap/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/sso/service_endpoint_resolver_gen.go
+++ b/internal/service/sso/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params sso.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up sso endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up sso endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/sso/service_endpoints_gen_test.go
+++ b/internal/service/sso/service_endpoints_gen_test.go
@@ -523,7 +523,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/ssoadmin/service_endpoint_resolver_gen.go
+++ b/internal/service/ssoadmin/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params ssoadmin.Endpoin
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up ssoadmin endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up ssoadmin endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/ssoadmin/service_endpoints_gen_test.go
+++ b/internal/service/ssoadmin/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/storagegateway/service_endpoint_resolver_gen.go
+++ b/internal/service/storagegateway/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params storagegateway.E
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up storagegateway endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up storagegateway endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/storagegateway/service_endpoints_gen_test.go
+++ b/internal/service/storagegateway/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/sts/service_endpoint_resolver_gen.go
+++ b/internal/service/sts/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params sts.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up sts endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up sts endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/sts/service_endpoints_gen_test.go
+++ b/internal/service/sts/service_endpoints_gen_test.go
@@ -659,7 +659,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/swf/service_endpoint_resolver_gen.go
+++ b/internal/service/swf/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params swf.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up swf endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up swf endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/swf/service_endpoints_gen_test.go
+++ b/internal/service/swf/service_endpoints_gen_test.go
@@ -523,7 +523,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/synthetics/service_endpoint_resolver_gen.go
+++ b/internal/service/synthetics/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params synthetics.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up synthetics endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up synthetics endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/synthetics/service_endpoints_gen_test.go
+++ b/internal/service/synthetics/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/taxsettings/service_endpoint_resolver_gen.go
+++ b/internal/service/taxsettings/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params taxsettings.Endp
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up taxsettings endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up taxsettings endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/taxsettings/service_endpoints_gen_test.go
+++ b/internal/service/taxsettings/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/timestreaminfluxdb/service_endpoint_resolver_gen.go
+++ b/internal/service/timestreaminfluxdb/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params timestreaminflux
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up timestreaminfluxdb endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up timestreaminfluxdb endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/timestreaminfluxdb/service_endpoints_gen_test.go
+++ b/internal/service/timestreaminfluxdb/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/timestreamquery/service_endpoint_resolver_gen.go
+++ b/internal/service/timestreamquery/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params timestreamquery.
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up timestreamquery endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up timestreamquery endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/timestreamquery/service_endpoints_gen_test.go
+++ b/internal/service/timestreamquery/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/timestreamwrite/service_endpoint_resolver_gen.go
+++ b/internal/service/timestreamwrite/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params timestreamwrite.
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up timestreamwrite endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up timestreamwrite endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/transcribe/service_endpoint_resolver_gen.go
+++ b/internal/service/transcribe/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params transcribe.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up transcribe endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up transcribe endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/transcribe/service_endpoints_gen_test.go
+++ b/internal/service/transcribe/service_endpoints_gen_test.go
@@ -601,7 +601,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/transfer/service_endpoint_resolver_gen.go
+++ b/internal/service/transfer/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params transfer.Endpoin
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up transfer endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up transfer endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/transfer/service_endpoints_gen_test.go
+++ b/internal/service/transfer/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/verifiedpermissions/service_endpoint_resolver_gen.go
+++ b/internal/service/verifiedpermissions/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params verifiedpermissi
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up verifiedpermissions endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up verifiedpermissions endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/verifiedpermissions/service_endpoints_gen_test.go
+++ b/internal/service/verifiedpermissions/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/vpclattice/service_endpoint_resolver_gen.go
+++ b/internal/service/vpclattice/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params vpclattice.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up vpclattice endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up vpclattice endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/vpclattice/service_endpoints_gen_test.go
+++ b/internal/service/vpclattice/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/waf/service_endpoint_resolver_gen.go
+++ b/internal/service/waf/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params waf.EndpointPara
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up waf endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up waf endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/waf/service_endpoints_gen_test.go
+++ b/internal/service/waf/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/wafregional/service_endpoint_resolver_gen.go
+++ b/internal/service/wafregional/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params wafregional.Endp
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up wafregional endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up wafregional endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/wafregional/service_endpoints_gen_test.go
+++ b/internal/service/wafregional/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/wafv2/service_endpoint_resolver_gen.go
+++ b/internal/service/wafv2/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params wafv2.EndpointPa
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up wafv2 endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up wafv2 endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/wafv2/service_endpoints_gen_test.go
+++ b/internal/service/wafv2/service_endpoints_gen_test.go
@@ -524,7 +524,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/wellarchitected/service_endpoint_resolver_gen.go
+++ b/internal/service/wellarchitected/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params wellarchitected.
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up wellarchitected endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up wellarchitected endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/wellarchitected/service_endpoints_gen_test.go
+++ b/internal/service/wellarchitected/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/workspaces/service_endpoint_resolver_gen.go
+++ b/internal/service/workspaces/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params workspaces.Endpo
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up workspaces endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up workspaces endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/workspaces/service_endpoints_gen_test.go
+++ b/internal/service/workspaces/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/workspacesweb/service_endpoint_resolver_gen.go
+++ b/internal/service/workspacesweb/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params workspacesweb.En
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up workspacesweb endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up workspacesweb endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/workspacesweb/service_endpoints_gen_test.go
+++ b/internal/service/workspacesweb/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {

--- a/internal/service/xray/service_endpoint_resolver_gen.go
+++ b/internal/service/xray/service_endpoint_resolver_gen.go
@@ -62,7 +62,7 @@ func (r resolverV2) ResolveEndpoint(ctx context.Context, params xray.EndpointPar
 				})
 				params.UseFIPS = aws.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up xray endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up xray endpoint %q: %w", hostname, err)
 				return
 			}
 		} else {

--- a/internal/service/xray/service_endpoints_gen_test.go
+++ b/internal/service/xray/service_endpoints_gen_test.go
@@ -521,7 +521,7 @@ func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
 	)
 }
 
-var errCancelOperation = fmt.Errorf("Test: Canceling request")
+var errCancelOperation = errors.New("Test: Canceling request")
 
 func addCancelRequestMiddleware() func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Use `%w` in generated call to `fmt.Errorf()` so as to keep the wrapper `error`.
Also, prefer `errors.New()` for simple error.