### PR TITLE
[bugfix] aws_db_instance: Fix to enable to update `database_insights_mode` with custom KMS key

### DIFF
--- a/.changelog/44050.txt
+++ b/.changelog/44050.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_instance: Fixes the behavior when modifying `database_insights_mode` when using custom KMS key
+```

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -2489,6 +2489,9 @@ func dbInstancePopulateModify(input *rds.ModifyDBInstanceInput, d *schema.Resour
 	if d.HasChange("database_insights_mode") {
 		input.DatabaseInsightsMode = types.DatabaseInsightsMode(d.Get("database_insights_mode").(string))
 		input.EnablePerformanceInsights = aws.Bool(d.Get("performance_insights_enabled").(bool))
+		if v, ok := d.Get("performance_insights_kms_key_id").(string); ok && v != "" {
+			input.PerformanceInsightsKMSKeyId = aws.String(v)
+		}
 		input.PerformanceInsightsRetentionPeriod = aws.Int32(int32(d.Get("performance_insights_retention_period").(int)))
 	}
 

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -5571,6 +5571,88 @@ func TestAccRDSInstance_PerformanceInsights_kmsKeyID(t *testing.T) {
 	})
 }
 
+func TestAccRDSInstance_PerformanceInsights_kmsKeyID_UpdateMode(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	// All RDS Instance tests should skip for testing.Short() except the 20 shortest running tests.
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var dbInstance types.DBInstance
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	kmsKeyResourceName := "aws_kms_key.test"
+	resourceName := "aws_db_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPerformanceInsightsDefaultVersionPreCheck(ctx, t, tfrds.InstanceEngineMySQL)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		CheckDestroy: testAccCheckClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_performanceInsightsKMSKeyIDUpdateMode(rName, string(types.DatabaseInsightsModeStandard)),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDBInstanceExists(ctx, resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "database_insights_mode", string(types.DatabaseInsightsModeStandard)),
+					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttrPair(resourceName, "performance_insights_kms_key_id", kmsKeyResourceName, names.AttrARN),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					names.AttrApplyImmediately,
+					names.AttrPassword,
+					"skip_final_snapshot",
+					names.AttrFinalSnapshotIdentifier,
+				},
+			},
+			{
+				Config: testAccInstanceConfig_performanceInsightsKMSKeyIDUpdateMode(rName, string(types.DatabaseInsightsModeAdvanced)),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDBInstanceExists(ctx, resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "database_insights_mode", string(types.DatabaseInsightsModeAdvanced)),
+					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttrPair(resourceName, "performance_insights_kms_key_id", kmsKeyResourceName, names.AttrARN),
+				),
+			},
+			{
+				Config: testAccInstanceConfig_performanceInsightsKMSKeyIDUpdateMode(rName, string(types.DatabaseInsightsModeStandard)),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDBInstanceExists(ctx, resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "database_insights_mode", string(types.DatabaseInsightsModeStandard)),
+					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttrPair(resourceName, "performance_insights_kms_key_id", kmsKeyResourceName, names.AttrARN),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRDSInstance_PerformanceInsights_retentionPeriod(t *testing.T) {
 	ctx := acctest.Context(t)
 
@@ -13490,6 +13572,55 @@ resource "aws_db_instance" "test" {
   username                              = "foo"
 }
 `, tfrds.InstanceEngineMySQL, mainInstanceClasses, rName))
+}
+
+func testAccInstanceConfig_performanceInsightsKMSKeyIDUpdateMode(rName, mode string) string {
+	var retentionPeriod int
+	switch mode {
+	case string(types.DatabaseInsightsModeStandard):
+		retentionPeriod = 7
+	case string(types.DatabaseInsightsModeAdvanced):
+		retentionPeriod = 465
+	}
+	return acctest.ConfigCompose(
+		acctest.ConfigRandomPassword(),
+		fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
+
+data "aws_rds_engine_version" "default" {
+  engine = %[1]q
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                        = data.aws_rds_engine_version.default.engine
+  engine_version                = data.aws_rds_engine_version.default.version
+  license_model                 = "general-public-license"
+  storage_type                  = "standard"
+  supports_performance_insights = true
+  preferred_instance_classes    = [%[2]s]
+}
+
+resource "aws_db_instance" "test" {
+  allocated_storage                     = 5
+  backup_retention_period               = 0
+  database_insights_mode                = %[4]q
+  db_name                               = "mydb"
+  engine                                = data.aws_rds_engine_version.default.engine
+  engine_version                        = data.aws_rds_engine_version.default.version
+  identifier                            = %[3]q
+  instance_class                        = data.aws_rds_orderable_db_instance.test.instance_class
+  password_wo                           = ephemeral.aws_secretsmanager_random_password.test.random_password
+  password_wo_version                   = 1
+  performance_insights_enabled          = true
+  performance_insights_kms_key_id       = aws_kms_key.test.arn
+  performance_insights_retention_period = %[5]d
+  skip_final_snapshot                   = true
+  username                              = "foo"
+}
+`, tfrds.InstanceEngineMySQL, mainInstanceClasses, rName, mode, retentionPeriod))
 }
 
 func testAccInstanceConfig_performanceInsightsRetentionPeriod(rName string, performanceInsightsRetentionPeriod int) string {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Fixes RDS instance `database_insights_mode` updates when using a custom KMS key for Performance Insights encryption.
This fix is the same as #43942, which addressed the same issue for RDS clusters.

When updating the `database_insights_mode` parameter on an RDS instance that has a custom KMS key configured for Performance Insights encryption, the provider was not properly setting the `performance_insights_kms_key_id` parameter in the `ModifyDBInstance` API call. As a result, the KMS key was being reset during the update, causing the update operation to fail.

This PR fixes the issue by ensuring that when `database_insights_mode` is updated, the existing `performance_insights_kms_key_id` value is also passed to the `ModifyDBInstance` API call if it is configured.


#### Changes

* **internal/service/rds/instance.go**: Added logic to include `performance_insights_kms_key_id` when updating `database_insights_mode`.
* **internal/service/rds/instance\_test.go**: Added comprehensive test `TestAccRDSInstance_PerformanceInsights_kmsKeyID_UpdateMode` to verify the fix.

  * Added a new test case to verify that the KMS key is preserved when switching between standard and advanced database insights modes.
  * Test covers both directions of the mode change (standard → advanced → standard).
  * Existing Performance Insights tests continue to pass.


### Relations

Closes #44046
Relates #43942

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccRDSInstance_PerformanceInsights_ PKG=rds                   
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstance_PerformanceInsights_'  -timeout 360m -vet=off
2025/08/27 07:46:45 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/27 07:46:45 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSInstance_PerformanceInsights_disabledToEnabled
=== PAUSE TestAccRDSInstance_PerformanceInsights_disabledToEnabled
=== RUN   TestAccRDSInstance_PerformanceInsights_enabledToDisabled
=== PAUSE TestAccRDSInstance_PerformanceInsights_enabledToDisabled
=== RUN   TestAccRDSInstance_PerformanceInsights_kmsKeyID
=== PAUSE TestAccRDSInstance_PerformanceInsights_kmsKeyID
=== RUN   TestAccRDSInstance_PerformanceInsights_kmsKeyID_UpdateMode
=== PAUSE TestAccRDSInstance_PerformanceInsights_kmsKeyID_UpdateMode
=== RUN   TestAccRDSInstance_PerformanceInsights_retentionPeriod
=== PAUSE TestAccRDSInstance_PerformanceInsights_retentionPeriod
=== RUN   TestAccRDSInstance_PerformanceInsights_databaseInsightsMode
=== PAUSE TestAccRDSInstance_PerformanceInsights_databaseInsightsMode
=== CONT  TestAccRDSInstance_PerformanceInsights_disabledToEnabled
=== CONT  TestAccRDSInstance_PerformanceInsights_kmsKeyID_UpdateMode
=== CONT  TestAccRDSInstance_PerformanceInsights_kmsKeyID
=== CONT  TestAccRDSInstance_PerformanceInsights_databaseInsightsMode
=== CONT  TestAccRDSInstance_PerformanceInsights_enabledToDisabled
=== CONT  TestAccRDSInstance_PerformanceInsights_retentionPeriod
--- PASS: TestAccRDSInstance_PerformanceInsights_disabledToEnabled (694.35s)
--- PASS: TestAccRDSInstance_PerformanceInsights_enabledToDisabled (826.38s)
--- PASS: TestAccRDSInstance_PerformanceInsights_retentionPeriod (1015.02s)
--- PASS: TestAccRDSInstance_PerformanceInsights_kmsKeyID (1025.83s)
--- PASS: TestAccRDSInstance_PerformanceInsights_kmsKeyID_UpdateMode (1046.41s)
--- PASS: TestAccRDSInstance_PerformanceInsights_databaseInsightsMode (1079.81s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        1084.052s


```
