### PR TITLE
[TechDebts/Test]aws_apigateway: Fix test errors due to removed `stage_name` argument in `aws_apigateway_deployment`

### DIFF
--- a/internal/service/apigateway/method_settings_test.go
+++ b/internal/service/apigateway/method_settings_test.go
@@ -673,7 +673,12 @@ EOF
 resource "aws_api_gateway_deployment" "test" {
   depends_on  = [aws_api_gateway_integration.test]
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = "dev"
+}
+
+resource "aws_api_gateway_stage" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = "dev"
+  deployment_id = aws_api_gateway_deployment.test.id
 }
 `, rName)
 }
@@ -683,7 +688,7 @@ func testAccMethodSettingsConfig_basic(rName string) string {
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = aws_api_gateway_deployment.test.stage_name
+  stage_name  = aws_api_gateway_stage.test.stage_name
 
   settings {}
 }
@@ -695,7 +700,7 @@ func testAccMethodSettingsConfig_cacheDataEncrypted(rName string, cacheDataEncry
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = aws_api_gateway_deployment.test.stage_name
+  stage_name  = aws_api_gateway_stage.test.stage_name
 
   settings {
     cache_data_encrypted = %[1]t
@@ -709,7 +714,7 @@ func testAccMethodSettingsConfig_cacheTTLInSeconds(rName string, cacheTtlInSecon
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = aws_api_gateway_deployment.test.stage_name
+  stage_name  = aws_api_gateway_stage.test.stage_name
 
   settings {
     cache_ttl_in_seconds = %[1]d
@@ -723,7 +728,7 @@ func testAccMethodSettingsConfig_cachingEnabled(rName string, cachingEnabled boo
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = aws_api_gateway_deployment.test.stage_name
+  stage_name  = aws_api_gateway_stage.test.stage_name
 
   settings {
     caching_enabled = %[1]t
@@ -737,7 +742,7 @@ func testAccMethodSettingsConfig_dataTraceEnabled(rName string, dataTraceEnabled
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = aws_api_gateway_deployment.test.stage_name
+  stage_name  = aws_api_gateway_stage.test.stage_name
 
   settings {
     data_trace_enabled = %[1]t
@@ -754,7 +759,7 @@ func testAccMethodSettingsConfig_loggingLevel(rName, loggingLevel string) string
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = aws_api_gateway_deployment.test.stage_name
+  stage_name  = aws_api_gateway_stage.test.stage_name
 
   settings {
     logging_level = %[1]q
@@ -770,7 +775,7 @@ func testAccMethodSettingsConfig_metricsEnabled(rName string, metricsEnabled boo
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = aws_api_gateway_deployment.test.stage_name
+  stage_name  = aws_api_gateway_stage.test.stage_name
 
   settings {
     metrics_enabled = %[1]t
@@ -786,7 +791,7 @@ func testAccMethodSettingsConfig_multiple(rName, loggingLevel string, metricsEna
 		fmt.Sprintf(`
 resource "aws_api_gateway_method_settings" "test" {
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = aws_api_gateway_deployment.test.stage_name
+  stage_name  = aws_api_gateway_stage.test.stage_name
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
 
   settings {
@@ -804,7 +809,7 @@ func testAccMethodSettingsConfig_requireAuthorizationForCacheControl(rName strin
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = aws_api_gateway_deployment.test.stage_name
+  stage_name  = aws_api_gateway_stage.test.stage_name
 
   settings {
     require_authorization_for_cache_control = %[1]t
@@ -818,7 +823,7 @@ func testAccMethodSettingsConfig_throttlingBurstLimit(rName string, throttlingBu
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = aws_api_gateway_deployment.test.stage_name
+  stage_name  = aws_api_gateway_stage.test.stage_name
 
   settings {
     throttling_burst_limit = %[1]d
@@ -832,7 +837,7 @@ func testAccMethodSettingsConfig_throttlingRateLimit(rName string, throttlingRat
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = aws_api_gateway_deployment.test.stage_name
+  stage_name  = aws_api_gateway_stage.test.stage_name
 
   settings {
     throttling_rate_limit = %[1]f
@@ -846,7 +851,7 @@ func testAccMethodSettingsConfig_unauthorizedCacheControlHeaderStrategy(rName, u
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = aws_api_gateway_deployment.test.stage_name
+  stage_name  = aws_api_gateway_stage.test.stage_name
 
   settings {
     unauthorized_cache_control_header_strategy = %[1]q

--- a/internal/service/apigateway/testdata/UsagePlan/tags/main_gen.tf
+++ b/internal/service/apigateway/testdata/UsagePlan/tags/main_gen.tf
@@ -52,12 +52,17 @@ resource "aws_api_gateway_deployment" "test" {
   depends_on = [aws_api_gateway_integration.test]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = "test"
   description = "This is a test"
 
   variables = {
     "a" = "2"
   }
+}
+
+resource "aws_api_gateway_stage" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = "test"
+  deployment_id = aws_api_gateway_deployment.test.id
 }
 
 resource "aws_api_gateway_deployment" "foo" {
@@ -67,8 +72,13 @@ resource "aws_api_gateway_deployment" "foo" {
   ]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = "foo"
   description = "This is a prod stage"
+}
+
+resource "aws_api_gateway_stage" "foo" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = "foo"
+  deployment_id = aws_api_gateway_deployment.foo.id
 }
 
 variable "rName" {

--- a/internal/service/apigateway/testdata/UsagePlan/tagsComputed1/main_gen.tf
+++ b/internal/service/apigateway/testdata/UsagePlan/tagsComputed1/main_gen.tf
@@ -56,12 +56,17 @@ resource "aws_api_gateway_deployment" "test" {
   depends_on = [aws_api_gateway_integration.test]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = "test"
   description = "This is a test"
 
   variables = {
     "a" = "2"
   }
+}
+
+resource "aws_api_gateway_stage" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = "test"
+  deployment_id = aws_api_gateway_deployment.test.id
 }
 
 resource "aws_api_gateway_deployment" "foo" {
@@ -71,8 +76,13 @@ resource "aws_api_gateway_deployment" "foo" {
   ]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = "foo"
   description = "This is a prod stage"
+}
+
+resource "aws_api_gateway_stage" "foo" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = "foo"
+  deployment_id = aws_api_gateway_deployment.foo.id
 }
 
 resource "null_resource" "test" {}

--- a/internal/service/apigateway/testdata/UsagePlan/tagsComputed2/main_gen.tf
+++ b/internal/service/apigateway/testdata/UsagePlan/tagsComputed2/main_gen.tf
@@ -57,12 +57,17 @@ resource "aws_api_gateway_deployment" "test" {
   depends_on = [aws_api_gateway_integration.test]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = "test"
   description = "This is a test"
 
   variables = {
     "a" = "2"
   }
+}
+
+resource "aws_api_gateway_stage" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = "test"
+  deployment_id = aws_api_gateway_deployment.test.id
 }
 
 resource "aws_api_gateway_deployment" "foo" {
@@ -72,8 +77,13 @@ resource "aws_api_gateway_deployment" "foo" {
   ]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = "foo"
   description = "This is a prod stage"
+}
+
+resource "aws_api_gateway_stage" "foo" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = "foo"
+  deployment_id = aws_api_gateway_deployment.foo.id
 }
 
 resource "null_resource" "test" {}

--- a/internal/service/apigateway/testdata/UsagePlan/tags_defaults/main_gen.tf
+++ b/internal/service/apigateway/testdata/UsagePlan/tags_defaults/main_gen.tf
@@ -58,12 +58,17 @@ resource "aws_api_gateway_deployment" "test" {
   depends_on = [aws_api_gateway_integration.test]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = "test"
   description = "This is a test"
 
   variables = {
     "a" = "2"
   }
+}
+
+resource "aws_api_gateway_stage" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = "test"
+  deployment_id = aws_api_gateway_deployment.test.id
 }
 
 resource "aws_api_gateway_deployment" "foo" {
@@ -73,8 +78,13 @@ resource "aws_api_gateway_deployment" "foo" {
   ]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = "foo"
   description = "This is a prod stage"
+}
+
+resource "aws_api_gateway_stage" "foo" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = "foo"
+  deployment_id = aws_api_gateway_deployment.foo.id
 }
 
 variable "rName" {

--- a/internal/service/apigateway/testdata/UsagePlan/tags_ignore/main_gen.tf
+++ b/internal/service/apigateway/testdata/UsagePlan/tags_ignore/main_gen.tf
@@ -61,12 +61,17 @@ resource "aws_api_gateway_deployment" "test" {
   depends_on = [aws_api_gateway_integration.test]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = "test"
   description = "This is a test"
 
   variables = {
     "a" = "2"
   }
+}
+
+resource "aws_api_gateway_stage" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = "test"
+  deployment_id = aws_api_gateway_deployment.test.id
 }
 
 resource "aws_api_gateway_deployment" "foo" {
@@ -76,8 +81,13 @@ resource "aws_api_gateway_deployment" "foo" {
   ]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = "foo"
   description = "This is a prod stage"
+}
+
+resource "aws_api_gateway_stage" "foo" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = "foo"
+  deployment_id = aws_api_gateway_deployment.foo.id
 }
 
 variable "rName" {

--- a/internal/service/apigateway/testdata/tmpl/usage_plan_tags.gtpl
+++ b/internal/service/apigateway/testdata/tmpl/usage_plan_tags.gtpl
@@ -49,12 +49,17 @@ resource "aws_api_gateway_deployment" "test" {
   depends_on = [aws_api_gateway_integration.test]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = "test"
   description = "This is a test"
 
   variables = {
     "a" = "2"
   }
+}
+
+resource "aws_api_gateway_stage" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = "test"
+  deployment_id = aws_api_gateway_deployment.test.id
 }
 
 resource "aws_api_gateway_deployment" "foo" {
@@ -64,6 +69,11 @@ resource "aws_api_gateway_deployment" "foo" {
   ]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = "foo"
   description = "This is a prod stage"
+}
+
+resource "aws_api_gateway_stage" "foo" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = "foo"
+  deployment_id = aws_api_gateway_deployment.foo.id
 }

--- a/internal/service/apigateway/usage_plan_key_test.go
+++ b/internal/service/apigateway/usage_plan_key_test.go
@@ -214,7 +214,12 @@ resource "aws_api_gateway_deployment" "test" {
 
   description = "This is a test"
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = "test"
+}
+
+resource "aws_api_gateway_stage" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = "test"
+  deployment_id = aws_api_gateway_deployment.test.id
 }
 `, rName)
 }
@@ -232,7 +237,7 @@ resource "aws_api_gateway_usage_plan" "test" {
 
   api_stages {
     api_id = aws_api_gateway_rest_api.test.id
-    stage  = aws_api_gateway_deployment.test.stage_name
+    stage  = aws_api_gateway_stage.test.stage_name
   }
 }
 
@@ -259,7 +264,7 @@ resource "aws_api_gateway_usage_plan" "test" {
 
   api_stages {
     api_id = aws_api_gateway_rest_api.test.id
-    stage  = aws_api_gateway_deployment.test.stage_name
+    stage  = aws_api_gateway_stage.test.stage_name
   }
 }
 

--- a/internal/service/apigateway/usage_plan_test.go
+++ b/internal/service/apigateway/usage_plan_test.go
@@ -603,12 +603,17 @@ resource "aws_api_gateway_deployment" "test" {
   depends_on = [aws_api_gateway_integration.test]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = "test"
   description = "This is a test"
 
   variables = {
     "a" = "2"
   }
+}
+
+resource "aws_api_gateway_stage" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = "test"
+  deployment_id = aws_api_gateway_deployment.test.id
 }
 
 resource "aws_api_gateway_deployment" "foo" {
@@ -618,8 +623,13 @@ resource "aws_api_gateway_deployment" "foo" {
   ]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = "foo"
   description = "This is a prod stage"
+}
+
+resource "aws_api_gateway_stage" "foo" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = "foo"
+  deployment_id = aws_api_gateway_deployment.foo.id
 }
 `, rName)
 }
@@ -711,7 +721,7 @@ resource "aws_api_gateway_usage_plan" "test" {
 
   api_stages {
     api_id = aws_api_gateway_rest_api.test.id
-    stage  = aws_api_gateway_deployment.test.stage_name
+    stage  = aws_api_gateway_stage.test.stage_name
   }
 }
 `, rName))
@@ -729,7 +739,7 @@ resource "aws_api_gateway_usage_plan" "test" {
 
   api_stages {
     api_id = aws_api_gateway_rest_api.test.id
-    stage  = aws_api_gateway_deployment.test.stage_name
+    stage  = aws_api_gateway_stage.test.stage_name
 
     throttle {
       path        = "${aws_api_gateway_resource.test.path}/${aws_api_gateway_method.test.http_method}"
@@ -753,7 +763,7 @@ resource "aws_api_gateway_usage_plan" "test" {
 
   api_stages {
     api_id = aws_api_gateway_rest_api.test.id
-    stage  = aws_api_gateway_deployment.test.stage_name
+    stage  = aws_api_gateway_stage.test.stage_name
 
     throttle {
       path        = "${aws_api_gateway_resource.test.path}/${aws_api_gateway_method.test.http_method}"
@@ -764,7 +774,7 @@ resource "aws_api_gateway_usage_plan" "test" {
 
   api_stages {
     api_id = aws_api_gateway_rest_api.test.id
-    stage  = aws_api_gateway_deployment.foo.stage_name
+    stage  = aws_api_gateway_stage.foo.stage_name
 
     throttle {
       path        = "${aws_api_gateway_resource.test.path}/${aws_api_gateway_method.test.http_method}"
@@ -783,7 +793,7 @@ resource "aws_api_gateway_usage_plan" "test" {
 
   api_stages {
     api_id = aws_api_gateway_rest_api.test.id
-    stage  = aws_api_gateway_deployment.foo.stage_name
+    stage  = aws_api_gateway_stage.foo.stage_name
   }
 }
 `, rName))
@@ -796,12 +806,12 @@ resource "aws_api_gateway_usage_plan" "test" {
 
   api_stages {
     api_id = aws_api_gateway_rest_api.test.id
-    stage  = aws_api_gateway_deployment.foo.stage_name
+    stage  = aws_api_gateway_stage.foo.stage_name
   }
 
   api_stages {
     api_id = aws_api_gateway_rest_api.test.id
-    stage  = aws_api_gateway_deployment.test.stage_name
+    stage  = aws_api_gateway_stage.test.stage_name
   }
 }
 `, rName))


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* PR #42249 removed the `stage_name` argument from `aws_apigateway_deployment`.
* Some acceptance tests in `aws_apigateway` were still using the `stage_name` argument of `aws_apigateway_deployment`.
* This PR fixes the acceptance tests by removing the `stage_name` argument from `aws_apigateway_deployment` and adding `aws_apigateway_stage`.

* Fixed resources
  * `aws_apigateway_usage_plan`
  * `aws_apigateway_usage_plan_key`
  * `aws_apigateway_method_settings`


### Output from Acceptance Testing

#### `aws_apigateway_usage_plan`
```console
$ make testacc TESTS=TestAccAPIGatewayUsagePlan_ PKG=apigateway
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayUsagePlan_'  -timeout 360m -vet=off
2025/08/17 15:19:10 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/17 15:19:10 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAPIGatewayUsagePlan_tags
=== PAUSE TestAccAPIGatewayUsagePlan_tags
=== RUN   TestAccAPIGatewayUsagePlan_tags_null
=== PAUSE TestAccAPIGatewayUsagePlan_tags_null
=== RUN   TestAccAPIGatewayUsagePlan_tags_EmptyMap
=== PAUSE TestAccAPIGatewayUsagePlan_tags_EmptyMap
=== RUN   TestAccAPIGatewayUsagePlan_tags_AddOnUpdate
=== PAUSE TestAccAPIGatewayUsagePlan_tags_AddOnUpdate
=== RUN   TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnCreate
=== PAUSE TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnCreate
=== RUN   TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccAPIGatewayUsagePlan_tags_DefaultTags_providerOnly
=== PAUSE TestAccAPIGatewayUsagePlan_tags_DefaultTags_providerOnly
=== RUN   TestAccAPIGatewayUsagePlan_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccAPIGatewayUsagePlan_tags_DefaultTags_nonOverlapping
=== RUN   TestAccAPIGatewayUsagePlan_tags_DefaultTags_overlapping
=== PAUSE TestAccAPIGatewayUsagePlan_tags_DefaultTags_overlapping
=== RUN   TestAccAPIGatewayUsagePlan_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccAPIGatewayUsagePlan_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccAPIGatewayUsagePlan_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccAPIGatewayUsagePlan_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccAPIGatewayUsagePlan_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccAPIGatewayUsagePlan_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccAPIGatewayUsagePlan_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccAPIGatewayUsagePlan_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccAPIGatewayUsagePlan_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccAPIGatewayUsagePlan_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccAPIGatewayUsagePlan_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccAPIGatewayUsagePlan_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnCreate
=== PAUSE TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnCreate
=== RUN   TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccAPIGatewayUsagePlan_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccAPIGatewayUsagePlan_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccAPIGatewayUsagePlan_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccAPIGatewayUsagePlan_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccAPIGatewayUsagePlan_basic
=== PAUSE TestAccAPIGatewayUsagePlan_basic
=== RUN   TestAccAPIGatewayUsagePlan_description
=== PAUSE TestAccAPIGatewayUsagePlan_description
=== RUN   TestAccAPIGatewayUsagePlan_productCode
=== PAUSE TestAccAPIGatewayUsagePlan_productCode
=== RUN   TestAccAPIGatewayUsagePlan_throttling
=== PAUSE TestAccAPIGatewayUsagePlan_throttling
=== RUN   TestAccAPIGatewayUsagePlan_throttlingInitialRateLimit
=== PAUSE TestAccAPIGatewayUsagePlan_throttlingInitialRateLimit
=== RUN   TestAccAPIGatewayUsagePlan_quota
=== PAUSE TestAccAPIGatewayUsagePlan_quota
=== RUN   TestAccAPIGatewayUsagePlan_apiStages
=== PAUSE TestAccAPIGatewayUsagePlan_apiStages
=== RUN   TestAccAPIGatewayUsagePlan_APIStages_multiple
=== PAUSE TestAccAPIGatewayUsagePlan_APIStages_multiple
=== RUN   TestAccAPIGatewayUsagePlan_APIStages_throttle
=== PAUSE TestAccAPIGatewayUsagePlan_APIStages_throttle
=== RUN   TestAccAPIGatewayUsagePlan_disappears
=== PAUSE TestAccAPIGatewayUsagePlan_disappears
=== CONT  TestAccAPIGatewayUsagePlan_tags
=== CONT  TestAccAPIGatewayUsagePlan_throttling
=== CONT  TestAccAPIGatewayUsagePlan_description
=== CONT  TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnCreate
=== CONT  TestAccAPIGatewayUsagePlan_APIStages_multiple
=== CONT  TestAccAPIGatewayUsagePlan_productCode
=== CONT  TestAccAPIGatewayUsagePlan_disappears
=== CONT  TestAccAPIGatewayUsagePlan_APIStages_throttle
=== CONT  TestAccAPIGatewayUsagePlan_tags_DefaultTags_nonOverlapping
=== CONT  TestAccAPIGatewayUsagePlan_tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccAPIGatewayUsagePlan_tags_DefaultTags_emptyProviderOnlyTag
=== CONT  TestAccAPIGatewayUsagePlan_tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccAPIGatewayUsagePlan_tags_DefaultTags_emptyResourceTag
=== CONT  TestAccAPIGatewayUsagePlan_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccAPIGatewayUsagePlan_tags_DefaultTags_overlapping
=== CONT  TestAccAPIGatewayUsagePlan_throttlingInitialRateLimit
=== CONT  TestAccAPIGatewayUsagePlan_tags_IgnoreTags_Overlap_DefaultTag
=== CONT  TestAccAPIGatewayUsagePlan_basic
=== CONT  TestAccAPIGatewayUsagePlan_tags_IgnoreTags_Overlap_ResourceTag
=== CONT  TestAccAPIGatewayUsagePlan_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccAPIGatewayUsagePlan_throttlingInitialRateLimit (37.95s)
=== CONT  TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnCreate
--- PASS: TestAccAPIGatewayUsagePlan_throttling (91.37s)
=== CONT  TestAccAPIGatewayUsagePlan_tags_DefaultTags_providerOnly
--- PASS: TestAccAPIGatewayUsagePlan_tags_DefaultTags_updateToProviderOnly (104.67s)
=== CONT  TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccAPIGatewayUsagePlan_tags_DefaultTags_overlapping (105.98s)
=== CONT  TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnCreate (142.21s)
=== CONT  TestAccAPIGatewayUsagePlan_quota
--- PASS: TestAccAPIGatewayUsagePlan_tags_DefaultTags_nullNonOverlappingResourceTag (161.26s)
=== CONT  TestAccAPIGatewayUsagePlan_apiStages
--- PASS: TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnUpdate_Replace (57.17s)
=== CONT  TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccAPIGatewayUsagePlan_APIStages_multiple (236.44s)
=== CONT  TestAccAPIGatewayUsagePlan_tags_EmptyMap
--- PASS: TestAccAPIGatewayUsagePlan_tags_DefaultTags_updateToResourceOnly (250.00s)
=== CONT  TestAccAPIGatewayUsagePlan_tags_AddOnUpdate
--- PASS: TestAccAPIGatewayUsagePlan_tags_DefaultTags_providerOnly (201.56s)
=== CONT  TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccAPIGatewayUsagePlan_tags_AddOnUpdate (68.18s)
=== CONT  TestAccAPIGatewayUsagePlan_tags_null
--- PASS: TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnUpdate_Add (60.55s)
--- PASS: TestAccAPIGatewayUsagePlan_apiStages (215.35s)
--- PASS: TestAccAPIGatewayUsagePlan_tags_DefaultTags_nonOverlapping (449.17s)
--- PASS: TestAccAPIGatewayUsagePlan_productCode (481.95s)
--- PASS: TestAccAPIGatewayUsagePlan_description (490.58s)
--- PASS: TestAccAPIGatewayUsagePlan_tags_IgnoreTags_Overlap_ResourceTag (547.09s)
--- PASS: TestAccAPIGatewayUsagePlan_tags_DefaultTags_nullOverlappingResourceTag (592.67s)
--- PASS: TestAccAPIGatewayUsagePlan_tags_IgnoreTags_Overlap_DefaultTag (599.49s)
--- PASS: TestAccAPIGatewayUsagePlan_basic (645.02s)
--- PASS: TestAccAPIGatewayUsagePlan_APIStages_throttle (683.07s)
--- PASS: TestAccAPIGatewayUsagePlan_disappears (744.49s)
--- PASS: TestAccAPIGatewayUsagePlan_tags_EmptyMap (569.52s)
--- PASS: TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnUpdate_Add (731.97s)
--- PASS: TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnCreate (829.31s)
--- PASS: TestAccAPIGatewayUsagePlan_quota (780.70s)
--- PASS: TestAccAPIGatewayUsagePlan_tags_null (669.65s)
--- PASS: TestAccAPIGatewayUsagePlan_tags_DefaultTags_emptyProviderOnlyTag (1049.87s)
--- PASS: TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnUpdate_Replace (907.76s)
--- PASS: TestAccAPIGatewayUsagePlan_tags (1138.99s)
--- PASS: TestAccAPIGatewayUsagePlan_tags_DefaultTags_emptyResourceTag (1186.16s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigateway 1190.167s
```

#### `aws_apigateway_usage_plan_key`
```console
$ make testacc TESTS=TestAccAPIGatewayUsagePlanKey_ PKG=apigateway
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayUsagePlanKey_'  -timeout 360m -vet=off
2025/08/17 15:40:22 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/17 15:40:22 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAPIGatewayUsagePlanKey_basic
=== PAUSE TestAccAPIGatewayUsagePlanKey_basic
=== RUN   TestAccAPIGatewayUsagePlanKey_disappears
=== PAUSE TestAccAPIGatewayUsagePlanKey_disappears
=== RUN   TestAccAPIGatewayUsagePlanKey_KeyID_concurrency
=== PAUSE TestAccAPIGatewayUsagePlanKey_KeyID_concurrency
=== CONT  TestAccAPIGatewayUsagePlanKey_basic
=== CONT  TestAccAPIGatewayUsagePlanKey_KeyID_concurrency
=== CONT  TestAccAPIGatewayUsagePlanKey_disappears
--- PASS: TestAccAPIGatewayUsagePlanKey_disappears (29.36s)
--- PASS: TestAccAPIGatewayUsagePlanKey_basic (60.37s)
--- PASS: TestAccAPIGatewayUsagePlanKey_KeyID_concurrency (95.16s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigateway 99.100s
```

#### `aws_apigateway_method_setting`
```console
$ make testacc TESTS=TestAccAPIGateway_serial/MethodSettings PKG=apigateway
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGateway_serial/MethodSettings'  -timeout 360m -vet=off
2025/08/17 15:42:40 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/17 15:42:40 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAPIGateway_serial
=== RUN   TestAccAPIGateway_serial/MethodSettings
=== RUN   TestAccAPIGateway_serial/MethodSettings/CacheTTLInSeconds
=== PAUSE TestAccAPIGateway_serial/MethodSettings/CacheTTLInSeconds
=== RUN   TestAccAPIGateway_serial/MethodSettings/Multiple
=== RUN   TestAccAPIGateway_serial/MethodSettings/ThrottlingBurstLimit
=== PAUSE TestAccAPIGateway_serial/MethodSettings/ThrottlingBurstLimit
=== RUN   TestAccAPIGateway_serial/MethodSettings/CachingEnabled
=== PAUSE TestAccAPIGateway_serial/MethodSettings/CachingEnabled
=== RUN   TestAccAPIGateway_serial/MethodSettings/LoggingLevel
=== RUN   TestAccAPIGateway_serial/MethodSettings/MetricsEnabled
=== PAUSE TestAccAPIGateway_serial/MethodSettings/MetricsEnabled
=== RUN   TestAccAPIGateway_serial/MethodSettings/ThrottlingBurstLimitDisabledByDefault
=== PAUSE TestAccAPIGateway_serial/MethodSettings/ThrottlingBurstLimitDisabledByDefault
=== RUN   TestAccAPIGateway_serial/MethodSettings/ThrottlingRateLimit
=== PAUSE TestAccAPIGateway_serial/MethodSettings/ThrottlingRateLimit
=== RUN   TestAccAPIGateway_serial/MethodSettings/disappears
=== RUN   TestAccAPIGateway_serial/MethodSettings/CacheDataEncrypted
=== PAUSE TestAccAPIGateway_serial/MethodSettings/CacheDataEncrypted
=== RUN   TestAccAPIGateway_serial/MethodSettings/DataTraceEnabled
=== PAUSE TestAccAPIGateway_serial/MethodSettings/DataTraceEnabled
=== RUN   TestAccAPIGateway_serial/MethodSettings/RequireAuthorizationForCacheControl
=== PAUSE TestAccAPIGateway_serial/MethodSettings/RequireAuthorizationForCacheControl
=== RUN   TestAccAPIGateway_serial/MethodSettings/ThrottlingRateLimitDisabledByDefault
=== PAUSE TestAccAPIGateway_serial/MethodSettings/ThrottlingRateLimitDisabledByDefault
=== RUN   TestAccAPIGateway_serial/MethodSettings/UnauthorizedCacheControlHeaderStrategy
=== PAUSE TestAccAPIGateway_serial/MethodSettings/UnauthorizedCacheControlHeaderStrategy
=== RUN   TestAccAPIGateway_serial/MethodSettings/basic
=== PAUSE TestAccAPIGateway_serial/MethodSettings/basic
=== CONT  TestAccAPIGateway_serial/MethodSettings/CacheTTLInSeconds
=== CONT  TestAccAPIGateway_serial/MethodSettings/CacheDataEncrypted
=== CONT  TestAccAPIGateway_serial/MethodSettings/ThrottlingRateLimitDisabledByDefault
=== CONT  TestAccAPIGateway_serial/MethodSettings/basic
=== CONT  TestAccAPIGateway_serial/MethodSettings/CachingEnabled
=== CONT  TestAccAPIGateway_serial/MethodSettings/RequireAuthorizationForCacheControl
=== CONT  TestAccAPIGateway_serial/MethodSettings/MetricsEnabled
=== CONT  TestAccAPIGateway_serial/MethodSettings/ThrottlingRateLimit
=== CONT  TestAccAPIGateway_serial/MethodSettings/ThrottlingBurstLimitDisabledByDefault
=== CONT  TestAccAPIGateway_serial/MethodSettings/UnauthorizedCacheControlHeaderStrategy
=== CONT  TestAccAPIGateway_serial/MethodSettings/ThrottlingBurstLimit
=== CONT  TestAccAPIGateway_serial/MethodSettings/DataTraceEnabled
--- PASS: TestAccAPIGateway_serial (877.61s)
    --- PASS: TestAccAPIGateway_serial/MethodSettings (178.36s)
        --- PASS: TestAccAPIGateway_serial/MethodSettings/Multiple (63.88s)
        --- PASS: TestAccAPIGateway_serial/MethodSettings/LoggingLevel (89.94s)
        --- PASS: TestAccAPIGateway_serial/MethodSettings/disappears (24.54s)
        --- PASS: TestAccAPIGateway_serial/MethodSettings/ThrottlingBurstLimit (50.81s)
        --- PASS: TestAccAPIGateway_serial/MethodSettings/ThrottlingRateLimitDisabledByDefault (60.35s)
        --- PASS: TestAccAPIGateway_serial/MethodSettings/RequireAuthorizationForCacheControl (94.47s)
        --- PASS: TestAccAPIGateway_serial/MethodSettings/CacheTTLInSeconds (94.99s)
        --- PASS: TestAccAPIGateway_serial/MethodSettings/CachingEnabled (107.63s)
        --- PASS: TestAccAPIGateway_serial/MethodSettings/CacheDataEncrypted (199.73s)
        --- PASS: TestAccAPIGateway_serial/MethodSettings/UnauthorizedCacheControlHeaderStrategy (254.22s)
        --- PASS: TestAccAPIGateway_serial/MethodSettings/basic (259.68s)
        --- PASS: TestAccAPIGateway_serial/MethodSettings/DataTraceEnabled (396.16s)
        --- PASS: TestAccAPIGateway_serial/MethodSettings/ThrottlingRateLimit (434.76s)
        --- PASS: TestAccAPIGateway_serial/MethodSettings/ThrottlingBurstLimitDisabledByDefault (522.19s)
        --- PASS: TestAccAPIGateway_serial/MethodSettings/MetricsEnabled (699.24s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigateway 881.563s
```
