### PR TITLE
d/aws_acmpca_certificate_authorities: new data source

### DIFF
--- a/internal/service/acmpca/certificate_authorities_data_source.go
+++ b/internal/service/acmpca/certificate_authorities_data_source.go
@@ -1,0 +1,94 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package acmpca
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/acmpca"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/acmpca/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_acmpca_certificate_authorities", name="Certificate Authorities")
+func newDataSourceCertificateAuthorities(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceCertificateAuthorities{}, nil
+}
+
+const (
+	DSNameCertificateAuthorities = "Certificate Authorities Data Source"
+)
+
+type dataSourceCertificateAuthorities struct {
+	framework.DataSourceWithModel[dataSourceCertificateAuthoritiesModel]
+}
+
+func (d *dataSourceCertificateAuthorities) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrResourceOwner: schema.StringAttribute{
+				CustomType:  fwtypes.StringEnumType[awstypes.ResourceOwner](),
+				Optional:    true,
+				Description: "Filter by resource owner. Valid values are `SELF` and `OTHER_ACCOUNTS`.",
+			},
+			names.AttrARNs: schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *dataSourceCertificateAuthorities) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().ACMPCAClient(ctx)
+
+	var data dataSourceCertificateAuthoritiesModel
+	smerr.EnrichAppend(ctx, &resp.Diagnostics, req.Config.Get(ctx, &data))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	out, err := findCertificateAuthorities(ctx, conn, data.ResourceOwner.ValueString())
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID)
+		return
+	}
+	data.ARNs = flex.FlattenFrameworkStringValueListOfString(ctx, out)
+
+	smerr.EnrichAppend(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data), smerr.ID)
+}
+
+type dataSourceCertificateAuthoritiesModel struct {
+	framework.WithRegionModel
+	ResourceOwner fwtypes.StringEnum[awstypes.ResourceOwner] `tfsdk:"resource_owner"`
+	ARNs          fwtypes.ListOfString                       `tfsdk:"arns"`
+}
+
+func findCertificateAuthorities(ctx context.Context, client *acmpca.Client, resourceOwner string) ([]string, error) {
+	var arns []string
+	input := &acmpca.ListCertificateAuthoritiesInput{}
+	if resourceOwner != "" {
+		input.ResourceOwner = awstypes.ResourceOwner(resourceOwner)
+	}
+	paginator := acmpca.NewListCertificateAuthoritiesPaginator(client, input)
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, ca := range page.CertificateAuthorities {
+			arns = append(arns, aws.ToString(ca.Arn))
+		}
+	}
+	return arns, nil
+}

--- a/internal/service/acmpca/certificate_authorities_data_source_test.go
+++ b/internal/service/acmpca/certificate_authorities_data_source_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package acmpca_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccACMPCACertificateAuthoritiesDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	domain1 := acctest.RandomDomainName()
+	domain2 := acctest.RandomDomainName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ACMPCAServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateAuthoritiesDataSourceConfig_arn(domain1, domain2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckTypeSetElemAttrPair("data.aws_acmpca_certificate_authorities.test", "arns.*", "aws_acmpca_certificate_authority.test1", names.AttrARN),
+					resource.TestCheckTypeSetElemAttrPair("data.aws_acmpca_certificate_authorities.test", "arns.*", "aws_acmpca_certificate_authority.test2", names.AttrARN),
+				),
+			},
+		},
+	})
+}
+
+func testAccCertificateAuthoritiesDataSourceConfig_arn(domain1 string, domain2 string) string {
+	return fmt.Sprintf(`
+data "aws_acmpca_certificate_authorities" "test" {
+  depends_on = [
+	aws_acmpca_certificate_authority.test1,
+	aws_acmpca_certificate_authority.test2,
+  ]
+}
+
+resource "aws_acmpca_certificate_authority" "test1" {
+  permanent_deletion_time_in_days = 7
+  type                            = "ROOT"
+
+  certificate_authority_configuration {
+    key_algorithm     = "RSA_4096"
+    signing_algorithm = "SHA512WITHRSA"
+
+    subject {
+      common_name = %[1]q
+    }
+  }
+}
+
+resource "aws_acmpca_certificate_authority" "test2" {
+  permanent_deletion_time_in_days = 7
+  type                            = "ROOT"
+
+  certificate_authority_configuration {
+    key_algorithm     = "RSA_4096"
+    signing_algorithm = "SHA512WITHRSA"
+
+    subject {
+      common_name = %[2]q
+    }
+  }
+}
+
+`, domain1, domain2)
+}

--- a/internal/service/acmpca/service_package_gen.go
+++ b/internal/service/acmpca/service_package_gen.go
@@ -18,7 +18,14 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
-	return []*inttypes.ServicePackageFrameworkDataSource{}
+	return []*inttypes.ServicePackageFrameworkDataSource{
+		{
+			Factory:  newDataSourceCertificateAuthorities,
+			TypeName: "aws_acmpca_certificate_authorities",
+			Name:     "Certificate Authorities",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.ServicePackageFrameworkResource {

--- a/website/docs/d/acmpca_certificate_authorities.html.markdown
+++ b/website/docs/d/acmpca_certificate_authorities.html.markdown
@@ -3,18 +3,9 @@ subcategory: "ACM PCA (Certificate Manager Private Certificate Authority)"
 layout: "aws"
 page_title: "AWS: aws_acmpca_certificate_authorities"
 description: |-
-  Provides details about an AWS ACM PCA (Certificate Manager Private Certificate Authority) Certificate Authorities.
+  Get information about a set of AWS ACM PCA (Certificate Manager Private Certificate Authority) Certificate Authorities.
 ---
-<!---
-Documentation guidelines:
-- Begin data source descriptions with "Provides details about..."
-- Use simple language and avoid jargon
-- Focus on brevity and clarity
-- Use present tense and active voice
-- Don't begin argument/attribute descriptions with "An", "The", "Defines", "Indicates", or "Specifies"
-- Boolean arguments should begin with "Whether to"
-- Use "example" instead of "test" in examples
---->
+
 
 # Data Source: aws_acmpca_certificate_authorities
 
@@ -29,19 +20,23 @@ data "aws_acmpca_certificate_authorities" "example" {
 }
 ```
 
+### List ACM PCAs shared via RAM
+
+```terraform
+data "aws_acmpca_certificate_authorities" "example" {
+  resource_owner = "OTHER_ACCOUNTS"
+}
+```
+
 ## Argument Reference
 
-The following arguments are required:
+This data source supports the following arguments:
 
-* `example_arg` - (Required) Brief description of the required argument.
-
-The following arguments are optional:
-
-* `optional_arg` - (Optional) Brief description of the optional argument.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `resource_owner` (Optional) Use this argument to filter the returned set of certificate authorities based on their owner. Valid values are `SELF` and `OTHER_ACCOUNTS` The default is `SELF`.
 
 ## Attribute Reference
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `arn` - ARN of the Certificate Authorities.
-* `example_attribute` - Brief description of the attribute.
+* `arns` - Set of ARNs of the matched ACM PCA

--- a/website/docs/d/acmpca_certificate_authorities.html.markdown
+++ b/website/docs/d/acmpca_certificate_authorities.html.markdown
@@ -1,0 +1,47 @@
+---
+subcategory: "ACM PCA (Certificate Manager Private Certificate Authority)"
+layout: "aws"
+page_title: "AWS: aws_acmpca_certificate_authorities"
+description: |-
+  Provides details about an AWS ACM PCA (Certificate Manager Private Certificate Authority) Certificate Authorities.
+---
+<!---
+Documentation guidelines:
+- Begin data source descriptions with "Provides details about..."
+- Use simple language and avoid jargon
+- Focus on brevity and clarity
+- Use present tense and active voice
+- Don't begin argument/attribute descriptions with "An", "The", "Defines", "Indicates", or "Specifies"
+- Boolean arguments should begin with "Whether to"
+- Use "example" instead of "test" in examples
+--->
+
+# Data Source: aws_acmpca_certificate_authorities
+
+Provides details about an AWS ACM PCA (Certificate Manager Private Certificate Authority) Certificate Authorities.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_acmpca_certificate_authorities" "example" {
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `example_arg` - (Required) Brief description of the required argument.
+
+The following arguments are optional:
+
+* `optional_arg` - (Optional) Brief description of the optional argument.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the Certificate Authorities.
+* `example_attribute` - Brief description of the attribute.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This pull request introduces a new data source for AWS ACM PCA Certificate Authorities to the provider, allowing users to query and filter certificate authorities, including those shared via AWS Resource Access Manager (RAM). The implementation includes the data source code, integration into the service package, comprehensive acceptance tests, and documentation for usage and arguments.

**New Data Source Implementation**

* `aws_acmpca_certificate_authorities` data source, enabling retrieval of ACM PCA Certificate Authority ARNs with optional filtering by resource owner (`SELF` or `OTHER_ACCOUNTS`).

The API does not support additional filtering. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #44255

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccACMPCACertificateAuthoritiesDataSource PKG=acmpca
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: f-aws_acmpca_certificate_authorities ..
TF_ACC=1 go1.24.6 test ./internal/service/acmpca/... -v -count 1 -parallel 20 -run='TestAccACMPCACertificateAuthoritiesDataSource'  -timeout 360m -vet=off
2025/09/17 20:27:19 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/17 20:27:20 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccACMPCACertificateAuthoritiesDataSource_basic
=== PAUSE TestAccACMPCACertificateAuthoritiesDataSource_basic
=== RUN   TestAccACMPCACertificateAuthoritiesDataSource_otherAccounts
=== PAUSE TestAccACMPCACertificateAuthoritiesDataSource_otherAccounts
=== CONT  TestAccACMPCACertificateAuthoritiesDataSource_basic
=== CONT  TestAccACMPCACertificateAuthoritiesDataSource_otherAccounts
--- PASS: TestAccACMPCACertificateAuthoritiesDataSource_basic (26.13s)
--- PASS: TestAccACMPCACertificateAuthoritiesDataSource_otherAccounts (39.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/acmpca     43.190s

...
```
