### PR TITLE
docs: add example for two log sources

### DIFF
--- a/website/docs/r/securitylake_subscriber.html.markdown
+++ b/website/docs/r/securitylake_subscriber.html.markdown
@@ -14,6 +14,8 @@ Terraform resource for managing an AWS Security Lake Subscriber.
 
 ## Example Usage
 
+### Basic Usage
+
 ```terraform
 resource "aws_securitylake_subscriber" "example" {
   subscriber_name = "example-name"
@@ -25,6 +27,36 @@ resource "aws_securitylake_subscriber" "example" {
       source_version = "1.0"
     }
   }
+  subscriber_identity {
+    external_id = "example"
+    principal   = "1234567890"
+  }
+
+  depends_on = [aws_securitylake_data_lake.example]
+}
+```
+
+### Multiple Log Sources
+
+```terraform
+resource "aws_securitylake_subscriber" "example" {
+  subscriber_name        = "example-name"
+  access_type            = "S3"
+
+  source {
+    aws_log_source_resource {
+      source_name    = "SH_FINDINGS"
+      source_version = "2.0"
+    }
+  }
+
+  source {
+    aws_log_source_resource {
+       source_name    = "ROUTE53"
+       source_version = "2.0"
+    }
+  }
+
   subscriber_identity {
     external_id = "example"
     principal   = "1234567890"
@@ -64,8 +96,8 @@ The `subscriber_identity` block supports the following arguments:
 
 The `aws_log_source_resource` block supports the following arguments:
 
-* `source_name` - (Required) Provides data expiration details of Amazon Security Lake object.
-* `source_version` - (Optional) Provides data storage transition details of Amazon Security Lake object.
+* `source_name` - (Required) The name for a AWS source. This must be a Regionally unique value. Valid values: `ROUTE53`, `VPC_FLOW`, `SH_FINDINGS`, `CLOUD_TRAIL_MGMT`, `LAMBDA_EXECUTION`, `S3_DATA`, `EKS_AUDIT` and `WAF`.
+* `source_version` - (Optional) The version for a AWS source. This must be a Regionally unique value.
 
 ### `custom_log_source_resource` Block
 


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls are implemented.

### Description

For the resource [`aws_securitylake_subscriber`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securitylake_subscriber) a 2nd example is added. This example shows how to use two log sources.


In addition, the documentation for the `aws_log_source_resource` block is updated. The [current documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securitylake_subscriber#aws_log_source_resource-block) contains incorrect descriptions (potentially caused by copy/pasting from `aws_securitylake_data_lake` docs):

> [aws_log_source_resource Block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securitylake_subscriber#aws_log_source_resource-block)
The aws_log_source_resource block supports the following arguments:
>
> [source_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securitylake_subscriber#source_name-1) - (Required) Provides data expiration details of Amazon Security Lake object.
> [source_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securitylake_subscriber#source_version-1) - (Optional) Provides data storage transition details of Amazon Security Lake object.



### Relations

- Closes #40846 
- Relates #38324 

### References

- [API - AwsLogSourceResource](https://docs.aws.amazon.com/security-lake/latest/APIReference/API_AwsLogSourceResource.html)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.