### PR TITLE
[Enhancement] aws lambda function:  Add `source_kms_key_arn` argument to encrypt deployment package with custom KMS key

### DIFF
--- a/.changelog/44080.txt
+++ b/.changelog/44080.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_lambda_function: Add `source_kms_key_arn` argument
+```
+
+```release-note:enhancement
+data-source/aws_lambda_function: Add `source_kms_key_arn` attribute
+```

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -390,6 +390,12 @@ func resourceFunction() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"source_kms_key_arn": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ValidateFunc:  verify.ValidARN,
+				ConflictsWith: []string{"image_uri"},
+			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			names.AttrTimeout: {
@@ -575,6 +581,10 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta an
 		input.SnapStart = expandSnapStart(v.([]any))
 	}
 
+	if v, ok := d.GetOk("source_kms_key_arn"); ok {
+		input.Code.SourceKMSKeyArn = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("tracing_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 		input.TracingConfig = &awstypes.TracingConfig{
 			Mode: awstypes.TracingMode(v.([]any)[0].(map[string]any)[names.AttrMode].(string)),
@@ -669,6 +679,7 @@ func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	function := output.Configuration
+	functionCode := output.Code
 	d.Set("architectures", function.Architectures)
 	functionARN := aws.ToString(function.FunctionArn)
 	d.Set(names.AttrARN, functionARN)
@@ -728,6 +739,7 @@ func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 	d.Set("source_code_hash", d.Get("source_code_hash"))
 	d.Set("source_code_size", function.CodeSize)
+	d.Set("source_kms_key_arn", functionCode.SourceKMSKeyArn)
 	d.Set(names.AttrTimeout, function.Timeout)
 	tracingConfigMode := awstypes.TracingModePassThrough
 	if function.TracingConfig != nil {
@@ -998,6 +1010,11 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta an
 			if v, ok := d.GetOk("s3_object_version"); ok {
 				input.S3ObjectVersion = aws.String(v.(string))
 			}
+		}
+
+		// If source_kms_key_arn is set, it should be always included in the update
+		if v, ok := d.GetOk("source_kms_key_arn"); ok {
+			input.SourceKMSKeyArn = aws.String(v.(string))
 		}
 
 		_, err := conn.UpdateFunctionCode(ctx, &input)
@@ -1489,6 +1506,7 @@ func needsFunctionCodeUpdate(d sdkv2.ResourceDiffer) bool {
 		d.HasChange(names.AttrS3Bucket) ||
 		d.HasChange("s3_key") ||
 		d.HasChange("s3_object_version") ||
+		d.HasChange("source_kms_key_arn") ||
 		d.HasChange("image_uri") ||
 		d.HasChange("architectures")
 }

--- a/internal/service/lambda/function_data_source.go
+++ b/internal/service/lambda/function_data_source.go
@@ -200,6 +200,10 @@ func dataSourceFunction() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"source_kms_key_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			names.AttrTags: tftags.TagsSchemaComputed(),
 			names.AttrTimeout: {
 				Type:     schema.TypeInt,
@@ -297,6 +301,7 @@ func dataSourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta an
 	}
 
 	function := output.Configuration
+	functionCode := output.Code
 	functionARN := aws.ToString(function.FunctionArn)
 	qualifierSuffix := fmt.Sprintf(":%s", aws.ToString(input.Qualifier))
 	versionSuffix := fmt.Sprintf(":%s", aws.ToString(function.Version))
@@ -358,6 +363,7 @@ func dataSourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta an
 	d.Set("signing_profile_version_arn", function.SigningProfileVersionArn)
 	d.Set("source_code_hash", function.CodeSha256)
 	d.Set("source_code_size", function.CodeSize)
+	d.Set("source_kms_key_arn", functionCode.SourceKMSKeyArn)
 	d.Set(names.AttrTimeout, function.Timeout)
 	tracingConfigMode := awstypes.TracingModePassThrough
 	if function.TracingConfig != nil {

--- a/internal/service/lambda/function_data_source_test.go
+++ b/internal/service/lambda/function_data_source_test.go
@@ -54,6 +54,7 @@ func TestAccLambdaFunctionDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "signing_profile_version_arn", resourceName, "signing_profile_version_arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "source_code_hash", resourceName, "code_sha256"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "source_code_size", resourceName, "source_code_size"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "source_kms_key_arn", resourceName, "source_kms_key_arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, acctest.CtTagsPercent, resourceName, acctest.CtTagsPercent),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrTimeout, resourceName, names.AttrTimeout),
 					resource.TestCheckResourceAttrPair(dataSourceName, "tracing_config.#", resourceName, "tracing_config.#"),

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -2380,7 +2380,7 @@ func TestAccLambdaFunction_sourceKMSKeyARN(t *testing.T) {
 					testAccCheckFunctionInvokeARN(resourceName, &conf),
 					testAccCheckFunctionQualifiedInvokeARN(resourceName, &conf),
 					testAccCheckFunctionName(&conf, rName),
-					resource.TestCheckResourceAttrPair(resourceName, "source_kms_key_arn", "aws_kms_key.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "source_kms_key_arn", "aws_kms_key.test", names.AttrARN),
 				),
 			},
 			{
@@ -2401,7 +2401,7 @@ func TestAccLambdaFunction_sourceKMSKeyARN(t *testing.T) {
 					testAccCheckFunctionInvokeARN(resourceName, &conf),
 					testAccCheckFunctionQualifiedInvokeARN(resourceName, &conf),
 					testAccCheckFunctionName(&conf, rName),
-					resource.TestCheckResourceAttrPair(resourceName, "source_kms_key_arn", "aws_kms_key.test2", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "source_kms_key_arn", "aws_kms_key.test2", names.AttrARN),
 				),
 			},
 		},

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -2356,6 +2356,58 @@ func TestAccLambdaFunction_ipv6AllowedForDualStack(t *testing.T) {
 	})
 }
 
+func TestAccLambdaFunction_sourceKMSKeyARN(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf lambda.GetFunctionOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lambda_function.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFunctionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionConfig_sourceKMSKeyARN(rName, "test"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckFunctionExists(ctx, resourceName, &conf),
+					testAccCheckFunctionInvokeARN(resourceName, &conf),
+					testAccCheckFunctionQualifiedInvokeARN(resourceName, &conf),
+					testAccCheckFunctionName(&conf, rName),
+					resource.TestCheckResourceAttrPair(resourceName, "source_kms_key_arn", "aws_kms_key.test", "arn"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
+			},
+			{
+				Config: testAccFunctionConfig_sourceKMSKeyARN(rName, "test2"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckFunctionExists(ctx, resourceName, &conf),
+					testAccCheckFunctionInvokeARN(resourceName, &conf),
+					testAccCheckFunctionQualifiedInvokeARN(resourceName, &conf),
+					testAccCheckFunctionName(&conf, rName),
+					resource.TestCheckResourceAttrPair(resourceName, "source_kms_key_arn", "aws_kms_key.test2", "arn"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccLambdaFunction_skipDestroy(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf lambda.GetFunctionOutput
@@ -4184,6 +4236,69 @@ resource "aws_lambda_function" "test" {
   }
 }
 `, rName))
+}
+
+func testAccFunctionConfig_sourceKMSKeyARN(rName, kmsIdentifier string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLambdaBase(rName, rName, rName),
+		fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = "%[1]s-1"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "kms-tf-1",
+  "Statement": [
+    {
+      "Sid": "Enable IAM User Permissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_kms_key" "test2" {
+  description             = "%[1]s-2"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "kms-tf-2",
+  "Statement": [
+    {
+      "Sid": "Enable IAM User Permissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_lambda_function" "test" {
+  filename           = "test-fixtures/lambdatest.zip"
+  function_name      = %[1]q
+  role               = aws_iam_role.iam_for_lambda.arn
+  handler            = "exports.example"
+  runtime            = "nodejs20.x"
+  source_kms_key_arn = aws_kms_key.%[2]s.arn
+}
+`, rName, kmsIdentifier))
 }
 
 func testAccFunctionConfig_skipDestroy(rName string) string {

--- a/website/docs/d/lambda_function.html.markdown
+++ b/website/docs/d/lambda_function.html.markdown
@@ -142,6 +142,7 @@ This data source exports the following attributes in addition to the arguments a
 * `signing_profile_version_arn` - ARN for a signing profile version.
 * `source_code_hash` - (**Deprecated** use `code_sha256` instead) Base64-encoded representation of raw SHA-256 sum of the zip file.
 * `source_code_size` - Size in bytes of the function .zip file.
+* `source_kms_key_arn` - ARN of the AWS Key Management Service key used to encrypt the function's `.zip` deployment package.
 * `tags` - Map of tags assigned to the Lambda Function.
 * `timeout` - Function execution time at which Lambda should terminate the function.
 * `tracing_config` - Tracing settings of the function. [See below](#tracing_config-attribute-reference).

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -521,6 +521,7 @@ The following arguments are optional:
 * `skip_destroy` - (Optional) Whether to retain the old version of a previously deployed Lambda Layer. Default is `false`.
 * `snap_start` - (Optional) Configuration block for snap start settings. [See below](#snap_start-configuration-block).
 * `source_code_hash` - (Optional) Base64-encoded SHA256 hash of the package file. Used to trigger updates when source code changes.
+* `source_kms_key_arn` - (Optional) ARN of the AWS Key Management Service key used to encrypt the function's `.zip` deployment package. Conflicts with `image_uri`.
 * `tags` - (Optional) Key-value map of tags for the Lambda function. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `timeout` - (Optional) Amount of time your Lambda Function has to run in seconds. Defaults to 3. Valid between 1 and 900.
 * `tracing_config` - (Optional) Configuration block for X-Ray tracing. [See below](#tracing_config-configuration-block).


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* Add `source_kms_key_arn` argument to allow users to provide their own KMS key for encrypting Lambda function source code.
*  The new attribute is available in both the resource and data source.


### Relations

Closes #43055 
Closes #40276

### References
https://docs.aws.amazon.com/lambda/latest/api/API_CreateFunction.html
https://docs.aws.amazon.com/lambda/latest/api/API_UpdateFunction.html
https://docs.aws.amazon.com/lambda/latest/api/API_GetFunction.html


### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccLambdaFunction_ PKG=lambda 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunction_'  -timeout 360m -vet=off
2025/08/29 14:28:00 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/29 14:28:00 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaFunction_Identity_Basic
=== PAUSE TestAccLambdaFunction_Identity_Basic
=== RUN   TestAccLambdaFunction_Identity_RegionOverride
=== PAUSE TestAccLambdaFunction_Identity_RegionOverride
=== RUN   TestAccLambdaFunction_Identity_ExistingResource
=== PAUSE TestAccLambdaFunction_Identity_ExistingResource
=== RUN   TestAccLambdaFunction_tags
=== PAUSE TestAccLambdaFunction_tags
=== RUN   TestAccLambdaFunction_tags_null
=== PAUSE TestAccLambdaFunction_tags_null
=== RUN   TestAccLambdaFunction_tags_EmptyMap
=== PAUSE TestAccLambdaFunction_tags_EmptyMap
=== RUN   TestAccLambdaFunction_tags_AddOnUpdate
=== PAUSE TestAccLambdaFunction_tags_AddOnUpdate
=== RUN   TestAccLambdaFunction_tags_EmptyTag_OnCreate
=== PAUSE TestAccLambdaFunction_tags_EmptyTag_OnCreate
=== RUN   TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccLambdaFunction_tags_DefaultTags_providerOnly
=== PAUSE TestAccLambdaFunction_tags_DefaultTags_providerOnly
=== RUN   TestAccLambdaFunction_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccLambdaFunction_tags_DefaultTags_nonOverlapping
=== RUN   TestAccLambdaFunction_tags_DefaultTags_overlapping
=== PAUSE TestAccLambdaFunction_tags_DefaultTags_overlapping
=== RUN   TestAccLambdaFunction_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccLambdaFunction_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccLambdaFunction_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccLambdaFunction_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccLambdaFunction_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccLambdaFunction_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccLambdaFunction_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccLambdaFunction_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccLambdaFunction_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccLambdaFunction_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccLambdaFunction_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccLambdaFunction_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccLambdaFunction_tags_ComputedTag_OnCreate
=== PAUSE TestAccLambdaFunction_tags_ComputedTag_OnCreate
=== RUN   TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccLambdaFunction_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccLambdaFunction_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccLambdaFunction_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccLambdaFunction_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== RUN   TestAccLambdaFunction_disappears
=== PAUSE TestAccLambdaFunction_disappears
=== RUN   TestAccLambdaFunction_unpublishedCodeUpdate
=== PAUSE TestAccLambdaFunction_unpublishedCodeUpdate
=== RUN   TestAccLambdaFunction_codeSigning
=== PAUSE TestAccLambdaFunction_codeSigning
=== RUN   TestAccLambdaFunction_concurrency
=== PAUSE TestAccLambdaFunction_concurrency
=== RUN   TestAccLambdaFunction_concurrencyCycle
=== PAUSE TestAccLambdaFunction_concurrencyCycle
=== RUN   TestAccLambdaFunction_expectFilenameAndS3Attributes
=== PAUSE TestAccLambdaFunction_expectFilenameAndS3Attributes
=== RUN   TestAccLambdaFunction_envVariables
=== PAUSE TestAccLambdaFunction_envVariables
=== RUN   TestAccLambdaFunction_EnvironmentVariables_noValue
=== PAUSE TestAccLambdaFunction_EnvironmentVariables_noValue
=== RUN   TestAccLambdaFunction_encryptedEnvVariables
=== PAUSE TestAccLambdaFunction_encryptedEnvVariables
=== RUN   TestAccLambdaFunction_nameValidation
=== PAUSE TestAccLambdaFunction_nameValidation
=== RUN   TestAccLambdaFunction_versioned
=== PAUSE TestAccLambdaFunction_versioned
=== RUN   TestAccLambdaFunction_versionedUpdate
=== PAUSE TestAccLambdaFunction_versionedUpdate
=== RUN   TestAccLambdaFunction_enablePublish
=== PAUSE TestAccLambdaFunction_enablePublish
=== RUN   TestAccLambdaFunction_disablePublish
=== PAUSE TestAccLambdaFunction_disablePublish
=== RUN   TestAccLambdaFunction_deadLetter
=== PAUSE TestAccLambdaFunction_deadLetter
=== RUN   TestAccLambdaFunction_deadLetterUpdated
=== PAUSE TestAccLambdaFunction_deadLetterUpdated
=== RUN   TestAccLambdaFunction_nilDeadLetter
=== PAUSE TestAccLambdaFunction_nilDeadLetter
=== RUN   TestAccLambdaFunction_fileSystem
=== PAUSE TestAccLambdaFunction_fileSystem
=== RUN   TestAccLambdaFunction_image
    function_test.go:903: Environment variable AWS_LAMBDA_IMAGE_LATEST_ID is not set
--- SKIP: TestAccLambdaFunction_image (0.00s)
=== RUN   TestAccLambdaFunction_architectures
=== PAUSE TestAccLambdaFunction_architectures
=== RUN   TestAccLambdaFunction_architecturesUpdate
=== PAUSE TestAccLambdaFunction_architecturesUpdate
=== RUN   TestAccLambdaFunction_architecturesWithLayer
=== PAUSE TestAccLambdaFunction_architecturesWithLayer
=== RUN   TestAccLambdaFunction_ephemeralStorage
=== PAUSE TestAccLambdaFunction_ephemeralStorage
=== RUN   TestAccLambdaFunction_loggingConfig
=== PAUSE TestAccLambdaFunction_loggingConfig
=== RUN   TestAccLambdaFunction_loggingConfigWithPublish
=== PAUSE TestAccLambdaFunction_loggingConfigWithPublish
=== RUN   TestAccLambdaFunction_tracing
=== PAUSE TestAccLambdaFunction_tracing
=== RUN   TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables
=== PAUSE TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables
=== RUN   TestAccLambdaFunction_layers
=== PAUSE TestAccLambdaFunction_layers
=== RUN   TestAccLambdaFunction_layersUpdate
=== PAUSE TestAccLambdaFunction_layersUpdate
=== RUN   TestAccLambdaFunction_vpc
=== PAUSE TestAccLambdaFunction_vpc
=== RUN   TestAccLambdaFunction_vpcRemoval
=== PAUSE TestAccLambdaFunction_vpcRemoval
=== RUN   TestAccLambdaFunction_vpcUpdate
=== PAUSE TestAccLambdaFunction_vpcUpdate
=== RUN   TestAccLambdaFunction_VPC_withInvocation
=== PAUSE TestAccLambdaFunction_VPC_withInvocation
=== RUN   TestAccLambdaFunction_VPCPublishNo_changes
=== PAUSE TestAccLambdaFunction_VPCPublishNo_changes
=== RUN   TestAccLambdaFunction_VPCPublishHas_changes
=== PAUSE TestAccLambdaFunction_VPCPublishHas_changes
=== RUN   TestAccLambdaFunction_VPC_properIAMDependencies
=== PAUSE TestAccLambdaFunction_VPC_properIAMDependencies
=== RUN   TestAccLambdaFunction_VPC_replaceSGWithDefault
=== PAUSE TestAccLambdaFunction_VPC_replaceSGWithDefault
=== RUN   TestAccLambdaFunction_VPC_replaceSGWithCustom
=== PAUSE TestAccLambdaFunction_VPC_replaceSGWithCustom
=== RUN   TestAccLambdaFunction_emptyVPC
=== PAUSE TestAccLambdaFunction_emptyVPC
=== RUN   TestAccLambdaFunction_s3
=== PAUSE TestAccLambdaFunction_s3
=== RUN   TestAccLambdaFunction_localUpdate
=== PAUSE TestAccLambdaFunction_localUpdate
=== RUN   TestAccLambdaFunction_LocalUpdate_nameOnly
=== PAUSE TestAccLambdaFunction_LocalUpdate_nameOnly
=== RUN   TestAccLambdaFunction_LocalUpdate_publish
=== PAUSE TestAccLambdaFunction_LocalUpdate_publish
=== RUN   TestAccLambdaFunction_S3Update_basic
=== PAUSE TestAccLambdaFunction_S3Update_basic
=== RUN   TestAccLambdaFunction_S3Update_unversioned
=== PAUSE TestAccLambdaFunction_S3Update_unversioned
=== RUN   TestAccLambdaFunction_snapStart
=== PAUSE TestAccLambdaFunction_snapStart
=== RUN   TestAccLambdaFunction_runtimes
=== PAUSE TestAccLambdaFunction_runtimes
=== RUN   TestAccLambdaFunction_Zip_validation
=== PAUSE TestAccLambdaFunction_Zip_validation
=== RUN   TestAccLambdaFunction_ipv6AllowedForDualStack
=== PAUSE TestAccLambdaFunction_ipv6AllowedForDualStack
=== RUN   TestAccLambdaFunction_sourceKMSKeyARN
=== PAUSE TestAccLambdaFunction_sourceKMSKeyARN
=== RUN   TestAccLambdaFunction_skipDestroy
=== PAUSE TestAccLambdaFunction_skipDestroy
=== CONT  TestAccLambdaFunction_Identity_Basic
=== CONT  TestAccLambdaFunction_disablePublish
=== CONT  TestAccLambdaFunction_tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Replace
=== CONT  TestAccLambdaFunction_tags_EmptyMap
=== CONT  TestAccLambdaFunction_enablePublish
=== CONT  TestAccLambdaFunction_versionedUpdate
=== CONT  TestAccLambdaFunction_nameValidation
=== CONT  TestAccLambdaFunction_versioned
=== CONT  TestAccLambdaFunction_tags_DefaultTags_providerOnly
=== CONT  TestAccLambdaFunction_EnvironmentVariables_noValue
=== CONT  TestAccLambdaFunction_encryptedEnvVariables
=== CONT  TestAccLambdaFunction_envVariables
=== CONT  TestAccLambdaFunction_skipDestroy
=== CONT  TestAccLambdaFunction_expectFilenameAndS3Attributes
=== CONT  TestAccLambdaFunction_sourceKMSKeyARN
=== CONT  TestAccLambdaFunction_tags_ComputedTag_OnCreate
=== CONT  TestAccLambdaFunction_concurrencyCycle
=== CONT  TestAccLambdaFunction_concurrency
=== CONT  TestAccLambdaFunction_ipv6AllowedForDualStack
--- PASS: TestAccLambdaFunction_nameValidation (7.24s)
=== CONT  TestAccLambdaFunction_Zip_validation
--- PASS: TestAccLambdaFunction_expectFilenameAndS3Attributes (7.39s)
=== CONT  TestAccLambdaFunction_codeSigning
--- PASS: TestAccLambdaFunction_Zip_validation (8.66s)
=== CONT  TestAccLambdaFunction_runtimes
--- PASS: TestAccLambdaFunction_skipDestroy (60.79s)
=== CONT  TestAccLambdaFunction_unpublishedCodeUpdate
--- PASS: TestAccLambdaFunction_Identity_Basic (60.85s)
=== CONT  TestAccLambdaFunction_snapStart
--- PASS: TestAccLambdaFunction_versioned (71.13s)
=== CONT  TestAccLambdaFunction_disappears
--- PASS: TestAccLambdaFunction_EnvironmentVariables_noValue (84.50s)
=== CONT  TestAccLambdaFunction_S3Update_unversioned
--- PASS: TestAccLambdaFunction_enablePublish (116.12s)
=== CONT  TestAccLambdaFunction_S3Update_basic
--- PASS: TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Replace (130.82s)
=== CONT  TestAccLambdaFunction_basic
--- PASS: TestAccLambdaFunction_concurrency (133.60s)
=== CONT  TestAccLambdaFunction_LocalUpdate_publish
--- PASS: TestAccLambdaFunction_concurrencyCycle (136.25s)
=== CONT  TestAccLambdaFunction_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccLambdaFunction_disablePublish (140.91s)
=== CONT  TestAccLambdaFunction_LocalUpdate_nameOnly
--- PASS: TestAccLambdaFunction_tags_DefaultTags_nullNonOverlappingResourceTag (141.58s)
=== CONT  TestAccLambdaFunction_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccLambdaFunction_tags_EmptyMap (159.13s)
=== CONT  TestAccLambdaFunction_localUpdate
--- PASS: TestAccLambdaFunction_tags_ComputedTag_OnCreate (163.02s)
=== CONT  TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccLambdaFunction_S3Update_unversioned (80.96s)
=== CONT  TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccLambdaFunction_envVariables (190.67s)
=== CONT  TestAccLambdaFunction_s3
--- PASS: TestAccLambdaFunction_S3Update_basic (84.44s)
=== CONT  TestAccLambdaFunction_emptyVPC
--- PASS: TestAccLambdaFunction_codeSigning (196.49s)
=== CONT  TestAccLambdaFunction_tags_EmptyTag_OnCreate
--- PASS: TestAccLambdaFunction_tags_DefaultTags_providerOnly (216.21s)
=== CONT  TestAccLambdaFunction_VPC_replaceSGWithCustom
--- PASS: TestAccLambdaFunction_encryptedEnvVariables (229.26s)
=== CONT  TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccLambdaFunction_s3 (55.11s)
=== CONT  TestAccLambdaFunction_VPC_replaceSGWithDefault
--- PASS: TestAccLambdaFunction_disappears (319.28s)
=== CONT  TestAccLambdaFunction_tags_AddOnUpdate
--- PASS: TestAccLambdaFunction_versionedUpdate (399.86s)
=== CONT  TestAccLambdaFunction_VPC_properIAMDependencies
--- PASS: TestAccLambdaFunction_basic (269.75s)
=== CONT  TestAccLambdaFunction_VPCPublishHas_changes
--- PASS: TestAccLambdaFunction_snapStart (346.95s)
=== CONT  TestAccLambdaFunction_tags
--- PASS: TestAccLambdaFunction_tags_IgnoreTags_Overlap_ResourceTag (315.66s)
=== CONT  TestAccLambdaFunction_VPCPublishNo_changes
--- PASS: TestAccLambdaFunction_sourceKMSKeyARN (452.31s)
=== CONT  TestAccLambdaFunction_tags_null
--- PASS: TestAccLambdaFunction_tags_IgnoreTags_Overlap_DefaultTag (318.83s)
=== CONT  TestAccLambdaFunction_Identity_ExistingResource
--- PASS: TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Replace (305.43s)
=== CONT  TestAccLambdaFunction_Identity_RegionOverride
--- PASS: TestAccLambdaFunction_emptyVPC (267.93s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Add (309.41s)
=== CONT  TestAccLambdaFunction_VPC_withInvocation
--- PASS: TestAccLambdaFunction_tags_EmptyTag_OnCreate (300.27s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccLambdaFunction_Identity_ExistingResource (94.29s)
=== CONT  TestAccLambdaFunction_ephemeralStorage
--- PASS: TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Add (465.07s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccLambdaFunction_runtimes (716.09s)
=== CONT  TestAccLambdaFunction_architecturesWithLayer
--- PASS: TestAccLambdaFunction_ipv6AllowedForDualStack (839.21s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccLambdaFunction_unpublishedCodeUpdate (789.75s)
=== CONT  TestAccLambdaFunction_loggingConfig
--- PASS: TestAccLambdaFunction_tags_AddOnUpdate (481.25s)
=== CONT  TestAccLambdaFunction_architecturesUpdate
--- PASS: TestAccLambdaFunction_VPC_replaceSGWithCustom (691.29s)
=== CONT  TestAccLambdaFunction_vpcUpdate
--- PASS: TestAccLambdaFunction_LocalUpdate_publish (805.97s)
=== CONT  TestAccLambdaFunction_nilDeadLetter
--- PASS: TestAccLambdaFunction_VPC_replaceSGWithDefault (844.18s)
=== CONT  TestAccLambdaFunction_deadLetterUpdated
--- PASS: TestAccLambdaFunction_LocalUpdate_nameOnly (1006.05s)
=== CONT  TestAccLambdaFunction_architectures
--- PASS: TestAccLambdaFunction_VPC_properIAMDependencies (758.38s)
=== CONT  TestAccLambdaFunction_deadLetter
--- PASS: TestAccLambdaFunction_tags (792.50s)
=== CONT  TestAccLambdaFunction_fileSystem
--- PASS: TestAccLambdaFunction_localUpdate (1178.54s)
=== CONT  TestAccLambdaFunction_layers
--- PASS: TestAccLambdaFunction_tags_null (908.15s)
=== CONT  TestAccLambdaFunction_tracing
--- PASS: TestAccLambdaFunction_Identity_RegionOverride (897.76s)
=== CONT  TestAccLambdaFunction_vpc
--- PASS: TestAccLambdaFunction_tags_DefaultTags_updateToResourceOnly (908.92s)
=== CONT  TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables
--- PASS: TestAccLambdaFunction_tags_DefaultTags_nullOverlappingResourceTag (1048.53s)
=== CONT  TestAccLambdaFunction_layersUpdate
--- PASS: TestAccLambdaFunction_VPCPublishHas_changes (1158.91s)
=== CONT  TestAccLambdaFunction_loggingConfigWithPublish
--- PASS: TestAccLambdaFunction_tags_DefaultTags_emptyProviderOnlyTag (1055.73s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_overlapping
--- PASS: TestAccLambdaFunction_tags_DefaultTags_emptyResourceTag (924.76s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccLambdaFunction_ephemeralStorage (1211.00s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_nonOverlapping
--- PASS: TestAccLambdaFunction_loggingConfig (975.80s)
=== CONT  TestAccLambdaFunction_vpcRemoval
--- PASS: TestAccLambdaFunction_VPCPublishNo_changes (1473.40s)
--- PASS: TestAccLambdaFunction_nilDeadLetter (1010.92s)
--- PASS: TestAccLambdaFunction_architectures (846.86s)
--- PASS: TestAccLambdaFunction_deadLetterUpdated (904.69s)
--- PASS: TestAccLambdaFunction_deadLetter (851.24s)
--- PASS: TestAccLambdaFunction_layers (840.10s)
--- PASS: TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables (814.38s)
--- PASS: TestAccLambdaFunction_tracing (843.95s)
--- PASS: TestAccLambdaFunction_architecturesWithLayer (1665.60s)
--- PASS: TestAccLambdaFunction_layersUpdate (856.73s)
--- PASS: TestAccLambdaFunction_architecturesUpdate (1546.32s)
--- PASS: TestAccLambdaFunction_tags_DefaultTags_updateToProviderOnly (660.59s)
--- PASS: TestAccLambdaFunction_tags_DefaultTags_overlapping (685.93s)
--- PASS: TestAccLambdaFunction_tags_DefaultTags_nonOverlapping (689.54s)
--- PASS: TestAccLambdaFunction_vpcUpdate (1562.12s)
--- PASS: TestAccLambdaFunction_loggingConfigWithPublish (966.78s)
--- PASS: TestAccLambdaFunction_fileSystem (1338.07s)
--- PASS: TestAccLambdaFunction_vpc (1217.90s)
--- PASS: TestAccLambdaFunction_vpcRemoval (1150.19s)
--- PASS: TestAccLambdaFunction_VPC_withInvocation (2660.90s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     3140.106s


```
