### PR TITLE
[Enhancement] d/aws_ec2_instance_type_offering: Add `location` attribute

### DIFF
--- a/.changelog/44328.txt
+++ b/.changelog/44328.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_ec2_instance_type_offering: Add `location` attribute
+```

--- a/internal/service/ec2/ec2_instance_type_offering_data_source.go
+++ b/internal/service/ec2/ec2_instance_type_offering_data_source.go
@@ -33,6 +33,10 @@ func dataSourceInstanceTypeOffering() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			names.AttrLocation: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"location_type": {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -71,44 +75,42 @@ func dataSourceInstanceTypeOfferingRead(ctx context.Context, d *schema.ResourceD
 		return sdkdiag.AppendErrorf(diags, "no EC2 Instance Type Offerings found matching criteria; try different search")
 	}
 
-	var foundInstanceTypes []string
-
-	for _, instanceTypeOffering := range instanceTypeOfferings {
-		foundInstanceTypes = append(foundInstanceTypes, string(instanceTypeOffering.InstanceType))
-	}
-
-	var resultInstanceType string
+	var resultInstanceTypeOffering *awstypes.InstanceTypeOffering
 
 	// Search preferred instance types in their given order and set result
 	// instance type for first match found
 	if v, ok := d.GetOk("preferred_instance_types"); ok {
 		for _, v := range v.([]any) {
 			if v, ok := v.(string); ok {
-				if slices.Contains(foundInstanceTypes, v) {
-					resultInstanceType = v
+				if i := slices.IndexFunc(instanceTypeOfferings, func(e awstypes.InstanceTypeOffering) bool {
+					return string(e.InstanceType) == v
+				}); i != -1 {
+					resultInstanceTypeOffering = &instanceTypeOfferings[i]
 				}
 
-				if resultInstanceType != "" {
+				if resultInstanceTypeOffering != nil {
 					break
 				}
 			}
 		}
 	}
 
-	if resultInstanceType == "" && len(foundInstanceTypes) > 1 {
+	if resultInstanceTypeOffering == nil && len(instanceTypeOfferings) > 1 {
 		return sdkdiag.AppendErrorf(diags, "multiple EC2 Instance Offerings found matching criteria; try different search")
 	}
 
-	if resultInstanceType == "" && len(foundInstanceTypes) == 1 {
-		resultInstanceType = foundInstanceTypes[0]
+	if resultInstanceTypeOffering == nil && len(instanceTypeOfferings) == 1 {
+		resultInstanceTypeOffering = &instanceTypeOfferings[0]
 	}
 
-	if resultInstanceType == "" {
+	if resultInstanceTypeOffering == nil {
 		return sdkdiag.AppendErrorf(diags, "no EC2 Instance Type Offerings found matching criteria; try different search")
 	}
 
-	d.SetId(resultInstanceType)
-	d.Set(names.AttrInstanceType, resultInstanceType)
+	d.SetId(string(resultInstanceTypeOffering.InstanceType))
+	d.Set(names.AttrInstanceType, string(resultInstanceTypeOffering.InstanceType))
+	d.Set(names.AttrLocation, resultInstanceTypeOffering.Location)
+	d.Set("location_type", string(resultInstanceTypeOffering.LocationType))
 
 	return diags
 }

--- a/internal/service/ec2/ec2_instance_type_offering_data_source_test.go
+++ b/internal/service/ec2/ec2_instance_type_offering_data_source_test.go
@@ -14,6 +14,7 @@ import (
 func TestAccEC2InstanceTypeOfferingDataSource_filter(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ec2_instance_type_offering.test"
+	dataSourceOfferingsName := "data.aws_ec2_instance_type_offerings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckInstanceTypeOfferings(ctx, t) },
@@ -24,7 +25,9 @@ func TestAccEC2InstanceTypeOfferingDataSource_filter(t *testing.T) {
 			{
 				Config: testAccInstanceTypeOfferingDataSourceConfig_filter(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrInstanceType),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrInstanceType, dataSourceOfferingsName, "instance_types.0"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrLocation, dataSourceOfferingsName, "locations.0"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "location_type", dataSourceOfferingsName, "location_types.0"),
 				),
 			},
 		},
@@ -34,6 +37,7 @@ func TestAccEC2InstanceTypeOfferingDataSource_filter(t *testing.T) {
 func TestAccEC2InstanceTypeOfferingDataSource_locationType(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ec2_instance_type_offering.test"
+	dataSourceOfferingsName := "data.aws_ec2_instance_type_offerings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckInstanceTypeOfferings(ctx, t) },
@@ -44,7 +48,9 @@ func TestAccEC2InstanceTypeOfferingDataSource_locationType(t *testing.T) {
 			{
 				Config: testAccInstanceTypeOfferingDataSourceConfig_location(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrInstanceType),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrInstanceType, dataSourceOfferingsName, "instance_types.0"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrLocation, dataSourceOfferingsName, "locations.0"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "location_type", dataSourceOfferingsName, "location_types.0"),
 				),
 			},
 		},
@@ -65,6 +71,8 @@ func TestAccEC2InstanceTypeOfferingDataSource_preferredInstanceTypes(t *testing.
 				Config: testAccInstanceTypeOfferingDataSourceConfig_preferreds(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrInstanceType, "t3.micro"),
+					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrLocation),
+					resource.TestCheckResourceAttrSet(dataSourceName, "location_type"),
 				),
 			},
 		},

--- a/website/docs/d/ec2_instance_type_offering.html.markdown
+++ b/website/docs/d/ec2_instance_type_offering.html.markdown
@@ -43,6 +43,7 @@ This data source exports the following attributes in addition to the arguments a
 
 * `id` - EC2 Instance Type.
 * `instance_type` - EC2 Instance Type.
+* `location` - Identifier for the location.
 
 ## Timeouts
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Add the `location` attribute to the `aws_ec2_instance_type_offering` data source.  
  * Previously, only the `instance_type` was retrieved from the AWS API response, and filtering was performed against a list of instance types.  
  * This PR updates the implementation to use the raw objects returned by the AWS API for filtering, allowing the `location` attribute to be retrieved as well.  

* Update acceptance tests to compare concrete values instead of only checking for attribute existence.  
  * The expected values are obtained from the `data.aws_ec2_instance_type_offerings` data source used in the configurations.  


### Relations

Closes #44322

### References
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_InstanceTypeOffering.html


### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccEC2InstanceTypeOfferingDataSource_' PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_ec2_instance_type_offering-export_location 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2InstanceTypeOfferingDataSource_'  -timeout 360m -vet=off
2025/09/17 22:26:57 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/17 22:26:57 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEC2InstanceTypeOfferingDataSource_filter
=== PAUSE TestAccEC2InstanceTypeOfferingDataSource_filter
=== RUN   TestAccEC2InstanceTypeOfferingDataSource_locationType
=== PAUSE TestAccEC2InstanceTypeOfferingDataSource_locationType
=== RUN   TestAccEC2InstanceTypeOfferingDataSource_preferredInstanceTypes
=== PAUSE TestAccEC2InstanceTypeOfferingDataSource_preferredInstanceTypes
=== CONT  TestAccEC2InstanceTypeOfferingDataSource_filter
=== CONT  TestAccEC2InstanceTypeOfferingDataSource_preferredInstanceTypes
=== CONT  TestAccEC2InstanceTypeOfferingDataSource_locationType
--- PASS: TestAccEC2InstanceTypeOfferingDataSource_preferredInstanceTypes (15.93s)
--- PASS: TestAccEC2InstanceTypeOfferingDataSource_filter (16.24s)
--- PASS: TestAccEC2InstanceTypeOfferingDataSource_locationType (16.56s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        21.427s

```
