### PR TITLE
polly: enable `go-vcr` support

### DIFF
--- a/docs/ai-agent-guides/go-vcr-migration.md
+++ b/docs/ai-agent-guides/go-vcr-migration.md
@@ -1,0 +1,15 @@
+# Adding `go-vcr` Support
+
+You are working on the [Terraform AWS Provider](https://github.com/hashicorp/terraform-provider-aws), specifically focused on enabling support for `go-vcr`.
+
+Follow the steps below to enable support for a single service.
+
+- The working branch name should begin with `f-go-vcr-` and be suffixed with the name of the service being updated, e.g. `f-go-vcr-s3`. If the current branch does not match this convention, create one. Ensure the branch is rebased with the `main` branch.
+- Follow the steps on [this page](../go-vcr.md) to enable `go-vcr` for the target service.
+- Once all acceptace tests are passing, commit the changes with a message like "service-name: enable `go-vcr` support", replacing `service-name` with the target service. Be sure to include the COMPLETE output from acceptance testing in the commit body, wrapped in a `console` code block. e.g.
+
+```console
+% make testacc PKG=polly VCR_MODE=REPLAY_ONLY VCR_PATH=/tmp/polly-vcr-testdata/
+
+<-- full results here -->
+```

--- a/internal/service/polly/voices_data_source_test.go
+++ b/internal/service/polly/voices_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccPollyVoicesDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_polly_voices.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.PollyEndpointID)
@@ -45,7 +45,7 @@ func TestAccPollyVoicesDataSource_languageCode(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_polly_voices.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.PollyEndpointID)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Enables `go-vcr` support for the `polly` service. Also adds a AI agent guide for enabling `go-vcr` by service.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Relates #25602
Relates #43717


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=polly VCR_MODE=REPLAY_ONLY VCR_PATH=/tmp/polly-vcr-testdata/

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-go-vcr-polly 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/polly/... -v -count 1 -parallel 20   -timeout 360m -vet=off
2025/09/18 12:02:01 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:01 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestEndpointConfiguration
=== RUN   TestEndpointConfiguration/no_config
2025/09/18 12:02:01 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:01 Initializing Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:01 [DEBUG] missing_context: A profile defined with name `org` is ignored. For use within a shared configuration file, a non-default profile must have `profile ` prefixed to the profile name. tf_aws.sdk=aws-sdk-go-v2
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar
2025/09/18 12:02:01 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:01 Initializing Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:01 [DEBUG] missing_context: A profile defined with name `org` is ignored. For use within a shared configuration file, a non-default profile must have `profile ` prefixed to the profile name. tf_aws.sdk=aws-sdk-go-v2
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar
2025/09/18 12:02:01 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:01 Initializing Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:01 [DEBUG] missing_context: A profile defined with name `org` is ignored. For use within a shared configuration file, a non-default profile must have `profile ` prefixed to the profile name. tf_aws.sdk=aws-sdk-go-v2
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file
2025/09/18 12:02:01 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:01 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestEndpointConfiguration/base_endpoint_envvar
2025/09/18 12:02:01 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:01 Initializing Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:01 [DEBUG] missing_context: A profile defined with name `org` is ignored. For use within a shared configuration file, a non-default profile must have `profile ` prefixed to the profile name. tf_aws.sdk=aws-sdk-go-v2
=== RUN   TestEndpointConfiguration/service_config_file_overrides_base_config_file
2025/09/18 12:02:01 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:01 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestEndpointConfiguration/service_aws_envvar
2025/09/18 12:02:01 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:01 Initializing Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:01 [DEBUG] missing_context: A profile defined with name `org` is ignored. For use within a shared configuration file, a non-default profile must have `profile ` prefixed to the profile name. tf_aws.sdk=aws-sdk-go-v2
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file
2025/09/18 12:02:01 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:01 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file
2025/09/18 12:02:01 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:01 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestEndpointConfiguration/base_endpoint_config_file
2025/09/18 12:02:01 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:01 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestEndpointConfiguration/service_config_file
2025/09/18 12:02:01 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:01 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestEndpointConfiguration/use_fips_config_with_package_name_endpoint_config
2025/09/18 12:02:02 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:02 Initializing Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:02 [DEBUG] missing_context: A profile defined with name `org` is ignored. For use within a shared configuration file, a non-default profile must have `profile ` prefixed to the profile name. tf_aws.sdk=aws-sdk-go-v2
=== RUN   TestEndpointConfiguration/package_name_endpoint_config
2025/09/18 12:02:02 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:02 Initializing Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:02 [DEBUG] missing_context: A profile defined with name `org` is ignored. For use within a shared configuration file, a non-default profile must have `profile ` prefixed to the profile name. tf_aws.sdk=aws-sdk-go-v2
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file
2025/09/18 12:02:02 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:02 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file
2025/09/18 12:02:02 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:02 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar
2025/09/18 12:02:02 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:02 Initializing Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:02 [DEBUG] missing_context: A profile defined with name `org` is ignored. For use within a shared configuration file, a non-default profile must have `profile ` prefixed to the profile name. tf_aws.sdk=aws-sdk-go-v2
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file
2025/09/18 12:02:02 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:02 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestEndpointConfiguration/use_fips_config
2025/09/18 12:02:02 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:02 Initializing Terraform AWS Provider (SDKv2-style)...
2025/09/18 12:02:02 [DEBUG] missing_context: A profile defined with name `org` is ignored. For use within a shared configuration file, a non-default profile must have `profile ` prefixed to the profile name. tf_aws.sdk=aws-sdk-go-v2
--- PASS: TestEndpointConfiguration (0.37s)
    --- PASS: TestEndpointConfiguration/no_config (0.02s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar (0.03s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar (0.03s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file (0.02s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar (0.02s)
    --- PASS: TestEndpointConfiguration/service_config_file_overrides_base_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar (0.01s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file (0.02s)
    --- PASS: TestEndpointConfiguration/base_endpoint_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/service_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/use_fips_config_with_package_name_endpoint_config (0.03s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config (0.03s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar (0.01s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/use_fips_config (0.02s)
=== RUN   TestAccPollyVoicesDataSource_basic
=== PAUSE TestAccPollyVoicesDataSource_basic
=== RUN   TestAccPollyVoicesDataSource_languageCode
=== PAUSE TestAccPollyVoicesDataSource_languageCode
=== CONT  TestAccPollyVoicesDataSource_basic
=== CONT  TestAccPollyVoicesDataSource_languageCode
    voices_data_source_test.go:48: stopping VCR recorder
    voices_data_source_test.go:48: randomness source not found for test TestAccPollyVoicesDataSource_languageCode
--- PASS: TestAccPollyVoicesDataSource_languageCode (7.20s)
=== NAME  TestAccPollyVoicesDataSource_basic
    voices_data_source_test.go:20: stopping VCR recorder
    voices_data_source_test.go:20: randomness source not found for test TestAccPollyVoicesDataSource_basic
--- PASS: TestAccPollyVoicesDataSource_basic (7.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/polly	14.139s
```