### PR TITLE
Direct Connect Hosted Connection - Deprecated Attribute (lag_id & region)

### DIFF
--- a/.changelog/44083.tx
+++ b/.changelog/44083.tx
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dx_hosted_connection: Updated documentation and removed deprecated attributes (`lag_id` & `region`)
+```

--- a/.changelog/44083.tx
+++ b/.changelog/44083.tx
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_dx_hosted_connection: Updated documentation and removed deprecated attributes (`lag_id` & `region`)
+resource/aws_dx_hosted_connection: Updated documentation to show the need of using the resource `aws_dx_connection_confirmation`
 ```

--- a/.changelog/44096.txt
+++ b/.changelog/44096.txt
@@ -1,0 +1,3 @@
+```release-note:deprecation
+resource/aws_dx_hosted_connection: Deprecation of attributes `lag_id` and `region`
+```

--- a/internal/service/directconnect/hosted_connection.go
+++ b/internal/service/directconnect/hosted_connection.go
@@ -61,11 +61,6 @@ func resourceHostedConnection() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-			"lag_id": {
-				Type:       schema.TypeString,
-				Computed:   true,
-				Deprecated: "lag_id is deprecated. Use connection_id instead.",
-			},
 			"loa_issue_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -92,11 +87,6 @@ func resourceHostedConnection() *schema.Resource {
 			names.AttrProviderName: {
 				Type:     schema.TypeString,
 				Computed: true,
-			},
-			names.AttrRegion: {
-				Type:       schema.TypeString,
-				Computed:   true,
-				Deprecated: "region is deprecated. Use connection_region instead.",
 			},
 			names.AttrState: {
 				Type:     schema.TypeString,
@@ -162,14 +152,12 @@ func resourceHostedConnectionRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("connection_region", connection.Region)
 	d.Set("has_logical_redundancy", connection.HasLogicalRedundancy)
 	d.Set("jumbo_frame_capable", connection.JumboFrameCapable)
-	d.Set("lag_id", connection.LagId)
 	d.Set("loa_issue_time", aws.ToTime(connection.LoaIssueTime).Format(time.RFC3339))
 	d.Set(names.AttrLocation, connection.Location)
 	d.Set(names.AttrName, connection.ConnectionName)
 	d.Set(names.AttrOwnerAccountID, connection.OwnerAccount)
 	d.Set("partner_name", connection.PartnerName)
 	d.Set(names.AttrProviderName, connection.ProviderName)
-	d.Set(names.AttrRegion, connection.Region)
 	d.Set(names.AttrState, connection.ConnectionState)
 	d.Set("vlan", connection.Vlan)
 

--- a/internal/service/directconnect/hosted_connection.go
+++ b/internal/service/directconnect/hosted_connection.go
@@ -61,7 +61,6 @@ func resourceHostedConnection() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-
 			"loa_issue_time": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/internal/service/directconnect/hosted_connection.go
+++ b/internal/service/directconnect/hosted_connection.go
@@ -61,6 +61,11 @@ func resourceHostedConnection() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"lag_id": {
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "lag_id is deprecated. Use connection_id instead.",
+			},
 			"loa_issue_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -88,7 +93,11 @@ func resourceHostedConnection() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
+			names.AttrRegion: {
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "region is deprecated. Use connection_region instead.",
+			},
 			names.AttrState: {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -153,14 +162,14 @@ func resourceHostedConnectionRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("connection_region", connection.Region)
 	d.Set("has_logical_redundancy", connection.HasLogicalRedundancy)
 	d.Set("jumbo_frame_capable", connection.JumboFrameCapable)
-
+	d.Set("lag_id", connection.LagId)
 	d.Set("loa_issue_time", aws.ToTime(connection.LoaIssueTime).Format(time.RFC3339))
 	d.Set(names.AttrLocation, connection.Location)
 	d.Set(names.AttrName, connection.ConnectionName)
 	d.Set(names.AttrOwnerAccountID, connection.OwnerAccount)
 	d.Set("partner_name", connection.PartnerName)
 	d.Set(names.AttrProviderName, connection.ProviderName)
-
+	d.Set(names.AttrRegion, connection.Region)
 	d.Set(names.AttrState, connection.ConnectionState)
 	d.Set("vlan", connection.Vlan)
 

--- a/internal/service/directconnect/hosted_connection.go
+++ b/internal/service/directconnect/hosted_connection.go
@@ -61,10 +61,7 @@ func resourceHostedConnection() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-			"lag_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+
 			"loa_issue_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -92,11 +89,7 @@ func resourceHostedConnection() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			names.AttrRegion: {
-				Type:       schema.TypeString,
-				Computed:   true,
-				Deprecated: "region is deprecated. Use connection_region instead.",
-			},
+
 			names.AttrState: {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -161,14 +154,14 @@ func resourceHostedConnectionRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("connection_region", connection.Region)
 	d.Set("has_logical_redundancy", connection.HasLogicalRedundancy)
 	d.Set("jumbo_frame_capable", connection.JumboFrameCapable)
-	d.Set("lag_id", connection.LagId)
+
 	d.Set("loa_issue_time", aws.ToTime(connection.LoaIssueTime).Format(time.RFC3339))
 	d.Set(names.AttrLocation, connection.Location)
 	d.Set(names.AttrName, connection.ConnectionName)
 	d.Set(names.AttrOwnerAccountID, connection.OwnerAccount)
 	d.Set("partner_name", connection.PartnerName)
 	d.Set(names.AttrProviderName, connection.ProviderName)
-	d.Set(names.AttrRegion, connection.Region)
+
 	d.Set(names.AttrState, connection.ConnectionState)
 	d.Set("vlan", connection.Vlan)
 

--- a/internal/service/directconnect/hosted_connection_test.go
+++ b/internal/service/directconnect/hosted_connection_test.go
@@ -42,7 +42,6 @@ func TestAccDirectConnectHostedConnection_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "connection_region"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, connectionName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrOwnerAccountID, ownerAccountID),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrRegion),
 					resource.TestCheckResourceAttr(resourceName, "vlan", "4094"),
 				),
 			},

--- a/internal/service/directconnect/hosted_connection_test.go
+++ b/internal/service/directconnect/hosted_connection_test.go
@@ -42,7 +42,7 @@ func TestAccDirectConnectHostedConnection_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "connection_region"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, connectionName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrOwnerAccountID, ownerAccountID),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrRegion),
+
 					resource.TestCheckResourceAttr(resourceName, "vlan", "4094"),
 				),
 			},

--- a/internal/service/directconnect/hosted_connection_test.go
+++ b/internal/service/directconnect/hosted_connection_test.go
@@ -42,7 +42,7 @@ func TestAccDirectConnectHostedConnection_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "connection_region"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, connectionName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrOwnerAccountID, ownerAccountID),
-
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrRegion),
 					resource.TestCheckResourceAttr(resourceName, "vlan", "4094"),
 				),
 			},

--- a/website/docs/r/dx_hosted_connection.html.markdown
+++ b/website/docs/r/dx_hosted_connection.html.markdown
@@ -55,7 +55,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `has_logical_redundancy` - Indicates whether the connection supports a secondary BGP peer in the same address family (IPv4/IPv6).
 * `id` - The ID of the hosted connection.
 * `jumbo_frame_capable` - Boolean value representing if jumbo frames have been enabled for this connection.
-* `loa_id` - (**Deprecated**) The ID of the LAG. You will find the information under `connection_id`.
+* `lag_id` - (**Deprecated**) The ID of the LAG. You will find the information under `connection_id`.
 * `loa_issue_time` - The time of the most recent call to [DescribeLoa](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeLoa.html) for this connection.
 * `location` - The location of the connection.
 * `partner_name` - The name of the AWS Direct Connect service provider associated with the connection.

--- a/website/docs/r/dx_hosted_connection.html.markdown
+++ b/website/docs/r/dx_hosted_connection.html.markdown
@@ -8,9 +8,9 @@ description: |-
 
 # Resource: aws_dx_hosted_connection
 
-Provides a hosted connection on the specified interconnect or a link aggregation group (LAG) of interconnects. Intended for use by AWS Direct Connect Partners only. 
+Provides a hosted connection on the specified interconnect or a link aggregation group (LAG) of interconnects. Intended for use by AWS Direct Connect Partners only.
 
-Once the hosted connection is created, the receiver AWS Account needs to confirm the creation by using the [aws_dx_connection_confirmation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dx_connection_confirmation) resource.
+With the hosted connection created, the receiver account needs to confirm the creation by using the [aws_dx_connection_confirmation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dx_connection_confirmation) resource.
 
 ## Example Usage
 

--- a/website/docs/r/dx_hosted_connection.html.markdown
+++ b/website/docs/r/dx_hosted_connection.html.markdown
@@ -15,17 +15,13 @@ Once the hosted connection is created, the receiver AWS Account needs to confirm
 ## Example Usage
 
 ```terraform
-provider "aws" {
-  alias = "partner"
-}
+provider "aws" {}
 
 provider "aws" {
-  alias = "customer"
+  alias = "receiver"
 }
 
 resource "aws_dx_hosted_connection" "hosted" {
-  provider = aws.partner
-
   connection_id    = "dxcon-ffabc123"
   bandwidth        = "100Mbps"
   name             = "tf-dx-hosted-connection"
@@ -34,7 +30,7 @@ resource "aws_dx_hosted_connection" "hosted" {
 }
 
 resource "aws_dx_connection_confirmation" "confirmation" {
-  provider = aws.customer
+  provider = aws.receiver
 
   connection_id = aws_dx_hosted_connection.hosted.id
 }
@@ -59,8 +55,10 @@ This resource exports the following attributes in addition to the arguments abov
 * `has_logical_redundancy` - Indicates whether the connection supports a secondary BGP peer in the same address family (IPv4/IPv6).
 * `id` - The ID of the hosted connection.
 * `jumbo_frame_capable` - Boolean value representing if jumbo frames have been enabled for this connection.
+* `loa_id` - (**Deprecated**) The ID of the LAG. You will find the information under `connection_id`.
 * `loa_issue_time` - The time of the most recent call to [DescribeLoa](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeLoa.html) for this connection.
 * `location` - The location of the connection.
 * `partner_name` - The name of the AWS Direct Connect service provider associated with the connection.
 * `provider_name` - The name of the service provider associated with the connection.
+* `region` - (**Deprecated**) The AWS Region where the connection is located. Use `connection_region` instead.
 * `state` - The state of the connection. Possible values include: ordering, requested, pending, available, down, deleting, deleted, rejected, unknown. See [AllocateHostedConnection](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_AllocateHostedConnection.html) for a description of each connection state.

--- a/website/docs/r/dx_hosted_connection.html.markdown
+++ b/website/docs/r/dx_hosted_connection.html.markdown
@@ -8,17 +8,35 @@ description: |-
 
 # Resource: aws_dx_hosted_connection
 
-Provides a hosted connection on the specified interconnect or a link aggregation group (LAG) of interconnects. Intended for use by AWS Direct Connect Partners only.
+Provides a hosted connection on the specified interconnect or a link aggregation group (LAG) of interconnects. Intended for use by AWS Direct Connect Partners only. 
+
+Once the hosted connection is created, the receiver AWS Account needs to confirm the creation by using the [aws_dx_connection_confirmation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dx_connection_confirmation) resource.
 
 ## Example Usage
 
 ```terraform
+provider "aws" {
+  alias = "partner"
+}
+
+provider "aws" {
+  alias = "customer"
+}
+
 resource "aws_dx_hosted_connection" "hosted" {
+  provider = aws.partner
+
   connection_id    = "dxcon-ffabc123"
   bandwidth        = "100Mbps"
   name             = "tf-dx-hosted-connection"
   owner_account_id = "123456789012"
   vlan             = 1
+}
+
+resource "aws_dx_connection_confirmation" "confirmation" {
+  provider = aws.customer
+
+  connection_id = aws_dx_hosted_connection.hosted.id
 }
 ```
 
@@ -41,10 +59,8 @@ This resource exports the following attributes in addition to the arguments abov
 * `has_logical_redundancy` - Indicates whether the connection supports a secondary BGP peer in the same address family (IPv4/IPv6).
 * `id` - The ID of the hosted connection.
 * `jumbo_frame_capable` - Boolean value representing if jumbo frames have been enabled for this connection.
-* `lag_id` - The ID of the LAG.
 * `loa_issue_time` - The time of the most recent call to [DescribeLoa](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeLoa.html) for this connection.
 * `location` - The location of the connection.
 * `partner_name` - The name of the AWS Direct Connect service provider associated with the connection.
 * `provider_name` - The name of the service provider associated with the connection.
-* `region` - (**Deprecated**) The AWS Region where the connection is located. Use `connection_region` instead.
 * `state` - The state of the connection. Possible values include: ordering, requested, pending, available, down, deleting, deleted, rejected, unknown. See [AllocateHostedConnection](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_AllocateHostedConnection.html) for a description of each connection state.

--- a/website/docs/r/dx_hosted_connection.html.markdown
+++ b/website/docs/r/dx_hosted_connection.html.markdown
@@ -55,10 +55,8 @@ This resource exports the following attributes in addition to the arguments abov
 * `has_logical_redundancy` - Indicates whether the connection supports a secondary BGP peer in the same address family (IPv4/IPv6).
 * `id` - The ID of the hosted connection.
 * `jumbo_frame_capable` - Boolean value representing if jumbo frames have been enabled for this connection.
-* `lag_id` - (**Deprecated**) The ID of the LAG. You will find the information under `connection_id`.
 * `loa_issue_time` - The time of the most recent call to [DescribeLoa](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeLoa.html) for this connection.
 * `location` - The location of the connection.
 * `partner_name` - The name of the AWS Direct Connect service provider associated with the connection.
 * `provider_name` - The name of the service provider associated with the connection.
-* `region` - (**Deprecated**) The AWS Region where the connection is located. Use `connection_region` instead.
 * `state` - The state of the connection. Possible values include: ordering, requested, pending, available, down, deleting, deleted, rejected, unknown. See [AllocateHostedConnection](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_AllocateHostedConnection.html) for a description of each connection state.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes in security controls, only removal of deprecated attributes.

### Description

* Removal of deprecated attributes: `lag_id` and `region`.
* No changes in resource functionality.

### Relations

### References

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccDirectConnectHostedConnection_basic PKG=directconnect

TF_ACC=1 go1.24.6 test ./internal/service/directconnect/... -v -count 1 -parallel 20 -run='TestAccDirectConnectHostedConnection_basic'  -timeout 360m -vet=off
2025/08/30 11:53:39 Creating Terraform AWS Provider (SDKv2-style)...
2025/08/30 11:53:39 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDirectConnectHostedConnection_basic
=== PAUSE TestAccDirectConnectHostedConnection_basic
=== CONT  TestAccDirectConnectHostedConnection_basic
--- PASS: TestAccDirectConnectHostedConnection_basic (14.69s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/directconnect      20.139s
...
```
