### PR TITLE
F/athena workgroup support managed query results configuration

### DIFF
--- a/.changelog/xxxxxx.txt
+++ b/.changelog/xxxxxx.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/athena_workgroup: Add `managed_query_results_configuration` argument
+```

--- a/internal/service/athena/workgroup.go
+++ b/internal/service/athena/workgroup.go
@@ -115,6 +115,9 @@ func resourceWorkGroup() *schema.Resource {
 							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
+							ConflictsWith: []string{
+								"configuration.0.managed_query_results_configuration",
+							},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"acl_configuration": {
@@ -157,9 +160,6 @@ func resourceWorkGroup() *schema.Resource {
 									"output_location": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ConflictsWith: []string{
-											"configuration.0.managed_query_results_configuration",
-										},
 									},
 								},
 							},

--- a/internal/service/athena/workgroup_test.go
+++ b/internal/service/athena/workgroup_test.go
@@ -48,6 +48,7 @@ func TestAccAthenaWorkGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.identity_center_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.publish_cloudwatch_metrics_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.result_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.managed_query_results_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.requester_pays_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
@@ -321,6 +322,73 @@ func TestAccAthenaWorkGroup_publishCloudWatchMetricsEnabled(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccAthenaWorkGroup_managedQueryResultsConfigurationEnabled(t *testing.T) {
+	ctx := acctest.Context(t)
+	var workgroup1, workGroup2 types.WorkGroup
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_athena_workgroup.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkGroupConfig_managedQueryResultsConfigurationEnabled(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkGroupExists(ctx, resourceName, &workgroup1),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.managed_query_results_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.managed_query_results_configuration.0.enabled", acctest.CtTrue),
+				),
+			},
+			{
+				Config: testAccWorkGroupConfig_managedQueryResultsConfigurationEnabled(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkGroupExists(ctx, resourceName, &workGroup2),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.managed_query_results_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.managed_query_results_configuration.0.enabled", acctest.CtFalse),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAthenaWorkGroup_managedQueryResultsConfiguration_kms(t *testing.T) {
+	ctx := acctest.Context(t)
+	var workgroup1 types.WorkGroup
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_athena_workgroup.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkGroupConfig_managedQueryResultsConfigurationKMS(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkGroupExists(ctx, resourceName, &workgroup1),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.managed_query_results_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.managed_query_results_configuration.0.encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "configuration.0.managed_query_results_configuration.0.encryption_configuration.0.kms_key_arn"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy},
+			},
+		},
+	})
+
 }
 
 func TestAccAthenaWorkGroup_ResultEncryption_sseS3(t *testing.T) {
@@ -970,6 +1038,43 @@ resource "aws_athena_workgroup" "test" {
   }
 }
 `, rName, encryptionOption)
+}
+
+func testAccWorkGroupConfig_managedQueryResultsConfigurationEnabled(rName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "aws_athena_workgroup" "test" {
+  name = %[1]q
+
+  configuration {
+    managed_query_results_configuration {
+      enabled = %[2]t
+    }
+  }
+}
+`, rName, enabled)
+}
+
+func testAccWorkGroupConfig_managedQueryResultsConfigurationKMS(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  description             = "Terraform Acceptance Testing"
+  enable_key_rotation     = true
+}
+
+resource "aws_athena_workgroup" "test" {
+  name = %[1]q
+
+  configuration {
+    managed_query_results_configuration {
+	  enabled     = true
+	  encryption_configuration {
+	  	kms_key_arn = aws_kms_key.test.arn
+	  }
+	}
+  }
+}
+`, rName)
 }
 
 func testAccWorkGroupConfig_state(rName, state string) string {

--- a/website/docs/r/athena_workgroup.html.markdown
+++ b/website/docs/r/athena_workgroup.html.markdown
@@ -54,6 +54,7 @@ This resource supports the following arguments:
 * `publish_cloudwatch_metrics_enabled` - (Optional) Boolean whether Amazon CloudWatch metrics are enabled for the workgroup. Defaults to `true`.
 * `requester_pays_enabled` - (Optional) If set to true , allows members assigned to a workgroup to reference Amazon S3 Requester Pays buckets in queries. If set to false , workgroup members cannot query data from Requester Pays buckets, and queries that retrieve data from Requester Pays buckets cause an error. The default is false . For more information about Requester Pays buckets, see [Requester Pays Buckets](https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) in the Amazon Simple Storage Service Developer Guide.
 * `result_configuration` - (Optional) Configuration block with result settings. See [Result Configuration](#result-configuration) below.
+* `managed_query_results_configuration` - (Optional) Configuration block for the managed query results configuration. See [Managed Query Results Configuration](#managed-query-results-configuration) below.
 
 #### Engine Version
 
@@ -79,6 +80,14 @@ This resource supports the following arguments:
 
 * `encryption_option` - (Required) Whether Amazon S3 server-side encryption with Amazon S3-managed keys (`SSE_S3`), server-side encryption with KMS-managed keys (`SSE_KMS`), or client-side encryption with KMS-managed keys (`CSE_KMS`) is used. If a query runs in a workgroup and the workgroup overrides client-side settings, then the workgroup's setting for encryption is used. It specifies whether query results must be encrypted, for all queries that run in this workgroup.
 * `kms_key_arn` - (Optional) For `SSE_KMS` and `CSE_KMS`, this is the KMS key ARN.
+
+#### Managed Query Results Configuration
+
+* `enabled` - (Optional) Boolean whether the workgroup enables the managed query results configuration. If set to `true`, Athena will manage query results in Athena owned storage. `output_location` of `result_configuration` cannot be specified if this is enabled. Defaults to `false`.
+* `encryption_configuration` - (Optional) Configuration block for the encryption configuration. See [Encryption Configuration](#encryption-configuration) above.
+
+##### Managed Query Results Configuration
+* `kms_key_arn` - (Optional) The KMS key ARN to use for encrypting managed query results.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. This PR adds support for configuring managed query results of Athena Workgroup.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds support for `managed_query_results_configuration` to the `aws_athena_workgroup` resource. 
This enables store query results into Athena owned storage.

Also support exclusive settings with `results_configuration`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #43246

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- https://docs.aws.amazon.com/athena/latest/ug/managed-results.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccAthenaWorkGroup_managedQueryResultsConfiguration PKG=athena

TF_ACC=1 go1.24.6 test ./internal/service/athena/... -v -count 1 -parallel 20 -run='TestAccAthenaWorkGroup_managedQueryResultsConfiguration'  -timeout 360m -vet=off
2025/09/13 21:27:11 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/13 21:27:11 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAthenaWorkGroup_managedQueryResultsConfigurationEnabled
=== PAUSE TestAccAthenaWorkGroup_managedQueryResultsConfigurationEnabled
=== RUN   TestAccAthenaWorkGroup_managedQueryResultsConfiguration_kms
=== PAUSE TestAccAthenaWorkGroup_managedQueryResultsConfiguration_kms
=== CONT  TestAccAthenaWorkGroup_managedQueryResultsConfigurationEnabled
=== CONT  TestAccAthenaWorkGroup_managedQueryResultsConfiguration_kms
--- PASS: TestAccAthenaWorkGroup_managedQueryResultsConfiguration_kms (32.76s)
--- PASS: TestAccAthenaWorkGroup_managedQueryResultsConfigurationEnabled (35.25s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/athena     41.848s
```
