### PR TITLE
Documentation: Specify that an SSM Parameter can be used in parent_image argument

### DIFF
--- a/website/docs/r/imagebuilder_image_recipe.html.markdown
+++ b/website/docs/r/imagebuilder_image_recipe.html.markdown
@@ -50,7 +50,7 @@ The following arguments are required:
 
 * `component` - (Required) Ordered configuration block(s) with components for the image recipe. Detailed below.
 * `name` - (Required) Name of the image recipe.
-* `parent_image` - (Required) The image recipe uses this image as a base from which to build your customized image. The value can be the base image ARN or an AMI ID.
+* `parent_image` - (Required) The image recipe uses this image as a base from which to build your customized image. The value can be the base image ARN, an AMI ID, or an SSM Parameter referencing the AMI. For an SSM Parameter, enter the prefix `ssm:`, followed by the parameter name or ARN.
 * `version` - (Required) The semantic version of the image recipe, which specifies the version in the following format, with numeric values in each position to indicate a specific version: major.minor.patch. For example: 1.0.0.
 
 The following arguments are optional:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

N/A

## Changes to Security Controls

None

## Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR updates the documentation as specified in #44161 to indicate that `aws_imagebuilder_image_recipe`'s `parent_image` argument accepts the `ssm:`-prefixed Name or ARN of an SSM Parameter containing the AMI data. This change documents new  functionality - added by Amazon on the underlying API - that was confirmed working in Terraform. 

## Relations
Closes #44161

## References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- CLI (find in page: `--parent-image`): https://docs.aws.amazon.com/cli/latest/reference/imagebuilder/create-image-recipe.html
- For additional references, see the linked issue.

## Output from Acceptance Testing
N/A
