### PR TITLE
[WIP] Generates `Identity_ExistingResource_NoRefresh_NoChange` for resource types added in v6.0 without previous errors

### DIFF
--- a/internal/service/apigateway/domain_name_access_association_identity_gen_test.go
+++ b/internal/service/apigateway/domain_name_access_association_identity_gen_test.go
@@ -336,3 +336,55 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Identity_ExistingResource(t *t
 		},
 	})
 }
+
+func TestAccAPIGatewayDomainNameAccessAssociation_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v awstypes.DomainNameAccessAssociation
+	resourceName := "aws_api_gateway_domain_name_access_association.test"
+	rName := acctest.RandomSubdomain()
+	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/DomainNameAccessAssociation/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:          config.StringVariable(rName),
+					acctest.CtCertificatePEM: config.StringVariable(certificatePEM),
+					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/DomainNameAccessAssociation/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:          config.StringVariable(rName),
+					acctest.CtCertificatePEM: config.StringVariable(certificatePEM),
+					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/appfabric/app_bundle_identity_gen_test.go
+++ b/internal/service/appfabric/app_bundle_identity_gen_test.go
@@ -303,3 +303,47 @@ func testAccAppFabricAppBundle_Identity_ExistingResource(t *testing.T) {
 		},
 	})
 }
+
+func testAccAppFabricAppBundle_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v awstypes.AppBundle
+	resourceName := "aws_appfabric_app_bundle.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, names.AppFabricServiceID),
+		CheckDestroy: testAccCheckAppBundleDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/AppBundle/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAppBundleExists(ctx, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/AppBundle/basic/"),
+				ConfigVariables:          config.Variables{},
+			},
+		},
+	})
+}

--- a/internal/service/auditmanager/account_registration_identity_gen_test.go
+++ b/internal/service/auditmanager/account_registration_identity_gen_test.go
@@ -277,3 +277,40 @@ func testAccAuditManagerAccountRegistration_Identity_ExistingResource(t *testing
 		},
 	})
 }
+
+func testAccAuditManagerAccountRegistration_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_auditmanager_account_registration.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.AuditManagerServiceID),
+		CheckDestroy: acctest.CheckDestroyNoop,
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/AccountRegistration/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{},
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/AccountRegistration/basic/"),
+				ConfigVariables:          config.Variables{},
+			},
+		},
+	})
+}

--- a/internal/service/batch/job_queue_identity_gen_test.go
+++ b/internal/service/batch/job_queue_identity_gen_test.go
@@ -307,3 +307,49 @@ func TestAccBatchJobQueue_Identity_ExistingResource(t *testing.T) {
 		},
 	})
 }
+
+func TestAccBatchJobQueue_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v types.JobQueueDetail
+	resourceName := "aws_batch_job_queue.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
+		CheckDestroy: testAccCheckJobQueueDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/JobQueue/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobQueueExists(ctx, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/JobQueue/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/bedrock/custom_model_identity_gen_test.go
+++ b/internal/service/bedrock/custom_model_identity_gen_test.go
@@ -336,3 +336,49 @@ func testAccBedrockCustomModel_Identity_ExistingResource(t *testing.T) {
 		},
 	})
 }
+
+func testAccBedrockCustomModel_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v bedrock.GetModelCustomizationJobOutput
+	resourceName := "aws_bedrock_custom_model.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	acctest.Test(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
+		CheckDestroy: testAccCheckCustomModelDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/CustomModel/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCustomModelExists(ctx, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/CustomModel/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/bedrock/model_invocation_logging_configuration_identity_gen_test.go
+++ b/internal/service/bedrock/model_invocation_logging_configuration_identity_gen_test.go
@@ -310,3 +310,48 @@ func testAccBedrockModelInvocationLoggingConfiguration_Identity_ExistingResource
 		},
 	})
 }
+
+func testAccBedrockModelInvocationLoggingConfiguration_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_bedrock_model_invocation_logging_configuration.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	acctest.Test(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
+		CheckDestroy: testAccCheckModelInvocationLoggingConfigurationDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/ModelInvocationLoggingConfiguration/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckModelInvocationLoggingConfigurationExists(ctx, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ModelInvocationLoggingConfiguration/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/cloudfront/key_value_store_identity_gen_test.go
+++ b/internal/service/cloudfront/key_value_store_identity_gen_test.go
@@ -186,3 +186,49 @@ func TestAccCloudFrontKeyValueStore_Identity_ExistingResource(t *testing.T) {
 		},
 	})
 }
+
+func TestAccCloudFrontKeyValueStore_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v awstypes.KeyValueStore
+	resourceName := "aws_cloudfront_key_value_store.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		CheckDestroy: testAccCheckKeyValueStoreDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/KeyValueStore/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKeyValueStoreExists(ctx, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/KeyValueStore/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/codeconnections/connection_identity_gen_test.go
+++ b/internal/service/codeconnections/connection_identity_gen_test.go
@@ -305,3 +305,49 @@ func TestAccCodeConnectionsConnection_Identity_ExistingResource(t *testing.T) {
 		},
 	})
 }
+
+func TestAccCodeConnectionsConnection_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v types.Connection
+	resourceName := "aws_codeconnections_connection.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
+		CheckDestroy: testAccCheckConnectionDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Connection/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckConnectionExists(ctx, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Connection/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/codeconnections/host_identity_gen_test.go
+++ b/internal/service/codeconnections/host_identity_gen_test.go
@@ -305,3 +305,49 @@ func TestAccCodeConnectionsHost_Identity_ExistingResource(t *testing.T) {
 		},
 	})
 }
+
+func TestAccCodeConnectionsHost_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v types.Host
+	resourceName := "aws_codeconnections_host.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
+		CheckDestroy: testAccCheckHostDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Host/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHostExists(ctx, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Host/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/devopsguru/event_sources_config_identity_gen_test.go
+++ b/internal/service/devopsguru/event_sources_config_identity_gen_test.go
@@ -298,3 +298,47 @@ func testAccDevOpsGuruEventSourcesConfig_Identity_ExistingResource(t *testing.T)
 		},
 	})
 }
+
+func testAccDevOpsGuruEventSourcesConfig_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v devopsguru.DescribeEventSourcesConfigOutput
+	resourceName := "aws_devopsguru_event_sources_config.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, names.DevOpsGuruServiceID),
+		CheckDestroy: testAccCheckEventSourcesConfigDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/EventSourcesConfig/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEventSourcesConfigExists(ctx, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/EventSourcesConfig/basic/"),
+				ConfigVariables:          config.Variables{},
+			},
+		},
+	})
+}

--- a/internal/service/devopsguru/service_integration_identity_gen_test.go
+++ b/internal/service/devopsguru/service_integration_identity_gen_test.go
@@ -295,3 +295,46 @@ func testAccDevOpsGuruServiceIntegration_Identity_ExistingResource(t *testing.T)
 		},
 	})
 }
+
+func testAccDevOpsGuruServiceIntegration_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_devopsguru_service_integration.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, names.DevOpsGuruServiceID),
+		CheckDestroy: testAccCheckServiceIntegrationDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/ServiceIntegration/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServiceIntegrationExists(ctx, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ServiceIntegration/basic/"),
+				ConfigVariables:          config.Variables{},
+			},
+		},
+	})
+}

--- a/internal/service/docdbelastic/cluster_identity_gen_test.go
+++ b/internal/service/docdbelastic/cluster_identity_gen_test.go
@@ -324,3 +324,49 @@ func TestAccDocDBElasticCluster_Identity_ExistingResource(t *testing.T) {
 		},
 	})
 }
+
+func TestAccDocDBElasticCluster_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v awstypes.Cluster
+	resourceName := "aws_docdbelastic_cluster.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.DocDBElasticServiceID),
+		CheckDestroy: testAccCheckClusterDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Cluster/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/dynamodb/resource_policy_identity_gen_test.go
+++ b/internal/service/dynamodb/resource_policy_identity_gen_test.go
@@ -324,3 +324,49 @@ func TestAccDynamoDBResourcePolicy_Identity_ExistingResource(t *testing.T) {
 		},
 	})
 }
+
+func TestAccDynamoDBResourcePolicy_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v dynamodb.GetResourcePolicyOutput
+	resourceName := "aws_dynamodb_resource_policy.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		CheckDestroy: testAccCheckResourcePolicyDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/ResourcePolicy/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckResourcePolicyExists(ctx, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ResourcePolicy/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/globalaccelerator/cross_account_attachment_identity_gen_test.go
+++ b/internal/service/globalaccelerator/cross_account_attachment_identity_gen_test.go
@@ -182,3 +182,49 @@ func TestAccGlobalAcceleratorCrossAccountAttachment_Identity_ExistingResource(t 
 		},
 	})
 }
+
+func TestAccGlobalAcceleratorCrossAccountAttachment_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v awstypes.Attachment
+	resourceName := "aws_globalaccelerator_cross_account_attachment.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.GlobalAcceleratorServiceID),
+		CheckDestroy: testAccCheckCrossAccountAttachmentDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/CrossAccountAttachment/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCrossAccountAttachmentExists(ctx, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/CrossAccountAttachment/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/iam/role_test.go
+++ b/internal/service/iam/role_test.go
@@ -972,6 +972,46 @@ func TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty(t *testing.T) {
 	})
 }
 
+func TestAccIAMRole_Identity_ExistingResource_NoRefreshFailure(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf awstypes.Role
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_role.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.100.0",
+					},
+				},
+				Config: testAccRoleConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRoleExists(ctx, resourceName, &conf),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccRoleConfig_invalidAssumeRolePolicy(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRoleExists(ctx, resourceName, &conf),
+				),
+				ExpectError: regexache.MustCompile(`Missing Resource Identity After Update`),
+			},
+		},
+	})
+}
+
 func testAccCheckRoleDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
@@ -1256,6 +1296,21 @@ resource "aws_iam_role" "test" {
       Sid    = ""
     }]
   })
+}
+`, rName)
+}
+
+func testAccRoleConfig_invalidAssumeRolePolicy(rName string) string {
+	return fmt.Sprintf(`
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  path = "/"
+
+  assume_role_policy = "{\"invalid\":true}"
 }
 `, rName)
 }

--- a/internal/service/iam/role_test.go
+++ b/internal/service/iam/role_test.go
@@ -1006,6 +1006,7 @@ func TestAccIAMRole_Identity_ExistingResource_NoRefreshFailure(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRoleExists(ctx, resourceName, &conf),
 				),
+				// We DON'T want this error. A fix should cause this test to begin failing.
 				ExpectError: regexache.MustCompile(`Missing Resource Identity After Update`),
 			},
 		},

--- a/internal/service/iam/role_test.go
+++ b/internal/service/iam/role_test.go
@@ -1006,8 +1006,8 @@ func TestAccIAMRole_Identity_ExistingResource_NoRefresh(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRoleExists(ctx, resourceName, &conf),
 				),
-				// We DON'T want this error. A fix should cause this test to begin failing.
-				ExpectError: regexache.MustCompile(`Missing Resource Identity After Update`),
+				// No error indicates the identity interceptor properly identified
+				// a fully null identity on update and set values appropriately.
 			},
 		},
 	})
@@ -1047,7 +1047,9 @@ func TestAccIAMRole_Identity_ExistingResource_NoRefreshFailure(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRoleExists(ctx, resourceName, &conf),
 				),
-				// We DON'T want this error. A fix should cause this test to begin failing.
+				// On an update failure, the identity interceptor is not executed and both
+				// the MalformedPolicyDocument error and a missing resource identity
+				// error will be present.
 				ExpectError: regexache.MustCompile(`Missing Resource Identity After Update`),
 			},
 		},

--- a/internal/service/iam/role_test.go
+++ b/internal/service/iam/role_test.go
@@ -1034,7 +1034,7 @@ func TestAccIAMRole_Identity_ExistingResource_NoRefresh_WithChange(t *testing.T)
 	})
 }
 
-func TestAccIAMRole_Identity_ExistingResource_NoRefreshFailure(t *testing.T) {
+func TestAccIAMRole_Identity_ExistingResource_NoRefresh_OnError(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Role
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/imagebuilder/lifecycle_policy_identity_gen_test.go
+++ b/internal/service/imagebuilder/lifecycle_policy_identity_gen_test.go
@@ -304,3 +304,48 @@ func TestAccImageBuilderLifecyclePolicy_Identity_ExistingResource(t *testing.T) 
 		},
 	})
 }
+
+func TestAccImageBuilderLifecyclePolicy_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_imagebuilder_lifecycle_policy.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.ImageBuilderServiceID),
+		CheckDestroy: testAccCheckLifecyclePolicyDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/LifecyclePolicy/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLifecyclePolicyExists(ctx, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/LifecyclePolicy/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/kinesis/resource_policy_identity_gen_test.go
+++ b/internal/service/kinesis/resource_policy_identity_gen_test.go
@@ -344,3 +344,53 @@ func TestAccKinesisResourcePolicy_Identity_ExistingResource(t *testing.T) {
 		},
 	})
 }
+
+func TestAccKinesisResourcePolicy_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_kinesis_resource_policy.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	providers := make(map[string]*schema.Provider)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, names.KinesisServiceID),
+		CheckDestroy: testAccCheckResourcePolicyDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5FactoriesNamed(ctx, t, providers, acctest.ProviderNameAlternate),
+				ConfigDirectory:          config.StaticDirectory("testdata/ResourcePolicy/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckResourcePolicyExists(ctx, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5FactoriesNamedAlternate(ctx, t, providers),
+				ConfigDirectory:          config.StaticDirectory("testdata/ResourcePolicy/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/networkfirewall/tls_inspection_configuration_identity_gen_test.go
+++ b/internal/service/networkfirewall/tls_inspection_configuration_identity_gen_test.go
@@ -348,3 +348,55 @@ func TestAccNetworkFirewallTLSInspectionConfiguration_Identity_ExistingResource(
 		},
 	})
 }
+
+func TestAccNetworkFirewallTLSInspectionConfiguration_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v networkfirewall.DescribeTLSInspectionConfigurationOutput
+	resourceName := "aws_networkfirewall_tls_inspection_configuration.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	common_name := acctest.RandomDomain()
+	certificate_domain := common_name.RandomSubdomain()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkFirewallServiceID),
+		CheckDestroy: testAccCheckTLSInspectionConfigurationDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/TLSInspectionConfiguration/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:      config.StringVariable(rName),
+					"certificate_domain": config.StringVariable(certificate_domain.String()),
+					"common_name":        config.StringVariable(common_name.String()),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTLSInspectionConfigurationExists(ctx, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/TLSInspectionConfiguration/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:      config.StringVariable(rName),
+					"certificate_domain": config.StringVariable(certificate_domain.String()),
+					"common_name":        config.StringVariable(common_name.String()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/paymentcryptography/key_identity_gen_test.go
+++ b/internal/service/paymentcryptography/key_identity_gen_test.go
@@ -300,3 +300,44 @@ func TestAccPaymentCryptographyKey_Identity_ExistingResource(t *testing.T) {
 		},
 	})
 }
+
+func TestAccPaymentCryptographyKey_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v paymentcryptography.GetKeyOutput
+	resourceName := "aws_paymentcryptography_key.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.PaymentCryptographyServiceID),
+		CheckDestroy: testAccCheckKeyDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Key/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKeyExists(ctx, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Key/basic/"),
+				ConfigVariables:          config.Variables{},
+			},
+		},
+	})
+}

--- a/internal/service/rds/integration_identity_gen_test.go
+++ b/internal/service/rds/integration_identity_gen_test.go
@@ -305,3 +305,49 @@ func TestAccRDSIntegration_Identity_ExistingResource(t *testing.T) {
 		},
 	})
 }
+
+func TestAccRDSIntegration_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v awstypes.Integration
+	resourceName := "aws_rds_integration.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
+		CheckDestroy: testAccCheckIntegrationDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Integration/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIntegrationExists(ctx, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Integration/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/rds/integration_test.go
+++ b/internal/service/rds/integration_test.go
@@ -236,9 +236,15 @@ resource "aws_db_subnet_group" "test" {
   }
 }
 
+data "aws_rds_engine_version" "test" {
+  engine  = "aurora-mysql"
+  version = "8.0"
+  latest  = true
+}
+
 resource "aws_rds_cluster_parameter_group" "test" {
   name   = %[1]q
-  family = "aurora-mysql8.0"
+  family = data.aws_rds_engine_version.test.parameter_group_family
 
   dynamic "parameter" {
     for_each = local.cluster_parameters
@@ -252,8 +258,8 @@ resource "aws_rds_cluster_parameter_group" "test" {
 
 resource "aws_rds_cluster" "test" {
   cluster_identifier  = %[1]q
-  engine              = "aurora-mysql"
-  engine_version      = "8.0.mysql_aurora.3.05.2"
+  engine              = data.aws_rds_engine_version.test.engine
+  engine_version      = data.aws_rds_engine_version.test.version_actual
   database_name       = "test"
   master_username     = "tfacctest"
   master_password     = "avoid-plaintext-passwords"
@@ -266,12 +272,20 @@ resource "aws_rds_cluster" "test" {
   apply_immediately = true
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = data.aws_rds_engine_version.test.engine
+  engine_version             = data.aws_rds_engine_version.test.version_actual
+  preferred_instance_classes = [%[2]s]
+  supports_clusters          = true
+  supports_global_databases  = true
+}
+
 resource "aws_rds_cluster_instance" "test" {
   identifier         = %[1]q
-  cluster_identifier = aws_rds_cluster.test.id
-  instance_class     = "db.r6g.large"
+  cluster_identifier = aws_rds_cluster.test.cluster_identifier
   engine             = aws_rds_cluster.test.engine
   engine_version     = aws_rds_cluster.test.engine_version
+  instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
 }
 
 resource "aws_redshift_cluster" "test" {
@@ -289,7 +303,7 @@ resource "aws_redshift_cluster" "test" {
   publicly_accessible                  = false
   encrypted                            = true
 }
-`, rName))
+`, rName, mainInstanceClasses))
 }
 
 func testAccIntegrationConfig_base(rName string) string {

--- a/internal/service/rds/testdata/Integration/basic/main_gen.tf
+++ b/internal/service/rds/testdata/Integration/basic/main_gen.tf
@@ -154,9 +154,15 @@ resource "aws_db_subnet_group" "test" {
   subnet_ids = aws_subnet.test[*].id
 }
 
+data "aws_rds_engine_version" "test" {
+  engine  = "aurora-mysql"
+  version = "8.0"
+  latest  = true
+}
+
 resource "aws_rds_cluster_parameter_group" "test" {
   name   = var.rName
-  family = "aurora-mysql8.0"
+  family = data.aws_rds_engine_version.test.parameter_group_family
 
   dynamic "parameter" {
     for_each = local.cluster_parameters
@@ -170,8 +176,8 @@ resource "aws_rds_cluster_parameter_group" "test" {
 
 resource "aws_rds_cluster" "test" {
   cluster_identifier  = var.rName
-  engine              = "aurora-mysql"
-  engine_version      = "8.0.mysql_aurora.3.05.2"
+  engine              = data.aws_rds_engine_version.test.engine
+  engine_version      = data.aws_rds_engine_version.test.version_actual
   database_name       = "test"
   master_username     = "tfacctest"
   master_password     = "avoid-plaintext-passwords"
@@ -184,12 +190,20 @@ resource "aws_rds_cluster" "test" {
   apply_immediately = true
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = data.aws_rds_engine_version.test.engine
+  engine_version             = data.aws_rds_engine_version.test.version_actual
+  preferred_instance_classes = local.mainInstanceClasses
+  supports_clusters          = true
+  supports_global_databases  = true
+}
+
 resource "aws_rds_cluster_instance" "test" {
   identifier         = var.rName
-  cluster_identifier = aws_rds_cluster.test.id
-  instance_class     = "db.r6g.large"
+  cluster_identifier = aws_rds_cluster.test.cluster_identifier
   engine             = aws_rds_cluster.test.engine
   engine_version     = aws_rds_cluster.test.engine_version
+  instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
 }
 
 resource "aws_redshift_cluster" "test" {
@@ -235,6 +249,60 @@ data "aws_availability_zones" "available" {
 
 locals {
   default_exclude_zone_ids = ["usw2-az4", "usgw1-az2"]
+}
+
+locals {
+  mainInstanceClasses = [
+    "db.t4g.micro",
+    "db.t3.micro",
+    "db.t4g.small",
+    "db.t3.small",
+    "db.t4g.medium",
+    "db.t3.medium",
+    "db.t4g.large",
+    "db.t3.large",
+    "db.m6g.large",
+    "db.m7g.large",
+    "db.m5.large",
+    "db.m6i.large",
+    "db.m6gd.large",
+    "db.m5d.large",
+    "db.r6g.large",
+    "db.m6id.large",
+    "db.r7g.large",
+    "db.r5.large",
+    "db.r6i.large",
+    "db.r6gd.large",
+    "db.m6in.large",
+    "db.t4g.xlarge",
+    "db.t3.xlarge",
+    "db.r5d.large",
+    "db.m6idn.large",
+    "db.r5b.large",
+    "db.r6id.large",
+    "db.m6g.xlarge",
+    "db.x2g.large",
+    "db.m7g.xlarge",
+    "db.m5.xlarge",
+    "db.m6i.xlarge",
+    "db.r6in.large",
+    "db.m6gd.xlarge",
+    "db.r6idn.large",
+    "db.m5d.xlarge",
+    "db.r6g.xlarge",
+    "db.m6id.xlarge",
+    "db.r7g.xlarge",
+    "db.r5.xlarge",
+    "db.r6i.xlarge",
+    "db.r6gd.xlarge",
+    "db.m6in.xlarge",
+    "db.t4g.2xlarge",
+    "db.t3.2xlarge",
+    "db.r5d.xlarge",
+    "db.m6idn.xlarge",
+    "db.r5b.xlarge",
+    "db.r6id.xlarge",
+  ]
 }
 
 variable "rName" {

--- a/internal/service/rds/testdata/Integration/basic_v5.100.0/main_gen.tf
+++ b/internal/service/rds/testdata/Integration/basic_v5.100.0/main_gen.tf
@@ -154,9 +154,15 @@ resource "aws_db_subnet_group" "test" {
   subnet_ids = aws_subnet.test[*].id
 }
 
+data "aws_rds_engine_version" "test" {
+  engine  = "aurora-mysql"
+  version = "8.0"
+  latest  = true
+}
+
 resource "aws_rds_cluster_parameter_group" "test" {
   name   = var.rName
-  family = "aurora-mysql8.0"
+  family = data.aws_rds_engine_version.test.parameter_group_family
 
   dynamic "parameter" {
     for_each = local.cluster_parameters
@@ -170,8 +176,8 @@ resource "aws_rds_cluster_parameter_group" "test" {
 
 resource "aws_rds_cluster" "test" {
   cluster_identifier  = var.rName
-  engine              = "aurora-mysql"
-  engine_version      = "8.0.mysql_aurora.3.05.2"
+  engine              = data.aws_rds_engine_version.test.engine
+  engine_version      = data.aws_rds_engine_version.test.version_actual
   database_name       = "test"
   master_username     = "tfacctest"
   master_password     = "avoid-plaintext-passwords"
@@ -184,12 +190,20 @@ resource "aws_rds_cluster" "test" {
   apply_immediately = true
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = data.aws_rds_engine_version.test.engine
+  engine_version             = data.aws_rds_engine_version.test.version_actual
+  preferred_instance_classes = local.mainInstanceClasses
+  supports_clusters          = true
+  supports_global_databases  = true
+}
+
 resource "aws_rds_cluster_instance" "test" {
   identifier         = var.rName
-  cluster_identifier = aws_rds_cluster.test.id
-  instance_class     = "db.r6g.large"
+  cluster_identifier = aws_rds_cluster.test.cluster_identifier
   engine             = aws_rds_cluster.test.engine
   engine_version     = aws_rds_cluster.test.engine_version
+  instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
 }
 
 resource "aws_redshift_cluster" "test" {
@@ -235,6 +249,60 @@ data "aws_availability_zones" "available" {
 
 locals {
   default_exclude_zone_ids = ["usw2-az4", "usgw1-az2"]
+}
+
+locals {
+  mainInstanceClasses = [
+    "db.t4g.micro",
+    "db.t3.micro",
+    "db.t4g.small",
+    "db.t3.small",
+    "db.t4g.medium",
+    "db.t3.medium",
+    "db.t4g.large",
+    "db.t3.large",
+    "db.m6g.large",
+    "db.m7g.large",
+    "db.m5.large",
+    "db.m6i.large",
+    "db.m6gd.large",
+    "db.m5d.large",
+    "db.r6g.large",
+    "db.m6id.large",
+    "db.r7g.large",
+    "db.r5.large",
+    "db.r6i.large",
+    "db.r6gd.large",
+    "db.m6in.large",
+    "db.t4g.xlarge",
+    "db.t3.xlarge",
+    "db.r5d.large",
+    "db.m6idn.large",
+    "db.r5b.large",
+    "db.r6id.large",
+    "db.m6g.xlarge",
+    "db.x2g.large",
+    "db.m7g.xlarge",
+    "db.m5.xlarge",
+    "db.m6i.xlarge",
+    "db.r6in.large",
+    "db.m6gd.xlarge",
+    "db.r6idn.large",
+    "db.m5d.xlarge",
+    "db.r6g.xlarge",
+    "db.m6id.xlarge",
+    "db.r7g.xlarge",
+    "db.r5.xlarge",
+    "db.r6i.xlarge",
+    "db.r6gd.xlarge",
+    "db.m6in.xlarge",
+    "db.t4g.2xlarge",
+    "db.t3.2xlarge",
+    "db.r5d.xlarge",
+    "db.m6idn.xlarge",
+    "db.r5b.xlarge",
+    "db.r6id.xlarge",
+  ]
 }
 
 variable "rName" {

--- a/internal/service/rds/testdata/Integration/basic_v6.0.0/main_gen.tf
+++ b/internal/service/rds/testdata/Integration/basic_v6.0.0/main_gen.tf
@@ -154,9 +154,15 @@ resource "aws_db_subnet_group" "test" {
   subnet_ids = aws_subnet.test[*].id
 }
 
+data "aws_rds_engine_version" "test" {
+  engine  = "aurora-mysql"
+  version = "8.0"
+  latest  = true
+}
+
 resource "aws_rds_cluster_parameter_group" "test" {
   name   = var.rName
-  family = "aurora-mysql8.0"
+  family = data.aws_rds_engine_version.test.parameter_group_family
 
   dynamic "parameter" {
     for_each = local.cluster_parameters
@@ -170,8 +176,8 @@ resource "aws_rds_cluster_parameter_group" "test" {
 
 resource "aws_rds_cluster" "test" {
   cluster_identifier  = var.rName
-  engine              = "aurora-mysql"
-  engine_version      = "8.0.mysql_aurora.3.05.2"
+  engine              = data.aws_rds_engine_version.test.engine
+  engine_version      = data.aws_rds_engine_version.test.version_actual
   database_name       = "test"
   master_username     = "tfacctest"
   master_password     = "avoid-plaintext-passwords"
@@ -184,12 +190,20 @@ resource "aws_rds_cluster" "test" {
   apply_immediately = true
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = data.aws_rds_engine_version.test.engine
+  engine_version             = data.aws_rds_engine_version.test.version_actual
+  preferred_instance_classes = local.mainInstanceClasses
+  supports_clusters          = true
+  supports_global_databases  = true
+}
+
 resource "aws_rds_cluster_instance" "test" {
   identifier         = var.rName
-  cluster_identifier = aws_rds_cluster.test.id
-  instance_class     = "db.r6g.large"
+  cluster_identifier = aws_rds_cluster.test.cluster_identifier
   engine             = aws_rds_cluster.test.engine
   engine_version     = aws_rds_cluster.test.engine_version
+  instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
 }
 
 resource "aws_redshift_cluster" "test" {
@@ -235,6 +249,60 @@ data "aws_availability_zones" "available" {
 
 locals {
   default_exclude_zone_ids = ["usw2-az4", "usgw1-az2"]
+}
+
+locals {
+  mainInstanceClasses = [
+    "db.t4g.micro",
+    "db.t3.micro",
+    "db.t4g.small",
+    "db.t3.small",
+    "db.t4g.medium",
+    "db.t3.medium",
+    "db.t4g.large",
+    "db.t3.large",
+    "db.m6g.large",
+    "db.m7g.large",
+    "db.m5.large",
+    "db.m6i.large",
+    "db.m6gd.large",
+    "db.m5d.large",
+    "db.r6g.large",
+    "db.m6id.large",
+    "db.r7g.large",
+    "db.r5.large",
+    "db.r6i.large",
+    "db.r6gd.large",
+    "db.m6in.large",
+    "db.t4g.xlarge",
+    "db.t3.xlarge",
+    "db.r5d.large",
+    "db.m6idn.large",
+    "db.r5b.large",
+    "db.r6id.large",
+    "db.m6g.xlarge",
+    "db.x2g.large",
+    "db.m7g.xlarge",
+    "db.m5.xlarge",
+    "db.m6i.xlarge",
+    "db.r6in.large",
+    "db.m6gd.xlarge",
+    "db.r6idn.large",
+    "db.m5d.xlarge",
+    "db.r6g.xlarge",
+    "db.m6id.xlarge",
+    "db.r7g.xlarge",
+    "db.r5.xlarge",
+    "db.r6i.xlarge",
+    "db.r6gd.xlarge",
+    "db.m6in.xlarge",
+    "db.t4g.2xlarge",
+    "db.t3.2xlarge",
+    "db.r5d.xlarge",
+    "db.m6idn.xlarge",
+    "db.r5b.xlarge",
+    "db.r6id.xlarge",
+  ]
 }
 
 variable "rName" {

--- a/internal/service/rds/testdata/Integration/region_override/main_gen.tf
+++ b/internal/service/rds/testdata/Integration/region_override/main_gen.tf
@@ -166,11 +166,19 @@ resource "aws_db_subnet_group" "test" {
   subnet_ids = aws_subnet.test[*].id
 }
 
+data "aws_rds_engine_version" "test" {
+  region = var.region
+
+  engine  = "aurora-mysql"
+  version = "8.0"
+  latest  = true
+}
+
 resource "aws_rds_cluster_parameter_group" "test" {
   region = var.region
 
   name   = var.rName
-  family = "aurora-mysql8.0"
+  family = data.aws_rds_engine_version.test.parameter_group_family
 
   dynamic "parameter" {
     for_each = local.cluster_parameters
@@ -186,8 +194,8 @@ resource "aws_rds_cluster" "test" {
   region = var.region
 
   cluster_identifier  = var.rName
-  engine              = "aurora-mysql"
-  engine_version      = "8.0.mysql_aurora.3.05.2"
+  engine              = data.aws_rds_engine_version.test.engine
+  engine_version      = data.aws_rds_engine_version.test.version_actual
   database_name       = "test"
   master_username     = "tfacctest"
   master_password     = "avoid-plaintext-passwords"
@@ -200,14 +208,24 @@ resource "aws_rds_cluster" "test" {
   apply_immediately = true
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+  region = var.region
+
+  engine                     = data.aws_rds_engine_version.test.engine
+  engine_version             = data.aws_rds_engine_version.test.version_actual
+  preferred_instance_classes = local.mainInstanceClasses
+  supports_clusters          = true
+  supports_global_databases  = true
+}
+
 resource "aws_rds_cluster_instance" "test" {
   region = var.region
 
   identifier         = var.rName
-  cluster_identifier = aws_rds_cluster.test.id
-  instance_class     = "db.r6g.large"
+  cluster_identifier = aws_rds_cluster.test.cluster_identifier
   engine             = aws_rds_cluster.test.engine
   engine_version     = aws_rds_cluster.test.engine_version
+  instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
 }
 
 resource "aws_redshift_cluster" "test" {
@@ -261,6 +279,60 @@ data "aws_availability_zones" "available" {
 
 locals {
   default_exclude_zone_ids = ["usw2-az4", "usgw1-az2"]
+}
+
+locals {
+  mainInstanceClasses = [
+    "db.t4g.micro",
+    "db.t3.micro",
+    "db.t4g.small",
+    "db.t3.small",
+    "db.t4g.medium",
+    "db.t3.medium",
+    "db.t4g.large",
+    "db.t3.large",
+    "db.m6g.large",
+    "db.m7g.large",
+    "db.m5.large",
+    "db.m6i.large",
+    "db.m6gd.large",
+    "db.m5d.large",
+    "db.r6g.large",
+    "db.m6id.large",
+    "db.r7g.large",
+    "db.r5.large",
+    "db.r6i.large",
+    "db.r6gd.large",
+    "db.m6in.large",
+    "db.t4g.xlarge",
+    "db.t3.xlarge",
+    "db.r5d.large",
+    "db.m6idn.large",
+    "db.r5b.large",
+    "db.r6id.large",
+    "db.m6g.xlarge",
+    "db.x2g.large",
+    "db.m7g.xlarge",
+    "db.m5.xlarge",
+    "db.m6i.xlarge",
+    "db.r6in.large",
+    "db.m6gd.xlarge",
+    "db.r6idn.large",
+    "db.m5d.xlarge",
+    "db.r6g.xlarge",
+    "db.m6id.xlarge",
+    "db.r7g.xlarge",
+    "db.r5.xlarge",
+    "db.r6i.xlarge",
+    "db.r6gd.xlarge",
+    "db.m6in.xlarge",
+    "db.t4g.2xlarge",
+    "db.t3.2xlarge",
+    "db.r5d.xlarge",
+    "db.m6idn.xlarge",
+    "db.r5b.xlarge",
+    "db.r6id.xlarge",
+  ]
 }
 
 variable "rName" {

--- a/internal/service/rds/testdata/tmpl/integration_tags.gtpl
+++ b/internal/service/rds/testdata/tmpl/integration_tags.gtpl
@@ -158,10 +158,17 @@ resource "aws_db_subnet_group" "test" {
   subnet_ids = aws_subnet.test[*].id
 }
 
+data "aws_rds_engine_version" "test" {
+{{- template "region" }}
+  engine  = "aurora-mysql"
+  version = "8.0"
+  latest  = true
+}
+
 resource "aws_rds_cluster_parameter_group" "test" {
 {{- template "region" }}
   name   = var.rName
-  family = "aurora-mysql8.0"
+  family = data.aws_rds_engine_version.test.parameter_group_family
 
   dynamic "parameter" {
     for_each = local.cluster_parameters
@@ -176,8 +183,8 @@ resource "aws_rds_cluster_parameter_group" "test" {
 resource "aws_rds_cluster" "test" {
 {{- template "region" }}
   cluster_identifier  = var.rName
-  engine              = "aurora-mysql"
-  engine_version      = "8.0.mysql_aurora.3.05.2"
+  engine              = data.aws_rds_engine_version.test.engine
+  engine_version      = data.aws_rds_engine_version.test.version_actual
   database_name       = "test"
   master_username     = "tfacctest"
   master_password     = "avoid-plaintext-passwords"
@@ -190,13 +197,22 @@ resource "aws_rds_cluster" "test" {
   apply_immediately = true
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+{{- template "region" }}
+  engine                     = data.aws_rds_engine_version.test.engine
+  engine_version             = data.aws_rds_engine_version.test.version_actual
+  preferred_instance_classes = local.mainInstanceClasses
+  supports_clusters          = true
+  supports_global_databases  = true
+}
+
 resource "aws_rds_cluster_instance" "test" {
 {{- template "region" }}
   identifier         = var.rName
-  cluster_identifier = aws_rds_cluster.test.id
-  instance_class     = "db.r6g.large"
+  cluster_identifier = aws_rds_cluster.test.cluster_identifier
   engine             = aws_rds_cluster.test.engine
   engine_version     = aws_rds_cluster.test.engine_version
+  instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
 }
 
 resource "aws_redshift_cluster" "test" {
@@ -216,3 +232,57 @@ resource "aws_redshift_cluster" "test" {
 }
 
 {{ template "acctest.ConfigVPCWithSubnets" 3 }}
+
+locals {
+  mainInstanceClasses = [
+    "db.t4g.micro",
+    "db.t3.micro",
+    "db.t4g.small",
+    "db.t3.small",
+    "db.t4g.medium",
+    "db.t3.medium",
+    "db.t4g.large",
+    "db.t3.large",
+    "db.m6g.large",
+    "db.m7g.large",
+    "db.m5.large",
+    "db.m6i.large",
+    "db.m6gd.large",
+    "db.m5d.large",
+    "db.r6g.large",
+    "db.m6id.large",
+    "db.r7g.large",
+    "db.r5.large",
+    "db.r6i.large",
+    "db.r6gd.large",
+    "db.m6in.large",
+    "db.t4g.xlarge",
+    "db.t3.xlarge",
+    "db.r5d.large",
+    "db.m6idn.large",
+    "db.r5b.large",
+    "db.r6id.large",
+    "db.m6g.xlarge",
+    "db.x2g.large",
+    "db.m7g.xlarge",
+    "db.m5.xlarge",
+    "db.m6i.xlarge",
+    "db.r6in.large",
+    "db.m6gd.xlarge",
+    "db.r6idn.large",
+    "db.m5d.xlarge",
+    "db.r6g.xlarge",
+    "db.m6id.xlarge",
+    "db.r7g.xlarge",
+    "db.r5.xlarge",
+    "db.r6i.xlarge",
+    "db.r6gd.xlarge",
+    "db.m6in.xlarge",
+    "db.t4g.2xlarge",
+    "db.t3.2xlarge",
+    "db.r5d.xlarge",
+    "db.m6idn.xlarge",
+    "db.r5b.xlarge",
+    "db.r6id.xlarge",
+  ]
+}

--- a/internal/service/resourceexplorer2/index_identity_gen_test.go
+++ b/internal/service/resourceexplorer2/index_identity_gen_test.go
@@ -290,3 +290,43 @@ func testAccResourceExplorer2Index_Identity_ExistingResource(t *testing.T) {
 		},
 	})
 }
+
+func testAccResourceExplorer2Index_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_resourceexplorer2_index.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.ResourceExplorer2ServiceID),
+		CheckDestroy: testAccCheckIndexDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Index/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIndexExists(ctx, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Index/basic/"),
+				ConfigVariables:          config.Variables{},
+			},
+		},
+	})
+}

--- a/internal/service/resourceexplorer2/view_identity_gen_test.go
+++ b/internal/service/resourceexplorer2/view_identity_gen_test.go
@@ -317,3 +317,49 @@ func testAccResourceExplorer2View_Identity_ExistingResource(t *testing.T) {
 		},
 	})
 }
+
+func testAccResourceExplorer2View_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v resourceexplorer2.GetViewOutput
+	resourceName := "aws_resourceexplorer2_view.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	acctest.Test(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.ResourceExplorer2ServiceID),
+		CheckDestroy: testAccCheckViewDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/View/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckViewExists(ctx, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/View/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/s3/object_test.go
+++ b/internal/service/s3/object_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -2114,6 +2116,119 @@ func TestAccS3Object_basicUpgrade(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckObjectExists(ctx, resourceName, &obj),
 				),
+			},
+		},
+	})
+}
+
+func TestAccS3Object_Identity_ExistingResource_NoRefresh_WithChange(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf s3.GetObjectOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_object.object"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckObjectDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "6.0.0",
+					},
+				},
+				Config: testAccObjectConfig_content(rName, "initial"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckObjectExists(ctx, resourceName, &conf),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccObjectConfig_content(rName, "updated"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckObjectExists(ctx, resourceName, &conf),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentity(resourceName, map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrRegion:    knownvalue.StringExact(acctest.Region()),
+						names.AttrBucket:    knownvalue.NotNull(),
+						names.AttrKey:       knownvalue.NotNull(),
+					}),
+					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrBucket)),
+					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrKey)),
+				},
+			},
+		},
+	})
+}
+
+func TestAccS3Object_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf s3.GetObjectOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_object.object"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckObjectDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "6.0.0",
+					},
+				},
+				Config: testAccObjectConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckObjectExists(ctx, resourceName, &conf),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccObjectConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckObjectExists(ctx, resourceName, &conf),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
 			},
 		},
 	})

--- a/internal/service/securityhub/automation_rule_identity_gen_test.go
+++ b/internal/service/securityhub/automation_rule_identity_gen_test.go
@@ -317,3 +317,49 @@ func testAccSecurityHubAutomationRule_Identity_ExistingResource(t *testing.T) {
 		},
 	})
 }
+
+func testAccSecurityHubAutomationRule_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v awstypes.AutomationRulesConfig
+	resourceName := "aws_securityhub_automation_rule.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	acctest.Test(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.SecurityHubServiceID),
+		CheckDestroy: testAccCheckAutomationRuleDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/AutomationRule/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAutomationRuleExists(ctx, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/AutomationRule/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/ssmcontacts/rotation_identity_gen_test.go
+++ b/internal/service/ssmcontacts/rotation_identity_gen_test.go
@@ -193,3 +193,48 @@ func testAccSSMContactsRotation_Identity_ExistingResource(t *testing.T) {
 		},
 	})
 }
+
+func testAccSSMContactsRotation_Identity_ExistingResource_NoRefresh_NoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_ssmcontacts_rotation.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	acctest.Test(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
+		CheckDestroy: testAccCheckRotationDestroy(ctx),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Rotation/basic_v5.100.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRotationExists(ctx, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Rotation/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Generates `Identity_ExistingResource_NoRefresh_NoChange` for resource types added in v6.0 without previous errors
