### PR TITLE
Add AppConfig multi-variate example

### DIFF
--- a/website/docs/r/appconfig_hosted_configuration_version.html.markdown
+++ b/website/docs/r/appconfig_hosted_configuration_version.html.markdown
@@ -79,6 +79,42 @@ resource "aws_appconfig_hosted_configuration_version" "example" {
 }
 ```
 
+### Multi-variate Feature Flags
+
+```terraform
+resource "aws_appconfig_hosted_configuration_version" "example" {
+  application_id           = aws_appconfig_application.example.id
+  configuration_profile_id = aws_appconfig_configuration_profile.example.configuration_profile_id
+  description              = "Example Multi-variate Feature Flag Configuration Version"
+  content_type             = "application/json"
+
+  content = jsonencode({
+    flags = {
+      loggingenabled = {
+        name = "loggingEnabled"
+      }
+    },
+    values = {
+      loggingenabled = {
+        _variants = concat([
+          for user_id in var.appcfg_enableLogging_userIds : {
+            enabled = true,
+            name    = "usersWithLoggingEnabled_${user_id}",
+            rule    = "(or (eq $userId \"${user_id}\"))"
+          }
+          ], [
+          {
+            enabled = false,
+            name    = "Default"
+          }
+        ])
+      }
+    },
+    version = "1"
+  })
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:

--- a/website/docs/r/appconfig_hosted_configuration_version.html.markdown
+++ b/website/docs/r/appconfig_hosted_configuration_version.html.markdown
@@ -79,13 +79,13 @@ resource "aws_appconfig_hosted_configuration_version" "example" {
 }
 ```
 
-### Multi-variate Feature Flags
+### Multi-variant Feature Flags
 
 ```terraform
 resource "aws_appconfig_hosted_configuration_version" "example" {
   application_id           = aws_appconfig_application.example.id
   configuration_profile_id = aws_appconfig_configuration_profile.example.configuration_profile_id
-  description              = "Example Multi-variate Feature Flag Configuration Version"
+  description              = "Example Multi-variant Feature Flag Configuration Version"
   content_type             = "application/json"
 
   content = jsonencode({
@@ -97,7 +97,7 @@ resource "aws_appconfig_hosted_configuration_version" "example" {
     values = {
       loggingenabled = {
         _variants = concat([
-          for user_id in var.appcfg_enableLogging_userIds : {
+          for user_id in var.appcfg_enableLogging_userIds : { # Flat list of userIds
             enabled = true,
             name    = "usersWithLoggingEnabled_${user_id}",
             rule    = "(or (eq $userId \"${user_id}\"))"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No. 

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adding an example of multi-variate AppConfig feature flags. These are feature flags that are part of a Configuration, and which can have Rules which provide different values for the boolean flags. In the example provided, a variable populated with a list of userIds is read and iterated, and for these users, we set loggingEnabled to True. All others (and those lacking Context) will receive loggingEnabled to False. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

[Creating a multi-variant feature flag AWS Documentation](https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-creating-multi-variant-feature-flags-procedures.html)

### Output from Acceptance Testing

n/a documentation only