### PR TITLE
[Enhancement] aws_ecr_repository_creation_template: Support `image_tag_mutability_exclusion_filter`

### DIFF
--- a/.changelog/43886.txt
+++ b/.changelog/43886.txt
@@ -3,9 +3,9 @@ resource/aws_ecr_repository_creation_template: Add `image_tag_mutability_exclusi
 ```
 
 ```release-note:enhancement
-data-source/aws_ecr_repository_creation_template: Add `image_tag_mutability_exclusion_filter` block
+data-source/aws_ecr_repository_creation_template: Add `image_tag_mutability_exclusion_filter` attribute
 ```
 
 ```release-note:enhancement
-data-source/aws_ecr_repository: Add `image_tag_mutability_exclusion_filter` block
+data-source/aws_ecr_repository: Add `image_tag_mutability_exclusion_filter` attribute
 ```

--- a/.changelog/43886.txt
+++ b/.changelog/43886.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_ecr_repository_creation_template: Add `image_tag_mutability_exclusion_filter` configuration block
+```
+
+```release-note:enhancement
+data-source/aws_ecr_repository_creation_template: Add `image_tag_mutability_exclusion_filter` block
+```
+
+```release-note:enhancement
+data-source/aws_ecr_repository: Add `image_tag_mutability_exclusion_filter` block
+```

--- a/internal/service/ecr/repository_creation_template.go
+++ b/internal/service/ecr/repository_creation_template.go
@@ -86,6 +86,32 @@ func resourceRepositoryCreationTemplate() *schema.Resource {
 				Default:          types.ImageTagMutabilityMutable,
 				ValidateDiagFunc: enum.Validate[types.ImageTagMutability](),
 			},
+			"image_tag_mutability_exclusion_filter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 5,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						names.AttrFilter: {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateDiagFunc: validation.AllDiag(
+								validation.ToDiagFunc(validation.StringLenBetween(1, 128)),
+								validation.ToDiagFunc(validation.StringMatch(
+									regexache.MustCompile(`^[a-zA-Z0-9._*-]+$`),
+									"must contain only letters, numbers, and special characters (._*-)",
+								)),
+								validateImageTagMutabilityExclusionFilter(),
+							),
+						},
+						"filter_type": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: enum.Validate[types.ImageTagMutabilityExclusionFilterType](),
+						},
+					},
+				},
+			},
 			"lifecycle_policy": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -139,6 +165,10 @@ func resourceRepositoryCreationTemplateCreate(ctx context.Context, d *schema.Res
 
 	if v, ok := d.GetOk(names.AttrDescription); ok {
 		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("image_tag_mutability_exclusion_filter"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.ImageTagMutabilityExclusionFilters = expandImageTagMutabilityExclusionFilters(v.([]any))
 	}
 
 	if v, ok := d.GetOk("lifecycle_policy"); ok {
@@ -198,6 +228,10 @@ func resourceRepositoryCreationTemplateRead(ctx context.Context, d *schema.Resou
 	}
 	d.Set("image_tag_mutability", rct.ImageTagMutability)
 
+	if err := d.Set("image_tag_mutability_exclusion_filter", flattenImageTagMutabilityExclusionFilters(rct.ImageTagMutabilityExclusionFilters)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting image_tag_mutability_exclusion_filter: %s", err)
+	}
+
 	if _, err := equivalentLifecyclePolicyJSON(d.Get("lifecycle_policy").(string), aws.ToString(rct.LifecyclePolicy)); err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
@@ -256,6 +290,12 @@ func resourceRepositoryCreationTemplateUpdate(ctx context.Context, d *schema.Res
 
 	if d.HasChange("image_tag_mutability") {
 		input.ImageTagMutability = types.ImageTagMutability((d.Get("image_tag_mutability").(string)))
+	}
+
+	if d.HasChange("image_tag_mutability_exclusion_filter") {
+		// To use image_tag_mutability_exclusion_filter, image_tag_mutability must be set
+		input.ImageTagMutability = types.ImageTagMutability((d.Get("image_tag_mutability").(string)))
+		input.ImageTagMutabilityExclusionFilters = expandImageTagMutabilityExclusionFilters(d.Get("image_tag_mutability_exclusion_filter").([]any))
 	}
 
 	if d.HasChange("lifecycle_policy") {

--- a/internal/service/ecr/repository_creation_template_data_source.go
+++ b/internal/service/ecr/repository_creation_template_data_source.go
@@ -59,6 +59,22 @@ func dataSourceRepositoryCreationTemplate() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"image_tag_mutability_exclusion_filter": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						names.AttrFilter: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"filter_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"lifecycle_policy": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -106,6 +122,9 @@ func dataSourceRepositoryCreationTemplateRead(ctx context.Context, d *schema.Res
 		return sdkdiag.AppendErrorf(diags, "setting encryption_configuration: %s", err)
 	}
 	d.Set("image_tag_mutability", rct.ImageTagMutability)
+	if err := d.Set("image_tag_mutability_exclusion_filter", flattenImageTagMutabilityExclusionFilters(rct.ImageTagMutabilityExclusionFilters)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting image_tag_mutability_exclusion_filter: %s", err)
+	}
 
 	policy, err := structure.NormalizeJsonString(aws.ToString(rct.LifecyclePolicy))
 	if err != nil {

--- a/internal/service/ecr/repository_creation_template_data_source_test.go
+++ b/internal/service/ecr/repository_creation_template_data_source_test.go
@@ -66,6 +66,31 @@ func TestAccECRRepositoryCreationTemplateDataSource_root(t *testing.T) {
 	})
 }
 
+func TestAccECRRepositoryCreationTemplateDataSource_mutabilityWithExclusion(t *testing.T) {
+	ctx := acctest.Context(t)
+	repositoryPrefix := "tf-test-" + sdkacctest.RandString(8)
+	dataSource := "data.aws_ecr_repository_creation_template.root"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRepositoryCreationTemplateDataSourceConfig_mutabilityWithExclusion(repositoryPrefix, "latest*", "prod-*"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSource, "image_tag_mutability", string(types.ImageTagMutabilityMutableWithExclusion)),
+					resource.TestCheckResourceAttr(dataSource, "image_tag_mutability_exclusion_filter.#", "2"),
+					resource.TestCheckResourceAttr(dataSource, "image_tag_mutability_exclusion_filter.0.filter", "latest*"),
+					resource.TestCheckResourceAttr(dataSource, "image_tag_mutability_exclusion_filter.0.filter_type", string(types.ImageTagMutabilityExclusionFilterTypeWildcard)),
+					resource.TestCheckResourceAttr(dataSource, "image_tag_mutability_exclusion_filter.1.filter", "prod-*"),
+					resource.TestCheckResourceAttr(dataSource, "image_tag_mutability_exclusion_filter.1.filter_type", string(types.ImageTagMutabilityExclusionFilterTypeWildcard)),
+				),
+			},
+		},
+	})
+}
+
 func testAccRepositoryCreationTemplateDataSourceConfig_basic(repositoryPrefix string) string {
 	return fmt.Sprintf(`
 resource "aws_ecr_repository_creation_template" "test" {
@@ -100,4 +125,36 @@ data "aws_ecr_repository_creation_template" "root" {
   prefix = aws_ecr_repository_creation_template.root.prefix
 }
 `
+}
+
+func testAccRepositoryCreationTemplateDataSourceConfig_mutabilityWithExclusion(repositoryPrefix, filter1, filter2 string) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_repository_creation_template" "test" {
+  prefix = %[1]q
+
+  applied_for = [
+    "PULL_THROUGH_CACHE",
+    "REPLICATION",
+  ]
+
+  resource_tags = {
+    Foo = "Bar"
+  }
+
+  image_tag_mutability = "MUTABLE_WITH_EXCLUSION"
+
+  image_tag_mutability_exclusion_filter {
+    filter      = %[2]q
+    filter_type = "WILDCARD"
+  }
+
+  image_tag_mutability_exclusion_filter {
+    filter      = %[3]q
+    filter_type = "WILDCARD"
+  }
+}
+data "aws_ecr_repository_creation_template" "root" {
+  prefix = aws_ecr_repository_creation_template.test.prefix
+}
+`, repositoryPrefix, filter1, filter2)
 }

--- a/internal/service/ecr/repository_creation_template_test.go
+++ b/internal/service/ecr/repository_creation_template_test.go
@@ -197,6 +197,50 @@ func TestAccECRRepositoryCreationTemplate_root(t *testing.T) {
 	})
 }
 
+func TestAccECRRepositoryCreationTemplate_mutabilityWithExclusion(t *testing.T) {
+	ctx := acctest.Context(t)
+	repositoryPrefix := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_ecr_repository_creation_template.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRepositoryCreationTemplateDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRepositoryCreationTemplateConfig_mutabilityWithExclusion(repositoryPrefix, "latest*", "prod-*"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRepositoryCreationTemplateExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability", string(types.ImageTagMutabilityMutableWithExclusion)),
+					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability_exclusion_filter.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability_exclusion_filter.0.filter", "latest*"),
+					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability_exclusion_filter.0.filter_type", string(types.ImageTagMutabilityExclusionFilterTypeWildcard)),
+					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability_exclusion_filter.1.filter", "prod-*"),
+					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability_exclusion_filter.1.filter_type", string(types.ImageTagMutabilityExclusionFilterTypeWildcard)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRepositoryCreationTemplateConfig_mutabilityWithExclusion(repositoryPrefix, "prod-*", "latest*"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRepositoryCreationTemplateExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability", string(types.ImageTagMutabilityMutableWithExclusion)),
+					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability_exclusion_filter.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability_exclusion_filter.0.filter", "prod-*"),
+					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability_exclusion_filter.0.filter_type", string(types.ImageTagMutabilityExclusionFilterTypeWildcard)),
+					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability_exclusion_filter.1.filter", "latest*"),
+					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability_exclusion_filter.1.filter_type", string(types.ImageTagMutabilityExclusionFilterTypeWildcard)),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRepositoryCreationTemplateDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ECRClient(ctx)
@@ -434,4 +478,33 @@ resource "aws_ecr_repository_creation_template" "root" {
   ]
 }
 `
+}
+
+func testAccRepositoryCreationTemplateConfig_mutabilityWithExclusion(repositoryPrefix, filter1, filter2 string) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_repository_creation_template" "test" {
+  prefix = %[1]q
+
+  applied_for = [
+    "PULL_THROUGH_CACHE",
+    "REPLICATION",
+  ]
+
+  resource_tags = {
+    Foo = "Bar"
+  }
+
+  image_tag_mutability = "MUTABLE_WITH_EXCLUSION"
+
+  image_tag_mutability_exclusion_filter {
+    filter      = %[2]q
+    filter_type = "WILDCARD"
+  }
+
+  image_tag_mutability_exclusion_filter {
+    filter      = %[3]q
+    filter_type = "WILDCARD"
+  }
+}
+`, repositoryPrefix, filter1, filter2)
 }

--- a/internal/service/ecr/repository_data_source.go
+++ b/internal/service/ecr/repository_data_source.go
@@ -61,6 +61,22 @@ func dataSourceRepository() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"image_tag_mutability_exclusion_filter": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						names.AttrFilter: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"filter_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"most_recent_image_tags": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -113,6 +129,9 @@ func dataSourceRepositoryRead(ctx context.Context, d *schema.ResourceData, meta 
 		return sdkdiag.AppendErrorf(diags, "setting image_scanning_configuration: %s", err)
 	}
 	d.Set("image_tag_mutability", repository.ImageTagMutability)
+	if err := d.Set("image_tag_mutability_exclusion_filter", flattenImageTagMutabilityExclusionFilters(repository.ImageTagMutabilityExclusionFilters)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting image_tag_mutability_exclusion_filter: %s", err)
+	}
 	d.Set(names.AttrName, repository.RepositoryName)
 	d.Set("registry_id", repository.RegistryId)
 	d.Set("repository_url", repository.RepositoryUri)

--- a/internal/service/ecr/repository_data_source_test.go
+++ b/internal/service/ecr/repository_data_source_test.go
@@ -71,6 +71,29 @@ func TestAccECRRepositoryDataSource_encryption(t *testing.T) {
 	})
 }
 
+func TestAccECRRepositoryDataSource_mutabilityWithExclusion(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ecr_repository.test"
+	dataSourceName := "data.aws_ecr_repository.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRepositoryDataSourceConfig_mutabilityWithExclusion(rName, "test*"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "image_tag_mutability_exclusion_filter.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "image_tag_mutability_exclusion_filter.0.filter", dataSourceName, "image_tag_mutability_exclusion_filter.0.filter"),
+					resource.TestCheckResourceAttrPair(resourceName, "image_tag_mutability_exclusion_filter.0.filter_type", dataSourceName, "image_tag_mutability_exclusion_filter.0.filter_type"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccECRRepositoryDataSource_nonExistent(t *testing.T) {
 	ctx := acctest.Context(t)
 	resource.ParallelTest(t, resource.TestCase{
@@ -129,4 +152,21 @@ data "aws_ecr_repository" "test" {
   name = aws_ecr_repository.test.name
 }
 `, rName)
+}
+
+func testAccRepositoryDataSourceConfig_mutabilityWithExclusion(rName, filter string) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_repository" "test" {
+  name                 = %[1]q
+  image_tag_mutability = "MUTABLE_WITH_EXCLUSION"
+
+  image_tag_mutability_exclusion_filter {
+    filter      = %[2]q
+    filter_type = "WILDCARD"
+  }
+}
+data "aws_ecr_repository" "test" {
+  name = aws_ecr_repository.test.name
+}
+`, rName, filter)
 }

--- a/website/docs/d/ecr_repository.html.markdown
+++ b/website/docs/d/ecr_repository.html.markdown
@@ -34,6 +34,7 @@ This data source exports the following attributes in addition to the arguments a
 * `encryption_configuration` - Encryption configuration for the repository. See [Encryption Configuration](#encryption-configuration) below.
 * `image_scanning_configuration` - Configuration block that defines image scanning configuration for the repository. See [Image Scanning Configuration](#image-scanning-configuration) below.
 * `image_tag_mutability` - The tag mutability setting for the repository.
+* `image_tag_mutability_exclusion_filter` - Block that defines filters to specify which image tags can override the default tag mutability setting.
 * `most_recent_image_tags` - List of image tags associated with the most recently pushed image in the repository.
 * `repository_url` - URL of the repository (in the form `aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName`).
 * `tags` - Map of tags assigned to the resource.
@@ -42,6 +43,11 @@ This data source exports the following attributes in addition to the arguments a
 
 * `encryption_type` - Encryption type to use for the repository, either `AES256` or `KMS`.
 * `kms_key` - If `encryption_type` is `KMS`, the ARN of the KMS key used.
+
+### Image Tag Mutability Exclusion Filter
+
+* `filter` - The filter pattern to use for excluding image tags from the mutability setting.
+* `filter_type` - The type of filter to use.
 
 ### Image Scanning Configuration
 

--- a/website/docs/d/ecr_repository_creation_template.html.markdown
+++ b/website/docs/d/ecr_repository_creation_template.html.markdown
@@ -34,6 +34,7 @@ This data source exports the following attributes in addition to the arguments a
 * `description` - The description for this template.
 * `encryption_configuration` - Encryption configuration for any created repositories. See [Encryption Configuration](#encryption-configuration) below.
 * `image_tag_mutability` - The tag mutability setting for any created repositories.
+* `image_tag_mutability_exclusion_filter` - Block that defines filters to specify which image tags can override the default tag mutability setting.
 * `lifecycle_policy` - The lifecycle policy document to apply to any created repositories.
 * `registry_id` - The registry ID the repository creation template applies to.
 * `repository_policy` - The registry policy document to apply to any created repositories.
@@ -43,3 +44,8 @@ This data source exports the following attributes in addition to the arguments a
 
 * `encryption_type` - Encryption type to use for any created repositories, either `AES256` or `KMS`.
 * `kms_key` - If `encryption_type` is `KMS`, the ARN of the KMS key used.
+
+### Image Tag Mutability Exclusion Filter
+
+* `filter` - The filter pattern to use for excluding image tags from the mutability setting.
+* `filter_type` - The type of filter to use.

--- a/website/docs/r/ecr_repository_creation_template.html.markdown
+++ b/website/docs/r/ecr_repository_creation_template.html.markdown
@@ -95,6 +95,7 @@ This resource supports the following arguments:
 * `description` - (Optional) The description for this template.
 * `encryption_configuration` - (Optional) Encryption configuration for any created repositories. See [below for schema](#encryption_configuration).
 * `image_tag_mutability` - (Optional) The tag mutability setting for any created repositories. Must be one of: `MUTABLE` or `IMMUTABLE`. Defaults to `MUTABLE`.
+* `image_tag_mutability_exclusion_filter` - (Optional) Configuration block that defines filters to specify which image tags can override the default tag mutability setting. Only applicable when `image_tag_mutability` is set to `IMMUTABLE_WITH_EXCLUSION` or `MUTABLE_WITH_EXCLUSION`. See [below for schema](#image_tag_mutability_exclusion_filter).
 * `lifecycle_policy` - (Optional) The lifecycle policy document to apply to any created repositories. See more details about [Policy Parameters](http://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html#lifecycle_policy_parameters) in the official AWS docs. Consider using the [`aws_ecr_lifecycle_policy_document` data_source](/docs/providers/aws/d/ecr_lifecycle_policy_document.html) to generate/manage the JSON document used for the `lifecycle_policy` argument.
 * `repository_policy` - (Optional) The registry policy document to apply to any created repositories. This is a JSON formatted string. For more information about building IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).
 * `resource_tags` - (Optional) A map of tags to assign to any created repositories.
@@ -103,6 +104,11 @@ This resource supports the following arguments:
 
 * `encryption_type` - (Optional) The encryption type to use for any created repositories. Valid values are `AES256` or `KMS`. Defaults to `AES256`.
 * `kms_key` - (Optional) The ARN of the KMS key to use when `encryption_type` is `KMS`. If not specified, uses the default AWS managed key for ECR.
+
+### image_tag_mutability_exclusion_filter
+
+* `filter` - (Required) The filter pattern to use for excluding image tags from the mutability setting. Must contain only letters, numbers, and special characters (._*-). Each filter can be up to 128 characters long and can contain a maximum of 2 wildcards (*).
+* `filter_type` - (Required) The type of filter to use. Must be `WILDCARD`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Add the `image_tag_mutability_exclusion_filter` configuration block for `aws_ecr_repository_creation_template`.

  * The same configuration block for `aws_ecr_repository` was implemented in #43569. The schema (including validation) is copied, and the existing expander and flattener are reused.
* Add support for the `image_tag_mutability_exclusion_filter` block in the `aws_ecr_repository_creation_template` data source.

  * Also add `image_tag_mutability_exclusion_filter` to the `aws_ecr_repository` data source.


### Relations

Closes #43882

### References
https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_CreateRepositoryCreationTemplate.html
https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_ImageTagMutabilityExclusionFilter.html

### Output from Acceptance Testing

#### `aws_ecr_repository_creation_template` resource
```console
$ make testacc TESTS=TestAccECRRepositoryCreationTemplate_ PKG=ecr
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRRepositoryCreationTemplate_'  -timeout 360m -vet=off
2025/08/15 00:38:31 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/15 00:38:31 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECRRepositoryCreationTemplate_basic
=== PAUSE TestAccECRRepositoryCreationTemplate_basic
=== RUN   TestAccECRRepositoryCreationTemplate_disappears
=== PAUSE TestAccECRRepositoryCreationTemplate_disappears
=== RUN   TestAccECRRepositoryCreationTemplate_failWhenAlreadyExists
=== PAUSE TestAccECRRepositoryCreationTemplate_failWhenAlreadyExists
=== RUN   TestAccECRRepositoryCreationTemplate_ignoreEquivalentLifecycle
=== PAUSE TestAccECRRepositoryCreationTemplate_ignoreEquivalentLifecycle
=== RUN   TestAccECRRepositoryCreationTemplate_repository
=== PAUSE TestAccECRRepositoryCreationTemplate_repository
=== RUN   TestAccECRRepositoryCreationTemplate_root
--- PASS: TestAccECRRepositoryCreationTemplate_root (20.79s)
=== RUN   TestAccECRRepositoryCreationTemplate_mutabilityWithExclusion
=== PAUSE TestAccECRRepositoryCreationTemplate_mutabilityWithExclusion
=== CONT  TestAccECRRepositoryCreationTemplate_basic
=== CONT  TestAccECRRepositoryCreationTemplate_ignoreEquivalentLifecycle
=== CONT  TestAccECRRepositoryCreationTemplate_failWhenAlreadyExists
=== CONT  TestAccECRRepositoryCreationTemplate_disappears
=== CONT  TestAccECRRepositoryCreationTemplate_mutabilityWithExclusion
=== CONT  TestAccECRRepositoryCreationTemplate_repository
--- PASS: TestAccECRRepositoryCreationTemplate_failWhenAlreadyExists (10.70s)
--- PASS: TestAccECRRepositoryCreationTemplate_disappears (18.00s)
--- PASS: TestAccECRRepositoryCreationTemplate_basic (20.35s)
--- PASS: TestAccECRRepositoryCreationTemplate_ignoreEquivalentLifecycle (26.88s)
--- PASS: TestAccECRRepositoryCreationTemplate_repository (32.06s)
--- PASS: TestAccECRRepositoryCreationTemplate_mutabilityWithExclusion (32.06s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        57.339s
```

#### `aws_ecr_repository_creation_template` data source
```console
$ make testacc TESTS=TestAccECRRepositoryCreationTemplateDataSource_ PKG=ecr
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRRepositoryCreationTemplateDataSource_'  -timeout 360m -vet=off
2025/08/15 00:40:14 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/15 00:40:14 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECRRepositoryCreationTemplateDataSource_basic
=== PAUSE TestAccECRRepositoryCreationTemplateDataSource_basic
=== RUN   TestAccECRRepositoryCreationTemplateDataSource_root
--- PASS: TestAccECRRepositoryCreationTemplateDataSource_root (20.31s)
=== RUN   TestAccECRRepositoryCreationTemplateDataSource_mutabilityWithExclusion
--- PASS: TestAccECRRepositoryCreationTemplateDataSource_mutabilityWithExclusion (14.55s)
=== CONT  TestAccECRRepositoryCreationTemplateDataSource_basic
--- PASS: TestAccECRRepositoryCreationTemplateDataSource_basic (15.15s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        54.027s
```

#### `aws_ecr_repository` data source
```console
$ make testacc TESTS=TestAccECRRepositoryDataSource_ PKG=ecr                       
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRRepositoryDataSource_'  -timeout 360m -vet=off
2025/08/15 00:31:33 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/15 00:31:33 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECRRepositoryDataSource_basic
=== PAUSE TestAccECRRepositoryDataSource_basic
=== RUN   TestAccECRRepositoryDataSource_encryption
=== PAUSE TestAccECRRepositoryDataSource_encryption
=== RUN   TestAccECRRepositoryDataSource_mutabilityWithExclusion
=== PAUSE TestAccECRRepositoryDataSource_mutabilityWithExclusion
=== RUN   TestAccECRRepositoryDataSource_nonExistent
=== PAUSE TestAccECRRepositoryDataSource_nonExistent
=== CONT  TestAccECRRepositoryDataSource_basic
=== CONT  TestAccECRRepositoryDataSource_mutabilityWithExclusion
=== CONT  TestAccECRRepositoryDataSource_encryption
=== CONT  TestAccECRRepositoryDataSource_nonExistent
--- PASS: TestAccECRRepositoryDataSource_nonExistent (4.99s)
--- PASS: TestAccECRRepositoryDataSource_mutabilityWithExclusion (19.39s)
--- PASS: TestAccECRRepositoryDataSource_basic (19.40s)
--- PASS: TestAccECRRepositoryDataSource_encryption (26.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        30.940s


```
