### PR TITLE
feat: Add r/aws_acm_account_configuration

### DIFF
--- a/.changelog/43928.txt
+++ b/.changelog/43928.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_acm_account_configuration
+```

--- a/internal/service/acm/account_configuration.go
+++ b/internal/service/acm/account_configuration.go
@@ -1,0 +1,220 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package acm
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/YakDriver/smarterr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/acm"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
+// @FrameworkResource("aws_acm_account_configuration", name="Account Configuration")
+func newResourceAccountConfiguration(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceAccountConfiguration{}
+
+	return r, nil
+}
+
+const (
+	ResNameAccountConfiguration = "Account Configuration"
+)
+
+const defaultDaysBeforeExpiry = 45
+
+type resourceAccountConfiguration struct {
+	framework.ResourceWithModel[resourceAccountConfigurationModel]
+	framework.WithNoOpDelete
+}
+
+func (r *resourceAccountConfiguration) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: framework.IDAttribute(),
+		},
+		Blocks: map[string]schema.Block{
+			"expiry_events": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[expiryEventsModel](ctx),
+				Validators: []validator.List{
+					listvalidator.IsRequired(),
+					listvalidator.SizeBetween(1, 1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"days_before_expiry": schema.Int32Attribute{
+							Optional: true,
+							Computed: true,
+							Default:  int32default.StaticInt32(defaultDaysBeforeExpiry),
+							Validators: []validator.Int32{
+								int32validator.Between(1, 45),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *resourceAccountConfiguration) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().ACMClient(ctx)
+
+	var plan resourceAccountConfigurationModel
+	smerr.EnrichAppend(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.ID = flex.StringValueToFramework(ctx, r.Meta().AccountID(ctx))
+
+	input := acm.PutAccountConfigurationInput{
+		IdempotencyToken: aws.String(strconv.FormatInt(time.Now().Unix(), 10)), // 32-char limit
+	}
+
+	// Expand the expiry events configuration
+	smerr.EnrichAppend(ctx, &resp.Diagnostics, flex.Expand(ctx, plan, &input, flex.WithFieldNamePrefix("AccountConfiguration")))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := conn.PutAccountConfiguration(ctx, &input)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ID.String())
+		return
+	}
+
+	smerr.EnrichAppend(ctx, &resp.Diagnostics, resp.State.Set(ctx, plan))
+}
+
+func (r *resourceAccountConfiguration) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().ACMClient(ctx)
+
+	var state resourceAccountConfigurationModel
+	smerr.EnrichAppend(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findAccountConfiguration(ctx, conn)
+	if tfresource.NotFound(err) {
+		resp.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ID.String())
+		return
+	}
+
+	smerr.EnrichAppend(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	smerr.EnrichAppend(ctx, &resp.Diagnostics, resp.State.Set(ctx, &state))
+}
+
+func (r *resourceAccountConfiguration) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().ACMClient(ctx)
+
+	var plan, state resourceAccountConfigurationModel
+	smerr.EnrichAppend(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
+	smerr.EnrichAppend(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	diff, d := flex.Diff(ctx, plan, state)
+	smerr.EnrichAppend(ctx, &resp.Diagnostics, d)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if diff.HasChanges() {
+		input := acm.PutAccountConfigurationInput{
+			IdempotencyToken: aws.String(strconv.FormatInt(time.Now().Unix(), 10)), // 32-char limit
+		}
+
+		smerr.EnrichAppend(ctx, &resp.Diagnostics, flex.Expand(ctx, plan, &input, flex.WithFieldNamePrefix("Test")))
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		_, err := conn.PutAccountConfiguration(ctx, &input)
+		if err != nil {
+			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ID.String())
+			return
+		}
+
+		out, err := findAccountConfiguration(ctx, conn)
+		if err != nil {
+			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ID.String())
+			return
+		}
+
+		smerr.EnrichAppend(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &plan))
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	smerr.EnrichAppend(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
+}
+
+func (r *resourceAccountConfiguration) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(names.AttrID), r.Meta().AccountID(ctx))...)
+}
+
+func findAccountConfiguration(ctx context.Context, conn *acm.Client) (*acm.GetAccountConfigurationOutput, error) {
+	input := acm.GetAccountConfigurationInput{}
+
+	out, err := conn.GetAccountConfiguration(ctx, &input)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return nil, smarterr.NewError(&retry.NotFoundError{
+				LastError:   err,
+				LastRequest: &input,
+			})
+		}
+
+		return nil, smarterr.NewError(err)
+	}
+
+	if out == nil {
+		return nil, smarterr.NewError(tfresource.NewEmptyResultError(&input))
+	}
+
+	return out, nil
+}
+
+type resourceAccountConfigurationModel struct {
+	framework.WithRegionModel
+	ExpiryEvents fwtypes.ListNestedObjectValueOf[expiryEventsModel] `tfsdk:"expiry_events"`
+	ID           types.String                                       `tfsdk:"id"`
+}
+
+type expiryEventsModel struct {
+	DaysBeforeExpiry types.Int32 `tfsdk:"days_before_expiry"`
+}

--- a/internal/service/acm/account_configuration_test.go
+++ b/internal/service/acm/account_configuration_test.go
@@ -1,0 +1,182 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package acm_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/acm"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfacm "github.com/hashicorp/terraform-provider-aws/internal/service/acm"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccACMAccountConfiguration_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]map[string]func(t *testing.T){
+		"ACMAccountConfiguration": {
+			acctest.CtBasic: testAccACMAccountConfiguration_basic,
+			"update":        testAccACMAccountConfiguration_update,
+		},
+	}
+
+	acctest.RunSerialTests2Levels(t, testCases, 0)
+}
+
+func testAccACMAccountConfiguration_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var accountConfiguration acm.GetAccountConfigurationOutput
+	resourceName := "aws_acm_account_configuration.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountConfigurationConfig_basic(14),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountConfigurationExists(ctx, resourceName, &accountConfiguration),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
+					resource.TestCheckResourceAttr(resourceName, "expiry_events.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "expiry_events.0.days_before_expiry", "14"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccACMAccountConfiguration_update(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var accountConfiguration acm.GetAccountConfigurationOutput
+	resourceName := "aws_acm_account_configuration.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountConfigurationConfig_basic(1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountConfigurationExists(ctx, resourceName, &accountConfiguration),
+					resource.TestCheckResourceAttr(resourceName, "expiry_events.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "expiry_events.0.days_before_expiry", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAccountConfigurationConfig_default(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountConfigurationExists(ctx, resourceName, &accountConfiguration),
+					resource.TestCheckResourceAttr(resourceName, "expiry_events.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "expiry_events.0.days_before_expiry", "45"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAccountConfigurationConfig_basic(30),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountConfigurationExists(ctx, resourceName, &accountConfiguration),
+					resource.TestCheckResourceAttr(resourceName, "expiry_events.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "expiry_events.0.days_before_expiry", "30"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAccountConfigurationExists(ctx context.Context, name string, accountConfiguration *acm.GetAccountConfigurationOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.ACMServiceID, create.ErrActionCheckingExistence, tfacm.ResNameAccountConfiguration, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.ACMServiceID, create.ErrActionCheckingExistence, tfacm.ResNameAccountConfiguration, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ACMClient(ctx)
+
+		input := acm.GetAccountConfigurationInput{}
+		resp, err := conn.GetAccountConfiguration(ctx, &input)
+		if err != nil {
+			return create.Error(names.ACMServiceID, create.ErrActionCheckingExistence, tfacm.ResNameAccountConfiguration, rs.Primary.ID, err)
+		}
+
+		*accountConfiguration = *resp
+
+		return nil
+	}
+}
+
+func testAccPreCheck(ctx context.Context, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ACMClient(ctx)
+
+	input := acm.GetAccountConfigurationInput{}
+
+	_, err := conn.GetAccountConfiguration(ctx, &input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccAccountConfigurationConfig_basic(daysBeforeExpiry int) string {
+	return fmt.Sprintf(`
+resource "aws_acm_account_configuration" "test" {
+  expiry_events {
+    days_before_expiry = %d
+  }
+}
+`, daysBeforeExpiry)
+}
+
+func testAccAccountConfigurationConfig_default() string {
+	return `
+resource "aws_acm_account_configuration" "test" {
+  expiry_events {}
+}
+`
+}

--- a/internal/service/acm/service_package_gen.go
+++ b/internal/service/acm/service_package_gen.go
@@ -23,7 +23,14 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.ServicePackageFrameworkResource {
-	return []*inttypes.ServicePackageFrameworkResource{}
+	return []*inttypes.ServicePackageFrameworkResource{
+		{
+			Factory:  newResourceAccountConfiguration,
+			TypeName: "aws_acm_account_configuration",
+			Name:     "Account Configuration",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*inttypes.ServicePackageSDKDataSource {

--- a/website/docs/r/acm_account_configuration.html.markdown
+++ b/website/docs/r/acm_account_configuration.html.markdown
@@ -1,0 +1,66 @@
+---
+subcategory: "ACM (Certificate Manager)"
+layout: "aws"
+page_title: "AWS: aws_acm_account_configuration"
+description: |-
+  Manages AWS ACM (Certificate Manager) Account Configuration for certificate expiry events.
+---
+
+# Resource: aws_acm_account_configuration
+
+Manages AWS ACM (Certificate Manager) Account Configuration. This resource allows you to configure account-level settings for ACM, such as certificate expiry event notifications.
+
+~> Each AWS account may only have one ACM Account Configuration per region. Multiple configurations of the resource against the same AWS account and region will cause perpetual differences.
+
+~> Deletion of this resource will not modify any settings, only remove the resource from the state.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_acm_account_configuration" "example" {
+  expiry_events {
+    days_before_expiry = 14
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `expiry_events` - (Required) Configuration block for certificate expiry events. See [expiry_events](#expiry_events-block) for details.
+
+The following arguments are optional:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
+### `expiry_events` Block
+
+The `expiry_events` configuration block supports the following arguments:
+
+* `days_before_expiry` - (Optional) Number of days before certificate expiry to send notifications. Must be between `1` and `45`. Defaults to `45`.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - AWS account ID where the ACM account configuration is managed.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import ACM Account Configuration using the `id`. For example:
+
+```terraform
+import {
+  to = aws_acm_account_configuration.example
+  id = "123456789012"
+}
+```
+
+Using `terraform import`, import ACM Account Configuration using the `id`. For example:
+
+```console
+% terraform import aws_acm_account_configuration.example 123456789012
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add a new `aws_acm_account_configuration` resource.

**Note:** I'll defer to a maintainer to see if the resource design is correct. Although the API reference says `expiry_events` and `days_before_expiry` are optional, the fact is that PutConfiguration requires both to be provided in the request, otherwise a 400 error is returned saying that they are missing. Instead of trying to fuss with default states or whatnot, I decided to make `expiry_events` block required and `days_before_expiry` optional with default value of `45` matching the true default in AWS.

Also, while testing during development, I saw error messages related to smerr such as what's below. This package is used in the skaff template and I haven't seen documentation about it, so I am not sure how it works. If there is anything that needs fixing, please help.

```sh
aws_acm_account_configuration.test: Creating...
╷
│ Error: operation error ACM:
│
│   with aws_acm_account_configuration.test,
│   on main.tf line 1, in resource "aws_acm_account_configuration" "test":
│    1: resource "aws_acm_account_configuration" "test" {
│
│ operation error ACM: PutAccountConfiguration, https response error StatusCode: 400, RequestID: c9fd6f32-6a04-412d-b66a-b7807a92407e, ValidationException:    
│ Configuration for events is empty. [smarterr summary template error: template "error_summary" not found] [smarterr detail template error: template
│ "error_detail" not found]
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36007

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [GetAccountConfiguration](https://docs.aws.amazon.com/acm/latest/APIReference/API_GetAccountConfiguration.html) and [PutAccountConfiguration](https://docs.aws.amazon.com/acm/latest/APIReference/API_PutAccountConfiguration.html) for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS="TestAccACMAccountConfiguration_serial/ACMAccountConfiguration" PKG=acm
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/acm/... -v -count 1 -parallel 20 -run='TestAccACMAccountConfiguration_serial/ACMAccountConfiguration'  -timeout 360m -vet=off
2025/08/17 20:14:05 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/17 20:14:05 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccACMAccountConfiguration_serial
=== PAUSE TestAccACMAccountConfiguration_serial
=== CONT  TestAccACMAccountConfiguration_serial
=== RUN   TestAccACMAccountConfiguration_serial/ACMAccountConfiguration
=== RUN   TestAccACMAccountConfiguration_serial/ACMAccountConfiguration/basic
=== RUN   TestAccACMAccountConfiguration_serial/ACMAccountConfiguration/update
--- PASS: TestAccACMAccountConfiguration_serial (64.14s)
    --- PASS: TestAccACMAccountConfiguration_serial/ACMAccountConfiguration (64.14s)
        --- PASS: TestAccACMAccountConfiguration_serial/ACMAccountConfiguration/basic (18.02s)
        --- PASS: TestAccACMAccountConfiguration_serial/ACMAccountConfiguration/update (46.13s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/acm        64.410s

$
```
