### PR TITLE
F/ Add support for additional_model_data_sources in aws_sagemaker_model resource

### DIFF
--- a/.changelog/43814.txt
+++ b/.changelog/43814.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sagemaker_model: Add `container.additional_model_data_sources` and `primary_container.additional_model_data_sources` arguments
+```

--- a/internal/service/sagemaker/model.go
+++ b/internal/service/sagemaker/model.go
@@ -907,6 +907,9 @@ func flattenContainer(container *awstypes.ContainerDefinition) []any {
 	if container.ModelDataSource != nil {
 		cfg["model_data_source"] = flattenModelDataSource(container.ModelDataSource)
 	}
+	if len(container.AdditionalModelDataSources) > 0 {
+		cfg["additional_model_data_sources"] = flattenAdditionalModelDataSources(container.AdditionalModelDataSources)
+	}
 	if container.ModelPackageName != nil {
 		cfg["model_package_name"] = aws.ToString(container.ModelPackageName)
 	}
@@ -943,6 +946,31 @@ func flattenModelDataSource(modelDataSource *awstypes.ModelDataSource) []any {
 	return []any{cfg}
 }
 
+func flattenAdditionalModelDataSource(ds *awstypes.AdditionalModelDataSource) []any {
+	if ds == nil {
+		return []any{}
+	}
+
+	m := make(map[string]any)
+	if ds.ChannelName != nil {
+		m["channel_name"] = aws.ToString(ds.ChannelName)
+	}
+	if ds.S3DataSource != nil {
+		m["s3_data_source"] = flattenS3ModelDataSource(ds.S3DataSource)
+	}
+	return []any{m}
+}
+
+func flattenAdditionalModelDataSources(additionalModelDataSources []awstypes.AdditionalModelDataSource) []any {
+	fSources := make([]any, 0, len(additionalModelDataSources))
+	for _, ds := range additionalModelDataSources {
+		flattened := flattenAdditionalModelDataSource(&ds)
+		if len(flattened) > 0 {
+			fSources = append(fSources, flattened[0].(map[string]any))
+		}
+	}
+	return fSources
+}
 func flattenS3ModelDataSource(s3ModelDataSource *awstypes.S3ModelDataSource) []any {
 	if s3ModelDataSource == nil {
 		return []any{}

--- a/internal/service/sagemaker/model.go
+++ b/internal/service/sagemaker/model.go
@@ -167,7 +167,7 @@ func resourceModel() *schema.Resource {
 								},
 							},
 						},
-						"additional_model_data_source": {
+						"additional_model_data_sources": {
 							Type:     schema.TypeList,
 							Optional: true,
 							Computed: true,
@@ -406,7 +406,7 @@ func resourceModel() *schema.Resource {
 								},
 							},
 						},
-						"additional_model_data_source": {
+						"additional_model_data_sources": {
 							Type:     schema.TypeList,
 							Optional: true,
 							Computed: true,
@@ -723,7 +723,7 @@ func expandContainer(m map[string]any) *awstypes.ContainerDefinition {
 		container.ModelDataSource = expandModelDataSource(v.([]any))
 	}
 
-	if v, ok := m["additional_model_data_source"]; ok {
+	if v, ok := m["additional_model_data_sources"]; ok {
 		container.AdditionalModelDataSources = expandAdditionalModelDataSources(v.([]any))
 	}
 	if v, ok := m[names.AttrEnvironment].(map[string]any); ok && len(v) > 0 {
@@ -761,13 +761,9 @@ func expandModelDataSource(l []any) *awstypes.ModelDataSource {
 	return &modelDataSource
 }
 
-func expandAdditionalModelDataSource(l []any) *awstypes.AdditionalModelDataSource {
-	if len(l) == 0 {
-		return nil
-	}
-	additionalModelDataSource := awstypes.AdditionalModelDataSource{}
+func expandAdditionalModelDataSource(m map[string]any) *awstypes.AdditionalModelDataSource {
 
-	m := l[0].(map[string]any)
+	additionalModelDataSource := awstypes.AdditionalModelDataSource{}
 
 	if v, ok := m["channel_name"]; ok && v.(string) != "" {
 		additionalModelDataSource.ChannelName = aws.String(v.(string))

--- a/internal/service/sagemaker/model_test.go
+++ b/internal/service/sagemaker/model_test.go
@@ -887,6 +887,115 @@ resource "aws_sagemaker_model" "test" {
 `, rName))
 }
 
+func TestAccSageMakerModel_primaryContainerAdditionalModelDataSources(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_model.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckModelDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccModelConfig_primaryContainerAdditionalModelDataSources(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckModelExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.additional_model_data_sources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.additional_model_data_sources.0.channel_name", "test-channel"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.additional_model_data_sources.0.s3_data_source.0.s3_data_type", "S3Prefix"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccModelConfig_primaryContainerAdditionalModelDataSources(rName string) string {
+	return acctest.ConfigCompose(testAccModelConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_model" "test" {
+  name               = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  primary_container {
+    image          = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+    model_data_url = "https://s3.amazonaws.com/${aws_s3_object.test.bucket}/${aws_s3_object.test.key}"
+	
+    additional_model_data_sources {
+      channel_name = "test-channel"
+      s3_data_source {
+        s3_uri       = "s3://${aws_s3_object.test.bucket}/model/"
+        s3_data_type = "S3Prefix"
+		compression_type = "None"
+      }
+    }
+  }
+}
+
+resource "aws_iam_policy" "test" {
+  name        = %[1]q
+  description = "Allow SageMaker AI to create model"
+  policy      = data.aws_iam_policy_document.policy.json
+}
+
+data "aws_iam_policy_document" "policy" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "cloudwatch:PutMetricData",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:CreateLogGroup",
+      "logs:DescribeLogStreams",
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      aws_s3_bucket.test.arn,
+      "${aws_s3_bucket.test.arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = aws_iam_policy.test.arn
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+
+resource "aws_s3_object" "test" {
+  bucket  = aws_s3_bucket.test.bucket
+  key     = "model/inference.py"
+  content = "some-data"
+}
+`, rName))
+}
 func testAccModelConfig_primaryContainerUncompressedModel(rName string) string {
 	return acctest.ConfigCompose(testAccModelConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {

--- a/website/docs/r/sagemaker_model.html.markdown
+++ b/website/docs/r/sagemaker_model.html.markdown
@@ -65,6 +65,7 @@ The `primary_container` and `container` block both support:
 * `model_data_url` - (Optional) The URL for the S3 location where model artifacts are stored.
 * `model_package_name` - (Optional) The Amazon Resource Name (ARN) of the model package to use to create the model.
 * `model_data_source` - (Optional) The location of model data to deploy. Use this for uncompressed model deployment. For information about how to deploy an uncompressed model, see [Deploying uncompressed models](https://docs.aws.amazon.com/sagemaker/latest/dg/large-model-inference-uncompressed.html) in the _AWS SageMaker AI Developer Guide_.
+* `additional_model_data_sources` - (Optional) Data sources that are available to your model in addition to the one that you specify for `model_data_source`.
 * `container_hostname` - (Optional) The DNS host name for the container.
 * `environment` - (Optional) Environment variables for the Docker container.
    A list of key value pairs.
@@ -83,6 +84,11 @@ The `primary_container` and `container` block both support:
 
 ### Model Data Source
 
+* `s3_data_source` - (Required) The S3 location of model data to deploy.
+
+### Additional Model Data Sources 
+
+* `channel_name` - (required) A custom name where the aditional object will be stored. it will be stored in `/opt/ml/additional-model-data-sources/<channel_name>/`.
 * `s3_data_source` - (Required) The S3 location of model data to deploy.
 
 #### S3 Data Source


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

AWS has functionality to add additional data sources to the model while building an endpoint. This functionality was not implemented in the provider



### Relations

Closes #43814 


### References

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker/client/create_model.html



### Output from Acceptance Testing




```console
% make testacc TESTS=TestAccSageMakerModel_primaryContainerAdditionalModelDataSources PKG=sagemaker

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws-sagemaker-model-additional-model-data-source 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerModel_primaryContainerAdditionalModelDataSources'  -timeout 360m -vet=off
2025/09/23 01:20:22 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/23 01:20:22 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSageMakerModel_primaryContainerAdditionalModelDataSources
=== PAUSE TestAccSageMakerModel_primaryContainerAdditionalModelDataSources
=== CONT  TestAccSageMakerModel_primaryContainerAdditionalModelDataSources
--- PASS: TestAccSageMakerModel_primaryContainerAdditionalModelDataSources (60.83s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  61.046s
...
```
