### PR TITLE
Remove incorrect availability zone rebalancing upgrade tests

### DIFF
--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -1106,7 +1106,7 @@ func TestAccECSService_BlueGreenDeployment_sigintRollback(t *testing.T) {
 				Config: testAccServiceConfig_blueGreenDeployment_withHookBehavior(rName, false),
 				PreConfig: func() {
 					go func() {
-						_ = exec.Command("go", "run", "test-fixtures/sigint_helper.go", "30").Start() //lintignore:XR007
+						_ = exec.Command("go", "run", "test-fixtures/sigint_helper.go", "30").Start() // lintignore:XR007
 					}()
 				},
 				ExpectError: regexache.MustCompile("execution halted|context canceled"),
@@ -2656,7 +2656,7 @@ func TestAccECSService_AvailabilityZoneRebalancing(t *testing.T) {
 		CheckDestroy:             testAccCheckServiceDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceConfig_availabilityZoneRebalancing(rName, awstypes.AvailabilityZoneRebalancingEnabled),
+				Config: testAccServiceConfig_availabilityZoneRebalancing(rName, "null"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(ctx, resourceName, &service),
 				),
@@ -2670,7 +2670,7 @@ func TestAccECSService_AvailabilityZoneRebalancing(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccServiceConfig_availabilityZoneRebalancing(rName, "null"),
+				Config: testAccServiceConfig_availabilityZoneRebalancing(rName, awstypes.AvailabilityZoneRebalancingEnabled),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(ctx, resourceName, &service),
 				),
@@ -2723,112 +2723,6 @@ func TestAccECSService_AvailabilityZoneRebalancing(t *testing.T) {
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("availability_zone_rebalancing"), tfknownvalue.StringExact(awstypes.AvailabilityZoneRebalancingEnabled)),
-				},
-			},
-		},
-	})
-}
-
-func TestAccECSService_AvailabilityZoneRebalancing_UpgradeV6_8_0_configured(t *testing.T) {
-	ctx := acctest.Context(t)
-	var service awstypes.Service
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_ecs_service.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:   acctest.ErrorCheck(t, names.ECSServiceID),
-		CheckDestroy: testAccCheckServiceDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"aws": {
-						Source:            "hashicorp/aws",
-						VersionConstraint: "6.8.0",
-					},
-				},
-				Config: testAccServiceConfig_availabilityZoneRebalancing(rName, awstypes.AvailabilityZoneRebalancingEnabled),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceExists(ctx, resourceName, &service),
-				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
-					},
-				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("availability_zone_rebalancing"), tfknownvalue.StringExact(awstypes.AvailabilityZoneRebalancingEnabled)),
-				},
-			},
-			{
-				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-				Config:                   testAccServiceConfig_availabilityZoneRebalancing(rName, awstypes.AvailabilityZoneRebalancingEnabled),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceExists(ctx, resourceName, &service),
-				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
-					},
-				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("availability_zone_rebalancing"), tfknownvalue.StringExact(awstypes.AvailabilityZoneRebalancingEnabled)),
-				},
-			},
-		},
-	})
-}
-
-func TestAccECSService_AvailabilityZoneRebalancing_UpgradeV6_8_0_unconfigured(t *testing.T) {
-	ctx := acctest.Context(t)
-	var service awstypes.Service
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_ecs_service.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:   acctest.ErrorCheck(t, names.ECSServiceID),
-		CheckDestroy: testAccCheckServiceDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"aws": {
-						Source:            "hashicorp/aws",
-						VersionConstraint: "6.8.0",
-					},
-				},
-				Config: testAccServiceConfig_availabilityZoneRebalancing(rName, "null"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceExists(ctx, resourceName, &service),
-				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
-					},
-				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("availability_zone_rebalancing"), tfknownvalue.StringExact(awstypes.AvailabilityZoneRebalancingDisabled)),
-				},
-			},
-			{
-				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-				Config:                   testAccServiceConfig_availabilityZoneRebalancing(rName, "null"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceExists(ctx, resourceName, &service),
-				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
-					},
-				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("availability_zone_rebalancing"), tfknownvalue.StringExact(awstypes.AvailabilityZoneRebalancingDisabled)),
 				},
 			},
 		},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The `TestAccECSService_AvailabilityZoneRebalancing_UpgradeV6_8_0_unconfigured` test incorrectly expects `availability_zone_rebalancing` to default to `DISABLED` when using v6.8.0 of the Terraform AWS provider.

Per the behavior change, creating an ECS Service with an unconfigured (null) `availability_zone_rebalancing` value now defaults to `ENABLED` instead of `DISABLED`. When updating a service with a persisted null value for `availability_zone_rebalancing`, the value will remain as `ENABLED`. Since this change is dictated by ECS backend rather than the Terraform resource provider, this change is irrespective of the user's AWS provider version. 

With this in mind, the `TestAccECSService_AvailabilityZoneRebalancing_UpgradeV6_8_0_configured` test can be removed as well. The `TestAccECSService_AvailabilityZoneRebalancing` test thoroughly tests the creation and modification of ECS services with different values for `availability_zone_rebalancing`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Relates #44117 


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make build && make testacc TESTS=TestAccECSService_AvailabilityZoneRebalancing PKG=ecs
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Building provider...
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSService_AvailabilityZoneRebalancing'  -timeout 360m -vet=off
2025/09/04 11:27:29 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/04 11:27:29 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSService_AvailabilityZoneRebalancing
=== PAUSE TestAccECSService_AvailabilityZoneRebalancing
=== CONT  TestAccECSService_AvailabilityZoneRebalancing
--- PASS: TestAccECSService_AvailabilityZoneRebalancing (110.49s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        115.124s
?       github.com/hashicorp/terraform-provider-aws/internal/service/ecs/test-fixtures
```
