### PR TITLE
fix: aws_bedrock_guardrail standard tier topic definition length cap is wrong

### DIFF
--- a/internal/service/bedrock/guardrail.go
+++ b/internal/service/bedrock/guardrail.go
@@ -61,6 +61,8 @@ const (
 	ResNameGuardrail = "Guardrail"
 )
 
+var _ resource.ResourceWithValidateConfig = &guardrailResource{}
+
 type guardrailResource struct {
 	framework.ResourceWithModel[guardrailResourceModel]
 	framework.WithTimeouts
@@ -349,7 +351,7 @@ func (r *guardrailResource) Schema(ctx context.Context, req resource.SchemaReque
 									"definition": schema.StringAttribute{
 										Required: true,
 										Validators: []validator.String{
-											stringvalidator.LengthBetween(1, 200),
+											stringvalidator.LengthBetween(1, 1000),
 										},
 									},
 									"examples": schema.ListAttribute{
@@ -427,9 +429,70 @@ func (r *guardrailResource) Schema(ctx context.Context, req resource.SchemaReque
 	}
 }
 
+func (r *guardrailResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+    var plan guardrailResourceModel
+    resp.Diagnostics.Append(req.Config.Get(ctx, &plan)...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+
+    resp.Diagnostics.Append(validateClassicTopicDefinitionLength(ctx, plan)...)
+}
+
+func validateClassicTopicDefinitionLength(ctx context.Context, plan guardrailResourceModel) (diags diag.Diagnostics) {
+	if !plan.TopicPolicy.IsNull() {
+		var topicPolicies []guardrailTopicPolicyConfigModel
+		diags.Append(plan.TopicPolicy.ElementsAs(ctx, &topicPolicies, false)...)
+		if diags.HasError() {
+			return
+		}
+
+		if len(topicPolicies) > 0 {
+			tp := topicPolicies[0]
+
+			if !tp.TierConfig.IsNull() {
+				var tierConfigs []guardrailTopicsTierConfigModel
+				diags.Append(tp.TierConfig.ElementsAs(ctx, &tierConfigs, false)...)
+				if diags.HasError() {
+					return
+				}
+
+				if len(tierConfigs) > 0 &&
+					tierConfigs[0].TierName.ValueString() == string(awstypes.GuardrailTopicsTierNameClassic) {
+
+					if !tp.Topics.IsNull() {
+						var topics []guardrailTopicConfigModel
+						diags.Append(tp.Topics.ElementsAs(ctx, &topics, false)...)
+						if diags.HasError() {
+							return
+						}
+
+						for _, topic := range topics {
+							if len(topic.Definition.ValueString()) > 200 {
+								diags.AddError(
+									"Invalid topic definition length",
+									"Attribute topic_policy_config.definition must be between 1 and 200 characters in CLASSIC mode.",
+								)
+								return
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return
+}
+
 func (r *guardrailResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan guardrailResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(validateClassicTopicDefinitionLength(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -533,6 +596,11 @@ func (r *guardrailResource) Update(ctx context.Context, req resource.UpdateReque
 	var plan, state guardrailResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(validateClassicTopicDefinitionLength(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}


### PR DESCRIPTION
### Description
The guardrails topic definition used to be capped at 200 characters. Since they released the standard tier, the character limit for that tier is set to 1000 characters. Standard tier: 1-1000 chars Classic tier: 1-200 chars.

I added updated the original validator to be 1000, and added an additional validation check to ensure that Classic tier definitions still have to be between 1-200. 

### Testing 
I tested via these test cases:
Standard with definition <= 1000 is good
Standard with definition > 1000 has error
Classic with definition <= 200 is good
Classic with definition > 200 has error
<img width="699" height="128" alt="image" src="https://github.com/user-attachments/assets/43da169a-6307-4744-bf89-50ce3e8cd2f7" />



