### PR TITLE
[Enhancement] aws_networkfirewall_rule_group: Support IPv6 CIDR blocks in stateless rule groups

### DIFF
--- a/internal/service/networkfirewall/rule_group.go
+++ b/internal/service/networkfirewall/rule_group.go
@@ -250,9 +250,12 @@ func resourceRuleGroup() *schema.Resource {
 																							Elem: &schema.Resource{
 																								Schema: map[string]*schema.Schema{
 																									"address_definition": {
-																										Type:         schema.TypeString,
-																										Required:     true,
-																										ValidateFunc: verify.ValidIPv4CIDRNetworkAddress,
+																										Type:     schema.TypeString,
+																										Required: true,
+																										ValidateFunc: validation.Any(
+																											verify.ValidIPv4CIDRNetworkAddress,
+																											verify.ValidIPv6CIDRNetworkAddress,
+																										),
 																									},
 																								},
 																							},
@@ -284,9 +287,12 @@ func resourceRuleGroup() *schema.Resource {
 																							Elem: &schema.Resource{
 																								Schema: map[string]*schema.Schema{
 																									"address_definition": {
-																										Type:         schema.TypeString,
-																										Required:     true,
-																										ValidateFunc: verify.ValidIPv4CIDRNetworkAddress,
+																										Type:     schema.TypeString,
+																										Required: true,
+																										ValidateFunc: validation.Any(
+																											verify.ValidIPv4CIDRNetworkAddress,
+																											verify.ValidIPv6CIDRNetworkAddress,
+																										),
 																									},
 																								},
 																							},

--- a/internal/service/networkfirewall/rule_group_test.go
+++ b/internal/service/networkfirewall/rule_group_test.go
@@ -228,12 +228,60 @@ func TestAccNetworkFirewallRuleGroup_Basic_statelessRule(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rule_group.0.rules_source.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "rule_group.0.rules_source.0.stateless_rules_and_custom_actions.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule_group.0.rules_source.0.stateless_rules_and_custom_actions.0.stateless_rule.*", map[string]string{
-						names.AttrPriority:                                   "1",
-						"rule_definition.#":                                  "1",
-						"rule_definition.0.actions.#":                        "1",
-						"rule_definition.0.match_attributes.#":               "1",
-						"rule_definition.0.match_attributes.0.destination.#": "1",
-						"rule_definition.0.match_attributes.0.source.#":      "1",
+						names.AttrPriority:                                                      "1",
+						"rule_definition.#":                                                     "1",
+						"rule_definition.0.actions.#":                                           "1",
+						"rule_definition.0.match_attributes.#":                                  "1",
+						"rule_definition.0.match_attributes.0.destination.#":                    "1",
+						"rule_definition.0.match_attributes.0.destination.0.address_definition": "1.2.3.4/32",
+						"rule_definition.0.match_attributes.0.source.#":                         "1",
+						"rule_definition.0.match_attributes.0.source.0.address_definition":      "124.1.1.5/32",
+					}),
+					resource.TestCheckTypeSetElemAttr(resourceName, "rule_group.0.rules_source.0.stateless_rules_and_custom_actions.0.stateless_rule.*.rule_definition.0.actions.*", "aws:drop"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccNetworkFirewallRuleGroup_Basic_statelessRuleIPv6(t *testing.T) {
+	ctx := acctest.Context(t)
+	var ruleGroup networkfirewall.DescribeRuleGroupOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_networkfirewall_rule_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkFirewallServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRuleGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuleGroupConfig_basicStatelessIPv6(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuleGroupExists(ctx, resourceName, &ruleGroup),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "network-firewall", fmt.Sprintf("stateless-rulegroup/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "capacity", "100"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(awstypes.RuleGroupTypeStateless)),
+					resource.TestCheckResourceAttr(resourceName, "rule_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule_group.0.rules_source.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule_group.0.rules_source.0.stateless_rules_and_custom_actions.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule_group.0.rules_source.0.stateless_rules_and_custom_actions.0.stateless_rule.*", map[string]string{
+						names.AttrPriority:                                                      "1",
+						"rule_definition.#":                                                     "1",
+						"rule_definition.0.actions.#":                                           "1",
+						"rule_definition.0.match_attributes.#":                                  "1",
+						"rule_definition.0.match_attributes.0.destination.#":                    "1",
+						"rule_definition.0.match_attributes.0.destination.0.address_definition": "1111:0000:0000:0000:0000:0000:0000:0111/128",
+						"rule_definition.0.match_attributes.0.source.#":                         "1",
+						"rule_definition.0.match_attributes.0.source.0.address_definition":      "1111:0000:0000:0000:0000:0000:0000:0000/64",
 					}),
 					resource.TestCheckTypeSetElemAttr(resourceName, "rule_group.0.rules_source.0.stateless_rules_and_custom_actions.0.stateless_rule.*.rule_definition.0.actions.*", "aws:drop"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
@@ -1577,6 +1625,40 @@ resource "aws_networkfirewall_rule_group" "test" {
               tcp_flag {
                 flags = ["SYN"]
                 masks = ["SYN", "ACK"]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, rName)
+}
+
+func testAccRuleGroupConfig_basicStatelessIPv6(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_networkfirewall_rule_group" "test" {
+  capacity = 100
+  name     = %[1]q
+  type     = "STATELESS"
+
+  rule_group {
+    rules_source {
+      stateless_rules_and_custom_actions {
+        stateless_rule {
+          priority = 1
+
+          rule_definition {
+            actions = ["aws:drop"]
+
+            match_attributes {
+              destination {
+                address_definition = "1111:0000:0000:0000:0000:0000:0000:0111/128"
+              }
+
+              source {
+                address_definition = "1111:0000:0000:0000:0000:0000:0000:0000/64"
               }
             }
           }

--- a/website/docs/r/networkfirewall_rule_group.html.markdown
+++ b/website/docs/r/networkfirewall_rule_group.html.markdown
@@ -519,7 +519,7 @@ The `dimension` block supports the following argument:
 
 The `destination` block supports the following argument:
 
-* `address_definition` - (Required)  An IP address or a block of IP addresses in CIDR notation. AWS Network Firewall supports all address ranges for IPv4.
+* `address_definition` - (Required)  An IP address or a block of IP addresses in CIDR notation. AWS Network Firewall supports all address ranges for IPv4 and IPv6.
 
 ### Destination Port
 
@@ -533,7 +533,7 @@ The `destination_port` block supports the following arguments:
 
 The `source` block supports the following argument:
 
-* `address_definition` - (Required)  An IP address or a block of IP addresses in CIDR notation. AWS Network Firewall supports all address ranges for IPv4.
+* `address_definition` - (Required)  An IP address or a block of IP addresses in CIDR notation. AWS Network Firewall supports all address ranges for IPv4 and IPv6.
 
 ### Source Port
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description


### Relations

Closes #44206 

### References
https://docs.aws.amazon.com/network-firewall/latest/APIReference/API_Address.html#networkfirewall-Type-Address-AddressDefinition


### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccNetworkFirewallRuleGroup_' PKG=networkfirewall 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_networkfirewall-support_ipv6 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/networkfirewall/... -v -count 1 -parallel 20 -run='TestAccNetworkFirewallRuleGroup_'  -timeout 360m -vet=off
2025/09/10 07:34:31 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/10 07:34:31 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_rulesSourceList
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_rulesSourceList
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_referenceSets
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_referenceSets
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_updateReferenceSets
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_updateReferenceSets
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_statefulRule
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_statefulRule
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_statelessRule
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_statelessRule
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_statelessRuleIPv6
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_statelessRuleIPv6
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_rules
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_rules
=== RUN   TestAccNetworkFirewallRuleGroup_statefulRuleOptions
=== PAUSE TestAccNetworkFirewallRuleGroup_statefulRuleOptions
=== RUN   TestAccNetworkFirewallRuleGroup_updateStatefulRuleOptions
=== PAUSE TestAccNetworkFirewallRuleGroup_updateStatefulRuleOptions
=== RUN   TestAccNetworkFirewallRuleGroup_statelessRuleWithCustomAction
=== PAUSE TestAccNetworkFirewallRuleGroup_statelessRuleWithCustomAction
=== RUN   TestAccNetworkFirewallRuleGroup_updateRules
=== PAUSE TestAccNetworkFirewallRuleGroup_updateRules
=== RUN   TestAccNetworkFirewallRuleGroup_updateRulesSourceList
=== PAUSE TestAccNetworkFirewallRuleGroup_updateRulesSourceList
=== RUN   TestAccNetworkFirewallRuleGroup_rulesSourceAndRuleVariables
=== PAUSE TestAccNetworkFirewallRuleGroup_rulesSourceAndRuleVariables
=== RUN   TestAccNetworkFirewallRuleGroup_updateStatefulRule
=== PAUSE TestAccNetworkFirewallRuleGroup_updateStatefulRule
=== RUN   TestAccNetworkFirewallRuleGroup_updateMultipleStatefulRules
=== PAUSE TestAccNetworkFirewallRuleGroup_updateMultipleStatefulRules
=== RUN   TestAccNetworkFirewallRuleGroup_StatefulRule_action
=== PAUSE TestAccNetworkFirewallRuleGroup_StatefulRule_action
=== RUN   TestAccNetworkFirewallRuleGroup_StatefulRule_header
=== PAUSE TestAccNetworkFirewallRuleGroup_StatefulRule_header
=== RUN   TestAccNetworkFirewallRuleGroup_updateStatelessRule
=== PAUSE TestAccNetworkFirewallRuleGroup_updateStatelessRule
=== RUN   TestAccNetworkFirewallRuleGroup_tags
=== PAUSE TestAccNetworkFirewallRuleGroup_tags
=== RUN   TestAccNetworkFirewallRuleGroup_encryptionConfiguration
=== PAUSE TestAccNetworkFirewallRuleGroup_encryptionConfiguration
=== RUN   TestAccNetworkFirewallRuleGroup_disappears
=== PAUSE TestAccNetworkFirewallRuleGroup_disappears
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_rulesSourceList
=== CONT  TestAccNetworkFirewallRuleGroup_updateRulesSourceList
=== CONT  TestAccNetworkFirewallRuleGroup_updateStatefulRule
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_statefulRule
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_statelessRuleIPv6
=== CONT  TestAccNetworkFirewallRuleGroup_rulesSourceAndRuleVariables
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_rules
=== CONT  TestAccNetworkFirewallRuleGroup_updateRules
=== CONT  TestAccNetworkFirewallRuleGroup_statelessRuleWithCustomAction
=== CONT  TestAccNetworkFirewallRuleGroup_updateStatefulRuleOptions
=== CONT  TestAccNetworkFirewallRuleGroup_statefulRuleOptions
=== CONT  TestAccNetworkFirewallRuleGroup_StatefulRule_header
=== CONT  TestAccNetworkFirewallRuleGroup_disappears
=== CONT  TestAccNetworkFirewallRuleGroup_encryptionConfiguration
=== CONT  TestAccNetworkFirewallRuleGroup_tags
=== CONT  TestAccNetworkFirewallRuleGroup_updateStatelessRule
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_updateReferenceSets
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_referenceSets
=== CONT  TestAccNetworkFirewallRuleGroup_updateMultipleStatefulRules
=== CONT  TestAccNetworkFirewallRuleGroup_StatefulRule_action
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_rulesSourceList (161.69s)
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_statelessRule
--- PASS: TestAccNetworkFirewallRuleGroup_statelessRuleWithCustomAction (162.44s)
--- PASS: TestAccNetworkFirewallRuleGroup_statefulRuleOptions (162.50s)
--- PASS: TestAccNetworkFirewallRuleGroup_StatefulRule_header (163.08s)
--- PASS: TestAccNetworkFirewallRuleGroup_updateRulesSourceList (165.97s)
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_statefulRule (167.49s)
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_statelessRuleIPv6 (168.66s)
--- PASS: TestAccNetworkFirewallRuleGroup_updateStatefulRule (168.85s)
--- PASS: TestAccNetworkFirewallRuleGroup_updateRules (168.98s)
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_referenceSets (174.12s)
--- PASS: TestAccNetworkFirewallRuleGroup_disappears (176.39s)
--- PASS: TestAccNetworkFirewallRuleGroup_tags (179.17s)
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_updateReferenceSets (191.86s)
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_rules (197.18s)
--- PASS: TestAccNetworkFirewallRuleGroup_updateStatelessRule (199.12s)
--- PASS: TestAccNetworkFirewallRuleGroup_rulesSourceAndRuleVariables (202.53s)
--- PASS: TestAccNetworkFirewallRuleGroup_updateMultipleStatefulRules (221.58s)
--- PASS: TestAccNetworkFirewallRuleGroup_StatefulRule_action (223.05s)
--- PASS: TestAccNetworkFirewallRuleGroup_encryptionConfiguration (228.18s)
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_statelessRule (134.89s)
--- PASS: TestAccNetworkFirewallRuleGroup_updateStatefulRuleOptions (330.21s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall    334.401s


```
