### PR TITLE
feat(go-vcr): include `go-vcr` retryer override when configured via extra options

### DIFF
--- a/internal/service/apigateway/service_package.go
+++ b/internal/service/apigateway/service_package.go
@@ -10,24 +10,35 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
 )
 
-func (p *servicePackage) withExtraOptions(_ context.Context, config map[string]any) []func(*apigateway.Options) {
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*apigateway.Options) {
 	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
 
 	return []func(*apigateway.Options){
 		func(o *apigateway.Options) {
-			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
-				// Many operations can return an error such as:
-				//   ConflictException: Unable to complete operation due to concurrent modification. Please try again later.
-				// Handle them all globally for the service client.
-				if errs.IsAErrorMessageContains[*types.ConflictException](err, "try again later") {
-					return aws.TrueTernary
-				}
-				return aws.UnknownTernary // Delegate to configured Retryer.
-			}))
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					// Many operations can return an error such as:
+					//   ConflictException: Unable to complete operation due to concurrent modification. Please try again later.
+					// Handle them all globally for the service client.
+					if errs.IsAErrorMessageContains[*types.ConflictException](err, "try again later") {
+						return aws.TrueTernary
+					}
+					return aws.UnknownTernary // Delegate to configured Retryer.
+				}),
+			}
+			// Include go-vcr retryable to prevent generated client retryer from being overridden
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, retry.IsErrorRetryableFunc(vcr.InteractionNotFoundRetryableFunc))
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
 		},
 	}
 }

--- a/internal/service/apigatewayv2/service_package.go
+++ b/internal/service/apigatewayv2/service_package.go
@@ -10,28 +10,39 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
 )
 
-func (p *servicePackage) withExtraOptions(_ context.Context, config map[string]any) []func(*apigatewayv2.Options) {
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*apigatewayv2.Options) {
 	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
 
 	return []func(*apigatewayv2.Options){
 		func(o *apigatewayv2.Options) {
-			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
-				if errs.IsAErrorMessageContains[*awstypes.ConflictException](err, "try again later") {
-					return aws.TrueTernary
-				}
-				// In some instances, ConflictException error responses have been observed as
-				// a *smithy.OperationError type (not an *awstypes.ConflictException), which
-				// can't be handled via errs.IsAErrorMessageContains. Instead we fall back
-				// to a simple match on the message contents.
-				if errs.Contains(err, "Unable to complete operation due to concurrent modification. Please try again later.") {
-					return aws.TrueTernary
-				}
-				return aws.UnknownTernary // Delegate to configured Retryer.
-			}))
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					if errs.IsAErrorMessageContains[*awstypes.ConflictException](err, "try again later") {
+						return aws.TrueTernary
+					}
+					// In some instances, ConflictException error responses have been observed as
+					// a *smithy.OperationError type (not an *awstypes.ConflictException), which
+					// can't be handled via errs.IsAErrorMessageContains. Instead we fall back
+					// to a simple match on the message contents.
+					if errs.Contains(err, "Unable to complete operation due to concurrent modification. Please try again later.") {
+						return aws.TrueTernary
+					}
+					return aws.UnknownTernary // Delegate to configured Retryer.
+				}),
+			}
+			// Include go-vcr retryable to prevent generated client retryer from being overridden
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, retry.IsErrorRetryableFunc(vcr.InteractionNotFoundRetryableFunc))
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
 		},
 	}
 }

--- a/internal/service/appsync/service_package.go
+++ b/internal/service/appsync/service_package.go
@@ -10,21 +10,32 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/appsync"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/appsync/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
 )
 
-func (p *servicePackage) withExtraOptions(_ context.Context, config map[string]any) []func(*appsync.Options) {
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*appsync.Options) {
 	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
 
 	return []func(*appsync.Options){
 		func(o *appsync.Options) {
-			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
-				if errs.IsAErrorMessageContains[*awstypes.ConcurrentModificationException](err, "a GraphQL API creation is already in progress") {
-					return aws.TrueTernary
-				}
-				return aws.UnknownTernary // Delegate to configured Retryer.
-			}))
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					if errs.IsAErrorMessageContains[*awstypes.ConcurrentModificationException](err, "a GraphQL API creation is already in progress") {
+						return aws.TrueTernary
+					}
+					return aws.UnknownTernary // Delegate to configured Retryer.
+				}),
+			}
+			// Include go-vcr retryable to prevent generated client retryer from being overridden
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, retry.IsErrorRetryableFunc(vcr.InteractionNotFoundRetryableFunc))
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
 		},
 	}
 }

--- a/internal/service/cloudformation/service_package.go
+++ b/internal/service/cloudformation/service_package.go
@@ -10,21 +10,32 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
 )
 
-func (p *servicePackage) withExtraOptions(_ context.Context, config map[string]any) []func(*cloudformation.Options) {
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*cloudformation.Options) {
 	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
 
 	return []func(*cloudformation.Options){
 		func(o *cloudformation.Options) {
-			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
-				if errs.IsAErrorMessageContains[*types.OperationInProgressException](err, "Another Operation on StackSet") {
-					return aws.TrueTernary
-				}
-				return aws.UnknownTernary // Delegate to configured Retryer.
-			}))
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					if errs.IsAErrorMessageContains[*types.OperationInProgressException](err, "Another Operation on StackSet") {
+						return aws.TrueTernary
+					}
+					return aws.UnknownTernary // Delegate to configured Retryer.
+				}),
+			}
+			// Include go-vcr retryable to prevent generated client retryer from being overridden
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, retry.IsErrorRetryableFunc(vcr.InteractionNotFoundRetryableFunc))
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
 		},
 	}
 }

--- a/internal/service/cloudhsmv2/service_package.go
+++ b/internal/service/cloudhsmv2/service_package.go
@@ -10,21 +10,32 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/cloudhsmv2"
 	"github.com/aws/aws-sdk-go-v2/service/cloudhsmv2/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
 )
 
-func (p *servicePackage) withExtraOptions(_ context.Context, config map[string]any) []func(*cloudhsmv2.Options) {
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*cloudhsmv2.Options) {
 	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
 
 	return []func(*cloudhsmv2.Options){
 		func(o *cloudhsmv2.Options) {
-			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
-				if errs.IsAErrorMessageContains[*types.CloudHsmInternalFailureException](err, "request was rejected because of an AWS CloudHSM internal failure") {
-					return aws.TrueTernary
-				}
-				return aws.UnknownTernary // Delegate to configured Retryer.
-			}))
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					if errs.IsAErrorMessageContains[*types.CloudHsmInternalFailureException](err, "request was rejected because of an AWS CloudHSM internal failure") {
+						return aws.TrueTernary
+					}
+					return aws.UnknownTernary // Delegate to configured Retryer.
+				}),
+			}
+			// Include go-vcr retryable to prevent generated client retryer from being overridden
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, retry.IsErrorRetryableFunc(vcr.InteractionNotFoundRetryableFunc))
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
 		},
 	}
 }

--- a/internal/service/dynamodb/service_package.go
+++ b/internal/service/dynamodb/service_package.go
@@ -10,21 +10,32 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
 )
 
-func (p *servicePackage) withExtraOptions(_ context.Context, config map[string]any) []func(*dynamodb.Options) {
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*dynamodb.Options) {
 	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
 
 	return []func(*dynamodb.Options){
 		func(o *dynamodb.Options) {
-			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
-				if errs.IsAErrorMessageContains[*awstypes.LimitExceededException](err, "Subscriber limit exceeded:") {
-					return aws.TrueTernary
-				}
-				return aws.UnknownTernary // Delegate to configured Retryer.
-			}))
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					if errs.IsAErrorMessageContains[*awstypes.LimitExceededException](err, "Subscriber limit exceeded:") {
+						return aws.TrueTernary
+					}
+					return aws.UnknownTernary // Delegate to configured Retryer.
+				}),
+			}
+			// Include go-vcr retryable to prevent generated client retryer from being overridden
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, retry.IsErrorRetryableFunc(vcr.InteractionNotFoundRetryableFunc))
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
 		},
 	}
 }

--- a/internal/service/ec2/service_package.go
+++ b/internal/service/ec2/service_package.go
@@ -10,41 +10,52 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
 )
 
-func (p *servicePackage) withExtraOptions(_ context.Context, config map[string]any) []func(*ec2.Options) {
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*ec2.Options) {
 	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
 
 	return []func(*ec2.Options){
 		func(o *ec2.Options) {
-			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
-				if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "This call cannot be completed because there are pending VPNs or Virtual Interfaces") { // AttachVpnGateway, DetachVpnGateway
-					return aws.TrueTernary
-				}
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "This call cannot be completed because there are pending VPNs or Virtual Interfaces") { // AttachVpnGateway, DetachVpnGateway
+						return aws.TrueTernary
+					}
 
-				if tfawserr.ErrCodeEquals(err, errCodeInsufficientInstanceCapacity) { // CreateCapacityReservation, RunInstances
-					return aws.TrueTernary
-				}
+					if tfawserr.ErrCodeEquals(err, errCodeInsufficientInstanceCapacity) { // CreateCapacityReservation, RunInstances
+						return aws.TrueTernary
+					}
 
-				if tfawserr.ErrMessageContains(err, errCodeOperationNotPermitted, "Endpoint cannot be created while another endpoint is being created") { // CreateClientVpnEndpoint
-					return aws.TrueTernary
-				}
+					if tfawserr.ErrMessageContains(err, errCodeOperationNotPermitted, "Endpoint cannot be created while another endpoint is being created") { // CreateClientVpnEndpoint
+						return aws.TrueTernary
+					}
 
-				if tfawserr.ErrMessageContains(err, errCodeConcurrentMutationLimitExceeded, "Cannot initiate another change for this endpoint at this time") { // CreateClientVpnRoute, DeleteClientVpnRoute
-					return aws.TrueTernary
-				}
+					if tfawserr.ErrMessageContains(err, errCodeConcurrentMutationLimitExceeded, "Cannot initiate another change for this endpoint at this time") { // CreateClientVpnRoute, DeleteClientVpnRoute
+						return aws.TrueTernary
+					}
 
-				if tfawserr.ErrMessageContains(err, errCodeVPNConnectionLimitExceeded, "maximum number of mutating objects has been reached") { // CreateVpnConnection
-					return aws.TrueTernary
-				}
+					if tfawserr.ErrMessageContains(err, errCodeVPNConnectionLimitExceeded, "maximum number of mutating objects has been reached") { // CreateVpnConnection
+						return aws.TrueTernary
+					}
 
-				if tfawserr.ErrMessageContains(err, errCodeVPNGatewayLimitExceeded, "maximum number of mutating objects has been reached") { // CreateVpnGateway
-					return aws.TrueTernary
-				}
+					if tfawserr.ErrMessageContains(err, errCodeVPNGatewayLimitExceeded, "maximum number of mutating objects has been reached") { // CreateVpnGateway
+						return aws.TrueTernary
+					}
 
-				return aws.UnknownTernary // Delegate to configured Retryer.
-			}))
+					return aws.UnknownTernary // Delegate to configured Retryer.
+				}),
+			}
+			// Include go-vcr retryable to prevent generated client retryer from being overridden
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, retry.IsErrorRetryableFunc(vcr.InteractionNotFoundRetryableFunc))
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
 		},
 	}
 }

--- a/internal/service/fms/service_package.go
+++ b/internal/service/fms/service_package.go
@@ -10,26 +10,37 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/fms"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/fms/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
 )
 
-func (p *servicePackage) withExtraOptions(_ context.Context, config map[string]any) []func(*fms.Options) {
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*fms.Options) {
 	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
 
 	return []func(*fms.Options){
 		func(o *fms.Options) {
-			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
-				// Acceptance testing creates and deletes resources in quick succession.
-				// The FMS onboarding process into Organizations is opaque to consumers.
-				// Since we cannot reasonably check this status before receiving the error,
-				// set the operation as retryable.
-				if errs.IsAErrorMessageContains[*awstypes.InvalidOperationException](err, "Your AWS Organization is currently onboarding with AWS Firewall Manager and cannot be offboarded") ||
-					errs.IsAErrorMessageContains[*awstypes.InvalidOperationException](err, "Your AWS Organization is currently offboarding with AWS Firewall Manager. Please submit onboard request after offboarded") {
-					return aws.TrueTernary
-				}
-				return aws.UnknownTernary // Delegate to configured Retryer.
-			}))
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					// Acceptance testing creates and deletes resources in quick succession.
+					// The FMS onboarding process into Organizations is opaque to consumers.
+					// Since we cannot reasonably check this status before receiving the error,
+					// set the operation as retryable.
+					if errs.IsAErrorMessageContains[*awstypes.InvalidOperationException](err, "Your AWS Organization is currently onboarding with AWS Firewall Manager and cannot be offboarded") ||
+						errs.IsAErrorMessageContains[*awstypes.InvalidOperationException](err, "Your AWS Organization is currently offboarding with AWS Firewall Manager. Please submit onboard request after offboarded") {
+						return aws.TrueTernary
+					}
+					return aws.UnknownTernary // Delegate to configured Retryer.
+				}),
+			}
+			// Include go-vcr retryable to prevent generated client retryer from being overridden
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, retry.IsErrorRetryableFunc(vcr.InteractionNotFoundRetryableFunc))
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
 		},
 	}
 }

--- a/internal/service/kafka/service_package.go
+++ b/internal/service/kafka/service_package.go
@@ -10,21 +10,32 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/kafka"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
 )
 
-func (p *servicePackage) withExtraOptions(_ context.Context, config map[string]any) []func(*kafka.Options) {
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*kafka.Options) {
 	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
 
 	return []func(*kafka.Options){
 		func(o *kafka.Options) {
-			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
-				if errs.IsAErrorMessageContains[*awstypes.TooManyRequestsException](err, "Too Many Requests") {
-					return aws.TrueTernary
-				}
-				return aws.UnknownTernary // Delegate to configured Retryer.
-			}))
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					if errs.IsAErrorMessageContains[*awstypes.TooManyRequestsException](err, "Too Many Requests") {
+						return aws.TrueTernary
+					}
+					return aws.UnknownTernary // Delegate to configured Retryer.
+				}),
+			}
+			// Include go-vcr retryable to prevent generated client retryer from being overridden
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, retry.IsErrorRetryableFunc(vcr.InteractionNotFoundRetryableFunc))
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
 		},
 	}
 }

--- a/internal/service/kinesis/service_package.go
+++ b/internal/service/kinesis/service_package.go
@@ -10,22 +10,33 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
 )
 
-func (p *servicePackage) withExtraOptions(_ context.Context, config map[string]any) []func(*kinesis.Options) {
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*kinesis.Options) {
 	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
 
 	return []func(*kinesis.Options){
 		func(o *kinesis.Options) {
-			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
-				if errs.IsAErrorMessageContains[*types.LimitExceededException](err, "simultaneously be in CREATING or DELETING") ||
-					errs.IsAErrorMessageContains[*types.LimitExceededException](err, "Rate exceeded for stream") {
-					return aws.TrueTernary
-				}
-				return aws.UnknownTernary // Delegate to configured Retryer.
-			}))
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					if errs.IsAErrorMessageContains[*types.LimitExceededException](err, "simultaneously be in CREATING or DELETING") ||
+						errs.IsAErrorMessageContains[*types.LimitExceededException](err, "Rate exceeded for stream") {
+						return aws.TrueTernary
+					}
+					return aws.UnknownTernary // Delegate to configured Retryer.
+				}),
+			}
+			// Include go-vcr retryable to prevent generated client retryer from being overridden
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, retry.IsErrorRetryableFunc(vcr.InteractionNotFoundRetryableFunc))
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
 		},
 	}
 }

--- a/internal/service/lightsail/service_package.go
+++ b/internal/service/lightsail/service_package.go
@@ -11,22 +11,33 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/lightsail"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/lightsail/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
 )
 
-func (p *servicePackage) withExtraOptions(_ context.Context, config map[string]any) []func(*lightsail.Options) {
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*lightsail.Options) {
 	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
 
 	return []func(*lightsail.Options){
 		func(o *lightsail.Options) {
-			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
-				if errs.IsAErrorMessageContains[*awstypes.InvalidInputException](err, "Please try again in a few minutes") ||
-					strings.Contains(err.Error(), "Please wait for it to complete before trying again") {
-					return aws.TrueTernary
-				}
-				return aws.UnknownTernary
-			}))
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					if errs.IsAErrorMessageContains[*awstypes.InvalidInputException](err, "Please try again in a few minutes") ||
+						strings.Contains(err.Error(), "Please wait for it to complete before trying again") {
+						return aws.TrueTernary
+					}
+					return aws.UnknownTernary
+				}),
+			}
+			// Include go-vcr retryable to prevent generated client retryer from being overridden
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, retry.IsErrorRetryableFunc(vcr.InteractionNotFoundRetryableFunc))
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
 		},
 	}
 }

--- a/internal/service/organizations/service_package.go
+++ b/internal/service/organizations/service_package.go
@@ -10,21 +10,32 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
 )
 
-func (p *servicePackage) withExtraOptions(_ context.Context, config map[string]any) []func(*organizations.Options) {
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*organizations.Options) {
 	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
 
 	return []func(*organizations.Options){
 		func(o *organizations.Options) {
-			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
-				if errs.IsAErrorMessageContains[*awstypes.ConcurrentModificationException](err, "Try again later") {
-					return aws.TrueTernary
-				}
-				return aws.UnknownTernary // Delegate to configured Retryer.
-			}))
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					if errs.IsAErrorMessageContains[*awstypes.ConcurrentModificationException](err, "Try again later") {
+						return aws.TrueTernary
+					}
+					return aws.UnknownTernary // Delegate to configured Retryer.
+				}),
+			}
+			// Include go-vcr retryable to prevent generated client retryer from being overridden
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, retry.IsErrorRetryableFunc(vcr.InteractionNotFoundRetryableFunc))
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
 		},
 	}
 }

--- a/internal/service/s3/service_package.go
+++ b/internal/service/s3/service_package.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
 )
 
 func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*s3.Options) {
@@ -38,12 +39,21 @@ func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string
 			o.UsePathStyle = config["s3_use_path_style"].(bool)
 		},
 		func(o *s3.Options) {
-			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
-				if tfawserr.ErrMessageContains(err, errCodeOperationAborted, "A conflicting conditional operation is currently in progress against this resource. Please try again.") {
-					return aws.TrueTernary
-				}
-				return aws.UnknownTernary // Delegate to configured Retryer.
-			}))
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					if tfawserr.ErrMessageContains(err, errCodeOperationAborted, "A conflicting conditional operation is currently in progress against this resource. Please try again.") {
+						return aws.TrueTernary
+					}
+					return aws.UnknownTernary // Delegate to configured Retryer.
+				}),
+			}
+			// Include go-vcr retryable to prevent generated client retryer from being overridden
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, retry.IsErrorRetryableFunc(vcr.InteractionNotFoundRetryableFunc))
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
 		},
 	}
 }

--- a/internal/service/schemas/service_package.go
+++ b/internal/service/schemas/service_package.go
@@ -10,21 +10,32 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/schemas"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/schemas/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
 )
 
-func (p *servicePackage) withExtraOptions(_ context.Context, config map[string]any) []func(*schemas.Options) {
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*schemas.Options) {
 	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
 
 	return []func(*schemas.Options){
 		func(o *schemas.Options) {
-			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
-				if errs.IsAErrorMessageContains[*awstypes.TooManyRequestsException](err, "Too Many Requests") {
-					return aws.TrueTernary
-				}
-				return aws.UnknownTernary // Delegate to configured Retryer.
-			}))
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					if errs.IsAErrorMessageContains[*awstypes.TooManyRequestsException](err, "Too Many Requests") {
+						return aws.TrueTernary
+					}
+					return aws.UnknownTernary // Delegate to configured Retryer.
+				}),
+			}
+			// Include go-vcr retryable to prevent generated client retryer from being overridden
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, retry.IsErrorRetryableFunc(vcr.InteractionNotFoundRetryableFunc))
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
 		},
 	}
 }

--- a/internal/service/ssoadmin/service_package.go
+++ b/internal/service/ssoadmin/service_package.go
@@ -10,21 +10,32 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
 	"github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
 )
 
-func (p *servicePackage) withExtraOptions(_ context.Context, config map[string]any) []func(*ssoadmin.Options) {
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*ssoadmin.Options) {
 	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
 
 	return []func(*ssoadmin.Options){
 		func(o *ssoadmin.Options) {
-			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
-				if errs.IsA[*types.ConflictException](err) || errs.IsA[*types.ThrottlingException](err) {
-					return aws.TrueTernary
-				}
-				return aws.UnknownTernary // Delegate to configured Retryer.
-			}))
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					if errs.IsA[*types.ConflictException](err) || errs.IsA[*types.ThrottlingException](err) {
+						return aws.TrueTernary
+					}
+					return aws.UnknownTernary // Delegate to configured Retryer.
+				}),
+			}
+			// Include go-vcr retryable to prevent generated client retryer from being overridden
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, retry.IsErrorRetryableFunc(vcr.InteractionNotFoundRetryableFunc))
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
 		},
 	}
 }


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
All generated service clients contain a functional option which overrides the default retryer with additional handling for `go-vcr`-specific errors. However, a handful of service clients include additional hand-written options which _also_ override the default retryer, typically addressing some nuance related to error codes unique to a given service. To ensure these service-local overrides do not overwrite the `go-vcr` handling, the extra options implementations have been modified to merge both sets of retryables.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42949
Relates https://github.com/hashicorp/terraform-provider-aws/issues/25602
Relates https://github.com/hashicorp/terraform-provider-aws/pull/42801


### Output from Acceptance Testing

Example of a `go-vcr` failure which previously hung due to unintentional retries on the EC2 client. This now fails immediately once the first `go-vcr` error is encountered (as desired).


```console
% VCR_MODE=REPLAY_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/ make testacc PKG=timestreaminfluxdb TESTS=TestAccTimestreamInfluxDBDBCluster_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/timestreaminfluxdb/... -v -count 1 -parallel 20 -run='TestAccTimestreamInfluxDBDBCluster_basic'  -timeout 360m -vet=off
2025/08/28 14:41:43 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/28 14:41:43 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccTimestreamInfluxDBDBCluster_basic
=== PAUSE TestAccTimestreamInfluxDBDBCluster_basic
=== CONT  TestAccTimestreamInfluxDBDBCluster_basic
    db_cluster_test.go:35: Step 1/2 error: Error running apply: exit status 1

        Error: creating Security Group (terraform-20250828184146602500000001): operation error EC2: CreateSecurityGroup, https response error StatusCode: 0, RequestID: , request send failed, Post "https://ec2.us-west-2.amazonaws.com/": requested interaction not found

          with aws_security_group.test,
          on terraform_plugin_test.tf line 42, in resource "aws_security_group" "test":
          42: resource "aws_security_group" "test" {

--- FAIL: TestAccTimestreamInfluxDBDBCluster_basic (5.38s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/timestreaminfluxdb 11.930s
FAIL
make: *** [testacc] Error 1
```