### PR TITLE
Technical debt: Use `internal/retry` for `tfresource.RetryWhen`

### DIFF
--- a/internal/service/apigateway/account.go
+++ b/internal/service/apigateway/account.go
@@ -96,7 +96,7 @@ func (r *accountResource) Create(ctx context.Context, request resource.CreateReq
 		}
 	}
 
-	output, err := tfresource.RetryGWhen(ctx, propagationTimeout,
+	output, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func(ctx context.Context) (*apigateway.UpdateAccountOutput, error) {
 			return conn.UpdateAccount(ctx, &input)
 		},
@@ -187,7 +187,7 @@ func (r *accountResource) Update(ctx context.Context, request resource.UpdateReq
 			}
 		}
 
-		output, err := tfresource.RetryGWhen(ctx, propagationTimeout,
+		output, err := tfresource.RetryWhen(ctx, propagationTimeout,
 			func(ctx context.Context) (*apigateway.UpdateAccountOutput, error) {
 				return conn.UpdateAccount(ctx, &input)
 			},

--- a/internal/service/appautoscaling/target.go
+++ b/internal/service/appautoscaling/target.go
@@ -295,7 +295,7 @@ func resourceTargetImport(ctx context.Context, d *schema.ResourceData, meta any)
 
 func registerScalableTarget(ctx context.Context, conn *applicationautoscaling.Client, input *applicationautoscaling.RegisterScalableTargetInput) error {
 	_, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.RegisterScalableTarget(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/appstream/fleet.go
+++ b/internal/service/appstream/fleet.go
@@ -293,7 +293,7 @@ func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 		timeout = 15 * time.Minute
 	)
 	outputRaw, err := tfresource.RetryWhen(ctx, timeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateFleet(ctx, &input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -4155,7 +4155,7 @@ func startInstanceRefresh(ctx context.Context, conn *autoscaling.Client, input *
 	name := aws.ToString(input.AutoScalingGroupName)
 
 	_, err := tfresource.RetryWhen(ctx, instanceRefreshStartedTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.StartInstanceRefresh(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/autoscaling/launch_configuration.go
+++ b/internal/service/autoscaling/launch_configuration.go
@@ -404,7 +404,7 @@ func resourceLaunchConfigurationCreate(ctx context.Context, d *schema.ResourceDa
 	// IAM profiles can take ~10 seconds to propagate in AWS:
 	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
 	_, err = tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return autoscalingconn.CreateLaunchConfiguration(ctx, &input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/backup/selection.go
+++ b/internal/service/backup/selection.go
@@ -207,7 +207,7 @@ func resourceSelectionCreate(ctx context.Context, d *schema.ResourceData, meta a
 
 	// Retry for IAM eventual consistency.
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateBackupSelection(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/bedrock/inference_profile.go
+++ b/internal/service/bedrock/inference_profile.go
@@ -161,7 +161,7 @@ func (r *inferenceProfileResource) Create(ctx context.Context, req resource.Crea
 
 	input.Tags = getTagsIn(ctx)
 
-	out, err := tfresource.RetryGWhen(ctx, 2*time.Minute, func(ctx context.Context) (*bedrock.CreateInferenceProfileOutput, error) {
+	out, err := tfresource.RetryWhen(ctx, 2*time.Minute, func(ctx context.Context) (*bedrock.CreateInferenceProfileOutput, error) {
 		return conn.CreateInferenceProfile(ctx, &input)
 	}, func(err error) (bool, error) {
 		if errs.IsA[*awstypes.ConflictException](err) {

--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -514,7 +514,7 @@ func prepareSupervisorToReleaseCollaborator(ctx context.Context, conn *bedrockag
 }
 
 func updateAgentWithRetry(ctx context.Context, conn *bedrockagent.Client, input bedrockagent.UpdateAgentInput, timeout time.Duration) (*bedrockagent.UpdateAgentOutput, error) {
-	return tfresource.RetryGWhen(ctx, timeout,
+	return tfresource.RetryWhen(ctx, timeout,
 		func(ctx context.Context) (*bedrockagent.UpdateAgentOutput, error) {
 			return conn.UpdateAgent(ctx, &input)
 		},

--- a/internal/service/cloudformation/stack_instances.go
+++ b/internal/service/cloudformation/stack_instances.go
@@ -298,7 +298,7 @@ func resourceStackInstancesCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	_, err = tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			input.OperationId = aws.String(sdkid.UniqueId())
 
 			output, err := conn.CreateStackInstances(ctx, input)

--- a/internal/service/cloudformation/stack_set.go
+++ b/internal/service/cloudformation/stack_set.go
@@ -271,7 +271,7 @@ func resourceStackSetCreate(ctx context.Context, d *schema.ResourceData, meta an
 	}
 
 	_, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			_, err := conn.CreateStackSet(ctx, input)
 
 			if err != nil {

--- a/internal/service/cloudformation/stack_set_instance.go
+++ b/internal/service/cloudformation/stack_set_instance.go
@@ -291,7 +291,7 @@ func resourceStackSetInstanceCreate(ctx context.Context, d *schema.ResourceData,
 		return create.AppendDiagError(diags, names.CloudFormation, create.ErrActionFlatteningResourceId, ResNameStackSetInstance, id, err)
 	}
 
-	output, err := tfresource.RetryGWhen(ctx, propagationTimeout,
+	output, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func(ctx context.Context) (*cloudformation.CreateStackInstancesOutput, error) {
 			input.OperationId = aws.String(sdkid.UniqueId())
 

--- a/internal/service/cloudtrail/trail.go
+++ b/internal/service/cloudtrail/trail.go
@@ -312,7 +312,7 @@ func resourceTrailCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateTrail(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -500,7 +500,7 @@ func resourceTrailUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 		}
 
 		_, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.UpdateTrail(ctx, input)
 			},
 			func(err error) (bool, error) {

--- a/internal/service/cognitoidp/user_pool.go
+++ b/internal/service/cognitoidp/user_pool.go
@@ -859,7 +859,7 @@ func resourceUserPoolCreate(ctx context.Context, d *schema.ResourceData, meta an
 		input.UserPoolTier = v
 	}
 
-	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateUserPool(ctx, input)
 	}, userPoolErrorRetryable)
 
@@ -897,7 +897,7 @@ func resourceUserPoolCreate(ctx context.Context, d *schema.ResourceData, meta an
 			input.WebAuthnConfiguration = expandWebAuthnConfigurationConfigType(webAuthnConfig)
 		}
 
-		_, err := tfresource.RetryWhen(ctx, propagationTimeout, func() (any, error) {
+		_, err := tfresource.RetryWhen(ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 			return conn.SetUserPoolMfaConfig(ctx, input)
 		}, userPoolErrorRetryable)
 
@@ -1045,7 +1045,7 @@ func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta an
 			}
 		}
 
-		_, err := tfresource.RetryWhen(ctx, propagationTimeout, func() (any, error) {
+		_, err := tfresource.RetryWhen(ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 			return conn.SetUserPoolMfaConfig(ctx, input)
 		}, userPoolErrorRetryable)
 
@@ -1226,7 +1226,7 @@ func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta an
 		}
 
 		_, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.UpdateUserPool(ctx, input)
 			},
 			func(err error) (bool, error) {

--- a/internal/service/datasync/location_s3.go
+++ b/internal/service/datasync/location_s3.go
@@ -127,7 +127,7 @@ func resourceLocationS3Create(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateLocationS3(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/deploy/deployment_group.go
+++ b/internal/service/deploy/deployment_group.go
@@ -524,7 +524,7 @@ func resourceDeploymentGroupCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, 5*time.Minute,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateDeploymentGroup(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -718,7 +718,7 @@ func resourceDeploymentGroupUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 
 		_, err := tfresource.RetryWhen(ctx, 5*time.Minute,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.UpdateDeploymentGroup(ctx, input)
 			},
 			func(err error) (bool, error) {

--- a/internal/service/docdb/cluster.go
+++ b/internal/service/docdb/cluster.go
@@ -868,7 +868,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 			timeout = 5 * time.Minute
 		)
 		_, err := tfresource.RetryWhen(ctx, timeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.ModifyDBCluster(ctx, &input)
 			},
 			func(err error) (bool, error) {
@@ -943,7 +943,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta any
 
 	log.Printf("[DEBUG] Deleting DocumentDB Cluster: %s", d.Id())
 	_, err := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutDelete),
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteDBCluster(ctx, &input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -618,7 +618,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 			input.SSESpecificationOverride = expandEncryptAtRestOptions(v.([]any))
 		}
 
-		_, err := tfresource.RetryWhen(ctx, createTableTimeout, func() (any, error) {
+		_, err := tfresource.RetryWhen(ctx, createTableTimeout, func(ctx context.Context) (any, error) {
 			return conn.RestoreTableToPointInTime(ctx, input)
 		}, func(err error) (bool, error) {
 			if tfawserr.ErrCodeEquals(err, errCodeThrottlingException) {
@@ -686,7 +686,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 
 		input.TableCreationParameters = tcp
 
-		importTableOutput, err := tfresource.RetryWhen(ctx, createTableTimeout, func() (any, error) {
+		importTableOutput, err := tfresource.RetryWhen(ctx, createTableTimeout, func(ctx context.Context) (any, error) {
 			return conn.ImportTable(ctx, input)
 		}, func(err error) (bool, error) {
 			if tfawserr.ErrCodeEquals(err, errCodeThrottlingException) {
@@ -777,7 +777,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 			input.TableClass = awstypes.TableClass(v.(string))
 		}
 
-		_, err := tfresource.RetryWhen(ctx, createTableTimeout, func() (any, error) {
+		_, err := tfresource.RetryWhen(ctx, createTableTimeout, func(ctx context.Context) (any, error) {
 			return conn.CreateTable(ctx, input)
 		}, func(err error) (bool, error) {
 			if tfawserr.ErrCodeEquals(err, errCodeThrottlingException) {
@@ -1982,7 +1982,7 @@ func deleteTable(ctx context.Context, conn *dynamodb.Client, tableName string) e
 		TableName: aws.String(tableName),
 	}
 
-	_, err := tfresource.RetryWhen(ctx, deleteTableTimeout, func() (any, error) {
+	_, err := tfresource.RetryWhen(ctx, deleteTableTimeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteTable(ctx, input)
 	}, func(err error) (bool, error) {
 		// Subscriber limit exceeded: Only 10 tables can be created, updated, or deleted simultaneously

--- a/internal/service/ec2/ec2_eip.go
+++ b/internal/service/ec2/ec2_eip.go
@@ -381,7 +381,7 @@ func associateEIP(ctx context.Context, conn *ec2.Client, allocationID, instanceI
 	}
 
 	_, err = tfresource.RetryWhen(ctx, ec2PropagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return findEIPByAssociationID(ctx, conn, aws.ToString(output.AssociationId))
 		},
 		func(err error) (bool, error) {

--- a/internal/service/ec2/ec2_eip_association.go
+++ b/internal/service/ec2/ec2_eip_association.go
@@ -118,7 +118,7 @@ func resourceEIPAssociationCreate(ctx context.Context, d *schema.ResourceData, m
 	d.SetId(aws.ToString(output.AssociationId))
 
 	_, err = tfresource.RetryWhen(ctx, ec2PropagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return findEIPByAssociationID(ctx, conn, d.Id())
 		},
 		func(err error) (bool, error) {

--- a/internal/service/ec2/ec2_spot_instance_request.go
+++ b/internal/service/ec2/ec2_spot_instance_request.go
@@ -211,7 +211,7 @@ func resourceSpotInstanceRequestCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, iamPropagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.RequestSpotInstances(ctx, &input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/ecrpublic/repository_policy.go
+++ b/internal/service/ecrpublic/repository_policy.go
@@ -81,7 +81,7 @@ func resourceRepositoryPolicyPut(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, policyPutTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.SetRepositoryPolicy(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/ecs/cluster_capacity_providers.go
+++ b/internal/service/ecs/cluster_capacity_providers.go
@@ -168,7 +168,7 @@ func retryClusterCapacityProvidersPut(ctx context.Context, conn *ecs.Client, inp
 		timeout = 10 * time.Minute
 	)
 	_, err := tfresource.RetryWhen(ctx, timeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.PutClusterCapacityProviders(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -1772,7 +1772,7 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		)
 		operationTime := time.Now().UTC()
 		_, err := tfresource.RetryWhen(ctx, timeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.UpdateService(ctx, &input)
 			},
 			func(err error) (bool, error) {
@@ -1843,7 +1843,7 @@ func resourceServiceDelete(ctx context.Context, d *schema.ResourceData, meta any
 
 	log.Printf("[DEBUG] Deleting ECS Service: %s", d.Id())
 	_, err = tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutDelete),
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteService(ctx, &ecs.DeleteServiceInput{
 				Cluster: aws.String(cluster),
 				Force:   aws.Bool(forceDelete),
@@ -1913,7 +1913,7 @@ func retryServiceCreate(ctx context.Context, conn *ecs.Client, input *ecs.Create
 		timeout              = propagationTimeout + serviceCreateTimeout
 	)
 	outputRaw, err := tfresource.RetryWhen(ctx, timeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateService(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/ecs/task_set.go
+++ b/internal/service/ecs/task_set.go
@@ -501,7 +501,7 @@ func retryTaskSetCreate(ctx context.Context, conn *ecs.Client, input *ecs.Create
 		timeout              = propagationTimeout + taskSetCreateTimeout
 	)
 	outputRaw, err := tfresource.RetryWhen(ctx, timeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateTaskSet(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/eks/addon.go
+++ b/internal/service/eks/addon.go
@@ -168,7 +168,7 @@ func resourceAddonCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	_, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateAddon(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -563,7 +563,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateCluster(ctx, &input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/elasticsearch/domain.go
+++ b/internal/service/elasticsearch/domain.go
@@ -653,7 +653,7 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateElasticsearchDomain(ctx, &input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/elb/load_balancer.go
+++ b/internal/service/elb/load_balancer.go
@@ -469,7 +469,7 @@ func resourceLoadBalancerUpdate(ctx context.Context, d *schema.ResourceData, met
 			// Occasionally AWS will error with a 'duplicate listener', without any
 			// other listeners on the ELB. Retry here to eliminate that.
 			_, err := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutUpdate),
-				func() (any, error) {
+				func(ctx context.Context) (any, error) {
 					return conn.CreateLoadBalancerListeners(ctx, input)
 				},
 				func(err error) (bool, error) {

--- a/internal/service/emr/cluster.go
+++ b/internal/service/emr/cluster.go
@@ -1016,7 +1016,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.RunJobFlow(ctx, &input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/emr/studio.go
+++ b/internal/service/emr/studio.go
@@ -160,7 +160,7 @@ func resourceStudioCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateStudio(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/firehose/delivery_stream.go
+++ b/internal/service/firehose/delivery_stream.go
@@ -1540,7 +1540,7 @@ func resourceDeliveryStreamCreate(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
-	_, err := retryDeliveryStreamOp(ctx, func() (any, error) {
+	_, err := retryDeliveryStreamOp(ctx, func(ctx context.Context) (any, error) {
 		return conn.CreateDeliveryStream(ctx, input)
 	})
 
@@ -1736,7 +1736,7 @@ func resourceDeliveryStreamUpdate(ctx context.Context, d *schema.ResourceData, m
 			}
 		}
 
-		_, err := retryDeliveryStreamOp(ctx, func() (any, error) {
+		_, err := retryDeliveryStreamOp(ctx, func(ctx context.Context) (any, error) {
 			return conn.UpdateDestination(ctx, input)
 		})
 
@@ -1808,7 +1808,7 @@ func resourceDeliveryStreamDelete(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func retryDeliveryStreamOp(ctx context.Context, f func() (any, error)) (any, error) {
+func retryDeliveryStreamOp(ctx context.Context, f func(context.Context) (any, error)) (any, error) {
 	return tfresource.RetryWhen(ctx, propagationTimeout,
 		f,
 		func(err error) (bool, error) {

--- a/internal/service/gamelift/build.go
+++ b/internal/service/gamelift/build.go
@@ -113,7 +113,7 @@ func resourceBuildCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateBuild(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/gamelift/script.go
+++ b/internal/service/gamelift/script.go
@@ -125,7 +125,7 @@ func resourceScriptCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateScript(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/iam/instance_profile.go
+++ b/internal/service/iam/instance_profile.go
@@ -274,7 +274,7 @@ func instanceProfileAddRole(ctx context.Context, conn *iam.Client, profileName, 
 	}
 
 	_, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.AddRoleToInstanceProfile(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -375,7 +375,7 @@ func resourceRoleUpdate(ctx context.Context, d *schema.ResourceData, meta any) d
 		}
 
 		_, err = tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.UpdateAssumeRolePolicy(ctx, input)
 			},
 			func(err error) (bool, error) {
@@ -609,7 +609,7 @@ func deleteRoleInstanceProfiles(ctx context.Context, conn *iam.Client, roleName 
 
 func retryCreateRole(ctx context.Context, conn *iam.Client, input *iam.CreateRoleInput) (*iam.CreateRoleOutput, error) {
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateRole(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/iam/user.go
+++ b/internal/service/iam/user.go
@@ -617,7 +617,7 @@ func userTags(ctx context.Context, conn *iam.Client, identifier string, optFns .
 
 func retryCreateUser(ctx context.Context, conn *iam.Client, input *iam.CreateUserInput) (*iam.CreateUserOutput, error) {
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateUser(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/imagebuilder/infrastructure_configuration.go
+++ b/internal/service/imagebuilder/infrastructure_configuration.go
@@ -246,7 +246,7 @@ func resourceInfrastructureConfigurationCreate(ctx context.Context, d *schema.Re
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateInfrastructureConfiguration(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -391,7 +391,7 @@ func resourceInfrastructureConfigurationUpdate(ctx context.Context, d *schema.Re
 		}
 
 		_, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.UpdateInfrastructureConfiguration(ctx, input)
 			},
 			func(err error) (bool, error) {

--- a/internal/service/kendra/data_source.go
+++ b/internal/service/kendra/data_source.go
@@ -648,7 +648,7 @@ func resourceDataSourceCreate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateDataSource(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -792,7 +792,7 @@ func resourceDataSourceUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		log.Printf("[DEBUG] Updating Kendra Data Source (%s): %#v", d.Id(), input)
 
 		_, err = tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.UpdateDataSource(ctx, input)
 			},
 			func(err error) (bool, error) {

--- a/internal/service/kendra/faq.go
+++ b/internal/service/kendra/faq.go
@@ -177,7 +177,7 @@ func resourceFaqCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateFaq(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/kendra/index.go
+++ b/internal/service/kendra/index.go
@@ -417,7 +417,7 @@ func resourceIndexCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateIndex(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -567,7 +567,7 @@ func resourceIndexUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 		}
 
 		_, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.UpdateIndex(ctx, input)
 			},
 			func(err error) (bool, error) {

--- a/internal/service/kendra/query_suggestions_block_list.go
+++ b/internal/service/kendra/query_suggestions_block_list.go
@@ -120,7 +120,7 @@ func resourceQuerySuggestionsBlockListCreate(ctx context.Context, d *schema.Reso
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateQuerySuggestionsBlockList(ctx, in)
 		},
 		func(err error) (bool, error) {
@@ -235,7 +235,7 @@ func resourceQuerySuggestionsBlockListUpdate(ctx context.Context, d *schema.Reso
 		log.Printf("[DEBUG] Updating Kendra QuerySuggestionsBlockList (%s): %#v", d.Id(), input)
 
 		_, err = tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.UpdateQuerySuggestionsBlockList(ctx, input)
 			},
 			func(err error) (bool, error) {

--- a/internal/service/kendra/thesaurus.go
+++ b/internal/service/kendra/thesaurus.go
@@ -120,7 +120,7 @@ func resourceThesaurusCreate(ctx context.Context, d *schema.ResourceData, meta a
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateThesaurus(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -236,7 +236,7 @@ func resourceThesaurusUpdate(ctx context.Context, d *schema.ResourceData, meta a
 		log.Printf("[DEBUG] Updating Kendra Thesaurus (%s): %#v", d.Id(), input)
 
 		_, err = tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.UpdateThesaurus(ctx, input)
 			},
 			func(err error) (bool, error) {

--- a/internal/service/kinesisanalyticsv2/application.go
+++ b/internal/service/kinesisanalyticsv2/application.go
@@ -1740,7 +1740,7 @@ func waitApplicationOperationSucceeded(ctx context.Context, conn *kinesisanalyti
 
 func waitIAMPropagation[T any](ctx context.Context, f func() (*T, error)) (*T, error) {
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return f()
 		},
 		func(err error) (bool, error) {

--- a/internal/service/lambda/event_source_mapping.go
+++ b/internal/service/lambda/event_source_mapping.go
@@ -848,7 +848,7 @@ type eventSourceMappingCU interface {
 
 func retryEventSourceMapping[T eventSourceMappingCU](ctx context.Context, f func() (*T, error)) (*T, error) {
 	outputRaw, err := tfresource.RetryWhen(ctx, lambdaPropagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return f()
 		},
 		func(err error) (bool, error) {

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -1403,7 +1403,7 @@ type functionCU interface {
 
 func retryFunctionOp[T functionCU](ctx context.Context, f func() (*T, error)) (*T, error) {
 	output, err := tfresource.RetryWhen(ctx, lambdaPropagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return f()
 		},
 		func(err error) (bool, error) {
@@ -1435,7 +1435,7 @@ func retryFunctionOp[T functionCU](ctx context.Context, f func() (*T, error)) (*
 			functionExtraThrottlingTimeout = 9 * time.Minute
 		)
 		output, err = tfresource.RetryWhen(ctx, functionExtraThrottlingTimeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return f()
 			},
 			func(err error) (bool, error) {

--- a/internal/service/lambda/function_event_invoke_config.go
+++ b/internal/service/lambda/function_event_invoke_config.go
@@ -128,7 +128,7 @@ func resourceFunctionEventInvokeConfigCreate(ctx context.Context, d *schema.Reso
 
 	// Retry for destination validation eventual consistency errors.
 	_, err := tfresource.RetryWhen(ctx, iamPropagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.PutFunctionEventInvokeConfig(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -212,7 +212,7 @@ func resourceFunctionEventInvokeConfigUpdate(ctx context.Context, d *schema.Reso
 
 	// Retry for destination validation eventual consistency errors.
 	_, err = tfresource.RetryWhen(ctx, iamPropagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.PutFunctionEventInvokeConfig(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/logs/subscription_filter.go
+++ b/internal/service/logs/subscription_filter.go
@@ -105,7 +105,7 @@ func resourceSubscriptionFilterPut(ctx context.Context, d *schema.ResourceData, 
 		timeout = 5 * time.Minute
 	)
 	_, err := tfresource.RetryWhen(ctx, timeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.PutSubscriptionFilter(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/medialive/input.go
+++ b/internal/service/medialive/input.go
@@ -226,7 +226,7 @@ func resourceInputCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 
 	// IAM propagation
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateInput(ctx, in)
 		},
 		func(err error) (bool, error) {
@@ -323,7 +323,7 @@ func resourceInputUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 		}
 
 		rawOutput, err := tfresource.RetryWhen(ctx, 2*time.Minute,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.UpdateInput(ctx, in)
 			},
 			func(err error) (bool, error) {

--- a/internal/service/neptune/cluster.go
+++ b/internal/service/neptune/cluster.go
@@ -711,7 +711,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 
 		_, err := tfresource.RetryWhen(ctx, 5*time.Minute,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.ModifyDBCluster(ctx, input)
 			},
 			func(err error) (bool, error) {

--- a/internal/service/neptune/global_cluster.go
+++ b/internal/service/neptune/global_cluster.go
@@ -313,7 +313,7 @@ func globalClusterUpgradeMajorEngineVersion(ctx context.Context, conn *neptune.C
 		GlobalClusterIdentifier:  aws.String(globalClusterID),
 	}
 	_, err := tfresource.RetryWhen(ctx, timeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.ModifyGlobalCluster(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -397,7 +397,7 @@ func globalClusterUpgradeMinorEngineVersion(ctx context.Context, conn *neptune.C
 				EngineVersion:       aws.String(engineVersion),
 			}
 			_, err = tfresource.RetryWhen(ctx, timeout,
-				func() (any, error) {
+				func(ctx context.Context) (any, error) {
 					return conn.ModifyDBCluster(ctx, input, optFn)
 				},
 				func(err error) (bool, error) {
@@ -448,7 +448,7 @@ func globalClusterUpgradeMinorEngineVersion(ctx context.Context, conn *neptune.C
 				EngineVersion:       aws.String(engineVersion),
 			}
 			_, err = tfresource.RetryWhen(ctx, timeout,
-				func() (any, error) {
+				func(ctx context.Context) (any, error) {
 					return conn.ModifyDBCluster(ctx, input, optFn)
 				},
 				func(err error) (bool, error) {

--- a/internal/service/networkmanager/connect_attachment.go
+++ b/internal/service/networkmanager/connect_attachment.go
@@ -152,7 +152,7 @@ func resourceConnectAttachmentCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutCreate),
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateConnectAttachment(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/networkmanager/connect_peer.go
+++ b/internal/service/networkmanager/connect_peer.go
@@ -217,7 +217,7 @@ func resourceConnectPeerCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutCreate),
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateConnectPeer(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/networkmanager/customer_gateway_association.go
+++ b/internal/service/networkmanager/customer_gateway_association.go
@@ -86,7 +86,7 @@ func resourceCustomerGatewayAssociationCreate(ctx context.Context, d *schema.Res
 
 	log.Printf("[DEBUG] Creating Network Manager Customer Gateway Association: %#v", input)
 	_, err := tfresource.RetryWhen(ctx, customerGatewayAssociationResourceNotFoundExceptionTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.AssociateCustomerGateway(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/networkmanager/global_network.go
+++ b/internal/service/networkmanager/global_network.go
@@ -160,7 +160,7 @@ func resourceGlobalNetworkDelete(ctx context.Context, d *schema.ResourceData, me
 
 	log.Printf("[DEBUG] Deleting Network Manager Global Network: %s", d.Id())
 	_, err := tfresource.RetryWhen(ctx, globalNetworkValidationExceptionTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteGlobalNetwork(ctx, &networkmanager.DeleteGlobalNetworkInput{
 				GlobalNetworkId: aws.String(d.Id()),
 			})

--- a/internal/service/networkmanager/site.go
+++ b/internal/service/networkmanager/site.go
@@ -222,7 +222,7 @@ func resourceSiteDelete(ctx context.Context, d *schema.ResourceData, meta any) d
 
 	log.Printf("[DEBUG] Deleting Network Manager Site: %s", d.Id())
 	_, err := tfresource.RetryWhen(ctx, siteValidationExceptionTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteSite(ctx, &networkmanager.DeleteSiteInput{
 				GlobalNetworkId: aws.String(globalNetworkID),
 				SiteId:          aws.String(d.Id()),

--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -826,7 +826,7 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta any)
 
 	// IAM Roles can take some time to propagate if set in AccessPolicies and created in the same terraform
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateDomain(ctx, &input)
 		},
 		domainErrorRetryable,
@@ -849,7 +849,7 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		}
 
 		_, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.UpdateDomainConfig(ctx, &input)
 			},
 			domainErrorRetryable,
@@ -1167,7 +1167,7 @@ func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 		}
 
 		_, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.UpdateDomainConfig(ctx, &input)
 			},
 			domainErrorRetryable,

--- a/internal/service/quicksight/account_settings.go
+++ b/internal/service/quicksight/account_settings.go
@@ -165,7 +165,7 @@ func (r *accountSettingsResource) ImportState(ctx context.Context, request resou
 }
 
 func updateAccountSettings(ctx context.Context, conn *quicksight.Client, input *quicksight.UpdateAccountSettingsInput, timeout time.Duration) (*awstypes.AccountSettings, error) {
-	return tfresource.RetryGWhen(ctx, timeout,
+	return tfresource.RetryWhen(ctx, timeout,
 		func(ctx context.Context) (*awstypes.AccountSettings, error) {
 			_, err := conn.UpdateAccountSettings(ctx, input)
 

--- a/internal/service/quicksight/data_source.go
+++ b/internal/service/quicksight/data_source.go
@@ -126,7 +126,7 @@ func resourceDataSourceCreate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateDataSource(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -239,7 +239,7 @@ func resourceDataSourceUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		}
 
 		outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.UpdateDataSource(ctx, input)
 			},
 			func(err error) (bool, error) {

--- a/internal/service/quicksight/vpc_connection.go
+++ b/internal/service/quicksight/vpc_connection.go
@@ -421,7 +421,7 @@ func findVPCConnection(ctx context.Context, conn *quicksight.Client, input *quic
 func retryVPCConnectionCreate(ctx context.Context, conn *quicksight.Client, in *quicksight.CreateVPCConnectionInput) (*quicksight.CreateVPCConnectionOutput, error) {
 	outputRaw, err := tfresource.RetryWhen(ctx,
 		iamPropagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateVPCConnection(ctx, in)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/rds/blue_green.go
+++ b/internal/service/rds/blue_green.go
@@ -68,7 +68,7 @@ func (o *blueGreenOrchestrator) Switchover(ctx context.Context, identifier strin
 		BlueGreenDeploymentIdentifier: aws.String(identifier),
 	}
 	_, err := tfresource.RetryWhen(ctx, 10*time.Minute,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return o.conn.SwitchoverBlueGreenDeployment(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -980,7 +980,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 
 		_, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.RestoreDBClusterFromS3(ctx, input)
 			},
 			func(err error) (bool, error) {
@@ -1781,7 +1781,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 			timeout = 5 * time.Minute
 		)
 		_, err := tfresource.RetryWhen(ctx, timeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.ModifyDBCluster(ctx, input)
 			},
 			func(err error) (bool, error) {
@@ -1905,14 +1905,14 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta any
 		timeout = 2 * time.Minute
 	)
 	_, err := tfresource.RetryWhen(ctx, timeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.DeleteDBCluster(ctx, input)
 		},
 		func(err error) (bool, error) {
 			if tfawserr.ErrMessageContains(err, errCodeInvalidParameterCombination, "disable deletion pro") {
 				if v, ok := d.GetOk(names.AttrDeletionProtection); (!ok || !v.(bool)) && d.Get(names.AttrApplyImmediately).(bool) {
 					_, err := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutDelete),
-						func() (any, error) {
+						func(ctx context.Context) (any, error) {
 							return conn.ModifyDBCluster(ctx, &rds.ModifyDBClusterInput{
 								ApplyImmediately:    aws.Bool(true),
 								DBClusterIdentifier: aws.String(d.Id()),

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -582,7 +582,7 @@ func globalClusterUpgradeMajorEngineVersion(ctx context.Context, conn *rds.Clien
 	}
 
 	_, err := tfresource.RetryWhen(ctx, timeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.ModifyGlobalCluster(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -679,7 +679,7 @@ func globalClusterUpgradeMinorEngineVersion(ctx context.Context, conn *rds.Clien
 
 		log.Printf("[INFO] Performing RDS Global Cluster (%s) Cluster (%s) minor version (%s) upgrade", globalClusterID, clusterID, engineVersion)
 		_, err = tfresource.RetryWhen(ctx, timeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.ModifyDBCluster(ctx, input, optFn)
 			},
 			func(err error) (bool, error) {

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -1159,7 +1159,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta an
 		}
 
 		outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.RestoreDBInstanceFromS3(ctx, input)
 			},
 			func(err error) (bool, error) {
@@ -1414,7 +1414,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta an
 		}
 
 		outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.RestoreDBInstanceFromDBSnapshot(ctx, input)
 			},
 			func(err error) (bool, error) {
@@ -1630,7 +1630,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta an
 		}
 
 		outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.RestoreDBInstanceToPointInTime(ctx, input)
 			},
 			func(err error) (bool, error) {
@@ -1850,7 +1850,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta an
 		}
 
 		outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.CreateDBInstance(ctx, input)
 			},
 			func(err error) (bool, error) {
@@ -2265,7 +2265,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta an
 				timeout = 5 * time.Minute
 			)
 			_, err = tfresource.RetryWhen(ctx, timeout,
-				func() (any, error) {
+				func(ctx context.Context) (any, error) {
 					return conn.DeleteDBInstance(ctx, input)
 				},
 				func(err error) (bool, error) {
@@ -2370,7 +2370,7 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta an
 	if tfawserr.ErrMessageContains(err, errCodeInvalidParameterCombination, "disable deletion pro") {
 		if v, ok := d.GetOk(names.AttrDeletionProtection); (!ok || !v.(bool)) && d.Get(names.AttrApplyImmediately).(bool) {
 			_, ierr := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutUpdate),
-				func() (any, error) {
+				func(ctx context.Context) (any, error) {
 					return conn.ModifyDBInstance(ctx, &rds.ModifyDBInstanceInput{
 						ApplyImmediately:     aws.Bool(true),
 						DBInstanceIdentifier: aws.String(d.Get(names.AttrIdentifier).(string)),
@@ -2705,7 +2705,7 @@ func dbInstancePopulateModify(input *rds.ModifyDBInstanceInput, d *schema.Resour
 
 func dbInstanceModify(ctx context.Context, conn *rds.Client, resourceID string, input *rds.ModifyDBInstanceInput, timeout time.Duration) error {
 	_, err := tfresource.RetryWhen(ctx, timeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.ModifyDBInstance(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -7093,7 +7093,7 @@ func TestAccRDSInstance_BlueGreenDeployment_outOfBand(t *testing.T) {
 						SkipFinalSnapshot:    aws.Bool(true),
 					}
 					_, err = tfresource.RetryWhen(ctx, 5*time.Minute,
-						func() (any, error) {
+						func(ctx context.Context) (any, error) {
 							return conn.DeleteDBInstance(ctx, deleteInput)
 						},
 						func(err error) (bool, error) {

--- a/internal/service/redshift/scheduled_action.go
+++ b/internal/service/redshift/scheduled_action.go
@@ -184,7 +184,7 @@ func resourceScheduledActionCreate(ctx context.Context, d *schema.ResourceData, 
 
 	log.Printf("[DEBUG] Creating Redshift Scheduled Action: %#v", input)
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateScheduledAction(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/redshiftserverless/workgroup.go
+++ b/internal/service/redshiftserverless/workgroup.go
@@ -545,7 +545,7 @@ func updateWorkgroup(ctx context.Context, conn *redshiftserverless.Client, input
 		retryTimeout = 20 * time.Minute
 	)
 	_, err := tfresource.RetryWhen(ctx, retryTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.UpdateWorkgroup(ctx, input)
 		}, func(err error) (bool, error) {
 			if errs.IsAErrorMessageContains[*awstypes.ConflictException](err, "operation running") {

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -1483,7 +1483,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 			}
 
 			_, err := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutUpdate),
-				func() (any, error) {
+				func(ctx context.Context) (any, error) {
 					return conn.PutBucketReplication(ctx, input)
 				},
 				func(err error) (bool, error) {

--- a/internal/service/scheduler/retry.go
+++ b/internal/service/scheduler/retry.go
@@ -20,7 +20,7 @@ func retryWhenIAMNotPropagated[T any](ctx context.Context, f func() (T, error)) 
 	v, err := tfresource.RetryWhen(
 		ctx,
 		iamPropagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return f()
 		},
 		func(err error) (bool, error) {

--- a/internal/service/secretsmanager/secret.go
+++ b/internal/service/secretsmanager/secret.go
@@ -174,7 +174,7 @@ func resourceSecretCreate(ctx context.Context, d *schema.ResourceData, meta any)
 
 	// Retry for secret recreation after deletion.
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateSecret(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/ses/receipt_rule.go
+++ b/internal/service/ses/receipt_rule.go
@@ -296,7 +296,7 @@ func resourceReceiptRuleCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	_, err := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutCreate),
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateReceiptRule(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -498,7 +498,7 @@ func resourceReceiptRuleUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	_, err := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutUpdate),
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.UpdateReceiptRule(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/sesv2/configuration_set_event_destination.go
+++ b/internal/service/sesv2/configuration_set_event_destination.go
@@ -223,7 +223,7 @@ func resourceConfigurationSetEventDestinationCreate(ctx context.Context, d *sche
 	configurationSetEventDestinationID := configurationSetEventDestinationCreateResourceID(d.Get("configuration_set_name").(string), d.Get("event_destination_name").(string))
 
 	out, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateConfigurationSetEventDestination(ctx, in)
 		},
 		func(err error) (bool, error) {
@@ -297,7 +297,7 @@ func resourceConfigurationSetEventDestinationUpdate(ctx context.Context, d *sche
 
 		log.Printf("[DEBUG] Updating SESV2 ConfigurationSetEventDestination (%s): %#v", d.Id(), in)
 		_, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (any, error) {
+			func(ctx context.Context) (any, error) {
 				return conn.UpdateConfigurationSetEventDestination(ctx, in)
 			},
 			func(err error) (bool, error) {

--- a/internal/service/signer/signing_profile_permission.go
+++ b/internal/service/signer/signing_profile_permission.go
@@ -121,7 +121,7 @@ func resourceSigningProfilePermissionCreate(ctx context.Context, d *schema.Resou
 	}
 
 	_, err = tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.AddProfilePermission(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/ssm/parameter.go
+++ b/internal/service/ssm/parameter.go
@@ -268,7 +268,7 @@ func resourceParameterRead(ctx context.Context, d *schema.ResourceData, meta any
 		timeout = 2 * time.Minute
 	)
 	outputRaw, err := tfresource.RetryWhen(ctx, timeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return findParameterByName(ctx, conn, d.Id(), true)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/synthetics/canary.go
+++ b/internal/service/synthetics/canary.go
@@ -336,7 +336,7 @@ func resourceCanaryCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	iamwaiterStopTime := time.Now().Add(propagationTimeout)
 
 	_, err = tfresource.RetryWhen(ctx, propagationTimeout+canaryCreatedTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return retryCreateCanary(ctx, conn, d, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/transcribe/language_model.go
+++ b/internal/service/transcribe/language_model.go
@@ -122,7 +122,7 @@ func resourceLanguageModelCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return conn.CreateLanguageModel(ctx, in)
 		},
 		func(err error) (bool, error) {

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -23,40 +23,12 @@ var ErrFoundResource = retry.ErrFoundResource
 // The error argument can be `nil`.
 // If the error is retryable, returns a bool value of `true` and an error (not necessarily the error passed as the argument).
 // If the error is not retryable, returns a bool value of `false` and either no error (success state) or an error (not necessarily the error passed as the argument).
-type Retryable = retryable
+type Retryable func(error) (bool, error)
 
 // RetryWhen retries the function `f` when the error it returns satisfies `retryable`.
 // `f` is retried until `timeout` expires.
-func RetryWhen(ctx context.Context, timeout time.Duration, f func() (any, error), retryable Retryable) (any, error) {
-	var output any
-
-	err := Retry(ctx, timeout, func() *sdkretry.RetryError {
-		var err error
-		var again bool
-
-		output, err = f()
-		again, err = retryable(err)
-
-		if again {
-			return sdkretry.RetryableError(err)
-		}
-
-		if err != nil {
-			return sdkretry.NonRetryableError(err)
-		}
-
-		return nil
-	})
-
-	if TimedOut(err) {
-		output, err = f()
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	return output, nil
+func RetryWhen[T any](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error), retryable Retryable) (T, error) {
+	return retryWhen(ctx, timeout, f, retryable)
 }
 
 // RetryGWhen is the generic version of RetryWhen which obviates the need for a type
@@ -314,9 +286,7 @@ func Retry(ctx context.Context, timeout time.Duration, f sdkretry.RetryFunc, opt
 	return resultErr
 }
 
-type retryable func(error) (bool, error)
-
-func retryWhen[T any](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error), retryable retryable, opts ...backoff.Option) (T, error) {
+func retryWhen[T any](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error), retryable Retryable, opts ...backoff.Option) (T, error) {
 	return retry.Op(f).If(func(_ T, err error) (bool, error) {
 		return retryable(err)
 	})(ctx, timeout, opts...)

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -31,13 +31,6 @@ func RetryWhen[T any](ctx context.Context, timeout time.Duration, f func(context
 	return retryWhen(ctx, timeout, f, retryable)
 }
 
-// RetryGWhen is the generic version of RetryWhen which obviates the need for a type
-// assertion after the call. It retries the function `f` when the error it returns
-// satisfies `retryable`. `f` is retried until `timeout` expires.
-func RetryGWhen[T any](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error), retryable Retryable) (T, error) {
-	return retryWhen(ctx, timeout, f, retryable)
-}
-
 // RetryWhenAWSErrCodeEquals retries the specified function when it returns one of the specified AWS error codes.
 func RetryWhenAWSErrCodeEquals[T any](ctx context.Context, timeout time.Duration, f func(context.Context) (T, error), codes ...string) (T, error) { // nosemgrep:ci.aws-in-func-name
 	return retryWhen(ctx, timeout, f, func(err error) (bool, error) {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Use the new primitives in `internal/retry` (as a replacement for the SDKv2 `helper/retry` package) for `tfresource.RetryWhen`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/42554.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43267.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43341.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43412.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43521.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43573.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43668.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43834.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43909.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/44030.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make sane
make: Sane Smoke Tests (x tests of Top y resources)
make: Like 'sanity' except full output and stops soon after 1st error
make: NOTE: NOT an exhaustive set of tests! Finds big problems only.
2025/08/26 11:28:49 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/26 11:28:49 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIAMInstanceProfile_tags
=== PAUSE TestAccIAMInstanceProfile_tags
=== RUN   TestAccIAMInstanceProfile_basic
=== PAUSE TestAccIAMInstanceProfile_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_basic
=== PAUSE TestAccIAMPolicyDocumentDataSource_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== RUN   TestAccIAMPolicy_tags
=== PAUSE TestAccIAMPolicy_tags
=== RUN   TestAccIAMPolicy_basic
=== PAUSE TestAccIAMPolicy_basic
=== RUN   TestAccIAMPolicy_policy
=== PAUSE TestAccIAMPolicy_policy
=== RUN   TestAccIAMRolePolicyAttachment_basic
=== PAUSE TestAccIAMRolePolicyAttachment_basic
=== RUN   TestAccIAMRolePolicyAttachment_disappears
=== PAUSE TestAccIAMRolePolicyAttachment_disappears
=== RUN   TestAccIAMRolePolicyAttachment_Disappears_role
=== PAUSE TestAccIAMRolePolicyAttachment_Disappears_role
=== RUN   TestAccIAMRolePolicy_basic
=== PAUSE TestAccIAMRolePolicy_basic
=== RUN   TestAccIAMRolePolicy_unknownsInPolicy
=== PAUSE TestAccIAMRolePolicy_unknownsInPolicy
=== RUN   TestAccIAMRole_basic
=== PAUSE TestAccIAMRole_basic
=== RUN   TestAccIAMRole_namePrefix
=== PAUSE TestAccIAMRole_namePrefix
=== RUN   TestAccIAMRole_disappears
=== PAUSE TestAccIAMRole_disappears
=== RUN   TestAccIAMRole_InlinePolicy_basic
=== PAUSE TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMInstanceProfile_tags
=== CONT  TestAccIAMRolePolicyAttachment_disappears
=== CONT  TestAccIAMRole_namePrefix
=== CONT  TestAccIAMRolePolicyAttachment_Disappears_role
=== CONT  TestAccIAMRole_basic
=== CONT  TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMRole_disappears
=== CONT  TestAccIAMPolicy_tags
=== CONT  TestAccIAMPolicy_policy
=== CONT  TestAccIAMRolePolicyAttachment_basic
=== CONT  TestAccIAMPolicy_basic
=== CONT  TestAccIAMRolePolicy_basic
=== CONT  TestAccIAMPolicyDocumentDataSource_basic
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== CONT  TestAccIAMInstanceProfile_basic
=== CONT  TestAccIAMRolePolicy_unknownsInPolicy
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceConflicting (13.05s)
--- PASS: TestAccIAMPolicyDocumentDataSource_basic (13.28s)
--- PASS: TestAccIAMRolePolicyAttachment_Disappears_role (17.10s)
--- PASS: TestAccIAMRole_disappears (17.11s)
--- PASS: TestAccIAMRolePolicyAttachment_disappears (17.36s)
--- PASS: TestAccIAMRole_basic (18.97s)
--- PASS: TestAccIAMPolicy_basic (19.79s)
--- PASS: TestAccIAMRole_namePrefix (19.82s)
--- PASS: TestAccIAMRolePolicy_basic (20.17s)
--- PASS: TestAccIAMRolePolicy_unknownsInPolicy (21.18s)
--- PASS: TestAccIAMInstanceProfile_basic (24.10s)
--- PASS: TestAccIAMPolicy_policy (28.01s)
--- PASS: TestAccIAMRolePolicyAttachment_basic (28.17s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (36.31s)
--- PASS: TestAccIAMPolicy_tags (54.99s)
--- PASS: TestAccIAMInstanceProfile_tags (75.78s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	81.711s
2025/08/26 11:30:41 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/26 11:30:41 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLogsGroup_basic
=== PAUSE TestAccLogsGroup_basic
=== RUN   TestAccLogsGroup_multiple
=== PAUSE TestAccLogsGroup_multiple
=== CONT  TestAccLogsGroup_basic
=== CONT  TestAccLogsGroup_multiple
--- PASS: TestAccLogsGroup_multiple (15.91s)
--- PASS: TestAccLogsGroup_basic (19.75s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	25.536s
2025/08/26 11:30:53 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/26 11:30:53 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCDataSource_basic
=== PAUSE TestAccVPCDataSource_basic
=== RUN   TestAccVPCRouteTableAssociation_Subnet_basic
=== PAUSE TestAccVPCRouteTableAssociation_Subnet_basic
=== RUN   TestAccVPCRouteTable_basic
=== PAUSE TestAccVPCRouteTable_basic
=== RUN   TestAccVPCSecurityGroupRule_race
=== PAUSE TestAccVPCSecurityGroupRule_race
=== RUN   TestAccVPCSecurityGroupRule_protocolChange
=== PAUSE TestAccVPCSecurityGroupRule_protocolChange
=== RUN   TestAccVPCSecurityGroup_basic
=== PAUSE TestAccVPCSecurityGroup_basic
=== RUN   TestAccVPCSecurityGroup_egressMode
=== PAUSE TestAccVPCSecurityGroup_egressMode
=== RUN   TestAccVPCSecurityGroup_vpcAllEgress
=== PAUSE TestAccVPCSecurityGroup_vpcAllEgress
=== RUN   TestAccVPCSubnet_basic
=== PAUSE TestAccVPCSubnet_basic
=== RUN   TestAccVPC_tenancy
=== PAUSE TestAccVPC_tenancy
=== CONT  TestAccVPCDataSource_basic
=== CONT  TestAccVPCSecurityGroup_basic
=== CONT  TestAccVPCSecurityGroupRule_race
=== CONT  TestAccVPC_tenancy
=== CONT  TestAccVPCSubnet_basic
=== CONT  TestAccVPCSecurityGroup_vpcAllEgress
=== CONT  TestAccVPCSecurityGroup_egressMode
=== CONT  TestAccVPCRouteTable_basic
=== CONT  TestAccVPCRouteTableAssociation_Subnet_basic
=== CONT  TestAccVPCSecurityGroupRule_protocolChange
--- PASS: TestAccVPCRouteTable_basic (23.68s)
--- PASS: TestAccVPCSubnet_basic (23.86s)
--- PASS: TestAccVPCSecurityGroup_basic (25.20s)
--- PASS: TestAccVPCSecurityGroup_vpcAllEgress (26.56s)
--- PASS: TestAccVPCRouteTableAssociation_Subnet_basic (27.81s)
--- PASS: TestAccVPCDataSource_basic (31.73s)
--- PASS: TestAccVPCSecurityGroup_egressMode (47.71s)
--- PASS: TestAccVPC_tenancy (51.08s)
--- PASS: TestAccVPCSecurityGroupRule_protocolChange (54.14s)
--- PASS: TestAccVPCSecurityGroupRule_race (169.29s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	187.150s
2025/08/26 11:30:49 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/26 11:30:49 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== CONT  TestAccECSService_basic
=== CONT  TestAccECSTaskDefinition_basic
--- PASS: TestAccECSTaskDefinition_basic (26.95s)
--- PASS: TestAccECSService_basic (75.20s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	88.803s
2025/08/26 11:30:57 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/26 11:30:57 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccELBV2TargetGroup_basic
=== PAUSE TestAccELBV2TargetGroup_basic
=== CONT  TestAccELBV2TargetGroup_basic
--- PASS: TestAccELBV2TargetGroup_basic (21.68s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	43.593s
2025/08/26 11:30:45 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/26 11:30:45 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKMSKey_basic
=== PAUSE TestAccKMSKey_basic
=== CONT  TestAccKMSKey_basic
--- PASS: TestAccKMSKey_basic (31.62s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	41.326s
2025/08/26 11:34:04 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/26 11:34:04 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== RUN   TestAccLambdaPermission_basic
=== PAUSE TestAccLambdaPermission_basic
=== CONT  TestAccLambdaFunction_basic
=== CONT  TestAccLambdaPermission_basic
--- PASS: TestAccLambdaPermission_basic (32.46s)
--- PASS: TestAccLambdaFunction_basic (43.15s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	49.109s
2025/08/26 11:34:08 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/26 11:34:08 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccMetaPartitionDataSource_basic
=== PAUSE TestAccMetaPartitionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_basic
=== PAUSE TestAccMetaRegionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_endpoint
=== PAUSE TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaPartitionDataSource_basic
=== CONT  TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaRegionDataSource_basic
--- PASS: TestAccMetaPartitionDataSource_basic (11.00s)
--- PASS: TestAccMetaRegionDataSource_endpoint (11.00s)
--- PASS: TestAccMetaRegionDataSource_basic (12.65s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	21.398s
2025/08/26 11:34:12 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/26 11:34:12 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRoute53Record_basic
=== PAUSE TestAccRoute53Record_basic
=== RUN   TestAccRoute53Record_Latency_basic
=== PAUSE TestAccRoute53Record_Latency_basic
=== RUN   TestAccRoute53ZoneDataSource_name
=== PAUSE TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_basic
=== CONT  TestAccRoute53Record_Latency_basic
=== CONT  TestAccRoute53ZoneDataSource_name
--- PASS: TestAccRoute53ZoneDataSource_name (73.29s)
--- PASS: TestAccRoute53Record_basic (137.83s)
--- PASS: TestAccRoute53Record_Latency_basic (138.96s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	151.567s
2025/08/26 11:34:20 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/26 11:34:20 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3BucketACL_updateACL
=== PAUSE TestAccS3BucketACL_updateACL
=== RUN   TestAccS3BucketPolicy_basic
=== PAUSE TestAccS3BucketPolicy_basic
=== RUN   TestAccS3BucketPublicAccessBlock_basic
=== PAUSE TestAccS3BucketPublicAccessBlock_basic
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Security_corsUpdate
=== PAUSE TestAccS3Bucket_Security_corsUpdate
=== RUN   TestAccS3Object_basic
=== PAUSE TestAccS3Object_basic
=== CONT  TestAccS3BucketACL_updateACL
=== CONT  TestAccS3Bucket_Basic_basic
=== CONT  TestAccS3BucketPublicAccessBlock_basic
=== CONT  TestAccS3BucketPolicy_basic
=== CONT  TestAccS3Object_basic
=== CONT  TestAccS3Bucket_Security_corsUpdate
--- PASS: TestAccS3BucketPublicAccessBlock_basic (21.03s)
--- PASS: TestAccS3BucketPolicy_basic (21.30s)
--- PASS: TestAccS3Bucket_Basic_basic (21.31s)
--- PASS: TestAccS3Object_basic (23.26s)
=== NAME  TestAccS3BucketACL_updateACL
    bucket_acl_test.go:431: Step 3/3 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
        
          map[string]string{
        - 	"access_control_policy.0.grant.1.grantee.0.display_name": "aws-hc1-terraform_team1_dev",
        + 	"access_control_policy.0.grant.1.grantee.0.display_name": "",
        - 	"access_control_policy.0.owner.0.display_name":           "aws-hc1-terraform_team1_dev",
        + 	"access_control_policy.0.owner.0.display_name":           "",
          }
--- FAIL: TestAccS3BucketACL_updateACL (34.02s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (35.66s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/s3	53.370s
2025/08/26 11:34:24 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/26 11:34:24 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSSMParameterEphemeral_basic
=== PAUSE TestAccSSMParameterEphemeral_basic
=== CONT  TestAccSSMParameterEphemeral_basic
--- PASS: TestAccSSMParameterEphemeral_basic (13.73s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	35.351s
2025/08/26 11:34:16 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/26 11:34:16 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSecretsManagerSecret_basic
=== PAUSE TestAccSecretsManagerSecret_basic
=== CONT  TestAccSecretsManagerSecret_basic
--- PASS: TestAccSecretsManagerSecret_basic (17.76s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	31.346s
2025/08/26 11:34:28 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/26 11:34:28 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSTSCallerIdentityDataSource_basic
=== PAUSE TestAccSTSCallerIdentityDataSource_basic
=== CONT  TestAccSTSCallerIdentityDataSource_basic
--- PASS: TestAccSTSCallerIdentityDataSource_basic (8.72s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sts	34.364s
FAIL
make: *** [sane] Error 1
```

Failure is unrelated to this change.