### PR TITLE
[Enhancement] aws_codebuild_webhook: Add `pull_request_build_policy` configuration block

### DIFF
--- a/.changelog/44201.txt
+++ b/.changelog/44201.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_codebuild_webhook: Add `pull_request_build_policy` configuration block
+```

--- a/internal/service/codebuild/project_test.go
+++ b/internal/service/codebuild/project_test.go
@@ -3140,6 +3140,13 @@ resource "aws_iam_role_policy" "test" {
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeVpcs"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Resource": "*",
+      "Action": [
+         "codeconnections:GetConnectionToken"
+      ]
     }
   ]
 }

--- a/internal/service/codebuild/webhook.go
+++ b/internal/service/codebuild/webhook.go
@@ -88,6 +88,30 @@ func resourceWebhook() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"pull_request_build_policy": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"approver_roles": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type:             schema.TypeString,
+								ValidateDiagFunc: enum.Validate[types.PullRequestBuildApproverRole](),
+							},
+						},
+						"requires_comment_approval": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: enum.Validate[types.PullRequestBuildCommentApproval](),
+						},
+					},
+				},
+			},
 			"scope_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -148,6 +172,10 @@ func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, meta any
 		input.ManualCreation = aws.Bool(v.(bool))
 	}
 
+	if v, ok := d.GetOk("pull_request_build_policy"); ok && len(v.([]any)) > 0 {
+		input.PullRequestBuildPolicy = expandWebhookPullRequestBuildPolicy(v.([]any)[0].(map[string]any))
+	}
+
 	if v, ok := d.GetOk("scope_configuration"); ok && len(v.([]any)) > 0 {
 		input.ScopeConfiguration = expandScopeConfiguration(v.([]any))
 	}
@@ -189,6 +217,9 @@ func resourceWebhookRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	d.Set("manual_creation", d.Get("manual_creation")) // Create-only.
 	d.Set("payload_url", webhook.PayloadUrl)
 	d.Set("project_name", d.Id())
+	if err := d.Set("pull_request_build_policy", flattenWebhookPullRequestBuildPolicy(webhook.PullRequestBuildPolicy)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting pull_request_build_policy: %s", err)
+	}
 	if err := d.Set("scope_configuration", flattenScopeConfiguration(webhook.ScopeConfiguration)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting scope_configuration: %s", err)
 	}
@@ -218,6 +249,10 @@ func resourceWebhookUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		input.FilterGroups = filterGroups
 	} else {
 		input.BranchFilter = aws.String(d.Get("branch_filter").(string))
+	}
+
+	if v, ok := d.GetOk("pull_request_build_policy"); ok && len(v.([]any)) > 0 {
+		input.PullRequestBuildPolicy = expandWebhookPullRequestBuildPolicy(v.([]any)[0].(map[string]any))
 	}
 
 	_, err := conn.UpdateWebhook(ctx, &input)
@@ -283,6 +318,32 @@ func expandWebhookFilterGroups(tfList []any) [][]types.WebhookFilter {
 	}
 
 	return apiObjects
+}
+
+func expandWebhookPullRequestBuildPolicy(tfMap map[string]any) *types.PullRequestBuildPolicy {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &types.PullRequestBuildPolicy{
+		RequiresCommentApproval: types.PullRequestBuildCommentApproval(tfMap["requires_comment_approval"].(string)),
+	}
+
+	if apiObject.RequiresCommentApproval != types.PullRequestBuildCommentApprovalDisabled {
+		if v, ok := tfMap["approver_roles"]; ok && v.(*schema.Set).Len() > 0 {
+			var roles []types.PullRequestBuildApproverRole
+			for _, role := range v.(*schema.Set).List() {
+				if role != nil {
+					roles = append(roles, types.PullRequestBuildApproverRole(role.(string)))
+				}
+			}
+			if len(roles) > 0 {
+				apiObject.ApproverRoles = roles
+			}
+		}
+	}
+
+	return apiObject
 }
 
 func expandWebhookFilters(tfList []any) []types.WebhookFilter {
@@ -366,6 +427,30 @@ func flattenWebhookFilterGroups(apiObjects [][]types.WebhookFilter) []any {
 	}
 
 	return tfList
+}
+
+func flattenWebhookPullRequestBuildPolicy(apiObject *types.PullRequestBuildPolicy) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		"requires_comment_approval": string(apiObject.RequiresCommentApproval),
+	}
+
+	if v := apiObject.ApproverRoles; len(v) > 0 {
+		var roles []string
+		for _, role := range v {
+			if role != "" {
+				roles = append(roles, string(role))
+			}
+		}
+		if len(roles) > 0 {
+			tfMap["approver_roles"] = roles
+		}
+	}
+
+	return []any{tfMap}
 }
 
 func flattenWebhookFilters(apiObjects []types.WebhookFilter) []any {

--- a/internal/service/codebuild/webhook_test.go
+++ b/internal/service/codebuild/webhook_test.go
@@ -93,6 +93,12 @@ func TestAccCodeBuildWebhook_gitHub(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "scope_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "secret", ""),
 					resource.TestMatchResourceAttr(resourceName, names.AttrURL, regexache.MustCompile(`^https://`)),
+					resource.TestCheckResourceAttr(resourceName, "pull_request_build_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "pull_request_build_policy.0.requires_comment_approval", string(types.PullRequestBuildCommentApprovalAllPullRequests)),
+					resource.TestCheckResourceAttr(resourceName, "pull_request_build_policy.0.approver_roles.#", "3"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "pull_request_build_policy.0.approver_roles.*", string(types.PullRequestBuildApproverRoleGithubWrite)),
+					resource.TestCheckTypeSetElemAttr(resourceName, "pull_request_build_policy.0.approver_roles.*", string(types.PullRequestBuildApproverRoleGithubMaintain)),
+					resource.TestCheckTypeSetElemAttr(resourceName, "pull_request_build_policy.0.approver_roles.*", string(types.PullRequestBuildApproverRoleGithubAdmin)),
 				),
 			},
 			{

--- a/internal/service/codebuild/webhook_test.go
+++ b/internal/service/codebuild/webhook_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	tfcodebuild "github.com/hashicorp/terraform-provider-aws/internal/service/codebuild"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -502,12 +503,13 @@ func TestAccCodeBuildWebhook_gitHubWithPullRequestBuildPolicy(t *testing.T) {
 				Config: testAccWebhookConfig_gitHubWithPullRequestBuildPolicy(
 					rName,
 					string(types.PullRequestBuildCommentApprovalAllPullRequests),
-					[]string{
-						string(types.PullRequestBuildApproverRoleGithubRead),
-						string(types.PullRequestBuildApproverRoleGithubWrite),
-						string(types.PullRequestBuildApproverRoleGithubMaintain),
-						string(types.PullRequestBuildApproverRoleGithubAdmin),
-					}),
+					enum.Slice(
+						types.PullRequestBuildApproverRoleGithubRead,
+						types.PullRequestBuildApproverRoleGithubWrite,
+						types.PullRequestBuildApproverRoleGithubMaintain,
+						types.PullRequestBuildApproverRoleGithubAdmin,
+					),
+				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckWebhookExists(ctx, resourceName, &webhook),
 					resource.TestCheckResourceAttr(resourceName, "pull_request_build_policy.#", "1"),
@@ -529,10 +531,11 @@ func TestAccCodeBuildWebhook_gitHubWithPullRequestBuildPolicy(t *testing.T) {
 				Config: testAccWebhookConfig_gitHubWithPullRequestBuildPolicy(
 					rName,
 					string(types.PullRequestBuildCommentApprovalForkPullRequests),
-					[]string{
-						string(types.PullRequestBuildApproverRoleGithubMaintain),
-						string(types.PullRequestBuildApproverRoleGithubAdmin),
-					}),
+					enum.Slice(
+						types.PullRequestBuildApproverRoleGithubMaintain,
+						types.PullRequestBuildApproverRoleGithubAdmin,
+					),
+				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckWebhookExists(ctx, resourceName, &webhook),
 					resource.TestCheckResourceAttr(resourceName, "pull_request_build_policy.#", "1"),

--- a/internal/service/codebuild/webhook_test.go
+++ b/internal/service/codebuild/webhook_test.go
@@ -787,8 +787,8 @@ func testAccWebhookConfig_gitHubWithPullRequestBuildPolicy(rName, requiresCommen
 resource "aws_codebuild_webhook" "test" {
   project_name = aws_codebuild_project.test.name
   pull_request_build_policy {
-     requires_comment_approval = %[1]q
-     approver_roles            = ["%[2]s"]
+    requires_comment_approval = %[1]q
+    approver_roles            = ["%[2]s"]
   }
 }
 `, requiresCommentApproval, strings.Join(approverRoles, "\", \"")))
@@ -799,7 +799,7 @@ func testAccWebhookConfig_gitHubWithPullRequestBuildPolicyNoApproverRoles(rName,
 resource "aws_codebuild_webhook" "test" {
   project_name = aws_codebuild_project.test.name
   pull_request_build_policy {
-     requires_comment_approval = %[1]q
+    requires_comment_approval = %[1]q
   }
 }
 `, requiresCommentApproval))

--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -93,7 +93,7 @@ This resource supports the following arguments:
 * `branch_filter` - (Optional) A regular expression used to determine which branches get built. Default is all branches are built. We recommend using `filter_group` over `branch_filter`.
 * `filter_group` - (Optional) Information about the webhook's trigger. See [filter_group](#filter_group) for details.
 * `scope_configuration` - (Optional) Scope configuration for global or organization webhooks. See [scope_configuration](#scope_configuration) for details.
-* `pull_request_build_policy` - (Optional) Defines comment-based approval requirements for triggering builds on pull requests. See [Pull Request Build Policy](#pull_request_build_policy) for details.
+* `pull_request_build_policy` - (Optional) Defines comment-based approval requirements for triggering builds on pull requests. See [pull_request_build_policy](#pull_request_build_policy) for details.
 
 ### filter_group
 
@@ -113,8 +113,8 @@ This resource supports the following arguments:
 
 ### pull_request_build_policy
 
-* `requires_comment_approval` - (Required) Specifies when comment-based approval is required before triggering a build on pull requests. Valid values for this parameter are: `DISABLED`, `ALL_PULL_REQUESTS`, and `FORK_PULL_REQUESTS`.
-* `approver_roles` - (Optional) List of repository roles that have approval privileges for pull request builds when comment approval is required. This field must be specified only when `requires_comment_approval` is not `DISABLED`. See the [AWS documentation](https://docs.aws.amazon.com/codebuild/latest/userguide/pull-request-build-policy.html#pull-request-build-policy.configuration) for its valid values and defaults.
+* `requires_comment_approval` - (Required) Specifies when comment-based approval is required before triggering a build on pull requests. Valid values are: `DISABLED`, `ALL_PULL_REQUESTS`, and `FORK_PULL_REQUESTS`.
+* `approver_roles` - (Optional) List of repository roles that have approval privileges for pull request builds when comment approval is required. This argument must be specified only when `requires_comment_approval` is not `DISABLED`. See the [AWS documentation](https://docs.aws.amazon.com/codebuild/latest/userguide/pull-request-build-policy.html#pull-request-build-policy.configuration) for valid values and defaults.
 
 ## Attribute Reference
 

--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -91,24 +91,30 @@ This resource supports the following arguments:
 * `build_type` - (Optional) The type of build this webhook will trigger. Valid values for this parameter are: `BUILD`, `BUILD_BATCH`.
 * `manual_creation` - (Optional) If true, CodeBuild doesn't create a webhook in GitHub and instead returns `payload_url` and `secret` values for the webhook. The `payload_url` and `secret` values in the output can be used to manually create a webhook within GitHub.
 * `branch_filter` - (Optional) A regular expression used to determine which branches get built. Default is all branches are built. We recommend using `filter_group` over `branch_filter`.
-* `filter_group` - (Optional) Information about the webhook's trigger. Filter group blocks are documented below.
-* `scope_configuration` - (Optional) Scope configuration for global or organization webhooks. Scope configuration blocks are documented below.
+* `filter_group` - (Optional) Information about the webhook's trigger. See [filter_group](#filter_group) for details.
+* `scope_configuration` - (Optional) Scope configuration for global or organization webhooks. See [scope_configuration](#scope_configuration) for details.
+* `pull_request_build_policy` - (Optional) Defines comment-based approval requirements for triggering builds on pull requests. See [Pull Request Build Policy](#pull_request_build_policy) for details.
 
-`filter_group` supports the following:
+### filter_group
 
-* `filter` - (Required) A webhook filter for the group. Filter blocks are documented below.
+* `filter` - (Required) A webhook filter for the group. See [filter](#filter) for details.
 
-`filter` supports the following:
+### filter
 
 * `type` - (Required) The webhook filter group's type. Valid values for this parameter are: `EVENT`, `BASE_REF`, `HEAD_REF`, `ACTOR_ACCOUNT_ID`, `FILE_PATH`, `COMMIT_MESSAGE`, `WORKFLOW_NAME`, `TAG_NAME`, `RELEASE_NAME`. At least one filter group must specify `EVENT` as its type.
 * `pattern` - (Required) For a filter that uses `EVENT` type, a comma-separated string that specifies one event: `PUSH`, `PULL_REQUEST_CREATED`, `PULL_REQUEST_UPDATED`, `PULL_REQUEST_REOPENED`. `PULL_REQUEST_MERGED`, `WORKFLOW_JOB_QUEUED` works with GitHub & GitHub Enterprise only. For a filter that uses any of the other filter types, a regular expression.
 * `exclude_matched_pattern` - (Optional) If set to `true`, the specified filter does *not* trigger a build. Defaults to `false`.
 
-`scope_configuration` supports the following:
+### scope_configuration
 
 * `name` - (Required) The name of either the enterprise or organization.
 * `scope` - (Required) The type of scope for a GitHub webhook. Valid values for this parameter are: `GITHUB_ORGANIZATION`, `GITHUB_GLOBAL`.
 * `domain` - (Optional) The domain of the GitHub Enterprise organization. Required if your project's source type is GITHUB_ENTERPRISE.
+
+### pull_request_build_policy
+
+* `requires_comment_approval` - (Required) Specifies when comment-based approval is required before triggering a build on pull requests. Valid values for this parameter are: `DISABLED`, `ALL_PULL_REQUESTS`, and `FORK_PULL_REQUESTS`.
+* `approver_roles` - (Optional) List of repository roles that have approval privileges for pull request builds when comment approval is required. This field must be specified only when `requires_comment_approval` is not `DISABLED`. See the [AWS documentation](https://docs.aws.amazon.com/codebuild/latest/userguide/pull-request-build-policy.html#pull-request-build-policy.configuration) for its valid values and defaults.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.


### Description

* Adds the `pull_request_build_policy` configuration block to `aws_codebuild_webhook`.

  * The `pull_request_build_policy` block is marked as `Computed`.

    * The AWS API returns this object even if the block is not specified in the configuration.
  * The `approver_roles` argument in `pull_request_build_policy` block is also marked as `Computed`.

    * The AWS API returns a default value for this block even if it is not specified in the configuration.

* Adds the `codeconnections:GetConnectionToken` permission to the role assumed by the CodeBuild service in acceptance tests, since this permission is required for the tests to run.

* Not directly related to the main topic of this PR, but also adds links to subsections in the documentation.

### Relations

Closes #44193

### References
https://docs.aws.amazon.com/codebuild/latest/userguide/pull-request-build-policy.html
https://docs.aws.amazon.com/codebuild/latest/APIReference/API_CreateWebhook.html#CodeBuild-CreateWebhook-request-pullRequestBuildPolicy

### Output from Acceptance Testing
```console
$ AWS_CODEBUILD_GITHUB_SOURCE_LOCATION="https://github.com/tabito-hara/xxxx.git" make testacc TESTS='TestAccCodeBuildWebhook_' PKG=codebuild 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_codebuild_webhook-add_pull_request_build_policy 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/codebuild/... -v -count 1 -parallel 20 -run='TestAccCodeBuildWebhook_'  -timeout 360m -vet=off
2025/09/09 20:53:39 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/09 20:53:39 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCodeBuildWebhook_bitbucket
=== PAUSE TestAccCodeBuildWebhook_bitbucket
=== RUN   TestAccCodeBuildWebhook_gitHub
=== PAUSE TestAccCodeBuildWebhook_gitHub
=== RUN   TestAccCodeBuildWebhook_gitHubEnterprise
=== PAUSE TestAccCodeBuildWebhook_gitHubEnterprise
=== RUN   TestAccCodeBuildWebhook_buildType
=== PAUSE TestAccCodeBuildWebhook_buildType
=== RUN   TestAccCodeBuildWebhook_scopeConfiguration
=== PAUSE TestAccCodeBuildWebhook_scopeConfiguration
=== RUN   TestAccCodeBuildWebhook_branchFilter
=== PAUSE TestAccCodeBuildWebhook_branchFilter
=== RUN   TestAccCodeBuildWebhook_filterGroup
=== PAUSE TestAccCodeBuildWebhook_filterGroup
=== RUN   TestAccCodeBuildWebhook_disappears
=== PAUSE TestAccCodeBuildWebhook_disappears
=== RUN   TestAccCodeBuildWebhook_Disappears_project
=== PAUSE TestAccCodeBuildWebhook_Disappears_project
=== RUN   TestAccCodeBuildWebhook_manualCreation
=== PAUSE TestAccCodeBuildWebhook_manualCreation
=== RUN   TestAccCodeBuildWebhook_upgradeV5_94_1
=== PAUSE TestAccCodeBuildWebhook_upgradeV5_94_1
=== RUN   TestAccCodeBuildWebhook_gitHubWithPullRequestBuildPolicy
=== PAUSE TestAccCodeBuildWebhook_gitHubWithPullRequestBuildPolicy
=== RUN   TestAccCodeBuildWebhook_gitHubWithPullRequestBuildPolicyNoApproverRoles
=== PAUSE TestAccCodeBuildWebhook_gitHubWithPullRequestBuildPolicyNoApproverRoles
=== CONT  TestAccCodeBuildWebhook_bitbucket
=== CONT  TestAccCodeBuildWebhook_disappears
=== CONT  TestAccCodeBuildWebhook_scopeConfiguration
=== CONT  TestAccCodeBuildWebhook_upgradeV5_94_1
=== CONT  TestAccCodeBuildWebhook_buildType
=== CONT  TestAccCodeBuildWebhook_gitHubWithPullRequestBuildPolicyNoApproverRoles
=== CONT  TestAccCodeBuildWebhook_gitHubEnterprise
=== CONT  TestAccCodeBuildWebhook_gitHub
=== CONT  TestAccCodeBuildWebhook_gitHubWithPullRequestBuildPolicy
=== CONT  TestAccCodeBuildWebhook_filterGroup
=== CONT  TestAccCodeBuildWebhook_manualCreation
=== CONT  TestAccCodeBuildWebhook_branchFilter
=== CONT  TestAccCodeBuildWebhook_Disappears_project
=== NAME  TestAccCodeBuildWebhook_gitHubEnterprise
    source_credential_test.go:143: skipping acceptance testing: Source Credentials (GITHUB_ENTERPRISE) not found
--- SKIP: TestAccCodeBuildWebhook_gitHubEnterprise (3.08s)
=== NAME  TestAccCodeBuildWebhook_bitbucket
    source_credential_test.go:143: skipping acceptance testing: Source Credentials (BITBUCKET) not found
--- SKIP: TestAccCodeBuildWebhook_bitbucket (3.09s)
--- PASS: TestAccCodeBuildWebhook_gitHubWithPullRequestBuildPolicyNoApproverRoles (42.67s)
--- PASS: TestAccCodeBuildWebhook_scopeConfiguration (49.63s)
--- PASS: TestAccCodeBuildWebhook_disappears (49.87s)
--- PASS: TestAccCodeBuildWebhook_filterGroup (51.38s)
--- PASS: TestAccCodeBuildWebhook_Disappears_project (51.77s)
--- PASS: TestAccCodeBuildWebhook_gitHub (51.86s)
--- PASS: TestAccCodeBuildWebhook_manualCreation (52.40s)
--- PASS: TestAccCodeBuildWebhook_branchFilter (64.85s)
--- PASS: TestAccCodeBuildWebhook_upgradeV5_94_1 (77.96s)
--- PASS: TestAccCodeBuildWebhook_gitHubWithPullRequestBuildPolicy (85.82s)
--- PASS: TestAccCodeBuildWebhook_buildType (89.09s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codebuild  94.413s
```
