### PR TITLE
r/aws_lambda_permission(test): scope down invoke function url permissions

### DIFF
--- a/internal/service/lambda/permission_test.go
+++ b/internal/service/lambda/permission_test.go
@@ -644,6 +644,7 @@ func TestAccLambdaPermission_FunctionURLs_iam(t *testing.T) {
 
 	resourceName := "aws_lambda_permission.test"
 	functionResourceName := "aws_lambda_function.test"
+	roleResourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -656,7 +657,7 @@ func TestAccLambdaPermission_FunctionURLs_iam(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPermissionExists(ctx, resourceName, &statement),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAction, "lambda:InvokeFunctionUrl"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrPrincipal, "*"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrPrincipal, roleResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "statement_id", "AllowExecutionWithIAM"),
 					resource.TestCheckResourceAttr(resourceName, "qualifier", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceName, "function_name"),
@@ -680,6 +681,7 @@ func TestAccLambdaPermission_FunctionURLs_none(t *testing.T) {
 
 	resourceName := "aws_lambda_permission.test"
 	functionResourceName := "aws_lambda_function.test"
+	roleResourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -692,7 +694,7 @@ func TestAccLambdaPermission_FunctionURLs_none(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPermissionExists(ctx, resourceName, &statement),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAction, "lambda:InvokeFunctionUrl"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrPrincipal, "*"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrPrincipal, roleResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "statement_id", "AllowExecutionFromWithoutAuth"),
 					resource.TestCheckResourceAttr(resourceName, "qualifier", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceName, "function_name"),
@@ -1060,7 +1062,7 @@ resource "aws_lambda_permission" "test" {
   statement_id           = "AllowExecutionWithIAM"
   action                 = "lambda:InvokeFunctionUrl"
   function_name          = aws_lambda_function.test.function_name
-  principal              = "*"
+  principal              = aws_iam_role.test.arn
   function_url_auth_type = "AWS_IAM"
 }
 `)
@@ -1072,7 +1074,7 @@ resource "aws_lambda_permission" "test" {
   statement_id           = "AllowExecutionFromWithoutAuth"
   action                 = "lambda:InvokeFunctionUrl"
   function_name          = aws_lambda_function.test.function_name
-  principal              = "*"
+  principal              = aws_iam_role.test.arn
   function_url_auth_type = "NONE"
 }
 `)


### PR DESCRIPTION



<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Previously the `_FunctionURLs` acceptance test configurations granted permissions to a wildcard (`*`) principal. The permissions have been scoped down to an individual IAM role for least privileged access instead.




### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html#urls-auth-iam

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=lambda TESTS=TestAccLambdaPermission_FunctionURLs
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaPermission_FunctionURLs'  -timeout 360m -vet=off
2025/08/20 19:57:29 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/20 19:57:29 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccLambdaPermission_FunctionURLs_none (30.39s)
--- PASS: TestAccLambdaPermission_FunctionURLs_iam (36.38s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     43.043s
```