### PR TITLE
[Enhancement] aws_datazone_domain: Support v2 domain by adding `domain_version` and `service_role` arguments

### DIFF
--- a/.changelog/44042.txt
+++ b/.changelog/44042.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_datazone_domain: Add `domain_version` and `service_role` arguments to support V2 domains
+```

--- a/internal/service/datazone/domain_test.go
+++ b/internal/service/datazone/domain_test.go
@@ -42,6 +42,8 @@ func TestAccDataZoneDomain_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "portal_url"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "datazone", "domain/{id}"),
+					resource.TestCheckResourceAttr(resourceName, "domain_version", "V1"),
+					resource.TestCheckNoResourceAttr(resourceName, names.AttrServiceRole),
 				),
 			},
 			{

--- a/internal/service/datazone/domain_test.go
+++ b/internal/service/datazone/domain_test.go
@@ -230,6 +230,44 @@ func TestAccDataZoneDomain_tags(t *testing.T) {
 	})
 }
 
+func TestAccDataZoneDomain_domainVersionV2(t *testing.T) {
+	ctx := acctest.Context(t)
+	var domain datazone.GetDomainOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_domainVersionV2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttrSet(resourceName, "portal_url"),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "datazone", "domain/{id}"),
+					resource.TestCheckResourceAttr(resourceName, "domain_version", "V2"),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_execution_role", "aws_iam_role.domain_execution", names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrServiceRole, "aws_iam_role.domain_service", names.AttrARN),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrApplyImmediately, "user", "skip_deletion_check"},
+			},
+		},
+	})
+}
+
 func testAccCheckDomainDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
@@ -426,4 +464,88 @@ resource "aws_datazone_domain" "test" {
 }
 `, rName, tagKey, tagValue, tagKey2, tagValue2),
 	)
+}
+
+func testAccDomainConfig_domainVersionV2(rName string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+# IAM role for Domain Execution
+data "aws_iam_policy_document" "assume_role_domain_execution" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+      "sts:SetContext"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["datazone.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "aws:SourceAccount"
+    }
+    condition {
+      test     = "ForAllValues:StringLike"
+      values   = ["datazone*"]
+      variable = "aws:TagKeys"
+    }
+  }
+}
+
+resource "aws_iam_role" "domain_execution" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role_domain_execution.json
+  name               = "%[1]s-domain-execution-role"
+}
+
+data "aws_iam_policy" "domain_execution_role" {
+  name = "SageMakerStudioDomainExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "domain_execution" {
+  policy_arn = data.aws_iam_policy.domain_execution_role.arn
+  role       = aws_iam_role.domain_execution.name
+}
+
+# IAM role for Domain Service
+data "aws_iam_policy_document" "assume_role_domain_service" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["datazone.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "aws:SourceAccount"
+    }
+  }
+}
+
+resource "aws_iam_role" "domain_service" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role_domain_service.json
+  name               = "%[1]s-domain-service-role"
+}
+
+data "aws_iam_policy" "domain_service_role" {
+  name = "SageMakerStudioDomainServiceRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "domain_service" {
+  policy_arn = data.aws_iam_policy.domain_service_role.arn
+  role       = aws_iam_role.domain_service.name
+}
+
+# DataZone Domain V2
+resource "aws_datazone_domain" "test" {
+  name                  = %[1]q
+  domain_execution_role = aws_iam_role.domain_execution.arn
+  domain_version        = "V2"
+  service_role          = aws_iam_role.domain_service.arn
+}
+`, rName)
 }

--- a/website/docs/r/datazone_domain.html.markdown
+++ b/website/docs/r/datazone_domain.html.markdown
@@ -75,7 +75,9 @@ The following arguments are optional:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `description` - (Optional) Description of the Domain.
+* `domain_version` - (Optional) Version of the Domain. Valid values are `V1` and `V2`. Defaults to `V1`.
 * `kms_key_identifier` - (Optional) ARN of the KMS key used to encrypt the Amazon DataZone domain, metadata and reporting data.
+* `service_role` - (Optional) ARN of the service role used by DataZone. Required when `domain_version` is set to `V2`.
 * `single_sign_on` - (Optional) Single sign on options, used to [enable AWS IAM Identity Center](https://docs.aws.amazon.com/datazone/latest/userguide/enable-IAM-identity-center-for-datazone.html) for DataZone.
 * `skip_deletion_check` - (Optional) Whether to skip the deletion check for the Domain.
 

--- a/website/docs/r/datazone_domain.html.markdown
+++ b/website/docs/r/datazone_domain.html.markdown
@@ -36,26 +36,26 @@ resource "aws_iam_role" "domain_execution_role" {
       },
     ]
   })
+}
 
-  inline_policy {
-    name = "domain_execution_policy"
-    policy = jsonencode({
-      Version = "2012-10-17"
-      Statement = [
-        {
-          # Consider scoping down
-          Action = [
-            "datazone:*",
-            "ram:*",
-            "sso:*",
-            "kms:*",
-          ]
-          Effect   = "Allow"
-          Resource = "*"
-        },
-      ]
-    })
-  }
+resource "aws_iam_role_policy" "domain_execution_role" {
+  role = aws_iam_role.domain_execution_role.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # Consider scoping down
+        Action = [
+          "datazone:*",
+          "ram:*",
+          "sso:*",
+          "kms:*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
 }
 
 resource "aws_datazone_domain" "example" {

--- a/website/docs/r/datazone_domain.html.markdown
+++ b/website/docs/r/datazone_domain.html.markdown
@@ -64,6 +64,90 @@ resource "aws_datazone_domain" "example" {
 }
 ```
 
+### V2 Domain
+
+```terraform
+data "aws_caller_identity" "current" {}
+
+# IAM role for Domain Execution
+data "aws_iam_policy_document" "assume_role_domain_execution" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+      "sts:SetContext"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["datazone.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "aws:SourceAccount"
+    }
+    condition {
+      test     = "ForAllValues:StringLike"
+      values   = ["datazone*"]
+      variable = "aws:TagKeys"
+    }
+  }
+}
+
+resource "aws_iam_role" "domain_execution" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role_domain_execution.json
+  name               = "example-domain-execution-role"
+}
+
+data "aws_iam_policy" "domain_execution_role" {
+  name = "SageMakerStudioDomainExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "domain_execution" {
+  policy_arn = data.aws_iam_policy.domain_execution_role.arn
+  role       = aws_iam_role.domain_execution.name
+}
+
+# IAM role for Domain Service
+data "aws_iam_policy_document" "assume_role_domain_service" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["datazone.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "aws:SourceAccount"
+    }
+  }
+}
+
+resource "aws_iam_role" "domain_service" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role_domain_service.json
+  name               = "example-domain-service-role"
+}
+
+data "aws_iam_policy" "domain_service_role" {
+  name = "SageMakerStudioDomainServiceRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "domain_service" {
+  policy_arn = data.aws_iam_policy.domain_service_role.arn
+  role       = aws_iam_role.domain_service.name
+}
+
+# DataZone Domain V2
+resource "aws_datazone_domain" "example" {
+  name                  = "example-domain"
+  domain_execution_role = aws_iam_role.domain_execution.arn
+  domain_version        = "V2"
+  service_role          = aws_iam_role.domain_service.arn
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* To support V2 domains, the `domain_version` and `service_role` arguments have been added.

  * Since the AWS API returns `domain_version` even if it is not specified, it is marked as `Computed`.
  * Because the UpdateDomain API does not accept `domain_version` as an argument, it is marked as `ForceNew`.
* An example for a V2 domain, including domain execution and a service role (identical to what the AWS Management Console creates), has been added.

  * This example is also used in the newly added acceptance test.


### Relations
Closes #44039

### References
https://docs.aws.amazon.com/datazone/latest/APIReference/API_CreateDomain.html#datazone-CreateDomain-request-domainVersion

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccDataZoneDomain_ PKG=datazone 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/datazone/... -v -count 1 -parallel 20 -run='TestAccDataZoneDomain_'  -timeout 360m -vet=off
2025/08/27 01:55:04 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/27 01:55:04 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDataZoneDomain_basic
=== PAUSE TestAccDataZoneDomain_basic
=== RUN   TestAccDataZoneDomain_disappears
=== PAUSE TestAccDataZoneDomain_disappears
=== RUN   TestAccDataZoneDomain_kms_key_identifier
=== PAUSE TestAccDataZoneDomain_kms_key_identifier
=== RUN   TestAccDataZoneDomain_description
=== PAUSE TestAccDataZoneDomain_description
=== RUN   TestAccDataZoneDomain_single_sign_on
=== PAUSE TestAccDataZoneDomain_single_sign_on
=== RUN   TestAccDataZoneDomain_tags
=== PAUSE TestAccDataZoneDomain_tags
=== RUN   TestAccDataZoneDomain_domainVersionV2
=== PAUSE TestAccDataZoneDomain_domainVersionV2
=== CONT  TestAccDataZoneDomain_basic
=== CONT  TestAccDataZoneDomain_single_sign_on
=== CONT  TestAccDataZoneDomain_kms_key_identifier
=== CONT  TestAccDataZoneDomain_description
=== CONT  TestAccDataZoneDomain_domainVersionV2
=== CONT  TestAccDataZoneDomain_tags
=== CONT  TestAccDataZoneDomain_disappears
--- PASS: TestAccDataZoneDomain_disappears (43.36s)
--- PASS: TestAccDataZoneDomain_kms_key_identifier (43.39s)
--- PASS: TestAccDataZoneDomain_single_sign_on (46.52s)
--- PASS: TestAccDataZoneDomain_basic (46.61s)
--- PASS: TestAccDataZoneDomain_description (46.82s)
--- PASS: TestAccDataZoneDomain_domainVersionV2 (60.32s)
--- PASS: TestAccDataZoneDomain_tags (86.79s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datazone   91.598s


```
