### PR TITLE
docs: add missing `AWS_IAM` to `auth_provider` in `appsync_api`

### DIFF
--- a/website/docs/r/appsync_api.html.markdown
+++ b/website/docs/r/appsync_api.html.markdown
@@ -131,7 +131,7 @@ The `event_config` block supports the following:
 
 The `auth_provider` block supports the following:
 
-* `auth_type` - (Required) Type of authentication provider. Valid values: `AMAZON_COGNITO_USER_POOLS`, `AWS_LAMBDA`, `OPENID_CONNECT`, `API_KEY`.
+* `auth_type` - (Required) Type of authentication provider. Valid values: `API_KEY`, `AWS_IAM`, `AMAZON_COGNITO_USER_POOLS`, `OPENID_CONNECT`, `AWS_LAMBDA`.
 * `cognito_config` - (Optional) Configuration for Cognito user pool authentication. Required when `auth_type` is `AMAZON_COGNITO_USER_POOLS`. See [Cognito Config](#cognito-config) below.
 * `lambda_authorizer_config` - (Optional) Configuration for Lambda authorization. Required when `auth_type` is `AWS_LAMBDA`. See [Lambda Authorizer Config](#lambda-authorizer-config) below.
 * `openid_connect_config` - (Optional) Configuration for OpenID Connect. Required when `auth_type` is `OPENID_CONNECT`. See [OpenID Connect Config](#openid-connect-config) below.


### PR DESCRIPTION

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

`AWS_IAM` is a valid auth provider type.

I copied the order of possible values from here for better consistency:

https://github.com/hashicorp/terraform-provider-aws/blob/d74e0fd412f19f4fbb931d9ae66eec0a4a94b9fb/website/docs/r/appsync_api.html.markdown?plain=1#L164-L168


### References

https://docs.aws.amazon.com/appsync/latest/APIReference/API_AuthProvider.html#appsync-Type-AuthProvider-authType