### PR TITLE
r/aws_rds_global_cluster: remove `engine` and `source_db_cluster_identifier` conflict

### DIFF
--- a/.changelog/44252.txt
+++ b/.changelog/44252.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_rds_global_cluster: Remove provider-side conflict between `source_db_cluster_identifier` and `engine` arguments
+```

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -71,12 +71,11 @@ func resourceGlobalCluster() *schema.Resource {
 				Computed: true,
 			},
 			names.AttrEngine: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"source_db_cluster_identifier"},
-				ValidateFunc:  validation.StringInSlice(globalClusterEngine_Values(), false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(globalClusterEngine_Values(), false),
 			},
 			"engine_lifecycle_support": {
 				Type:         schema.TypeString,
@@ -124,12 +123,11 @@ func resourceGlobalCluster() *schema.Resource {
 				Computed: true,
 			},
 			"source_db_cluster_identifier": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{names.AttrEngine},
-				RequiredWith:  []string{names.AttrForceDestroy},
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				RequiredWith: []string{names.AttrForceDestroy},
 			},
 			names.AttrStorageEncrypted: {
 				Type:     schema.TypeBool,
@@ -175,6 +173,10 @@ func resourceGlobalClusterCreate(ctx context.Context, d *schema.ResourceData, me
 
 	if v, ok := d.GetOk("source_db_cluster_identifier"); ok {
 		input.SourceDBClusterIdentifier = aws.String(v.(string))
+		// Engine and engine version cannot be sent during create requests if a source
+		// DB cluster is specified.
+		input.Engine = nil
+		input.EngineVersion = nil
 	}
 
 	if v, ok := d.GetOk(names.AttrStorageEncrypted); ok {

--- a/internal/service/rds/global_cluster_test.go
+++ b/internal/service/rds/global_cluster_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -623,6 +624,49 @@ func TestAccRDSGlobalCluster_storageEncrypted(t *testing.T) {
 					testAccCheckGlobalClusterRecreated(&globalCluster1, &globalCluster2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStorageEncrypted, acctest.CtFalse),
 				),
+			},
+		},
+	})
+}
+
+// Creates a global cluster from an existing regional source, then completes a major version upgrade
+func TestAccRDSGlobalCluster_SourceDBClusterIdentifier_EngineVersion_updateMajor(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.GlobalCluster
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_rds_global_cluster.test"
+	engineVersion := "15.10"
+	engineVersionUpdated := "16.6"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalCluster(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGlobalClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalClusterConfig_sourceClusterIDEngineVersion(rName, engineVersion),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlobalClusterExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, engineVersion),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				Config: testAccGlobalClusterConfig_sourceClusterIDEngineVersion(rName, engineVersionUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlobalClusterExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, engineVersionUpdated),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})
@@ -1278,6 +1322,40 @@ resource "aws_rds_global_cluster" "test" {
   source_db_cluster_identifier = aws_rds_cluster.test.arn
 }
 `, rName)
+}
+
+func testAccGlobalClusterConfig_sourceClusterIDEngineVersion(rName, engineVersion string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster" "test" {
+  cluster_identifier  = %[1]q
+  engine              = "aurora-postgresql"
+  engine_version      = %[2]q
+  master_password     = "mustbeeightcharacters"
+  master_username     = "test"
+  skip_final_snapshot = true
+  database_name       = "database04"
+
+  lifecycle {
+    ignore_changes = [global_cluster_identifier, engine_version]
+  }
+}
+
+resource "aws_rds_cluster_instance" "test" {
+  identifier         = %[1]q
+  cluster_identifier = aws_rds_cluster.test.id
+  engine             = aws_rds_cluster.test.engine
+  engine_version     = aws_rds_cluster.test.engine_version
+  instance_class     = "db.r5.large"
+}
+
+resource "aws_rds_global_cluster" "test" {
+  force_destroy                = true
+  global_cluster_identifier    = %[1]q
+  engine                       = aws_rds_cluster.test.engine
+  engine_version               = %[2]q
+  source_db_cluster_identifier = aws_rds_cluster.test.arn
+}
+`, rName, engineVersion)
 }
 
 func testAccGlobalClusterConfig_storageEncrypted(rName string, storageEncrypted bool) string {

--- a/website/docs/r/rds_global_cluster.html.markdown
+++ b/website/docs/r/rds_global_cluster.html.markdown
@@ -211,19 +211,24 @@ resource "aws_rds_cluster_instance" "primary" {
 
 ## Argument Reference
 
-This resource supports the following arguments:
+The following arguments are required:
 
-* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `global_cluster_identifier` - (Required, Forces new resources) Global cluster identifier.
+
+The following arguments are optional:
+
 * `database_name` - (Optional, Forces new resources) Name for an automatically created database on cluster creation. Terraform will only perform drift detection if a configuration value is provided.
 * `deletion_protection` - (Optional) If the Global Cluster should have deletion protection enabled. The database can't be deleted when this value is set to `true`. The default is `false`.
 * `engine` - (Optional, Forces new resources) Name of the database engine to be used for this DB cluster. Terraform will only perform drift detection if a configuration value is provided. Valid values: `aurora`, `aurora-mysql`, `aurora-postgresql`. Defaults to `aurora`. Conflicts with `source_db_cluster_identifier`.
 * `engine_lifecycle_support` - (Optional) The life cycle type for this DB instance. This setting applies only to Aurora PostgreSQL-based global databases. Valid values are `open-source-rds-extended-support`, `open-source-rds-extended-support-disabled`. Default value is `open-source-rds-extended-support`. [Using Amazon RDS Extended Support]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/extended-support.html
 * `engine_version` - (Optional) Engine version of the Aurora global database. The `engine`, `engine_version`, and `instance_class` (on the `aws_rds_cluster_instance`) must together support global databases. See [Using Amazon Aurora global databases](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html) for more information. By upgrading the engine version, Terraform will upgrade cluster members. **NOTE:** To avoid an `inconsistent final plan` error while upgrading, use the `lifecycle` `ignore_changes` for `engine_version` meta argument on the associated `aws_rds_cluster` resource as shown above in [Upgrading Engine Versions](#upgrading-engine-versions) example.
 * `force_destroy` - (Optional) Enable to remove DB Cluster members from Global Cluster on destroy. Required with `source_db_cluster_identifier`.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `source_db_cluster_identifier` - (Optional) Amazon Resource Name (ARN) to use as the primary DB Cluster of the Global Cluster on creation. Terraform cannot perform drift detection of this value. **NOTE:** After initial creation, this argument can be removed and replaced with `engine` and `engine_version`. This allows upgrading the engine version of the Global Cluster.
 * `storage_encrypted` - (Optional, Forces new resources) Specifies whether the DB cluster is encrypted. The default is `false` unless `source_db_cluster_identifier` is specified and encrypted. Terraform will only perform drift detection if a configuration value is provided.
 * `tags` - (Optional) A map of tags to assign to the DB cluster. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+~> When both `source_db_cluster_identifier` and `engine`/`engine_version` are set, all engine related values will be ignored during creation. The global cluster will inherit the `engine` and `engine_version` values from the source cluster. After the first apply, any differences between the inherited and configured values will trigger an in-place update.
 
 ## Attribute Reference
 


### PR DESCRIPTION



### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This enables both arguments to be set upon creation, rather than requiring users to set a source DB for the initial global cluster creation and removing it to set `engine` and `engine_version` for subsequent major version upgrades. During create operations the `engine` and `engine_version` values will be ignored if `source_db_cluster_identifier` is set. If the engine version varies from what is inherited from the source cluster a second change will be planned immediately following the initial apply.

To support future major version upgrades on a promoted global cluster, the following configuration is now valid.

```terraform
resource "aws_rds_global_cluster" "test" {
  force_destroy                = true
  global_cluster_identifier    = "my-cluster"
  engine                       = local.engine
  engine_version               = local.engine_version
  source_db_cluster_identifier = aws_rds_cluster.test.arn
}
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28761
Closes #44251 (this solution is preferred over the write-only alternative)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make testacc PKG=rds TESTS=TestAccRDSGlobalCluster_SourceDBClusterIdentifier
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-rds_global_cluster-rm-engine-conflict 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSGlobalCluster_SourceDBClusterIdentifier'  -timeout 360m -vet=off
2025/09/11 13:05:11 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/11 13:05:11 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccRDSGlobalCluster_SourceDBClusterIdentifier_databaseName (192.02s)
--- PASS: TestAccRDSGlobalCluster_SourceDBClusterIdentifier_storageEncrypted (192.05s)
--- PASS: TestAccRDSGlobalCluster_SourceDBClusterIdentifier_EngineVersion_updateMajor (1849.39s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        1855.979s
```

```console
% make testacc PKG=rds TESTS=TestAccRDSGlobalCluster_SourceDBClusterIdentifier
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-rds_global_cluster-rm-engine-conflict 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSGlobalCluster_SourceDBClusterIdentifier'  -timeout 360m -vet=off
2025/09/11 13:05:11 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/11 13:05:11 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccRDSGlobalCluster_SourceDBClusterIdentifier_databaseName (192.02s)
--- PASS: TestAccRDSGlobalCluster_SourceDBClusterIdentifier_storageEncrypted (192.05s)
--- PASS: TestAccRDSGlobalCluster_SourceDBClusterIdentifier_EngineVersion_updateMajor (1849.39s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        1855.979s
```

```console
% make testacc PKG=rds TESTS=TestAccRDSGlobalCluster_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-rds_global_cluster-rm-engine-conflict 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSGlobalCluster_'  -timeout 360m -vet=off
2025/09/12 10:00:33 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/12 10:00:33 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccRDSGlobalCluster_forceDestroy (31.24s)
=== CONT  TestAccRDSGlobalCluster_EngineVersion_auroraPostgreSQL
=== NAME  TestAccRDSGlobalCluster_storageEncrypted
    global_cluster_test.go:602: Step 3/3 error: Error running apply: exit status 1

        Error: creating RDS Global Cluster (tf-acc-test-1266092778766974036): operation error RDS: CreateGlobalCluster, https response error StatusCode: 400, RequestID: 15aa4798-dc3b-40c7-98b1-4e1d443d2d14, GlobalClusterAlreadyExistsFault: Global cluster tf-acc-test-1266092778766974036 already exists

          with aws_rds_global_cluster.test,
          on terraform_plugin_test.tf line 12, in resource "aws_rds_global_cluster" "test":
          12: resource "aws_rds_global_cluster" "test" {

--- PASS: TestAccRDSGlobalCluster_tags_DefaultTags_emptyProviderOnlyTag (42.04s)
=== CONT  TestAccRDSGlobalCluster_sourceDBClusterIdentifier
--- FAIL: TestAccRDSGlobalCluster_storageEncrypted (42.79s)
=== CONT  TestAccRDSGlobalCluster_EngineVersion_auroraMySQL
--- PASS: TestAccRDSGlobalCluster_tags_DefaultTags_nullOverlappingResourceTag (44.13s)
=== CONT  TestAccRDSGlobalCluster_tags_AddOnUpdate
--- PASS: TestAccRDSGlobalCluster_tags_DefaultTags_emptyResourceTag (44.16s)
=== CONT  TestAccRDSGlobalCluster_tags_EmptyTag_OnCreate
--- PASS: TestAccRDSGlobalCluster_tags_DefaultTags_nullNonOverlappingResourceTag (44.55s)
=== CONT  TestAccRDSGlobalCluster_disappears
--- PASS: TestAccRDSGlobalCluster_tags_ComputedTag_OnCreate (45.52s)
=== CONT  TestAccRDSGlobalCluster_databaseName
--- PASS: TestAccRDSGlobalCluster_tags_DefaultTags_updateToProviderOnly (65.49s)
=== CONT  TestAccRDSGlobalCluster_basic
--- PASS: TestAccRDSGlobalCluster_EngineVersion_auroraPostgreSQL (35.94s)
=== CONT  TestAccRDSGlobalCluster_tags_EmptyMap
--- PASS: TestAccRDSGlobalCluster_tags_DefaultTags_updateToResourceOnly (67.40s)
=== CONT  TestAccRDSGlobalCluster_EngineVersion_updateMajor
--- PASS: TestAccRDSGlobalCluster_tags_ComputedTag_OnUpdate_Add (69.44s)
=== CONT  TestAccRDSGlobalCluster_EngineVersion_updateMinorMultiRegion
--- PASS: TestAccRDSGlobalCluster_tags_ComputedTag_OnUpdate_Replace (73.49s)
=== CONT  TestAccRDSGlobalCluster_tags_null
--- PASS: TestAccRDSGlobalCluster_disappears (30.15s)
=== CONT  TestAccRDSGlobalCluster_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccRDSGlobalCluster_EngineVersion_auroraMySQL (35.53s)
=== CONT  TestAccRDSGlobalCluster_tags_DefaultTags_providerOnly
=== NAME  TestAccRDSGlobalCluster_databaseName
    global_cluster_test.go:171: Step 3/3 error: Error running apply: exit status 1

        Error: creating RDS Global Cluster (tf-acc-test-5146216102148161976): operation error RDS: CreateGlobalCluster, https response error StatusCode: 400, RequestID: bf20209e-2aa5-4eca-89c9-2f7c8065cfe0, GlobalClusterAlreadyExistsFault: Global cluster tf-acc-test-5146216102148161976 already exists

          with aws_rds_global_cluster.test,
          on terraform_plugin_test.tf line 12, in resource "aws_rds_global_cluster" "test":
          12: resource "aws_rds_global_cluster" "test" {

--- FAIL: TestAccRDSGlobalCluster_databaseName (38.02s)
=== CONT  TestAccRDSGlobalCluster_tags_DefaultTags_nonOverlapping
--- PASS: TestAccRDSGlobalCluster_tags_IgnoreTags_Overlap_DefaultTag (84.98s)
=== CONT  TestAccRDSGlobalCluster_EngineVersion_updateMinor
--- PASS: TestAccRDSGlobalCluster_deletionProtection (87.05s)
=== CONT  TestAccRDSGlobalCluster_engineLifecycleSupport_disabled
--- PASS: TestAccRDSGlobalCluster_basic (30.27s)
=== CONT  TestAccRDSGlobalCluster_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccRDSGlobalCluster_tags_EmptyTag_OnUpdate_Add (95.97s)
--- PASS: TestAccRDSGlobalCluster_tags_DefaultTags_overlapping (101.57s)
--- PASS: TestAccRDSGlobalCluster_tags_AddOnUpdate (58.35s)
--- PASS: TestAccRDSGlobalCluster_tags_EmptyTag_OnCreate (60.96s)
--- PASS: TestAccRDSGlobalCluster_tags_EmptyMap (44.07s)
--- PASS: TestAccRDSGlobalCluster_engineLifecycleSupport_disabled (24.83s)
--- PASS: TestAccRDSGlobalCluster_tags_null (40.28s)
--- PASS: TestAccRDSGlobalCluster_tags (116.69s)
--- PASS: TestAccRDSGlobalCluster_tags_EmptyTag_OnUpdate_Replace (35.37s)
--- PASS: TestAccRDSGlobalCluster_tags_IgnoreTags_Overlap_ResourceTag (59.60s)
--- PASS: TestAccRDSGlobalCluster_tags_DefaultTags_nonOverlapping (58.38s)
--- PASS: TestAccRDSGlobalCluster_tags_DefaultTags_providerOnly (76.94s)
--- PASS: TestAccRDSGlobalCluster_SourceDBClusterIdentifier_storageEncrypted (194.09s)
--- PASS: TestAccRDSGlobalCluster_SourceDBClusterIdentifier_databaseName (204.21s)
--- PASS: TestAccRDSGlobalCluster_sourceDBClusterIdentifier (193.83s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_updateMinor (1283.77s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_updateMajor (1709.34s)
--- PASS: TestAccRDSGlobalCluster_SourceDBClusterIdentifier_EngineVersion_updateMajor (1865.42s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_updateMinorMultiRegion (3051.41s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_updateMajorMultiRegion (3467.62s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/rds        3474.432s
```

Failures are pre-existing and unrelated to this change.