### PR TITLE
`aws-sdk-go-v2` updates (Release 2025-08-29)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -134,7 +134,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/grafana v1.31.2
 	github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.2
 	github.com/aws/aws-sdk-go-v2/service/groundstation v1.37.2
-	github.com/aws/aws-sdk-go-v2/service/guardduty v1.63.1
+	github.com/aws/aws-sdk-go-v2/service/guardduty v1.63.2
 	github.com/aws/aws-sdk-go-v2/service/healthlake v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/iam v1.47.3
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.32.2

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.2 h1:VEeScKJn6CH3rH9IP8yMc
 github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.2/go.mod h1:iXva/vNMQB6FX7ooA7rahCAn7TlyQPVW+DTkix4E0kE=
 github.com/aws/aws-sdk-go-v2/service/groundstation v1.37.2 h1:x4EqAoItA797CzLaIwBjFxBdiqVppAJoJYh0+jiOlu8=
 github.com/aws/aws-sdk-go-v2/service/groundstation v1.37.2/go.mod h1:+XX2J867OOegjDEhNJgAEcxcjfYHN3Lgt/UoCL/AF9Y=
-github.com/aws/aws-sdk-go-v2/service/guardduty v1.63.1 h1:fVcUqFCHzgZ/ZHDlN1uwXv2j47z82ok6Eid6DqrHU7g=
-github.com/aws/aws-sdk-go-v2/service/guardduty v1.63.1/go.mod h1:+WymZY55JdQABVxO9YFyYDmVtjZQyh2GWaTo2wK1cas=
+github.com/aws/aws-sdk-go-v2/service/guardduty v1.63.2 h1:I8pteGdTARKWNd5K8n5MjR4RnKdmV2lxfp3GWF1/Y+4=
+github.com/aws/aws-sdk-go-v2/service/guardduty v1.63.2/go.mod h1:HssjGKML+1CKdk/rpboJ1GDnqPdIRbKcaHn+rWb8WnI=
 github.com/aws/aws-sdk-go-v2/service/healthlake v1.35.1 h1:Q947iRDzikQFezOGSDtrwUc3MC6NhTs9hHBNamUoIOA=
 github.com/aws/aws-sdk-go-v2/service/healthlake v1.35.1/go.mod h1:DmDO9bdGxMg218F+zRYKyjjtqogS22LKF/E83fXDAmw=
 github.com/aws/aws-sdk-go-v2/service/iam v1.47.3 h1:BDkM6KWoryEstnb0fTg5Ip+WsxAph/aCNqwws/sS5yE=


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Manual update of `github.com/aws/aws-sdk-go-v2/aws` dependencies to [Release 2025-08-29](https://github.com/aws/aws-sdk-go-v2/commit/640b80872b2c49ad5227a4738e15e4189be4863c) due to dependabot failures.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/39287.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43585.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43619.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43709.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43829.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43980.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/44036.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make sane
make: Sane Smoke Tests (x tests of Top y resources)
make: Like 'sanity' except full output and stops soon after 1st error
make: NOTE: NOT an exhaustive set of tests! Finds big problems only.
2025/09/02 08:19:16 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/02 08:19:16 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIAMInstanceProfile_tags
=== PAUSE TestAccIAMInstanceProfile_tags
=== RUN   TestAccIAMInstanceProfile_basic
=== PAUSE TestAccIAMInstanceProfile_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_basic
=== PAUSE TestAccIAMPolicyDocumentDataSource_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== RUN   TestAccIAMPolicy_tags
=== PAUSE TestAccIAMPolicy_tags
=== RUN   TestAccIAMPolicy_basic
=== PAUSE TestAccIAMPolicy_basic
=== RUN   TestAccIAMPolicy_policy
=== PAUSE TestAccIAMPolicy_policy
=== RUN   TestAccIAMRolePolicyAttachment_basic
=== PAUSE TestAccIAMRolePolicyAttachment_basic
=== RUN   TestAccIAMRolePolicyAttachment_disappears
=== PAUSE TestAccIAMRolePolicyAttachment_disappears
=== RUN   TestAccIAMRolePolicyAttachment_Disappears_role
=== PAUSE TestAccIAMRolePolicyAttachment_Disappears_role
=== RUN   TestAccIAMRolePolicy_basic
=== PAUSE TestAccIAMRolePolicy_basic
=== RUN   TestAccIAMRolePolicy_unknownsInPolicy
=== PAUSE TestAccIAMRolePolicy_unknownsInPolicy
=== RUN   TestAccIAMRole_basic
=== PAUSE TestAccIAMRole_basic
=== RUN   TestAccIAMRole_namePrefix
=== PAUSE TestAccIAMRole_namePrefix
=== RUN   TestAccIAMRole_disappears
=== PAUSE TestAccIAMRole_disappears
=== RUN   TestAccIAMRole_InlinePolicy_basic
=== PAUSE TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMInstanceProfile_tags
=== CONT  TestAccIAMRolePolicyAttachment_disappears
=== CONT  TestAccIAMRole_namePrefix
=== CONT  TestAccIAMPolicy_tags
=== CONT  TestAccIAMRolePolicyAttachment_basic
=== CONT  TestAccIAMPolicy_policy
=== CONT  TestAccIAMPolicy_basic
=== CONT  TestAccIAMRole_basic
=== CONT  TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMRole_disappears
=== CONT  TestAccIAMPolicyDocumentDataSource_basic
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== CONT  TestAccIAMRolePolicy_basic
=== CONT  TestAccIAMRolePolicy_unknownsInPolicy
=== CONT  TestAccIAMRolePolicyAttachment_Disappears_role
=== CONT  TestAccIAMInstanceProfile_basic
--- PASS: TestAccIAMPolicyDocumentDataSource_basic (12.85s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceConflicting (13.37s)
--- PASS: TestAccIAMRole_disappears (17.46s)
--- PASS: TestAccIAMRolePolicyAttachment_disappears (17.57s)
--- PASS: TestAccIAMRolePolicyAttachment_Disappears_role (17.61s)
--- PASS: TestAccIAMPolicy_basic (18.90s)
--- PASS: TestAccIAMRole_namePrefix (19.69s)
--- PASS: TestAccIAMRolePolicy_unknownsInPolicy (19.84s)
--- PASS: TestAccIAMRolePolicy_basic (20.13s)
--- PASS: TestAccIAMRole_basic (20.16s)
--- PASS: TestAccIAMInstanceProfile_basic (24.22s)
--- PASS: TestAccIAMPolicy_policy (27.86s)
--- PASS: TestAccIAMRolePolicyAttachment_basic (28.04s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (35.83s)
--- PASS: TestAccIAMPolicy_tags (54.24s)
--- PASS: TestAccIAMInstanceProfile_tags (75.25s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	80.928s
2025/09/02 08:22:23 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/02 08:22:23 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLogsGroup_basic
=== PAUSE TestAccLogsGroup_basic
=== RUN   TestAccLogsGroup_multiple
=== PAUSE TestAccLogsGroup_multiple
=== CONT  TestAccLogsGroup_basic
=== CONT  TestAccLogsGroup_multiple
--- PASS: TestAccLogsGroup_multiple (16.37s)
--- PASS: TestAccLogsGroup_basic (18.86s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	24.738s
2025/09/02 08:22:32 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/02 08:22:32 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCDataSource_basic
=== PAUSE TestAccVPCDataSource_basic
=== RUN   TestAccVPCRouteTableAssociation_Subnet_basic
=== PAUSE TestAccVPCRouteTableAssociation_Subnet_basic
=== RUN   TestAccVPCRouteTable_basic
=== PAUSE TestAccVPCRouteTable_basic
=== RUN   TestAccVPCSecurityGroupRule_race
=== PAUSE TestAccVPCSecurityGroupRule_race
=== RUN   TestAccVPCSecurityGroupRule_protocolChange
=== PAUSE TestAccVPCSecurityGroupRule_protocolChange
=== RUN   TestAccVPCSecurityGroup_basic
=== PAUSE TestAccVPCSecurityGroup_basic
=== RUN   TestAccVPCSecurityGroup_egressMode
=== PAUSE TestAccVPCSecurityGroup_egressMode
=== RUN   TestAccVPCSecurityGroup_vpcAllEgress
=== PAUSE TestAccVPCSecurityGroup_vpcAllEgress
=== RUN   TestAccVPCSubnet_basic
=== PAUSE TestAccVPCSubnet_basic
=== RUN   TestAccVPC_tenancy
=== PAUSE TestAccVPC_tenancy
=== CONT  TestAccVPCDataSource_basic
=== CONT  TestAccVPCSecurityGroup_basic
=== CONT  TestAccVPCSubnet_basic
=== CONT  TestAccVPC_tenancy
=== CONT  TestAccVPCSecurityGroup_vpcAllEgress
=== CONT  TestAccVPCSecurityGroupRule_race
=== CONT  TestAccVPCSecurityGroup_egressMode
=== CONT  TestAccVPCRouteTable_basic
=== CONT  TestAccVPCSecurityGroupRule_protocolChange
=== CONT  TestAccVPCRouteTableAssociation_Subnet_basic
--- PASS: TestAccVPCSubnet_basic (23.44s)
--- PASS: TestAccVPCRouteTable_basic (24.15s)
--- PASS: TestAccVPCSecurityGroup_vpcAllEgress (27.03s)
--- PASS: TestAccVPCRouteTableAssociation_Subnet_basic (27.43s)
--- PASS: TestAccVPCSecurityGroup_basic (27.67s)
--- PASS: TestAccVPCDataSource_basic (32.81s)
--- PASS: TestAccVPCSecurityGroup_egressMode (48.60s)
--- PASS: TestAccVPC_tenancy (51.16s)
--- PASS: TestAccVPCSecurityGroupRule_protocolChange (57.79s)
--- PASS: TestAccVPCSecurityGroupRule_race (176.40s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	189.313s
2025/09/02 08:22:27 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/02 08:22:27 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== CONT  TestAccECSService_basic
=== CONT  TestAccECSTaskDefinition_basic
--- PASS: TestAccECSTaskDefinition_basic (28.92s)
--- PASS: TestAccECSService_basic (76.96s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	85.614s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/ecs/test-fixtures	[no test files]
2025/09/02 08:22:36 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/02 08:22:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccELBV2TargetGroup_basic
=== PAUSE TestAccELBV2TargetGroup_basic
=== CONT  TestAccELBV2TargetGroup_basic
--- PASS: TestAccELBV2TargetGroup_basic (24.14s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	41.001s
2025/09/02 08:22:40 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/02 08:22:40 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKMSKey_basic
=== PAUSE TestAccKMSKey_basic
=== CONT  TestAccKMSKey_basic
--- PASS: TestAccKMSKey_basic (29.03s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	49.848s
2025/09/02 08:26:20 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/02 08:26:20 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== RUN   TestAccLambdaPermission_basic
=== PAUSE TestAccLambdaPermission_basic
=== CONT  TestAccLambdaFunction_basic
=== CONT  TestAccLambdaPermission_basic
--- PASS: TestAccLambdaPermission_basic (32.52s)
--- PASS: TestAccLambdaFunction_basic (42.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	48.513s
2025/09/02 08:26:24 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/02 08:26:24 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccMetaPartitionDataSource_basic
=== PAUSE TestAccMetaPartitionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_basic
=== PAUSE TestAccMetaRegionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_endpoint
=== PAUSE TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaPartitionDataSource_basic
=== CONT  TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaRegionDataSource_basic
--- PASS: TestAccMetaRegionDataSource_endpoint (10.47s)
--- PASS: TestAccMetaPartitionDataSource_basic (10.49s)
--- PASS: TestAccMetaRegionDataSource_basic (13.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	23.056s
2025/09/02 08:26:29 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/02 08:26:29 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRoute53Record_basic
=== PAUSE TestAccRoute53Record_basic
=== RUN   TestAccRoute53Record_Latency_basic
=== PAUSE TestAccRoute53Record_Latency_basic
=== RUN   TestAccRoute53ZoneDataSource_name
=== PAUSE TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_basic
=== CONT  TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_Latency_basic
--- PASS: TestAccRoute53ZoneDataSource_name (73.24s)
--- PASS: TestAccRoute53Record_basic (137.59s)
--- PASS: TestAccRoute53Record_Latency_basic (138.50s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	151.918s
2025/09/02 08:26:33 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/02 08:26:33 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3BucketACL_updateACL
=== PAUSE TestAccS3BucketACL_updateACL
=== RUN   TestAccS3BucketPolicy_basic
=== PAUSE TestAccS3BucketPolicy_basic
=== RUN   TestAccS3BucketPublicAccessBlock_basic
=== PAUSE TestAccS3BucketPublicAccessBlock_basic
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Security_corsUpdate
=== PAUSE TestAccS3Bucket_Security_corsUpdate
=== RUN   TestAccS3Object_basic
=== PAUSE TestAccS3Object_basic
=== CONT  TestAccS3BucketACL_updateACL
=== CONT  TestAccS3Bucket_Basic_basic
=== CONT  TestAccS3Object_basic
=== CONT  TestAccS3BucketPublicAccessBlock_basic
=== CONT  TestAccS3BucketPolicy_basic
=== CONT  TestAccS3Bucket_Security_corsUpdate
--- PASS: TestAccS3BucketPublicAccessBlock_basic (22.94s)
--- PASS: TestAccS3BucketPolicy_basic (23.01s)
--- PASS: TestAccS3Bucket_Basic_basic (23.61s)
--- PASS: TestAccS3Object_basic (25.27s)
--- PASS: TestAccS3BucketACL_updateACL (35.83s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (36.60s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	50.652s
2025/09/02 08:26:45 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/02 08:26:45 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSSMParameterEphemeral_basic
=== PAUSE TestAccSSMParameterEphemeral_basic
=== CONT  TestAccSSMParameterEphemeral_basic
--- PASS: TestAccSSMParameterEphemeral_basic (12.60s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	38.639s
2025/09/02 08:26:37 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/02 08:26:37 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSecretsManagerSecret_basic
=== PAUSE TestAccSecretsManagerSecret_basic
=== CONT  TestAccSecretsManagerSecret_basic
--- PASS: TestAccSecretsManagerSecret_basic (17.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	35.639s
2025/09/02 08:26:41 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/02 08:26:41 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSTSCallerIdentityDataSource_basic
=== PAUSE TestAccSTSCallerIdentityDataSource_basic
=== CONT  TestAccSTSCallerIdentityDataSource_basic
--- PASS: TestAccSTSCallerIdentityDataSource_basic (9.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sts	31.727s
```
