### PR TITLE
[Docs] aws_bcmdataexports_export: Add `BILLING_VIEW_ARN` to documentation example and clarify `table_configurations` and `query`

### DIFF
--- a/website/docs/r/bcmdataexports_export.html.markdown
+++ b/website/docs/r/bcmdataexports_export.html.markdown
@@ -69,8 +69,8 @@ The following arguments are required:
 
 ### `data_query` Argument Reference
 
-* `query_statement` - (Required) Query statement.
-* `table_configurations` - (Optional) Table configuration.
+* `query_statement` - (Required) Query statement. The SQL table name for CUR 2.0 is `COST_AND_USAGE_REPORT`. See the [AWS documentation](https://docs.aws.amazon.com/cur/latest/userguide/table-dictionary-cur2.html) for a list of available columns.
+* `table_configurations` - (Optional) Table configuration. See the [AWS documentation](https://docs.aws.amazon.com/cur/latest/userguide/table-dictionary-cur2.html#cur2-table-configurations) for the available configurations. In addition to those listed in the documentation, `BILLING_VIEW_ARN` must also be included, as shown in the example above.
 
 ### `destination_configurations` Argument Reference
 

--- a/website/docs/r/bcmdataexports_export.html.markdown
+++ b/website/docs/r/bcmdataexports_export.html.markdown
@@ -15,6 +15,8 @@ Terraform resource for managing an AWS BCM Data Exports Export.
 ### Basic Usage
 
 ```terraform
+data "aws_caller_identity" "current" {}
+
 resource "aws_bcmdataexports_export" "test" {
   export {
     name = "testexample"
@@ -22,6 +24,7 @@ resource "aws_bcmdataexports_export" "test" {
       query_statement = "SELECT identity_line_item_id, identity_time_interval, line_item_product_code,line_item_unblended_cost FROM COST_AND_USAGE_REPORT"
       table_configurations = {
         COST_AND_USAGE_REPORT = {
+          BILLING_VIEW_ARN                      = "arn:aws:billing::${data.aws_caller_identity.current.account_id}:billingview/primary"
           TIME_GRANULARITY                      = "HOURLY",
           INCLUDE_RESOURCES                     = "FALSE",
           INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY = "FALSE",


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* As reported in #43978, if `COST_AND_USAGE_REPORT.BILLING_VIEW_ARN` is not included in `table_configuration`, it is automatically added in the refreshed state. This mismatch between the configuration and the refreshed state causes the following error:

  > produced an unexpected new value:
  > export\[0].data\_query\[0].table\_configurations\["COST\_AND\_USAGE\_REPORT"]: new element "BILLING\_VIEW\_ARN" has appeared.

  * The type of `table_configuration` is `fwtypes.MapOfMapOfStringType`, and part of it is marked as `Computed`. It would not be straightforward to treat only a subset of the map as `Computed`.

* As a workaround, adding `BILLING_VIEW_ARN` to the configuration allows `terraform apply` to succeed.

* Although this does not address the root cause, the documentation example has been updated to include `BILLING_VIEW_ARN`.

* References for `query` and `table_configuration` have also been added.

### Relations
Relates #43978

### References
https://docs.aws.amazon.com/cur/latest/userguide/table-dictionary-cur2.html


