### PR TITLE
Technical debt: Use `internal/retry` for `tfresource.RetryWhenG`

### DIFF
--- a/internal/service/apigateway/account.go
+++ b/internal/service/apigateway/account.go
@@ -97,7 +97,7 @@ func (r *accountResource) Create(ctx context.Context, request resource.CreateReq
 	}
 
 	output, err := tfresource.RetryGWhen(ctx, propagationTimeout,
-		func() (*apigateway.UpdateAccountOutput, error) {
+		func(ctx context.Context) (*apigateway.UpdateAccountOutput, error) {
 			return conn.UpdateAccount(ctx, &input)
 		},
 		func(err error) (bool, error) {
@@ -188,7 +188,7 @@ func (r *accountResource) Update(ctx context.Context, request resource.UpdateReq
 		}
 
 		output, err := tfresource.RetryGWhen(ctx, propagationTimeout,
-			func() (*apigateway.UpdateAccountOutput, error) {
+			func(ctx context.Context) (*apigateway.UpdateAccountOutput, error) {
 				return conn.UpdateAccount(ctx, &input)
 			},
 			func(err error) (bool, error) {

--- a/internal/service/bedrock/inference_profile.go
+++ b/internal/service/bedrock/inference_profile.go
@@ -161,7 +161,7 @@ func (r *inferenceProfileResource) Create(ctx context.Context, req resource.Crea
 
 	input.Tags = getTagsIn(ctx)
 
-	out, err := tfresource.RetryGWhen(ctx, 2*time.Minute, func() (*bedrock.CreateInferenceProfileOutput, error) {
+	out, err := tfresource.RetryGWhen(ctx, 2*time.Minute, func(ctx context.Context) (*bedrock.CreateInferenceProfileOutput, error) {
 		return conn.CreateInferenceProfile(ctx, &input)
 	}, func(err error) (bool, error) {
 		if errs.IsA[*awstypes.ConflictException](err) {

--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -515,7 +515,7 @@ func prepareSupervisorToReleaseCollaborator(ctx context.Context, conn *bedrockag
 
 func updateAgentWithRetry(ctx context.Context, conn *bedrockagent.Client, input bedrockagent.UpdateAgentInput, timeout time.Duration) (*bedrockagent.UpdateAgentOutput, error) {
 	return tfresource.RetryGWhen(ctx, timeout,
-		func() (*bedrockagent.UpdateAgentOutput, error) {
+		func(ctx context.Context) (*bedrockagent.UpdateAgentOutput, error) {
 			return conn.UpdateAgent(ctx, &input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/cloudformation/stack_set_instance.go
+++ b/internal/service/cloudformation/stack_set_instance.go
@@ -292,7 +292,7 @@ func resourceStackSetInstanceCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	output, err := tfresource.RetryGWhen(ctx, propagationTimeout,
-		func() (*cloudformation.CreateStackInstancesOutput, error) {
+		func(ctx context.Context) (*cloudformation.CreateStackInstancesOutput, error) {
 			input.OperationId = aws.String(sdkid.UniqueId())
 
 			return conn.CreateStackInstances(ctx, input)

--- a/internal/service/quicksight/account_settings.go
+++ b/internal/service/quicksight/account_settings.go
@@ -166,7 +166,7 @@ func (r *accountSettingsResource) ImportState(ctx context.Context, request resou
 
 func updateAccountSettings(ctx context.Context, conn *quicksight.Client, input *quicksight.UpdateAccountSettingsInput, timeout time.Duration) (*awstypes.AccountSettings, error) {
 	return tfresource.RetryGWhen(ctx, timeout,
-		func() (*awstypes.AccountSettings, error) {
+		func(ctx context.Context) (*awstypes.AccountSettings, error) {
 			_, err := conn.UpdateAccountSettings(ctx, input)
 
 			if err != nil {

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -23,7 +23,7 @@ var ErrFoundResource = retry.ErrFoundResource
 // The error argument can be `nil`.
 // If the error is retryable, returns a bool value of `true` and an error (not necessarily the error passed as the argument).
 // If the error is not retryable, returns a bool value of `false` and either no error (success state) or an error (not necessarily the error passed as the argument).
-type Retryable func(error) (bool, error)
+type Retryable = retryable
 
 // RetryWhen retries the function `f` when the error it returns satisfies `retryable`.
 // `f` is retried until `timeout` expires.
@@ -62,37 +62,8 @@ func RetryWhen(ctx context.Context, timeout time.Duration, f func() (any, error)
 // RetryGWhen is the generic version of RetryWhen which obviates the need for a type
 // assertion after the call. It retries the function `f` when the error it returns
 // satisfies `retryable`. `f` is retried until `timeout` expires.
-func RetryGWhen[T any](ctx context.Context, timeout time.Duration, f func() (T, error), retryable Retryable) (T, error) {
-	var output T
-
-	err := Retry(ctx, timeout, func() *sdkretry.RetryError {
-		var err error
-		var again bool
-
-		output, err = f()
-		again, err = retryable(err)
-
-		if again {
-			return sdkretry.RetryableError(err)
-		}
-
-		if err != nil {
-			return sdkretry.NonRetryableError(err)
-		}
-
-		return nil
-	})
-
-	if TimedOut(err) {
-		output, err = f()
-	}
-
-	if err != nil {
-		var zero T
-		return zero, err
-	}
-
-	return output, nil
+func RetryGWhen[T any](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error), retryable Retryable) (T, error) {
+	return retryWhen(ctx, timeout, f, retryable)
 }
 
 // RetryWhenAWSErrCodeEquals retries the specified function when it returns one of the specified AWS error codes.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Use the new primitives in `internal/retry` (as a replacement for the SDKv2 `helper/retry` package) for `tfresource.RetryWhenG`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/42554.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43267.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43341.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43412.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43521.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43573.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43668.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43834.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43909.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccAPIGateway_serial/^Account$$' PKG=apigateway
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/apigateway/... -v -count 1 -parallel 20  -run=TestAccAPIGateway_serial/^Account$ -timeout 360m -vet=off
2025/08/25 15:20:34 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/25 15:20:34 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAPIGateway_serial
=== RUN   TestAccAPIGateway_serial/Account
=== RUN   TestAccAPIGateway_serial/Account/basic
=== RUN   TestAccAPIGateway_serial/Account/CloudwatchRoleARN_Value
=== RUN   TestAccAPIGateway_serial/Account/CloudwatchRoleARN_Empty
=== RUN   TestAccAPIGateway_serial/Account/FrameworkMigration_Basic
=== RUN   TestAccAPIGateway_serial/Account/FrameworkMigration_CloudwatchRoleARN
=== RUN   TestAccAPIGateway_serial/Account/UpgradeV6
--- PASS: TestAccAPIGateway_serial (362.80s)
    --- PASS: TestAccAPIGateway_serial/Account (362.80s)
        --- PASS: TestAccAPIGateway_serial/Account/basic (26.26s)
        --- PASS: TestAccAPIGateway_serial/Account/CloudwatchRoleARN_Value (89.39s)
        --- PASS: TestAccAPIGateway_serial/Account/CloudwatchRoleARN_Empty (48.71s)
        --- PASS: TestAccAPIGateway_serial/Account/FrameworkMigration_Basic (43.05s)
        --- PASS: TestAccAPIGateway_serial/Account/FrameworkMigration_CloudwatchRoleARN (66.72s)
        --- PASS: TestAccAPIGateway_serial/Account/UpgradeV6 (88.66s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigateway	368.296s
```
