### PR TITLE
[bugfix] r/aws_rds_cluster_role_association: Change `feature_name` argument from required to optional

### DIFF
--- a/.changelog/44143.txt
+++ b/.changelog/44143.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_rds_cluster_role_association: Change `feature_name` argument from required to optional
+resource/aws_rds_cluster_role_association: Make `feature_name` optional
 ```

--- a/.changelog/44143.txt
+++ b/.changelog/44143.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_cluster_role_association: Change `feature_name` argument from required to optional
+```

--- a/internal/service/rds/cluster_role_association.go
+++ b/internal/service/rds/cluster_role_association.go
@@ -50,7 +50,7 @@ func resourceClusterRoleAssociation() *schema.Resource {
 			},
 			"feature_name": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			names.AttrRoleARN: {

--- a/internal/service/rds/cluster_role_association.go
+++ b/internal/service/rds/cluster_role_association.go
@@ -72,8 +72,11 @@ func resourceClusterRoleAssociationCreate(ctx context.Context, d *schema.Resourc
 	id := clusterRoleAssociationCreateResourceID(dbClusterID, roleARN)
 	input := rds.AddRoleToDBClusterInput{
 		DBClusterIdentifier: aws.String(dbClusterID),
-		FeatureName:         aws.String(d.Get("feature_name").(string)),
 		RoleArn:             aws.String(roleARN),
+	}
+
+	if v, ok := d.GetOk("feature_name"); ok {
+		input.FeatureName = aws.String(v.(string))
 	}
 
 	_, err := tfresource.RetryWhenIsA[any, *types.InvalidDBClusterStateFault](ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {

--- a/website/docs/r/rds_cluster_role_association.html.markdown
+++ b/website/docs/r/rds_cluster_role_association.html.markdown
@@ -29,7 +29,7 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `db_cluster_identifier` - (Required) DB Cluster Identifier to associate with the IAM Role.
-* `feature_name` - (Required) Name of the feature for association. This can be found in the AWS documentation relevant to the integration or a full list is available in the `SupportedFeatureNames` list returned by [AWS CLI rds describe-db-engine-versions](https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-engine-versions.html).
+* `feature_name` - (Optional) Name of the feature for association. This can be found in the AWS documentation relevant to the integration or a full list is available in the `SupportedFeatureNames` list returned by [AWS CLI rds describe-db-engine-versions](https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-engine-versions.html).
 * `role_arn` - (Required) Amazon Resource Name (ARN) of the IAM Role to associate with the DB Cluster.
 
 ## Attribute Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* The `feature_name` argument in `aws_rds_cluster_role_association` was previously marked as required.
* However:

  * The [current AWS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_AddRoleToDBCluster.html) describes it as `Required: No`.
  * The newly added acceptance test confirmed that API requests without `feature_name` are accepted when the DB engine is MySQL, which means the `feature_name` argument is not always required.
  * The AWS Management Console for a MySQL cluster also provides a UI to specify only the role without a feature name.
* This PR changes `feature_name` from required to optional.

### Relations

Closes #44140

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccRDSClusterRoleAssociation_' PKG=rds 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSClusterRoleAssociation_'  -timeout 360m -vet=off
2025/09/05 00:57:25 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/05 00:57:25 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSClusterRoleAssociation_basic
=== PAUSE TestAccRDSClusterRoleAssociation_basic
=== RUN   TestAccRDSClusterRoleAssociation_mysqlWithoutFeatureName
=== PAUSE TestAccRDSClusterRoleAssociation_mysqlWithoutFeatureName
=== RUN   TestAccRDSClusterRoleAssociation_disappears
=== PAUSE TestAccRDSClusterRoleAssociation_disappears
=== RUN   TestAccRDSClusterRoleAssociation_Disappears_cluster
=== PAUSE TestAccRDSClusterRoleAssociation_Disappears_cluster
=== RUN   TestAccRDSClusterRoleAssociation_Disappears_role
=== PAUSE TestAccRDSClusterRoleAssociation_Disappears_role
=== CONT  TestAccRDSClusterRoleAssociation_basic
=== CONT  TestAccRDSClusterRoleAssociation_Disappears_cluster
=== CONT  TestAccRDSClusterRoleAssociation_Disappears_role
=== CONT  TestAccRDSClusterRoleAssociation_disappears
=== CONT  TestAccRDSClusterRoleAssociation_mysqlWithoutFeatureName
--- PASS: TestAccRDSClusterRoleAssociation_Disappears_cluster (148.07s)
--- PASS: TestAccRDSClusterRoleAssociation_mysqlWithoutFeatureName (151.53s)
--- PASS: TestAccRDSClusterRoleAssociation_disappears (168.43s)
--- PASS: TestAccRDSClusterRoleAssociation_Disappears_role (179.45s)
--- PASS: TestAccRDSClusterRoleAssociation_basic (181.95s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        186.137s


```
