### PR TITLE
[Enhancement] r/aws_lightsail_static_ip_attachment: Support resource import

### DIFF
--- a/.changelog/43874.txt
+++ b/.changelog/43874.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lightsail_static_ip_attachment: Support resource import
+```

--- a/internal/service/lightsail/static_ip_attachment.go
+++ b/internal/service/lightsail/static_ip_attachment.go
@@ -23,6 +23,10 @@ func ResourceStaticIPAttachment() *schema.Resource {
 		ReadWithoutTimeout:   resourceStaticIPAttachmentRead,
 		DeleteWithoutTimeout: resourceStaticIPAttachmentDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"static_ip_name": {
 				Type:     schema.TypeString,
@@ -65,7 +69,7 @@ func resourceStaticIPAttachmentRead(ctx context.Context, d *schema.ResourceData,
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
-	staticIpName := d.Get("static_ip_name").(string)
+	staticIpName := d.Id()
 	log.Printf("[INFO] Reading Lightsail Static IP Attachment: %q", staticIpName)
 	out, err := conn.GetStaticIp(ctx, &lightsail.GetStaticIpInput{
 		StaticIpName: aws.String(staticIpName),
@@ -86,6 +90,7 @@ func resourceStaticIPAttachmentRead(ctx context.Context, d *schema.ResourceData,
 
 	d.Set("instance_name", out.StaticIp.AttachedTo)
 	d.Set(names.AttrIPAddress, out.StaticIp.IpAddress)
+	d.Set("static_ip_name", out.StaticIp.Name)
 
 	return diags
 }

--- a/internal/service/lightsail/static_ip_attachment_test.go
+++ b/internal/service/lightsail/static_ip_attachment_test.go
@@ -26,6 +26,7 @@ func TestAccLightsailStaticIPAttachment_basic(t *testing.T) {
 	staticIpName := fmt.Sprintf("tf-test-lightsail-%s", sdkacctest.RandString(5))
 	instanceName := fmt.Sprintf("tf-test-lightsail-%s", sdkacctest.RandString(5))
 	keypairName := fmt.Sprintf("tf-test-lightsail-%s", sdkacctest.RandString(5))
+	resourceName := "aws_lightsail_static_ip_attachment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
@@ -36,9 +37,14 @@ func TestAccLightsailStaticIPAttachment_basic(t *testing.T) {
 			{
 				Config: testAccStaticIPAttachmentConfig_basic(staticIpName, instanceName, keypairName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStaticIPAttachmentExists(ctx, "aws_lightsail_static_ip_attachment.test"),
-					resource.TestCheckResourceAttrSet("aws_lightsail_static_ip_attachment.test", names.AttrIPAddress),
+					testAccCheckStaticIPAttachmentExists(ctx, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrIPAddress),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* Fix to support the import operation for `aws_lightsail_static_ip_attachment`.
  * In the same way as `aws_lightsail_static_ip` in #43672

  * In the `Read` function:

    * `d.Id()` is used to obtain the static IP name instead of `d.Get("static_ip_name")`, because the `static_ip_name` attribute is unknown and only `id` is known during import.
    * `d.Set("static_ip_name", ...)` is called to populate the `name` attribute in the import process.
  * The `Importer` is defined in the schema.
  * A test case is added to verify the import functionality.
  * Although import was previously unsupported, instructions for import were included in the documentation. This PR does not update the documentation.

### Relations

Closes #43870


### Output from Acceptance Testing
```console
$ make testacc TESTS=TestAccLightsailStaticIPAttachment_basic PKG=lightsail
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/lightsail/... -v -count 1 -parallel 20 -run='TestAccLightsailStaticIPAttachment_basic'  -timeout 360m -vet=off
2025/08/14 08:17:15 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/14 08:17:15 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLightsailStaticIPAttachment_basic
=== PAUSE TestAccLightsailStaticIPAttachment_basic
=== CONT  TestAccLightsailStaticIPAttachment_basic
--- PASS: TestAccLightsailStaticIPAttachment_basic (93.48s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  98.079s

```
