### PR TITLE
Add data source to list glue catalog tables in a given catalog database.

### DIFF
--- a/internal/service/glue/catalog_tables_data_source.go
+++ b/internal/service/glue/catalog_tables_data_source.go
@@ -1,0 +1,428 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package glue
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/glue"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/glue/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_glue_catalog_tables", name="Catalog Tables")
+func dataSourceCatalogTables() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceCatalogTablesRead,
+
+		Schema: map[string]*schema.Schema{
+			names.AttrCatalogID: {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			names.AttrDatabaseName: {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"expression": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A regular expression to filter the list of table names",
+			},
+			"table_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The type of tables to return. Valid values are EXTERNAL_TABLE, MANAGED_TABLE, VIRTUAL_VIEW",
+			},
+			"tables": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						names.AttrARN: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrCatalogID: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrDatabaseName: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrDescription: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrName: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrOwner: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrParameters: {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"partition_keys": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									names.AttrComment: {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									names.AttrName: {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									names.AttrParameters: {
+										Type:     schema.TypeMap,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									names.AttrType: {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"retention": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"storage_descriptor": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"additional_locations": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"bucket_columns": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+									"columns": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												names.AttrComment: {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												names.AttrName: {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												names.AttrParameters: {
+													Type:     schema.TypeMap,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												names.AttrType: {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"compressed": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"input_format": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									names.AttrLocation: {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"number_of_buckets": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"output_format": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									names.AttrParameters: {
+										Type:     schema.TypeMap,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"ser_de_info": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												names.AttrName: {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												names.AttrParameters: {
+													Type:     schema.TypeMap,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"serialization_library": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"schema_reference": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"schema_id": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"registry_name": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"schema_arn": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"schema_name": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+														},
+													},
+												},
+												"schema_version_id": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"schema_version_number": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"skewed_info": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"skewed_column_names": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Schema{
+														Type: schema.TypeString,
+													},
+												},
+												"skewed_column_value_location_maps": {
+													Type:     schema.TypeMap,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"skewed_column_values": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+									"sort_columns": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"column": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"sort_order": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"stored_as_sub_directories": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"table_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"target_table": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									names.AttrCatalogID: {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									names.AttrDatabaseName: {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									names.AttrName: {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									names.AttrRegion: {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"view_original_text": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"view_expanded_text": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceCatalogTablesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	conn := meta.(*conns.AWSClient).GlueClient(ctx)
+
+	catalogID := createCatalogID(d, meta.(*conns.AWSClient).AccountID(ctx))
+	dbName := d.Get(names.AttrDatabaseName).(string)
+
+	d.SetId(fmt.Sprintf("%s:%s", catalogID, dbName))
+
+	input := &glue.GetTablesInput{
+		CatalogId:    aws.String(catalogID),
+		DatabaseName: aws.String(dbName),
+	}
+
+	if v, ok := d.GetOk("expression"); ok {
+		input.Expression = aws.String(v.(string))
+	}
+
+	var tables []awstypes.Table
+	paginator := glue.NewGetTablesPaginator(conn, input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "reading Glue Catalog Tables for database %s: %s", dbName, err)
+		}
+
+		tables = append(tables, page.TableList...)
+	}
+
+	// Filter by table type if specified
+	if v, ok := d.GetOk("table_type"); ok {
+		tableType := v.(string)
+		var filteredTables []awstypes.Table
+		for _, table := range tables {
+			if aws.ToString(table.TableType) == tableType {
+				filteredTables = append(filteredTables, table)
+			}
+		}
+		tables = filteredTables
+	}
+
+	err := d.Set(names.AttrCatalogID, catalogID)
+	if err != nil {
+		return nil
+	}
+	err = d.Set(names.AttrDatabaseName, dbName)
+	if err != nil {
+		return nil
+	}
+
+	if err := d.Set("tables", flattenCatalogTables(ctx, tables, catalogID, dbName, meta.(*conns.AWSClient))); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting tables: %s", err)
+	}
+
+	return diags
+}
+
+func flattenCatalogTables(ctx context.Context, tables []awstypes.Table, catalogID, dbName string, awsClient *conns.AWSClient) []map[string]any {
+	if len(tables) == 0 {
+		return nil
+	}
+
+	var tfList []map[string]any
+
+	for _, table := range tables {
+		tfMap := map[string]any{}
+
+		tableArn := arn.ARN{
+			Partition: awsClient.Partition(ctx),
+			Service:   "glue",
+			Region:    awsClient.Region(ctx),
+			AccountID: awsClient.AccountID(ctx),
+			Resource:  fmt.Sprintf("table/%s/%s", dbName, aws.ToString(table.Name)),
+		}.String()
+		tfMap[names.AttrARN] = tableArn
+
+		tfMap[names.AttrCatalogID] = catalogID
+		tfMap[names.AttrDatabaseName] = dbName
+		tfMap[names.AttrName] = aws.ToString(table.Name)
+		tfMap[names.AttrDescription] = aws.ToString(table.Description)
+		tfMap[names.AttrOwner] = aws.ToString(table.Owner)
+		tfMap["retention"] = table.Retention
+		tfMap[names.AttrParameters] = table.Parameters
+		tfMap["table_type"] = aws.ToString(table.TableType)
+		tfMap["view_original_text"] = aws.ToString(table.ViewOriginalText)
+		tfMap["view_expanded_text"] = aws.ToString(table.ViewExpandedText)
+
+		if table.StorageDescriptor != nil {
+			tfMap["storage_descriptor"] = flattenStorageDescriptor(table.StorageDescriptor)
+		}
+
+		if len(table.PartitionKeys) > 0 {
+			tfMap["partition_keys"] = flattenColumns(table.PartitionKeys)
+		}
+
+		if table.TargetTable != nil {
+			tfMap["target_table"] = []map[string]any{flattenTableTargetTable(table.TargetTable)}
+		}
+
+		tfList = append(tfList, tfMap)
+	}
+
+	return tfList
+}

--- a/internal/service/glue/catalog_tables_data_source_test.go
+++ b/internal/service/glue/catalog_tables_data_source_test.go
@@ -1,0 +1,333 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package glue_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccGlueCatalogTablesDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	datasourceName := "data.aws_glue_catalog_tables.test"
+
+	dbName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	tName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	tName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlueServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCatalogTablesDataSourceConfig_basic(dbName, tName1, tName2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(datasourceName, names.AttrDatabaseName, dbName),
+					resource.TestCheckResourceAttr(datasourceName, "tables.#", "2"),
+					resource.TestCheckResourceAttr(datasourceName, "tables.0.name", tName1),
+					resource.TestCheckResourceAttr(datasourceName, "tables.1.name", tName2),
+					resource.TestCheckResourceAttr(datasourceName, "tables.0.table_type", "EXTERNAL_TABLE"),
+					resource.TestCheckResourceAttr(datasourceName, "tables.1.table_type", "EXTERNAL_TABLE"),
+					resource.TestCheckResourceAttrSet(datasourceName, "tables.0.arn"),
+					resource.TestCheckResourceAttrSet(datasourceName, "tables.1.arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGlueCatalogTablesDataSource_expression(t *testing.T) {
+	ctx := acctest.Context(t)
+	datasourceName := "data.aws_glue_catalog_tables.test"
+
+	dbName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	tName1 := "table_test_1"
+	tName2 := "table_test_2"
+	tName3 := "other_table"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlueServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCatalogTablesDataSourceConfig_expression(dbName, tName1, tName2, tName3),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(datasourceName, names.AttrDatabaseName, dbName),
+					resource.TestCheckResourceAttr(datasourceName, "expression", "table_test_.*"),
+					resource.TestCheckResourceAttr(datasourceName, "tables.#", "2"),
+					resource.TestCheckResourceAttr(datasourceName, "tables.0.name", tName1),
+					resource.TestCheckResourceAttr(datasourceName, "tables.1.name", tName2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGlueCatalogTablesDataSource_tableType(t *testing.T) {
+	ctx := acctest.Context(t)
+	datasourceName := "data.aws_glue_catalog_tables.test"
+
+	dbName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	tName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	tName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlueServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCatalogTablesDataSourceConfig_tableType(dbName, tName1, tName2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(datasourceName, names.AttrDatabaseName, dbName),
+					resource.TestCheckResourceAttr(datasourceName, "table_type", "EXTERNAL_TABLE"),
+					resource.TestCheckResourceAttr(datasourceName, "tables.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "tables.0.name", tName1),
+					resource.TestCheckResourceAttr(datasourceName, "tables.0.table_type", "EXTERNAL_TABLE"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCatalogTablesDataSourceConfig_basic(dbName, tName1, tName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test1" {
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[2]q
+
+  description = "Test table 1"
+  table_type  = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL              = "TRUE"
+    "parquet.compression" = "SNAPPY"
+  }
+
+  storage_descriptor {
+    location      = "s3://my-bucket/event-streams/my-stream1"
+    input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+
+    ser_de_info {
+      name                  = "my-stream1"
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+
+      parameters = {
+        "serialization.format" = 1
+      }
+    }
+
+    columns {
+      name = "my_string"
+      type = "string"
+    }
+  }
+}
+
+resource "aws_glue_catalog_table" "test2" {
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[3]q
+
+  description = "Test table 2"
+  table_type  = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL              = "TRUE"
+    "parquet.compression" = "SNAPPY"
+  }
+
+  storage_descriptor {
+    location      = "s3://my-bucket/event-streams/my-stream2"
+    input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+
+    ser_de_info {
+      name                  = "my-stream2"
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+
+      parameters = {
+        "serialization.format" = 1
+      }
+    }
+
+    columns {
+      name = "my_string"
+      type = "string"
+    }
+  }
+}
+
+data "aws_glue_catalog_tables" "test" {
+  database_name = aws_glue_catalog_database.test.name
+
+  depends_on = [
+    aws_glue_catalog_table.test1,
+    aws_glue_catalog_table.test2,
+  ]
+}
+`, dbName, tName1, tName2)
+}
+
+func testAccCatalogTablesDataSourceConfig_expression(dbName, tName1, tName2, tName3 string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test1" {
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[2]q
+
+  description = "Test table 1"
+  table_type  = "EXTERNAL_TABLE"
+
+  storage_descriptor {
+    location      = "s3://my-bucket/event-streams/my-stream1"
+    input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+
+    ser_de_info {
+      name                  = "my-stream1"
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+    }
+
+    columns {
+      name = "my_string"
+      type = "string"
+    }
+  }
+}
+
+resource "aws_glue_catalog_table" "test2" {
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[3]q
+
+  description = "Test table 2"
+  table_type  = "EXTERNAL_TABLE"
+
+  storage_descriptor {
+    location      = "s3://my-bucket/event-streams/my-stream2"
+    input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+
+    ser_de_info {
+      name                  = "my-stream2"
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+    }
+
+    columns {
+      name = "my_string"
+      type = "string"
+    }
+  }
+}
+
+resource "aws_glue_catalog_table" "test3" {
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[4]q
+
+  description = "Other table"
+  table_type  = "EXTERNAL_TABLE"
+
+  storage_descriptor {
+    location      = "s3://my-bucket/event-streams/my-stream3"
+    input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+
+    ser_de_info {
+      name                  = "my-stream3"
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+    }
+
+    columns {
+      name = "my_string"
+      type = "string"
+    }
+  }
+}
+
+data "aws_glue_catalog_tables" "test" {
+  database_name = aws_glue_catalog_database.test.name
+  expression    = "table_test_.*"
+
+  depends_on = [
+    aws_glue_catalog_table.test1,
+    aws_glue_catalog_table.test2,
+    aws_glue_catalog_table.test3,
+  ]
+}
+`, dbName, tName1, tName2, tName3)
+}
+
+func testAccCatalogTablesDataSourceConfig_tableType(dbName, tName1, tName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test1" {
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[2]q
+
+  description = "External table"
+  table_type  = "EXTERNAL_TABLE"
+
+  storage_descriptor {
+    location      = "s3://my-bucket/event-streams/my-stream1"
+    input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+
+    ser_de_info {
+      name                  = "my-stream1"
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+    }
+
+    columns {
+      name = "my_string"
+      type = "string"
+    }
+  }
+}
+
+resource "aws_glue_catalog_table" "test2" {
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[3]q
+
+  description = "Virtual view"
+  table_type  = "VIRTUAL_VIEW"
+
+  view_original_text = "SELECT * FROM test1"
+  view_expanded_text = "SELECT my_string FROM test1"
+
+  storage_descriptor {
+    columns {
+      name = "my_string"
+      type = "string"
+    }
+  }
+}
+
+data "aws_glue_catalog_tables" "test" {
+  database_name = aws_glue_catalog_database.test.name
+  table_type    = "EXTERNAL_TABLE"
+
+  depends_on = [
+    aws_glue_catalog_table.test1,
+    aws_glue_catalog_table.test2,
+  ]
+}
+`, dbName, tName1, tName2)
+}

--- a/internal/service/glue/service_package_gen.go
+++ b/internal/service/glue/service_package_gen.go
@@ -49,6 +49,12 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*inttypes.Service
 			Region:   unique.Make(inttypes.ResourceRegionDefault()),
 		},
 		{
+			Factory:  dataSourceCatalogTables,
+			TypeName: "aws_glue_catalog_tables",
+			Name:     "Catalog Tables",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+		{
 			Factory:  dataSourceConnection,
 			TypeName: "aws_glue_connection",
 			Name:     "Connection",

--- a/website/docs/d/glue_catalog_tables.html.markdown
+++ b/website/docs/d/glue_catalog_tables.html.markdown
@@ -1,0 +1,140 @@
+---
+subcategory: "Glue"
+layout: "aws"
+page_title: "AWS: aws_glue_catalog_tables"
+description: |-
+  Get information on AWS Glue Data Catalog Tables within a database
+---
+
+# Data Source: aws_glue_catalog_tables
+
+This data source can be used to fetch information about multiple AWS Glue Data Catalog Tables within a database.
+
+## Example Usage
+
+```terraform
+data "aws_glue_catalog_tables" "example" {
+  database_name = "my_database"
+}
+```
+
+### Filter by table name expression
+
+```terraform
+data "aws_glue_catalog_tables" "example" {
+  database_name = "my_database"
+  expression    = "test_.*"
+}
+```
+
+### Filter by table type
+
+```terraform
+data "aws_glue_catalog_tables" "example" {
+  database_name = "my_database"
+  table_type    = "EXTERNAL_TABLE"
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `database_name` - (Required) Name of the metadata database where the table metadata resides.
+* `catalog_id` - (Optional) ID of the Glue Catalog and database where the table metadata resides. If omitted, this defaults to the current AWS Account ID.
+* `expression` - (Optional) A regular expression to filter the list of table names. Only table names matching this expression will be returned.
+* `table_type` - (Optional) The type of tables to return. Valid values are `EXTERNAL_TABLE`, `MANAGED_TABLE`, `VIRTUAL_VIEW`.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `id` - Catalog ID and Database name.
+* `tables` - List of tables in the database. See [`tables`](#tables) below.
+
+### tables
+
+Each table in the list contains the following attributes:
+
+* `arn` - The ARN of the Glue Table.
+* `catalog_id` - ID of the Glue Catalog where the table resides.
+* `database_name` - Name of the metadata database where the table metadata resides.
+* `description` - Description of the table.
+* `name` - Name of the table.
+* `owner` - Owner of the table.
+* `parameters` - Properties associated with this table, as a list of key-value pairs.
+* `partition_keys` - Configuration block of columns by which the table is partitioned. Only primitive types are supported as partition keys. See [`partition_keys`](#partition_keys) below.
+* `retention` - Retention time for this table.
+* `storage_descriptor` - Configuration block for information about the physical storage of this table. For more information, refer to the [Glue Developer Guide](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-StorageDescriptor). See [`storage_descriptor`](#storage_descriptor) below.
+* `table_type` - Type of this table (EXTERNAL_TABLE, VIRTUAL_VIEW, etc.). While optional, some Athena DDL queries such as `ALTER TABLE` and `SHOW CREATE TABLE` will fail if this argument is empty.
+* `target_table` - Configuration block of a target table for resource linking. See [`target_table`](#target_table) below.
+* `view_expanded_text` - If the table is a view, the expanded text of the view; otherwise null.
+* `view_original_text` - If the table is a view, the original text of the view; otherwise null.
+
+### partition_keys
+
+* `comment` - Free-form text comment.
+* `name` - Name of the Partition Key.
+* `parameters` - Map of key-value pairs.
+* `type` - Datatype of data in the Partition Key.
+
+### storage_descriptor
+
+* `additional_locations` - List of locations that point to the path where a Delta table is located
+* `bucket_columns` - List of reducer grouping columns, clustering columns, and bucketing columns in the table.
+* `columns` - Configuration block for columns in the table. See [`columns`](#columns) below.
+* `compressed` - Whether the data in the table is compressed.
+* `input_format` - Input format: SequenceFileInputFormat (binary), or TextInputFormat, or a custom format.
+* `location` - Physical location of the table. By default, this takes the form of the warehouse location, followed by the database location in the warehouse, followed by the table name.
+* `number_of_buckets` - Is if the table contains any dimension columns.
+* `output_format` - Output format: SequenceFileOutputFormat (binary), or IgnoreKeyTextOutputFormat, or a custom format.
+* `parameters` - User-supplied properties in key-value form.
+* `schema_reference` - Object that references a schema stored in the AWS Glue Schema Registry. See [`schema_reference`](#schema_reference) below.
+* `ser_de_info` - Configuration block for serialization and deserialization ("SerDe") information. See [`ser_de_info`](#ser_de_info) below.
+* `skewed_info` - Configuration block with information about values that appear very frequently in a column (skewed values). See [`skewed_info`](#skewed_info) below.
+* `sort_columns` - Configuration block for the sort order of each bucket in the table. See [`sort_columns`](#sort_columns) below.
+* `stored_as_sub_directories` - Whether the table data is stored in subdirectories.
+
+#### columns
+
+* `comment` - Free-form text comment.
+* `name` - Name of the Column.
+* `parameters` - Key-value pairs defining properties associated with the column.
+* `type` - Datatype of data in the Column.
+
+#### schema_reference
+
+* `schema_id` - Configuration block that contains schema identity fields. See [`schema_id`](#schema_id) below.
+* `schema_version_id` - Unique ID assigned to a version of the schema.
+* `schema_version_number` - Version number of the schema.
+
+##### schema_id
+
+* `registry_name` - Name of the schema registry that contains the schema.
+* `schema_arn` - ARN of the schema.
+* `schema_name` - Name of the schema.
+
+#### ser_de_info
+
+* `name` - Name of the SerDe.
+* `parameters` - Map of initialization parameters for the SerDe, in key-value form.
+* `serialization_library` - Usually the class that implements the SerDe. An example is `org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe`.
+
+#### sort_columns
+
+* `column` - Name of the column.
+* `sort_order` - Whether the column is sorted in ascending (`1`) or descending order (`0`).
+
+#### skewed_info
+
+* `skewed_column_names` - List of names of columns that contain skewed values.
+* `skewed_column_value_location_maps` - List of values that appear so frequently as to be considered skewed.
+* `skewed_column_values` - Map of skewed values to the columns that contain them.
+
+### target_table
+
+* `catalog_id` - ID of the Data Catalog in which the table resides.
+* `database_name` - Name of the catalog database that contains the target table.
+* `name` - Name of the target table.
+* `region` - Region of the target table.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to security controls. This PR only adds a new read-only data source that uses existing AWS Glue API permissions.

### Description

Adds a new `aws_glue_catalog_tables` data source that allows users to retrieve information about multiple AWS Glue Catalog tables within a database. This complements the
existing `aws_glue_catalog_table` data source by providing the ability to list and filter tables in bulk.

**Key Features:**
- Lists all tables within a specified Glue Catalog database
- Optional filtering by table name using regular expressions (`expression` parameter)
- Optional filtering by table type (`table_type` parameter: `EXTERNAL_TABLE`, `MANAGED_TABLE`, `VIRTUAL_VIEW`)
- Returns comprehensive table metadata including storage descriptors, partition keys, and table parameters
- Supports pagination for databases with large numbers of tables


### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccGlueCatalogTablesDataSource PKG=glue

=== RUN   TestAccGlueCatalogTablesDataSource_basic
=== PAUSE TestAccGlueCatalogTablesDataSource_basic
=== RUN   TestAccGlueCatalogTablesDataSource_expression
=== PAUSE TestAccGlueCatalogTablesDataSource_expression
=== RUN   TestAccGlueCatalogTablesDataSource_tableType
=== PAUSE TestAccGlueCatalogTablesDataSource_tableType
=== CONT  TestAccGlueCatalogTablesDataSource_basic
=== CONT  TestAccGlueCatalogTablesDataSource_tableType
=== CONT  TestAccGlueCatalogTablesDataSource_expression
--- PASS: TestAccGlueCatalogTablesDataSource_basic (9.18s)
--- PASS: TestAccGlueCatalogTablesDataSource_expression (9.49s)
--- PASS: TestAccGlueCatalogTablesDataSource_tableType (9.51s)
PASS
ok    github.com/hashicorp/terraform-provider-aws/internal/service/glue       13.466s
```

Example Usage
```hcl
# Get all tables in a database
data "aws_glue_catalog_tables" "all" {
  database_name = "my_database"
}

# Filter tables by name pattern
data "aws_glue_catalog_tables" "test_tables" {
  database_name = "my_database"
  expression    = "test_.*"
}

# Filter by table type
data "aws_glue_catalog_tables" "external_tables" {
  database_name = "my_database"
  table_type    = "EXTERNAL_TABLE"
}

# Use the results
output "table_names" {
  value = [for table in data.aws_glue_catalog_tables.all.tables : table.name]
}
```

Files Changed

- internal/service/glue/catalog_tables_data_source.go - New data source implementation
- internal/service/glue/catalog_tables_data_source_test.go - Comprehensive test coverage
- internal/service/glue/service_package_gen.go - Register new data source
- website/docs/d/glue_catalog_tables.html.markdown - Documentation with examples
