### PR TITLE
feat: update maximum length for GuardrailTopicConfig definition

### DIFF
--- a/.changelog/44386.txt
+++ b/.changelog/44386.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrock_guardrail: Increase upper limit of `topic_policy_config.topicsConfig.definition` from 200 to 1000
+```

--- a/internal/service/bedrock/guardrail.go
+++ b/internal/service/bedrock/guardrail.go
@@ -349,7 +349,7 @@ func (r *guardrailResource) Schema(ctx context.Context, req resource.SchemaReque
 									"definition": schema.StringAttribute{
 										Required: true,
 										Validators: []validator.String{
-											stringvalidator.LengthBetween(1, 200),
+											stringvalidator.LengthBetween(1, 1000),
 										},
 									},
 									"examples": schema.ListAttribute{

--- a/website/docs/r/bedrock_guardrail.html.markdown
+++ b/website/docs/r/bedrock_guardrail.html.markdown
@@ -145,7 +145,7 @@ The `filters_config` configuration block supports the following arguments:
 
 #### Topics Config
 
-* `definition` (Required) Definition of topic in topic policy.
+* `definition` (Required) Definition of topic in topic policy. Maximum length of 1000.
 * `name` (Required) Name of topic in topic policy.
 * `type` (Required) Type of topic in a policy.
 * `examples` (Optional) List of text examples.


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls are implemented.

### Description

Update the validation for the [`definition`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrock_guardrail#definition-1) in [`aws_bedrock_guardrail`](aws_bedrock_guardrail) to support standard tier configurations.

### Relations

Closes #44343 

### References

- [Safeguard tiers for guardrails policies
](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-tiers.html#guardrails-tiers-key-differences) mentioning the different definitionlength for classic and standard tier.

### Output from Acceptance Testing

One test fails - but to my current understanding it's unrelated to my changes.
```console
❯ make testacc TESTS=TestAccBedrockGuardrail_ PKG=bedrock
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_bedrock_guardrail-update-limit 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/bedrock/... -v -count 1 -parallel 20 -run='TestAccBedrockGuardrail_'  -timeout 360m -vet=off
2025/09/20 11:18:07 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/20 11:18:07 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockGuardrail_tags
=== PAUSE TestAccBedrockGuardrail_tags
=== RUN   TestAccBedrockGuardrail_tags_null
=== PAUSE TestAccBedrockGuardrail_tags_null
=== RUN   TestAccBedrockGuardrail_tags_EmptyMap
=== PAUSE TestAccBedrockGuardrail_tags_EmptyMap
=== RUN   TestAccBedrockGuardrail_tags_AddOnUpdate
=== PAUSE TestAccBedrockGuardrail_tags_AddOnUpdate
=== RUN   TestAccBedrockGuardrail_tags_EmptyTag_OnCreate
=== PAUSE TestAccBedrockGuardrail_tags_EmptyTag_OnCreate
=== RUN   TestAccBedrockGuardrail_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccBedrockGuardrail_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccBedrockGuardrail_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccBedrockGuardrail_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccBedrockGuardrail_tags_DefaultTags_providerOnly
=== PAUSE TestAccBedrockGuardrail_tags_DefaultTags_providerOnly
=== RUN   TestAccBedrockGuardrail_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccBedrockGuardrail_tags_DefaultTags_nonOverlapping
=== RUN   TestAccBedrockGuardrail_tags_DefaultTags_overlapping
=== PAUSE TestAccBedrockGuardrail_tags_DefaultTags_overlapping
=== RUN   TestAccBedrockGuardrail_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccBedrockGuardrail_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccBedrockGuardrail_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccBedrockGuardrail_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccBedrockGuardrail_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccBedrockGuardrail_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccBedrockGuardrail_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccBedrockGuardrail_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccBedrockGuardrail_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccBedrockGuardrail_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccBedrockGuardrail_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccBedrockGuardrail_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccBedrockGuardrail_tags_ComputedTag_OnCreate
=== PAUSE TestAccBedrockGuardrail_tags_ComputedTag_OnCreate
=== RUN   TestAccBedrockGuardrail_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccBedrockGuardrail_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccBedrockGuardrail_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccBedrockGuardrail_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccBedrockGuardrail_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccBedrockGuardrail_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccBedrockGuardrail_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccBedrockGuardrail_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccBedrockGuardrail_basic
=== PAUSE TestAccBedrockGuardrail_basic
=== RUN   TestAccBedrockGuardrail_disappears
=== PAUSE TestAccBedrockGuardrail_disappears
=== RUN   TestAccBedrockGuardrail_kmsKey
=== PAUSE TestAccBedrockGuardrail_kmsKey
=== RUN   TestAccBedrockGuardrail_update
=== PAUSE TestAccBedrockGuardrail_update
=== RUN   TestAccBedrockGuardrail_wordConfigAction
=== PAUSE TestAccBedrockGuardrail_wordConfigAction
=== RUN   TestAccBedrockGuardrail_crossRegion
=== PAUSE TestAccBedrockGuardrail_crossRegion
=== RUN   TestAccBedrockGuardrail_enhancedActions
=== PAUSE TestAccBedrockGuardrail_enhancedActions
=== CONT  TestAccBedrockGuardrail_tags
=== CONT  TestAccBedrockGuardrail_tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccBedrockGuardrail_tags_DefaultTags_emptyProviderOnlyTag
=== CONT  TestAccBedrockGuardrail_tags_DefaultTags_emptyResourceTag
=== CONT  TestAccBedrockGuardrail_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccBedrockGuardrail_tags_DefaultTags_updateToProviderOnly
=== CONT  TestAccBedrockGuardrail_tags_DefaultTags_overlapping
=== CONT  TestAccBedrockGuardrail_tags_DefaultTags_nonOverlapping
=== CONT  TestAccBedrockGuardrail_tags_DefaultTags_providerOnly
=== CONT  TestAccBedrockGuardrail_enhancedActions
=== CONT  TestAccBedrockGuardrail_crossRegion
=== CONT  TestAccBedrockGuardrail_wordConfigAction
=== CONT  TestAccBedrockGuardrail_tags_EmptyTag_OnUpdate_Replace
=== CONT  TestAccBedrockGuardrail_update
=== CONT  TestAccBedrockGuardrail_kmsKey
=== CONT  TestAccBedrockGuardrail_disappears
=== CONT  TestAccBedrockGuardrail_basic
=== CONT  TestAccBedrockGuardrail_tags_IgnoreTags_Overlap_ResourceTag
=== CONT  TestAccBedrockGuardrail_tags_EmptyTag_OnUpdate_Add
=== CONT  TestAccBedrockGuardrail_tags_EmptyTag_OnCreate
--- PASS: TestAccBedrockGuardrail_disappears (75.60s)
=== CONT  TestAccBedrockGuardrail_tags_AddOnUpdate
--- PASS: TestAccBedrockGuardrail_crossRegion (91.97s)
=== CONT  TestAccBedrockGuardrail_tags_EmptyMap
--- PASS: TestAccBedrockGuardrail_tags_DefaultTags_nullOverlappingResourceTag (92.09s)
=== CONT  TestAccBedrockGuardrail_tags_null
=== NAME  TestAccBedrockGuardrail_update
    guardrail_test.go:151: Step 2/3 error: Error running apply: exit status 1
        
        Error: Provider produced inconsistent result after apply
        
        When applying changes to aws_bedrock_guardrail.test, provider
        "provider[\"registry.terraform.io/hashicorp/aws\"]" produced an unexpected
        new value: .topic_policy_config[0].tier_config: was null, but now
        cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{"tier_name":cty.StringVal("CLASSIC")})}).
        
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
        
        Error: Provider produced inconsistent result after apply
        
        When applying changes to aws_bedrock_guardrail.test, provider
        "provider[\"registry.terraform.io/hashicorp/aws\"]" produced an unexpected
        new value: .content_policy_config[0].tier_config: was null, but now
        cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{"tier_name":cty.StringVal("CLASSIC")})}).
        
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
--- PASS: TestAccBedrockGuardrail_tags_DefaultTags_emptyProviderOnlyTag (116.48s)
=== CONT  TestAccBedrockGuardrail_tags_ComputedTag_OnCreate
--- FAIL: TestAccBedrockGuardrail_update (126.45s)
=== CONT  TestAccBedrockGuardrail_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccBedrockGuardrail_tags_DefaultTags_emptyResourceTag (137.68s)
=== CONT  TestAccBedrockGuardrail_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccBedrockGuardrail_basic (138.10s)
=== CONT  TestAccBedrockGuardrail_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccBedrockGuardrail_kmsKey (147.78s)
=== CONT  TestAccBedrockGuardrail_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccBedrockGuardrail_tags_DefaultTags_updateToProviderOnly (156.97s)
--- PASS: TestAccBedrockGuardrail_enhancedActions (161.96s)
--- PASS: TestAccBedrockGuardrail_tags_EmptyTag_OnUpdate_Replace (170.05s)
--- PASS: TestAccBedrockGuardrail_tags_EmptyTag_OnCreate (179.52s)
--- PASS: TestAccBedrockGuardrail_tags_DefaultTags_updateToResourceOnly (179.52s)
--- PASS: TestAccBedrockGuardrail_wordConfigAction (190.49s)
--- PASS: TestAccBedrockGuardrail_tags_EmptyMap (103.40s)
--- PASS: TestAccBedrockGuardrail_tags_null (105.43s)
--- PASS: TestAccBedrockGuardrail_tags_ComputedTag_OnCreate (91.94s)
--- PASS: TestAccBedrockGuardrail_tags_AddOnUpdate (149.67s)
--- PASS: TestAccBedrockGuardrail_tags_IgnoreTags_Overlap_ResourceTag (234.44s)
--- PASS: TestAccBedrockGuardrail_tags_DefaultTags_nullNonOverlappingResourceTag (90.70s)
--- PASS: TestAccBedrockGuardrail_tags_EmptyTag_OnUpdate_Add (239.02s)
--- PASS: TestAccBedrockGuardrail_tags_DefaultTags_nonOverlapping (252.99s)
--- PASS: TestAccBedrockGuardrail_tags_ComputedTag_OnUpdate_Add (127.49s)
--- PASS: TestAccBedrockGuardrail_tags_ComputedTag_OnUpdate_Replace (128.21s)
--- PASS: TestAccBedrockGuardrail_tags_IgnoreTags_Overlap_DefaultTag (149.59s)
--- PASS: TestAccBedrockGuardrail_tags_DefaultTags_providerOnly (297.90s)
--- PASS: TestAccBedrockGuardrail_tags (297.90s)
--- PASS: TestAccBedrockGuardrail_tags_DefaultTags_overlapping (297.90s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/bedrock    298.161s
FAIL
make: *** [GNUmakefile:680: testacc] Error 1
```
