### PR TITLE
aws_athena_data_catalog: Handles incorrect error type now returned by AWS

### DIFF
--- a/internal/service/athena/data_catalog.go
+++ b/internal/service/athena/data_catalog.go
@@ -198,6 +198,9 @@ func resourceDataCatalogDelete(ctx context.Context, d *schema.ResourceData, meta
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags
 	}
+	if errs.IsAErrorMessageContains[*types.InvalidRequestException](err, "was not found") {
+		return diags
+	}
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting Athena Data Catalog (%s): %s", d.Id(), err)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

The AWS API has been returning `InvalidRequestException` instead of `ResourceNotFoundException` when trying to delete missing Data Catalog.

The description of `InvalidRequestException` is

> Indicates that something is wrong with the input to the request. For example, a required parameter may be missing or out of range.

This was causing the acceptance test `TestAccAthenaDataCatalog_disappears` to fail with the error

> Error: deleting Athena Data Catalog (tf-test-alu48tu6): operation error Athena: DeleteDataCatalog, https response error StatusCode: 400, RequestID: ..., InvalidRequestException: DataCatalog tf-test-alu48tu6 was not found

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=athena TESTS='TestAccAthenaDataCatalog_basic|TestAccAthenaDataCatalog_disappears'

--- PASS: TestAccAthenaDataCatalog_disappears (12.52s)
--- PASS: TestAccAthenaDataCatalog_basic (14.60s)
```
