### PR TITLE
[Docs] aws_gamelift_fleet: Add description of conflicts between `build_id` and `script_id`

### DIFF
--- a/website/docs/r/gamelift_fleet.html.markdown
+++ b/website/docs/r/gamelift_fleet.html.markdown
@@ -33,7 +33,7 @@ resource "aws_gamelift_fleet" "example" {
 This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `build_id` - (Optional) ID of the GameLift Build to be deployed on the fleet.
+* `build_id` - (Optional) ID of the GameLift Build to be deployed on the fleet. Conflicts with `script_id`.
 * `certificate_configuration` - (Optional) Prompts GameLift to generate a TLS/SSL certificate for the fleet. See [certificate_configuration](#certificate_configuration).
 * `description` - (Optional) Human-readable description of the fleet.
 * `ec2_inbound_permission` - (Optional) Range of IP addresses and port settings that permit inbound traffic to access server processes running on the fleet. See below.
@@ -45,7 +45,7 @@ This resource supports the following arguments:
 * `new_game_session_protection_policy` - (Optional) Game session protection policy to apply to all instances in this fleetE.g., `FullProtection`. Defaults to `NoProtection`.
 * `resource_creation_limit_policy` - (Optional) Policy that limits the number of game sessions an individual player can create over a span of time for this fleet. See below.
 * `runtime_configuration` - (Optional) Instructions for launching server processes on each instance in the fleet. See below.
-* `script_id` - (Optional) ID of the GameLift Script to be deployed on the fleet.
+* `script_id` - (Optional) ID of the GameLift Script to be deployed on the fleet. Conflicts with `build_id`.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Nested Fields


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Add description of conflicts between `build_id` and `script_id`.
  ```
  ExactlyOneOf: []string{"build_id", "script_id"},
  ```

### Relations
Closes #43897

### References
https://github.com/hashicorp/terraform-provider-aws/blob/791e2b7854ee029d50f5c8c7a6f58df20e32764c/internal/service/gamelift/fleet.go#L61-L66

https://github.com/hashicorp/terraform-provider-aws/blob/791e2b7854ee029d50f5c8c7a6f58df20e32764c/internal/service/gamelift/fleet.go#L233-L238

