### PR TITLE
docs: fix `appsync_api` lambda authorizer example to use `arn` instead of `invoke_arn` in `authorizer_uri`

### DIFF
--- a/website/docs/r/appsync_api.html.markdown
+++ b/website/docs/r/appsync_api.html.markdown
@@ -84,7 +84,7 @@ resource "aws_appsync_api" "example" {
     auth_provider {
       auth_type = "AWS_LAMBDA"
       lambda_authorizer_config {
-        authorizer_uri                   = aws_lambda_function.example.invoke_arn
+        authorizer_uri                   = aws_lambda_function.example.arn
         authorizer_result_ttl_in_seconds = 300
       }
     }


### PR DESCRIPTION

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

```hcl
resource "aws_lambda_function" "example" {
  filename = "function.zip"
  function_name = "example-function"
  handler = "index.handler"
  runtime = "nodejs22.x"
  role = aws_iam_role.example.arn
}

resource "aws_appsync_api" "example" {
  name = "example-api"

  event_config {
    auth_provider {
      auth_type = "AWS_LAMBDA"
      lambda_authorizer_config {
        authorizer_uri = aws_lambda_function.example.invoke_arn
      }
    }
    connection_auth_mode {
      auth_type = "AWS_LAMBDA"
    }
    default_publish_auth_mode {
      auth_type = "AWS_LAMBDA"
    }
    default_subscribe_auth_mode {
      auth_type = "AWS_LAMBDA"
    }
  }
}
```

```plaintext
aws_lambda_function.example: Creating...
aws_lambda_function.example: Creation complete after 6s [id=example-function]
aws_appsync_api.example: Creating...
╷
│ Error: creating AppSync API
│
│   with aws_appsync_api.example,
│   on infrastructure.tf line 49, in resource "aws_appsync_api" "example":
│   49: resource "aws_appsync_api" "example" {
│
│ ID: example-api
│ Cause: operation error AppSync: CreateApi, , BadRequestException: Lambda Authorizer URI must be a valid Lambda
│ function ARN."
│
╵
```

`authorizer_uri = aws_lambda_function.example.invoke_arn` is invalid.

From AWS Docs linked in references:

>  **authorizerUri**
>
>    The Amazon Resource Name (ARN) of the Lambda function to be called for authorization. This can be a standard Lambda ARN, a version ARN (.../v3), or an alias ARN. 

`invoke_arn` has the following format `arn:aws:apigateway:<region>:lambda:path/2015-03-31/functions/arn:aws:lambda:<region>:<account id>:function:<function name>/invocations`

### References

https://docs.aws.amazon.com/appsync/latest/APIReference/API_LambdaAuthorizerConfig.html#appsync-Type-LambdaAuthorizerConfig-authorizerUri
