### PR TITLE
Add "parameter" attributes to aws_db_parameter_group and aws_rds_cluster_parameter_group data sources

### DIFF
--- a/internal/service/rds/cluster_parameter_group_data_source.go
+++ b/internal/service/rds/cluster_parameter_group_data_source.go
@@ -6,12 +6,17 @@ package rds
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/types"
+	fwtypes "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	ifwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -30,7 +35,7 @@ type clusterParameterGroupDataSource struct {
 	framework.DataSourceWithModel[clusterParameterGroupDataSourceModel]
 }
 
-func (d *clusterParameterGroupDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, response *datasource.SchemaResponse) {
+func (d *clusterParameterGroupDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, response *datasource.SchemaResponse) {
 	response.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			names.AttrARN: framework.ARNAttributeComputedOnly(),
@@ -42,6 +47,24 @@ func (d *clusterParameterGroupDataSource) Schema(_ context.Context, _ datasource
 			},
 			names.AttrName: schema.StringAttribute{
 				Required: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrParameters: schema.SetNestedBlock{
+				CustomType: ifwtypes.NewSetNestedObjectTypeOf[parameterModel](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"apply_method": schema.StringAttribute{
+							Computed: true,
+						},
+						names.AttrName: schema.StringAttribute{
+							Computed: true,
+						},
+						names.AttrValue: schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -75,13 +98,64 @@ func (d *clusterParameterGroupDataSource) Read(ctx context.Context, request data
 
 	data.Family = fwflex.StringToFramework(ctx, output.DBParameterGroupFamily)
 
+	// Read parameters
+	input := &rds.DescribeDBClusterParametersInput{
+		DBClusterParameterGroupName: aws.String(data.Name.ValueString()),
+	}
+
+	parameters, err := findDBClusterParameters(ctx, conn, input, tfslices.PredicateTrue[*types.Parameter]())
+
+	if err != nil {
+		response.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.RDS, create.ErrActionReading, DSNameClusterParameterGroup+" parameters", data.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	// Convert parameters to parameterModel structs for Plugin Framework
+	parameterModels := make([]parameterModel, 0, len(parameters))
+	for _, param := range parameters {
+		if param.ParameterName == nil {
+			continue
+		}
+
+		model := parameterModel{
+			ApplyMethod: fwtypes.StringValue(string(param.ApplyMethod)),
+			Name:        fwtypes.StringValue(aws.ToString(param.ParameterName)),
+			Value:       fwtypes.StringValue(""),
+		}
+
+		if param.ParameterValue != nil {
+			model.Value = fwtypes.StringValue(aws.ToString(param.ParameterValue))
+		}
+
+		parameterModels = append(parameterModels, model)
+	}
+
+	// Convert to SetNestedObjectValueOf for Plugin Framework
+	parametersValue, diags := ifwtypes.NewSetNestedObjectValueOfValueSlice(ctx, parameterModels)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	data.Parameters = parametersValue
+
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
 type clusterParameterGroupDataSourceModel struct {
 	framework.WithRegionModel
-	ARN         types.String `tfsdk:"arn"`
-	Description types.String `tfsdk:"description"`
-	Family      types.String `tfsdk:"family"`
-	Name        types.String `tfsdk:"name"`
+	ARN         fwtypes.String                                  `tfsdk:"arn"`
+	Description fwtypes.String                                  `tfsdk:"description"`
+	Family      fwtypes.String                                  `tfsdk:"family"`
+	Name        fwtypes.String                                  `tfsdk:"name"`
+	Parameters  ifwtypes.SetNestedObjectValueOf[parameterModel] `tfsdk:"parameters"`
+}
+
+type parameterModel struct {
+	ApplyMethod fwtypes.String `tfsdk:"apply_method"`
+	Name        fwtypes.String `tfsdk:"name"`
+	Value       fwtypes.String `tfsdk:"value"`
 }

--- a/internal/service/rds/cluster_parameter_group_data_source_test.go
+++ b/internal/service/rds/cluster_parameter_group_data_source_test.go
@@ -38,6 +38,42 @@ func TestAccRDSClusterParameterGroupDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccRDSClusterParameterGroupDataSource_parameters(t *testing.T) {
+	ctx := acctest.Context(t)
+	datasourceName := "data.aws_rds_cluster_parameter_group.test"
+	resourceName := "aws_rds_cluster_parameter_group.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterParameterGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterParameterGroupDataSourceConfig_parameters(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrDescription, resourceName, names.AttrDescription),
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrFamily, resourceName, names.AttrFamily),
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrName, resourceName, names.AttrName),
+					resource.TestCheckResourceAttrSet(datasourceName, "parameters.#"),
+					resource.TestCheckTypeSetElemNestedAttrs(datasourceName, "parameters.*", map[string]string{
+						names.AttrName:  "client_encoding",
+						names.AttrValue: "UTF8",
+						"apply_method":  "pending-reboot",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(datasourceName, "parameters.*", map[string]string{
+						names.AttrName:  "log_statement",
+						names.AttrValue: "all",
+						"apply_method":  "immediate",
+					}),
+				),
+			},
+		},
+	})
+}
+
 func testAccClusterParameterGroupDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_cluster_parameter_group" "test" {
@@ -48,6 +84,31 @@ resource "aws_rds_cluster_parameter_group" "test" {
     name         = "client_encoding"
     value        = "UTF8"
     apply_method = "pending-reboot"
+  }
+}
+
+data "aws_rds_cluster_parameter_group" "test" {
+  name = aws_rds_cluster_parameter_group.test.name
+}
+`, rName)
+}
+
+func testAccClusterParameterGroupDataSourceConfig_parameters(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster_parameter_group" "test" {
+  name   = %[1]q
+  family = "postgres15"
+
+  parameter {
+    name         = "client_encoding"
+    value        = "UTF8"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "log_statement"
+    value        = "all"
+    apply_method = "immediate"
   }
 }
 

--- a/internal/service/rds/parameter_group_data_source.go
+++ b/internal/service/rds/parameter_group_data_source.go
@@ -7,10 +7,13 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -37,6 +40,26 @@ func dataSourceParameterGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			names.AttrParameters: {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"apply_method": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrName: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrValue: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -56,6 +79,21 @@ func dataSourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set(names.AttrDescription, output.Description)
 	d.Set(names.AttrFamily, output.DBParameterGroupFamily)
 	d.Set(names.AttrName, output.DBParameterGroupName)
+
+	// Read parameters
+	input := &rds.DescribeDBParametersInput{
+		DBParameterGroupName: aws.String(d.Id()),
+	}
+
+	parameters, err := findDBParameters(ctx, conn, input, tfslices.PredicateTrue[*types.Parameter]())
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading RDS DB Parameter Group (%s) parameters: %s", d.Id(), err)
+	}
+
+	if err := d.Set(names.AttrParameters, flattenParameters(parameters)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting parameters: %s", err)
+	}
 
 	return diags
 }

--- a/internal/service/rds/parameter_group_data_source_test.go
+++ b/internal/service/rds/parameter_group_data_source_test.go
@@ -37,6 +37,41 @@ func TestAccRDSParameterGroupDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccRDSParameterGroupDataSource_parameters(t *testing.T) {
+	ctx := acctest.Context(t)
+	datasourceName := "data.aws_db_parameter_group.test"
+	resourceName := "aws_db_parameter_group.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccParameterGroupDataSourceConfig_parameters(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrDescription, resourceName, names.AttrDescription),
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrFamily, resourceName, names.AttrFamily),
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrName, resourceName, names.AttrName),
+					resource.TestCheckResourceAttrSet(datasourceName, "parameters.#"),
+					resource.TestCheckTypeSetElemNestedAttrs(datasourceName, "parameters.*", map[string]string{
+						names.AttrName:  "client_encoding",
+						names.AttrValue: "UTF8",
+						"apply_method":  "pending-reboot",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(datasourceName, "parameters.*", map[string]string{
+						names.AttrName:  "log_statement",
+						names.AttrValue: "all",
+						"apply_method":  "immediate",
+					}),
+				),
+			},
+		},
+	})
+}
+
 func testAccParameterGroupDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_db_parameter_group" "test" {
@@ -47,6 +82,31 @@ resource "aws_db_parameter_group" "test" {
     name         = "client_encoding"
     value        = "UTF8"
     apply_method = "pending-reboot"
+  }
+}
+
+data "aws_db_parameter_group" "test" {
+  name = aws_db_parameter_group.test.name
+}
+`, rName)
+}
+
+func testAccParameterGroupDataSourceConfig_parameters(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_db_parameter_group" "test" {
+  name   = %[1]q
+  family = "postgres12"
+
+  parameter {
+    name         = "client_encoding"
+    value        = "UTF8"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "log_statement"
+    value        = "all"
+    apply_method = "immediate"
   }
 }
 

--- a/website/docs/d/db_parameter_group.html.markdown
+++ b/website/docs/d/db_parameter_group.html.markdown
@@ -32,3 +32,7 @@ This data source exports the following attributes in addition to the arguments a
 * `arn` - ARN of the parameter group.
 * `family` - Family of the parameter group.
 * `description` - Description of the parameter group.
+* `parameters` - Set of parameters in the parameter group. Each parameter block supports the following:
+  * `apply_method` - Method to apply the parameter (e.g., `immediate` or `pending-reboot`).
+  * `name` - Name of the parameter.
+  * `value` - Value of the parameter.

--- a/website/docs/d/rds_cluster_parameter_group.html.markdown
+++ b/website/docs/d/rds_cluster_parameter_group.html.markdown
@@ -32,3 +32,7 @@ This data source exports the following attributes in addition to the arguments a
 * `arn` - ARN of the cluster parameter group.
 * `family` - Family of the cluster parameter group.
 * `description` - Description of the cluster parameter group.
+* `parameters` - Set of parameters in the cluster parameter group. Each parameter block supports the following:
+  * `apply_method` - Method to apply the parameter (e.g., `immediate` or `pending-reboot`).
+  * `name` - Name of the parameter.
+  * `value` - Value of the parameter.


### PR DESCRIPTION
Implements/resolves #38793 
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
Adding "parameter" attributes to the `aws_db_paraemeter_group` and `aws_rds_cluster_parameter` group data sources.

### Relations
Closes #38793


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
> make testacc TESTS=TestAccRDSClusterParameterGroupDataSource_ PKG=rds
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSClusterParameterGroupDataSource_'  -timeout 360m -vet=off
2025/08/25 11:36:32 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/25 11:36:32 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSClusterParameterGroupDataSource_basic
=== PAUSE TestAccRDSClusterParameterGroupDataSource_basic
=== RUN   TestAccRDSClusterParameterGroupDataSource_parameters
=== PAUSE TestAccRDSClusterParameterGroupDataSource_parameters
=== CONT  TestAccRDSClusterParameterGroupDataSource_basic
=== CONT  TestAccRDSClusterParameterGroupDataSource_parameters
--- PASS: TestAccRDSClusterParameterGroupDataSource_parameters (26.95s)
--- PASS: TestAccRDSClusterParameterGroupDataSource_basic (26.96s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	33.479s
```

```console
> make testacc TESTS=TestAccRDSParameterGroupDataSource_ PKG=rds
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSParameterGroupDataSource_'  -timeout 360m -vet=off
2025/08/25 11:38:12 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/25 11:38:12 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSParameterGroupDataSource_basic
=== PAUSE TestAccRDSParameterGroupDataSource_basic
=== RUN   TestAccRDSParameterGroupDataSource_parameters
=== PAUSE TestAccRDSParameterGroupDataSource_parameters
=== CONT  TestAccRDSParameterGroupDataSource_basic
=== CONT  TestAccRDSParameterGroupDataSource_parameters
--- PASS: TestAccRDSParameterGroupDataSource_parameters (23.31s)
--- PASS: TestAccRDSParameterGroupDataSource_basic (23.37s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	29.851s
```