### PR TITLE
[Enhancement] r/aws_cloudfront_distribution: Add `origin.response_completion_timeout` argument

### DIFF
--- a/.changelog/44163.txt
+++ b/.changelog/44163.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudfront_distribution: Add `origin.response_completion_timeout` argument
+```

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -697,7 +697,7 @@ func resourceDistribution() *schema.Resource {
 						"response_completion_timeout": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  0, // Zero is equivalent to unspecified
+							Computed: true,
 						},
 						"s3_origin_config": {
 							Type:     schema.TypeList,
@@ -2217,6 +2217,8 @@ func flattenOrigin(apiObject *awstypes.Origin) map[string]any {
 
 	if apiObject.ResponseCompletionTimeout != nil {
 		tfMap["response_completion_timeout"] = aws.ToInt32(apiObject.ResponseCompletionTimeout)
+	} else {
+		tfMap["response_completion_timeout"] = 0
 	}
 
 	if apiObject.S3OriginConfig != nil && aws.ToString(apiObject.S3OriginConfig.OriginAccessIdentity) != "" {

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -697,11 +697,7 @@ func resourceDistribution() *schema.Resource {
 						"response_completion_timeout": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  0, // Zero equals to unspecified
-							ValidateFunc: validation.Any(
-								validation.IntAtLeast(30),
-								validation.IntInSlice([]int{0}),
-							),
+							Default:  0, // Zero is equivalent to unspecified
 						},
 						"s3_origin_config": {
 							Type:     schema.TypeList,

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -1498,6 +1498,78 @@ func TestAccCloudFrontDistribution_vpcOriginConfig(t *testing.T) {
 	})
 }
 
+func TestAccCloudFrontDistribution_responseCompletionTimeout(t *testing.T) {
+	ctx := acctest.Context(t)
+	var distribution awstypes.Distribution
+	resourceName := "aws_cloudfront_distribution.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDistributionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistributionConfig_responseCompletionTimeout(false, false, 60),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionExists(ctx, resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "origin.*", map[string]string{
+						"custom_header.#":             "0",
+						"custom_origin_config.#":      "1",
+						"origin_id":                   "test",
+						"origin_shield.#":             "0",
+						"s3_origin_config.#":          "0",
+						"vpc_origin_config.#":         "0",
+						"response_completion_timeout": "60",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
+			},
+			{
+				Config: testAccDistributionConfig_responseCompletionTimeout(false, false, 30),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionExists(ctx, resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "origin.*", map[string]string{
+						"custom_header.#":             "0",
+						"custom_origin_config.#":      "1",
+						"origin_id":                   "test",
+						"origin_shield.#":             "0",
+						"s3_origin_config.#":          "0",
+						"vpc_origin_config.#":         "0",
+						"response_completion_timeout": "30",
+					}),
+				),
+			},
+			{
+				Config: testAccDistributionConfig_enabled(false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionExists(ctx, resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "origin.*", map[string]string{
+						"custom_header.#":             "0",
+						"custom_origin_config.#":      "1",
+						"origin_id":                   "test",
+						"origin_shield.#":             "0",
+						"s3_origin_config.#":          "0",
+						"vpc_origin_config.#":         "0",
+						"response_completion_timeout": "0",
+					}),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudFrontDistribution_grpcConfig(t *testing.T) {
 	ctx := acctest.Context(t)
 	var distribution awstypes.Distribution
@@ -4586,6 +4658,54 @@ resource "aws_cloudfront_distribution" "test" {
   }
 }
 `)
+}
+
+func testAccDistributionConfig_responseCompletionTimeout(enabled, retainOnDelete bool, responseCompletionTimeout int) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_distribution" "test" {
+  enabled          = %[1]t
+  retain_on_delete = %[2]t
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "test"
+    viewer_protocol_policy = "allow-all"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  origin {
+    domain_name = "www.example.com"
+    origin_id   = "test"
+
+    response_completion_timeout = %[3]d
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+`, enabled, retainOnDelete, responseCompletionTimeout)
 }
 
 func testAccDistributionConfig_grpcConfig() string {

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -39,6 +39,8 @@ func TestAccCloudFrontDistribution_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDistributionExists(ctx, resourceName, &distribution),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
+					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.response_completion_timeout", "0"),
 				),
 			},
 			{

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -486,7 +486,7 @@ argument should not be specified.
 * `origin_id` (Required) - Unique identifier for the origin.
 * `origin_path` (Optional) - Optional element that causes CloudFront to request your content from a directory in your Amazon S3 bucket or your custom origin.
 * `origin_shield` - (Optional) [CloudFront Origin Shield](#origin-shield-arguments) configuration information. Using Origin Shield can help reduce the load on your origin. For more information, see [Using Origin Shield](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-shield.html) in the Amazon CloudFront Developer Guide.
-* `response_completion_timeout` - (Optional) Time (in seconds) that a request from CloudFront to the origin can stay open and wait for a response. Must be integer greater than or equal to the value of `origin_read_timeout`. If omitted or explicitly set to `0`, no maximum value is enforced. Defaults to `0`.
+* `response_completion_timeout` - (Optional) Time (in seconds) that a request from CloudFront to the origin can stay open and wait for a response. Must be integer greater than or equal to the value of `origin_read_timeout`. If omitted or explicitly set to `0`, no maximum value is enforced.
 * `s3_origin_config` - (Optional) [CloudFront S3 origin](#s3-origin-config-arguments) configuration information. If a custom origin is required, use `custom_origin_config` instead.
 * `vpc_origin_config` - (Optional) The [VPC origin configuration](#vpc-origin-config-arguments).
 

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -486,8 +486,9 @@ argument should not be specified.
 * `origin_id` (Required) - Unique identifier for the origin.
 * `origin_path` (Optional) - Optional element that causes CloudFront to request your content from a directory in your Amazon S3 bucket or your custom origin.
 * `origin_shield` - (Optional) [CloudFront Origin Shield](#origin-shield-arguments) configuration information. Using Origin Shield can help reduce the load on your origin. For more information, see [Using Origin Shield](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-shield.html) in the Amazon CloudFront Developer Guide.
+* `response_completion_timeout` - (Optional) Time (in seconds) that a request from CloudFront to the origin can stay open and wait for a response. Must be greater than or equal to the value of `origin_read_timeout`. If omitted or explicitly set to `0`, no maximum value is enforced. Valid values are integers greater than or equal to `30`, or `0` (default).
 * `s3_origin_config` - (Optional) [CloudFront S3 origin](#s3-origin-config-arguments) configuration information. If a custom origin is required, use `custom_origin_config` instead.
-* `vpc_origin_config` - (Optional) The VPC origin configuration.
+* `vpc_origin_config` - (Optional) The [VPC origin configuration](#vpc-origin-config-arguments).
 
 ##### Custom Origin Config Arguments
 

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -486,7 +486,7 @@ argument should not be specified.
 * `origin_id` (Required) - Unique identifier for the origin.
 * `origin_path` (Optional) - Optional element that causes CloudFront to request your content from a directory in your Amazon S3 bucket or your custom origin.
 * `origin_shield` - (Optional) [CloudFront Origin Shield](#origin-shield-arguments) configuration information. Using Origin Shield can help reduce the load on your origin. For more information, see [Using Origin Shield](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-shield.html) in the Amazon CloudFront Developer Guide.
-* `response_completion_timeout` - (Optional) Time (in seconds) that a request from CloudFront to the origin can stay open and wait for a response. Must be greater than or equal to the value of `origin_read_timeout`. If omitted or explicitly set to `0`, no maximum value is enforced. Valid values are integers greater than or equal to `30`, or `0` (default).
+* `response_completion_timeout` - (Optional) Time (in seconds) that a request from CloudFront to the origin can stay open and wait for a response. Must be integer greater than or equal to the value of `origin_read_timeout`. If omitted or explicitly set to `0`, no maximum value is enforced. Defaults to `0`.
 * `s3_origin_config` - (Optional) [CloudFront S3 origin](#s3-origin-config-arguments) configuration information. If a custom origin is required, use `custom_origin_config` instead.
 * `vpc_origin_config` - (Optional) The [VPC origin configuration](#vpc-origin-config-arguments).
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.


### Description

* This PR adds the `origin.response_completion_timeout` argument.

  * Issue #44116 requests support for both `origin.response_completion_timeout` and `origin.s3_origin_config.origin_read_timeout`.
  * Since the implementation of `origin.s3_origin_config.origin_read_timeout` is currently blocked due to an unexpected behavior in the Terraform Plugin SDK, `origin.response_completion_timeout` has been implemented first.

    * I opened issue #44172 to clarify what is blocking its implementation.
  * `origin.response_completion_timeout` is marked as `Computed`.

    * If this argument is not specified in the configuration, its value in the state is `0`.
    * Because it is both `Optional` and `Computed`, this argument does not appear in the plan when upgrading the AWS Provider to a version that supports it.

      * I think this behavior is preferable to setting a `Default` value in the schema.



### Relations

Closes #44116
Relates #44172


### References
https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_Origin.html#cloudfront-Type-Origin-ResponseCompletionTimeout

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccCloudFrontDistribution_ PKG=cloudfront                   
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontDistribution_'  -timeout 360m -vet=off
2025/09/08 00:53:36 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/08 00:53:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudFrontDistribution_basic
=== PAUSE TestAccCloudFrontDistribution_basic
=== RUN   TestAccCloudFrontDistribution_disappears
=== PAUSE TestAccCloudFrontDistribution_disappears
=== RUN   TestAccCloudFrontDistribution_tags
=== PAUSE TestAccCloudFrontDistribution_tags
=== RUN   TestAccCloudFrontDistribution_s3Origin
=== PAUSE TestAccCloudFrontDistribution_s3Origin
=== RUN   TestAccCloudFrontDistribution_customOrigin
=== PAUSE TestAccCloudFrontDistribution_customOrigin
=== RUN   TestAccCloudFrontDistribution_originPolicyDefault
=== PAUSE TestAccCloudFrontDistribution_originPolicyDefault
=== RUN   TestAccCloudFrontDistribution_originPolicyOrdered
=== PAUSE TestAccCloudFrontDistribution_originPolicyOrdered
=== RUN   TestAccCloudFrontDistribution_multiOrigin
=== PAUSE TestAccCloudFrontDistribution_multiOrigin
=== RUN   TestAccCloudFrontDistribution_orderedCacheBehavior
=== PAUSE TestAccCloudFrontDistribution_orderedCacheBehavior
=== RUN   TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== PAUSE TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== RUN   TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy
=== PAUSE TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy
=== RUN   TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
=== PAUSE TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
=== RUN   TestAccCloudFrontDistribution_Origin_emptyDomainName
=== PAUSE TestAccCloudFrontDistribution_Origin_emptyDomainName
=== RUN   TestAccCloudFrontDistribution_Origin_emptyOriginID
=== PAUSE TestAccCloudFrontDistribution_Origin_emptyOriginID
=== RUN   TestAccCloudFrontDistribution_Origin_connectionAttempts
=== PAUSE TestAccCloudFrontDistribution_Origin_connectionAttempts
=== RUN   TestAccCloudFrontDistribution_Origin_connectionTimeout
=== PAUSE TestAccCloudFrontDistribution_Origin_connectionTimeout
=== RUN   TestAccCloudFrontDistribution_Origin_originShield
=== PAUSE TestAccCloudFrontDistribution_Origin_originShield
=== RUN   TestAccCloudFrontDistribution_Origin_originAccessControl
=== PAUSE TestAccCloudFrontDistribution_Origin_originAccessControl
=== RUN   TestAccCloudFrontDistribution_noOptionalItems
=== PAUSE TestAccCloudFrontDistribution_noOptionalItems
=== RUN   TestAccCloudFrontDistribution_http11
=== PAUSE TestAccCloudFrontDistribution_http11
=== RUN   TestAccCloudFrontDistribution_isIPV6Enabled
=== PAUSE TestAccCloudFrontDistribution_isIPV6Enabled
=== RUN   TestAccCloudFrontDistribution_noCustomErrorResponse
=== PAUSE TestAccCloudFrontDistribution_noCustomErrorResponse
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
=== RUN   TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
=== PAUSE TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
=== RUN   TestAccCloudFrontDistribution_enabled
=== PAUSE TestAccCloudFrontDistribution_enabled
=== RUN   TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
=== PAUSE TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
=== RUN   TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
=== PAUSE TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
=== RUN   TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
=== PAUSE TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
=== RUN   TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate
=== PAUSE TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate
=== RUN   TestAccCloudFrontDistribution_waitForDeployment
=== PAUSE TestAccCloudFrontDistribution_waitForDeployment
=== RUN   TestAccCloudFrontDistribution_preconditionFailed
=== PAUSE TestAccCloudFrontDistribution_preconditionFailed
=== RUN   TestAccCloudFrontDistribution_originGroups
=== PAUSE TestAccCloudFrontDistribution_originGroups
=== RUN   TestAccCloudFrontDistribution_vpcOriginConfig
=== PAUSE TestAccCloudFrontDistribution_vpcOriginConfig
=== RUN   TestAccCloudFrontDistribution_responseCompletionTimeout
=== PAUSE TestAccCloudFrontDistribution_responseCompletionTimeout
=== RUN   TestAccCloudFrontDistribution_grpcConfig
=== PAUSE TestAccCloudFrontDistribution_grpcConfig
=== CONT  TestAccCloudFrontDistribution_basic
=== CONT  TestAccCloudFrontDistribution_isIPV6Enabled
=== CONT  TestAccCloudFrontDistribution_grpcConfig
=== CONT  TestAccCloudFrontDistribution_responseCompletionTimeout
=== CONT  TestAccCloudFrontDistribution_vpcOriginConfig
=== CONT  TestAccCloudFrontDistribution_originGroups
=== CONT  TestAccCloudFrontDistribution_preconditionFailed
=== CONT  TestAccCloudFrontDistribution_waitForDeployment
=== CONT  TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate
=== CONT  TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
=== CONT  TestAccCloudFrontDistribution_enabled
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
=== CONT  TestAccCloudFrontDistribution_noCustomErrorResponse
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames (265.67s)
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy
--- PASS: TestAccCloudFrontDistribution_grpcConfig (269.14s)
=== CONT  TestAccCloudFrontDistribution_http11
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames (294.16s)
=== CONT  TestAccCloudFrontDistribution_noOptionalItems
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners (298.99s)
=== CONT  TestAccCloudFrontDistribution_Origin_originAccessControl
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups (299.52s)
=== CONT  TestAccCloudFrontDistribution_Origin_originShield
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers (301.28s)
=== CONT  TestAccCloudFrontDistribution_Origin_connectionTimeout
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers (302.13s)
=== CONT  TestAccCloudFrontDistribution_Origin_connectionAttempts
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN (307.08s)
=== CONT  TestAccCloudFrontDistribution_Origin_emptyOriginID
--- PASS: TestAccCloudFrontDistribution_Origin_emptyOriginID (0.73s)
=== CONT  TestAccCloudFrontDistribution_Origin_emptyDomainName
--- PASS: TestAccCloudFrontDistribution_Origin_emptyDomainName (0.66s)
=== CONT  TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
--- PASS: TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate (312.85s)
=== CONT  TestAccCloudFrontDistribution_originPolicyDefault
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN (313.56s)
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy
--- PASS: TestAccCloudFrontDistribution_basic (324.22s)
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehavior
--- PASS: TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN (333.63s)
=== CONT  TestAccCloudFrontDistribution_multiOrigin
--- PASS: TestAccCloudFrontDistribution_responseCompletionTimeout (452.06s)
=== CONT  TestAccCloudFrontDistribution_originPolicyOrdered
--- PASS: TestAccCloudFrontDistribution_isIPV6Enabled (483.68s)
=== CONT  TestAccCloudFrontDistribution_s3Origin
--- PASS: TestAccCloudFrontDistribution_waitForDeployment (531.04s)
=== CONT  TestAccCloudFrontDistribution_customOrigin
--- PASS: TestAccCloudFrontDistribution_noCustomErrorResponse (539.20s)
=== CONT  TestAccCloudFrontDistribution_tags
--- PASS: TestAccCloudFrontDistribution_originGroups (540.00s)
=== CONT  TestAccCloudFrontDistribution_disappears
--- PASS: TestAccCloudFrontDistribution_preconditionFailed (625.99s)
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy (491.74s)
--- PASS: TestAccCloudFrontDistribution_http11 (489.03s)
--- PASS: TestAccCloudFrontDistribution_noOptionalItems (489.19s)
--- PASS: TestAccCloudFrontDistribution_enabled (785.27s)
--- PASS: TestAccCloudFrontDistribution_originPolicyDefault (479.10s)
--- PASS: TestAccCloudFrontDistribution_disappears (253.96s)
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy (490.49s)
--- PASS: TestAccCloudFrontDistribution_tags (283.74s)
--- PASS: TestAccCloudFrontDistribution_Origin_connectionTimeout (541.51s)
--- PASS: TestAccCloudFrontDistribution_Origin_connectionAttempts (540.88s)
--- PASS: TestAccCloudFrontDistribution_Origin_originShield (544.34s)
--- PASS: TestAccCloudFrontDistribution_multiOrigin (512.69s)
--- PASS: TestAccCloudFrontDistribution_forwardedValuesToCachePolicy (612.53s)
--- PASS: TestAccCloudFrontDistribution_Origin_originAccessControl (622.22s)
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehavior (599.63s)
--- PASS: TestAccCloudFrontDistribution_originPolicyOrdered (499.51s)
--- PASS: TestAccCloudFrontDistribution_s3Origin (502.13s)
--- PASS: TestAccCloudFrontDistribution_customOrigin (523.86s)
--- PASS: TestAccCloudFrontDistribution_vpcOriginConfig (1249.78s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 1254.644s



```
