### PR TITLE
fix: aws_rds_cluster needs performance insights retention passed to nable database insights

### DIFF
--- a/.changelog/42541.txt
+++ b/.changelog/42541.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_cluster: Fixes the behavior when enabling database_insights_mode="advanced" without changing performance insights retention window
+```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -1615,6 +1615,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		if d.HasChange("database_insights_mode") {
 			input.DatabaseInsightsMode = types.DatabaseInsightsMode(d.Get("database_insights_mode").(string))
 			input.EnablePerformanceInsights = aws.Bool(d.Get("performance_insights_enabled").(bool))
+			input.PerformanceInsightsRetentionPeriod = aws.Int32(int32(d.Get("performance_insights_retention_period").(int)))
 		}
 
 		if d.HasChange("db_cluster_instance_class") {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

This resolves an issue where if performance insights retention period had already been set on an RDS Cluster, there is no `has_change` on that input and it is not passed as required to the upstream API for RDS and results in a 400.

An example AWS CLI error occurs when this is performed on a database with performance insights already enabled and set to the right retention window, but the retention window isn't passed.

```console
aws rds modify-db-cluster  --db-cluster-identifier test --database-insights-mode advanced --enable-performance-insights

An error occurred (InvalidParameterCombination) when calling the ModifyDBCluster operation: To enable the Advanced mode of Database Insights, modify your cluster to enable Performance Insights and set the retention period for Performance Insights to at least 465 days.
```

### Relations

Closes #42539

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccRDSCluster_databaseInsightsMode_update PKG=rds

I don't have a default VPC, so it's barfing errors.  I can try to fix it if it's absolutely required.
...
```
