### PR TITLE
Add support for importing aws_dynamodb_table_item

### DIFF
--- a/.changelog/44089.txt
+++ b/.changelog/44089.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dynamodb_table_item: Add import support
+```

--- a/internal/service/dynamodb/table_item.go
+++ b/internal/service/dynamodb/table_item.go
@@ -33,6 +33,10 @@ func resourceTableItem() *schema.Resource {
 		UpdateWithoutTimeout: resourceTableItemUpdate,
 		DeleteWithoutTimeout: resourceTableItemDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceTableItemImportState,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"hash_key": {
 				Type:     schema.TypeString,
@@ -308,4 +312,100 @@ func expandTableItemQueryKey(attrs map[string]awstypes.AttributeValue, hashKey, 
 	}
 
 	return queryKey
+}
+
+func createTableItemKeyAttr(attrTypes map[string]awstypes.ScalarAttributeType, name, value string) (awstypes.AttributeValue, error) {
+	attrType, ok := attrTypes[name]
+	if !ok {
+		return nil, fmt.Errorf("key %s not found in attribute definitions", name)
+	}
+	switch attrType {
+	case awstypes.ScalarAttributeTypeS:
+		return &awstypes.AttributeValueMemberS{Value: value}, nil
+	case awstypes.ScalarAttributeTypeN:
+		return &awstypes.AttributeValueMemberN{Value: value}, nil
+	case awstypes.ScalarAttributeTypeB:
+		data, err := itypes.Base64Decode(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid base64 value for binary attribute %s: %s", name, err)
+		}
+		return &awstypes.AttributeValueMemberB{Value: data}, nil
+	default:
+		return nil, fmt.Errorf("unsupported attribute type: %s", attrType)
+	}
+}
+
+func resourceTableItemImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
+
+	idParts := strings.Split(d.Id(), "|")
+	if len(idParts) < 3 || len(idParts) > 4 {
+		return nil, fmt.Errorf("unexpected format for import ID (%s), expected tableName|hashKeyName|hashKeyValue[|rangeKeyValue]", d.Id())
+	}
+
+	tableName := idParts[0]
+	hashKey := idParts[1]
+	hashValue := idParts[2]
+	var rangeValue string
+	if len(idParts) == 4 {
+		rangeValue = idParts[3]
+	}
+
+	output, err := conn.DescribeTable(ctx, &dynamodb.DescribeTableInput{
+		TableName: aws.String(tableName),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describing table %s: %s", tableName, err)
+	}
+
+	var rangeKey string
+	if rangeValue != "" {
+		var found bool
+		for _, elem := range output.Table.KeySchema {
+			if aws.ToString(elem.AttributeName) != hashKey && elem.KeyType == awstypes.KeyTypeRange {
+				rangeKey = aws.ToString(elem.AttributeName)
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("import ID contains range key value but table %s does not have a range key", tableName)
+		}
+	}
+
+	attrTypes := map[string]awstypes.ScalarAttributeType{}
+	for _, v := range output.Table.AttributeDefinitions {
+		attrTypes[aws.ToString(v.AttributeName)] = v.AttributeType
+	}
+
+	key := map[string]awstypes.AttributeValue{}
+	key[hashKey], err = createTableItemKeyAttr(attrTypes, hashKey, hashValue)
+	if err != nil {
+		return nil, err
+	}
+	if rangeValue != "" {
+		key[rangeKey], err = createTableItemKeyAttr(attrTypes, rangeKey, rangeValue)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	item, err := findTableItemByTwoPartKey(ctx, conn, tableName, key)
+	if err != nil {
+		return nil, fmt.Errorf("reading DynamoDB Table Item: %s: %s", d.Id(), err)
+	}
+	itemAttrs, err := flattenTableItemAttributes(item)
+	if err != nil {
+		return nil, fmt.Errorf("flattening item attributes: %s", err)
+	}
+
+	d.Set(names.AttrTableName, tableName)
+	d.Set("hash_key", hashKey)
+	if rangeKey != "" {
+		d.Set("range_key", rangeKey)
+	}
+	d.Set("item", itemAttrs)
+	d.SetId(tableItemCreateResourceID(tableName, hashKey, rangeKey, item))
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/service/dynamodb/table_item_test.go
+++ b/internal/service/dynamodb/table_item_test.go
@@ -5,6 +5,7 @@ package dynamodb_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -28,13 +29,13 @@ func TestAccDynamoDBTableItem_basic(t *testing.T) {
 
 	tableName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	hashKey := "hashKey"
-	itemContent := `{
+	itemContent := testAccNormalizeItemJSON(t, `{
 	"hashKey": {"S": "something"},
 	"one": {"N": "11111"},
 	"two": {"N": "22222"},
 	"three": {"N": "33333"},
 	"four": {"N": "44444"}
-}`
+}`)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -52,6 +53,11 @@ func TestAccDynamoDBTableItem_basic(t *testing.T) {
 					acctest.CheckResourceAttrEquivalentJSON("aws_dynamodb_table_item.test", "item", itemContent),
 				),
 			},
+			{
+				ResourceName:      "aws_dynamodb_table_item.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -63,14 +69,14 @@ func TestAccDynamoDBTableItem_rangeKey(t *testing.T) {
 	tableName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	hashKey := "hashKey"
 	rangeKey := "rangeKey"
-	itemContent := `{
+	itemContent := testAccNormalizeItemJSON(t, `{
 	"hashKey": {"S": "something"},
 	"rangeKey": {"S": "something-else"},
 	"one": {"N": "11111"},
 	"two": {"N": "22222"},
 	"three": {"N": "33333"},
 	"four": {"N": "44444"}
-}`
+}`)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -88,6 +94,11 @@ func TestAccDynamoDBTableItem_rangeKey(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test", names.AttrTableName, tableName),
 					acctest.CheckResourceAttrEquivalentJSON("aws_dynamodb_table_item.test", "item", itemContent),
 				),
+			},
+			{
+				ResourceName:      "aws_dynamodb_table_item.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -716,4 +727,17 @@ resource "aws_dynamodb_table_item" "test" {
 ITEM
 }
 `, tableName, hashKey, content)
+}
+
+func testAccNormalizeItemJSON(t *testing.T, item string) string {
+	t.Helper()
+	var data any
+	if err := json.Unmarshal([]byte(item), &data); err != nil {
+		t.Fatalf("failed to unmarshal JSON: %s", err)
+	}
+	normalized, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("failed to marshal JSON: %s", err)
+	}
+	return string(normalized)
 }

--- a/website/docs/r/dynamodb_table_item.html.markdown
+++ b/website/docs/r/dynamodb_table_item.html.markdown
@@ -62,4 +62,17 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-You cannot import DynamoDB table items.
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import DynamoDB table items using the `table_name|hash_key_name|hash_key_value[|range_key_value]`. For example:
+
+```terraform
+import {
+  to = aws_dynamodb_table_item.example
+  id = "example-table|exampleHashKey|exampleHashValue"
+}
+```
+
+Using `terraform import`, import DynamoDB table items using the `table_name|hash_key_name|hash_key_value[|range_key_value]`. For example:
+
+```console
+% terraform import aws_dynamodb_table_item.example 'example-table|exampleHashKey|exampleHashValue'
+```


### PR DESCRIPTION
### Description

Add support for importing `aws_dynamodb_table_item`. The import id format is the same as the resource id: `tableName|hashKeyName|hashKeyValue[|rangeKeyValue]`. This has the unfortunate limitation of not allowing `|` to be used in the key value.

### Output from Acceptance Testing

```console
% AWS_PROFILE=default make testacc TESTS=TestAccDynamoDBTableItem PKG=dynamodb
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTableItem'  -timeout 360m -vet=off
2025/09/02 13:17:12 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/02 13:17:12 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDynamoDBTableItemDataSource_basic
=== PAUSE TestAccDynamoDBTableItemDataSource_basic
=== RUN   TestAccDynamoDBTableItemDataSource_projectionExpression
=== PAUSE TestAccDynamoDBTableItemDataSource_projectionExpression
=== RUN   TestAccDynamoDBTableItemDataSource_expressionAttributeNames
=== PAUSE TestAccDynamoDBTableItemDataSource_expressionAttributeNames
=== RUN   TestAccDynamoDBTableItem_basic
=== PAUSE TestAccDynamoDBTableItem_basic
=== RUN   TestAccDynamoDBTableItem_rangeKey
=== PAUSE TestAccDynamoDBTableItem_rangeKey
=== RUN   TestAccDynamoDBTableItem_withMultipleItems
=== PAUSE TestAccDynamoDBTableItem_withMultipleItems
=== RUN   TestAccDynamoDBTableItem_withDuplicateItemsSameRangeKey
=== PAUSE TestAccDynamoDBTableItem_withDuplicateItemsSameRangeKey
=== RUN   TestAccDynamoDBTableItem_withDuplicateItemsDifferentRangeKey
=== PAUSE TestAccDynamoDBTableItem_withDuplicateItemsDifferentRangeKey
=== RUN   TestAccDynamoDBTableItem_wonkyItems
=== PAUSE TestAccDynamoDBTableItem_wonkyItems
=== RUN   TestAccDynamoDBTableItem_update
=== PAUSE TestAccDynamoDBTableItem_update
=== RUN   TestAccDynamoDBTableItem_updateWithRangeKey
=== PAUSE TestAccDynamoDBTableItem_updateWithRangeKey
=== RUN   TestAccDynamoDBTableItem_disappears
=== PAUSE TestAccDynamoDBTableItem_disappears
=== RUN   TestAccDynamoDBTableItem_mapOutOfBandUpdate
=== PAUSE TestAccDynamoDBTableItem_mapOutOfBandUpdate
=== CONT  TestAccDynamoDBTableItemDataSource_basic
=== CONT  TestAccDynamoDBTableItem_withDuplicateItemsDifferentRangeKey
=== CONT  TestAccDynamoDBTableItem_rangeKey
=== CONT  TestAccDynamoDBTableItem_withDuplicateItemsSameRangeKey
=== CONT  TestAccDynamoDBTableItem_withMultipleItems
=== CONT  TestAccDynamoDBTableItemDataSource_projectionExpression
=== CONT  TestAccDynamoDBTableItem_updateWithRangeKey
=== CONT  TestAccDynamoDBTableItem_disappears
=== CONT  TestAccDynamoDBTableItem_mapOutOfBandUpdate
=== CONT  TestAccDynamoDBTableItem_update
=== CONT  TestAccDynamoDBTableItem_wonkyItems
=== CONT  TestAccDynamoDBTableItemDataSource_expressionAttributeNames
=== CONT  TestAccDynamoDBTableItem_basic
--- PASS: TestAccDynamoDBTableItem_withDuplicateItemsSameRangeKey (20.34s)
--- PASS: TestAccDynamoDBTableItemDataSource_expressionAttributeNames (29.96s)
--- PASS: TestAccDynamoDBTableItemDataSource_basic (30.01s)
--- PASS: TestAccDynamoDBTableItem_withDuplicateItemsDifferentRangeKey (30.26s)
--- PASS: TestAccDynamoDBTableItem_withMultipleItems (31.89s)
--- PASS: TestAccDynamoDBTableItem_disappears (32.07s)
--- PASS: TestAccDynamoDBTableItem_basic (33.70s)
--- PASS: TestAccDynamoDBTableItem_rangeKey (33.74s)
--- PASS: TestAccDynamoDBTableItem_wonkyItems (37.17s)
--- PASS: TestAccDynamoDBTableItemDataSource_projectionExpression (37.25s)
--- PASS: TestAccDynamoDBTableItem_mapOutOfBandUpdate (40.82s)
--- PASS: TestAccDynamoDBTableItem_update (43.35s)
--- PASS: TestAccDynamoDBTableItem_updateWithRangeKey (49.60s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	49.778s
```
