### PR TITLE
attribute names and description for managedRuleGroupConfigATPResponse…

### DIFF
--- a/website/docs/cdktf/python/r/wafv2_web_acl.html.markdown
+++ b/website/docs/cdktf/python/r/wafv2_web_acl.html.markdown
@@ -915,8 +915,8 @@ The `managed_rule_group_configs` block support the following arguments:
 ### `json` Block
 
 * `identifier` (Required) The identifier for the value to match against in the JSON.
-* `success_strings` (Required) Strings in the body of the response that indicate a successful login attempt.
-* `failure_strings` (Required) Strings in the body of the response that indicate a failed login attempt.
+* `success_values` (Required) Strings in the response JSON that indicate a successful login attempt.
+* `failure_values` (Required) Strings in the response JSON that indicate a failed login attempt.
 
 ### `status_code` Block
 


### PR DESCRIPTION
…InspectionSchema json object updated

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls
N/A

### Description

Update managedRuleGroupConfigATPResponseInspectionSchema json object to have attributes `failure_values` & `success_values` as used in schema and AWS docs. Also update the description of these attributes.

The go schema correctly uses `failure_values` and `success_values`: https://github.com/hashicorp/terraform-provider-aws/blob/d74e0fd412f19f4fbb931d9ae66eec0a4a94b9fb/internal/service/wafv2/schemas.go#L1671

it appears this section may have been copy pasted incorrectly from here: https://github.com/hashicorp/terraform-provider-aws/blob/d74e0fd412f19f4fbb931d9ae66eec0a4a94b9fb/website/docs/r/wafv2_web_acl.html.markdown?plain=1#L900

### Relations


### References
AWS docs reference here: https://docs.aws.amazon.com/waf/latest/APIReference/API_ResponseInspectionJson.html

### Output from Acceptance Testing
