### PR TITLE
TechDebt: Document import by identity for parameterized resources

### DIFF
--- a/website/docs/r/appflow_connector_profile.html.markdown
+++ b/website/docs/r/appflow_connector_profile.html.markdown
@@ -324,6 +324,32 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_appflow_connector_profile.example
+  identity = {
+    name = "example_profile"
+  }
+}
+
+resource "aws_appflow_connector_profile" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `name` (String) Name of the Appflow connector profile.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import AppFlow Connector Profile using the connector profile `name`. For example:
 
 ```terraform

--- a/website/docs/r/appflow_flow.html.markdown
+++ b/website/docs/r/appflow_flow.html.markdown
@@ -418,6 +418,32 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_appflow_flow.example
+  identity = {
+    name = "example-flow"
+  }
+}
+
+resource "aws_appflow_flow" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `name` (String) Name of the AppFlow flow.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import AppFlow flows using the `name`. For example:
 
 ```terraform

--- a/website/docs/r/cloudfront_key_value_store.html.markdown
+++ b/website/docs/r/cloudfront_key_value_store.html.markdown
@@ -47,6 +47,31 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_cloudfront_key_value_store.example
+  identity = {
+    name = "example_store"
+  }
+}
+
+resource "aws_cloudfront_key_value_store" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `name` (String) Name of the CloudFront Key Value Store.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import CloudFront Key Value Store using the `name`. For example:
 
 ```terraform

--- a/website/docs/r/cloudfrontkeyvaluestore_key.html.markdown
+++ b/website/docs/r/cloudfrontkeyvaluestore_key.html.markdown
@@ -53,7 +53,7 @@ import {
   to = aws_cloudfrontkeyvaluestore_key.example
   identity = {
     key_value_store_arn = "arn:aws:cloudfront::111111111111:key-value-store/8562g61f-caba-2845-9d99-b97diwae5d3c"
-    key = "someKey"
+    key                 = "someKey"
   }
 }
 

--- a/website/docs/r/cloudfrontkeyvaluestore_key.html.markdown
+++ b/website/docs/r/cloudfrontkeyvaluestore_key.html.markdown
@@ -46,6 +46,33 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_cloudfrontkeyvaluestore_key.example
+  identity = {
+    key_value_store_arn = "arn:aws:cloudfront::111111111111:key-value-store/8562g61f-caba-2845-9d99-b97diwae5d3c"
+    key = "someKey"
+  }
+}
+
+resource "aws_cloudfrontkeyvaluestore_key" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `key_value_store_arn` (String) ARN of the CloudFront Key Value Store.
+* `key` (String) Key name.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import CloudFront KeyValueStore Key using the `key_value_store_arn` and 'key' separated by `,`. For example:
 
 ```terraform

--- a/website/docs/r/cloudwatch_event_rule.html.markdown
+++ b/website/docs/r/cloudwatch_event_rule.html.markdown
@@ -91,7 +91,7 @@ In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp
 import {
   to = aws_cloudwatch_event_rule.example
   identity = {
-    name = "capture-console-sign-in"
+    name           = "capture-console-sign-in"
     event_bus_name = "example-event-bus"
   }
 }
@@ -110,6 +110,7 @@ resource "aws_cloudwatch_event_rule" "example" {
 #### Optional
 
 * `event_bus_name` (String) Name of the event bus. If omitted, `default` is used.
+
 - `account_id` (String) AWS Account where this resource is managed.
 - `region` (String) Region where this resource is managed.
 

--- a/website/docs/r/cloudwatch_event_rule.html.markdown
+++ b/website/docs/r/cloudwatch_event_rule.html.markdown
@@ -85,11 +85,39 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_cloudwatch_event_rule.example
+  identity = {
+    name = "capture-console-sign-in"
+    event_bus_name = "example-event-bus"
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `name` (String) Name of the EventBridge rule.
+
+#### Optional
+
+* `event_bus_name` (String) Name of the event bus. If omitted, `default` is used.
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import EventBridge Rules using the `event_bus_name/rule_name` (if you omit `event_bus_name`, the `default` event bus will be used). For example:
 
 ```terraform
 import {
-  to = aws_cloudwatch_event_rule.console
+  to = aws_cloudwatch_event_rule.example
   id = "example-event-bus/capture-console-sign-in"
 }
 ```
@@ -97,5 +125,5 @@ import {
 Using `terraform import`, import EventBridge Rules using the `event_bus_name/rule_name` (if you omit `event_bus_name`, the `default` event bus will be used). For example:
 
 ```console
-% terraform import aws_cloudwatch_event_rule.console example-event-bus/capture-console-sign-in
+% terraform import aws_cloudwatch_event_rule.example example-event-bus/capture-console-sign-in
 ```

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -690,11 +690,41 @@ This resource exports no additional attributes.
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_cloudwatch_event_target.example
+  identity = {
+    event_bus_name = "default"
+    rule = "rule-name"
+    target_id = "target-id"
+  }
+}
+
+resource "aws_cloudwatch_event_target" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `event_bus_name` (String) Event bus name for the target.
+* `rule` (String) Rule name for the target.
+* `target_id` (String) Target ID.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import EventBridge Targets using `event_bus_name/rule-name/target-id` (if you omit `event_bus_name`, the `default` event bus will be used). For example:
 
  ```terraform
 import {
-  to = aws_cloudwatch_event_target.test-event-target
+  to = aws_cloudwatch_event_target.example
   id = "rule-name/target-id"
 }
 ```
@@ -702,5 +732,5 @@ import {
 Using `terraform import`, import EventBridge Targets using `event_bus_name/rule-name/target-id` (if you omit `event_bus_name`, the `default` event bus will be used). For example:
 
  ```console
-% terraform import aws_cloudwatch_event_target.test-event-target rule-name/target-id
+% terraform import aws_cloudwatch_event_target.example rule-name/target-id
 ```

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -697,8 +697,8 @@ import {
   to = aws_cloudwatch_event_target.example
   identity = {
     event_bus_name = "default"
-    rule = "rule-name"
-    target_id = "target-id"
+    rule           = "rule-name"
+    target_id      = "target-id"
   }
 }
 

--- a/website/docs/r/cloudwatch_log_group.html.markdown
+++ b/website/docs/r/cloudwatch_log_group.html.markdown
@@ -49,11 +49,37 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_cloudwatch_log_group.example
+  identity = {
+    name = "yada"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `name` (String) Name of the CloudWatch log group.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Cloudwatch Log Groups using the `name`. For example:
 
 ```terraform
 import {
-  to = aws_cloudwatch_log_group.test_group
+  to = aws_cloudwatch_log_group.example
   id = "yada"
 }
 ```
@@ -61,5 +87,5 @@ import {
 Using `terraform import`, import Cloudwatch Log Groups using the `name`. For example:
 
 ```console
-% terraform import aws_cloudwatch_log_group.test_group yada
+% terraform import aws_cloudwatch_log_group.example yada
 ```

--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -249,11 +249,37 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_cloudwatch_metric_alarm.example
+  identity = {
+    alarm_name = "alarm-12345"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `alarm_name` (String) Name of the CloudWatch metric alarm.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import CloudWatch Metric Alarm using the `alarm_name`. For example:
 
 ```terraform
 import {
-  to = aws_cloudwatch_metric_alarm.test
+  to = aws_cloudwatch_metric_alarm.example
   id = "alarm-12345"
 }
 ```
@@ -261,5 +287,5 @@ import {
 Using `terraform import`, import CloudWatch Metric Alarm using the `alarm_name`. For example:
 
 ```console
-% terraform import aws_cloudwatch_metric_alarm.test alarm-12345
+% terraform import aws_cloudwatch_metric_alarm.example alarm-12345
 ```

--- a/website/docs/r/cognito_log_delivery_configuration.html.markdown
+++ b/website/docs/r/cognito_log_delivery_configuration.html.markdown
@@ -202,6 +202,32 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_cognito_log_delivery_configuration.example
+  identity = {
+    user_pool_id = "us-west-2_example123"
+  }
+}
+
+resource "aws_cognito_log_delivery_configuration" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `user_pool_id` (String) ID of the Cognito User Pool.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Cognito IDP (Identity Provider) Log Delivery Configuration using the `user_pool_id`. For example:
 
 ```terraform

--- a/website/docs/r/dx_gateway.html.markdown
+++ b/website/docs/r/dx_gateway.html.markdown
@@ -43,11 +43,37 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_dx_gateway.example
+  identity = {
+    id = "abcd1234-dcba-5678-be23-cdef9876ab45"
+  }
+}
+
+resource "aws_dx_gateway" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `id` (String) ID of the Direct Connect Gateway.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Direct Connect Gateways using the gateway `id`. For example:
 
 ```terraform
 import {
-  to = aws_dx_gateway.test
+  to = aws_dx_gateway.example
   id = "abcd1234-dcba-5678-be23-cdef9876ab45"
 }
 ```
@@ -55,5 +81,5 @@ import {
 Using `terraform import`, import Direct Connect Gateways using the gateway `id`. For example:
 
 ```console
-% terraform import aws_dx_gateway.test abcd1234-dcba-5678-be23-cdef9876ab45
+% terraform import aws_dx_gateway.example abcd1234-dcba-5678-be23-cdef9876ab45
 ```

--- a/website/docs/r/iam_role.html.markdown
+++ b/website/docs/r/iam_role.html.markdown
@@ -223,11 +223,36 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_iam_role.example
+  identity = {
+    name = "developer_name"
+  }
+}
+
+resource "aws_iam_role" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `name` (String) Name of the IAM role.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import IAM Roles using the `name`. For example:
 
 ```terraform
 import {
-  to = aws_iam_role.developer
+  to = aws_iam_role.example
   id = "developer_name"
 }
 ```
@@ -235,5 +260,5 @@ import {
 Using `terraform import`, import IAM Roles using the `name`. For example:
 
 ```console
-% terraform import aws_iam_role.developer developer_name
+% terraform import aws_iam_role.example developer_name
 ```

--- a/website/docs/r/iam_role_policy.html.markdown
+++ b/website/docs/r/iam_role_policy.html.markdown
@@ -75,11 +75,38 @@ This resource exports no additional attributes.
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_iam_role_policy.example
+  identity = {
+    role = "role_of_mypolicy_name"
+    name = "mypolicy_name"
+  }
+}
+
+resource "aws_iam_role_policy" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `role` (String) Name of the IAM role.
+* `name` (String) Name of the role policy.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import IAM Role Policies using the `role_name:role_policy_name`. For example:
 
 ```terraform
 import {
-  to = aws_iam_role_policy.mypolicy
+  to = aws_iam_role_policy.example
   id = "role_of_mypolicy_name:mypolicy_name"
 }
 ```
@@ -87,5 +114,5 @@ import {
 Using `terraform import`, import IAM Role Policies using the `role_name:role_policy_name`. For example:
 
 ```console
-% terraform import aws_iam_role_policy.mypolicy role_of_mypolicy_name:mypolicy_name
+% terraform import aws_iam_role_policy.example role_of_mypolicy_name:mypolicy_name
 ```

--- a/website/docs/r/iam_role_policy_attachment.html.markdown
+++ b/website/docs/r/iam_role_policy_attachment.html.markdown
@@ -68,11 +68,38 @@ This resource exports no additional attributes.
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_iam_role_policy_attachment.example
+  identity = {
+    role = "test-role"
+    policy_arn = "arn:aws:iam::xxxxxxxxxxxx:policy/test-policy"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `role` (String) Name of the IAM role.
+* `policy_arn` (String) ARN of the IAM policy.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import IAM role policy attachments using the role name and policy arn separated by `/`. For example:
 
 ```terraform
 import {
-  to = aws_iam_role_policy_attachment.test-attach
+  to = aws_iam_role_policy_attachment.example
   id = "test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy"
 }
 ```
@@ -80,5 +107,5 @@ import {
 Using `terraform import`, import IAM role policy attachments using the role name and policy arn separated by `/`. For example:
 
 ```console
-% terraform import aws_iam_role_policy_attachment.test-attach test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+% terraform import aws_iam_role_policy_attachment.example test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
 ```

--- a/website/docs/r/iam_role_policy_attachment.html.markdown
+++ b/website/docs/r/iam_role_policy_attachment.html.markdown
@@ -74,7 +74,7 @@ In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp
 import {
   to = aws_iam_role_policy_attachment.example
   identity = {
-    role = "test-role"
+    role       = "test-role"
     policy_arn = "arn:aws:iam::xxxxxxxxxxxx:policy/test-policy"
   }
 }

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -599,6 +599,32 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_lambda_function.example
+  identity = {
+    function_name = "example"
+  }
+}
+
+resource "aws_lambda_function" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `function_name` (String) Name of the Lambda function.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lambda Functions using the `function_name`. For example:
 
 ```terraform

--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -243,7 +243,7 @@ import {
   to = aws_lambda_permission.example
   identity = {
     function_name = "my_test_lambda_function"
-    statement_id = "AllowExecutionFromCloudWatch"
+    statement_id  = "AllowExecutionFromCloudWatch"
   }
 }
 
@@ -262,6 +262,7 @@ resource "aws_lambda_permission" "example" {
 #### Optional
 
 * `qualifier` (String) Qualifier for the function version or alias.
+
 - `account_id` (String) AWS Account where this resource is managed.
 - `region` (String) Region where this resource is managed.
 

--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -236,11 +236,40 @@ This resource exports no additional attributes.
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_lambda_permission.example
+  identity = {
+    function_name = "my_test_lambda_function"
+    statement_id = "AllowExecutionFromCloudWatch"
+  }
+}
+
+resource "aws_lambda_permission" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `function_name` (String) Lambda function name.
+* `statement_id` (String) Statement ID for the permission.
+
+#### Optional
+
+* `qualifier` (String) Qualifier for the function version or alias.
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lambda permission statements using function_name/statement_id with an optional qualifier. For example:
 
 ```terraform
 import {
-  to = aws_lambda_permission.test_lambda_permission
+  to = aws_lambda_permission.example
   id = "my_test_lambda_function/AllowExecutionFromCloudWatch"
 }
 ```
@@ -249,7 +278,7 @@ Using `qualifier`:
 
 ```terraform
 import {
-  to = aws_lambda_permission.test_lambda_permission
+  to = aws_lambda_permission.example
   id = "my_test_lambda_function:qualifier_name/AllowExecutionFromCloudWatch"
 }
 ```
@@ -258,5 +287,5 @@ For backwards compatibility, the following legacy `terraform import` commands ar
 
 ```console
 % terraform import aws_lambda_permission.example my_test_lambda_function/AllowExecutionFromCloudWatch
-% terraform import aws_lambda_permission.test_lambda_permission my_test_lambda_function:qualifier_name/AllowExecutionFromCloudWatch
+% terraform import aws_lambda_permission.example my_test_lambda_function:qualifier_name/AllowExecutionFromCloudWatch
 ```

--- a/website/docs/r/organizations_account.html.markdown
+++ b/website/docs/r/organizations_account.html.markdown
@@ -59,11 +59,36 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_organizations_account.example
+  identity = {
+    id = "111111111111"
+  }
+}
+
+resource "aws_organizations_account" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `id` (String) ID of the AWS Organizations account.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import the AWS member account using the `account_id`. For example:
 
 ```terraform
 import {
-  to = aws_organizations_account.my_account
+  to = aws_organizations_account.example
   id = "111111111111"
 }
 ```
@@ -71,13 +96,13 @@ import {
 Using `terraform import`, import the AWS member account using the `account_id`. For example:
 
 ```console
-% terraform import aws_organizations_account.my_account 111111111111
+% terraform import aws_organizations_account.example 111111111111
 ```
 
 To import accounts that have set iam_user_access_to_billing, use the following:
 
 ```console
-% terraform import aws_organizations_account.my_account 111111111111_ALLOW
+% terraform import aws_organizations_account.example 111111111111_ALLOW
 ```
 
 Certain resource arguments, like `role_name`, do not have an Organizations API method for reading the information after account creation. If the argument is set in the Terraform configuration on an imported resource, Terraform will always show a difference. To workaround this behavior, either omit the argument from the Terraform configuration or use [`ignore_changes`](https://www.terraform.io/docs/configuration/meta-arguments/lifecycle.html#ignore_changes) to hide the difference. For example:

--- a/website/docs/r/organizations_delegated_administrator.html.markdown
+++ b/website/docs/r/organizations_delegated_administrator.html.markdown
@@ -41,6 +41,33 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_organizations_delegated_administrator.example
+  identity = {
+    service_principal = "config.amazonaws.com"
+    delegated_account_id = "123456789012"
+  }
+}
+
+resource "aws_organizations_delegated_administrator" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `service_principal` (String) Service principal for the AWS service.
+* `delegated_account_id` (String) Account ID to be designated as a delegated administrator.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `aws_organizations_delegated_administrator` using the account ID and its service principal. For example:
 
 ```terraform

--- a/website/docs/r/organizations_delegated_administrator.html.markdown
+++ b/website/docs/r/organizations_delegated_administrator.html.markdown
@@ -47,7 +47,7 @@ In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp
 import {
   to = aws_organizations_delegated_administrator.example
   identity = {
-    service_principal = "config.amazonaws.com"
+    service_principal    = "config.amazonaws.com"
     delegated_account_id = "123456789012"
   }
 }

--- a/website/docs/r/organizations_organization.html.markdown
+++ b/website/docs/r/organizations_organization.html.markdown
@@ -67,11 +67,36 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_organizations_organization.example
+  identity = {
+    id = "o-1234567"
+  }
+}
+
+resource "aws_organizations_organization" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `id` (String) ID of the AWS Organizations organization.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import the AWS organization using the `id`. For example:
 
 ```terraform
 import {
-  to = aws_organizations_organization.my_org
+  to = aws_organizations_organization.example
   id = "o-1234567"
 }
 ```
@@ -79,5 +104,5 @@ import {
 Using `terraform import`, import the AWS organization using the `id`. For example:
 
 ```console
-% terraform import aws_organizations_organization.my_org o-1234567
+% terraform import aws_organizations_organization.example o-1234567
 ```

--- a/website/docs/r/organizations_organizational_unit.html.markdown
+++ b/website/docs/r/organizations_organizational_unit.html.markdown
@@ -42,6 +42,31 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_organizations_organizational_unit.example
+  identity = {
+    id = "ou-1234567"
+  }
+}
+
+resource "aws_organizations_organizational_unit" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `id` (String) ID of the organizational unit.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import AWS Organizations Organizational Units using the `id`. For example:
 
 ```terraform

--- a/website/docs/r/organizations_policy_attachment.html.markdown
+++ b/website/docs/r/organizations_policy_attachment.html.markdown
@@ -53,13 +53,40 @@ This resource exports no additional attributes.
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_organizations_policy_attachment.example
+  identity = {
+    policy_id = "p-12345678"
+    target_id = "123456789012"
+  }
+}
+
+resource "aws_organizations_policy_attachment" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `policy_id` (String) Organizations policy ID.
+* `target_id` (String) Organizations target ID (account, OU, or root).
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `aws_organizations_policy_attachment` using the target ID and policy ID. For example:
 
 With an account target:
 
 ```terraform
 import {
-  to = aws_organizations_policy_attachment.account
+  to = aws_organizations_policy_attachment.example
   id = "123456789012:p-12345678"
 }
 ```
@@ -69,5 +96,5 @@ Using `terraform import`, import `aws_organizations_policy_attachment` using the
 With an account target:
 
 ```console
-% terraform import aws_organizations_policy_attachment.account 123456789012:p-12345678
+% terraform import aws_organizations_policy_attachment.example 123456789012:p-12345678
 ```

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -249,13 +249,43 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_route53_record.example
+  identity = {
+    zone_id = "Z4KAPRWWNC7JR"
+    name = "dev.example.com"
+    type = "NS"
+  }
+}
+
+resource "aws_route53_record" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `zone_id` (String) Hosted zone ID for the record.
+* `name` (String) Name of the record.
+* `type` (String) Record type.
+
+#### Optional
+
+* `set_identifier` (String) Set identifier for the record.
+- `account_id` (String) AWS Account where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Route53 Records using the ID of the record, record name, record type, and set identifier. For example:
 
 Using the ID of the record, which is the zone identifier, record name, and record type, separated by underscores (`_`):
 
 ```terraform
 import {
-  to = aws_route53_record.myrecord
+  to = aws_route53_record.example
   id = "Z4KAPRWWNC7JR_dev.example.com_NS"
 }
 ```
@@ -264,7 +294,7 @@ If the record also contains a set identifier, append it:
 
 ```terraform
 import {
-  to = aws_route53_record.myrecord
+  to = aws_route53_record.example
   id = "Z4KAPRWWNC7JR_dev.example.com_NS_dev"
 }
 ```
@@ -273,7 +303,7 @@ If the record name is the empty string, it can be omitted:
 
 ```terraform
 import {
-  to = aws_route53_record.myrecord
+  to = aws_route53_record.example
   id = "Z4KAPRWWNC7JR__NS"
 }
 ```
@@ -283,11 +313,11 @@ import {
 Using the ID of the record, which is the zone identifier, record name, and record type, separated by underscores (`_`):
 
 ```console
-% terraform import aws_route53_record.myrecord Z4KAPRWWNC7JR_dev_NS
+% terraform import aws_route53_record.example Z4KAPRWWNC7JR_dev_NS
 ```
 
 If the record also contains a set identifier, append it:
 
 ```console
-% terraform import aws_route53_record.myrecord Z4KAPRWWNC7JR_dev_NS_dev
+% terraform import aws_route53_record.example Z4KAPRWWNC7JR_dev_NS_dev
 ```

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -256,8 +256,8 @@ import {
   to = aws_route53_record.example
   identity = {
     zone_id = "Z4KAPRWWNC7JR"
-    name = "dev.example.com"
-    type = "NS"
+    name    = "dev.example.com"
+    type    = "NS"
   }
 }
 
@@ -277,6 +277,7 @@ resource "aws_route53_record" "example" {
 #### Optional
 
 * `set_identifier` (String) Set identifier for the record.
+
 - `account_id` (String) AWS Account where this resource is managed.
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Route53 Records using the ID of the record, record name, record type, and set identifier. For example:

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -325,11 +325,37 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_s3_bucket.example
+  identity = {
+    bucket = "bucket-name"
+  }
+}
+
+resource "aws_s3_bucket" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `bucket` (String) Name of the S3 bucket.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import S3 bucket using the `bucket`. For example:
 
 ```terraform
 import {
-  to = aws_s3_bucket.bucket
+  to = aws_s3_bucket.example
   id = "bucket-name"
 }
 ```
@@ -337,5 +363,5 @@ import {
 Using `terraform import`, import S3 bucket using the `bucket`. For example:
 
 ```console
-% terraform import aws_s3_bucket.bucket bucket-name
+% terraform import aws_s3_bucket.example bucket-name
 ```

--- a/website/docs/r/s3_bucket_acl.html.markdown
+++ b/website/docs/r/s3_bucket_acl.html.markdown
@@ -167,6 +167,34 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_s3_bucket_acl.example
+  identity = {
+    bucket = "bucket-name"
+  }
+}
+
+resource "aws_s3_bucket_acl" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `bucket` (String) S3 bucket name.
+
+#### Optional
+
+* `expected_bucket_owner` (String) Account ID of the expected bucket owner.
+* `acl` (String) Canned ACL to apply to the bucket.
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import S3 bucket ACL using `bucket`, `expected_bucket_owner`, and/or `acl`, depending on your situation. For example:
 
 If the owner (account ID) of the source bucket is the _same_ account used to configure the Terraform AWS Provider, and the source bucket is **not configured** with a

--- a/website/docs/r/s3_bucket_acl.html.markdown
+++ b/website/docs/r/s3_bucket_acl.html.markdown
@@ -192,6 +192,7 @@ resource "aws_s3_bucket_acl" "example" {
 
 * `expected_bucket_owner` (String) Account ID of the expected bucket owner.
 * `acl` (String) Canned ACL to apply to the bucket.
+
 - `account_id` (String) AWS Account where this resource is managed.
 - `region` (String) Region where this resource is managed.
 

--- a/website/docs/r/s3_bucket_cors_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_cors_configuration.html.markdown
@@ -91,6 +91,7 @@ resource "aws_s3_bucket_cors_configuration" "example" {
 #### Optional
 
 * `expected_bucket_owner` (String) Account ID of the expected bucket owner.
+
 - `account_id` (String) AWS Account where this resource is managed.
 - `region` (String) Region where this resource is managed.
 

--- a/website/docs/r/s3_bucket_cors_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_cors_configuration.html.markdown
@@ -67,6 +67,33 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_s3_bucket_cors_configuration.example
+  identity = {
+    bucket = "bucket-name"
+  }
+}
+
+resource "aws_s3_bucket_cors_configuration" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `bucket` (String) S3 bucket name.
+
+#### Optional
+
+* `expected_bucket_owner` (String) Account ID of the expected bucket owner.
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import S3 bucket CORS configuration using the `bucket` or using the `bucket` and `expected_bucket_owner` separated by a comma (`,`). For example:
 
 If the owner (account ID) of the source bucket is the same account used to configure the Terraform AWS Provider, import using the `bucket`:

--- a/website/docs/r/s3_bucket_logging.html.markdown
+++ b/website/docs/r/s3_bucket_logging.html.markdown
@@ -145,6 +145,33 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_s3_bucket_logging.example
+  identity = {
+    bucket = "bucket-name"
+  }
+}
+
+resource "aws_s3_bucket_logging" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `bucket` (String) S3 bucket name.
+
+#### Optional
+
+* `expected_bucket_owner` (String) Account ID of the expected bucket owner.
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import S3 bucket logging using the `bucket` or using the `bucket` and `expected_bucket_owner` separated by a comma (`,`). For example:
 
 If the owner (account ID) of the source bucket is the same account used to configure the Terraform AWS Provider, import using the `bucket`:

--- a/website/docs/r/s3_bucket_logging.html.markdown
+++ b/website/docs/r/s3_bucket_logging.html.markdown
@@ -169,6 +169,7 @@ resource "aws_s3_bucket_logging" "example" {
 #### Optional
 
 * `expected_bucket_owner` (String) Account ID of the expected bucket owner.
+
 - `account_id` (String) AWS Account where this resource is managed.
 - `region` (String) Region where this resource is managed.
 

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -188,7 +188,7 @@ import {
   to = aws_s3_bucket_object.example
   identity = {
     bucket = "some-bucket-name"
-    key = "some/key.txt"
+    key    = "some/key.txt"
   }
 }
 

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -181,6 +181,34 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_s3_bucket_object.example
+  identity = {
+    bucket = "some-bucket-name"
+    key = "some/key.txt"
+  }
+}
+
+resource "aws_s3_bucket_object" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `bucket` (String) S3 bucket name.
+* `key` (String) Object key.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import objects using the `id` or S3 URL. For example:
 
 Import using the `id`, which is the bucket name and the key together:

--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -62,11 +62,37 @@ This resource exports no additional attributes.
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_s3_bucket_policy.example
+  identity = {
+    bucket = "my-tf-test-bucket"
+  }
+}
+
+resource "aws_s3_bucket_policy" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `bucket` (String) Name of the S3 bucket.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import S3 bucket policies using the bucket name. For example:
 
 ```terraform
 import {
-  to = aws_s3_bucket_policy.allow_access_from_another_account
+  to = aws_s3_bucket_policy.example
   id = "my-tf-test-bucket"
 }
 ```
@@ -74,5 +100,5 @@ import {
 Using `terraform import`, import S3 bucket policies using the bucket name. For example:
 
 ```console
-% terraform import aws_s3_bucket_policy.allow_access_from_another_account my-tf-test-bucket
+% terraform import aws_s3_bucket_policy.example my-tf-test-bucket
 ```

--- a/website/docs/r/s3_bucket_server_side_encryption_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_server_side_encryption_configuration.html.markdown
@@ -67,6 +67,33 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_s3_bucket_server_side_encryption_configuration.example
+  identity = {
+    bucket = "bucket-name"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `bucket` (String) S3 bucket name.
+
+#### Optional
+
+* `expected_bucket_owner` (String) Account ID of the expected bucket owner.
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import S3 bucket server-side encryption configuration using the `bucket` or using the `bucket` and `expected_bucket_owner` separated by a comma (`,`). For example:
 
 If the owner (account ID) of the source bucket is the same account used to configure the Terraform AWS Provider, import using the `bucket`:

--- a/website/docs/r/s3_bucket_server_side_encryption_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_server_side_encryption_configuration.html.markdown
@@ -91,6 +91,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "example" {
 #### Optional
 
 * `expected_bucket_owner` (String) Account ID of the expected bucket owner.
+
 - `account_id` (String) AWS Account where this resource is managed.
 - `region` (String) Region where this resource is managed.
 

--- a/website/docs/r/s3_bucket_versioning.html.markdown
+++ b/website/docs/r/s3_bucket_versioning.html.markdown
@@ -116,6 +116,33 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_s3_bucket_versioning.example
+  identity = {
+    bucket = "bucket-name"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `bucket` (String) S3 bucket name.
+
+#### Optional
+
+* `expected_bucket_owner` (String) Account ID of the expected bucket owner.
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import S3 bucket versioning using the `bucket` or using the `bucket` and `expected_bucket_owner` separated by a comma (`,`). For example:
 
 If the owner (account ID) of the source bucket is the same account used to configure the Terraform AWS Provider, import using the `bucket`:

--- a/website/docs/r/s3_bucket_versioning.html.markdown
+++ b/website/docs/r/s3_bucket_versioning.html.markdown
@@ -140,6 +140,7 @@ resource "aws_s3_bucket_versioning" "example" {
 #### Optional
 
 * `expected_bucket_owner` (String) Account ID of the expected bucket owner.
+
 - `account_id` (String) AWS Account where this resource is managed.
 - `region` (String) Region where this resource is managed.
 

--- a/website/docs/r/s3_bucket_website_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_website_configuration.html.markdown
@@ -135,6 +135,33 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_s3_bucket_website_configuration.example
+  identity = {
+    bucket = "bucket-name"
+  }
+}
+
+resource "aws_s3_bucket_website_configuration" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `bucket` (String) S3 bucket name.
+
+#### Optional
+
+* `expected_bucket_owner` (String) Account ID of the expected bucket owner.
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import S3 bucket website configuration using the `bucket` or using the `bucket` and `expected_bucket_owner` separated by a comma (`,`). For example:
 
 If the owner (account ID) of the source bucket is the same account used to configure the Terraform AWS Provider, import using the `bucket`:

--- a/website/docs/r/s3_bucket_website_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_website_configuration.html.markdown
@@ -159,6 +159,7 @@ resource "aws_s3_bucket_website_configuration" "example" {
 #### Optional
 
 * `expected_bucket_owner` (String) Account ID of the expected bucket owner.
+
 - `account_id` (String) AWS Account where this resource is managed.
 - `region` (String) Region where this resource is managed.
 

--- a/website/docs/r/s3_object.html.markdown
+++ b/website/docs/r/s3_object.html.markdown
@@ -228,7 +228,7 @@ import {
   to = aws_s3_object.example
   identity = {
     bucket = "some-bucket-name"
-    key = "some/key.txt"
+    key    = "some/key.txt"
   }
 }
 

--- a/website/docs/r/s3_object.html.markdown
+++ b/website/docs/r/s3_object.html.markdown
@@ -221,6 +221,34 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_s3_object.example
+  identity = {
+    bucket = "some-bucket-name"
+    key = "some/key.txt"
+  }
+}
+
+resource "aws_s3_object" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `bucket` (String) S3 bucket name.
+* `key` (String) Object key.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import objects using the `id` or S3 URL. For example:
 
 Import using the `id`, which is the bucket name and the key together:

--- a/website/docs/r/sagemaker_user_profile.html.markdown
+++ b/website/docs/r/sagemaker_user_profile.html.markdown
@@ -230,11 +230,39 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_sagemaker_user_profile.example
+  identity = {
+    domain_id = "domain-id"
+    user_profile_name = "profile-name"
+  }
+}
+
+resource "aws_sagemaker_user_profile" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `domain_id` (String) SageMaker domain ID.
+* `user_profile_name` (String) Name of the user profile.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import SageMaker AI User Profiles using the `arn`. For example:
 
 ```terraform
 import {
-  to = aws_sagemaker_user_profile.test_user_profile
+  to = aws_sagemaker_user_profile.example
   id = "arn:aws:sagemaker:us-west-2:123456789012:user-profile/domain-id/profile-name"
 }
 ```
@@ -242,5 +270,5 @@ import {
 Using `terraform import`, import SageMaker AI User Profiles using the `arn`. For example:
 
 ```console
-% terraform import aws_sagemaker_user_profile.test_user_profile arn:aws:sagemaker:us-west-2:123456789012:user-profile/domain-id/profile-name
+% terraform import aws_sagemaker_user_profile.example arn:aws:sagemaker:us-west-2:123456789012:user-profile/domain-id/profile-name
 ```

--- a/website/docs/r/sagemaker_user_profile.html.markdown
+++ b/website/docs/r/sagemaker_user_profile.html.markdown
@@ -236,7 +236,7 @@ In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp
 import {
   to = aws_sagemaker_user_profile.example
   identity = {
-    domain_id = "domain-id"
+    domain_id         = "domain-id"
     user_profile_name = "profile-name"
   }
 }

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -312,11 +312,37 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_security_group.example
+  identity = {
+    id = "sg-903004f8"
+  }
+}
+
+resource "aws_security_group" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `id` (String) ID of the security group.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Security Groups using the security group `id`. For example:
 
 ```terraform
 import {
-  to = aws_security_group.elb_sg
+  to = aws_security_group.example
   id = "sg-903004f8"
 }
 ```
@@ -324,5 +350,5 @@ import {
 Using `terraform import`, import Security Groups using the security group `id`. For example:
 
 ```console
-% terraform import aws_security_group.elb_sg sg-903004f8
+% terraform import aws_security_group.example sg-903004f8
 ```

--- a/website/docs/r/sqs_queue.html.markdown
+++ b/website/docs/r/sqs_queue.html.markdown
@@ -143,11 +143,37 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_sqs_queue.example
+  identity = {
+    url = "https://queue.amazonaws.com/80398EXAMPLE/MyQueue"
+  }
+}
+
+resource "aws_sqs_queue" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `url` (String) URL of the SQS queue.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import SQS Queues using the queue `url`. For example:
 
 ```terraform
 import {
-  to = aws_sqs_queue.public_queue
+  to = aws_sqs_queue.example
   id = "https://queue.amazonaws.com/80398EXAMPLE/MyQueue"
 }
 ```
@@ -155,5 +181,5 @@ import {
 Using `terraform import`, import SQS Queues using the queue `url`. For example:
 
 ```console
-% terraform import aws_sqs_queue.public_queue https://queue.amazonaws.com/80398EXAMPLE/MyQueue
+% terraform import aws_sqs_queue.example https://queue.amazonaws.com/80398EXAMPLE/MyQueue
 ```

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -91,11 +91,37 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_subnet.example
+  identity = {
+    id = "subnet-9d4a7b6c"
+  }
+}
+
+resource "aws_subnet" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `id` (String) ID of the subnet.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import subnets using the subnet `id`. For example:
 
 ```terraform
 import {
-  to = aws_subnet.public_subnet
+  to = aws_subnet.example
   id = "subnet-9d4a7b6c"
 }
 ```
@@ -103,5 +129,5 @@ import {
 Using `terraform import`, import subnets using the subnet `id`. For example:
 
 ```console
-% terraform import aws_subnet.public_subnet subnet-9d4a7b6c
+% terraform import aws_subnet.example subnet-9d4a7b6c
 ```

--- a/website/docs/r/vpc_security_group_vpc_association.html.markdown
+++ b/website/docs/r/vpc_security_group_vpc_association.html.markdown
@@ -48,7 +48,7 @@ In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp
 import {
   to = aws_vpc_security_group_vpc_association.example
   identity = {
-    vpc_id = "vpc-67890"
+    vpc_id            = "vpc-67890"
     security_group_id = "sg-12345"
   }
 }

--- a/website/docs/r/vpc_security_group_vpc_association.html.markdown
+++ b/website/docs/r/vpc_security_group_vpc_association.html.markdown
@@ -42,6 +42,34 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_vpc_security_group_vpc_association.example
+  identity = {
+    vpc_id = "vpc-67890"
+    security_group_id = "sg-12345"
+  }
+}
+
+resource "aws_vpc_security_group_vpc_association" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `vpc_id` (String) VPC ID.
+* `security_group_id` (String) Security Group ID.
+
+#### Optional
+
+- `account_id` (String) AWS Account where this resource is managed.
+- `region` (String) Region where this resource is managed.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import a Security Group VPC Association using the `security_group_id` and `vpc_id` arguments, separated by a comma (`,`). For example:
 
 ```terraform


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Backfills documentation for resources with a parameterized resource identity.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/42983
Relates https://github.com/hashicorp/terraform-provider-aws/issues/42988
Relates #44210