### PR TITLE
Fix doc for batch_job_definition resource

### DIFF
--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -344,7 +344,7 @@ The following arguments are optional:
 
 #### eks_metadata
 
-* `labels` - Key-value pairs used to identify, sort, and organize cube resources.
+* `labels` - Key-value pairs used to identify, sort, and organize kubernetes resources.
 
 #### `eks_secret`
 


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

Not required.

## Changes to Security Controls

None

### Description

- The documentation for `aws_batch_job_definition` resource's   `eks_properties.pod_properties.metadata.labels` is probably incorrect, I have made a correction to it.
- I must add that terraform docs have it same as [AWS docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-batch-jobdefinition-eksmetadata.html#cfn-batch-jobdefinition-eksmetadata-annotations:~:text=Key%2Dvalue%20pairs%20used%20to%20identify%2C%20sort%2C%20and%20organize%20cube%20resources.) which seem wrong too.
 
### Relations

None

### References

Link to [AWS API docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-batch-jobdefinition-eksmetadata.html#cfn-batch-jobdefinition-eksmetadata-annotations:~:text=Key%2Dvalue%20pairs%20used%20to%20identify%2C%20sort%2C%20and%20organize%20cube%20resources.) which seem wrong too.
  from where this was probably copied.


### Output from Acceptance Testing

Is this needed for a single work change? I did run the test regardless and it failed with this msg after 2 hours `make: *** [testacc] Error 1`
