### PR TITLE
Added `deletion_protection` to `aws_msk_cluster`

### DIFF
--- a/.changelog/44233.txt
+++ b/.changelog/44233.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_msk_cluster: Add `deletion_protection` argument
+```

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -528,6 +528,10 @@ func resourceCluster() *schema.Resource {
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			names.AttrDeletionProtection: {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"zookeeper_connect_string": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -1007,6 +1011,10 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KafkaClient(ctx)
+
+	if d.Get(names.AttrDeletionProtection).(bool) {
+		return sdkdiag.AppendErrorf(diags, "cannot delete MSK Cluster (%s): deletion_protection is enabled", d.Id())
+	}
 
 	log.Printf("[DEBUG] Deleting MSK Cluster: %s", d.Id())
 	_, err := conn.DeleteCluster(ctx, &kafka.DeleteClusterInput{

--- a/internal/service/kafka/cluster_test.go
+++ b/internal/service/kafka/cluster_test.go
@@ -2424,7 +2424,7 @@ resource "aws_msk_cluster" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func TestAccMSKCluster_deletionProtection(t *testing.T) {
+func TestAccKafkaCluster_deletionProtection(t *testing.T) {
 	ctx := acctest.Context(t)
 	var cluster1 types.ClusterInfo
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -210,6 +210,9 @@ This resource supports the following arguments:
 * `number_of_broker_nodes` - (Required) The desired total number of broker nodes in the kafka cluster.  It must be a multiple of the number of specified client subnets.
 * `client_authentication` - (Optional) Configuration block for specifying a client authentication. See [client_authentication Argument Reference](#client_authentication-argument-reference) below.
 * `configuration_info` - (Optional) Configuration block for specifying an MSK Configuration to attach to Kafka brokers. See [configuration_info Argument Reference](#configuration_info-argument-reference) below.
+* `deletion_protection` - (Optional) If the MSK cluster should have deletion protection enabled.
+  The cluster can't be deleted when this value is set to `true`.
+  The default is `false`.
 * `encryption_info` - (Optional) Configuration block for specifying encryption. See [encryption_info Argument Reference](#encryption_info-argument-reference) below.
 * `enhanced_monitoring` - (Optional) Specify the desired enhanced MSK CloudWatch monitoring level. See [Monitoring Amazon MSK with Amazon CloudWatch](https://docs.aws.amazon.com/msk/latest/developerguide/monitoring.html)
 * `open_monitoring` - (Optional) Configuration block for JMX and Node monitoring for the MSK cluster. See [open_monitoring Argument Reference](#open_monitoring-argument-reference) below.


### PR DESCRIPTION
Adds deletion protection support to the `aws_msk_cluster` resource, implementing Terraform-level protection similar to the existing `aws_rds_cluster` resource.

###   Reasoning

Since you cannot use variables in the `lifecycle` block, preventing destruction is either always on or always off. This would allow for it to be variable, like with `aws_rds_cluster`, so users can turn it off for development if they so choose, and on for production. While AWS MSK does not currently support deletion protection at the API level (unlike RDS), this implementation provides Terraform-level protection, preventing cluster deletion when enabled.

###   Changes Made

  - Added deletion_protection optional boolean argument to `aws_msk_cluster` resource schema
  - Implemented deletion protection logic in the delete function to block deletion when enabled
  - Added comprehensive test coverage following existing patterns from `aws_rds_cluster` tests
  - Updated resource documentation to match `aws_rds_cluster` documentation format

###   Expected User Experience

  - Users can now set `deletion_protection = true` to protect MSK clusters from accidental deletion
  - Attempting to delete a protected cluster will result in a clear error message
  - To delete a protected cluster, users must first set `deletion_protection = false` and apply the change
  - The parameter is optional and defaults to false to maintain backward compatibility

  ### Testing

  - Added `TestAccMSKCluster_deletionProtection` test that validates both enabling and disabling deletion protection
  - Test includes proper import state verification
  - Follows the same test pattern established by `TestAccRDSCluster_deletionProtection`

  Closes #44209