### PR TITLE
[doc]: add example values to reserved instance offering

### DIFF
--- a/website/docs/d/rds_reserved_instance_offering.html.markdown
+++ b/website/docs/d/rds_reserved_instance_offering.html.markdown
@@ -31,7 +31,7 @@ This data source supports the following arguments:
 * `duration` - (Required) Duration of the reservation in years or seconds. Valid values are `1`, `3`, `31536000`, `94608000`
 * `multi_az` - (Required) Whether the reservation applies to Multi-AZ deployments.
 * `offering_type` - (Required) Offering type of this reserved DB instance. Valid values are `No Upfront`, `Partial Upfront`, `All Upfront`.
-* `product_description` - (Required) Description of the reserved DB instance.
+* `product_description` - (Required) Description of the reserved DB instance. Example values are `postgresql`, `aurora-postgresql`, `mysql`, `aurora-mysql`, `mariadb`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds most common product types for the reserved instance offering data source. This is to explicitly show that there are differences between aurora postgresql and rds postgresql offerings.