### PR TITLE
fix: fix inconsistent result after apply for imagebuilder_lifecycle_policy

### DIFF
--- a/.changelog/43925.txt
+++ b/.changelog/43925.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/imagebuilder_lifecycle_policy: Fix `Provider produced inconsistent result after apply` error
+resource/imagebuilder_lifecycle_policy: Fix `Provider produced inconsistent result after apply` error when `policy_detail.exclusion_rules.amis.is_public` is omitted
 ```

--- a/.changelog/43925.txt
+++ b/.changelog/43925.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/imagebuilder_lifecycle_policy: Fix `Provider produced inconsistent result after apply` error
+```

--- a/internal/service/imagebuilder/lifecycle_policy.go
+++ b/internal/service/imagebuilder/lifecycle_policy.go
@@ -170,6 +170,10 @@ func (r *lifecyclePolicyResource) Schema(ctx context.Context, request resource.S
 											Attributes: map[string]schema.Attribute{
 												"is_public": schema.BoolAttribute{
 													Optional: true,
+													Computed: true,
+													PlanModifiers: []planmodifier.Bool{
+														boolplanmodifier.UseStateForUnknown(),
+													},
 												},
 												"regions": schema.ListAttribute{
 													CustomType:  fwtypes.ListOfStringType,

--- a/internal/service/imagebuilder/lifecycle_policy_test.go
+++ b/internal/service/imagebuilder/lifecycle_policy_test.go
@@ -131,7 +131,7 @@ func TestAccImageBuilderLifecyclePolicy_policyDetails(t *testing.T) {
 	})
 }
 
-func TestAccImageBuilderLifecyclePolicy_policyDetailsExclusionRulesAmisIsPublic(t *testing.T) {
+func TestAccImageBuilderLifecyclePolicy_policyDetailsExclusionRulesAMIsIsPublic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_imagebuilder_lifecycle_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -143,7 +143,7 @@ func TestAccImageBuilderLifecyclePolicy_policyDetailsExclusionRulesAmisIsPublic(
 		CheckDestroy:             testAccCheckLifecyclePolicyDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLifecyclePolicyConfig_policyDetailsExclusionRulesAmisIsPublic(rName),
+				Config: testAccLifecyclePolicyConfig_policyDetailsExclusionRulesAMIsIsPublic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLifecyclePolicyExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "policy_detail.#", "1"),
@@ -492,7 +492,7 @@ resource "aws_imagebuilder_lifecycle_policy" "test" {
 `, rName))
 }
 
-func testAccLifecyclePolicyConfig_policyDetailsExclusionRulesAmisIsPublic(rName string) string {
+func testAccLifecyclePolicyConfig_policyDetailsExclusionRulesAMIsIsPublic(rName string) string {
 	return acctest.ConfigCompose(testAccLifecyclePolicyConfig_base(rName), fmt.Sprintf(`
 resource "aws_imagebuilder_lifecycle_policy" "test" {
   name           = %[1]q
@@ -509,7 +509,7 @@ resource "aws_imagebuilder_lifecycle_policy" "test" {
     }
     exclusion_rules {
       amis {
-        regions   = [data.aws_region.current.region]
+        regions = [data.aws_region.current.region]
         last_launched {
           unit  = "WEEKS"
           value = 2

--- a/internal/service/imagebuilder/lifecycle_policy_test.go
+++ b/internal/service/imagebuilder/lifecycle_policy_test.go
@@ -131,6 +131,46 @@ func TestAccImageBuilderLifecyclePolicy_policyDetails(t *testing.T) {
 	})
 }
 
+func TestAccImageBuilderLifecyclePolicy_policyDetailsExclusionRulesAmisIsPublic(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_imagebuilder_lifecycle_policy.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ImageBuilderServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLifecyclePolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLifecyclePolicyConfig_policyDetailsExclusionRulesAmisIsPublic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLifecyclePolicyExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.0.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.0.action.0.type", string(awstypes.LifecyclePolicyDetailActionTypeDelete)),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.0.action.0.include_resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.0.action.0.include_resources.0.amis", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.0.action.0.include_resources.0.snapshots", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.0.exclusion_rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.0.exclusion_rules.0.amis.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.0.exclusion_rules.0.amis.0.is_public", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.0.exclusion_rules.0.amis.0.regions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.0.exclusion_rules.0.amis.0.last_launched.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.0.exclusion_rules.0.amis.0.last_launched.0.unit", string(awstypes.LifecyclePolicyTimeUnitWeeks)),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.0.exclusion_rules.0.amis.0.last_launched.0.value", "2"),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.0.exclusion_rules.0.amis.0.tag_map.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.0.exclusion_rules.0.amis.0.tag_map.key1", acctest.CtValue1),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.0.exclusion_rules.0.amis.0.tag_map.key2", acctest.CtValue2),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.0.filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.0.filter.0.type", string(awstypes.LifecyclePolicyDetailFilterTypeCount)),
+					resource.TestCheckResourceAttr(resourceName, "policy_detail.0.filter.0.value", "10"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccImageBuilderLifecyclePolicy_resourceSelection(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_imagebuilder_lifecycle_policy.test"
@@ -424,6 +464,51 @@ resource "aws_imagebuilder_lifecycle_policy" "test" {
     exclusion_rules {
       amis {
         is_public = true
+        regions   = [data.aws_region.current.region]
+        last_launched {
+          unit  = "WEEKS"
+          value = 2
+        }
+        tag_map = {
+          "key1" = "value1"
+          "key2" = "value2"
+        }
+      }
+    }
+    filter {
+      type  = "COUNT"
+      value = "10"
+    }
+  }
+  resource_selection {
+    tag_map = {
+      "key1" = "value1"
+      "key2" = "value2"
+    }
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName))
+}
+
+func testAccLifecyclePolicyConfig_policyDetailsExclusionRulesAmisIsPublic(rName string) string {
+	return acctest.ConfigCompose(testAccLifecyclePolicyConfig_base(rName), fmt.Sprintf(`
+resource "aws_imagebuilder_lifecycle_policy" "test" {
+  name           = %[1]q
+  description    = "Used for setting lifecycle policies"
+  execution_role = aws_iam_role.test.arn
+  resource_type  = "AMI_IMAGE"
+  policy_detail {
+    action {
+      type = "DELETE"
+      include_resources {
+        amis      = true
+        snapshots = true
+      }
+    }
+    exclusion_rules {
+      amis {
         regions   = [data.aws_region.current.region]
         last_launched {
           unit  = "WEEKS"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls are  implemented.

### Description

Not specifying the argument `policy_detail.exclusion_rules.amis.is_public` in the resource [`aws_imagebuilder_lifecycle_policy`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/imagebuilder_lifecycle_policy) leads to an error during `terraform apply`. The error is as below:

```plain
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to aws_imagebuilder_lifecycle_policy.default, provider "provider[\"registry.terraform.io/hashicorp/aws\"]" produced an unexpected new value: .policy_detail: planned set element
│ cty.ObjectVal(map[string]cty.Value{"action":cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{"include_resources":cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{"amis":cty.True, "containers":cty.UnknownVal(cty.Bool), "snapshots":cty.True})}),
│ "type":cty.StringVal("DELETE")})}), "exclusion_rules":cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{"amis":cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{"is_public":cty.NullVal(cty.Bool),
│ "last_launched":cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{"unit":cty.StringVal("WEEKS"), "value":cty.NumberIntVal(1)})}), "regions":cty.NullVal(cty.List(cty.String)), "shared_accounts":cty.NullVal(cty.List(cty.String)), "tag_map":cty.NullVal(cty.Map(cty.String))})}),
│ "tag_map":cty.NullVal(cty.Map(cty.String))})}), "filter":cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{"retain_at_least":cty.NullVal(cty.Number), "type":cty.StringVal("COUNT"), "unit":cty.NullVal(cty.String), "value":cty.NumberIntVal(1)})})}) does not correlate with any
│ element in actual.
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
```

The existing test [`TestAccImageBuilderLifecyclePolicy_policyDetails`](https://github.com/hashicorp/terraform-provider-aws/blob/ddc0f64d8c1012f9b89cf9c12adde2601a47cece/internal/service/imagebuilder/lifecycle_policy_test.go#L380) for the resource has `policy_detail.exclusion_rules.amis.is_public`  set, hence the issue was not detected.

### Relations

Closes #43752 

### References

- [Resource documentation `imagebuilder_lifecycle_policy `in Terraform registry](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/imagebuilder_lifecycle_policy)
- [AWS API API_CreateLifecyclePolicy](https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_CreateLifecyclePolicy.html)
- [AWS APIUpdateLifecyclePolicy](https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_UpdateLifecyclePolicy.html)

### Output from Acceptance Testing

```console
❯ make testacc TESTS=TestAccImageBuilderLifecyclePolicy_  PKG=imagebuilder
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderLifecyclePolicy_'  -timeout 360m -vet=off
2025/08/17 19:09:09 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/17 19:09:09 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccImageBuilderLifecyclePolicy_Identity_Basic
=== PAUSE TestAccImageBuilderLifecyclePolicy_Identity_Basic
=== RUN   TestAccImageBuilderLifecyclePolicy_Identity_RegionOverride
=== PAUSE TestAccImageBuilderLifecyclePolicy_Identity_RegionOverride
=== RUN   TestAccImageBuilderLifecyclePolicy_Identity_ExistingResource
=== PAUSE TestAccImageBuilderLifecyclePolicy_Identity_ExistingResource
=== RUN   TestAccImageBuilderLifecyclePolicy_basic
=== PAUSE TestAccImageBuilderLifecyclePolicy_basic
=== RUN   TestAccImageBuilderLifecyclePolicy_policyDetails
=== PAUSE TestAccImageBuilderLifecyclePolicy_policyDetails
=== RUN   TestAccImageBuilderLifecyclePolicy_policyDetailsExclusionRulesAMIsIsPublic
=== PAUSE TestAccImageBuilderLifecyclePolicy_policyDetailsExclusionRulesAMIsIsPublic
=== RUN   TestAccImageBuilderLifecyclePolicy_resourceSelection
=== PAUSE TestAccImageBuilderLifecyclePolicy_resourceSelection
=== RUN   TestAccImageBuilderLifecyclePolicy_tags
=== PAUSE TestAccImageBuilderLifecyclePolicy_tags
=== RUN   TestAccImageBuilderLifecyclePolicy_disappears
=== PAUSE TestAccImageBuilderLifecyclePolicy_disappears
=== CONT  TestAccImageBuilderLifecyclePolicy_Identity_Basic
=== CONT  TestAccImageBuilderLifecyclePolicy_policyDetailsExclusionRulesAMIsIsPublic
=== CONT  TestAccImageBuilderLifecyclePolicy_Identity_ExistingResource
=== CONT  TestAccImageBuilderLifecyclePolicy_Identity_RegionOverride
=== CONT  TestAccImageBuilderLifecyclePolicy_resourceSelection
=== CONT  TestAccImageBuilderLifecyclePolicy_tags
=== CONT  TestAccImageBuilderLifecyclePolicy_disappears
=== CONT  TestAccImageBuilderLifecyclePolicy_basic
=== CONT  TestAccImageBuilderLifecyclePolicy_policyDetails
--- PASS: TestAccImageBuilderLifecyclePolicy_policyDetailsExclusionRulesAMIsIsPublic (42.55s)
--- PASS: TestAccImageBuilderLifecyclePolicy_disappears (44.72s)
--- PASS: TestAccImageBuilderLifecyclePolicy_basic (48.79s)
--- PASS: TestAccImageBuilderLifecyclePolicy_Identity_Basic (65.66s)
--- PASS: TestAccImageBuilderLifecyclePolicy_policyDetails (69.28s)
--- PASS: TestAccImageBuilderLifecyclePolicy_resourceSelection (70.14s)
--- PASS: TestAccImageBuilderLifecyclePolicy_Identity_RegionOverride (76.29s)
--- PASS: TestAccImageBuilderLifecyclePolicy_tags (85.42s)
--- PASS: TestAccImageBuilderLifecyclePolicy_Identity_ExistingResource (132.48s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       132.686s
```
