### PR TITLE
Updating Amazon Bedrock Knowledge Bases to support Amazon OpenSearch Managed Clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ FEATURES:
 
 ENHANCEMENTS:
 
+* resource/aws_bedrockagent_knowledge_base: Add support for OpenSearch managed clusters in `storage_configuration` ([#42588](https://github.com/hashicorp/terraform-provider-aws/issues/42588))
 * data-source/aws_network_interface: Add `attachment.network_card_index` attribute ([#42188](https://github.com/hashicorp/terraform-provider-aws/issues/42188))
 * data-source/aws_sesv2_email_identity: Add `verification_status` attribute ([#44045](https://github.com/hashicorp/terraform-provider-aws/issues/44045))
 * data-source/aws_signer_signing_profile: Add `signing_material` and `signing_parameters` attributes ([#43921](https://github.com/hashicorp/terraform-provider-aws/issues/43921))

--- a/internal/service/bedrockagent/knowledge_base.go
+++ b/internal/service/bedrockagent/knowledge_base.go
@@ -431,6 +431,77 @@ func (r *knowledgeBaseResource) Schema(ctx context.Context, request resource.Sch
 								},
 							},
 						},
+						"opensearch_managed_cluster_configuration": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[opensearchManagedClusterConfigurationModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							PlanModifiers: []planmodifier.List{
+								listplanmodifier.RequiresReplace(),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"domain_arn": schema.StringAttribute{
+										CustomType: fwtypes.ARNType,
+										Required:   true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.RequiresReplace(),
+										},
+									},
+									"domain_endpoint": schema.StringAttribute{
+										Required: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.RequiresReplace(),
+										},
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(
+												regexache.MustCompile(`^https://.*$`),
+												"must be a valid HTTPS URL",
+											),
+										},
+									},
+									"vector_index_name": schema.StringAttribute{
+										Required: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.RequiresReplace(),
+										},
+									},
+								},
+								Blocks: map[string]schema.Block{
+									"field_mapping": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[opensearchManagedClusterFieldMappingModel](ctx),
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										PlanModifiers: []planmodifier.List{
+											listplanmodifier.RequiresReplace(),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"metadata_field": schema.StringAttribute{
+													Required: true,
+													PlanModifiers: []planmodifier.String{
+														stringplanmodifier.RequiresReplace(),
+													},
+												},
+												"text_field": schema.StringAttribute{
+													Required: true,
+													PlanModifiers: []planmodifier.String{
+														stringplanmodifier.RequiresReplace(),
+													},
+												},
+												"vector_field": schema.StringAttribute{
+													Required: true,
+													PlanModifiers: []planmodifier.String{
+														stringplanmodifier.RequiresReplace(),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 						"opensearch_serverless_configuration": schema.ListNestedBlock{
 							CustomType: fwtypes.NewListNestedObjectTypeOf[opensearchServerlessConfigurationModel](ctx),
 							Validators: []validator.List{
@@ -834,11 +905,12 @@ type storageLocationModel struct {
 }
 
 type storageConfigurationModel struct {
-	OpensearchServerlessConfiguration fwtypes.ListNestedObjectValueOf[opensearchServerlessConfigurationModel] `tfsdk:"opensearch_serverless_configuration"`
-	PineconeConfiguration             fwtypes.ListNestedObjectValueOf[pineconeConfigurationModel]             `tfsdk:"pinecone_configuration"`
-	RDSConfiguration                  fwtypes.ListNestedObjectValueOf[rdsConfigurationModel]                  `tfsdk:"rds_configuration"`
-	RedisEnterpriseCloudConfiguration fwtypes.ListNestedObjectValueOf[redisEnterpriseCloudConfigurationModel] `tfsdk:"redis_enterprise_cloud_configuration"`
-	Type                              types.String                                                            `tfsdk:"type"`
+	OpensearchManagedClusterConfiguration fwtypes.ListNestedObjectValueOf[opensearchManagedClusterConfigurationModel] `tfsdk:"opensearch_managed_cluster_configuration"`
+	OpensearchServerlessConfiguration     fwtypes.ListNestedObjectValueOf[opensearchServerlessConfigurationModel]     `tfsdk:"opensearch_serverless_configuration"`
+	PineconeConfiguration                 fwtypes.ListNestedObjectValueOf[pineconeConfigurationModel]                 `tfsdk:"pinecone_configuration"`
+	RDSConfiguration                      fwtypes.ListNestedObjectValueOf[rdsConfigurationModel]                      `tfsdk:"rds_configuration"`
+	RedisEnterpriseCloudConfiguration     fwtypes.ListNestedObjectValueOf[redisEnterpriseCloudConfigurationModel]     `tfsdk:"redis_enterprise_cloud_configuration"`
+	Type                                  types.String                                                                `tfsdk:"type"`
 }
 
 type opensearchServerlessConfigurationModel struct {
@@ -848,6 +920,19 @@ type opensearchServerlessConfigurationModel struct {
 }
 
 type opensearchServerlessFieldMappingModel struct {
+	MetadataField types.String `tfsdk:"metadata_field"`
+	TextField     types.String `tfsdk:"text_field"`
+	VectorField   types.String `tfsdk:"vector_field"`
+}
+
+type opensearchManagedClusterConfigurationModel struct {
+	DomainARN       fwtypes.ARN                                                                `tfsdk:"domain_arn"`
+	DomainEndpoint  types.String                                                               `tfsdk:"domain_endpoint"`
+	FieldMapping    fwtypes.ListNestedObjectValueOf[opensearchManagedClusterFieldMappingModel] `tfsdk:"field_mapping"`
+	VectorIndexName types.String                                                               `tfsdk:"vector_index_name"`
+}
+
+type opensearchManagedClusterFieldMappingModel struct {
 	MetadataField types.String `tfsdk:"metadata_field"`
 	TextField     types.String `tfsdk:"text_field"`
 	VectorField   types.String `tfsdk:"vector_field"`

--- a/internal/service/bedrockagent/knowledge_base_test.go
+++ b/internal/service/bedrockagent/knowledge_base_test.go
@@ -449,6 +449,51 @@ func testAccCheckKnowledgeBaseExists(ctx context.Context, n string, v *types.Kno
 	}
 }
 
+func TestAccKnowledgeBase_OpenSearchManagedCluster_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	domain := skipIfOSDomainEnvVarNotSet(t)
+	bedrockIAMRoleName := skipIfIAMRoleVarNotSet(t)
+
+	var knowledgebase types.KnowledgeBase
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_bedrockagent_knowledge_base.test"
+	foundationModel := "amazon.titan-embed-text-v2:0"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckKnowledgeBaseDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKnowledgeBaseConfig_OpenSearchManagedCluster_basic(rName, domain, bedrockIAMRoleName, foundationModel),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKnowledgeBaseExists(ctx, resourceName, &knowledgebase),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "knowledge_base_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "knowledge_base_configuration.0.vector_knowledge_base_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "knowledge_base_configuration.0.type", "VECTOR"),
+					resource.TestCheckResourceAttr(resourceName, "storage_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_configuration.0.type", "OPENSEARCH_MANAGED_CLUSTER"),
+					resource.TestCheckResourceAttr(resourceName, "storage_configuration.0.opensearch_managed_cluster_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_configuration.0.opensearch_managed_cluster_configuration.0.vector_index_name", "knowledge-index"),
+					resource.TestCheckResourceAttr(resourceName, "storage_configuration.0.opensearch_managed_cluster_configuration.0.field_mapping.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_configuration.0.opensearch_managed_cluster_configuration.0.field_mapping.0.vector_field", "vector_embedding"),
+					resource.TestCheckResourceAttr(resourceName, "storage_configuration.0.opensearch_managed_cluster_configuration.0.field_mapping.0.text_field", "text"),
+					resource.TestCheckResourceAttr(resourceName, "storage_configuration.0.opensearch_managed_cluster_configuration.0.field_mapping.0.metadata_field", "metadata"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 // skipIfOSSCollectionNameEnvVarNotSet handles skipping tests when an environment
 // variable providing a valid OSS collection name is unset
 //
@@ -498,6 +543,18 @@ func skipIfOSDomainEnvVarNotSet(t *testing.T) string {
 	if v == "" {
 		acctest.Skip(t, "This test requires external configuration of an OpenSearch domain. "+
 			"Set the TF_AWS_BEDROCK_OS_DOMAIN_NAME environment variable to the OpenSearch domain name.")
+	}
+	return v
+}
+
+func skipIfIAMRoleVarNotSet(t *testing.T) string {
+	t.Helper()
+
+	v := os.Getenv("TF_AWS_BEDROCK_IAM_ROLE_ARN")
+	if v == "" {
+		acctest.Skip(t, "This test requires external configuration of an IAM Role with permissions on the OpenSearch Cluster."+
+			"It must be able to be assumed by the Amazon Bedrock service"+
+			"Set the TF_AWS_BEDROCK_IAM_ROLE_ARN environment variable to the IAM Role's ARN.")
 	}
 	return v
 }
@@ -957,166 +1014,20 @@ resource "aws_bedrockagent_knowledge_base" "test" {
 `, rName, model))
 }
 
-func testAccKnowledgeBase_OpenSearchManagedCluster_basic(t *testing.T) {
-	ctx := acctest.Context(t)
-	domain := skipIfOSDomainEnvVarNotSet(t)
-
-	var knowledgebase types.KnowledgeBase
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_bedrockagent_knowledge_base.test"
-	foundationModel := "amazon.titan-embed-text-v2:0"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-		},
-		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckKnowledgeBaseDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccKnowledgeBaseConfig_OpenSearchManagedCluster_basic(rName, domain, foundationModel),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKnowledgeBaseExists(ctx, resourceName, &knowledgebase),
-					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrRoleARN, "aws_iam_role.test", names.AttrARN),
-					resource.TestCheckResourceAttr(resourceName, "knowledge_base_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "knowledge_base_configuration.0.vector_knowledge_base_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "knowledge_base_configuration.0.type", "VECTOR"),
-					resource.TestCheckResourceAttr(resourceName, "storage_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "storage_configuration.0.type", "OPENSEARCH_MANAGED_CLUSTER"),
-					resource.TestCheckResourceAttr(resourceName, "storage_configuration.0.opensearch_managed_cluster_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "storage_configuration.0.opensearch_managed_cluster_configuration.0.vector_index_name", "bedrock-knowledge-base-default-index"),
-					resource.TestCheckResourceAttr(resourceName, "storage_configuration.0.opensearch_managed_cluster_configuration.0.field_mapping.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "storage_configuration.0.opensearch_managed_cluster_configuration.0.field_mapping.0.vector_field", "bedrock-knowledge-base-default-vector"),
-					resource.TestCheckResourceAttr(resourceName, "storage_configuration.0.opensearch_managed_cluster_configuration.0.field_mapping.0.text_field", "text_chunk"),
-					resource.TestCheckResourceAttr(resourceName, "storage_configuration.0.opensearch_managed_cluster_configuration.0.field_mapping.0.metadata_field", "metadata"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func testAccKnowledgeBaseConfigBase_openSearchManagedCluster(rName, domainName, model string) string {
-	return fmt.Sprintf(`
+func testAccKnowledgeBaseConfig_OpenSearchManagedCluster_basic(rName, domainName, bedrockRole, model string) string {
+	return acctest.ConfigCompose(
+		fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 data "aws_partition" "current" {}
 
 data "aws_opensearch_domain" "test" {
-  domain_name = %[2]q
+  domain_name = %[4]q
 }
 
-# See the Amazon Bedrock documentation for creating a service role:
-# https://docs.aws.amazon.com/bedrock/latest/userguide/kb-permissions.html
-data "aws_iam_policy_document" "test_trust" {
-  statement {
-    effect = "Allow"
-    actions = [
-      "sts:AssumeRole",
-    ]
-    principals {
-      type        = "Service"
-      identifiers = ["bedrock.amazonaws.com"]
-    }
-    condition {
-      test     = "StringEquals"
-      variable = "aws:SourceAccount"
-      values = [
-        data.aws_caller_identity.current.account_id,
-      ]
-    }
-    condition {
-      test     = "ArnLike"
-      variable = "aws:SourceArn"
-      values = [
-        "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:knowledge-base/*"
-      ]
-    }
-  }
-}
-
-data "aws_iam_policy_document" "test" {
-  statement {
-    effect = "Allow"
-    actions = [
-      "bedrock:ListFoundationModels",
-      "bedrock:ListCustomModels",
-    ]
-    resources = [
-      "*",
-    ]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "bedrock:InvokeModel",
-    ]
-    resources = [
-      "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:foundation-model/%[3]s",
-    ]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "bedrock:RetreiveAndGenerate",
-    ]
-    resources = [
-      "*",
-    ]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "es:ESHttpDelete",
-      "es:ESHttpGet",
-      "es:ESHttpHead",
-      "es:ESHttpPost",
-      "es:ESHttpPut",
-    ]
-    resources = [
-      data.aws_opensearch_domain.test.arn,
-      "${data.aws_opensearch_domain.test.arn}/*",
-    ]
-  }
-}
-
-resource "aws_iam_role" "test" {
-  name               = %[1]q
-  assume_role_policy = data.aws_iam_policy_document.test_trust.json
-}
-
-resource "aws_iam_policy" "test" {
-  name   = %[1]q
-  policy = data.aws_iam_policy_document.test.json
-}
-
-resource "aws_iam_role_policy_attachment" "test" {
-  role       = aws_iam_role.test.name
-  policy_arn = aws_iam_policy.test.arn
-}
-`, rName, domainName, model)
-}
-
-func testAccKnowledgeBaseConfig_OpenSearchManagedCluster_basic(rName, domainName, model string) string {
-	return acctest.ConfigCompose(
-		testAccKnowledgeBaseConfigBase_openSearchManagedCluster(rName, domainName, model),
-		fmt.Sprintf(`
 resource "aws_bedrockagent_knowledge_base" "test" {
-  depends_on = [
-    aws_iam_role_policy_attachment.test,
-  ]
-
   name     = %[1]q
-  role_arn = aws_iam_role.test.arn
+  role_arn = %[3]q #aws_iam_role.test.arn
 
   knowledge_base_configuration {
     vector_knowledge_base_configuration {
@@ -1129,15 +1040,15 @@ resource "aws_bedrockagent_knowledge_base" "test" {
     type = "OPENSEARCH_MANAGED_CLUSTER"
     opensearch_managed_cluster_configuration {
       domain_arn      = data.aws_opensearch_domain.test.arn
-      domain_endpoint = data.aws_opensearch_domain.test.endpoint
-      vector_index_name = "bedrock-knowledge-base-default-index"
+      domain_endpoint = "https://${data.aws_opensearch_domain.test.endpoint}"
+      vector_index_name = "knowledge-index"
       field_mapping {
-        vector_field   = "bedrock-knowledge-base-default-vector"
-        text_field     = "text_chunk"
+        vector_field   = "vector_embedding"
+        text_field     = "text"
         metadata_field = "metadata"
       }
     }
   }
 }
-`, rName, model))
+`, rName, model, bedrockRole, domainName))
 }

--- a/website/docs/cdktf/python/r/bedrockagent_knowledge_base.html.markdown
+++ b/website/docs/cdktf/python/r/bedrockagent_knowledge_base.html.markdown
@@ -185,8 +185,9 @@ The `s3_location` configuration block supports the following arguments:
 
 The `storage_configuration` configuration block supports the following arguments:
 
-* `type` - (Required) Vector store service in which the knowledge base is stored. Valid Values: `OPENSEARCH_SERVERLESS`, `PINECONE`, `REDIS_ENTERPRISE_CLOUD`, `RDS`.
-* `opensearch_serverless_configuration` - (Optional) The storage configuration of the knowledge base in Amazon OpenSearch Service. See [`opensearch_serverless_configuration` block](#opensearch_serverless_configuration-block) for details.
+* `type` - (Required) Vector store service in which the knowledge base is stored. Valid Values: `OPENSEARCH_SERVERLESS`, `OPENSEARCH_MANAGED_CLUSTER`, `PINECONE`, `REDIS_ENTERPRISE_CLOUD`, `RDS`.
+* `opensearch_serverless_configuration` - (Optional) The storage configuration of the knowledge base in Amazon OpenSearch Service Serverless. See [`opensearch_serverless_configuration` block](#opensearch_serverless_configuration-block) for details.
+* `opensearch_managed_cluster_configuration` - (Optional) The storage configuration of the knowledge base in Amazon OpenSearch Service Managed Cluster. See [`opensearch_managed_cluster_configuration` block](#opensearch_managed_cluster_configuration-block) for details.
 * `pinecone_configuration` - (Optional)  The storage configuration of the knowledge base in Pinecone. See [`pinecone_configuration` block](#pinecone_configuration-block) for details.
 * `rds_configuration` - (Optional) Details about the storage configuration of the knowledge base in Amazon RDS. For more information, see [Create a vector index in Amazon RDS](https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base-setup.html). See [`rds_configuration` block](#rds_configuration-block) for details.
 * `redis_enterprise_cloud_configuration` - (Optional) The storage configuration of the knowledge base in Redis Enterprise Cloud. See [`redis_enterprise_cloud_configuration` block](#redis_enterprise_cloud_configuration-block) for details.
@@ -196,6 +197,18 @@ The `storage_configuration` configuration block supports the following arguments
 The `opensearch_serverless_configuration` configuration block supports the following arguments:
 
 * `collection_arn` - (Required) ARN of the OpenSearch Service vector store.
+* `field_mapping` - (Required) The names of the fields to which to map information about the vector store. This block supports the following arguments:
+    * `metadata_field` - (Required) Name of the field in which Amazon Bedrock stores metadata about the vector store.
+    * `text_field` - (Required) Name of the field in which Amazon Bedrock stores the raw text from your data. The text is split according to the chunking strategy you choose.
+    * `vector_field` - (Required) Name of the field in which Amazon Bedrock stores the vector embeddings for your data sources.
+* `vector_index_name` - (Required) Name of the vector store.
+
+### `opensearch_managed_cluster_configuration` block
+
+The `opensearch_managed_cluster_configuration` configuration block supports the following arguments:
+
+* `domain_arn` - (Required) ARN of the OpenSearch domain.
+* `domain_endpoint` - (Required) Endpoint URL of the OpenSearch domain.
 * `field_mapping` - (Required) The names of the fields to which to map information about the vector store. This block supports the following arguments:
     * `metadata_field` - (Required) Name of the field in which Amazon Bedrock stores metadata about the vector store.
     * `text_field` - (Required) Name of the field in which Amazon Bedrock stores the raw text from your data. The text is split according to the chunking strategy you choose.

--- a/website/docs/cdktf/typescript/r/bedrockagent_knowledge_base.html.markdown
+++ b/website/docs/cdktf/typescript/r/bedrockagent_knowledge_base.html.markdown
@@ -210,8 +210,9 @@ The `s3Location` configuration block supports the following arguments:
 
 The `storageConfiguration` configuration block supports the following arguments:
 
-* `type` - (Required) Vector store service in which the knowledge base is stored. Valid Values: `OPENSEARCH_SERVERLESS`, `PINECONE`, `REDIS_ENTERPRISE_CLOUD`, `RDS`.
-* `opensearchServerlessConfiguration` - (Optional) The storage configuration of the knowledge base in Amazon OpenSearch Service. See [`opensearchServerlessConfiguration` block](#opensearch_serverless_configuration-block) for details.
+* `type` - (Required) Vector store service in which the knowledge base is stored. Valid Values: `OPENSEARCH_SERVERLESS`, `OPENSEARCH_MANAGED_CLUSTER`, `PINECONE`, `REDIS_ENTERPRISE_CLOUD`, `RDS`.
+* `opensearchServerlessConfiguration` - (Optional) The storage configuration of the knowledge base in Amazon OpenSearch Service Serverless. See [`opensearchServerlessConfiguration` block](#opensearch_serverless_configuration-block) for details.
+* `opensearchManagedClusterConfiguration` - (Optional) The storage configuration of the knowledge base in Amazon OpenSearch Service Managed Cluster. See [`opensearchManagedClusterConfiguration` block](#opensearch_managed_cluster_configuration-block) for details.
 * `pineconeConfiguration` - (Optional)  The storage configuration of the knowledge base in Pinecone. See [`pineconeConfiguration` block](#pinecone_configuration-block) for details.
 * `rdsConfiguration` - (Optional) Details about the storage configuration of the knowledge base in Amazon RDS. For more information, see [Create a vector index in Amazon RDS](https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base-setup.html). See [`rdsConfiguration` block](#rds_configuration-block) for details.
 * `redisEnterpriseCloudConfiguration` - (Optional) The storage configuration of the knowledge base in Redis Enterprise Cloud. See [`redisEnterpriseCloudConfiguration` block](#redis_enterprise_cloud_configuration-block) for details.
@@ -221,6 +222,18 @@ The `storageConfiguration` configuration block supports the following arguments:
 The `opensearchServerlessConfiguration` configuration block supports the following arguments:
 
 * `collectionArn` - (Required) ARN of the OpenSearch Service vector store.
+* `fieldMapping` - (Required) The names of the fields to which to map information about the vector store. This block supports the following arguments:
+    * `metadataField` - (Required) Name of the field in which Amazon Bedrock stores metadata about the vector store.
+    * `textField` - (Required) Name of the field in which Amazon Bedrock stores the raw text from your data. The text is split according to the chunking strategy you choose.
+    * `vectorField` - (Required) Name of the field in which Amazon Bedrock stores the vector embeddings for your data sources.
+* `vectorIndexName` - (Required) Name of the vector store.
+
+### `opensearchManagedClusterConfiguration` block
+
+The `opensearchManagedClusterConfiguration` configuration block supports the following arguments:
+
+* `domainArn` - (Required) ARN of the OpenSearch domain.
+* `domainEndpoint` - (Required) Endpoint URL of the OpenSearch domain.
 * `fieldMapping` - (Required) The names of the fields to which to map information about the vector store. This block supports the following arguments:
     * `metadataField` - (Required) Name of the field in which Amazon Bedrock stores metadata about the vector store.
     * `textField` - (Required) Name of the field in which Amazon Bedrock stores the raw text from your data. The text is split according to the chunking strategy you choose.

--- a/website/docs/cdktf/typescript/r/bedrockagent_knowledge_base.html.markdown
+++ b/website/docs/cdktf/typescript/r/bedrockagent_knowledge_base.html.markdown
@@ -238,7 +238,7 @@ The `opensearchManagedClusterConfiguration` configuration block supports the fol
     * `metadataField` - (Required) Name of the field in which Amazon Bedrock stores metadata about the vector store.
     * `textField` - (Required) Name of the field in which Amazon Bedrock stores the raw text from your data. The text is split according to the chunking strategy you choose.
     * `vectorField` - (Required) Name of the field in which Amazon Bedrock stores the vector embeddings for your data sources.
-* `vectorIndexName` - (Required) Name of the vector store.
+* `vectorIndexName` - (Required) Name of the vector index.
 
 ### `pineconeConfiguration` block
 

--- a/website/docs/r/bedrockagent_knowledge_base.html.markdown
+++ b/website/docs/r/bedrockagent_knowledge_base.html.markdown
@@ -39,6 +39,34 @@ resource "aws_bedrockagent_knowledge_base" "example" {
 }
 ```
 
+### OpenSearch Managed Cluster Configuration
+
+```terraform
+resource "aws_bedrockagent_knowledge_base" "example" {
+  name     = "example"
+  role_arn = aws_iam_role.example.arn
+  knowledge_base_configuration {
+    vector_knowledge_base_configuration {
+      embedding_model_arn = "arn:aws:bedrock:us-west-2::foundation-model/amazon.titan-embed-text-v2:0"
+    }
+    type = "VECTOR"
+  }
+  storage_configuration {
+    type = "OPENSEARCH_MANAGED_CLUSTER"
+    opensearch_managed_cluster_configuration {
+      domain_arn      = "arn:aws:es:us-west-2:123456789012:domain/example-domain"
+      domain_endpoint = "https://search-example-domain.us-west-2.es.amazonaws.com"
+      vector_index_name = "example_index"
+      field_mapping {
+        metadata_field = "metadata"
+        text_field     = "chunks"
+        vector_field   = "embedding"
+      }
+    }
+  }
+}
+```
+
 ### With Supplemental Data Storage Configuration
 
 ```terraform
@@ -149,8 +177,9 @@ The `s3_location` configuration block supports the following arguments:
 
 The `storage_configuration` configuration block supports the following arguments:
 
-* `type` - (Required) Vector store service in which the knowledge base is stored. Valid Values: `OPENSEARCH_SERVERLESS`, `PINECONE`, `REDIS_ENTERPRISE_CLOUD`, `RDS`.
-* `opensearch_serverless_configuration` - (Optional) The storage configuration of the knowledge base in Amazon OpenSearch Service. See [`opensearch_serverless_configuration` block](#opensearch_serverless_configuration-block) for details.
+* `type` - (Required) Vector store service in which the knowledge base is stored. Valid Values: `OPENSEARCH_SERVERLESS`, `OPENSEARCH_MANAGED_CLUSTER`, `PINECONE`, `REDIS_ENTERPRISE_CLOUD`, `RDS`.
+* `opensearch_serverless_configuration` - (Optional) The storage configuration of the knowledge base in Amazon OpenSearch Service Serverless. See [`opensearch_serverless_configuration` block](#opensearch_serverless_configuration-block) for details.
+* `opensearch_managed_cluster_configuration` - (Optional) The storage configuration of the knowledge base in Amazon OpenSearch Service Managed Cluster. See [`opensearch_managed_cluster_configuration` block](#opensearch_managed_cluster_configuration-block) for details.
 * `pinecone_configuration` - (Optional)  The storage configuration of the knowledge base in Pinecone. See [`pinecone_configuration` block](#pinecone_configuration-block) for details.
 * `rds_configuration` - (Optional) Details about the storage configuration of the knowledge base in Amazon RDS. For more information, see [Create a vector index in Amazon RDS](https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base-setup.html). See [`rds_configuration` block](#rds_configuration-block) for details.
 * `redis_enterprise_cloud_configuration` - (Optional) The storage configuration of the knowledge base in Redis Enterprise Cloud. See [`redis_enterprise_cloud_configuration` block](#redis_enterprise_cloud_configuration-block) for details.
@@ -160,6 +189,18 @@ The `storage_configuration` configuration block supports the following arguments
 The `opensearch_serverless_configuration` configuration block supports the following arguments:
 
 * `collection_arn` - (Required) ARN of the OpenSearch Service vector store.
+* `field_mapping` - (Required) The names of the fields to which to map information about the vector store. This block supports the following arguments:
+    * `metadata_field` - (Required) Name of the field in which Amazon Bedrock stores metadata about the vector store.
+    * `text_field` - (Required) Name of the field in which Amazon Bedrock stores the raw text from your data. The text is split according to the chunking strategy you choose.
+    * `vector_field` - (Required) Name of the field in which Amazon Bedrock stores the vector embeddings for your data sources.
+* `vector_index_name` - (Required) Name of the vector store.
+
+### `opensearch_managed_cluster_configuration` block
+
+The `opensearch_managed_cluster_configuration` configuration block supports the following arguments:
+
+* `domain_arn` - (Required) ARN of the OpenSearch domain.
+* `domain_endpoint` - (Required) Endpoint URL of the OpenSearch domain.
 * `field_mapping` - (Required) The names of the fields to which to map information about the vector store. This block supports the following arguments:
     * `metadata_field` - (Required) Name of the field in which Amazon Bedrock stores metadata about the vector store.
     * `text_field` - (Required) Name of the field in which Amazon Bedrock stores the raw text from your data. The text is split according to the chunking strategy you choose.


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None

### Description
This update allows the creation of Amazon Bedrock Knowledge Bases using Amazon OpenSearch Managed Clusters


### Relations
Closes #42588 

### References
[Managed Cluster Support Announcement Blog](https://aws.amazon.com/blogs/machine-learning/amazon-bedrock-knowledge-bases-now-supports-amazon-opensearch-service-managed-cluster-as-vector-store/)


### Output from Acceptance Testing

```console
make testacc TESTS=TestAccKnowledgeBase_OpenSearchManagedCluster_basic PKG=bedrockagent
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/bedrockagent/... -v -count 1 -parallel 20 -run='TestAccKnowledgeBase_OpenSearchManagedCluster_basic'  -timeout 360m -vet=off
2025/08/27 23:29:59 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/27 23:29:59 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKnowledgeBase_OpenSearchManagedCluster_basic
--- PASS: TestAccKnowledgeBase_OpenSearchManagedCluster_basic (14.15s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       18.019s

...
```
