### PR TITLE
fix: validation to prevent cw alarm overrides

### DIFF
--- a/.changelog/44169.txt
+++ b/.changelog/44169.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_metric_alarm: Prevent silent overwrites when multiple resources have the same `alarm_name`
+```

--- a/internal/service/cloudwatch/metric_alarm.go
+++ b/internal/service/cloudwatch/metric_alarm.go
@@ -6,6 +6,7 @@ package cloudwatch
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 
 	"github.com/YakDriver/regexache"
@@ -21,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -323,9 +325,19 @@ func resourceMetricAlarmCreate(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).CloudWatchClient(ctx)
 
 	name := d.Get("alarm_name").(string)
+	
+	// Check if alarm already exists to prevent silent overwrites
+	existing, err := findMetricAlarmByName(ctx, conn, name)
+	if err != nil && !retry.NotFound(err) {
+		return smerr.Append(ctx, diags, err, smerr.ID, name)
+	}
+	if existing != nil {
+		return smerr.Append(ctx, diags, fmt.Errorf("CloudWatch metric alarm %q already exists", name), smerr.ID, name)
+	}
+
 	input := expandPutMetricAlarmInput(ctx, d)
 
-	_, err := conn.PutMetricAlarm(ctx, input)
+	_, err = conn.PutMetricAlarm(ctx, input)
 
 	// Some partitions (e.g. ISO) may not support tag-on-create.
 	if input.Tags != nil && errs.IsUnsupportedOperationInPartitionError(meta.(*conns.AWSClient).Partition(ctx), err) {

--- a/internal/service/cloudwatch/metric_alarm_test.go
+++ b/internal/service/cloudwatch/metric_alarm_test.go
@@ -1136,3 +1136,49 @@ resource "aws_cloudwatch_metric_alarm" "test" {
 }
 `, rName)
 }
+
+func TestAccCloudWatchMetricAlarm_duplicateName(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMetricAlarmDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccMetricAlarmConfig_duplicateName(rName),
+				ExpectError: regexache.MustCompile(`CloudWatch metric alarm ".*" already\s+exists`),
+			},
+		},
+	})
+}
+
+func testAccMetricAlarmConfig_duplicateName(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_metric_alarm" "first" {
+  alarm_name          = %[1]q
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = "120"
+  statistic           = "Average"
+  threshold           = "80"
+}
+
+resource "aws_cloudwatch_metric_alarm" "second" {
+  alarm_name          = %[1]q
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = "90"
+  
+  depends_on = [aws_cloudwatch_metric_alarm.first]
+}
+`, rName)
+}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to security controls.

### Description
Fixes a bug in the `aws_cloudwatch_metric_alarm` resource where multiple resources with the same `alarm_name` would silently overwrite each other. The resource now checks for existing alarms during creation and returns an error if an alarm with the same name already exists, preventing data loss.


### Relations

Closes #44169 

### References

### Output from Acceptance Testing

```console

 make testacc TESTS=TestAccCloudWatchMetricAlarm_duplicateName PKG=cloudwatch
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.6 test ./internal/service/cloudwatch/... -v -count 1 -parallel 20 -run='TestAccCloudWatchMetricAlarm_duplicateName'  -timeout 360m -vet=off
2025/09/07 01:26:37 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/07 01:26:37 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudWatchMetricAlarm_duplicateName
=== PAUSE TestAccCloudWatchMetricAlarm_duplicateName
=== CONT  TestAccCloudWatchMetricAlarm_duplicateName
--- PASS: TestAccCloudWatchMetricAlarm_duplicateName (8.23s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch 13.486s

```
