### PR TITLE
docs: document skipping name generator when unused

### DIFF
--- a/docs/ai-agent-guides/arn-based-resource-identity.md
+++ b/docs/ai-agent-guides/arn-based-resource-identity.md
@@ -97,6 +97,7 @@ Relates #42984
 - Ensure template files are in the correct location (`testdata/tmpl`)
 - Verify template file names match the resource name
 - If identity tests are not generated, verify that the `identitytests` generator is being called within the service's `generate.go` file. If it isn't, add the following line to `generate.go` next to the existing `go:generate` directives.
+- If a generated test does not reference the `var.rName` variable, add an `// @Testing(generator=false)` annotation to remove it from the generated configuration.
 
 ```go
 //go:generate go run ../../generate/identitytests/main.go

--- a/docs/ai-agent-guides/parameterized-resource-identity.md
+++ b/docs/ai-agent-guides/parameterized-resource-identity.md
@@ -110,6 +110,7 @@ Relates #42988
 - Ensure template files are in the correct location (`testdata/tmpl`)
 - Verify template file names match the resource name
 - If identity tests are not generated, verify that the `identitytests` generator is being called within the service's `generate.go` file. If it isn't, add the following line to `generate.go` next to the existing `go:generate` directives.
+- If a generated test does not reference the `var.rName` variable, add an `// @Testing(generator=false)` annotation to remove it from the generated configuration.
 
 ```go
 //go:generate go run ../../generate/identitytests/main.go


### PR DESCRIPTION

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds instructions for how to omit the `rName` variable from acceptance test generation when unused.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #42983

