### PR TITLE
[Enhancement] aws_vpc_ipam:  Add `metered_account` argument

### DIFF
--- a/internal/service/ec2/vpc_ipam.go
+++ b/internal/service/ec2/vpc_ipam.go
@@ -72,6 +72,12 @@ func resourceIPAM() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"metered_account": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ValidateDiagFunc: enum.Validate[awstypes.IpamMeteredAccount](),
+			},
 			"operating_regions": {
 				Type:     schema.TypeSet,
 				Required: true,
@@ -145,6 +151,10 @@ func resourceIPAMCreate(ctx context.Context, d *schema.ResourceData, meta any) d
 		input.EnablePrivateGua = aws.Bool(v.(bool))
 	}
 
+	if v, ok := d.GetOk("metered_account"); ok {
+		input.MeteredAccount = awstypes.IpamMeteredAccount(v.(string))
+	}
+
 	if v, ok := d.GetOk("tier"); ok {
 		input.Tier = awstypes.IpamTier(v.(string))
 	}
@@ -185,6 +195,7 @@ func resourceIPAMRead(ctx context.Context, d *schema.ResourceData, meta any) dia
 	d.Set("default_resource_discovery_id", ipam.DefaultResourceDiscoveryId)
 	d.Set(names.AttrDescription, ipam.Description)
 	d.Set("enable_private_gua", ipam.EnablePrivateGua)
+	d.Set("metered_account", ipam.MeteredAccount)
 	if err := d.Set("operating_regions", flattenIPAMOperatingRegions(ipam.OperatingRegions)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting operating_regions: %s", err)
 	}
@@ -213,6 +224,10 @@ func resourceIPAMUpdate(ctx context.Context, d *schema.ResourceData, meta any) d
 
 		if d.HasChange("enable_private_gua") {
 			input.EnablePrivateGua = aws.Bool(d.Get("enable_private_gua").(bool))
+		}
+
+		if d.HasChange("metered_account") {
+			input.MeteredAccount = awstypes.IpamMeteredAccount(d.Get("metered_account").(string))
 		}
 
 		if d.HasChange("operating_regions") {

--- a/internal/service/ec2/vpc_ipam_data_source.go
+++ b/internal/service/ec2/vpc_ipam_data_source.go
@@ -45,6 +45,9 @@ func (d *ipamDataSource) Schema(ctx context.Context, request datasource.SchemaRe
 			"enable_private_gua": schema.BoolAttribute{
 				Computed: true,
 			},
+			"metered_account": schema.StringAttribute{
+				Computed: true,
+			},
 			names.AttrID: schema.StringAttribute{
 				Required: true,
 			},
@@ -124,6 +127,7 @@ type ipamModel struct {
 	IpamARN                               types.String                                              `tfsdk:"arn"`
 	IpamID                                types.String                                              `tfsdk:"id"`
 	IpamRegion                            types.String                                              `tfsdk:"ipam_region"`
+	MeteredAccount                        types.String                                              `tfsdk:"metered_account"`
 	OperatingRegions                      fwtypes.ListNestedObjectValueOf[ipamOperatingRegionModel] `tfsdk:"operating_regions"`
 	OwnerID                               types.String                                              `tfsdk:"owner_id"`
 	PrivateDefaultScopeID                 types.String                                              `tfsdk:"private_default_scope_id"`

--- a/internal/service/ec2/vpc_ipam_data_source_test.go
+++ b/internal/service/ec2/vpc_ipam_data_source_test.go
@@ -33,6 +33,7 @@ func TestAccIPAMDataSource_basic(t *testing.T) { // nosemgrep:ci.vpc-in-test-nam
 					resource.TestCheckResourceAttrPair(dataSourceName, "default_resource_discovery_id", resourceName, "default_resource_discovery_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "default_resource_discovery_association_id", resourceName, "default_resource_discovery_association_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "enable_private_gua", resourceName, "enable_private_gua"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "metered_account", resourceName, "metered_account"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "operating_regions.0.region_name", resourceName, "operating_regions.0.region_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "private_default_scope_id", resourceName, "private_default_scope_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "public_default_scope_id", resourceName, "public_default_scope_id"),

--- a/internal/service/ec2/vpc_ipam_test.go
+++ b/internal/service/ec2/vpc_ipam_test.go
@@ -14,6 +14,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -40,6 +41,7 @@ func TestAccIPAM_basic(t *testing.T) { // nosemgrep:ci.vpc-in-test-name
 					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "ec2", "ipam/{id}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 					resource.TestCheckResourceAttr(resourceName, "enable_private_gua", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "metered_account", string(awstypes.IpamMeteredAccountIpamOwner)),
 					resource.TestCheckResourceAttr(resourceName, "operating_regions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scope_count", "2"),
 					resource.TestMatchResourceAttr(resourceName, "private_default_scope_id", regexache.MustCompile(`^ipam-scope-[0-9a-f]+`)),
@@ -297,6 +299,45 @@ func TestAccIPAM_enablePrivateGUA(t *testing.T) { // nosemgrep:ci.vpc-in-test-na
 	})
 }
 
+func TestAccIPAM_meteredAccount(t *testing.T) { // nosemgrep:ci.vpc-in-test-name
+	ctx := acctest.Context(t)
+	var ipam awstypes.Ipam
+	resourceName := "aws_vpc_ipam.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIPAMDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIPAMConfig_meteredAccount(string(awstypes.IpamMeteredAccountIpamOwner)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIPAMExists(ctx, resourceName, &ipam),
+					resource.TestCheckResourceAttr(resourceName, "metered_account", string(awstypes.IpamMeteredAccountIpamOwner)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccIPAMConfig_meteredAccount(string(awstypes.IpamMeteredAccountResourceOwner)),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIPAMExists(ctx, resourceName, &ipam),
+					resource.TestCheckResourceAttr(resourceName, "metered_account", string(awstypes.IpamMeteredAccountResourceOwner)),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIPAMExists(ctx context.Context, n string, v *awstypes.Ipam) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -471,4 +512,17 @@ resource "aws_vpc_ipam" "test" {
   }
 }
 `, enablePrivateGUA)
+}
+
+func testAccIPAMConfig_meteredAccount(meteredAccount string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+resource "aws_vpc_ipam" "test" {
+  operating_regions {
+    region_name = data.aws_region.current.region
+  }
+  metered_account = %[1]q
+}
+`, meteredAccount)
 }

--- a/website/docs/d/vpc_ipam.html.markdown
+++ b/website/docs/d/vpc_ipam.html.markdown
@@ -38,6 +38,7 @@ This data source exports the following attributes in addition to the arguments a
 * `enable_private_gua` - If private GUA is enabled.
 * `id` - ID of the IPAM resource.
 * `ipam_region` - Region that the IPAM exists in.
+* `metered_account` - AWS account that is charged for active IP addresses managed in IPAM.
 * `operating_regions` - Regions that the IPAM is configured to operate in.
 * `owner_id` - ID of the account that owns this IPAM.
 * `private_default_scope_id` - ID of the default private scope.

--- a/website/docs/r/vpc_ipam.html.markdown
+++ b/website/docs/r/vpc_ipam.html.markdown
@@ -63,6 +63,7 @@ This resource supports the following arguments:
 * `cascade` - (Optional) Enables you to quickly delete an IPAM, private scopes, pools in private scopes, and any allocations in the pools in private scopes.
 * `description` - (Optional) A description for the IPAM.
 * `enable_private_gua` - (Optional) Enable this option to use your own GUA ranges as private IPv6 addresses. Default: `false`.
+* `metered_account` - (Optional) AWS account that is charged for active IP addresses managed in IPAM. Valid values are `ipam-owner` (default) and `resource-owner`.
 * `operating_regions` - (Required) Determines which locales can be chosen when you create pools. Locale is the Region where you want to make an IPAM pool available for allocations. You can only create pools with locales that match the operating Regions of the IPAM. You can only create VPCs from a pool whose locale matches the VPC's Region. You specify a region using the [region_name](#operating_regions) parameter. You **must** set your provider block region as an operating_region.
 * `tier` - (Optional) specifies the IPAM tier. Valid options include `free` and `advanced`. Default is `advanced`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* Add `metered_account` argument to the `aws_vpc_ipam` resource.
* Add `metered_account` attribute to the `aws_vpc_ipam` data source.

### Relations

Closes #43966 

### References
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateIpam.html#API_CreateIpam_RequestParameters

### Output from Acceptance Testing
```console


```
