### PR TITLE
resource/aws_dsql_cluster: Fixes `deletion_protection_enabled`, adds `force_destroy`, and fixes sweeper

### DIFF
--- a/internal/service/dsql/cluster.go
+++ b/internal/service/dsql/cluster.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -65,6 +66,8 @@ func (r *clusterResource) Schema(ctx context.Context, request resource.SchemaReq
 			names.AttrARN: framework.ARNAttributeComputedOnly(),
 			"deletion_protection_enabled": schema.BoolAttribute{
 				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"encryption_details": framework.ResourceComputedListOfObjectsAttribute[encryptionDetailsModel](ctx),
 			names.AttrIdentifier: framework.IDAttribute(),

--- a/internal/service/dsql/cluster.go
+++ b/internal/service/dsql/cluster.go
@@ -70,6 +70,11 @@ func (r *clusterResource) Schema(ctx context.Context, request resource.SchemaReq
 				Default:  booldefault.StaticBool(false),
 			},
 			"encryption_details": framework.ResourceComputedListOfObjectsAttribute[encryptionDetailsModel](ctx),
+			names.AttrForceDestroy: schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
+			},
 			names.AttrIdentifier: framework.IDAttribute(),
 			"kms_encryption_key": schema.StringAttribute{
 				Optional: true,
@@ -313,6 +318,19 @@ func (r *clusterResource) Delete(ctx context.Context, request resource.DeleteReq
 
 	conn := r.Meta().DSQLClient(ctx)
 
+	if data.ForceDestroy.ValueBool() {
+		input := dsql.UpdateClusterInput{
+			Identifier:                data.Identifier.ValueStringPointer(),
+			DeletionProtectionEnabled: aws.Bool(false),
+			ClientToken:               aws.String(sdkid.UniqueId()),
+		}
+		// Changing DeletionProtectionEnabled is instantaneous, no need to wait.
+		if _, err := conn.UpdateCluster(ctx, &input); err != nil {
+			response.Diagnostics.AddError(fmt.Sprintf("disabling deletion protection for Aurora DSQL Cluster (%s)", data.Identifier.ValueString()), err.Error())
+			return
+		}
+	}
+
 	id := fwflex.StringValueFromFramework(ctx, data.Identifier)
 	tflog.Debug(ctx, "deleting Aurora DSQL Cluster", map[string]any{
 		names.AttrIdentifier: id,
@@ -342,6 +360,9 @@ func (r *clusterResource) Delete(ctx context.Context, request resource.DeleteReq
 
 func (r *clusterResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root(names.AttrIdentifier), request, response)
+
+	// Set force_destroy to false on import to prevent accidental deletion
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root(names.AttrForceDestroy), types.BoolValue(false))...)
 }
 
 func findClusterByID(ctx context.Context, conn *dsql.Client, id string) (*dsql.GetClusterOutput, error) {
@@ -445,10 +466,12 @@ func waitClusterUpdated(ctx context.Context, conn *dsql.Client, id string, timeo
 
 func waitClusterDeleted(ctx context.Context, conn *dsql.Client, id string, timeout time.Duration) (*dsql.GetClusterOutput, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(awstypes.ClusterStatusDeleting, awstypes.ClusterStatusPendingDelete),
-		Target:  []string{},
-		Refresh: statusCluster(ctx, conn, id),
-		Timeout: timeout,
+		Pending:      enum.Slice(awstypes.ClusterStatusDeleting, awstypes.ClusterStatusPendingDelete),
+		Target:       []string{},
+		Refresh:      statusCluster(ctx, conn, id),
+		Timeout:      timeout,
+		Delay:        1 * time.Minute,
+		PollInterval: 10 * time.Second,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
@@ -526,6 +549,7 @@ type clusterResourceModel struct {
 	ARN                       types.String                                                `tfsdk:"arn"`
 	DeletionProtectionEnabled types.Bool                                                  `tfsdk:"deletion_protection_enabled"`
 	EncryptionDetails         fwtypes.ListNestedObjectValueOf[encryptionDetailsModel]     `tfsdk:"encryption_details"`
+	ForceDestroy              types.Bool                                                  `tfsdk:"force_destroy"`
 	Identifier                types.String                                                `tfsdk:"identifier"`
 	KMSEncryptionKey          types.String                                                `tfsdk:"kms_encryption_key"`
 	MultiRegionProperties     fwtypes.ListNestedObjectValueOf[multiRegionPropertiesModel] `tfsdk:"multi_region_properties"`

--- a/internal/service/dsql/cluster.go
+++ b/internal/service/dsql/cluster.go
@@ -43,6 +43,7 @@ import (
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/dsql;dsql.GetClusterOutput")
 // @Testing(importStateIdAttribute="identifier")
+// @Testing(generator=false)
 func newClusterResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &clusterResource{}
 

--- a/internal/service/dsql/cluster_tags_gen_test.go
+++ b/internal/service/dsql/cluster_tags_gen_test.go
@@ -21,7 +21,6 @@ func TestAccDSQLCluster_tags(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -32,7 +31,6 @@ func TestAccDSQLCluster_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -63,7 +61,6 @@ func TestAccDSQLCluster_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -77,7 +74,6 @@ func TestAccDSQLCluster_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -113,7 +109,6 @@ func TestAccDSQLCluster_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -128,7 +123,6 @@ func TestAccDSQLCluster_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -159,7 +153,6 @@ func TestAccDSQLCluster_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -173,7 +166,6 @@ func TestAccDSQLCluster_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -194,7 +186,6 @@ func TestAccDSQLCluster_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:                         resourceName,
@@ -212,7 +203,6 @@ func TestAccDSQLCluster_tags_null(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -223,7 +213,6 @@ func TestAccDSQLCluster_tags_null(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: nil,
 					}),
@@ -254,7 +243,6 @@ func TestAccDSQLCluster_tags_null(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: nil,
 					}),
@@ -277,7 +265,6 @@ func TestAccDSQLCluster_tags_EmptyMap(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -288,7 +275,6 @@ func TestAccDSQLCluster_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -309,7 +295,6 @@ func TestAccDSQLCluster_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ResourceName:                         resourceName,
@@ -330,7 +315,6 @@ func TestAccDSQLCluster_tags_AddOnUpdate(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -341,7 +325,6 @@ func TestAccDSQLCluster_tags_AddOnUpdate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -362,7 +345,6 @@ func TestAccDSQLCluster_tags_AddOnUpdate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -393,7 +375,6 @@ func TestAccDSQLCluster_tags_AddOnUpdate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -413,7 +394,6 @@ func TestAccDSQLCluster_tags_EmptyTag_OnCreate(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -424,7 +404,6 @@ func TestAccDSQLCluster_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -455,7 +434,6 @@ func TestAccDSQLCluster_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -469,7 +447,6 @@ func TestAccDSQLCluster_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -490,7 +467,6 @@ func TestAccDSQLCluster_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:                         resourceName,
@@ -508,7 +484,6 @@ func TestAccDSQLCluster_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -519,7 +494,6 @@ func TestAccDSQLCluster_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -550,7 +524,6 @@ func TestAccDSQLCluster_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 						acctest.CtKey2: config.StringVariable(""),
@@ -586,7 +559,6 @@ func TestAccDSQLCluster_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 						acctest.CtKey2: config.StringVariable(""),
@@ -601,7 +573,6 @@ func TestAccDSQLCluster_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -632,7 +603,6 @@ func TestAccDSQLCluster_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -652,7 +622,6 @@ func TestAccDSQLCluster_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -663,7 +632,6 @@ func TestAccDSQLCluster_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -694,7 +662,6 @@ func TestAccDSQLCluster_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -725,7 +692,6 @@ func TestAccDSQLCluster_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -745,7 +711,6 @@ func TestAccDSQLCluster_tags_DefaultTags_providerOnly(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -756,7 +721,6 @@ func TestAccDSQLCluster_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -785,7 +749,6 @@ func TestAccDSQLCluster_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -801,7 +764,6 @@ func TestAccDSQLCluster_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -833,7 +795,6 @@ func TestAccDSQLCluster_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -850,7 +811,6 @@ func TestAccDSQLCluster_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -879,7 +839,6 @@ func TestAccDSQLCluster_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -895,7 +854,6 @@ func TestAccDSQLCluster_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -917,7 +875,6 @@ func TestAccDSQLCluster_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:                         resourceName,
@@ -935,7 +892,6 @@ func TestAccDSQLCluster_tags_DefaultTags_nonOverlapping(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -946,7 +902,6 @@ func TestAccDSQLCluster_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -983,7 +938,6 @@ func TestAccDSQLCluster_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1001,7 +955,6 @@ func TestAccDSQLCluster_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1Updated),
 					}),
@@ -1043,7 +996,6 @@ func TestAccDSQLCluster_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1Updated),
 					}),
@@ -1062,7 +1014,6 @@ func TestAccDSQLCluster_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1084,7 +1035,6 @@ func TestAccDSQLCluster_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:                         resourceName,
@@ -1102,7 +1052,6 @@ func TestAccDSQLCluster_tags_DefaultTags_overlapping(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1113,7 +1062,6 @@ func TestAccDSQLCluster_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1148,7 +1096,6 @@ func TestAccDSQLCluster_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1166,7 +1113,6 @@ func TestAccDSQLCluster_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 						acctest.CtOverlapKey2: config.StringVariable("providervalue2"),
@@ -1207,7 +1153,6 @@ func TestAccDSQLCluster_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 						acctest.CtOverlapKey2: config.StringVariable("providervalue2"),
@@ -1227,7 +1172,6 @@ func TestAccDSQLCluster_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1262,7 +1206,6 @@ func TestAccDSQLCluster_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1285,7 +1228,6 @@ func TestAccDSQLCluster_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1296,7 +1238,6 @@ func TestAccDSQLCluster_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1328,7 +1269,6 @@ func TestAccDSQLCluster_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1357,7 +1297,6 @@ func TestAccDSQLCluster_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1378,7 +1317,6 @@ func TestAccDSQLCluster_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1389,7 +1327,6 @@ func TestAccDSQLCluster_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1418,7 +1355,6 @@ func TestAccDSQLCluster_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1450,7 +1386,6 @@ func TestAccDSQLCluster_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1470,7 +1405,6 @@ func TestAccDSQLCluster_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1481,7 +1415,6 @@ func TestAccDSQLCluster_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1516,7 +1449,6 @@ func TestAccDSQLCluster_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1539,7 +1471,6 @@ func TestAccDSQLCluster_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1550,7 +1481,6 @@ func TestAccDSQLCluster_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -1579,7 +1509,6 @@ func TestAccDSQLCluster_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -1600,7 +1529,6 @@ func TestAccDSQLCluster_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1611,7 +1539,6 @@ func TestAccDSQLCluster_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1646,7 +1573,6 @@ func TestAccDSQLCluster_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1672,7 +1598,6 @@ func TestAccDSQLCluster_tags_DefaultTags_nullNonOverlappingResourceTag(t *testin
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1683,7 +1608,6 @@ func TestAccDSQLCluster_tags_DefaultTags_nullNonOverlappingResourceTag(t *testin
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1720,7 +1644,6 @@ func TestAccDSQLCluster_tags_DefaultTags_nullNonOverlappingResourceTag(t *testin
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1746,7 +1669,6 @@ func TestAccDSQLCluster_tags_ComputedTag_OnCreate(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1757,7 +1679,6 @@ func TestAccDSQLCluster_tags_ComputedTag_OnCreate(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1786,7 +1707,6 @@ func TestAccDSQLCluster_tags_ComputedTag_OnCreate(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				ResourceName:                         resourceName,
@@ -1804,7 +1724,6 @@ func TestAccDSQLCluster_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1815,7 +1734,6 @@ func TestAccDSQLCluster_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1847,7 +1765,6 @@ func TestAccDSQLCluster_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tagsComputed2/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 					"knownTagKey":   config.StringVariable(acctest.CtKey1),
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
@@ -1884,7 +1801,6 @@ func TestAccDSQLCluster_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tagsComputed2/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 					"knownTagKey":   config.StringVariable(acctest.CtKey1),
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
@@ -1904,7 +1820,6 @@ func TestAccDSQLCluster_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1915,7 +1830,6 @@ func TestAccDSQLCluster_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1947,7 +1861,6 @@ func TestAccDSQLCluster_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1976,7 +1889,6 @@ func TestAccDSQLCluster_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				ResourceName:                         resourceName,
@@ -1994,7 +1906,6 @@ func TestAccDSQLCluster_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -2006,7 +1917,6 @@ func TestAccDSQLCluster_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_ignore/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -2055,7 +1965,6 @@ func TestAccDSQLCluster_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_ignore/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1Updated),
 					}),
@@ -2104,7 +2013,6 @@ func TestAccDSQLCluster_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_ignore/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1Again),
 					}),
@@ -2157,7 +2065,6 @@ func TestAccDSQLCluster_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -2169,7 +2076,6 @@ func TestAccDSQLCluster_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_ignore/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtResourceKey1: config.StringVariable(acctest.CtResourceValue1),
 						acctest.CtResourceKey2: config.StringVariable(acctest.CtResourceValue2),
@@ -2227,7 +2133,6 @@ func TestAccDSQLCluster_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_ignore/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtResourceKey1: config.StringVariable(acctest.CtResourceValue1Updated),
 						acctest.CtResourceKey2: config.StringVariable(acctest.CtResourceValue2),
@@ -2284,7 +2189,6 @@ func TestAccDSQLCluster_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Cluster/tags_ignore/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtResourceKey1: config.StringVariable(acctest.CtResourceValue1Again),
 						acctest.CtResourceKey2: config.StringVariable(acctest.CtResourceValue2Updated),

--- a/internal/service/dsql/cluster_test.go
+++ b/internal/service/dsql/cluster_test.go
@@ -41,7 +41,7 @@ func TestAccDSQLCluster_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_basic(false),
+				Config: testAccClusterConfig_basic(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster),
 				),
@@ -90,7 +90,7 @@ func TestAccDSQLCluster_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_basic(false),
+				Config: testAccClusterConfig_basic(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster),
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfdsql.ResourceCluster, resourceName),
@@ -116,7 +116,7 @@ func TestAccDSQLCluster_deletionProtection(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_basic(true),
+				Config: testAccClusterConfig_deletionProtection(true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster),
 				),
@@ -137,7 +137,7 @@ func TestAccDSQLCluster_deletionProtection(t *testing.T) {
 				ImportStateVerify:                    true,
 			},
 			{
-				Config: testAccClusterConfig_basic(false),
+				Config: testAccClusterConfig_deletionProtection(false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster),
 				),
@@ -281,7 +281,14 @@ func testAccPreCheck(ctx context.Context, t *testing.T) {
 	}
 }
 
-func testAccClusterConfig_basic(deletionProtection bool) string {
+func testAccClusterConfig_basic() string {
+	return `
+resource "aws_dsql_cluster" "test" {
+}
+`
+}
+
+func testAccClusterConfig_deletionProtection(deletionProtection bool) string {
 	return fmt.Sprintf(`
 resource "aws_dsql_cluster" "test" {
   deletion_protection_enabled = %[1]t

--- a/internal/service/dsql/sweep.go
+++ b/internal/service/dsql/sweep.go
@@ -21,9 +21,9 @@ func RegisterSweepers() {
 
 func sweepClusters(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	conn := client.DSQLClient(ctx)
-	var input dsql.ListClustersInput
-	sweepResources := make([]sweep.Sweepable, 0)
+	var sweepResources []sweep.Sweepable
 
+	var input dsql.ListClustersInput
 	pages := dsql.NewListClustersPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
@@ -34,8 +34,9 @@ func sweepClusters(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepa
 
 		for _, v := range page.Clusters {
 			sweepResources = append(sweepResources, framework.NewSweepResource(newClusterResource, client,
-				framework.NewAttribute(names.AttrIdentifier, aws.ToString(v.Identifier))),
-			)
+				framework.NewAttribute(names.AttrIdentifier, aws.ToString(v.Identifier)),
+				framework.NewAttribute(names.AttrForceDestroy, true),
+			))
 		}
 	}
 

--- a/internal/service/dsql/testdata/Cluster/tags/main_gen.tf
+++ b/internal/service/dsql/testdata/Cluster/tags/main_gen.tf
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resource "aws_dsql_cluster" "test" {
-  deletion_protection_enabled = false
 
   tags = var.resource_tags
 }

--- a/internal/service/dsql/testdata/Cluster/tags/main_gen.tf
+++ b/internal/service/dsql/testdata/Cluster/tags/main_gen.tf
@@ -6,17 +6,6 @@ resource "aws_dsql_cluster" "test" {
   tags = var.resource_tags
 }
 
-output "rName" {
-  value       = var.rName
-  description = "To prevent tflint issues"
-}
-
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/dsql/testdata/Cluster/tagsComputed1/main_gen.tf
+++ b/internal/service/dsql/testdata/Cluster/tagsComputed1/main_gen.tf
@@ -4,7 +4,6 @@
 provider "null" {}
 
 resource "aws_dsql_cluster" "test" {
-  deletion_protection_enabled = false
 
   tags = {
     (var.unknownTagKey) = null_resource.test.id

--- a/internal/service/dsql/testdata/Cluster/tagsComputed1/main_gen.tf
+++ b/internal/service/dsql/testdata/Cluster/tagsComputed1/main_gen.tf
@@ -10,18 +10,7 @@ resource "aws_dsql_cluster" "test" {
   }
 }
 
-output "rName" {
-  value       = var.rName
-  description = "To prevent tflint issues"
-}
-
 resource "null_resource" "test" {}
-
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
 
 variable "unknownTagKey" {
   type     = string

--- a/internal/service/dsql/testdata/Cluster/tagsComputed2/main_gen.tf
+++ b/internal/service/dsql/testdata/Cluster/tagsComputed2/main_gen.tf
@@ -4,7 +4,6 @@
 provider "null" {}
 
 resource "aws_dsql_cluster" "test" {
-  deletion_protection_enabled = false
 
   tags = {
     (var.unknownTagKey) = null_resource.test.id

--- a/internal/service/dsql/testdata/Cluster/tagsComputed2/main_gen.tf
+++ b/internal/service/dsql/testdata/Cluster/tagsComputed2/main_gen.tf
@@ -11,18 +11,7 @@ resource "aws_dsql_cluster" "test" {
   }
 }
 
-output "rName" {
-  value       = var.rName
-  description = "To prevent tflint issues"
-}
-
 resource "null_resource" "test" {}
-
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
 
 variable "unknownTagKey" {
   type     = string

--- a/internal/service/dsql/testdata/Cluster/tags_defaults/main_gen.tf
+++ b/internal/service/dsql/testdata/Cluster/tags_defaults/main_gen.tf
@@ -12,17 +12,6 @@ resource "aws_dsql_cluster" "test" {
   tags = var.resource_tags
 }
 
-output "rName" {
-  value       = var.rName
-  description = "To prevent tflint issues"
-}
-
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/dsql/testdata/Cluster/tags_defaults/main_gen.tf
+++ b/internal/service/dsql/testdata/Cluster/tags_defaults/main_gen.tf
@@ -8,7 +8,6 @@ provider "aws" {
 }
 
 resource "aws_dsql_cluster" "test" {
-  deletion_protection_enabled = false
 
   tags = var.resource_tags
 }

--- a/internal/service/dsql/testdata/Cluster/tags_ignore/main_gen.tf
+++ b/internal/service/dsql/testdata/Cluster/tags_ignore/main_gen.tf
@@ -15,17 +15,6 @@ resource "aws_dsql_cluster" "test" {
   tags = var.resource_tags
 }
 
-output "rName" {
-  value       = var.rName
-  description = "To prevent tflint issues"
-}
-
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/dsql/testdata/Cluster/tags_ignore/main_gen.tf
+++ b/internal/service/dsql/testdata/Cluster/tags_ignore/main_gen.tf
@@ -11,7 +11,6 @@ provider "aws" {
 }
 
 resource "aws_dsql_cluster" "test" {
-  deletion_protection_enabled = false
 
   tags = var.resource_tags
 }

--- a/internal/service/dsql/testdata/tmpl/cluster_tags.gtpl
+++ b/internal/service/dsql/testdata/tmpl/cluster_tags.gtpl
@@ -1,6 +1,4 @@
 resource "aws_dsql_cluster" "test" {
-  deletion_protection_enabled = false
-
 {{- template "tags" . }}
 }
 

--- a/internal/service/dsql/testdata/tmpl/cluster_tags.gtpl
+++ b/internal/service/dsql/testdata/tmpl/cluster_tags.gtpl
@@ -1,8 +1,3 @@
 resource "aws_dsql_cluster" "test" {
 {{- template "tags" . }}
 }
-
-output "rName" {
-  value       = var.rName
-  description = "To prevent tflint issues"
-}

--- a/website/docs/r/dsql_cluster.html.markdown
+++ b/website/docs/r/dsql_cluster.html.markdown
@@ -28,7 +28,10 @@ resource "aws_dsql_cluster" "example" {
 
 This resource supports the following arguments:
 
-* `deletion_protection_enabled` - (Required) Whether deletion protection is enabled in this cluster.
+* `deletion_protection_enabled` - (Optional) Whether deletion protection is enabled in this cluster.
+  Default value is `false`.
+* `force_destroy` - (Optional) Destroys cluster even if `deletion_protection_enabled` is set to `true`.
+  Default value is `false`.
 * `kms_encryption_key` - (Optional) The ARN of the AWS KMS key that encrypts data in the DSQL Cluster, or `"AWS_OWNED_KMS_KEY"`.
 * `multi_region_properties` - (Optional) Multi-region properties of the DSQL Cluster.
     * `witness_region` - (Required) Witness region for the multi-region clusters. Setting this makes this cluster a multi-region cluster. Changing it recreates the resource.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Fixes `deletion_protection_enabled` to actually be `Optional` and not return error on Read

Adds `force_destroy` to support sweeper when `deletion_protection_enabled` is `true`

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=dsql TESTS=TestAccDSQLCluster_

--- PASS: TestAccDSQLCluster_forceDestroy (217.88s)
--- PASS: TestAccDSQLCluster_disappears (225.09s)
--- PASS: TestAccDSQLCluster_deletionProtection (230.17s)
--- PASS: TestAccDSQLCluster_tags_DefaultTags_updateToProviderOnly (230.17s)
--- PASS: TestAccDSQLCluster_tags_DefaultTags_nullNonOverlappingResourceTag (233.73s)
--- PASS: TestAccDSQLCluster_tags_DefaultTags_emptyResourceTag (239.50s)
--- PASS: TestAccDSQLCluster_tags_DefaultTags_emptyProviderOnlyTag (239.72s)
--- PASS: TestAccDSQLCluster_tags_ComputedTag_OnCreate (263.18s)
--- PASS: TestAccDSQLCluster_tags_EmptyTag_OnCreate (266.14s)
--- PASS: TestAccDSQLCluster_tags_ComputedTag_OnUpdate_Add (276.49s)
--- PASS: TestAccDSQLCluster_tags_EmptyTag_OnUpdate_Replace (279.95s)
--- PASS: TestAccDSQLCluster_tags_ComputedTag_OnUpdate_Replace (281.03s)
--- PASS: TestAccDSQLCluster_tags_DefaultTags_updateToResourceOnly (281.70s)
--- PASS: TestAccDSQLCluster_tags_DefaultTags_overlapping (290.51s)
--- PASS: TestAccDSQLCluster_tags_IgnoreTags_Overlap_ResourceTag (290.63s)
--- PASS: TestAccDSQLCluster_tags_IgnoreTags_Overlap_DefaultTag (294.21s)
--- PASS: TestAccDSQLCluster_tags_DefaultTags_providerOnly (296.62s)
--- PASS: TestAccDSQLCluster_tags_DefaultTags_nonOverlapping (297.08s)
--- PASS: TestAccDSQLCluster_tags (325.92s)
--- PASS: TestAccDSQLCluster_tags_DefaultTags_nullOverlappingResourceTag (198.54s)
--- PASS: TestAccDSQLCluster_basic (177.76s)
--- PASS: TestAccDSQLCluster_tags_EmptyMap (187.15s)
--- PASS: TestAccDSQLCluster_tags_AddOnUpdate (188.36s)
--- PASS: TestAccDSQLCluster_tags_EmptyTag_OnUpdate_Add (224.97s)
--- PASS: TestAccDSQLCluster_tags_null (217.94s)
--- PASS: TestAccDSQLCluster_encryption (746.23s)
```
