### PR TITLE
fix: s/TLSv1.2/TLSv1.2_2021/g

### DIFF
--- a/internal/service/cloudfront/continuous_deployment_policy_test.go
+++ b/internal/service/cloudfront/continuous_deployment_policy_test.go
@@ -359,7 +359,7 @@ resource "aws_cloudfront_distribution" "staging" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -409,7 +409,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -457,7 +457,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 

--- a/internal/service/cloudfront/create_invalidation_action_test.go
+++ b/internal/service/cloudfront/create_invalidation_action_test.go
@@ -168,7 +168,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -1909,7 +1909,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -1959,7 +1959,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -3164,7 +3164,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -3213,7 +3213,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -3262,7 +3262,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -3311,7 +3311,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -3357,7 +3357,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -3422,7 +3422,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -3487,7 +3487,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -3552,7 +3552,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -3617,7 +3617,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -3666,7 +3666,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -3727,7 +3727,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -3786,7 +3786,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -3833,7 +3833,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -3881,7 +3881,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -3996,7 +3996,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -4063,7 +4063,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -4693,7 +4693,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 
@@ -4743,7 +4743,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 

--- a/internal/service/cloudfront/monitoring_subscription_test.go
+++ b/internal/service/cloudfront/monitoring_subscription_test.go
@@ -189,7 +189,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 

--- a/internal/service/cloudfront/vpc_origin_test.go
+++ b/internal/service/cloudfront/vpc_origin_test.go
@@ -293,7 +293,7 @@ resource "aws_cloudfront_vpc_origin" "test" {
     origin_protocol_policy = "http-only"
 
     origin_ssl_protocols {
-      items    = ["TLSv1.2"]
+      items    = ["TLSv1.2_2021"]
       quantity = 1
     }
   }
@@ -312,7 +312,7 @@ resource "aws_cloudfront_vpc_origin" "test" {
     origin_protocol_policy = "https-only"
 
     origin_ssl_protocols {
-      items    = ["TLSv1.2", "TLSv1.1"]
+      items    = ["TLSv1.2_2021", "TLSv1.1"]
       quantity = 2
     }
   }
@@ -331,7 +331,7 @@ resource "aws_cloudfront_vpc_origin" "test" {
     origin_protocol_policy = "http-only"
 
     origin_ssl_protocols {
-      items    = ["TLSv1.2"]
+      items    = ["TLSv1.2_2021"]
       quantity = 1
     }
   }
@@ -354,7 +354,7 @@ resource "aws_cloudfront_vpc_origin" "test" {
     origin_protocol_policy = "http-only"
 
     origin_ssl_protocols {
-      items    = ["TLSv1.2"]
+      items    = ["TLSv1.2_2021"]
       quantity = 1
     }
   }

--- a/internal/service/logs/delivery_source_test.go
+++ b/internal/service/logs/delivery_source_test.go
@@ -281,7 +281,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 

--- a/internal/service/rds/option_group_test.go
+++ b/internal/service/rds/option_group_test.go
@@ -1221,7 +1221,7 @@ resource "aws_db_option_group" "test" {
     }
     option_settings {
       name  = "MINIMUM_TLS_VERSION"
-      value = "TLSv1.2"
+      value = "TLSv1.2_2021"
     }
     option_settings {
       name  = "TLS_CIPHER_SUITE"
@@ -1282,7 +1282,7 @@ resource "aws_db_option_group" "test" {
     }
     option_settings {
       name  = "MINIMUM_TLS_VERSION"
-      value = "TLSv1.2"
+      value = "TLSv1.2_2021"
     }
     option_settings {
       name  = "TLS_CIPHER_SUITE"

--- a/internal/service/shield/application_layer_automatic_response_test.go
+++ b/internal/service/shield/application_layer_automatic_response_test.go
@@ -159,7 +159,7 @@ resource "aws_cloudfront_distribution" "test" {
       origin_ssl_protocols = [
         "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
+        "TLSv1.2_2021",
       ]
     }
     # This is a fake origin and it's set to this name to indicate that.

--- a/internal/service/shield/protection_test.go
+++ b/internal/service/shield/protection_test.go
@@ -544,7 +544,7 @@ resource "aws_cloudfront_distribution" "test" {
       origin_ssl_protocols = [
         "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
+        "TLSv1.2_2021",
       ]
     }
 
@@ -614,7 +614,7 @@ resource "aws_cloudfront_distribution" "test" {
       origin_ssl_protocols = [
         "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
+        "TLSv1.2_2021",
       ]
     }
 
@@ -687,7 +687,7 @@ resource "aws_cloudfront_distribution" "test" {
       origin_ssl_protocols = [
         "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
+        "TLSv1.2_2021",
       ]
     }
 

--- a/internal/service/shield/testdata/ApplicationLayerAutomaticResponse/basic/main_gen.tf
+++ b/internal/service/shield/testdata/ApplicationLayerAutomaticResponse/basic/main_gen.tf
@@ -48,7 +48,7 @@ resource "aws_cloudfront_distribution" "test" {
       origin_ssl_protocols = [
         "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
+        "TLSv1.2_2021",
       ]
     }
 

--- a/internal/service/shield/testdata/ApplicationLayerAutomaticResponse/basic_v5.100.0/main_gen.tf
+++ b/internal/service/shield/testdata/ApplicationLayerAutomaticResponse/basic_v5.100.0/main_gen.tf
@@ -48,7 +48,7 @@ resource "aws_cloudfront_distribution" "test" {
       origin_ssl_protocols = [
         "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
+        "TLSv1.2_2021",
       ]
     }
 

--- a/internal/service/shield/testdata/ApplicationLayerAutomaticResponse/basic_v6.0.0/main_gen.tf
+++ b/internal/service/shield/testdata/ApplicationLayerAutomaticResponse/basic_v6.0.0/main_gen.tf
@@ -48,7 +48,7 @@ resource "aws_cloudfront_distribution" "test" {
       origin_ssl_protocols = [
         "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
+        "TLSv1.2_2021",
       ]
     }
 

--- a/internal/service/shield/testdata/tmpl/application_layer_automatic_response_basic.gtpl
+++ b/internal/service/shield/testdata/tmpl/application_layer_automatic_response_basic.gtpl
@@ -45,7 +45,7 @@ resource "aws_cloudfront_distribution" "test" {
       origin_ssl_protocols = [
         "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
+        "TLSv1.2_2021",
       ]
     }
 

--- a/internal/service/wafv2/web_acl_data_source_test.go
+++ b/internal/service/wafv2/web_acl_data_source_test.go
@@ -449,7 +449,7 @@ resource "aws_cloudfront_distribution" "test" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2_2021"]
     }
   }
 

--- a/website/docs/cdktf/python/r/cloudfront_vpc_origin.html.markdown
+++ b/website/docs/cdktf/python/r/cloudfront_vpc_origin.html.markdown
@@ -41,7 +41,7 @@ class MyConvertedCode(TerraformStack):
                 name="example-vpc-origin",
                 origin_protocol_policy="https-only",
                 origin_ssl_protocols=[CloudfrontVpcOriginVpcOriginEndpointConfigOriginSslProtocols(
-                    items=["TLSv1.2"],
+                    items=["TLSv1.2_2021"],
                     quantity=1
                 )
                 ]

--- a/website/docs/cdktf/typescript/r/cloudfront_vpc_origin.html.markdown
+++ b/website/docs/cdktf/typescript/r/cloudfront_vpc_origin.html.markdown
@@ -43,7 +43,7 @@ class MyConvertedCode extends TerraformStack {
           originProtocolPolicy: "https-only",
           originSslProtocols: [
             {
-              items: ["TLSv1.2"],
+              items: ["TLSv1.2_2021"],
               quantity: 1,
             },
           ],

--- a/website/docs/r/cloudfront_vpc_origin.html.markdown
+++ b/website/docs/r/cloudfront_vpc_origin.html.markdown
@@ -29,7 +29,7 @@ resource "aws_cloudfront_vpc_origin" "alb" {
     origin_protocol_policy = "https-only"
 
     origin_ssl_protocols {
-      items    = ["TLSv1.2"]
+      items    = ["TLSv1.2_2021"]
       quantity = 1
     }
   }


### PR DESCRIPTION
per [this table](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html), `TLSv1.2` is not a valid TLS protocol, thus updating it to `TLSv1.2_2021`

<img width="1385" height="368" alt="image" src="https://github.com/user-attachments/assets/325f96f2-ceb7-476d-850d-3290c04ebd72" />

relates to https://github.com/hashicorp/terraform-provider-aws/issues/43250
