### PR TITLE
[Docs] aws_launch_template: Add condition for using `capacity_reservation_target`

### DIFF
--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -186,7 +186,7 @@ The `ebs` block supports the following:
 
 The `capacity_reservation_specification` block supports the following:
 
-* `capacity_reservation_preference` - Indicates the instance's Capacity Reservation preferences. Can be `capacity-reservations-only`, `open` or `none`. (Default `none`). If `capacity_reservation_id` or `capacity_reservation_resource_group_arn` is specified in `capacity_reservation_target` block, either omit `capacity_reservation_preference` or set it to `capacity-reservations-only`.
+* `capacity_reservation_preference` - Indicates the instance's Capacity Reservation preferences. Can be `capacity-reservations-only`, `open` or `none`. If `capacity_reservation_id` or `capacity_reservation_resource_group_arn` is specified in `capacity_reservation_target` block, either omit `capacity_reservation_preference` or set it to `capacity-reservations-only`.
 * `capacity_reservation_target` - Used to target a specific Capacity Reservation:
 
 The `capacity_reservation_target` block supports the following:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.


### Description

* Update the `aws_launch_template` documentation to clarify the conditions for using `capacity_reservation_target` attributes.

  * If `capacity_reservation_id` or `capacity_reservation_resource_group_arn` is specified in the `capacity_reservation_target` block, `capacity_reservation_preference` must either be omitted or set to `capacity-reservations-only`.
  * This behavior was confirmed and noted in [this comment](https://github.com/hashicorp/terraform-provider-aws/issues/43881#issuecomment-3189087506).
* The current documentation states that the default value of `capacity_reservation_preference` is `none`. However, this default is not implemented in the Terraform schema and is not mentioned in the [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CapacityReservationSpecification.html#API_CapacityReservationSpecification_Contents). Based on the behavior described above, the default value should be removed.

  * It was confirmed that even if `capacity_reservation_preference` is set to `none`, an error occurs when `capacity_reservation_id` or `capacity_reservation_resource_group_arn` is specified.


### Relations
Closes #43881

### References
https://github.com/hashicorp/terraform-provider-aws/issues/43881#issuecomment-3189087506

