### PR TITLE
New data source: [wip] r/aws_cloudfront_connection_group: Added new connection group resource as part of Cloudfront's SaaS Manager feature

### DIFF
--- a/internal/service/cloudfront/connection_group_data_source.go
+++ b/internal/service/cloudfront/connection_group_data_source.go
@@ -1,0 +1,99 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudfront
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_cloudfront_connection_group", name="Connection Group")
+// @Tags(identifierAttribute="arn")
+func dataSourceConnectionGroup() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceConnectionGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			"anycast_ip_list_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrARN: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrEnabled: {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"etag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrID: {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ipv6_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"is_default": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"last_modified_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrName: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"routing_endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrStatus: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrTags: tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceConnectionGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
+
+	id := d.Get(names.AttrID).(string)
+	output, err := findConnectionGroupByID(ctx, conn, id)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading CloudFront Connection Group (%s): %s", id, err)
+	}
+
+	d.SetId(aws.ToString(output.ConnectionGroup.Id))
+	connectionGroup := output.ConnectionGroup
+	d.Set("anycast_ip_list_id", connectionGroup.AnycastIpListId)
+	d.Set(names.AttrARN, connectionGroup.Arn)
+	d.Set(names.AttrEnabled, connectionGroup.Enabled)
+	d.Set("etag", output.ETag)
+	d.Set("ipv6_enabled", connectionGroup.Ipv6Enabled)
+	d.Set("is_default", connectionGroup.IsDefault)
+	d.Set("last_modified_time", connectionGroup.LastModifiedTime.String())
+	d.Set(names.AttrName, connectionGroup.Name)
+	d.Set("routing_endpoint", connectionGroup.RoutingEndpoint)
+	d.Set(names.AttrStatus, connectionGroup.Status)
+
+	return diags
+}

--- a/internal/service/cloudfront/connection_group_data_source_test.go
+++ b/internal/service/cloudfront/connection_group_data_source_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudfront_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccCloudFrontConnectionGroupDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_cloudfront_connection_group.test"
+	resourceName := "aws_cloudfront_connection_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConnectionGroupDataSourceConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "anycast_ip_list_id", resourceName, "anycast_ip_list_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrEnabled, resourceName, names.AttrEnabled),
+					resource.TestCheckResourceAttrPair(dataSourceName, "etag", resourceName, "etag"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ipv6_enabled", resourceName, "ipv6_enabled"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "is_default", resourceName, "is_default"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "last_modified_time", resourceName, "last_modified_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrName, resourceName, names.AttrName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "routing_endpoint", resourceName, "routing_endpoint"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrStatus, resourceName, names.AttrStatus),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudFrontConnectionGroupDataSource_anycast(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_cloudfront_connection_group.testip"
+	resourceName := "aws_cloudfront_connection_group.testip"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConnectionGroupDataSourceConfig_anycast(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "anycast_ip_list_id", resourceName, "anycast_ip_list_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrEnabled, resourceName, names.AttrEnabled),
+					resource.TestCheckResourceAttrPair(dataSourceName, "etag", resourceName, "etag"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ipv6_enabled", resourceName, "ipv6_enabled"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "is_default", resourceName, "is_default"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "last_modified_time", resourceName, "last_modified_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrName, resourceName, names.AttrName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "routing_endpoint", resourceName, "routing_endpoint"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrStatus, resourceName, names.AttrStatus),
+				),
+			},
+		},
+	})
+}
+
+func testAccConnectionGroupDataSourceConfig_basic() string {
+	return acctest.ConfigCompose(testAccConnectionGroupConfig_basic(), `
+data "aws_cloudfront_connection_group" "test" {
+  id = aws_cloudfront_connection_group.test.id
+}
+`)
+}
+
+func testAccConnectionGroupDataSourceConfig_anycast() string {
+	return acctest.ConfigCompose(testAccConnectionGroupConfig_anycastIpList(), `
+data "aws_cloudfront_connection_group" "testip" {
+  id = aws_cloudfront_connection_group.testip.id
+}
+`)
+}

--- a/internal/service/cloudfront/service_package_gen.go
+++ b/internal/service/cloudfront/service_package_gen.go
@@ -67,6 +67,15 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*inttypes.Service
 			Region:   unique.Make(inttypes.ResourceRegionDisabled()),
 		},
 		{
+			Factory:  dataSourceConnectionGroup,
+			TypeName: "aws_cloudfront_connection_group",
+			Name:     "Connection Group",
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrARN,
+			}),
+			Region: unique.Make(inttypes.ResourceRegionDisabled()),
+		},
+		{
 			Factory:  dataSourceDistribution,
 			TypeName: "aws_cloudfront_distribution",
 			Name:     "Distribution",


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
