### PR TITLE
feat: Add support for Witness Region for Global Tables with MRSC

### DIFF
--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -3239,6 +3239,68 @@ func TestAccDynamoDBTable_Replica_MRSC_Create(t *testing.T) {
 	})
 }
 
+func TestAccDynamoDBTable_Replica_MRSC_Create_witness(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var conf, replica1 awstypes.TableDescription
+	resourceName := "aws_dynamodb_table.test_mrsc"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 3)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 3), // 3 due to shared test configuration
+		CheckDestroy:             testAccCheckTableDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_MRSC_replica_witness(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(ctx, resourceName, &conf),
+					testAccCheckReplicaExists(ctx, resourceName, acctest.AlternateRegion(), &replica1),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("replica"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"region_name":      knownvalue.StringExact(acctest.AlternateRegion()),
+							"consistency_mode": knownvalue.StringExact((string(awstypes.MultiRegionConsistencyStrong))),
+						}),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("global_table_witness_region_name"), knownvalue.StringExact(acctest.ThirdRegion())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTable_Replica_MRSC_Create_witness_too_many_replicas(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 3)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 3), // 3 due to shared test configuration
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTableConfig_MRSC_replica_witness_too_many_replicas(rName),
+				ExpectError: regexache.MustCompile(`MRSC Replica count of 2 was provided and a Witness region was also provided`),
+			},
+		},
+	})
+}
+
 func TestAccDynamoDBTable_Replica_MRSC_doubleAddCMK(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -4071,7 +4133,7 @@ func TestAccDynamoDBTable_Replica_MRSC_TooManyReplicas(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTableConfig_MRSC_replica_count3(rName),
-				ExpectError: regexache.MustCompile(`Using MultiRegionStrongConsistency supports at most 2 replicas`),
+				ExpectError: regexache.MustCompile(`Too many Replicas were provided 3`),
 			},
 		},
 	})
@@ -5828,6 +5890,79 @@ resource "aws_dynamodb_table" "test_mrsc" {
     region_name      = data.aws_region.third.name
     consistency_mode = "STRONG"
   }
+}
+`, rName))
+}
+
+func testAccTableConfig_MRSC_replica_witness(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(3), // Prevent "Provider configuration not present" errors
+		fmt.Sprintf(`
+data "aws_region" "alternate" {
+  provider = "awsalternate"
+}
+
+data "aws_region" "third" {
+  provider = "awsthird"
+}
+
+resource "aws_dynamodb_table" "test_mrsc" {
+  name             = %[1]q
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name      = data.aws_region.alternate.name
+    consistency_mode = "STRONG"
+  }
+
+  global_table_witness_region_name = data.aws_region.third.name
+}
+`, rName))
+}
+
+func testAccTableConfig_MRSC_replica_witness_too_many_replicas(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(3), // Prevent "Provider configuration not present" errors
+		fmt.Sprintf(`
+data "aws_region" "alternate" {
+  provider = "awsalternate"
+}
+
+data "aws_region" "third" {
+  provider = "awsthird"
+}
+
+resource "aws_dynamodb_table" "test_mrsc" {
+  name             = %[1]q
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name      = data.aws_region.alternate.name
+    consistency_mode = "STRONG"
+  }
+
+  replica {
+    region_name      = data.aws_region.third.name
+    consistency_mode = "STRONG"
+  }
+
+  global_table_witness_region_name = data.aws_region.third.name
 }
 `, rName))
 }


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No

### Description
This adds support for leveraging a Witness Region in DynamoDB Global Tables with Mutli-Region Strong Consistency.


### Relations
Closes #43612

### References

### Output from Acceptance Testing
```console
% make testacc PKG=dynamodb TESTS=TestAccDynamoDBTable_Replica_MRSC_witness
make: Fixing source code with gofmt...
gofmt -s -w ./internal ./names ./.ci/providerlint/helper ./.ci/providerlint/main.go ./.ci/providerlint/passes
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Building provider...
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_Replica_MRSC_witness'  -timeout 360m -vet=off
2025/08/14 16:33:27 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/14 16:33:27 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_doubleAddCMK
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_witness_doubleAddCMK
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_pitr
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_pitr (216.84s)
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_pitrKMS
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_witness_pitrKMS
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_oneOfTwo
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_oneOfTwo (243.75s)
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_twoOfTwo
^[[C--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_twoOfTwo (233.29s)
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica (227.64s)
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_tags_notPropagatedToAddedReplica
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_notPropagatedToAddedReplica (235.11s)
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_tags_nonPropagatedTagsAreUnmanaged
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_nonPropagatedTagsAreUnmanaged (236.11s)
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_tagsUpdate
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tagsUpdate (306.48s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_doubleAddCMK
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_pitrKMS
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_pitrKMS (325.32s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_doubleAddCMK (656.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   2363.769s
...
```
