### PR TITLE
docs: add import by identity instructions to resource identity guides

### DIFF
--- a/docs/ai-agent-guides/arn-based-resource-identity.md
+++ b/docs/ai-agent-guides/arn-based-resource-identity.md
@@ -53,7 +53,37 @@ data "aws_region" "current" {
 
 Repeat steps 2 and 3 for each resource in the service. When all resources are complete, proceed to the next section.
 
-## 4. Submit a pull request
+## 4. Update import documentation
+
+- Update the import section of the registry documentation for each resource following the template below.
+
+````markdown
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = <resource-name>.example
+  identity = {
+    "arn" = <example-arn-value>
+  }
+}
+
+resource "<resource-name>" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+- `arn` (String) <description here>.
+````
+
+- The instructions for importing by `identity`, including the identity schema, should appear before instructions for import blocks with an `id` argument or importing via the CLI.
+- Refer to `website/docs/r/acm_certificate.html.markdown` for a reference implementation.
+
+## 5. Submit a pull request
 
 **!!!Important!!!**: Ask for confirmation before proceeding with this step.
 

--- a/docs/ai-agent-guides/parameterized-resource-identity.md
+++ b/docs/ai-agent-guides/parameterized-resource-identity.md
@@ -66,7 +66,42 @@ data "aws_region" "current" {
 
 Repeat steps 2 and 3 for each resource in the service. When all resources are complete, proceed to the next section.
 
-## 4. Submit a pull request
+## 4. Update import documentation
+
+- Update the import section of the registry documentation for each resource following the template below.
+
+````markdown
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = <resource-name>.example
+  identity = {
+    <required key/value pairs here>
+  }
+}
+
+resource "<resource-name>" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+<required attributes here>
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+````
+
+- The instructions for importing by `identity`, including the identity schema, should appear before instructions for import blocks with an `id` argument or importing via the CLI.
+- Refer to `website/docs/r/kms_key.html.markdown` for a reference implementation.
+
+## 5. Submit a pull request
 
 **!!!Important!!!**: Ask for confirmation before proceeding with this step.
 

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -213,11 +213,32 @@ Renewal summary objects export the following attributes:
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_acm_certificate.example
+  identity = {
+    "arn" = "arn:aws:acm:eu-central-1:123456789012:certificate/7e7a28d2-163f-4b8f-b9cd-822f96c08d6a"
+  }
+}
+
+resource "aws_acm_certificate" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+- `arn` (String) ARN of the certificate.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import certificates using their ARN. For example:
 
 ```terraform
 import {
-  to = aws_acm_certificate.cert
+  to = aws_acm_certificate.example
   id = "arn:aws:acm:eu-central-1:123456789012:certificate/7e7a28d2-163f-4b8f-b9cd-822f96c08d6a"
 }
 ```
@@ -225,5 +246,5 @@ import {
 Using `terraform import`, import certificates using their ARN. For example:
 
 ```console
-% terraform import aws_acm_certificate.cert arn:aws:acm:eu-central-1:123456789012:certificate/7e7a28d2-163f-4b8f-b9cd-822f96c08d6a
+% terraform import aws_acm_certificate.example arn:aws:acm:eu-central-1:123456789012:certificate/7e7a28d2-163f-4b8f-b9cd-822f96c08d6a
 ```


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Extends the AI agent guides for implementing resource identity with instructions for updating the relevant section of the registry documentation.

Also adds "import by identity" documentation for the `aws_acm_certificate` resource as a reference. This is the first resource with an ARN-based identity to have the corresponding registry documentation.

### Relations

Relates #42983
