### PR TITLE
[Enhancement] aws_glue_catalog_table_optimizer: Add `iceberg_configuration.run_rate_in_hours` arguments to `retention_configuration` and `orphan_file_deletion_configuration` blocks

### DIFF
--- a/internal/service/glue/catalog_table_optimizer.go
+++ b/internal/service/glue/catalog_table_optimizer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -108,13 +109,20 @@ func (r *catalogTableOptimizerResource) Schema(ctx context.Context, _ resource.S
 										},
 										NestedObject: schema.NestedBlockObject{
 											Attributes: map[string]schema.Attribute{
-												"snapshot_retention_period_in_days": schema.Int32Attribute{
+												"clean_expired_files": schema.BoolAttribute{
 													Optional: true,
 												},
 												"number_of_snapshots_to_retain": schema.Int32Attribute{
 													Optional: true,
 												},
-												"clean_expired_files": schema.BoolAttribute{
+												"run_rate_in_hours": schema.Int32Attribute{
+													Optional: true,
+													Computed: true,
+													PlanModifiers: []planmodifier.Int32{
+														int32planmodifier.UseStateForUnknown(),
+													},
+												},
+												"snapshot_retention_period_in_days": schema.Int32Attribute{
 													Optional: true,
 												},
 											},
@@ -137,11 +145,18 @@ func (r *catalogTableOptimizerResource) Schema(ctx context.Context, _ resource.S
 										},
 										NestedObject: schema.NestedBlockObject{
 											Attributes: map[string]schema.Attribute{
+												names.AttrLocation: schema.StringAttribute{
+													Optional: true,
+												},
 												"orphan_file_retention_period_in_days": schema.Int32Attribute{
 													Optional: true,
 												},
-												names.AttrLocation: schema.StringAttribute{
+												"run_rate_in_hours": schema.Int32Attribute{
 													Optional: true,
+													Computed: true,
+													PlanModifiers: []planmodifier.Int32{
+														int32planmodifier.UseStateForUnknown(),
+													},
 												},
 											},
 										},
@@ -206,6 +221,28 @@ func (r *catalogTableOptimizerResource) Create(ctx context.Context, request reso
 			create.ProblemStandardMessage(names.Glue, create.ErrActionCreating, ResNameCatalogTableOptimizer, id, err),
 			err.Error(),
 		)
+		return
+	}
+
+	output, err := findCatalogTableOptimizer(ctx, conn, plan.CatalogID.ValueString(), plan.DatabaseName.ValueString(), plan.TableName.ValueString(), plan.Type.ValueString())
+	if err != nil {
+		id, _ := flex.FlattenResourceId([]string{
+			plan.CatalogID.ValueString(),
+			plan.DatabaseName.ValueString(),
+			plan.TableName.ValueString(),
+			plan.Type.ValueString(),
+		}, idParts, false)
+
+		response.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Glue, create.ErrActionReading, ResNameCatalogTableOptimizer, id, err),
+			err.Error(),
+		)
+		return
+	}
+
+	response.Diagnostics.Append(fwflex.Flatten(ctx, output.TableOptimizer, &plan)...)
+
+	if response.Diagnostics.HasError() {
 		return
 	}
 
@@ -287,6 +324,27 @@ func (r *catalogTableOptimizerResource) Update(ctx context.Context, request reso
 				create.ProblemStandardMessage(names.Glue, create.ErrActionUpdating, ResNameCatalogTableOptimizer, id, err),
 				err.Error(),
 			)
+			return
+		}
+		output, err := findCatalogTableOptimizer(ctx, conn, plan.CatalogID.ValueString(), plan.DatabaseName.ValueString(), plan.TableName.ValueString(), plan.Type.ValueString())
+		if err != nil {
+			id, _ := flex.FlattenResourceId([]string{
+				plan.CatalogID.ValueString(),
+				plan.DatabaseName.ValueString(),
+				plan.TableName.ValueString(),
+				plan.Type.ValueString(),
+			}, idParts, false)
+
+			response.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.Glue, create.ErrActionReading, ResNameCatalogTableOptimizer, id, err),
+				err.Error(),
+			)
+			return
+		}
+
+		response.Diagnostics.Append(fwflex.Flatten(ctx, output.TableOptimizer, &plan)...)
+
+		if response.Diagnostics.HasError() {
 			return
 		}
 	}
@@ -376,9 +434,10 @@ type retentionConfigurationData struct {
 }
 
 type icebergRetentionConfigurationData struct {
-	SnapshotRetentionPeriodInDays types.Int32 `tfsdk:"snapshot_retention_period_in_days"`
-	NumberOfSnapshotsToRetain     types.Int32 `tfsdk:"number_of_snapshots_to_retain"`
 	CleanExpiredFiles             types.Bool  `tfsdk:"clean_expired_files"`
+	NumberOfSnapshotsToRetain     types.Int32 `tfsdk:"number_of_snapshots_to_retain"`
+	RunRateInHours                types.Int32 `tfsdk:"run_rate_in_hours"`
+	SnapshotRetentionPeriodInDays types.Int32 `tfsdk:"snapshot_retention_period_in_days"`
 }
 
 type orphanFileDeletionConfigurationData struct {
@@ -386,8 +445,9 @@ type orphanFileDeletionConfigurationData struct {
 }
 
 type icebergOrphanFileDeletionConfigurationData struct {
-	OrphanFileRetentionPeriodInDays types.Int32  `tfsdk:"orphan_file_retention_period_in_days"`
 	Location                        types.String `tfsdk:"location"`
+	OrphanFileRetentionPeriodInDays types.Int32  `tfsdk:"orphan_file_retention_period_in_days"`
+	RunRateInHours                  types.Int32  `tfsdk:"run_rate_in_hours"`
 }
 
 func findCatalogTableOptimizer(ctx context.Context, conn *glue.Client, catalogID, dbName, tableName, optimizerType string) (*glue.GetTableOptimizerOutput, error) {

--- a/internal/service/glue/catalog_table_optimizer_test.go
+++ b/internal/service/glue/catalog_table_optimizer_test.go
@@ -149,6 +149,7 @@ func testAccCatalogTableOptimizer_RetentionConfiguration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.retention_configuration.0.iceberg_configuration.0.snapshot_retention_period_in_days", "7"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.retention_configuration.0.iceberg_configuration.0.number_of_snapshots_to_retain", "3"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.retention_configuration.0.iceberg_configuration.0.clean_expired_files", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.retention_configuration.0.iceberg_configuration.0.run_rate_in_hours", "24"),
 				),
 			},
 			{
@@ -170,6 +171,62 @@ func testAccCatalogTableOptimizer_RetentionConfiguration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.retention_configuration.0.iceberg_configuration.0.snapshot_retention_period_in_days", "6"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.retention_configuration.0.iceberg_configuration.0.number_of_snapshots_to_retain", "3"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.retention_configuration.0.iceberg_configuration.0.clean_expired_files", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.retention_configuration.0.iceberg_configuration.0.run_rate_in_hours", "24"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCatalogTableOptimizer_RetentionConfigurationWithRunRateInHours(t *testing.T) {
+	ctx := acctest.Context(t)
+	var catalogTableOptimizer glue.GetTableOptimizerOutput
+
+	resourceName := "aws_glue_catalog_table_optimizer.test"
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlueServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCatalogTableOptimizerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCatalogTableOptimizerConfig_retentionConfigurationWithRunRateInHours(rName, 7, 6),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogTableOptimizerExists(ctx, resourceName, &catalogTableOptimizer),
+					acctest.CheckResourceAttrAccountID(ctx, resourceName, names.AttrCatalogID),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDatabaseName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrTableName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "retention"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.retention_configuration.0.iceberg_configuration.0.snapshot_retention_period_in_days", "7"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.retention_configuration.0.iceberg_configuration.0.number_of_snapshots_to_retain", "3"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.retention_configuration.0.iceberg_configuration.0.clean_expired_files", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.retention_configuration.0.iceberg_configuration.0.run_rate_in_hours", "6"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportStateIdFunc:                    testAccCatalogTableOptimizerStateIDFunc(resourceName),
+				ImportStateVerifyIdentifierAttribute: names.AttrTableName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+			},
+			{
+				Config: testAccCatalogTableOptimizerConfig_retentionConfigurationWithRunRateInHours(rName, 6, 4),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogTableOptimizerExists(ctx, resourceName, &catalogTableOptimizer),
+					acctest.CheckResourceAttrAccountID(ctx, resourceName, names.AttrCatalogID),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDatabaseName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrTableName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "retention"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.retention_configuration.0.iceberg_configuration.0.snapshot_retention_period_in_days", "6"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.retention_configuration.0.iceberg_configuration.0.number_of_snapshots_to_retain", "3"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.retention_configuration.0.iceberg_configuration.0.clean_expired_files", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.retention_configuration.0.iceberg_configuration.0.run_rate_in_hours", "4"),
 				),
 			},
 		},
@@ -201,6 +258,7 @@ func testAccCatalogTableOptimizer_DeleteOrphanFileConfiguration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.orphan_file_deletion_configuration.0.iceberg_configuration.0.orphan_file_retention_period_in_days", "7"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.orphan_file_deletion_configuration.0.iceberg_configuration.0.location", fmt.Sprintf("s3://%s/files/", rName)),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.orphan_file_deletion_configuration.0.iceberg_configuration.0.run_rate_in_hours", "24"),
 				),
 			},
 			{
@@ -221,6 +279,60 @@ func testAccCatalogTableOptimizer_DeleteOrphanFileConfiguration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.orphan_file_deletion_configuration.0.iceberg_configuration.0.orphan_file_retention_period_in_days", "6"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.orphan_file_deletion_configuration.0.iceberg_configuration.0.location", fmt.Sprintf("s3://%s/files/", rName)),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.orphan_file_deletion_configuration.0.iceberg_configuration.0.run_rate_in_hours", "24"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCatalogTableOptimizer_DeleteOrphanFileConfigurationWithRunRateInHours(t *testing.T) {
+	ctx := acctest.Context(t)
+	var catalogTableOptimizer glue.GetTableOptimizerOutput
+
+	resourceName := "aws_glue_catalog_table_optimizer.test"
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlueServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCatalogTableOptimizerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCatalogTableOptimizerConfig_orphanFileDeletionConfigurationWithRunRateInHours(rName, 7, 6),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogTableOptimizerExists(ctx, resourceName, &catalogTableOptimizer),
+					acctest.CheckResourceAttrAccountID(ctx, resourceName, names.AttrCatalogID),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDatabaseName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrTableName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "orphan_file_deletion"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.orphan_file_deletion_configuration.0.iceberg_configuration.0.orphan_file_retention_period_in_days", "7"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.orphan_file_deletion_configuration.0.iceberg_configuration.0.location", fmt.Sprintf("s3://%s/files/", rName)),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.orphan_file_deletion_configuration.0.iceberg_configuration.0.run_rate_in_hours", "6"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportStateIdFunc:                    testAccCatalogTableOptimizerStateIDFunc(resourceName),
+				ImportStateVerifyIdentifierAttribute: names.AttrTableName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+			},
+			{
+				Config: testAccCatalogTableOptimizerConfig_orphanFileDeletionConfigurationWithRunRateInHours(rName, 6, 4),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogTableOptimizerExists(ctx, resourceName, &catalogTableOptimizer),
+					acctest.CheckResourceAttrAccountID(ctx, resourceName, names.AttrCatalogID),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDatabaseName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrTableName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "orphan_file_deletion"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.orphan_file_deletion_configuration.0.iceberg_configuration.0.orphan_file_retention_period_in_days", "6"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.orphan_file_deletion_configuration.0.iceberg_configuration.0.location", fmt.Sprintf("s3://%s/files/", rName)),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.orphan_file_deletion_configuration.0.iceberg_configuration.0.run_rate_in_hours", "4"),
 				),
 			},
 		},
@@ -472,8 +584,37 @@ resource "aws_glue_catalog_table_optimizer" "test" {
       }
     }
   }
+  depends_on = [aws_iam_role_policy.test]
 }
 `, retentionPeriod))
+}
+
+func testAccCatalogTableOptimizerConfig_retentionConfigurationWithRunRateInHours(rName string, retentionPeriod, runRateInHours int) string {
+	return acctest.ConfigCompose(
+		testAccCatalogTableOptimizerConfig_baseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_glue_catalog_table_optimizer" "test" {
+  catalog_id    = data.aws_caller_identity.current.account_id
+  database_name = aws_glue_catalog_database.test.name
+  table_name    = aws_glue_catalog_table.test.name
+  type          = "retention"
+
+  configuration {
+    role_arn = aws_iam_role.test.arn
+    enabled  = true
+
+    retention_configuration {
+      iceberg_configuration {
+        snapshot_retention_period_in_days = %[1]d
+        number_of_snapshots_to_retain     = 3
+        clean_expired_files               = true
+        run_rate_in_hours                 = %[2]d
+      }
+    }
+  }
+  depends_on = [aws_iam_role_policy.test]
+}
+`, retentionPeriod, runRateInHours))
 }
 
 func testAccCatalogTableOptimizerConfig_orphanFileDeletionConfiguration(rName string, retentionPeriod int) string {
@@ -497,6 +638,34 @@ resource "aws_glue_catalog_table_optimizer" "test" {
       }
     }
   }
+  depends_on = [aws_iam_role_policy.test]
 }
 `, retentionPeriod))
+}
+
+func testAccCatalogTableOptimizerConfig_orphanFileDeletionConfigurationWithRunRateInHours(rName string, retentionPeriod, runRateInHours int) string {
+	return acctest.ConfigCompose(
+		testAccCatalogTableOptimizerConfig_baseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_glue_catalog_table_optimizer" "test" {
+  catalog_id    = data.aws_caller_identity.current.account_id
+  database_name = aws_glue_catalog_database.test.name
+  table_name    = aws_glue_catalog_table.test.name
+  type          = "orphan_file_deletion"
+
+  configuration {
+    role_arn = aws_iam_role.test.arn
+    enabled  = true
+
+    orphan_file_deletion_configuration {
+      iceberg_configuration {
+        orphan_file_retention_period_in_days = %[1]d
+        location                             = "s3://${aws_s3_bucket.bucket.bucket}/files/"
+        run_rate_in_hours                    = %[2]d
+      }
+    }
+  }
+  depends_on = [aws_iam_role_policy.test]
+}
+`, retentionPeriod, runRateInHours))
 }

--- a/internal/service/glue/glue_test.go
+++ b/internal/service/glue/glue_test.go
@@ -14,11 +14,13 @@ func TestAccGlue_serial(t *testing.T) {
 
 	testCases := map[string]map[string]func(t *testing.T){
 		"CatalogTableOptimizer": {
-			acctest.CtBasic:                 testAccCatalogTableOptimizer_basic,
-			"deleteOrphanFileConfiguration": testAccCatalogTableOptimizer_DeleteOrphanFileConfiguration,
-			acctest.CtDisappears:            testAccCatalogTableOptimizer_disappears,
-			"retentionConfiguration":        testAccCatalogTableOptimizer_RetentionConfiguration,
-			"update":                        testAccCatalogTableOptimizer_update,
+			acctest.CtBasic:                                   testAccCatalogTableOptimizer_basic,
+			"deleteOrphanFileConfiguration":                   testAccCatalogTableOptimizer_DeleteOrphanFileConfiguration,
+			"deleteOrphanFileConfigurationWithRunRateInHours": testAccCatalogTableOptimizer_DeleteOrphanFileConfigurationWithRunRateInHours,
+			acctest.CtDisappears:                              testAccCatalogTableOptimizer_disappears,
+			"retentionConfiguration":                          testAccCatalogTableOptimizer_RetentionConfiguration,
+			"retentionConfigurationWithRunRateInHours":        testAccCatalogTableOptimizer_RetentionConfigurationWithRunRateInHours,
+			"update": testAccCatalogTableOptimizer_update,
 		},
 		"DataCatalogEncryptionSettings": {
 			acctest.CtBasic: testAccDataCatalogEncryptionSettings_basic,

--- a/website/docs/r/glue_catalog_table_optimizer.html.markdown
+++ b/website/docs/r/glue_catalog_table_optimizer.html.markdown
@@ -101,15 +101,17 @@ This resource supports the following arguments:
 ### Orphan File Deletion Configuration
 
 * `iceberg_configuration` (Optional) - The configuration for an Iceberg orphan file deletion optimizer.
-    * `orphan_file_retention_period_in_days` (Optional) - The number of days that orphan files should be retained before file deletion. Defaults to `3`.
     * `location` (Optional) - Specifies a directory in which to look for files. You may choose a sub-directory rather than the top-level table location. Defaults to the table's location.
-  
+    * `orphan_file_retention_period_in_days` (Optional) - The number of days that orphan files should be retained before file deletion. Defaults to `3`.
+    * `run_rate_in_hours` (Optional) - interval in hours between orphan file deletion job runs. Defaults to `24`.
+
 ### Retention Configuration
 
 * `iceberg_configuration` (Optional) - The configuration for an Iceberg snapshot retention optimizer.
-    * `snapshot_retention_period_in_days` (Optional) - The number of days to retain the Iceberg snapshots. Defaults to `5`, or the corresponding Iceberg table configuration field if it exists.
-    * `number_of_snapshots_to_retain` (Optional) - The number of Iceberg snapshots to retain within the retention period. Defaults to `1` or the corresponding Iceberg table configuration field if it exists.
     * `clean_expired_files` (Optional) - If set to `false`, snapshots are only deleted from table metadata, and the underlying data and metadata files are not deleted. Defaults to `false`.
+    * `number_of_snapshots_to_retain` (Optional) - The number of Iceberg snapshots to retain within the retention period. Defaults to `1` or the corresponding Iceberg table configuration field if it exists.
+    * `run_rate_in_hours` (Optional) - Interval in hours between retention job runs. Defaults to `24`.
+    * `snapshot_retention_period_in_days` (Optional) - The number of days to retain the Iceberg snapshots. Defaults to `5`, or the corresponding Iceberg table configuration field if it exists.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Adds the `iceberg_configuration.run_rate_in_hours` argument to the `retention_configuration` and `orphan_file_deletion_configuration` blocks.

  * Adds a "Read" step to the "Create" and "Update" processes.

    * Previously, the plan was stored in the state without any modification during the "Create" and "Update" processes.
    * However, `run_rate_in_hours` should be marked as `Computed`, since the AWS API returns a default value even if it is not specified.
    * Without the "Read" step, the configuration would become inconsistent with the state refreshed by the "Read" process.


### Relations

Closes #44200

### References
https://docs.aws.amazon.com/it_it/glue/latest/webapi/API_CreateTableOptimizer.html

### Output from Acceptance Testing
```console
$ make testacc TESTS='TestAccGlue_serial/CatalogTableOptimizer/' PKG=glue 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_glue_catalog_table_optimizer-add_run_rate_in_hours 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlue_serial/CatalogTableOptimizer/'  -timeout 360m -vet=off
2025/09/10 00:45:40 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/10 00:45:40 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccGlue_serial
=== PAUSE TestAccGlue_serial
=== CONT  TestAccGlue_serial
=== RUN   TestAccGlue_serial/CatalogTableOptimizer
=== RUN   TestAccGlue_serial/CatalogTableOptimizer/retentionConfigurationWithRunRateInHours
=== RUN   TestAccGlue_serial/CatalogTableOptimizer/update
=== PAUSE TestAccGlue_serial/CatalogTableOptimizer/update
=== RUN   TestAccGlue_serial/CatalogTableOptimizer/basic
=== RUN   TestAccGlue_serial/CatalogTableOptimizer/deleteOrphanFileConfiguration
=== RUN   TestAccGlue_serial/CatalogTableOptimizer/deleteOrphanFileConfigurationWithRunRateInHours
=== RUN   TestAccGlue_serial/CatalogTableOptimizer/disappears
=== RUN   TestAccGlue_serial/CatalogTableOptimizer/retentionConfiguration
=== CONT  TestAccGlue_serial/CatalogTableOptimizer/update
--- PASS: TestAccGlue_serial (401.29s)
    --- PASS: TestAccGlue_serial/CatalogTableOptimizer (338.12s)
        --- PASS: TestAccGlue_serial/CatalogTableOptimizer/retentionConfigurationWithRunRateInHours (62.90s)
        --- PASS: TestAccGlue_serial/CatalogTableOptimizer/basic (47.89s)
        --- PASS: TestAccGlue_serial/CatalogTableOptimizer/deleteOrphanFileConfiguration (60.21s)
        --- PASS: TestAccGlue_serial/CatalogTableOptimizer/deleteOrphanFileConfigurationWithRunRateInHours (60.44s)
        --- PASS: TestAccGlue_serial/CatalogTableOptimizer/disappears (45.96s)
        --- PASS: TestAccGlue_serial/CatalogTableOptimizer/retentionConfiguration (60.72s)
        --- PASS: TestAccGlue_serial/CatalogTableOptimizer/update (63.17s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       406.027s


```
