### PR TITLE
feat: allow configuration of dualStackIPv6 in ECS default settings

### DIFF
--- a/internal/service/ecs/account_setting_default.go
+++ b/internal/service/ecs/account_setting_default.go
@@ -12,6 +12,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -34,10 +35,10 @@ func resourceAccountSettingDefault() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			names.AttrName: {
-				Type:             schema.TypeString,
-				ForceNew:         true,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.SettingName](),
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(append(enum.Values[awstypes.SettingName](), "dualStackIPv6"), false),
 			},
 			"principal_arn": {
 				Type:     schema.TypeString,

--- a/internal/service/ecs/account_setting_default_test.go
+++ b/internal/service/ecs/account_setting_default_test.go
@@ -31,6 +31,7 @@ func TestAccECSAccountSettingDefault_serial(t *testing.T) {
 		"vpcTrunking":                     testAccAccountSettingDefault_vpcTrunking,
 		"containerInsights":               testAccAccountSettingDefault_containerInsights,
 		"fargateTaskRetirementWaitPeriod": testAccAccountSettingDefault_fargateTaskRetirementWaitPeriod,
+		"dualStackIPv6":                   testAccAccountSettingDefault_dualStackIPv6,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)
@@ -99,6 +100,35 @@ func testAccAccountSettingDefault_defaultLogDriverMode(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrValue, "non-blocking"),
 					acctest.MatchResourceAttrGlobalARN(ctx, resourceName, "principal_arn", "iam", regexache.MustCompile("root")),
 				),
+			},
+		},
+	})
+}
+
+func testAccAccountSettingDefault_dualStackIPv6(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_ecs_account_setting_default.test"
+	settingName := "dualStackIPv6"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAccountSettingDefaultDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountSettingDefaultConfig_basic(settingName, names.AttrEnabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountSettingDefaultExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, settingName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrValue, names.AttrEnabled),
+					acctest.MatchResourceAttrGlobalARN(ctx, resourceName, "principal_arn", "iam", regexache.MustCompile("root")),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
