### PR TITLE
[bugfix] aws_chatbot_slack_channel_configuration: Mark `configuration_name` as ForceNew

### DIFF
--- a/internal/service/chatbot/slack_channel_configuration.go
+++ b/internal/service/chatbot/slack_channel_configuration.go
@@ -59,6 +59,9 @@ func (r *slackChannelConfigurationResource) Schema(ctx context.Context, request 
 			"chat_configuration_arn": framework.ARNAttributeComputedOnly(),
 			"configuration_name": schema.StringAttribute{
 				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"guardrail_policy_arns": schema.ListAttribute{
 				CustomType: fwtypes.ListOfStringType,

--- a/internal/service/chatbot/slack_channel_configuration_test.go
+++ b/internal/service/chatbot/slack_channel_configuration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/chatbot/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -46,6 +47,8 @@ func testAccSlackChannelConfiguration_basic(t *testing.T) {
 
 	var slackchannelconfiguration types.SlackChannelConfiguration
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameUpdated := rName + "-updated"
+	resourceName := testResourceSlackChannelConfiguration
 
 	// The slack workspace must be created via the AWS Console. It cannot be created via APIs or Terraform.
 	// Once it is created, export the name of the workspace in the env variable for this test
@@ -80,6 +83,24 @@ func testAccSlackChannelConfiguration_basic(t *testing.T) {
 				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(testResourceSlackChannelConfiguration, "chat_configuration_arn"),
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "chat_configuration_arn",
+			},
+			{
+				Config: testAccSlackChannelConfigurationConfig_basic(rNameUpdated, channelID, teamID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSlackChannelConfigurationExists(ctx, testResourceSlackChannelConfiguration, &slackchannelconfiguration),
+					resource.TestCheckResourceAttr(testResourceSlackChannelConfiguration, "configuration_name", rNameUpdated),
+					acctest.MatchResourceAttrGlobalARN(ctx, testResourceSlackChannelConfiguration, "chat_configuration_arn", "chatbot", regexache.MustCompile(fmt.Sprintf(`chat-configuration/slack-channel/%s`, rName))),
+					resource.TestCheckResourceAttrPair(testResourceSlackChannelConfiguration, names.AttrIAMRoleARN, "aws_iam_role.test", names.AttrARN),
+					resource.TestCheckResourceAttr(testResourceSlackChannelConfiguration, "slack_channel_id", channelID),
+					resource.TestCheckResourceAttrSet(testResourceSlackChannelConfiguration, "slack_channel_name"),
+					resource.TestCheckResourceAttr(testResourceSlackChannelConfiguration, "slack_team_id", teamID),
+					resource.TestCheckResourceAttrSet(testResourceSlackChannelConfiguration, "slack_team_name"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations

Closes #43995

### Output from Acceptance Testing

```console


```
