### PR TITLE
[Enhancement]  r/aws_bedrock_guardrail: Add action arguments to `word_policy_config`

### DIFF
--- a/.changelog/44224.txt
+++ b/.changelog/44224.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrock_guardrail: Add `input_action`, `output_action`, `input_enabled`, and `output_enabled` arguments to `word_policy_config.managed_word_lists_config` and `word_policy_config.words_config` configuration blocks
+```

--- a/internal/service/bedrock/guardrail.go
+++ b/internal/service/bedrock/guardrail.go
@@ -395,6 +395,20 @@ func (r *guardrailResource) Schema(ctx context.Context, req resource.SchemaReque
 							CustomType: fwtypes.NewListNestedObjectTypeOf[managedWordListsConfig](ctx),
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
+									"input_action": schema.StringAttribute{
+										Optional:   true,
+										CustomType: fwtypes.StringEnumType[awstypes.GuardrailWordAction](),
+									},
+									"input_enabled": schema.BoolAttribute{
+										Optional: true,
+									},
+									"output_action": schema.StringAttribute{
+										Optional:   true,
+										CustomType: fwtypes.StringEnumType[awstypes.GuardrailWordAction](),
+									},
+									"output_enabled": schema.BoolAttribute{
+										Optional: true,
+									},
 									names.AttrType: schema.StringAttribute{
 										Required:   true,
 										CustomType: fwtypes.StringEnumType[awstypes.GuardrailManagedWordsType](),
@@ -404,8 +418,26 @@ func (r *guardrailResource) Schema(ctx context.Context, req resource.SchemaReque
 						},
 						"words_config": schema.ListNestedBlock{
 							CustomType: fwtypes.NewListNestedObjectTypeOf[wordsConfig](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtLeast(1),
+								listvalidator.SizeAtMost(10000),
+							},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
+									"input_action": schema.StringAttribute{
+										Optional:   true,
+										CustomType: fwtypes.StringEnumType[awstypes.GuardrailWordAction](),
+									},
+									"input_enabled": schema.BoolAttribute{
+										Optional: true,
+									},
+									"output_action": schema.StringAttribute{
+										Optional:   true,
+										CustomType: fwtypes.StringEnumType[awstypes.GuardrailWordAction](),
+									},
+									"output_enabled": schema.BoolAttribute{
+										Optional: true,
+									},
 									"text": schema.StringAttribute{
 										Required: true,
 										Validators: []validator.String{
@@ -836,9 +868,17 @@ type wordPolicyConfig struct {
 }
 
 type managedWordListsConfig struct {
-	Type fwtypes.StringEnum[awstypes.GuardrailManagedWordsType] `tfsdk:"type"`
+	InputAction   fwtypes.StringEnum[awstypes.GuardrailWordAction]       `tfsdk:"input_action"`
+	InputEnabled  types.Bool                                             `tfsdk:"input_enabled"`
+	OutputAction  fwtypes.StringEnum[awstypes.GuardrailWordAction]       `tfsdk:"output_action"`
+	OutputEnabled types.Bool                                             `tfsdk:"output_enabled"`
+	Type          fwtypes.StringEnum[awstypes.GuardrailManagedWordsType] `tfsdk:"type"`
 }
 
 type wordsConfig struct {
-	Text types.String `tfsdk:"text"`
+	InputAction   fwtypes.StringEnum[awstypes.GuardrailWordAction] `tfsdk:"input_action"`
+	InputEnabled  types.Bool                                       `tfsdk:"input_enabled"`
+	OutputAction  fwtypes.StringEnum[awstypes.GuardrailWordAction] `tfsdk:"output_action"`
+	OutputEnabled types.Bool                                       `tfsdk:"output_enabled"`
+	Text          types.String                                     `tfsdk:"text"`
 }

--- a/internal/service/bedrock/guardrail_test.go
+++ b/internal/service/bedrock/guardrail_test.go
@@ -207,6 +207,92 @@ func TestAccBedrockGuardrail_update(t *testing.T) {
 	})
 }
 
+func TestAccBedrockGuardrail_wordConfigAction(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_bedrock_guardrail.test"
+	var guardrail bedrock.GetGuardrailOutput
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGuardrailDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGuardrailConfig_wordConfigAction(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGuardrailExists(ctx, resourceName, &guardrail),
+					resource.TestCheckResourceAttrSet(resourceName, "guardrail_arn"),
+					resource.TestCheckResourceAttr(resourceName, "blocked_input_messaging", "test"),
+					resource.TestCheckResourceAttr(resourceName, "blocked_outputs_messaging", "test"),
+					resource.TestCheckResourceAttr(resourceName, "content_policy_config.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreatedAt),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "test"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "sensitive_information_policy_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "READY"),
+					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, "DRAFT"),
+					resource.TestCheckResourceAttr(resourceName, "word_policy_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.managed_word_lists_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.managed_word_lists_config.0.input_action", string(types.GuardrailWordActionBlock)),
+					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.managed_word_lists_config.0.input_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.managed_word_lists_config.0.output_action", string(types.GuardrailWordActionBlock)),
+					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.managed_word_lists_config.0.output_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.managed_word_lists_config.0.type", string(types.GuardrailManagedWordsTypeProfanity)),
+					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.words_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.words_config.0.input_action", string(types.GuardrailWordActionBlock)),
+					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.words_config.0.input_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.words_config.0.output_action", string(types.GuardrailWordActionBlock)),
+					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.words_config.0.output_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.words_config.0.text", "HATE"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    testAccGuardrailImportStateIDFunc(resourceName),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "guardrail_id",
+			},
+			{
+				Config: testAccGuardrailConfig_wordConfig_only(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGuardrailExists(ctx, resourceName, &guardrail),
+					resource.TestCheckResourceAttrSet(resourceName, "guardrail_arn"),
+					resource.TestCheckResourceAttr(resourceName, "blocked_input_messaging", "test"),
+					resource.TestCheckResourceAttr(resourceName, "blocked_outputs_messaging", "test"),
+					resource.TestCheckResourceAttr(resourceName, "content_policy_config.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreatedAt),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "test"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "sensitive_information_policy_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "READY"),
+					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, "DRAFT"),
+					resource.TestCheckResourceAttr(resourceName, "word_policy_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.managed_word_lists_config.#", "1"),
+					resource.TestCheckNoResourceAttr(resourceName, "word_policy_config.0.managed_word_lists_config.0.input_action"),
+					resource.TestCheckNoResourceAttr(resourceName, "word_policy_config.0.managed_word_lists_config.0.input_enabled"),
+					resource.TestCheckNoResourceAttr(resourceName, "word_policy_config.0.managed_word_lists_config.0.output_action"),
+					resource.TestCheckNoResourceAttr(resourceName, "word_policy_config.0.managed_word_lists_config.0.output_enabled"),
+					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.managed_word_lists_config.0.type", string(types.GuardrailManagedWordsTypeProfanity)),
+					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.words_config.#", "1"),
+					resource.TestCheckNoResourceAttr(resourceName, "word_policy_config.0.words_config.0.input_action"),
+					resource.TestCheckNoResourceAttr(resourceName, "word_policy_config.0.words_config.0.input_enabled"),
+					resource.TestCheckNoResourceAttr(resourceName, "word_policy_config.0.words_config.0.output_action"),
+					resource.TestCheckNoResourceAttr(resourceName, "word_policy_config.0.words_config.0.output_enabled"),
+					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.words_config.0.text", "HATE"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccBedrockGuardrail_crossRegion(t *testing.T) {
 	ctx := acctest.Context(t)
 
@@ -490,6 +576,36 @@ resource "aws_bedrock_guardrail" "test" {
     }
     words_config {
       text = "HATE"
+    }
+  }
+}
+`, rName))
+}
+
+func testAccGuardrailConfig_wordConfigAction(rName string) string {
+	return acctest.ConfigCompose(
+		testAccCustomModelConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_bedrock_guardrail" "test" {
+  name                      = %[1]q
+  blocked_input_messaging   = "test"
+  blocked_outputs_messaging = "test"
+  description               = "test"
+
+  word_policy_config {
+    managed_word_lists_config {
+      input_action   = "BLOCK"
+      input_enabled  = true
+      output_action  = "BLOCK"
+      output_enabled = true
+      type           = "PROFANITY"
+    }
+    words_config {
+      input_action   = "BLOCK"
+      input_enabled  = true
+      output_action  = "BLOCK"
+      output_enabled = true
+      text           = "HATE"
     }
   }
 }

--- a/website/docs/r/bedrock_guardrail.html.markdown
+++ b/website/docs/r/bedrock_guardrail.html.markdown
@@ -189,10 +189,18 @@ The `tier_config` configuration block supports the following arguments:
 #### Managed Word Lists Config
 
 * `type` (Required) Options for managed words.
+* `input_action` (Optional) Action to take when harmful content is detected in the input. Valid values: `BLOCK`, `NONE`.
+* `input_enabled` (Optional) Whether to enable guardrail evaluation on the input. When disabled, you aren't charged for the evaluation.
+* `output_action` (Optional) Action to take when harmful content is detected in the output. Valid values: `BLOCK`, `NONE`.
+* `output_enabled` (Optional) Whether to enable guardrail evaluation on the output. When disabled, you aren't charged for the evaluation.
 
 #### Words Config
 
 * `text` (Required) The custom word text.
+* `input_action` (Optional) Action to take when harmful content is detected in the input. Valid values: `BLOCK`, `NONE`.
+* `input_enabled` (Optional) Whether to enable guardrail evaluation on the input. When disabled, you aren't charged for the evaluation.
+* `output_action` (Optional) Action to take when harmful content is detected in the output. Valid values: `BLOCK`, `NONE`.
+* `output_enabled` (Optional) Whether to enable guardrail evaluation on the output. When disabled, you aren't charged for the evaluation.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* Add action arguments to `word_policy_config` in `aws_bedrock_guardrail`
* Affected Arguments

  * `word_policy_config.managed_word_lists_config`

    - `input_action`
    - `input_enabled`
    - `output_action`
    - `output_enabled`

  * word_policy_config.words_config

    - `input_action`
    - `input_enabled`
    - `output_action`
    - `output_enabled`

  * If these arguments are not specified in the configuration, the "Read" API returns `null` for them. This means that it should not be marked as `Computed`.

### Relations
Closes #44220

### References
https://docs.aws.amazon.com/bedrock/latest/APIReference/API_CreateGuardrail.html



### Output from Acceptance Testing
```console
$ make testacc TESTS='TestAccBedrockGuardrail_' PKG=bedrock 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_bedrock_guardrail-add_action_to_word_policy_config 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/bedrock/... -v -count 1 -parallel 20 -run='TestAccBedrockGuardrail_'  -timeout 360m -vet=off
2025/09/10 22:43:41 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/10 22:43:41 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockGuardrail_tags
=== PAUSE TestAccBedrockGuardrail_tags
=== RUN   TestAccBedrockGuardrail_tags_null
=== PAUSE TestAccBedrockGuardrail_tags_null
=== RUN   TestAccBedrockGuardrail_tags_EmptyMap
=== PAUSE TestAccBedrockGuardrail_tags_EmptyMap
=== RUN   TestAccBedrockGuardrail_tags_AddOnUpdate
=== PAUSE TestAccBedrockGuardrail_tags_AddOnUpdate
=== RUN   TestAccBedrockGuardrail_tags_EmptyTag_OnCreate
=== PAUSE TestAccBedrockGuardrail_tags_EmptyTag_OnCreate
=== RUN   TestAccBedrockGuardrail_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccBedrockGuardrail_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccBedrockGuardrail_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccBedrockGuardrail_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccBedrockGuardrail_tags_DefaultTags_providerOnly
=== PAUSE TestAccBedrockGuardrail_tags_DefaultTags_providerOnly
=== RUN   TestAccBedrockGuardrail_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccBedrockGuardrail_tags_DefaultTags_nonOverlapping
=== RUN   TestAccBedrockGuardrail_tags_DefaultTags_overlapping
=== PAUSE TestAccBedrockGuardrail_tags_DefaultTags_overlapping
=== RUN   TestAccBedrockGuardrail_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccBedrockGuardrail_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccBedrockGuardrail_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccBedrockGuardrail_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccBedrockGuardrail_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccBedrockGuardrail_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccBedrockGuardrail_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccBedrockGuardrail_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccBedrockGuardrail_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccBedrockGuardrail_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccBedrockGuardrail_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccBedrockGuardrail_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccBedrockGuardrail_tags_ComputedTag_OnCreate
=== PAUSE TestAccBedrockGuardrail_tags_ComputedTag_OnCreate
=== RUN   TestAccBedrockGuardrail_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccBedrockGuardrail_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccBedrockGuardrail_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccBedrockGuardrail_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccBedrockGuardrail_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccBedrockGuardrail_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccBedrockGuardrail_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccBedrockGuardrail_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccBedrockGuardrail_basic
=== PAUSE TestAccBedrockGuardrail_basic
=== RUN   TestAccBedrockGuardrail_disappears
=== PAUSE TestAccBedrockGuardrail_disappears
=== RUN   TestAccBedrockGuardrail_kmsKey
=== PAUSE TestAccBedrockGuardrail_kmsKey
=== RUN   TestAccBedrockGuardrail_update
=== PAUSE TestAccBedrockGuardrail_update
=== RUN   TestAccBedrockGuardrail_wordConfigAction
=== PAUSE TestAccBedrockGuardrail_wordConfigAction
=== RUN   TestAccBedrockGuardrail_crossRegion
=== PAUSE TestAccBedrockGuardrail_crossRegion
=== RUN   TestAccBedrockGuardrail_enhancedActions
=== PAUSE TestAccBedrockGuardrail_enhancedActions
=== CONT  TestAccBedrockGuardrail_tags
=== CONT  TestAccBedrockGuardrail_tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccBedrockGuardrail_tags_DefaultTags_providerOnly
=== CONT  TestAccBedrockGuardrail_basic
=== CONT  TestAccBedrockGuardrail_wordConfigAction
=== CONT  TestAccBedrockGuardrail_tags_DefaultTags_emptyResourceTag
=== CONT  TestAccBedrockGuardrail_tags_ComputedTag_OnCreate
=== CONT  TestAccBedrockGuardrail_tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccBedrockGuardrail_tags_ComputedTag_OnUpdate_Replace
=== CONT  TestAccBedrockGuardrail_enhancedActions
=== CONT  TestAccBedrockGuardrail_tags_IgnoreTags_Overlap_ResourceTag
=== CONT  TestAccBedrockGuardrail_tags_IgnoreTags_Overlap_DefaultTag
=== CONT  TestAccBedrockGuardrail_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccBedrockGuardrail_tags_DefaultTags_emptyProviderOnlyTag
=== CONT  TestAccBedrockGuardrail_tags_DefaultTags_overlapping
=== CONT  TestAccBedrockGuardrail_tags_DefaultTags_nonOverlapping
=== CONT  TestAccBedrockGuardrail_crossRegion
=== CONT  TestAccBedrockGuardrail_tags_DefaultTags_updateToProviderOnly
=== CONT  TestAccBedrockGuardrail_update
=== CONT  TestAccBedrockGuardrail_kmsKey
--- PASS: TestAccBedrockGuardrail_enhancedActions (32.07s)
=== CONT  TestAccBedrockGuardrail_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccBedrockGuardrail_basic (34.81s)
=== CONT  TestAccBedrockGuardrail_disappears
--- PASS: TestAccBedrockGuardrail_crossRegion (37.26s)
=== CONT  TestAccBedrockGuardrail_tags_EmptyTag_OnUpdate_Replace
=== NAME  TestAccBedrockGuardrail_update
    guardrail_test.go:151: Step 2/3 error: Error running apply: exit status 1
        
        Error: Provider produced inconsistent result after apply
        
        When applying changes to aws_bedrock_guardrail.test, provider
        "provider[\"registry.terraform.io/hashicorp/aws\"]" produced an unexpected
        new value: .topic_policy_config[0].tier_config: was null, but now
        cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{"tier_name":cty.StringVal("CLASSIC")})}).
        
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
        
        Error: Provider produced inconsistent result after apply
        
        When applying changes to aws_bedrock_guardrail.test, provider
        "provider[\"registry.terraform.io/hashicorp/aws\"]" produced an unexpected
        new value: .content_policy_config[0].tier_config: was null, but now
        cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{"tier_name":cty.StringVal("CLASSIC")})}).
        
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
--- FAIL: TestAccBedrockGuardrail_update (50.06s)
=== CONT  TestAccBedrockGuardrail_tags_EmptyMap
--- PASS: TestAccBedrockGuardrail_kmsKey (56.11s)
=== CONT  TestAccBedrockGuardrail_tags_AddOnUpdate
--- PASS: TestAccBedrockGuardrail_tags_ComputedTag_OnCreate (59.96s)
=== CONT  TestAccBedrockGuardrail_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccBedrockGuardrail_disappears (31.48s)
=== CONT  TestAccBedrockGuardrail_tags_null
--- PASS: TestAccBedrockGuardrail_tags_DefaultTags_emptyResourceTag (66.35s)
=== CONT  TestAccBedrockGuardrail_tags_EmptyTag_OnCreate
--- PASS: TestAccBedrockGuardrail_tags_DefaultTags_nullOverlappingResourceTag (67.44s)
--- PASS: TestAccBedrockGuardrail_wordConfigAction (76.38s)
--- PASS: TestAccBedrockGuardrail_tags_ComputedTag_OnUpdate_Replace (87.52s)
--- PASS: TestAccBedrockGuardrail_tags_EmptyMap (46.44s)
--- PASS: TestAccBedrockGuardrail_tags_DefaultTags_updateToResourceOnly (96.57s)
--- PASS: TestAccBedrockGuardrail_tags_DefaultTags_nullNonOverlappingResourceTag (98.52s)
--- PASS: TestAccBedrockGuardrail_tags_IgnoreTags_Overlap_DefaultTag (101.98s)
--- PASS: TestAccBedrockGuardrail_tags_ComputedTag_OnUpdate_Add (71.77s)
--- PASS: TestAccBedrockGuardrail_tags_DefaultTags_emptyProviderOnlyTag (105.87s)
--- PASS: TestAccBedrockGuardrail_tags_EmptyTag_OnUpdate_Replace (70.52s)
--- PASS: TestAccBedrockGuardrail_tags_DefaultTags_overlapping (110.26s)
--- PASS: TestAccBedrockGuardrail_tags_null (44.71s)
--- PASS: TestAccBedrockGuardrail_tags_AddOnUpdate (64.74s)
--- PASS: TestAccBedrockGuardrail_tags_DefaultTags_nonOverlapping (128.36s)
--- PASS: TestAccBedrockGuardrail_tags_EmptyTag_OnCreate (66.56s)
--- PASS: TestAccBedrockGuardrail_tags_IgnoreTags_Overlap_ResourceTag (137.53s)
--- PASS: TestAccBedrockGuardrail_tags (137.82s)
--- PASS: TestAccBedrockGuardrail_tags_DefaultTags_providerOnly (139.00s)
--- PASS: TestAccBedrockGuardrail_tags_EmptyTag_OnUpdate_Add (80.98s)
--- PASS: TestAccBedrockGuardrail_tags_DefaultTags_updateToProviderOnly (151.57s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/bedrock    156.413s
FAIL
make: *** [testacc] Error 1
```

Failure is unrelated to this change.
It is the same as https://github.com/hashicorp/terraform-provider-aws/pull/43702#pullrequestreview-3089560240