### PR TITLE
docs: add note to vpc_config section

### DIFF
--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -567,7 +567,7 @@ The following arguments are optional:
 
 ### vpc_config Configuration Block
 
-~> NOTE: If subnet_ids, security_group_ids and ipv6_allowed_for_dual_stack are empty then vpc_config is considered to be empty or unset.
+~> **NOTE:** If `subnet_ids`, `security_group_ids` and `ipv6_allowed_for_dual_stack` are empty then `vpc_config` is considered to be empty or unset.
 
 * `ipv6_allowed_for_dual_stack` - (Optional) Whether to allow outbound IPv6 traffic on VPC functions connected to dual-stack subnets. Default: `false`.
 * `security_group_ids` - (Required) List of security group IDs associated with the Lambda function.

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -567,6 +567,8 @@ The following arguments are optional:
 
 ### vpc_config Configuration Block
 
+~> NOTE: If subnet_ids, security_group_ids and ipv6_allowed_for_dual_stack are empty then vpc_config is considered to be empty or unset.
+
 * `ipv6_allowed_for_dual_stack` - (Optional) Whether to allow outbound IPv6 traffic on VPC functions connected to dual-stack subnets. Default: `false`.
 * `security_group_ids` - (Required) List of security group IDs associated with the Lambda function.
 * `subnet_ids` - (Required) List of subnet IDs associated with the Lambda function.


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls are implemented.

### Description

This [commit](https://github.com/hashicorp/terraform-provider-aws/commit/2e516d75803c62445b13597ac5b0dc66b9ba5e5b#diff-dbb900253ab554e20258590c65deb99a6a85788310ee15ec5bc59cd03075ad51L355) re-worked parts of the Lambda function documentation. As part of this, a note on the `vpc_config` block was removed.

This note is re-added to the documentation.


### Relations

Closes #44115 

### References

- Pull request for [resource/aws_lambda_function: Ignore the VPC configuration if it is empty](https://github.com/hashicorp/terraform-provider-aws/pull/1341) (handling empty VPC configuration)
- Commit [https://github.com/hashicorp/terraform-provider-aws/commit/a0cbaed98bc37acf6967e35205495e49db42c2f0](https://github.com/hashicorp/terraform-provider-aws/commit/a0cbaed98bc37acf6967e35205495e49db42c2f0) (adding the note initially)
- Commit [https://github.com/hashicorp/terraform-provider-aws/commit/2e516d75803c62445b13597ac5b0dc66b9ba5e5b#diff-dbb900253ab554e20258590c65deb99a6a85788310ee15ec5bc59cd03075ad51L355](https://github.com/hashicorp/terraform-provider-aws/commit/2e516d75803c62445b13597ac5b0dc66b9ba5e5b#diff-dbb900253ab554e20258590c65deb99a6a85788310ee15ec5bc59cd03075ad51L355) (removing the note)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.
