### PR TITLE
sweepers: `aws_acm_certificate` and `aws_api_gateway_domain_name`

### DIFF
--- a/internal/service/acm/sweep.go
+++ b/internal/service/acm/sweep.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/acm"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
@@ -48,7 +50,12 @@ func sweepCertificates(region string) error {
 	conn := client.ACMClient(ctx)
 	var sweepResources []sweep.Sweepable
 
-	input := acm.ListCertificatesInput{}
+	input := acm.ListCertificatesInput{
+		Includes: &awstypes.Filters{
+			// By default, ListCertificates only returns  RSA_1024 and RSA_2048 certificates
+			KeyTypes: enum.EnumValues[awstypes.KeyAlgorithm](),
+		},
+	}
 	pages := acm.NewListCertificatesPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)

--- a/internal/service/apigateway/sweep.go
+++ b/internal/service/apigateway/sweep.go
@@ -305,7 +305,7 @@ func sweepDomainNames(region string) error {
 		for _, v := range page.Items {
 			r := resourceDomainName()
 			d := r.Data(nil)
-			d.SetId(aws.ToString(v.DomainName))
+			d.SetId(domainNameCreateResourceID(aws.ToString(v.DomainName), aws.ToString(v.DomainNameId)))
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Fixes to sweepers:

* `aws_acm_certificate`: By default `ListCertificates` doesn't list all certificate types
* `aws_api_gateway_domain_name`: Failed to delete domain names with private endpoints
