### PR TITLE
F/bedrock guardrails topic content modalities

### DIFF
--- a/internal/service/bedrock/guardrail.go
+++ b/internal/service/bedrock/guardrail.go
@@ -152,6 +152,26 @@ func (r *guardrailResource) Schema(ctx context.Context, req resource.SchemaReque
 							CustomType: fwtypes.NewSetNestedObjectTypeOf[guardrailContentFilterConfigModel](ctx),
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
+									"input_modalities": schema.ListAttribute{
+										Optional:    true,
+										Computed:    true,
+										ElementType: fwtypes.StringEnumType[awstypes.GuardrailModality](),
+										Validators: []validator.List{
+											listvalidator.ValueStringsAre(
+												stringvalidator.OneOf("TEXT", "IMAGE"),
+											),
+										},
+									},
+									"output_modalities": schema.ListAttribute{
+										Optional:    true,
+										Computed:    true,
+										ElementType: fwtypes.StringEnumType[awstypes.GuardrailModality](),
+										Validators: []validator.List{
+											listvalidator.ValueStringsAre(
+												stringvalidator.OneOf("TEXT", "IMAGE"),
+											),
+										},
+									},
 									"input_strength": schema.StringAttribute{
 										Required:   true,
 										CustomType: fwtypes.StringEnumType[awstypes.GuardrailFilterStrength](),
@@ -799,9 +819,11 @@ type guardrailContentPolicyConfigModel struct {
 }
 
 type guardrailContentFilterConfigModel struct {
-	InputStrength  fwtypes.StringEnum[awstypes.GuardrailFilterStrength]    `tfsdk:"input_strength"`
-	OutputStrength fwtypes.StringEnum[awstypes.GuardrailFilterStrength]    `tfsdk:"output_strength"`
-	Type           fwtypes.StringEnum[awstypes.GuardrailContentFilterType] `tfsdk:"type"`
+	InputModalities  fwtypes.ListOfStringEnum[awstypes.GuardrailModality]    `tfsdk:"input_modalities"`
+	OutputModalities fwtypes.ListOfStringEnum[awstypes.GuardrailModality]    `tfsdk:"output_modalities"`
+	InputStrength    fwtypes.StringEnum[awstypes.GuardrailFilterStrength]    `tfsdk:"input_strength"`
+	OutputStrength   fwtypes.StringEnum[awstypes.GuardrailFilterStrength]    `tfsdk:"output_strength"`
+	Type             fwtypes.StringEnum[awstypes.GuardrailContentFilterType] `tfsdk:"type"`
 }
 
 type guardrailContentFiltersTierConfigModel struct {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This will allow configurations of the input and output modality settings for content filters, ie "TEXT" and/or "IMAGE". 
There is a known issue that I'm not sure how to fix quickly, which is that the list ["TEXT", "IMAGE"] must be in this order like the AWS docs. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42924

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
AWS [added image content filtering for Bedrock Guardrails ](https://aws.amazon.com/blogs/machine-learning/amazon-bedrock-guardrails-image-content-filters-provide-industry-leading-safeguards-helping-customer-block-up-to-88-of-harmful-multimodal-content-generally-available-today/)at the end of March 2025.

[AWS API docs] (https://docs.aws.amazon.com/bedrock/latest/APIReference/API_CreateGuardrail.html)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Basic test:
```console
% make testacc TESTS=TestAccBedrockGuardrail_basic PKG=bedrock     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f/bedrock_guardrails_topic_content_modalities 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/bedrock/... -v -count 1 -parallel 20 -run='TestAccBedrockGuardrail_basic'  -timeout 360m -vet=off
2025/09/21 18:22:24 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/21 18:22:24 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockGuardrail_basic
=== PAUSE TestAccBedrockGuardrail_basic
=== CONT  TestAccBedrockGuardrail_basic
--- PASS: TestAccBedrockGuardrail_basic (10.25s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrock    14.451s
...
```
Created test:
```console
% make testacc TESTS=TestAccBedrockGuardrail_contentModality PKG=bedrock
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f/bedrock_guardrails_topic_content_modalities 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/bedrock/... -v -count 1 -parallel 20 -run='TestAccBedrockGuardrail_conentModality'  -timeout 360m -vet=off
2025/09/21 18:29:48 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/21 18:29:48 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockGuardrail_contentModality
=== PAUSE TestAccBedrockGuardrail_contentModality
=== CONT  TestAccBedrockGuardrail_contentModality
--- PASS: TestAccBedrockGuardrail_contentModality (10.35s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrock    14.620s
...
