### PR TITLE
[WIP] feat: Add sort and z-order compaction support to r/aws_s3tables_table

### DIFF
--- a/.changelog/43923.txt
+++ b/.changelog/43923.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3tables_table: Add `maintenance_configuration.iceberg_compaction.settings.strategy` argument
+```

--- a/internal/service/s3tables/table.go
+++ b/internal/service/s3tables/table.go
@@ -82,7 +82,7 @@ func (r *tableResource) Schema(ctx context.Context, request resource.SchemaReque
 			},
 			// TODO: Once Protocol v6 is supported, convert this to a `schema.SingleNestedAttribute` with full schema information
 			// Validations needed:
-			// * iceberg_compaction.settings.target_file_size_mb:  int32validator.Between(64, 512)
+			// * iceberg_compaction.settings.target_file_size_mb: int32validator.Between(64, 512)
 			// * iceberg_snapshot_management.settings.max_snapshot_age_hours: int32validator.AtLeast(1)
 			// * iceberg_snapshot_management.settings.min_snapshots_to_keep:  int32validator.AtLeast(1)
 			"maintenance_configuration": schema.ObjectAttribute{
@@ -758,7 +758,8 @@ type tableMaintenanceConfigurationValueModel[T any] struct {
 }
 
 type icebergCompactionSettingsModel struct {
-	TargetFileSizeMB types.Int32 `tfsdk:"target_file_size_mb"`
+	Strategy         fwtypes.StringEnum[awstypes.IcebergCompactionStrategy] `tfsdk:"strategy"`
+	TargetFileSizeMB types.Int32                                            `tfsdk:"target_file_size_mb"`
 }
 
 type icebergSnapshotManagementSettingsModel struct {

--- a/website/docs/r/s3tables_table.html.markdown
+++ b/website/docs/r/s3tables_table.html.markdown
@@ -32,6 +32,43 @@ resource "aws_s3tables_table_bucket" "example" {
 }
 ```
 
+### With Compaction Strategy
+
+```terraform
+resource "aws_s3tables_table" "example" {
+  name             = "example_table"
+  namespace        = aws_s3tables_namespace.example.namespace
+  table_bucket_arn = aws_s3tables_namespace.example.table_bucket_arn
+  format           = "ICEBERG"
+
+  maintenance_configuration = {
+    iceberg_compaction = {
+      settings = {
+        strategy            = "z-order"
+        target_file_size_mb = 256
+      }
+      status = "enabled"
+    }
+    iceberg_snapshot_management = {
+      settings = {
+        max_snapshot_age_hours = 72
+        min_snapshots_to_keep  = 1
+      }
+      status = "enabled"
+    }
+  }
+}
+
+resource "aws_s3tables_namespace" "example" {
+  namespace        = "example_namespace"
+  table_bucket_arn = aws_s3tables_table_bucket.example.arn
+}
+
+resource "aws_s3tables_table_bucket" "example" {
+  name = "example-bucket"
+}
+```
+
 ### With Metadata Schema
 
 ```terraform
@@ -131,8 +168,9 @@ The `iceberg_compaction` object supports the following arguments:
 
 ### `iceberg_compaction.settings`
 
-The `iceberg_compaction.settings` object supports the following argument:
+The `iceberg_compaction.settings` object supports the following arguments:
 
+* `strategy` - (Optional) The compaction strategy to use for the table. This determines how files are selected and combined during compaction operations. Valid values are `auto`, `binpack`, `sort`, and `z-order`. Defaults to `auto`.
 * `target_file_size_mb` - (Required) Data objects smaller than this size may be combined with others to improve query performance.
   Must be between `64` and `512`.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add support for the sort and z-order compaction strategy to the `aws_s3tables_table` resource.

**Note:** This feature cannot be completed because the two new strategies require sort order to be specified in the table metadata, yet there is no way to set this in the `aws_s3tables_table` resource. I am creating this PR just to keep track of the code changes - I will keep it in DRAFT until a resolution for the sort order is available...

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #43167

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to the AWS SDK for Go v2 for specs. The [API reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_s3Buckets_IcebergCompactionSettings.html) isn't even updated to reflect the `strategy` attribute. I will open an AWS Support Case to get this addressed.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccS3TablesTable_ PKG=s3tables
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/s3tables/... -v -count 1 -parallel 20 -run='TestAccS3TablesTable_'  -timeout 360m -vet=off    
2025/08/16 22:24:22 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/16 22:24:22 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3TablesTable_basic
=== PAUSE TestAccS3TablesTable_basic
=== RUN   TestAccS3TablesTable_disappears
=== PAUSE TestAccS3TablesTable_disappears
=== RUN   TestAccS3TablesTable_rename
=== PAUSE TestAccS3TablesTable_rename
=== RUN   TestAccS3TablesTable_updateNamespace
=== PAUSE TestAccS3TablesTable_updateNamespace
=== RUN   TestAccS3TablesTable_updateNameAndNamespace
=== PAUSE TestAccS3TablesTable_updateNameAndNamespace
=== RUN   TestAccS3TablesTable_maintenanceConfiguration
=== PAUSE TestAccS3TablesTable_maintenanceConfiguration
=== RUN   TestAccS3TablesTable_compactionStrategy
=== PAUSE TestAccS3TablesTable_compactionStrategy
=== RUN   TestAccS3TablesTable_encryptionConfiguration
=== PAUSE TestAccS3TablesTable_encryptionConfiguration
=== RUN   TestAccS3TablesTable_metadata
=== PAUSE TestAccS3TablesTable_metadata
=== CONT  TestAccS3TablesTable_basic
=== CONT  TestAccS3TablesTable_maintenanceConfiguration
=== CONT  TestAccS3TablesTable_updateNamespace
=== CONT  TestAccS3TablesTable_updateNameAndNamespace
=== CONT  TestAccS3TablesTable_encryptionConfiguration
=== CONT  TestAccS3TablesTable_metadata
=== CONT  TestAccS3TablesTable_compactionStrategy
=== CONT  TestAccS3TablesTable_disappears
=== CONT  TestAccS3TablesTable_rename
=== NAME  TestAccS3TablesTable_compactionStrategy
    table_test.go:481: Step 1/4 error: Error running apply: exit status 1

        Error: putting S3 Tables Table (tf_acc_test_9174382277842168773) maintenance configuration (icebergCompaction)

          with aws_s3tables_table.test,
          on terraform_plugin_test.tf line 12, in resource "aws_s3tables_table" "test":
          12: resource "aws_s3tables_table" "test" {

        operation error S3Tables: PutTableMaintenanceConfiguration, https response
        error StatusCode: 400, RequestID: 10424394-f516-4495-95b8-1ee9f4ac08af,
        BadRequestException: The specified compaction strategy requires sort order in
        the table metadata.
    panic.go:636: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: deleting Amazon S3 Tables Namespace ("tf_acc_test_7948767596760045402"): operation error S3Tables: DeleteNamespace, https response error StatusCode: 400, RequestID: 86f3d0ba-b72e-4661-a186-a879310803b8, BadRequestException: The namespace that you tried to delete is not empty.

        operation error S3Tables: DeleteNamespace, https response error StatusCode:
        400, RequestID: 86f3d0ba-b72e-4661-a186-a879310803b8, BadRequestException:
        The namespace that you tried to delete is not empty.        
--- FAIL: TestAccS3TablesTable_compactionStrategy (16.51s)
--- PASS: TestAccS3TablesTable_disappears (27.67s)
--- PASS: TestAccS3TablesTable_metadata (31.40s)
--- PASS: TestAccS3TablesTable_basic (32.62s)
--- PASS: TestAccS3TablesTable_encryptionConfiguration (37.93s)
--- PASS: TestAccS3TablesTable_updateNamespace (47.85s)
--- PASS: TestAccS3TablesTable_rename (48.23s)
--- PASS: TestAccS3TablesTable_updateNameAndNamespace (48.24s)
--- PASS: TestAccS3TablesTable_maintenanceConfiguration (50.70s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/s3tables       51.016s
FAIL
make: *** [GNUmakefile:645: testacc] Error 1
```
