### PR TITLE
d/aws_account_account: new data source 

### DIFF
--- a/.changelog/44085.txt
+++ b/.changelog/44085.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_account_account
+```

--- a/internal/service/account/account_data_source.go
+++ b/internal/service/account/account_data_source.go
@@ -1,0 +1,100 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package account
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/account"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_account_account", name="Account")
+func newAccountDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceAccount{}, nil
+}
+
+const (
+	DSNameAccount = "Account Data Source"
+)
+
+type dataSourceAccount struct {
+	framework.DataSourceWithModel[dataSourceAccountModel]
+}
+
+func (d *dataSourceAccount) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"account_created_date": schema.StringAttribute{
+				CustomType: timetypes.RFC3339Type{},
+				Computed:   true,
+			},
+			names.AttrAccountID: schema.StringAttribute{
+				Computed: true,
+				Optional: true,
+			},
+			"account_name": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+	}
+}
+
+func (d *dataSourceAccount) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().AccountClient(ctx)
+
+	// TIP: -- 2. Fetch the config
+	var data dataSourceAccountModel
+	smerr.EnrichAppend(ctx, &resp.Diagnostics, req.Config.Get(ctx, &data))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findAccountInformation(ctx, conn, data.AccountID.ValueString())
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID)
+		return
+	}
+
+	smerr.EnrichAppend(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &data, flex.WithFieldNamePrefix("Account")), smerr.ID)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	smerr.EnrichAppend(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data), smerr.ID)
+}
+
+type dataSourceAccountModel struct {
+	AccountCreatedDate timetypes.RFC3339 `tfsdk:"account_created_date"`
+	AccountID          types.String      `tfsdk:"account_id"`
+	AccountName        types.String      `tfsdk:"account_name"`
+}
+
+func findAccountInformation(ctx context.Context, conn *account.Client, accountID string) (*account.GetAccountInformationOutput, error) {
+	input := account.GetAccountInformationInput{}
+	if accountID != "" {
+		input.AccountId = aws.String(accountID)
+	}
+
+	output, err := conn.GetAccountInformation(ctx, &input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
+}

--- a/internal/service/account/account_data_source_test.go
+++ b/internal/service/account/account_data_source_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package account_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func testAccAccountDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_account_account.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AccountServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountDataSourceConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrAccountID),
+					resource.TestCheckResourceAttrSet(dataSourceName, "account_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "account_created_date"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAccountDataSource_accountID(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_account_account.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+			acctest.PreCheckOrganizationsEnabledServicePrincipal(ctx, t, "account.amazonaws.com")
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AccountServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountDataSourceConfig_organization(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrAccountID),
+					resource.TestCheckResourceAttrSet(dataSourceName, "account_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "account_created_date"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAccountDataSourceConfig_basic() string {
+	return `
+data "aws_account_account" "test" {}
+`
+}
+
+func testAccAccountDataSourceConfig_organization() string {
+	return acctest.ConfigCompose(acctest.ConfigAlternateAccountProvider(), `
+data "aws_caller_identity" "test" {
+  provider = "awsalternate"
+}
+
+data "aws_account_account" "test" {
+  account_id = data.aws_caller_identity.test.account_id
+}
+`)
+}

--- a/internal/service/account/account_test.go
+++ b/internal/service/account/account_test.go
@@ -13,6 +13,10 @@ func TestAccAccount_serial(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]map[string]func(t *testing.T){
+		"Account": {
+			"dataSourceBasic":     testAccAccountDataSource_basic,
+			"dataSourceAccountID": testAccAccountDataSource_accountID,
+		},
 		"AlternateContact": {
 			acctest.CtBasic:      testAccAlternateContact_basic,
 			acctest.CtDisappears: testAccAlternateContact_disappears,

--- a/internal/service/account/service_package_gen.go
+++ b/internal/service/account/service_package_gen.go
@@ -21,6 +21,12 @@ type servicePackage struct{}
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
 	return []*inttypes.ServicePackageFrameworkDataSource{
 		{
+			Factory:  newAccountDataSource,
+			TypeName: "aws_account_account",
+			Name:     "Account",
+			Region:   unique.Make(inttypes.ResourceRegionDisabled()),
+		},
+		{
 			Factory:  newPrimaryContactDataSource,
 			TypeName: "aws_account_primary_contact",
 			Name:     "Primary Contact",

--- a/website/docs/d/account_account.html.markdown
+++ b/website/docs/d/account_account.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Account Management"
+layout: "aws"
+page_title: "AWS: aws_account_account"
+description: |-
+  Provides details about an AWS Account.
+---
+
+# Data Source: aws_account_account
+
+Provides the account information about an AWS Account.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_account_account" "example" {
+}
+```
+
+### Organization Management Account Usage
+
+```terraform
+data "aws_account_account" "example" {
+  account_id = "123456789000"
+}
+```
+
+## Argument Reference
+
+The following arguments are optional:
+
+* `account_id` - (Optional) The ID of the target account when managing member accounts. The caller must be an identity in the organization's management account or a delegated administrator account. It will return current user's account by default if omitted.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `account_name` - The name of the account.
+* `account_created_date` - The date and time the account was created.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.
No
## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
No
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This data source returns the GetAccountInformation action from AWS Account Management API. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42386

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
References

https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/account#Client.GetAccountInformation

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
