### PR TITLE
r/aws_scheduler_schedule: add `action_after_completion` argument

### DIFF
--- a/.changelog/44264.txt
+++ b/.changelog/44264.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_scheduler_schedule: Add `action_after_completion` argument
+```

--- a/internal/service/scheduler/schedule.go
+++ b/internal/service/scheduler/schedule.go
@@ -45,6 +45,12 @@ func resourceSchedule() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"action_after_completion": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ValidateDiagFunc: enum.Validate[types.ActionAfterCompletion](),
+			},
 			names.AttrARN: {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -442,6 +448,10 @@ func resourceScheduleCreate(ctx context.Context, d *schema.ResourceData, meta an
 		ScheduleExpression: aws.String(d.Get(names.AttrScheduleExpression).(string)),
 	}
 
+	if v, ok := d.Get("action_after_completion").(string); ok && v != "" {
+		in.ActionAfterCompletion = types.ActionAfterCompletion(v)
+	}
+
 	if v, ok := d.Get(names.AttrDescription).(string); ok && v != "" {
 		in.Description = aws.String(v)
 	}
@@ -532,6 +542,7 @@ func resourceScheduleRead(ctx context.Context, d *schema.ResourceData, meta any)
 		return create.AppendDiagError(diags, names.Scheduler, create.ErrActionReading, ResNameSchedule, d.Id(), err)
 	}
 
+	d.Set("action_after_completion", out.ActionAfterCompletion)
 	d.Set(names.AttrARN, out.Arn)
 	d.Set(names.AttrDescription, out.Description)
 
@@ -577,6 +588,10 @@ func resourceScheduleUpdate(ctx context.Context, d *schema.ResourceData, meta an
 		Name:               aws.String(d.Get(names.AttrName).(string)),
 		ScheduleExpression: aws.String(d.Get(names.AttrScheduleExpression).(string)),
 		Target:             expandTarget(ctx, d.Get(names.AttrTarget).([]any)[0].(map[string]any)),
+	}
+
+	if v, ok := d.Get("action_after_completion").(string); ok && v != "" {
+		in.ActionAfterCompletion = types.ActionAfterCompletion(v)
 	}
 
 	if v, ok := d.Get(names.AttrDescription).(string); ok && v != "" {

--- a/website/docs/r/scheduler_schedule.html.markdown
+++ b/website/docs/r/scheduler_schedule.html.markdown
@@ -72,13 +72,14 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `action_after_completion` - (Optional) Action that applies to the schedule after completing invocation of the target. Valid values are `NONE` and `DELETE`. Defaults to `NONE`.
 * `description` - (Optional) Brief description of the schedule.
 * `end_date` - (Optional) The date, in UTC, before which the schedule can invoke its target. Depending on the schedule's recurrence expression, invocations might stop on, or before, the end date you specify. EventBridge Scheduler ignores the end date for one-time schedules. Example: `2030-01-01T01:00:00Z`.
 * `group_name` - (Optional, Forces new resource) Name of the schedule group to associate with this schedule. When omitted, the `default` schedule group is used.
 * `kms_key_arn` - (Optional) ARN for the customer managed KMS key that EventBridge Scheduler will use to encrypt and decrypt your data.
 * `name` - (Optional, Forces new resource) Name of the schedule. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `schedule_expression_timezone` - (Optional) Timezone in which the scheduling expression is evaluated. Defaults to `UTC`. Example: `Australia/Sydney`.
 * `start_date` - (Optional) The date, in UTC, after which the schedule can begin invoking its target. Depending on the schedule's recurrence expression, invocations might occur on, or after, the start date you specify. EventBridge Scheduler ignores the start date for one-time schedules. Example: `2030-01-01T01:00:00Z`.
 * `state` - (Optional) Specifies whether the schedule is enabled or disabled. One of: `ENABLED` (default), `DISABLED`.


### PR DESCRIPTION




<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This argument aligns with the `ActionAfterCompletion` field in the Create and Update APIs. When unset, the value defaults to `NONE`.

- https://docs.aws.amazon.com/scheduler/latest/APIReference/API_CreateSchedule.html#scheduler-CreateSchedule-request-ActionAfterCompletion

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38166 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=scheduler TESTS=TestAccSchedulerSchedule_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 tmp1 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/scheduler/... -v -count 1 -parallel 20 -run='TestAccSchedulerSchedule_'  -timeout 360m -vet=off
2025/09/12 12:02:05 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/12 12:02:05 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccSchedulerSchedule_basic (69.73s)
=== CONT  TestAccSchedulerSchedule_targetECSParameters
--- PASS: TestAccSchedulerSchedule_nameGenerated (72.83s)
=== CONT  TestAccSchedulerSchedule_disappears
--- PASS: TestAccSchedulerSchedule_namePrefix (75.09s)
=== CONT  TestAccSchedulerSchedule_targetARN
--- PASS: TestAccSchedulerSchedule_groupName (80.71s)
=== CONT  TestAccSchedulerSchedule_state
--- PASS: TestAccSchedulerSchedule_targetInput (98.37s)
--- PASS: TestAccSchedulerSchedule_scheduleExpression (102.96s)
--- PASS: TestAccSchedulerSchedule_targetRoleARN (105.14s)
--- PASS: TestAccSchedulerSchedule_actionAfterCompletion (108.99s)
--- PASS: TestAccSchedulerSchedule_startDate (119.81s)
--- PASS: TestAccSchedulerSchedule_flexibleTimeWindow (120.33s)
--- PASS: TestAccSchedulerSchedule_scheduleExpressionTimezone (121.86s)
--- PASS: TestAccSchedulerSchedule_targetRetryPolicy (123.36s)
--- PASS: TestAccSchedulerSchedule_kmsKeyARN (124.96s)
--- PASS: TestAccSchedulerSchedule_description (125.05s)
--- PASS: TestAccSchedulerSchedule_endDate (125.43s)
--- PASS: TestAccSchedulerSchedule_disappears (53.28s)
--- PASS: TestAccSchedulerSchedule_targetSQSParameters (126.52s)
--- PASS: TestAccSchedulerSchedule_targetEventBridgeParameters (127.22s)
--- PASS: TestAccSchedulerSchedule_targetDeadLetterConfig (127.23s)
--- PASS: TestAccSchedulerSchedule_targetKinesisParameters (136.70s)
--- PASS: TestAccSchedulerSchedule_targetARN (68.21s)
--- PASS: TestAccSchedulerSchedule_targetSageMakerPipelineParameters (146.42s)
--- PASS: TestAccSchedulerSchedule_state (76.45s)
--- PASS: TestAccSchedulerSchedule_targetECSParameters (124.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/scheduler  201.405s
```
