### PR TITLE
Technical debt: Use `internal/retry` for `tfresource.RetryWhenIsA`

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1925,7 +1925,7 @@ func CheckACMPCACertificateAuthorityActivateRootCA(ctx context.Context, certific
 		}
 
 		// Wait for certificate status to become ISSUED.
-		outputRaw, err := tfresource.RetryWhenIsA[*acmpcatypes.RequestInProgressException](ctx, CertificateIssueTimeout, func() (any, error) {
+		getCertOutput, err := tfresource.RetryWhenIsA[*acmpca.GetCertificateOutput, *acmpcatypes.RequestInProgressException](ctx, CertificateIssueTimeout, func(ctx context.Context) (*acmpca.GetCertificateOutput, error) {
 			return tfacmpca.FindCertificateByTwoPartKey(ctx, conn, arn, aws.ToString(issueCertOutput.CertificateArn))
 		})
 
@@ -1933,7 +1933,6 @@ func CheckACMPCACertificateAuthorityActivateRootCA(ctx context.Context, certific
 			return fmt.Errorf("waiting for ACM PCA Certificate Authority (%s) Root CA certificate to become ISSUED: %w", arn, err)
 		}
 
-		getCertOutput := outputRaw.(*acmpca.GetCertificateOutput)
 		importCACertificateInput := acmpca.ImportCertificateAuthorityCertificateInput{
 			CertificateAuthorityArn: aws.String(arn),
 			Certificate:             []byte(aws.ToString(getCertOutput.Certificate)),
@@ -1986,7 +1985,7 @@ func CheckACMPCACertificateAuthorityActivateSubordinateCA(ctx context.Context, r
 		}
 
 		// Wait for certificate status to become ISSUED.
-		outputRaw, err := tfresource.RetryWhenIsA[*acmpcatypes.RequestInProgressException](ctx, CertificateIssueTimeout, func() (any, error) {
+		getCertOutput, err := tfresource.RetryWhenIsA[*acmpca.GetCertificateOutput, *acmpcatypes.RequestInProgressException](ctx, CertificateIssueTimeout, func(ctx context.Context) (*acmpca.GetCertificateOutput, error) {
 			return tfacmpca.FindCertificateByTwoPartKey(ctx, conn, rootCertificateAuthorityArn, aws.ToString(issueCertOutput.CertificateArn))
 		})
 
@@ -1994,7 +1993,6 @@ func CheckACMPCACertificateAuthorityActivateSubordinateCA(ctx context.Context, r
 			return fmt.Errorf("waiting for ACM PCA Certificate Authority (%s) Subordinate CA certificate (%s) to become ISSUED: %w", arn, aws.ToString(issueCertOutput.CertificateArn), err)
 		}
 
-		getCertOutput := outputRaw.(*acmpca.GetCertificateOutput)
 		importCACertificateInput := acmpca.ImportCertificateAuthorityCertificateInput{
 			CertificateAuthorityArn: aws.String(arn),
 			Certificate:             []byte(aws.ToString(getCertOutput.Certificate)),

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -552,8 +552,8 @@ func resourceCertificateDelete(ctx context.Context, d *schema.ResourceData, meta
 	input := acm.DeleteCertificateInput{
 		CertificateArn: aws.String(d.Id()),
 	}
-	_, err := tfresource.RetryWhenIsA[*types.ResourceInUseException](ctx, certificateCrossServicePropagationTimeout,
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.ResourceInUseException](ctx, certificateCrossServicePropagationTimeout,
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteCertificate(ctx, &input)
 		})
 

--- a/internal/service/acmpca/certificate.go
+++ b/internal/service/acmpca/certificate.go
@@ -177,7 +177,7 @@ func resourceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta
 	d.SetId(aws.ToString(outputRaw.(*acmpca.IssueCertificateOutput).CertificateArn))
 
 	// Wait for certificate status to become ISSUED.
-	_, err = tfresource.RetryWhenIsA[*types.RequestInProgressException](ctx, certificateIssueTimeout, func() (any, error) {
+	_, err = tfresource.RetryWhenIsA[any, *types.RequestInProgressException](ctx, certificateIssueTimeout, func(ctx context.Context) (any, error) {
 		return findCertificateByTwoPartKey(ctx, conn, d.Id(), certificateAuthorityARN)
 	})
 

--- a/internal/service/apigateway/base_path_mapping.go
+++ b/internal/service/apigateway/base_path_mapping.go
@@ -87,7 +87,7 @@ func resourceBasePathMappingCreate(ctx context.Context, d *schema.ResourceData, 
 	const (
 		timeout = 30 * time.Second
 	)
-	_, err := tfresource.RetryWhenIsA[*types.BadRequestException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.BadRequestException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.CreateBasePathMapping(ctx, &input)
 	})
 

--- a/internal/service/apigateway/method_response.go
+++ b/internal/service/apigateway/method_response.go
@@ -112,7 +112,7 @@ func resourceMethodResponseCreate(ctx context.Context, d *schema.ResourceData, m
 	const (
 		timeout = 2 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*types.ConflictException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.ConflictException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.PutMethodResponse(ctx, &input)
 	})
 

--- a/internal/service/apigatewayv2/authorizer.go
+++ b/internal/service/apigatewayv2/authorizer.go
@@ -263,7 +263,7 @@ func resourceAuthorizerDelete(ctx context.Context, d *schema.ResourceData, meta 
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
 	log.Printf("[DEBUG] Deleting API Gateway v2 Authorizer: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteAuthorizer(ctx, &apigatewayv2.DeleteAuthorizerInput{
 			ApiId:        aws.String(d.Get("api_id").(string)),
 			AuthorizerId: aws.String(d.Id()),

--- a/internal/service/appautoscaling/policy.go
+++ b/internal/service/appautoscaling/policy.go
@@ -307,7 +307,7 @@ func resourcePolicyPut(ctx context.Context, d *schema.ResourceData, meta any) di
 	id := d.Get(names.AttrName).(string)
 	input := expandPutScalingPolicyInput(d)
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.FailedResourceAccessException](ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.FailedResourceAccessException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutScalingPolicy(ctx, &input)
 	})
 
@@ -326,7 +326,7 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta any) d
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppAutoScalingClient(ctx)
 
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.FailedResourceAccessException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.FailedResourceAccessException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return findScalingPolicyByFourPartKey(ctx, conn, d.Get(names.AttrName).(string), d.Get("service_namespace").(string), d.Get(names.AttrResourceID).(string), d.Get("scalable_dimension").(string))
 	})
 
@@ -371,7 +371,7 @@ func resourcePolicyDelete(ctx context.Context, d *schema.ResourceData, meta any)
 		ServiceNamespace:  awstypes.ServiceNamespace(d.Get("service_namespace").(string)),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.FailedResourceAccessException](ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.FailedResourceAccessException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteScalingPolicy(ctx, &input)
 	})
 

--- a/internal/service/appautoscaling/scheduled_action.go
+++ b/internal/service/appautoscaling/scheduled_action.go
@@ -160,7 +160,7 @@ func resourceScheduledActionPut(ctx context.Context, d *schema.ResourceData, met
 	const (
 		timeout = 5 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*awstypes.ObjectNotFoundException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ObjectNotFoundException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.PutScheduledAction(ctx, &input)
 	})
 

--- a/internal/service/appconfig/deployment.go
+++ b/internal/service/appconfig/deployment.go
@@ -131,7 +131,7 @@ func resourceDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta 
 	const (
 		timeout = 30 * time.Minute // AWS SDK for Go v1 compatibility.
 	)
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, timeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.ConflictException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.StartDeployment(ctx, &input)
 	})
 

--- a/internal/service/appstream/fleet_stack_association.go
+++ b/internal/service/appstream/fleet_stack_association.go
@@ -63,7 +63,7 @@ func resourceFleetStackAssociationCreate(ctx context.Context, d *schema.Resource
 	const (
 		timeout = 15 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*awstypes.ResourceNotFoundException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ResourceNotFoundException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.AssociateFleet(ctx, &input)
 	})
 

--- a/internal/service/appstream/stack.go
+++ b/internal/service/appstream/stack.go
@@ -301,7 +301,7 @@ func resourceStackCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 		input.UserSettings = expandUserSettings(v.(*schema.Set).List())
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.ResourceNotFoundException](ctx, stackOperationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.ResourceNotFoundException](ctx, stackOperationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateStack(ctx, &input)
 	})
 

--- a/internal/service/appsync/domain_name.go
+++ b/internal/service/appsync/domain_name.go
@@ -138,7 +138,7 @@ func resourceDomainNameDelete(ctx context.Context, d *schema.ResourceData, meta 
 	const (
 		timeout = 5 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*awstypes.ConcurrentModificationException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ConcurrentModificationException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteDomainName(ctx, &appsync.DeleteDomainNameInput{
 			DomainName: aws.String(d.Id()),
 		})

--- a/internal/service/auditmanager/assessment.go
+++ b/internal/service/auditmanager/assessment.go
@@ -178,7 +178,7 @@ func (r *assessmentResource) Create(ctx context.Context, request resource.Create
 	// Example:
 	//   ResourceNotFoundException: The operation tried to access a nonexistent resource. The resource
 	//   might not be specified correctly, or its status might not be active. Check and try again.
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.ResourceNotFoundException](ctx, iamPropagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.ResourceNotFoundException](ctx, iamPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateAssessment(ctx, &input)
 	})
 

--- a/internal/service/auditmanager/assessment_delegation.go
+++ b/internal/service/auditmanager/assessment_delegation.go
@@ -130,7 +130,7 @@ func (r *assessmentDelegationResource) Create(ctx context.Context, request resou
 	// Example:
 	//   ResourceNotFoundException: The operation tried to access a nonexistent resource. The resource
 	//   might not be specified correctly, or its status might not be active. Check and try again.
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.ResourceNotFoundException](ctx, iamPropagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.ResourceNotFoundException](ctx, iamPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.BatchCreateDelegationByAssessment(ctx, &input)
 	})
 

--- a/internal/service/auditmanager/assessment_report.go
+++ b/internal/service/auditmanager/assessment_report.go
@@ -154,7 +154,7 @@ func (r *assessmentReportResource) Delete(ctx context.Context, request resource.
 	const (
 		timeout = 5 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*awstypes.ValidationException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ValidationException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteAssessmentReport(ctx, &input)
 	})
 

--- a/internal/service/autoscaling/launch_configuration.go
+++ b/internal/service/autoscaling/launch_configuration.go
@@ -516,8 +516,8 @@ func resourceLaunchConfigurationDelete(ctx context.Context, d *schema.ResourceDa
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Auto Scaling Launch Configuration: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*awstypes.ResourceInUseFault](ctx, propagationTimeout,
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ResourceInUseFault](ctx, propagationTimeout,
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteLaunchConfiguration(ctx, &autoscaling.DeleteLaunchConfigurationInput{
 				LaunchConfigurationName: aws.String(d.Id()),
 			})

--- a/internal/service/backup/framework.go
+++ b/internal/service/backup/framework.go
@@ -217,7 +217,7 @@ func resourceFrameworkUpdate(ctx context.Context, d *schema.ResourceData, meta a
 			IdempotencyToken:     aws.String(sdkid.UniqueId()),
 		}
 
-		_, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+		_, err := tfresource.RetryWhenIsA[any, *awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 			return conn.UpdateFramework(ctx, input)
 		})
 
@@ -238,7 +238,7 @@ func resourceFrameworkDelete(ctx context.Context, d *schema.ResourceData, meta a
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Backup Framework: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteFramework(ctx, &backup.DeleteFrameworkInput{
 			FrameworkName: aws.String(d.Id()),
 		})

--- a/internal/service/budgets/budget_action.go
+++ b/internal/service/budgets/budget_action.go
@@ -251,7 +251,7 @@ func resourceBudgetActionCreate(ctx context.Context, d *schema.ResourceData, met
 		ResourceTags:     getTagsIn(ctx),
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.AccessDeniedException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.AccessDeniedException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateBudgetAction(ctx, input)
 	})
 
@@ -382,7 +382,7 @@ func resourceBudgetActionDelete(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	log.Printf("[DEBUG] Deleting Budget Action: %s", d.Id())
-	_, err = tfresource.RetryWhenIsA[*awstypes.ResourceLockedException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err = tfresource.RetryWhenIsA[any, *awstypes.ResourceLockedException](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteBudgetAction(ctx, &budgets.DeleteBudgetActionInput{
 			AccountId:  aws.String(accountID),
 			ActionId:   aws.String(actionID),

--- a/internal/service/ce/cost_category.go
+++ b/internal/service/ce/cost_category.go
@@ -316,8 +316,8 @@ func resourceCostCategoryCreate(ctx context.Context, d *schema.ResourceData, met
 		input.SplitChargeRules = expandCostCategorySplitChargeRules(v.(*schema.Set).List())
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.ResourceNotFoundException](ctx, d.Timeout(schema.TimeoutCreate),
-		func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.ResourceNotFoundException](ctx, d.Timeout(schema.TimeoutCreate),
+		func(ctx context.Context) (any, error) {
 			return conn.CreateCostCategoryDefinition(ctx, input)
 		})
 

--- a/internal/service/cloudformation/stack_instances.go
+++ b/internal/service/cloudformation/stack_instances.go
@@ -549,7 +549,7 @@ func deleteStackInstances(ctx context.Context, d *schema.ResourceData, meta any,
 	}
 
 	log.Printf("[DEBUG] Deleting CloudFormation Stack Instances: %s", d.Id())
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.OperationInProgressException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.OperationInProgressException](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteStackInstances(ctx, input)
 	})
 

--- a/internal/service/cloudformation/stack_set_instance.go
+++ b/internal/service/cloudformation/stack_set_instance.go
@@ -455,7 +455,7 @@ func resourceStackSetInstanceDelete(ctx context.Context, d *schema.ResourceData,
 	}
 
 	log.Printf("[DEBUG] Deleting CloudFormation StackSet Instance: %s", d.Id())
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.OperationInProgressException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.OperationInProgressException](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteStackInstances(ctx, input)
 	})
 

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -917,7 +917,7 @@ func resourceDistributionCreate(ctx context.Context, d *schema.ResourceData, met
 	const (
 		timeout = 1 * time.Minute
 	)
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.InvalidViewerCertificate](ctx, timeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidViewerCertificate](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.CreateDistributionWithTags(ctx, &input)
 	})
 
@@ -1045,7 +1045,7 @@ func resourceDistributionUpdate(ctx context.Context, d *schema.ResourceData, met
 		const (
 			timeout = 1 * time.Minute
 		)
-		_, err := tfresource.RetryWhenIsA[*awstypes.InvalidViewerCertificate](ctx, timeout, func() (any, error) {
+		_, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidViewerCertificate](ctx, timeout, func(ctx context.Context) (any, error) {
 			return conn.UpdateDistribution(ctx, &input)
 		})
 
@@ -1133,7 +1133,7 @@ func resourceDistributionDelete(ctx context.Context, d *schema.ResourceData, met
 		const (
 			timeout = 3 * time.Minute
 		)
-		_, err = tfresource.RetryWhenIsA[*awstypes.DistributionNotDisabled](ctx, timeout, func() (any, error) {
+		_, err = tfresource.RetryWhenIsA[any, *awstypes.DistributionNotDisabled](ctx, timeout, func(ctx context.Context) (any, error) {
 			return nil, deleteDistribution(ctx, conn, d.Id())
 		})
 	}

--- a/internal/service/cognitoidp/managed_user_pool_client.go
+++ b/internal/service/cognitoidp/managed_user_pool_client.go
@@ -493,7 +493,7 @@ func (r *managedUserPoolClientResource) Create(ctx context.Context, request reso
 		const (
 			timeout = 2 * time.Minute
 		)
-		output, err := tfresource.RetryWhenIsA[*awstypes.ConcurrentModificationException](ctx, timeout, func() (any, error) {
+		output, err := tfresource.RetryWhenIsA[any, *awstypes.ConcurrentModificationException](ctx, timeout, func(ctx context.Context) (any, error) {
 			return conn.UpdateUserPoolClient(ctx, &input)
 		})
 		if err != nil {
@@ -605,7 +605,7 @@ func (r *managedUserPoolClientResource) Update(ctx context.Context, request reso
 	const (
 		timeout = 2 * time.Minute
 	)
-	output, err := tfresource.RetryWhenIsA[*awstypes.ConcurrentModificationException](ctx, timeout, func() (any, error) {
+	output, err := tfresource.RetryWhenIsA[any, *awstypes.ConcurrentModificationException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.UpdateUserPoolClient(ctx, &input)
 	})
 

--- a/internal/service/cognitoidp/user_pool_client.go
+++ b/internal/service/cognitoidp/user_pool_client.go
@@ -472,7 +472,7 @@ func (r *userPoolClientResource) Update(ctx context.Context, request resource.Up
 	const (
 		timeout = 2 * time.Minute
 	)
-	output, err := tfresource.RetryWhenIsA[*awstypes.ConcurrentModificationException](ctx, timeout, func() (any, error) {
+	output, err := tfresource.RetryWhenIsA[any, *awstypes.ConcurrentModificationException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.UpdateUserPoolClient(ctx, &input)
 	})
 

--- a/internal/service/configservice/config_rule.go
+++ b/internal/service/configservice/config_rule.go
@@ -236,7 +236,7 @@ func resourceConfigRulePut(ctx context.Context, d *schema.ResourceData, meta any
 			Tags:       getTagsIn(ctx),
 		}
 
-		_, err := tfresource.RetryWhenIsA[*types.InsufficientPermissionsException](ctx, propagationTimeout, func() (any, error) {
+		_, err := tfresource.RetryWhenIsA[any, *types.InsufficientPermissionsException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 			return conn.PutConfigRule(ctx, input)
 		})
 
@@ -303,7 +303,7 @@ func resourceConfigRuleDelete(ctx context.Context, d *schema.ResourceData, meta 
 		timeout = 2 * time.Minute
 	)
 	log.Printf("[DEBUG] Deleting ConfigService Config Rule: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*types.ResourceInUseException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.ResourceInUseException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteConfigRule(ctx, &configservice.DeleteConfigRuleInput{
 			ConfigRuleName: aws.String(d.Id()),
 		})

--- a/internal/service/configservice/conformance_pack.go
+++ b/internal/service/configservice/conformance_pack.go
@@ -187,7 +187,7 @@ func resourceConformancePackDelete(ctx context.Context, d *schema.ResourceData, 
 		timeout = 5 * time.Minute
 	)
 	log.Printf("[DEBUG] Deleting ConfigService Conformance Pack: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*types.ResourceInUseException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.ResourceInUseException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteConformancePack(ctx, &configservice.DeleteConformancePackInput{
 			ConformancePackName: aws.String(d.Id()),
 		})

--- a/internal/service/configservice/delivery_channel.go
+++ b/internal/service/configservice/delivery_channel.go
@@ -114,7 +114,7 @@ func resourceDeliveryChannelPut(ctx context.Context, d *schema.ResourceData, met
 		input.DeliveryChannel.SnsTopicARN = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenIsA[*types.InsufficientDeliveryPolicyException](ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.InsufficientDeliveryPolicyException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutDeliveryChannel(ctx, input)
 	})
 

--- a/internal/service/configservice/organization_conformance_pack.go
+++ b/internal/service/configservice/organization_conformance_pack.go
@@ -157,7 +157,7 @@ func resourceOrganizationConformancePackCreate(ctx context.Context, d *schema.Re
 		input.TemplateS3Uri = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenIsA[*types.OrganizationAccessDeniedException](ctx, organizationsPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.OrganizationAccessDeniedException](ctx, organizationsPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutOrganizationConformancePack(ctx, input)
 	})
 
@@ -255,7 +255,7 @@ func resourceOrganizationConformancePackDelete(ctx context.Context, d *schema.Re
 		timeout = 5 * time.Minute
 	)
 	log.Printf("[DEBUG] Deleting ConfigService Organization Conformance Pack: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*types.ResourceInUseException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.ResourceInUseException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteOrganizationConformancePack(ctx, &configservice.DeleteOrganizationConformancePackInput{
 			OrganizationConformancePackName: aws.String(d.Id()),
 		})
@@ -364,7 +364,7 @@ func findOrganizationConformancePackStatuses(ctx context.Context, conn *configse
 		const (
 			timeout = 15 * time.Second
 		)
-		outputRaw, err := tfresource.RetryWhenIsA[*types.OrganizationAccessDeniedException](ctx, timeout, func() (any, error) {
+		outputRaw, err := tfresource.RetryWhenIsA[any, *types.OrganizationAccessDeniedException](ctx, timeout, func(ctx context.Context) (any, error) {
 			return pages.NextPage(ctx)
 		})
 

--- a/internal/service/configservice/organization_custom_policy_rule.go
+++ b/internal/service/configservice/organization_custom_policy_rule.go
@@ -190,7 +190,7 @@ func resourceOrganizationCustomPolicyRuleCreate(ctx context.Context, d *schema.R
 		input.OrganizationCustomPolicyRuleMetadata.TagValueScope = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenIsA[*types.OrganizationAccessDeniedException](ctx, organizationsPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.OrganizationAccessDeniedException](ctx, organizationsPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutOrganizationConfigRule(ctx, input)
 	})
 
@@ -319,7 +319,7 @@ func resourceOrganizationCustomPolicyRuleDelete(ctx context.Context, d *schema.R
 		timeout = 2 * time.Minute
 	)
 	log.Printf("[DEBUG] Deleting ConfigService Organization Custom Policy Rule: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*types.ResourceInUseException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.ResourceInUseException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteOrganizationConfigRule(ctx, &configservice.DeleteOrganizationConfigRuleInput{
 			OrganizationConfigRuleName: aws.String(d.Id()),
 		})

--- a/internal/service/configservice/organization_custom_rule.go
+++ b/internal/service/configservice/organization_custom_rule.go
@@ -170,7 +170,7 @@ func resourceOrganizationCustomRuleCreate(ctx context.Context, d *schema.Resourc
 		input.OrganizationCustomRuleMetadata.TagValueScope = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenIsA[*types.OrganizationAccessDeniedException](ctx, organizationsPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.OrganizationAccessDeniedException](ctx, organizationsPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutOrganizationConfigRule(ctx, input)
 	})
 
@@ -285,7 +285,7 @@ func resourceOrganizationCustomRuleDelete(ctx context.Context, d *schema.Resourc
 		timeout = 2 * time.Minute
 	)
 	log.Printf("[DEBUG] Deleting ConfigService Organization Custom Rule: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*types.ResourceInUseException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.ResourceInUseException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteOrganizationConfigRule(ctx, &configservice.DeleteOrganizationConfigRuleInput{
 			OrganizationConfigRuleName: aws.String(d.Id()),
 		})

--- a/internal/service/configservice/organization_managed_rule.go
+++ b/internal/service/configservice/organization_managed_rule.go
@@ -162,7 +162,7 @@ func resourceOrganizationManagedRuleCreate(ctx context.Context, d *schema.Resour
 		input.OrganizationManagedRuleMetadata.TagValueScope = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenIsA[*types.OrganizationAccessDeniedException](ctx, organizationsPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.OrganizationAccessDeniedException](ctx, organizationsPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutOrganizationConfigRule(ctx, input)
 	})
 
@@ -275,7 +275,7 @@ func resourceOrganizationManagedRuleDelete(ctx context.Context, d *schema.Resour
 		timeout = 2 * time.Minute
 	)
 	log.Printf("[DEBUG] Deleting ConfigService Organization Managed Rule: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*types.ResourceInUseException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.ResourceInUseException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteOrganizationConfigRule(ctx, &configservice.DeleteOrganizationConfigRuleInput{
 			OrganizationConfigRuleName: aws.String(d.Id()),
 		})
@@ -398,7 +398,7 @@ func findOrganizationConfigRuleStatuses(ctx context.Context, conn *configservice
 		const (
 			timeout = 15 * time.Second
 		)
-		outputRaw, err := tfresource.RetryWhenIsA[*types.OrganizationAccessDeniedException](ctx, timeout, func() (any, error) {
+		outputRaw, err := tfresource.RetryWhenIsA[any, *types.OrganizationAccessDeniedException](ctx, timeout, func(ctx context.Context) (any, error) {
 			return pages.NextPage(ctx)
 		})
 

--- a/internal/service/configservice/remediation_configuration.go
+++ b/internal/service/configservice/remediation_configuration.go
@@ -252,7 +252,7 @@ func resourceRemediationConfigurationDelete(ctx context.Context, d *schema.Resou
 		timeout = 2 * time.Minute
 	)
 	log.Printf("[DEBUG] Deleting ConfigService Remediation Configuration: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*types.ResourceInUseException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.ResourceInUseException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteRemediationConfiguration(ctx, input)
 	})
 

--- a/internal/service/connect/bot_association.go
+++ b/internal/service/connect/bot_association.go
@@ -89,7 +89,7 @@ func resourceBotAssociationCreate(ctx context.Context, d *schema.ResourceData, m
 	const (
 		timeout = 5 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidRequestException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidRequestException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.AssociateBot(ctx, input)
 	})
 

--- a/internal/service/connect/queue.go
+++ b/internal/service/connect/queue.go
@@ -360,7 +360,7 @@ func resourceQueueDelete(ctx context.Context, d *schema.ResourceData, meta any) 
 	const (
 		timeout = 1 * time.Minute
 	)
-	_, err = tfresource.RetryWhenIsA[*awstypes.ResourceInUseException](ctx, timeout, func() (any, error) {
+	_, err = tfresource.RetryWhenIsA[any, *awstypes.ResourceInUseException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteQueue(ctx, &connect.DeleteQueueInput{
 			InstanceId: aws.String(instanceID),
 			QueueId:    aws.String(queueID),

--- a/internal/service/detective/graph.go
+++ b/internal/service/detective/graph.go
@@ -62,7 +62,7 @@ func resourceGraphCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 		Tags: getTagsIn(ctx),
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.InternalServerException](ctx, timeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.InternalServerException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.CreateGraph(ctx, input)
 	})
 

--- a/internal/service/detective/member.go
+++ b/internal/service/detective/member.go
@@ -117,7 +117,7 @@ func resourceMemberCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		input.Message = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.InternalServerException](ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.InternalServerException](ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.CreateMembers(ctx, input)
 	})
 

--- a/internal/service/dlm/lifecycle_policy.go
+++ b/internal/service/dlm/lifecycle_policy.go
@@ -498,7 +498,7 @@ func resourceLifecyclePolicyCreate(ctx context.Context, d *schema.ResourceData, 
 		Tags:             getTagsIn(ctx),
 	}
 
-	out, err := tfresource.RetryWhenIsA[*awstypes.InvalidRequestException](ctx, createRetryTimeout, func() (any, error) {
+	out, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidRequestException](ctx, createRetryTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateLifecyclePolicy(ctx, &input)
 	})
 

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -831,8 +831,8 @@ func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta an
 		expandTopLevelConnectionInfo(d, &input)
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.AccessDeniedFault](ctx, d.Timeout(schema.TimeoutCreate),
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.AccessDeniedFault](ctx, d.Timeout(schema.TimeoutCreate),
+		func(ctx context.Context) (any, error) {
 			return conn.CreateEndpoint(ctx, &input)
 		})
 

--- a/internal/service/dms/replication_subnet_group.go
+++ b/internal/service/dms/replication_subnet_group.go
@@ -81,7 +81,7 @@ func resourceReplicationSubnetGroupCreate(ctx context.Context, d *schema.Resourc
 		Tags:                              getTagsIn(ctx),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.AccessDeniedFault](ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.AccessDeniedFault](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateReplicationSubnetGroup(ctx, input)
 	})
 	if err != nil {

--- a/internal/service/dms/s3_endpoint.go
+++ b/internal/service/dms/s3_endpoint.go
@@ -351,7 +351,7 @@ func resourceS3EndpointCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	input.ExtraConnectionAttributes = extraConnectionAnomalies(d)
 
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.AccessDeniedFault](ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.AccessDeniedFault](ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.CreateEndpoint(ctx, input)
 	})
 
@@ -493,7 +493,7 @@ func resourceS3EndpointUpdate(ctx context.Context, d *schema.ResourceData, meta 
 			input.ExtraConnectionAttributes = extraConnectionAnomalies(d)
 		}
 
-		_, err := tfresource.RetryWhenIsA[*awstypes.AccessDeniedFault](ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+		_, err := tfresource.RetryWhenIsA[any, *awstypes.AccessDeniedFault](ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 			return conn.ModifyEndpoint(ctx, input)
 		})
 

--- a/internal/service/ecs/capacity_provider.go
+++ b/internal/service/ecs/capacity_provider.go
@@ -206,7 +206,7 @@ func resourceCapacityProviderUpdate(ctx context.Context, d *schema.ResourceData,
 		const (
 			timeout = 10 * time.Minute
 		)
-		_, err := tfresource.RetryWhenIsA[*awstypes.UpdateInProgressException](ctx, timeout, func() (any, error) {
+		_, err := tfresource.RetryWhenIsA[any, *awstypes.UpdateInProgressException](ctx, timeout, func(ctx context.Context) (any, error) {
 			return conn.UpdateCapacityProvider(ctx, input)
 		})
 

--- a/internal/service/elasticache/global_replication_group.go
+++ b/internal/service/elasticache/global_replication_group.go
@@ -610,7 +610,7 @@ func deleteGlobalReplicationGroup(ctx context.Context, conn *elasticache.Client,
 		RetainPrimaryReplicationGroup: aws.Bool(true),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidGlobalReplicationGroupStateFault](ctx, readyTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidGlobalReplicationGroupStateFault](ctx, readyTimeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteGlobalReplicationGroup(ctx, input)
 	})
 

--- a/internal/service/elasticache/parameter_group.go
+++ b/internal/service/elasticache/parameter_group.go
@@ -293,7 +293,7 @@ func deleteParameterGroup(ctx context.Context, conn *elasticache.Client, name st
 	const (
 		timeout = 3 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidCacheParameterGroupStateFault](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidCacheParameterGroupStateFault](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteCacheParameterGroup(ctx, &elasticache.DeleteCacheParameterGroupInput{
 			CacheParameterGroupName: aws.String(name),
 		})

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -1082,7 +1082,7 @@ func resourceReplicationGroupDelete(ctx context.Context, d *schema.ResourceData,
 		timeout = 10 * time.Minute // 10 minutes should give any creating/deleting cache clusters or snapshots time to complete.
 	)
 	log.Printf("[INFO] Deleting ElastiCache Replication Group: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidReplicationGroupStateFault](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidReplicationGroupStateFault](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteReplicationGroup(ctx, input)
 	})
 
@@ -1114,7 +1114,7 @@ func disassociateReplicationGroup(ctx context.Context, conn *elasticache.Client,
 		ReplicationGroupRegion:   aws.String(region),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidGlobalReplicationGroupStateFault](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidGlobalReplicationGroupStateFault](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DisassociateGlobalReplicationGroup(ctx, input)
 	})
 

--- a/internal/service/elasticache/user_group_association.go
+++ b/internal/service/elasticache/user_group_association.go
@@ -72,7 +72,7 @@ func resourceUserGroupAssociationCreate(ctx context.Context, d *schema.ResourceD
 		UserIdsToAdd: []string{userID},
 	}
 
-	if _, err := tfresource.RetryWhenIsA[*awstypes.InvalidUserGroupStateFault](ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	if _, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidUserGroupStateFault](ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.ModifyUserGroup(ctx, input)
 	}); err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating ElastiCache User Group Association (%s): %s", id, err)
@@ -126,7 +126,7 @@ func resourceUserGroupAssociationDelete(ctx context.Context, d *schema.ResourceD
 	userGroupID, userID := parts[0], parts[1]
 
 	log.Printf("[INFO] Deleting ElastiCache User Group Association: %s", d.Id())
-	_, err = tfresource.RetryWhenIsA[*awstypes.InvalidUserGroupStateFault](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err = tfresource.RetryWhenIsA[any, *awstypes.InvalidUserGroupStateFault](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.ModifyUserGroup(ctx, &elasticache.ModifyUserGroupInput{
 			UserGroupId:     aws.String(userGroupID),
 			UserIdsToRemove: []string{userID},

--- a/internal/service/elb/load_balancer.go
+++ b/internal/service/elb/load_balancer.go
@@ -304,7 +304,7 @@ func resourceLoadBalancerCreate(ctx context.Context, d *schema.ResourceData, met
 		input.Subnets = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
 
-	_, err = tfresource.RetryWhenIsA[*awstypes.CertificateNotFoundException](ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	_, err = tfresource.RetryWhenIsA[any, *awstypes.CertificateNotFoundException](ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.CreateLoadBalancer(ctx, input)
 	})
 

--- a/internal/service/elbv2/listener.go
+++ b/internal/service/elbv2/listener.go
@@ -765,7 +765,7 @@ func resourceListenerUpdate(ctx context.Context, d *schema.ResourceData, meta an
 			input.SslPolicy = aws.String(v.(string))
 		}
 
-		_, err := tfresource.RetryWhenIsA[*awstypes.CertificateNotFoundException](ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+		_, err := tfresource.RetryWhenIsA[any, *awstypes.CertificateNotFoundException](ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 			return conn.ModifyListener(ctx, input)
 		})
 
@@ -1036,7 +1036,7 @@ func (m listenerAttributeMap) flatten(d *schema.ResourceData, apiObjects []awsty
 }
 
 func retryListenerCreate(ctx context.Context, conn *elasticloadbalancingv2.Client, input *elasticloadbalancingv2.CreateListenerInput, timeout time.Duration) (*elasticloadbalancingv2.CreateListenerOutput, error) {
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.CertificateNotFoundException](ctx, timeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.CertificateNotFoundException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.CreateListener(ctx, input)
 	})
 

--- a/internal/service/elbv2/listener_certificate.go
+++ b/internal/service/elbv2/listener_certificate.go
@@ -67,7 +67,7 @@ func resourceListenerCertificateCreate(ctx context.Context, d *schema.ResourceDa
 		ListenerArn: aws.String(listenerARN),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.CertificateNotFoundException](ctx, iamPropagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.CertificateNotFoundException](ctx, iamPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.AddListenerCertificates(ctx, input)
 	})
 

--- a/internal/service/elbv2/listener_rule.go
+++ b/internal/service/elbv2/listener_rule.go
@@ -729,7 +729,7 @@ func retryListenerRuleCreate(ctx context.Context, conn *elasticloadbalancingv2.C
 	const (
 		timeout = 5 * time.Minute
 	)
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.PriorityInUseException](ctx, timeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.PriorityInUseException](ctx, timeout, func(ctx context.Context) (any, error) {
 		priority, err := highestListenerRulePriority(ctx, conn, listenerARN)
 		if err != nil {
 			return nil, err

--- a/internal/service/elbv2/target_group_attachment.go
+++ b/internal/service/elbv2/target_group_attachment.go
@@ -79,7 +79,7 @@ func resourceAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta 
 	const (
 		timeout = 10 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidTargetException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidTargetException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.RegisterTargets(ctx, input)
 	})
 

--- a/internal/service/fms/policy.go
+++ b/internal/service/fms/policy.go
@@ -334,7 +334,7 @@ func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	const (
 		timeout = 1 * time.Minute
 	)
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.InternalErrorException](ctx, timeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.InternalErrorException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.PutPolicy(ctx, input)
 	})
 
@@ -412,7 +412,7 @@ func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 		const (
 			timeout = 1 * time.Minute
 		)
-		_, err := tfresource.RetryWhenIsA[*awstypes.InternalErrorException](ctx, timeout, func() (any, error) {
+		_, err := tfresource.RetryWhenIsA[any, *awstypes.InternalErrorException](ctx, timeout, func(ctx context.Context) (any, error) {
 			return conn.PutPolicy(ctx, input)
 		})
 

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -562,7 +562,7 @@ func deleteRole(ctx context.Context, conn *iam.Client, roleName string, forceDet
 		RoleName: aws.String(roleName),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.DeleteConflictException](ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.DeleteConflictException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteRole(ctx, input)
 	})
 

--- a/internal/service/iam/user_policy_attachment.go
+++ b/internal/service/iam/user_policy_attachment.go
@@ -122,7 +122,7 @@ func resourceUserPolicyAttachmentImport(ctx context.Context, d *schema.ResourceD
 }
 
 func attachPolicyToUser(ctx context.Context, conn *iam.Client, user, policyARN string) error {
-	_, err := tfresource.RetryWhenIsA[*awstypes.ConcurrentModificationException](ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ConcurrentModificationException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.AttachUserPolicy(ctx, &iam.AttachUserPolicyInput{
 			PolicyArn: aws.String(policyARN),
 			UserName:  aws.String(user),
@@ -137,7 +137,7 @@ func attachPolicyToUser(ctx context.Context, conn *iam.Client, user, policyARN s
 }
 
 func detachPolicyFromUser(ctx context.Context, conn *iam.Client, user, policyARN string) error {
-	_, err := tfresource.RetryWhenIsA[*awstypes.ConcurrentModificationException](ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ConcurrentModificationException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.DetachUserPolicy(ctx, &iam.DetachUserPolicyInput{
 			PolicyArn: aws.String(policyARN),
 			UserName:  aws.String(user),

--- a/internal/service/iot/ca_certificate.go
+++ b/internal/service/iot/ca_certificate.go
@@ -160,7 +160,7 @@ func resourceCACertificateCreate(ctx context.Context, d *schema.ResourceData, me
 		input.VerificationCertificate = aws.String(v.(string))
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.InvalidRequestException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidRequestException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.RegisterCACertificate(ctx, input)
 	})
 
@@ -242,7 +242,7 @@ func resourceCACertificateUpdate(ctx context.Context, d *schema.ResourceData, me
 			}
 		}
 
-		_, err := tfresource.RetryWhenIsA[*awstypes.InvalidRequestException](ctx, propagationTimeout, func() (any, error) {
+		_, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidRequestException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 			return conn.UpdateCACertificate(ctx, input)
 		})
 

--- a/internal/service/iot/logging_options.go
+++ b/internal/service/iot/logging_options.go
@@ -70,7 +70,7 @@ func resourceLoggingOptionsPut(ctx context.Context, d *schema.ResourceData, meta
 		input.RoleArn = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidRequestException](ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidRequestException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.SetV2LoggingOptions(ctx, input)
 	})
 

--- a/internal/service/iot/policy.go
+++ b/internal/service/iot/policy.go
@@ -286,8 +286,8 @@ func deletePolicy(ctx context.Context, conn *iot.Client, name string) error {
 		PolicyName: aws.String(name),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.DeleteConflictException](ctx, propagationTimeout,
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.DeleteConflictException](ctx, propagationTimeout,
+		func(ctx context.Context) (any, error) {
 			return conn.DeletePolicy(ctx, input)
 		})
 
@@ -308,8 +308,8 @@ func deletePolicyVersion(ctx context.Context, conn *iot.Client, name, versionID 
 		PolicyVersionId: aws.String(versionID),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.DeleteConflictException](ctx, propagationTimeout,
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.DeleteConflictException](ctx, propagationTimeout,
+		func(ctx context.Context) (any, error) {
 			return conn.DeletePolicyVersion(ctx, input)
 		})
 

--- a/internal/service/iot/provisioning_template.go
+++ b/internal/service/iot/provisioning_template.go
@@ -155,8 +155,8 @@ func resourceProvisioningTemplateCreate(ctx context.Context, d *schema.ResourceD
 		input.Type = awstypes.TemplateType(v)
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.InvalidRequestException](ctx, propagationTimeout,
-		func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidRequestException](ctx, propagationTimeout,
+		func(ctx context.Context) (any, error) {
 			return conn.CreateProvisioningTemplate(ctx, input)
 		})
 
@@ -234,8 +234,8 @@ func resourceProvisioningTemplateUpdate(ctx context.Context, d *schema.ResourceD
 			input.PreProvisioningHook = expandProvisioningHook(v.([]any)[0].(map[string]any))
 		}
 
-		_, err := tfresource.RetryWhenIsA[*awstypes.InvalidRequestException](ctx, propagationTimeout,
-			func() (any, error) {
+		_, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidRequestException](ctx, propagationTimeout,
+			func(ctx context.Context) (any, error) {
 				return conn.UpdateProvisioningTemplate(ctx, input)
 			})
 

--- a/internal/service/iot/thing_group.go
+++ b/internal/service/iot/thing_group.go
@@ -238,8 +238,8 @@ func resourceThingGroupDelete(ctx context.Context, d *schema.ResourceData, meta 
 	const (
 		timeout = 1 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidRequestException](ctx, timeout,
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidRequestException](ctx, timeout,
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteThingGroup(ctx, &iot.DeleteThingGroupInput{
 				ThingGroupName: aws.String(d.Id()),
 			})

--- a/internal/service/iot/thing_type.go
+++ b/internal/service/iot/thing_type.go
@@ -194,8 +194,8 @@ func resourceThingTypeDelete(ctx context.Context, d *schema.ResourceData, meta a
 	}
 
 	log.Printf("[DEBUG] Deleting IoT Thing Type: %s", d.Id())
-	_, err = tfresource.RetryWhenIsA[*awstypes.InvalidRequestException](ctx, deprecatePropagationTimeout,
-		func() (any, error) {
+	_, err = tfresource.RetryWhenIsA[any, *awstypes.InvalidRequestException](ctx, deprecatePropagationTimeout,
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteThingType(ctx, &iot.DeleteThingTypeInput{
 				ThingTypeName: aws.String(d.Id()),
 			})

--- a/internal/service/iot/topic_rule.go
+++ b/internal/service/iot/topic_rule.go
@@ -1257,8 +1257,8 @@ func resourceTopicRuleCreate(ctx context.Context, d *schema.ResourceData, meta a
 		TopicRulePayload: expandTopicRulePayload(d),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidRequestException](ctx, propagationTimeout,
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidRequestException](ctx, propagationTimeout,
+		func(ctx context.Context) (any, error) {
 			return conn.CreateTopicRule(ctx, input)
 		})
 
@@ -1387,8 +1387,8 @@ func resourceTopicRuleUpdate(ctx context.Context, d *schema.ResourceData, meta a
 			TopicRulePayload: expandTopicRulePayload(d),
 		}
 
-		_, err := tfresource.RetryWhenIsA[*awstypes.InvalidRequestException](ctx, propagationTimeout,
-			func() (any, error) {
+		_, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidRequestException](ctx, propagationTimeout,
+			func(ctx context.Context) (any, error) {
 				return conn.ReplaceTopicRule(ctx, input)
 			})
 

--- a/internal/service/iot/topic_rule_destination.go
+++ b/internal/service/iot/topic_rule_destination.go
@@ -102,8 +102,8 @@ func resourceTopicRuleDestinationCreate(ctx context.Context, d *schema.ResourceD
 		input.DestinationConfiguration.VpcConfiguration = expandVPCDestinationConfiguration(v.([]any)[0].(map[string]any))
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.InvalidRequestException](ctx, propagationTimeout,
-		func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidRequestException](ctx, propagationTimeout,
+		func(ctx context.Context) (any, error) {
 			return conn.CreateTopicRuleDestination(ctx, input)
 		})
 

--- a/internal/service/kms/alias.go
+++ b/internal/service/kms/alias.go
@@ -81,7 +81,7 @@ func resourceAliasCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 		TargetKeyId: aws.String(d.Get("target_key_id").(string)),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.NotFoundException](ctx, keyRotationUpdatedTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.NotFoundException](ctx, keyRotationUpdatedTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateAlias(ctx, input)
 	})
 

--- a/internal/service/kms/external_key.go
+++ b/internal/service/kms/external_key.go
@@ -344,7 +344,7 @@ func importExternalKeyMaterial(ctx context.Context, conn *kms.Client, resourceTy
 	}
 
 	// Wait for propagation since KMS is eventually consistent.
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.NotFoundException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.NotFoundException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.GetParametersForImport(ctx, &inputGPFI)
 	})
 
@@ -387,7 +387,7 @@ func importExternalKeyMaterial(ctx context.Context, conn *kms.Client, resourceTy
 	}
 
 	// Wait for propagation since KMS is eventually consistent.
-	_, err = tfresource.RetryWhenIsA[*awstypes.NotFoundException](ctx, propagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryWhenIsA[any, *awstypes.NotFoundException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.ImportKeyMaterial(ctx, &inputIKM)
 	})
 

--- a/internal/service/kms/key.go
+++ b/internal/service/kms/key.go
@@ -526,7 +526,7 @@ func updateKeyDescription(ctx context.Context, conn *kms.Client, resourceTypeNam
 func updateKeyEnabled(ctx context.Context, conn *kms.Client, resourceTypeName, keyID string, enabled bool) error {
 	var action string
 
-	updateFunc := func() (any, error) {
+	updateFunc := func(ctx context.Context) (any, error) {
 		var err error
 
 		if enabled {
@@ -548,7 +548,7 @@ func updateKeyEnabled(ctx context.Context, conn *kms.Client, resourceTypeName, k
 		return nil, err
 	}
 
-	if _, err := tfresource.RetryWhenIsA[*awstypes.NotFoundException](ctx, propagationTimeout, updateFunc); err != nil {
+	if _, err := tfresource.RetryWhenIsA[any, *awstypes.NotFoundException](ctx, propagationTimeout, updateFunc); err != nil {
 		return fmt.Errorf("%s %s (%s): %w", action, resourceTypeName, keyID, err)
 	}
 

--- a/internal/service/kms/wait.go
+++ b/internal/service/kms/wait.go
@@ -26,7 +26,7 @@ const (
 
 // waitIAMPropagation retries the specified function if the returned error indicates an IAM eventual consistency issue.
 func waitIAMPropagation[T any](ctx context.Context, timeout time.Duration, f func() (T, error)) (T, error) {
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.MalformedPolicyDocumentException](ctx, timeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.MalformedPolicyDocumentException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return f()
 	})
 

--- a/internal/service/lambda/event_source_mapping.go
+++ b/internal/service/lambda/event_source_mapping.go
@@ -821,7 +821,7 @@ func resourceEventSourceMappingDelete(ctx context.Context, d *schema.ResourceDat
 	const (
 		timeout = 5 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*awstypes.ResourceInUseException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ResourceInUseException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteEventSourceMapping(ctx, &lambda.DeleteEventSourceMappingInput{
 			UUID: aws.String(d.Id()),
 		})

--- a/internal/service/lexmodels/bot.go
+++ b/internal/service/lexmodels/bot.go
@@ -254,7 +254,7 @@ func resourceBotCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 	}
 
 	var output *lexmodelbuildingservice.PutBotOutput
-	_, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		var err error
 
 		if output != nil {
@@ -377,7 +377,7 @@ func resourceBotUpdate(ctx context.Context, d *schema.ResourceData, meta any) di
 		input.VoiceId = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 		return conn.PutBot(ctx, input)
 	})
 
@@ -401,7 +401,7 @@ func resourceBotDelete(ctx context.Context, d *schema.ResourceData, meta any) di
 	}
 
 	log.Printf("[DEBUG] Deleting Lex Bot: (%s)", d.Id())
-	_, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteBot(ctx, input)
 	})
 

--- a/internal/service/lexmodels/bot_alias.go
+++ b/internal/service/lexmodels/bot_alias.go
@@ -280,7 +280,7 @@ func resourceBotAliasDelete(ctx context.Context, d *schema.ResourceData, meta an
 	botAliasName, botName := d.Get(names.AttrName).(string), d.Get("bot_name").(string)
 
 	log.Printf("[DEBUG] Deleting Lex Model Bot Alias: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteBotAlias(ctx, &lexmodelbuildingservice.DeleteBotAliasInput{
 			BotName: aws.String(botName),
 			Name:    aws.String(botAliasName),

--- a/internal/service/lexmodels/intent.go
+++ b/internal/service/lexmodels/intent.go
@@ -334,7 +334,7 @@ func resourceIntentCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		input.Slots = expandSlots(v.(*schema.Set).List())
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.PutIntent(ctx, input)
 	})
 
@@ -498,7 +498,7 @@ func resourceIntentDelete(ctx context.Context, d *schema.ResourceData, meta any)
 	conn := meta.(*conns.AWSClient).LexModelsClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Lex Model Intent: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteIntent(ctx, &lexmodelbuildingservice.DeleteIntentInput{
 			Name: aws.String(d.Id()),
 		})

--- a/internal/service/lexmodels/slot_type.go
+++ b/internal/service/lexmodels/slot_type.go
@@ -154,7 +154,7 @@ func resourceSlotTypeCreate(ctx context.Context, d *schema.ResourceData, meta an
 	}
 
 	var output *lexmodelbuildingservice.PutSlotTypeOutput
-	_, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		var err error
 
 		if output != nil {
@@ -228,7 +228,7 @@ func resourceSlotTypeUpdate(ctx context.Context, d *schema.ResourceData, meta an
 		input.EnumerationValues = expandEnumerationValues(v.(*schema.Set).List())
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
 		return conn.PutSlotType(ctx, input)
 	})
 
@@ -248,7 +248,7 @@ func resourceSlotTypeDelete(ctx context.Context, d *schema.ResourceData, meta an
 	}
 
 	log.Printf("[DEBUG] Deleting Lex Slot Type: (%s)", d.Id())
-	_, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteSlotType(ctx, input)
 	})
 

--- a/internal/service/logs/destination.go
+++ b/internal/service/logs/destination.go
@@ -87,7 +87,7 @@ func resourceDestinationCreate(ctx context.Context, d *schema.ResourceData, meta
 		TargetArn:       aws.String(d.Get(names.AttrTargetARN).(string)),
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.InvalidParameterException](ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidParameterException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutDestination(ctx, input)
 	})
 
@@ -142,7 +142,7 @@ func resourceDestinationUpdate(ctx context.Context, d *schema.ResourceData, meta
 			TargetArn:       aws.String(d.Get(names.AttrTargetARN).(string)),
 		}
 
-		_, err := tfresource.RetryWhenIsA[*awstypes.InvalidParameterException](ctx, propagationTimeout, func() (any, error) {
+		_, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidParameterException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 			return conn.PutDestination(ctx, input)
 		})
 

--- a/internal/service/neptune/parameter_group.go
+++ b/internal/service/neptune/parameter_group.go
@@ -205,7 +205,7 @@ func resourceParameterGroupDelete(ctx context.Context, d *schema.ResourceData, m
 	conn := meta.(*conns.AWSClient).NeptuneClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Neptune Parameter Group: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidDBParameterGroupStateFault](ctx, dbParameterGroupDeleteRetryTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidDBParameterGroupStateFault](ctx, dbParameterGroupDeleteRetryTimeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteDBParameterGroup(ctx, &neptune.DeleteDBParameterGroupInput{
 			DBParameterGroupName: aws.String(d.Id()),
 		})

--- a/internal/service/organizations/account.go
+++ b/internal/service/organizations/account.go
@@ -146,8 +146,8 @@ func resourceAccountCreate(ctx context.Context, d *schema.ResourceData, meta any
 			input.RoleName = aws.String(v.(string))
 		}
 
-		outputRaw, err := tfresource.RetryWhenIsA[*awstypes.FinalizingOrganizationException](ctx, organizationFinalizationTimeout,
-			func() (any, error) {
+		outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.FinalizingOrganizationException](ctx, organizationFinalizationTimeout,
+			func(ctx context.Context) (any, error) {
 				return conn.CreateGovCloudAccount(ctx, input)
 			})
 
@@ -171,8 +171,8 @@ func resourceAccountCreate(ctx context.Context, d *schema.ResourceData, meta any
 			input.RoleName = aws.String(v.(string))
 		}
 
-		outputRaw, err := tfresource.RetryWhenIsA[*awstypes.FinalizingOrganizationException](ctx, organizationFinalizationTimeout,
-			func() (any, error) {
+		outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.FinalizingOrganizationException](ctx, organizationFinalizationTimeout,
+			func(ctx context.Context) (any, error) {
 				return conn.CreateAccount(ctx, input)
 			})
 

--- a/internal/service/organizations/organizational_unit.go
+++ b/internal/service/organizations/organizational_unit.go
@@ -94,7 +94,7 @@ func resourceOrganizationalUnitCreate(ctx context.Context, d *schema.ResourceDat
 		Tags:     getTagsIn(ctx),
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.FinalizingOrganizationException](ctx, organizationFinalizationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.FinalizingOrganizationException](ctx, organizationFinalizationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateOrganizationalUnit(ctx, input)
 	})
 

--- a/internal/service/organizations/policy.go
+++ b/internal/service/organizations/policy.go
@@ -95,7 +95,7 @@ func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		Tags:        getTagsIn(ctx),
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.FinalizingOrganizationException](ctx, organizationFinalizationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.FinalizingOrganizationException](ctx, organizationFinalizationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreatePolicy(ctx, input)
 	})
 

--- a/internal/service/organizations/policy_attachment.go
+++ b/internal/service/organizations/policy_attachment.go
@@ -68,7 +68,7 @@ func resourcePolicyAttachmentCreate(ctx context.Context, d *schema.ResourceData,
 		TargetId: aws.String(targetID),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.FinalizingOrganizationException](ctx, organizationFinalizationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.FinalizingOrganizationException](ctx, organizationFinalizationTimeout, func(ctx context.Context) (any, error) {
 		return conn.AttachPolicy(ctx, &input)
 	})
 

--- a/internal/service/organizations/resource_policy.go
+++ b/internal/service/organizations/resource_policy.go
@@ -76,7 +76,7 @@ func resourceResourcePolicyCreate(ctx context.Context, d *schema.ResourceData, m
 		Tags:    getTagsIn(ctx),
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.FinalizingOrganizationException](ctx, organizationFinalizationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.FinalizingOrganizationException](ctx, organizationFinalizationTimeout, func(ctx context.Context) (any, error) {
 		return conn.PutResourcePolicy(ctx, input)
 	})
 

--- a/internal/service/osis/pipeline.go
+++ b/internal/service/osis/pipeline.go
@@ -226,7 +226,7 @@ func (r *pipelineResource) Create(ctx context.Context, request resource.CreateRe
 	input.Tags = getTagsIn(ctx)
 
 	// Retry for IAM eventual consistency.
-	_, err := tfresource.RetryWhenIsA[*awstypes.ValidationException](ctx, propagationTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ValidationException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreatePipeline(ctx, &input)
 	})
 

--- a/internal/service/qldb/ledger.go
+++ b/internal/service/qldb/ledger.go
@@ -187,7 +187,7 @@ func resourceLedgerDelete(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	log.Printf("[INFO] Deleting QLDB Ledger: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*types.ResourceInUseException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.ResourceInUseException](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteLedger(ctx, input)
 	})
 

--- a/internal/service/qldb/stream.go
+++ b/internal/service/qldb/stream.go
@@ -207,7 +207,7 @@ func resourceStreamDelete(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	log.Printf("[INFO] Deleting QLDB Stream: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*types.ResourceInUseException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.ResourceInUseException](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.CancelJournalKinesisStream(ctx, input)
 	})
 

--- a/internal/service/rds/cluster_parameter_group.go
+++ b/internal/service/rds/cluster_parameter_group.go
@@ -267,7 +267,7 @@ func resourceClusterParameterGroupDelete(ctx context.Context, d *schema.Resource
 	input := rds.DeleteDBClusterParameterGroupInput{
 		DBClusterParameterGroupName: aws.String(d.Id()),
 	}
-	_, err := tfresource.RetryWhenIsA[*types.InvalidDBParameterGroupStateFault](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.InvalidDBParameterGroupStateFault](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteDBClusterParameterGroup(ctx, &input)
 	})
 

--- a/internal/service/rds/cluster_role_association.go
+++ b/internal/service/rds/cluster_role_association.go
@@ -76,7 +76,7 @@ func resourceClusterRoleAssociationCreate(ctx context.Context, d *schema.Resourc
 		RoleArn:             aws.String(roleARN),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*types.InvalidDBClusterStateFault](ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.InvalidDBClusterStateFault](ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.AddRoleToDBCluster(ctx, &input)
 	})
 
@@ -142,7 +142,7 @@ func resourceClusterRoleAssociationDelete(ctx context.Context, d *schema.Resourc
 		FeatureName:         aws.String(d.Get("feature_name").(string)),
 		RoleArn:             aws.String(roleARN),
 	}
-	_, err = tfresource.RetryWhenIsA[*types.InvalidDBClusterStateFault](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err = tfresource.RetryWhenIsA[any, *types.InvalidDBClusterStateFault](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.RemoveRoleFromDBCluster(ctx, &input)
 	})
 

--- a/internal/service/rds/cluster_snapshot.go
+++ b/internal/service/rds/cluster_snapshot.go
@@ -140,7 +140,7 @@ func resourceClusterSnapshotCreate(ctx context.Context, d *schema.ResourceData, 
 	const (
 		timeout = 2 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*types.InvalidDBClusterStateFault](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.InvalidDBClusterStateFault](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.CreateDBClusterSnapshot(ctx, input)
 	})
 

--- a/internal/service/rds/instance_role_association.go
+++ b/internal/service/rds/instance_role_association.go
@@ -82,7 +82,7 @@ func resourceInstanceRoleAssociationCreate(ctx context.Context, d *schema.Resour
 		RoleArn:              aws.String(roleARN),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*types.InvalidDBInstanceStateFault](ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.InvalidDBInstanceStateFault](ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.AddRoleToDBInstance(ctx, &input)
 	})
 
@@ -148,7 +148,7 @@ func resourceInstanceRoleAssociationDelete(ctx context.Context, d *schema.Resour
 		FeatureName:          aws.String(d.Get("feature_name").(string)),
 		RoleArn:              aws.String(roleARN),
 	}
-	_, err = tfresource.RetryWhenIsA[*types.InvalidDBInstanceStateFault](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err = tfresource.RetryWhenIsA[any, *types.InvalidDBInstanceStateFault](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.RemoveRoleFromDBInstance(ctx, &input)
 	})
 

--- a/internal/service/rds/option_group.go
+++ b/internal/service/rds/option_group.go
@@ -252,7 +252,7 @@ func resourceOptionGroupDelete(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	log.Printf("[DEBUG] Deleting RDS DB Option Group: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*types.InvalidOptionGroupStateFault](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.InvalidOptionGroupStateFault](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteOptionGroup(ctx, &rds.DeleteOptionGroupInput{
 			OptionGroupName: aws.String(d.Id()),
 		})

--- a/internal/service/rds/parameter_group.go
+++ b/internal/service/rds/parameter_group.go
@@ -308,7 +308,7 @@ func resourceParameterGroupDelete(ctx context.Context, d *schema.ResourceData, m
 	input := rds.DeleteDBParameterGroupInput{
 		DBParameterGroupName: aws.String(d.Id()),
 	}
-	_, err := tfresource.RetryWhenIsA[*types.InvalidDBParameterGroupStateFault](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.InvalidDBParameterGroupStateFault](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteDBParameterGroup(ctx, &input)
 	})
 

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -858,8 +858,8 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 				ClusterIdentifier: aws.String(d.Id()),
 			}
 
-			_, err := tfresource.RetryWhenIsA[*awstypes.InvalidClusterStateFault](ctx, clusterInvalidClusterStateFaultTimeout,
-				func() (any, error) {
+			_, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidClusterStateFault](ctx, clusterInvalidClusterStateFaultTimeout,
+				func(ctx context.Context) (any, error) {
 					return conn.RebootCluster(ctx, input)
 				})
 
@@ -954,8 +954,8 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	log.Printf("[DEBUG] Deleting Redshift Cluster: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidClusterStateFault](ctx, clusterInvalidClusterStateFaultTimeout,
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidClusterStateFault](ctx, clusterInvalidClusterStateFaultTimeout,
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteCluster(ctx, input)
 		})
 

--- a/internal/service/route53/cidr_collection.go
+++ b/internal/service/route53/cidr_collection.go
@@ -83,7 +83,7 @@ func (r *cidrCollectionResource) Create(ctx context.Context, request resource.Cr
 	const (
 		timeout = 2 * time.Minute
 	)
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.ConcurrentModification](ctx, timeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.ConcurrentModification](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.CreateCidrCollection(ctx, input)
 	})
 

--- a/internal/service/route53/hosted_zone_dnssec.go
+++ b/internal/service/route53/hosted_zone_dnssec.go
@@ -178,7 +178,7 @@ func hostedZoneDNSSECDisable(ctx context.Context, conn *route53.Client, hostedZo
 	const (
 		timeout = 5 * time.Minute
 	)
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.KeySigningKeyInParentDSRecord](ctx, timeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.KeySigningKeyInParentDSRecord](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DisableHostedZoneDNSSEC(ctx, input)
 	})
 

--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -365,7 +365,7 @@ func resourceRecordCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		HostedZoneId: aws.String(cleanZoneID(aws.ToString(zoneRecord.HostedZone.Id))),
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.NoSuchHostedZone](ctx, 1*time.Minute, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.NoSuchHostedZone](ctx, 1*time.Minute, func(ctx context.Context) (any, error) {
 		return conn.ChangeResourceRecordSets(ctx, input)
 	})
 

--- a/internal/service/route53/traffic_policy.go
+++ b/internal/service/route53/traffic_policy.go
@@ -102,7 +102,7 @@ func resourceTrafficPolicyCreate(ctx context.Context, d *schema.ResourceData, me
 		input.Comment = aws.String(v.(string))
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.NoSuchTrafficPolicy](ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.NoSuchTrafficPolicy](ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.CreateTrafficPolicy(ctx, input)
 	})
 

--- a/internal/service/route53/traffic_policy_instance.go
+++ b/internal/service/route53/traffic_policy_instance.go
@@ -89,7 +89,7 @@ func resourceTrafficPolicyInstanceCreate(ctx context.Context, d *schema.Resource
 		TTL:                  aws.Int64(int64(d.Get("ttl").(int))),
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.NoSuchTrafficPolicy](ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.NoSuchTrafficPolicy](ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.CreateTrafficPolicyInstance(ctx, input)
 	})
 

--- a/internal/service/route53/vpc_association_authorization.go
+++ b/internal/service/route53/vpc_association_authorization.go
@@ -80,7 +80,7 @@ func resourceVPCAssociationAuthorizationCreate(ctx context.Context, d *schema.Re
 		input.VPC.VPCRegion = awstypes.VPCRegion(v.(string))
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.ConcurrentModification](ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.ConcurrentModification](ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.CreateVPCAssociationAuthorization(ctx, input)
 	})
 
@@ -106,7 +106,7 @@ func resourceVPCAssociationAuthorizationRead(ctx context.Context, d *schema.Reso
 
 	// InvalidPaginationToken errors can manifest when many authorization resources are
 	// managed concurrently. Retry these errors for a short duration.
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.InvalidPaginationToken](ctx, d.Timeout(schema.TimeoutRead), func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidPaginationToken](ctx, d.Timeout(schema.TimeoutRead), func(ctx context.Context) (any, error) {
 		return findVPCAssociationAuthorizationByTwoPartKey(ctx, conn, zoneID, vpcID)
 	})
 
@@ -138,7 +138,7 @@ func resourceVPCAssociationAuthorizationDelete(ctx context.Context, d *schema.Re
 	}
 
 	log.Printf("[INFO] Deleting Route53 VPC Association Authorization: %s", d.Id())
-	_, err = tfresource.RetryWhenIsA[*awstypes.ConcurrentModification](ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	_, err = tfresource.RetryWhenIsA[any, *awstypes.ConcurrentModification](ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.DeleteVPCAssociationAuthorization(ctx, &route53.DeleteVPCAssociationAuthorizationInput{
 			HostedZoneId: aws.String(zoneID),
 			VPC: &awstypes.VPC{

--- a/internal/service/securitylake/data_lake.go
+++ b/internal/service/securitylake/data_lake.go
@@ -585,7 +585,7 @@ func retryDataLakeConflictWithMutex[T any](ctx context.Context, f func() (T, err
 
 	const dataLakeTimeout = 2 * time.Minute
 
-	raw, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, dataLakeTimeout, func() (any, error) {
+	raw, err := tfresource.RetryWhenIsA[any, *awstypes.ConflictException](ctx, dataLakeTimeout, func(ctx context.Context) (any, error) {
 		return f()
 	})
 	if err != nil {

--- a/internal/service/servicediscovery/http_namespace.go
+++ b/internal/service/servicediscovery/http_namespace.go
@@ -138,7 +138,7 @@ func resourceHTTPNamespaceDelete(ctx context.Context, d *schema.ResourceData, me
 	const (
 		timeout = 2 * time.Minute
 	)
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.ResourceInUse](ctx, timeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.ResourceInUse](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteNamespace(ctx, &servicediscovery.DeleteNamespaceInput{
 			Id: aws.String(d.Id()),
 		})

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -473,7 +473,7 @@ func putTopicAttribute(ctx context.Context, conn *sns.Client, arn string, name, 
 		TopicArn:       aws.String(arn),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*types.InvalidParameterException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.InvalidParameterException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.SetTopicAttributes(ctx, input)
 	})
 

--- a/internal/service/vpclattice/target_group.go
+++ b/internal/service/vpclattice/target_group.go
@@ -309,7 +309,7 @@ func resourceTargetGroupDelete(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	// Draining the targets can take a moment, so we need to retry on conflict.
-	_, err := tfresource.RetryWhenIsA[*types.ConflictException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.ConflictException](ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return conn.DeleteTargetGroup(ctx, &input)
 	})
 

--- a/internal/service/waf/rule.go
+++ b/internal/service/waf/rule.go
@@ -182,7 +182,7 @@ func resourceRuleDelete(ctx context.Context, d *schema.ResourceData, meta any) d
 	const (
 		timeout = 1 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*awstypes.WAFReferencedItemException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.WAFReferencedItemException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return newRetryer(conn).RetryWithToken(ctx, func(token *string) (any, error) {
 			input := &waf.DeleteRuleInput{
 				ChangeToken: token,

--- a/internal/service/waf/token_handlers.go
+++ b/internal/service/waf/token_handlers.go
@@ -30,7 +30,7 @@ func (t *retryer) RetryWithToken(ctx context.Context, f withTokenFunc) (any, err
 	const (
 		timeout = 15 * time.Minute
 	)
-	return tfresource.RetryWhenIsA[*awstypes.WAFStaleDataException](ctx, timeout, func() (any, error) {
+	return tfresource.RetryWhenIsA[any, *awstypes.WAFStaleDataException](ctx, timeout, func(ctx context.Context) (any, error) {
 		input := &waf.GetChangeTokenInput{}
 		output, err := t.connection.GetChangeToken(ctx, input)
 

--- a/internal/service/wafregional/token_handlers.go
+++ b/internal/service/wafregional/token_handlers.go
@@ -29,7 +29,7 @@ func (t *retryer) RetryWithToken(ctx context.Context, f withTokenFunc) (any, err
 	const (
 		timeout = 15 * time.Minute
 	)
-	return tfresource.RetryWhenIsA[*awstypes.WAFStaleDataException](ctx, timeout, func() (any, error) {
+	return tfresource.RetryWhenIsA[any, *awstypes.WAFStaleDataException](ctx, timeout, func(ctx context.Context) (any, error) {
 		input := &wafregional.GetChangeTokenInput{}
 		output, err := t.connection.GetChangeToken(ctx, input)
 

--- a/internal/service/wafregional/web_acl_association.go
+++ b/internal/service/wafregional/web_acl_association.go
@@ -67,7 +67,7 @@ func resourceWebACLAssociationCreate(ctx context.Context, d *schema.ResourceData
 		WebACLId:    aws.String(webACLID),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.WAFUnavailableEntityException](ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.WAFUnavailableEntityException](ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.AssociateWebACL(ctx, input)
 	})
 

--- a/internal/service/wafv2/ip_set.go
+++ b/internal/service/wafv2/ip_set.go
@@ -249,7 +249,7 @@ func resourceIPSetDelete(ctx context.Context, d *schema.ResourceData, meta any) 
 	const (
 		timeout = 5 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*awstypes.WAFAssociatedItemException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.WAFAssociatedItemException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteIPSet(ctx, input)
 	})
 

--- a/internal/service/wafv2/regex_pattern_set.go
+++ b/internal/service/wafv2/regex_pattern_set.go
@@ -228,7 +228,7 @@ func resourceRegexPatternSetDelete(ctx context.Context, d *schema.ResourceData, 
 	const (
 		timeout = 5 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*awstypes.WAFAssociatedItemException](ctx, timeout, func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.WAFAssociatedItemException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteRegexPatternSet(ctx, input)
 	})
 

--- a/internal/service/wafv2/rule_group.go
+++ b/internal/service/wafv2/rule_group.go
@@ -197,7 +197,7 @@ func resourceRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta a
 	const (
 		timeout = 5 * time.Minute
 	)
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.WAFUnavailableEntityException](ctx, timeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.WAFUnavailableEntityException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.CreateRuleGroup(ctx, input)
 	})
 
@@ -288,7 +288,7 @@ func resourceRuleGroupUpdate(ctx context.Context, d *schema.ResourceData, meta a
 		const (
 			timeout = 5 * time.Minute
 		)
-		_, err := tfresource.RetryWhenIsA[*awstypes.WAFUnavailableEntityException](ctx, timeout, func() (any, error) {
+		_, err := tfresource.RetryWhenIsA[any, *awstypes.WAFUnavailableEntityException](ctx, timeout, func(ctx context.Context) (any, error) {
 			return conn.UpdateRuleGroup(ctx, input)
 		})
 

--- a/internal/service/wafv2/web_acl.go
+++ b/internal/service/wafv2/web_acl.go
@@ -305,7 +305,7 @@ func resourceWebACLCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	const (
 		timeout = 5 * time.Minute
 	)
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.WAFUnavailableEntityException](ctx, timeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[any, *awstypes.WAFUnavailableEntityException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.CreateWebACL(ctx, input)
 	})
 
@@ -449,7 +449,7 @@ func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 		const (
 			timeout = 5 * time.Minute
 		)
-		_, err := tfresource.RetryWhenIsA[*awstypes.WAFUnavailableEntityException](ctx, timeout, func() (any, error) {
+		_, err := tfresource.RetryWhenIsA[any, *awstypes.WAFUnavailableEntityException](ctx, timeout, func(ctx context.Context) (any, error) {
 			return conn.UpdateWebACL(ctx, input)
 		})
 

--- a/internal/service/wafv2/web_acl_association.go
+++ b/internal/service/wafv2/web_acl_association.go
@@ -78,7 +78,7 @@ func resourceWebACLAssociationCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	log.Printf("[INFO] Creating WAFv2 WebACL Association: %s", d.Id())
-	if _, err = tfresource.RetryWhenIsA[*awstypes.WAFUnavailableEntityException](ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
+	if _, err = tfresource.RetryWhenIsA[any, *awstypes.WAFUnavailableEntityException](ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 		return conn.AssociateWebACL(ctx, input)
 	}); err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating WAFv2 WebACL Association (%s): %s", id, err)

--- a/internal/service/wafv2/web_acl_rule_group_association.go
+++ b/internal/service/wafv2/web_acl_rule_group_association.go
@@ -629,7 +629,7 @@ func (r *resourceWebACLRuleGroupAssociation) Create(ctx context.Context, req res
 	}
 
 	const timeout = 5 * time.Minute
-	_, err = tfresource.RetryWhenIsA[*awstypes.WAFUnavailableEntityException](ctx, timeout, func() (any, error) {
+	_, err = tfresource.RetryWhenIsA[any, *awstypes.WAFUnavailableEntityException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.UpdateWebACL(ctx, updateInput)
 	})
 
@@ -952,7 +952,7 @@ func (r *resourceWebACLRuleGroupAssociation) Update(ctx context.Context, req res
 	}
 
 	updateTimeout := r.UpdateTimeout(ctx, plan.Timeouts)
-	_, err = tfresource.RetryWhenIsA[*awstypes.WAFUnavailableEntityException](ctx, updateTimeout, func() (any, error) {
+	_, err = tfresource.RetryWhenIsA[any, *awstypes.WAFUnavailableEntityException](ctx, updateTimeout, func(ctx context.Context) (any, error) {
 		return conn.UpdateWebACL(ctx, updateInput)
 	})
 
@@ -1043,7 +1043,7 @@ func (r *resourceWebACLRuleGroupAssociation) Delete(ctx context.Context, req res
 	}
 
 	const timeout = 5 * time.Minute
-	_, err = tfresource.RetryWhenIsA[*awstypes.WAFUnavailableEntityException](ctx, timeout, func() (any, error) {
+	_, err = tfresource.RetryWhenIsA[any, *awstypes.WAFUnavailableEntityException](ctx, timeout, func(ctx context.Context) (any, error) {
 		return conn.UpdateWebACL(ctx, updateInput)
 	})
 

--- a/internal/service/workspaces/directory.go
+++ b/internal/service/workspaces/directory.go
@@ -384,8 +384,8 @@ func resourceDirectoryCreate(ctx context.Context, d *schema.ResourceData, meta a
 	const (
 		timeout = 2 * time.Minute
 	)
-	output, err := tfresource.RetryWhenIsA[*types.InvalidResourceStateException](ctx, timeout,
-		func() (any, error) {
+	output, err := tfresource.RetryWhenIsA[any, *types.InvalidResourceStateException](ctx, timeout,
+		func(ctx context.Context) (any, error) {
 			return conn.RegisterWorkspaceDirectory(ctx, &input)
 		})
 
@@ -675,8 +675,8 @@ func resourceDirectoryDelete(ctx context.Context, d *schema.ResourceData, meta a
 	const (
 		timeout = 2 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*types.InvalidResourceStateException](ctx, timeout,
-		func() (any, error) {
+	_, err := tfresource.RetryWhenIsA[any, *types.InvalidResourceStateException](ctx, timeout,
+		func(ctx context.Context) (any, error) {
 			return conn.DeregisterWorkspaceDirectory(ctx, &input)
 		})
 

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -128,9 +128,9 @@ func RetryWhenAWSErrMessageContains[T any](ctx context.Context, timeout time.Dur
 	})
 }
 
-func RetryWhenIsA[T error](ctx context.Context, timeout time.Duration, f func() (any, error)) (any, error) {
-	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
-		if errs.IsA[T](err) {
+func RetryWhenIsA[T any, E error](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error)) (T, error) {
+	return retryWhen(ctx, timeout, f, func(err error) (bool, error) {
+		if errs.IsA[E](err) {
 			return true, err
 		}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Use the new primitives in `internal/retry` (as a replacement for the SDKv2 `helper/retry` package) for `tfresource.RetryWhenIsA`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/42554.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43267.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43341.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43412.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43521.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43573.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43668.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43834.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccKMSKey_isEnabled' PKG=kms
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/kms/... -v -count 1 -parallel 20  -run=TestAccKMSKey_isEnabled -timeout 360m -vet=off
2025/08/15 10:47:16 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/15 10:47:16 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKMSKey_isEnabled
=== PAUSE TestAccKMSKey_isEnabled
=== CONT  TestAccKMSKey_isEnabled
--- PASS: TestAccKMSKey_isEnabled (103.60s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	108.820s
```
```console
% make testacc TESTARGS='-run=TestAccIAMRole_basic' PKG=iam
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/iam/... -v -count 1 -parallel 20  -run=TestAccIAMRole_basic -timeout 360m -vet=off
2025/08/15 10:57:56 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/15 10:57:56 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIAMRole_basic
=== PAUSE TestAccIAMRole_basic
=== CONT  TestAccIAMRole_basic
--- PASS: TestAccIAMRole_basic (12.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	17.719s
```
```console
% make testacc TESTARGS='-run=TestAccWAFV2WebACL_basic' PKG=wafv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/wafv2/... -v -count 1 -parallel 20  -run=TestAccWAFV2WebACL_basic -timeout 360m -vet=off
2025/08/15 11:01:17 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/15 11:01:17 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccWAFV2WebACL_basic
=== PAUSE TestAccWAFV2WebACL_basic
=== CONT  TestAccWAFV2WebACL_basic
--- PASS: TestAccWAFV2WebACL_basic (17.60s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafv2	22.898s
```