### PR TITLE
.ci/scripts: support for `new-action` entry types

### DIFF
--- a/.ci/scripts/changelog.tmpl
+++ b/.ci/scripts/changelog.tmpl
@@ -15,7 +15,7 @@ NOTES:
 {{ end -}}
 {{- end -}}
 
-{{- $features := combineTypes .NotesByType.feature (index .NotesByType "new-resource" ) (index .NotesByType "new-data-source") (index .NotesByType "new-ephemeral") (index .NotesByType "new-function") (index .NotesByType "new-guide") }}
+{{- $features := combineTypes .NotesByType.feature (index .NotesByType "new-resource" ) (index .NotesByType "new-data-source") (index .NotesByType "new-ephemeral") (index .NotesByType "new-function") (index .NotesByType "new-action") (index .NotesByType "new-guide") }}
 {{- if $features }}
 FEATURES:
 

--- a/.ci/scripts/release-note.tmpl
+++ b/.ci/scripts/release-note.tmpl
@@ -7,6 +7,8 @@
 * **New Ephemeral Resource:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/hashicorp/terraform-provider-aws/issues/{{- .Issue -}}))
 {{- else if eq "new-function" .Type -}}
 * **New Function:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/hashicorp/terraform-provider-aws/issues/{{- .Issue -}}))
+{{- else if eq "new-action" .Type -}}
+* **New Action:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/hashicorp/terraform-provider-aws/issues/{{- .Issue -}}))
 {{- else if eq "new-guide" .Type -}}
 * **New Guide:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/hashicorp/terraform-provider-aws/issues/{{- .Issue -}}))
 {{- else -}}


### PR DESCRIPTION

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds support for a new changelog entry type, `new-action`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/go-changelog/pull/45
Relates #40222

Relates https://github.com/hashicorp/terraform-provider-aws/pull/43972
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43955
Relates https://github.com/hashicorp/terraform-provider-aws/pull/44214
Relates https://github.com/hashicorp/terraform-provider-aws/pull/44232
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43700