### PR TITLE
DSQL: remove preview restrictions on tests

### DIFF
--- a/internal/service/dsql/cluster_peering_test.go
+++ b/internal/service/dsql/cluster_peering_test.go
@@ -25,12 +25,6 @@ func TestAccDSQLClusterPeering_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			// Because dsql is in preview, we need to skip the PreCheckPartitionHasService
-			// acctest.PreCheckPartitionHasService(t, names.DSQLEndpointID)
-			// PreCheck for the region configuration as long as DSQL is in preview
-			acctest.PreCheckRegion(t, "us-east-1", "us-east-2")          //lintignore:AWSAT003
-			acctest.PreCheckAlternateRegion(t, "us-east-2", "us-east-1") //lintignore:AWSAT003
-			acctest.PreCheckThirdRegion(t, "us-west-2")                  //lintignore:AWSAT003
 			testAccPreCheck(ctx, t)
 			acctest.PreCheckMultipleRegion(t, 2)
 		},

--- a/internal/service/dsql/cluster_test.go
+++ b/internal/service/dsql/cluster_test.go
@@ -34,12 +34,6 @@ func TestAccDSQLCluster_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			// Because dsql is in preview, we need to skip the PreCheckPartitionHasService
-			// acctest.PreCheckPartitionHasService(t, names.DSQLEndpointID)
-			// PreCheck for the region configuration as long as DSQL is in preview
-			acctest.PreCheckRegion(t, "us-east-1", "us-east-2")          //lintignore:AWSAT003
-			acctest.PreCheckAlternateRegion(t, "us-east-2", "us-east-1") //lintignore:AWSAT003
-			acctest.PreCheckThirdRegion(t, "us-west-2")                  //lintignore:AWSAT003
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.DSQLServiceID),
@@ -89,12 +83,6 @@ func TestAccDSQLCluster_disappears(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			// Because dsql is in preview, we need to skip the PreCheckPartitionHasService
-			// acctest.PreCheckPartitionHasService(t, names.DSQLEndpointID)
-			// PreCheck for the region configuration as long as DSQL is in preview
-			acctest.PreCheckRegion(t, "us-east-1", "us-east-2")          //lintignore:AWSAT003
-			acctest.PreCheckAlternateRegion(t, "us-east-2", "us-east-1") //lintignore:AWSAT003
-			acctest.PreCheckThirdRegion(t, "us-west-2")                  //lintignore:AWSAT003
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.DSQLServiceID),
@@ -121,12 +109,6 @@ func TestAccDSQLCluster_deletionProtection(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			// Because dsql is in preview, we need to skip the PreCheckPartitionHasService
-			// acctest.PreCheckPartitionHasService(t, names.DSQLEndpointID)
-			// PreCheck for the region configuration as long as DSQL is in preview
-			acctest.PreCheckRegion(t, "us-east-1", "us-east-2")          //lintignore:AWSAT003
-			acctest.PreCheckAlternateRegion(t, "us-east-2", "us-east-1") //lintignore:AWSAT003
-			acctest.PreCheckThirdRegion(t, "us-west-2")                  //lintignore:AWSAT003
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.DSQLServiceID),
@@ -181,12 +163,6 @@ func TestAccDSQLCluster_encryption(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			// Because dsql is in preview, we need to skip the PreCheckPartitionHasService
-			// acctest.PreCheckPartitionHasService(t, names.DSQLEndpointID)
-			// PreCheck for the region configuration as long as DSQL is in preview
-			acctest.PreCheckRegion(t, "us-east-1", "us-east-2")          //lintignore:AWSAT003
-			acctest.PreCheckAlternateRegion(t, "us-east-2", "us-east-1") //lintignore:AWSAT003
-			acctest.PreCheckThirdRegion(t, "us-west-2")                  //lintignore:AWSAT003
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.DSQLServiceID),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

DSQL was made [generally available on 27 May 2025](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://aws.amazon.com/blogs/aws/amazon-aurora-dsql-is-now-generally-available/&ved=2ahUKEwj5io3T6-WPAxWpLDQIHZJ1AWsQFnoECCEQAQ&usg=AOvVaw2_WA2DD2htaMX0M_MKGGPZ). Remove region restrictions on tests.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=dsql TESTS='TestAccDSQLCluster_|TestAccDSQLClusterPeering_'

--- PASS: TestAccDSQLCluster_disappears (190.75s)
--- PASS: TestAccDSQLCluster_tags_DefaultTags_emptyResourceTag (205.40s)
--- PASS: TestAccDSQLCluster_tags_EmptyTag_OnUpdate_Replace (207.86s)
--- PASS: TestAccDSQLCluster_tags_IgnoreTags_Overlap_DefaultTag (208.83s)
--- PASS: TestAccDSQLCluster_tags_DefaultTags_updateToResourceOnly (212.22s)
--- PASS: TestAccDSQLCluster_basic (213.80s)
--- PASS: TestAccDSQLCluster_tags_DefaultTags_overlapping (219.29s)
--- PASS: TestAccDSQLCluster_tags_ComputedTag_OnCreate (238.45s)
--- PASS: TestAccDSQLClusterPeering_basic (306.50s)
--- PASS: TestAccDSQLCluster_tags_AddOnUpdate (189.06s)
--- PASS: TestAccDSQLCluster_tags_DefaultTags_nullNonOverlappingResourceTag (195.13s)
--- PASS: TestAccDSQLCluster_tags_DefaultTags_nullOverlappingResourceTag (207.90s)
--- PASS: TestAccDSQLCluster_tags_DefaultTags_updateToProviderOnly (209.96s)
--- PASS: TestAccDSQLCluster_deletionProtection (208.80s)
--- PASS: TestAccDSQLCluster_tags_IgnoreTags_Overlap_ResourceTag (230.64s)
--- PASS: TestAccDSQLCluster_tags_EmptyTag_OnCreate (216.36s)
--- PASS: TestAccDSQLCluster_tags_EmptyTag_OnUpdate_Add (260.29s)
--- PASS: TestAccDSQLCluster_tags_DefaultTags_emptyProviderOnlyTag (201.93s)
--- PASS: TestAccDSQLCluster_tags_EmptyMap (228.51s)
--- PASS: TestAccDSQLCluster_tags_null (238.55s)
--- PASS: TestAccDSQLCluster_tags_ComputedTag_OnUpdate_Replace (220.66s)
--- PASS: TestAccDSQLCluster_encryption (652.89s)
--- PASS: TestAccDSQLCluster_tags_DefaultTags_nonOverlapping (242.84s)
--- PASS: TestAccDSQLCluster_tags_ComputedTag_OnUpdate_Add (235.50s)
--- PASS: TestAccDSQLCluster_tags (275.28s)
--- PASS: TestAccDSQLCluster_tags_DefaultTags_providerOnly (298.24s)
```
