### PR TITLE
[Docs] aws_ecs_service: Update `service_connect_configuration.service.client_alias` argument description to require exactly one alias

### DIFF
--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -342,7 +342,7 @@ For more information, see [Task Networking](https://docs.aws.amazon.com/AmazonEC
 
 `service` supports the following:
 
-* `client_alias` - (Optional) List of client aliases for this Service Connect service. You use these to assign names that can be used by client applications. The maximum number of client aliases that you can have in this list is 1. [See below](#client_alias).
+* `client_alias` - (Optional) List of client aliases for this Service Connect service. You use these to assign names that can be used by client applications. For each service block where enabled is true, exactly one `client_alias` with one `port` should be specified. [See below](#client_alias).
 * `discovery_name` - (Optional) Name of the new AWS Cloud Map service that Amazon ECS creates for this Amazon ECS service.
 * `ingress_port_override` - (Optional) Port number for the Service Connect proxy to listen on.
 * `port_name` - (Required) Name of one of the `portMappings` from all the containers in the task definition of this Amazon ECS service.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.


### Description

* This PR updates the documentation for `aws_ecs_service` to clarify that `service_connect_configuration.service.client_alias` must contain exactly one `client_alias`.
* [According to the AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ServiceConnectService.html#ECS-Type-ServiceConnectService-clientAliases):

  * The maximum number of client aliases you can have in this list is 1.
  * You must provide at least one `client_alias` with one port.

Taken together, these statements imply that exactly one `client_alias` must be specified, even though the documentation does not state this directly.

In the current implementation of the Terraform AWS Provider, at most one `client_alias` is allowed:

https://github.com/hashicorp/terraform-provider-aws/blob/68357d75b40e2787e043e9038169be33980378f2/internal/service/ecs/service.go#L331-L347

After removing the validation on the Terraform side, I confirmed that the AWS API also rejects more than one `client_alias`.

This confirms that exactly one `client_alias` should always be specified.

Based on this, I have updated the documentation to require exactly one `client_alias` when `enabled` is set to `true`.

The revised description aligns with the AWS documentation (though not stated explicitly), the current Terraform AWS Provider implementation, and AWS API behavior.

### Relations

Closes #44027

### References
https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ServiceConnectService.html#ECS-Type-ServiceConnectService-clientAliases

