### PR TITLE
[Docs] `aws_datasync_location_object_storage`: Update the documentation to reflect that `agent_arns` is optional

### DIFF
--- a/website/docs/r/datasync_location_object_storage.html.markdown
+++ b/website/docs/r/datasync_location_object_storage.html.markdown
@@ -27,7 +27,7 @@ resource "aws_datasync_location_object_storage" "example" {
 This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `agent_arns` - (Required) A list of DataSync Agent ARNs with which this location will be associated.
+* `agent_arns` - (Optional) A list of DataSync Agent ARNs with which this location will be associated. For agentless cross-cloud transfers, this parameter does not need to be specified.
 * `access_key` - (Optional) The access key is used if credentials are required to access the self-managed object storage server. If your object storage requires a user name and password to authenticate, use `access_key` and `secret_key` to provide the user name and password, respectively.
 * `bucket_name` - (Required) The bucket on the self-managed object storage server that is used to read data from.
 * `secret_key` - (Optional) The secret key is used if credentials are required to access the self-managed object storage server. If your object storage requires a user name and password to authenticate, use `access_key` and `secret_key` to provide the user name and password, respectively.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* PR #43400 made `agent_arns` optional.
* However, the documentation was not updated to reflect this change.
* This PR updates the documentation to indicate that `agent_arns` is optional.


### Relations
Closes #44158
Relates #43400


### References
https://docs.aws.amazon.com/datasync/latest/userguide/API_CreateLocationObjectStorage.html#DataSync-CreateLocationObjectStorage-request-AgentArns

