### PR TITLE
[Docs] aws_s3_bucket_logging: Add an example using bucket policy to grant permission and clarify S3 key format

### DIFF
--- a/website/docs/r/s3_bucket_logging.html.markdown
+++ b/website/docs/r/s3_bucket_logging.html.markdown
@@ -128,8 +128,8 @@ The `grantee` configuration block supports the following arguments:
 
 The `target_object_key_format` configuration block supports the following arguments:
 
-* `partitioned_prefix` - (Optional) Partitioned S3 key for log objects. [See below](#partitioned_prefix).
-* `simple_prefix` - (Optional) Use the simple format for S3 keys for log objects. To use, set `simple_prefix {}`.
+* `partitioned_prefix` - (Optional) Partitioned S3 key for log objects, in the form `[target_prefix][SourceAccountId]/[SourceRegion]/[SourceBucket]/[YYYY]/[MM]/[DD]/[YYYY]-[MM]-[DD]-[hh]-[mm]-[ss]-[UniqueString]`. Conflicts with `simple_prefix`. [See below](#partitioned_prefix).
+* `simple_prefix` - (Optional) Use the simple format for S3 keys for log objects, in the form `[target_prefix][YYYY]-[MM]-[DD]-[hh]-[mm]-[ss]-[UniqueString]`. To use, set `simple_prefix {}`. Conflicts with `partitioned_prefix`.
 
 ### partitioned_prefix
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Added an example configuration using a bucket policy to grant permission for S3 server access logging.

  * While bucket ACLs can also be used to grant permission, this approach is no longer recommended.
* Additionally, added a description of the S3 key format.



### References
https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html
