### PR TITLE
[Enhancement] aws_pinpointsmsvoice2_phone_number: Support Amazon Connect as the inbound destination for two-way SMS

### DIFF
--- a/.changelog/44372.txt
+++ b/.changelog/44372.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_pinpointsmsvoicev2_phone_number: Update `two_way_channel_arn` argument to accept `connect.[region].amazonaws.com` in addition to ARNs
+```

--- a/internal/service/pinpointsmsvoicev2/phone_number.go
+++ b/internal/service/pinpointsmsvoicev2/phone_number.go
@@ -128,11 +128,14 @@ func (r *phoneNumberResource) Schema(ctx context.Context, request resource.Schem
 			names.AttrTags:    tftags.TagsAttribute(),
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 			"two_way_channel_arn": schema.StringAttribute{
-				CustomType: fwtypes.ARNType,
-				Optional:   true,
+				Optional: true,
 				Validators: []validator.String{
 					stringvalidator.AlsoRequires(
 						path.MatchRelative().AtParent().AtName("two_way_channel_enabled"),
+					),
+					stringvalidator.Any(
+						stringvalidator.RegexMatches(regexache.MustCompile(`^arn`), "must be a valid ARN"),
+						stringvalidator.RegexMatches(regexache.MustCompile(`^connect\.[a-z0-9-]+\.amazonaws.com$`), "Must be connect.{region}.amazonaws.com"),
 					),
 				},
 			},
@@ -390,7 +393,7 @@ type phoneNumberResourceModel struct {
 	Tags                      tftags.Map                                         `tfsdk:"tags"`
 	TagsAll                   tftags.Map                                         `tfsdk:"tags_all"`
 	Timeouts                  timeouts.Value                                     `tfsdk:"timeouts"`
-	TwoWayChannelARN          fwtypes.ARN                                        `tfsdk:"two_way_channel_arn"`
+	TwoWayChannelARN          types.String                                       `tfsdk:"two_way_channel_arn"`
 	TwoWayEnabled             types.Bool                                         `tfsdk:"two_way_channel_enabled"`
 	TwoWayChannelRole         fwtypes.ARN                                        `tfsdk:"two_way_channel_role"`
 }

--- a/internal/service/pinpointsmsvoicev2/phone_number.go
+++ b/internal/service/pinpointsmsvoicev2/phone_number.go
@@ -35,6 +35,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -134,7 +135,7 @@ func (r *phoneNumberResource) Schema(ctx context.Context, request resource.Schem
 						path.MatchRelative().AtParent().AtName("two_way_channel_enabled"),
 					),
 					stringvalidator.Any(
-						stringvalidator.RegexMatches(regexache.MustCompile(`^arn`), "must be a valid ARN"),
+						fwvalidators.ARN(),
 						stringvalidator.RegexMatches(regexache.MustCompile(`^connect\.[a-z0-9-]+\.amazonaws.com$`), "Must be connect.{region}.amazonaws.com"),
 					),
 				},

--- a/internal/service/pinpointsmsvoicev2/phone_number_test.go
+++ b/internal/service/pinpointsmsvoicev2/phone_number_test.go
@@ -176,6 +176,42 @@ func TestAccPinpointSMSVoiceV2PhoneNumber_twoWayChannelRole(t *testing.T) {
 		},
 	})
 }
+
+func TestAccPinpointSMSVoiceV2PhoneNumber_twoWayChannelConnect(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	iamRoleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_pinpointsmsvoicev2_phone_number.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckPhoneNumber(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.PinpointSMSVoiceV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPhoneNumberDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPhoneNumberConfig_two_way_channel_connect(iamRoleName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("iso_country_code"), knownvalue.StringExact("US")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("message_type"), knownvalue.StringExact("TRANSACTIONAL")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("number_type"), knownvalue.StringExact("SIMULATOR")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("two_way_channel_enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("two_way_channel_arn"), knownvalue.StringRegexp(regexache.MustCompile(`^connect\.[a-z0-9-]+\.amazonaws\.com`))),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("two_way_channel_role"), tfknownvalue.GlobalARNRegexp("iam", regexache.MustCompile(fmt.Sprintf(`role/%s`, iamRoleName)))),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccPinpointSMSVoiceV2PhoneNumber_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var phoneNumber awstypes.PhoneNumberInformation
@@ -439,6 +475,64 @@ resource "aws_pinpointsmsvoicev2_phone_number" "test" {
   ]
 }
 `, snsTopicName, iamRoleName)
+}
+
+func testAccPhoneNumberConfig_two_way_channel_connect(iamRoleName string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "sms-voice.amazonaws.com"
+        }
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = "pinpointsmsvoicev2-sns-policy"
+  role = aws_iam_role.test.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "connect:SendChatIntegrationEvent",
+        ],
+        Resource = ["*"]
+      }
+    ]
+  })
+}
+
+resource "aws_pinpointsmsvoicev2_phone_number" "test" {
+  iso_country_code        = "US"
+  message_type            = "TRANSACTIONAL"
+  number_type             = "SIMULATOR"
+  two_way_channel_arn     = "connect.${data.aws_region.current.region}.amazonaws.com"
+  two_way_channel_role    = aws_iam_role.test.arn
+  two_way_channel_enabled = true
+  number_capabilities = [
+    "SMS",
+    "VOICE",
+  ]
+}
+`, iamRoleName)
 }
 
 func testAccPhoneNumberConfig_tags1(tagKey1, tagValue1 string) string {

--- a/website/docs/r/pinpointsmsvoicev2_phone_number.html.markdown
+++ b/website/docs/r/pinpointsmsvoicev2_phone_number.html.markdown
@@ -37,7 +37,7 @@ This resource supports the following arguments:
 * `opt_out_list_name` - (Optional) The name of the opt-out list to associate with the phone number.
 * `registration_id` - (Optional) Use this field to attach your phone number for an external registration process.
 * `self_managed_opt_outs_enabled` - (Optional) When set to `false` an end recipient sends a message that begins with HELP or STOP to one of your dedicated numbers, AWS End User Messaging SMS and Voice automatically replies with a customizable message and adds the end recipient to the opt-out list. When set to true you’re responsible for responding to HELP and STOP requests. You’re also responsible for tracking and honoring opt-out request.
-* `two_way_channel_arn` - (Optional) The Amazon Resource Name (ARN) of the two way channel.
+* `two_way_channel_arn` - (Optional) Configuration for two-way SMS. Specify an ARN to receive incoming SMS messages, or `connect.[region].amazonaws.com` (with `[region]` replaced by the AWS Region of the Amazon Connect instance) to set Amazon Connect as the inbound destination.
 * `two_way_channel_enabled` - (Optional) By default this is set to `false`. When set to `true` you can receive incoming text messages from your end recipients.
 * `two_way_channel_role` - (Optional) IAM Role ARN for a service to assume, to be able to post inbound SMS messages.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR updates the `two_way_channel_arn` argument to support using Amazon Connect as the inbound destination for two-way SMS.  

* The argument type is changed from `ARNType` to `StringType`, removing the strict ARN-only validation.  
* Instead of removing validation entirely, new checks ensure the value either starts with `arn` or matches `connect\.[a-z0-9-]+\.amazonaws.com`.  
* A new acceptance test confirms that `connect.[region].amazonaws.com` is accepted as a valid value for `two_way_channel_arn`.  


### Relations

Closes #44321

### References
https://docs.aws.amazon.com/sms-voice/latest/userguide/two-way-sms-phone-number.html

> To set Amazon Connect as the inbound destination set `TwoWayARN` to `connect.region.amazonaws.com`. Replace region with the AWS Region the Amazon Connect instance is hosted in.


### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccPinpointSMSVoiceV2PhoneNumber_' PKG=pinpointsmsvoicev2 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿  f-aws_pinpointsmsvoice2_phone_number-support_amazon_connect_two_way_channel 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/pinpointsmsvoicev2/... -v -count 1 -parallel 20 -run='TestAccPinpointSMSVoiceV2PhoneNumber_'  -timeout 360m -vet=off
2025/09/19 07:47:20 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/19 07:47:20 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccPinpointSMSVoiceV2PhoneNumber_basic
=== PAUSE TestAccPinpointSMSVoiceV2PhoneNumber_basic
=== RUN   TestAccPinpointSMSVoiceV2PhoneNumber_full
=== PAUSE TestAccPinpointSMSVoiceV2PhoneNumber_full
=== RUN   TestAccPinpointSMSVoiceV2PhoneNumber_twoWayChannelRole
=== PAUSE TestAccPinpointSMSVoiceV2PhoneNumber_twoWayChannelRole
=== RUN   TestAccPinpointSMSVoiceV2PhoneNumber_twoWayChannelConnect
=== PAUSE TestAccPinpointSMSVoiceV2PhoneNumber_twoWayChannelConnect
=== RUN   TestAccPinpointSMSVoiceV2PhoneNumber_disappears
=== PAUSE TestAccPinpointSMSVoiceV2PhoneNumber_disappears
=== RUN   TestAccPinpointSMSVoiceV2PhoneNumber_tags
=== PAUSE TestAccPinpointSMSVoiceV2PhoneNumber_tags
=== CONT  TestAccPinpointSMSVoiceV2PhoneNumber_basic
=== CONT  TestAccPinpointSMSVoiceV2PhoneNumber_twoWayChannelConnect
=== CONT  TestAccPinpointSMSVoiceV2PhoneNumber_twoWayChannelRole
=== CONT  TestAccPinpointSMSVoiceV2PhoneNumber_tags
=== CONT  TestAccPinpointSMSVoiceV2PhoneNumber_disappears
=== CONT  TestAccPinpointSMSVoiceV2PhoneNumber_full
--- PASS: TestAccPinpointSMSVoiceV2PhoneNumber_basic (45.90s)
--- PASS: TestAccPinpointSMSVoiceV2PhoneNumber_twoWayChannelConnect (50.37s)
--- PASS: TestAccPinpointSMSVoiceV2PhoneNumber_tags (61.25s)
--- PASS: TestAccPinpointSMSVoiceV2PhoneNumber_twoWayChannelRole (68.25s)
--- PASS: TestAccPinpointSMSVoiceV2PhoneNumber_disappears (70.83s)
--- PASS: TestAccPinpointSMSVoiceV2PhoneNumber_full (73.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/pinpointsmsvoicev2 77.692s

```
