### PR TITLE
[test fix] Fix flaky test `internal/json.TestCreatePatchFromStrings` by introducing transformer for `cmp.Diff` to sort elements during comparison

### DIFF
--- a/internal/json/patch_test.go
+++ b/internal/json/patch_test.go
@@ -4,10 +4,11 @@
 package json_test
 
 import (
+	"cmp"
 	"slices"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	gocmp "github.com/google/go-cmp/cmp"
 	tfjson "github.com/hashicorp/terraform-provider-aws/internal/json"
 	mattbairdjsonpatch "github.com/mattbaird/jsonpatch"
 )
@@ -73,32 +74,20 @@ func TestCreatePatchFromStrings(t *testing.T) {
 			t.Parallel()
 
 			got, err := tfjson.CreatePatchFromStrings(testCase.a, testCase.b)
-			if got, want := err != nil, testCase.wantErr; !cmp.Equal(got, want) {
+			if got, want := err != nil, testCase.wantErr; !gocmp.Equal(got, want) {
 				t.Errorf("CreatePatchFromStrings(%s, %s) err %t, want %t", testCase.a, testCase.b, got, want)
 			}
 			if err == nil {
-				sortTransformer := cmp.Transformer("SortPatchOps", func(ops []mattbairdjsonpatch.JsonPatchOperation) []mattbairdjsonpatch.JsonPatchOperation {
+				sortTransformer := gocmp.Transformer("SortPatchOps", func(ops []mattbairdjsonpatch.JsonPatchOperation) []mattbairdjsonpatch.JsonPatchOperation {
 					sorted := make([]mattbairdjsonpatch.JsonPatchOperation, len(ops))
 					copy(sorted, ops)
 					slices.SortFunc(sorted, func(a, b mattbairdjsonpatch.JsonPatchOperation) int {
-						if a.Operation != b.Operation {
-							if a.Operation < b.Operation {
-								return -1
-							}
-							return 1
-						}
-						if a.Path < b.Path {
-							return -1
-						}
-						if a.Path > b.Path {
-							return 1
-						}
-						return 0
+						return cmp.Or(cmp.Compare(a.Operation, b.Operation), cmp.Compare(a.Path, b.Path))
 					})
 					return sorted
 				})
 
-				if diff := cmp.Diff(got, testCase.wantPatch, sortTransformer); diff != "" {
+				if diff := gocmp.Diff(got, testCase.wantPatch, sortTransformer); diff != "" {
 					t.Errorf("unexpected diff (+wanted, -got): %s", diff)
 				}
 			}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* Fixed the flaky test `internal/json.TestCreatePatchFromStrings`, caused by order issue of lists.
  * Used a transformer for `cmp.Diff` to sort elements during comparison
* Ran the modified test multiple times with no failures
  * Without this change, the test failed frequently

### Relations

Closes #44156

### References
https://pkg.go.dev/github.com/google/go-cmp/cmp#Option
