### PR TITLE
Add Kendra knowledge base support to aws_bedrockagent_knowledge_base resource

### DIFF
--- a/internal/service/bedrockagent/bedrockagent_test.go
+++ b/internal/service/bedrockagent/bedrockagent_test.go
@@ -20,6 +20,7 @@ func TestAccBedrockAgent_serial(t *testing.T) {
 			"OpenSearchBasic":                   testAccKnowledgeBase_OpenSearch_basic,
 			"OpenSearchUpdate":                  testAccKnowledgeBase_OpenSearch_update,
 			"OpenSearchSupplementalDataStorage": testAccKnowledgeBase_OpenSearch_supplementalDataStorage,
+			"KendraBasic":                       testAccKnowledgeBase_Kendra_basic,
 		},
 		"DataSource": {
 			acctest.CtBasic:        testAccDataSource_basic,

--- a/internal/service/bedrockagent/knowledge_base.go
+++ b/internal/service/bedrockagent/knowledge_base.go
@@ -115,8 +115,6 @@ func (r *knowledgeBaseResource) Schema(ctx context.Context, request resource.Sch
 						"vector_knowledge_base_configuration": schema.ListNestedBlock{
 							CustomType: fwtypes.NewListNestedObjectTypeOf[vectorKnowledgeBaseConfigurationModel](ctx),
 							Validators: []validator.List{
-								listvalidator.IsRequired(),
-								listvalidator.SizeAtLeast(1),
 								listvalidator.SizeAtMost(1),
 							},
 							PlanModifiers: []planmodifier.List{
@@ -206,14 +204,32 @@ func (r *knowledgeBaseResource) Schema(ctx context.Context, request resource.Sch
 								},
 							},
 						},
+						"kendra_knowledge_base_configuration": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[kendraKnowledgeBaseConfigurationModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							PlanModifiers: []planmodifier.List{
+								listplanmodifier.RequiresReplace(),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"kendra_index_arn": schema.StringAttribute{
+										CustomType: fwtypes.ARNType,
+										Required:   true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.RequiresReplace(),
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
 			"storage_configuration": schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[storageConfigurationModel](ctx),
 				Validators: []validator.List{
-					listvalidator.IsRequired(),
-					listvalidator.SizeAtLeast(1),
 					listvalidator.SizeAtMost(1),
 				},
 				PlanModifiers: []planmodifier.List{
@@ -803,6 +819,7 @@ type knowledgeBaseResourceModel struct {
 type knowledgeBaseConfigurationModel struct {
 	Type                             types.String                                                           `tfsdk:"type"`
 	VectorKnowledgeBaseConfiguration fwtypes.ListNestedObjectValueOf[vectorKnowledgeBaseConfigurationModel] `tfsdk:"vector_knowledge_base_configuration"`
+	KendraKnowledgeBaseConfiguration fwtypes.ListNestedObjectValueOf[kendraKnowledgeBaseConfigurationModel] `tfsdk:"kendra_knowledge_base_configuration"`
 }
 
 type vectorKnowledgeBaseConfigurationModel struct {
@@ -827,6 +844,10 @@ type supplementalDataStorageConfigurationModel struct {
 type storageLocationModel struct {
 	Type       fwtypes.StringEnum[awstypes.SupplementalDataStorageLocationType] `tfsdk:"type"`
 	S3Location fwtypes.ListNestedObjectValueOf[s3LocationModel]                 `tfsdk:"s3_location"`
+}
+
+type kendraKnowledgeBaseConfigurationModel struct {
+	KendraIndexARN fwtypes.ARN `tfsdk:"kendra_index_arn"`
 }
 
 type storageConfigurationModel struct {

--- a/internal/service/bedrockagent/knowledge_base_test.go
+++ b/internal/service/bedrockagent/knowledge_base_test.go
@@ -402,6 +402,35 @@ func testAccKnowledgeBase_OpenSearch_supplementalDataStorage(t *testing.T) {
 	})
 }
 
+func testAccKnowledgeBase_Kendra_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	kendraIndexArn := skipIfKendraIndexArnEnvVarNotSet(t)
+
+	var knowledgebase types.KnowledgeBase
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_bedrockagent_knowledge_base.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckKnowledgeBaseDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKnowledgeBaseConfig_Kendra_basic(rName, kendraIndexArn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKnowledgeBaseExists(ctx, resourceName, &knowledgebase),
+					resource.TestCheckResourceAttr(resourceName, "knowledge_base_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "knowledge_base_configuration.0.kendra_knowledge_base_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "knowledge_base_configuration.0.type", "KENDRA"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckKnowledgeBaseDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).BedrockAgentClient(ctx)
@@ -482,6 +511,26 @@ func skipIfOSSCollectionNameEnvVarNotSet(t *testing.T) string {
 		acctest.Skip(t, "This test requires external configuration of an OpenSearch collection vector index. "+
 			"Set the TF_AWS_BEDROCK_OSS_COLLECTION_NAME environment variable to the OpenSearch collection name "+
 			"where the vector index is configured.")
+	}
+	return v
+}
+
+// skipIfKendraIndexArnEnvVarNotSet handles skipping tests when an environment
+// variable providing a valid Kendra index ARN is unset
+//
+// This should be called in all acceptance tests currently dependent on a Kendra index.
+//
+// To create a Kendra index to be used with this environment variable:
+// 1. In the AWS console, navigate to Amazon Kendra
+// 2. Create a new index with "GEN_AI_ENTERPRISE_EDITION" edition
+// 3. Wait for the index to be in "ACTIVE" status (this can take 20+ minutes)
+// 4. Copy the index ARN and set it as the TF_AWS_KENDRA_INDEX_ARN environment variable
+func skipIfKendraIndexArnEnvVarNotSet(t *testing.T) string {
+	t.Helper()
+	v := os.Getenv("TF_AWS_KENDRA_INDEX_ARN")
+	if v == "" {
+		acctest.Skip(t, "This test requires a pre-existing Kendra index. "+
+			"Set the TF_AWS_KENDRA_INDEX_ARN environment variable to the ARN of an existing Kendra index.")
 	}
 	return v
 }
@@ -939,4 +988,67 @@ resource "aws_bedrockagent_knowledge_base" "test" {
   }
 }
 `, rName, model))
+}
+
+func testAccKnowledgeBaseConfig_Kendra_basic(rName, kendraIndexArn string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "bedrock.amazonaws.com"
+        }
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+          ArnLike = {
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:knowledge-base/*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = "%[1]s-bedrock"
+  role = aws_iam_role.test.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "kendra:Retrieve",
+          "kendra:DescribeIndex"
+        ]
+        Resource = %[2]q
+      }
+    ]
+  })
+}
+
+resource "aws_bedrockagent_knowledge_base" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.test.arn
+  depends_on = [aws_iam_role_policy.test]
+
+  knowledge_base_configuration {
+    type = "KENDRA"
+    kendra_knowledge_base_configuration {
+      kendra_index_arn = %[2]q
+    }
+  }
+}
+`, rName, kendraIndexArn)
 }

--- a/website/docs/cdktf/typescript/r/bedrockagent_knowledge_base.html.markdown
+++ b/website/docs/cdktf/typescript/r/bedrockagent_knowledge_base.html.markdown
@@ -144,6 +144,21 @@ class MyConvertedCode extends TerraformStack {
 
 ```
 
+### Kendra Knowledge Base
+
+```hcl
+resource "aws_bedrockagent_knowledge_base" "kendra_example" {
+  name     = "example-kendra-kb"
+  role_arn = aws_iam_role.example.arn
+
+  knowledge_base_configuration {
+    type = "KENDRA"
+    kendra_knowledge_base_configuration {
+      kendra_index_arn = "arn:aws:kendra:us-east-1:123456789012:index/example-index-id"
+    }
+  }
+}
+
 ## Argument Reference
 
 The following arguments are required:
@@ -163,8 +178,9 @@ The following arguments are optional:
 
 The `knowledgeBaseConfiguration` configuration block supports the following arguments:
 
-* `type` - (Required) Type of data that the data source is converted into for the knowledge base. Valid Values: `VECTOR`.
-* `vectorKnowledgeBaseConfiguration` - (Optional) Details about the embeddings model that'sused to convert the data source. See [`vectorKnowledgeBaseConfiguration` block](#vector_knowledge_base_configuration-block) for details.
+* `type` - (Required) Type of data that the data source is converted into for the knowledge base. Valid Values: `VECTOR`, `KENDRA`.
+* `vectorKnowledgeBaseConfiguration` - (Optional) Details about the embeddings model that's used to convert the data source. See [`vectorKnowledgeBaseConfiguration` block](#vector_knowledge_base_configuration-block) for details.
+* `kendraKnowledgeBaseConfiguration` - (Optional) Configuration for Kendra knowledge base. See [`kendraKnowledgeBaseConfiguration` block](#kendra_knowledge_base_configuration-block) for details.
 
 ### `vectorKnowledgeBaseConfiguration` block
 
@@ -205,6 +221,12 @@ The `storageLocation` configuration block supports the following arguments:
 The `s3Location` configuration block supports the following arguments:
 
 * `uri` - (Required) URI of the location.
+
+### `kendraKnowledgeBaseConfiguration` block
+
+The `kendraKnowledgeBaseConfiguration` configuration block supports the following arguments:
+
+* `kendraIndexArn` - (Required) ARN of the Amazon Kendra index.
 
 ### `storageConfiguration` block
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

N/a

### Description

Adds support for `KENDRA` type knowledge bases in the `aws_bedrockagent_knowledge_base` resource. Users can now create knowledge bases that use Amazon Kendra indexes as the data source.



### Relations

Closes #43836

### References
- KnowledgeBaseConfiguration
https://docs.aws.amazon.com/ko_kr/bedrock/latest/APIReference/API_agent_KnowledgeBaseConfiguration.html
- KendraKnowledgeBaseConfiguration
https://docs.aws.amazon.com/ko_kr/bedrock/latest/APIReference/API_agent_KendraKnowledgeBaseConfiguration.html

### Output from Acceptance Testing

```console
% export TF_AWS_KENDRA_INDEX_ARN="arn:aws:kendra:us-west-2:{accound-id}:index/{index-id}"
% make testacc TESTS=TestAccBedrockAgent_serial/KnowledgeBase/KendraBasic PKG=bedrockagent

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_bedrockagent_knowledge_base-configuration 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/bedrockagent/... -v -count 1 -parallel 20 -run='TestAccBedrockAgent_serial/KnowledgeBase/KendraBasic'  -timeout 360m -vet=off
2025/09/20 16:27:30 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/20 16:27:30 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockAgent_serial
=== PAUSE TestAccBedrockAgent_serial
=== CONT  TestAccBedrockAgent_serial
=== RUN   TestAccBedrockAgent_serial/KnowledgeBase
=== RUN   TestAccBedrockAgent_serial/KnowledgeBase/KendraBasic
--- PASS: TestAccBedrockAgent_serial (30.09s)
    --- PASS: TestAccBedrockAgent_serial/KnowledgeBase (30.09s)
        --- PASS: TestAccBedrockAgent_serial/KnowledgeBase/KendraBasic (30.09s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       30.309s
```
