### PR TITLE
r/aws_acm_certificate: add write-only support for the `private_key` by adding `private_key_wo` and `private_key_wo_version`

### DIFF
--- a/.changelog/44414.txt
+++ b/.changelog/44414.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_acm_certificate: Added write-only support for the `private_key` argument, via the `private_key_wo` and `private_key_wo_version` arguments.
+```

--- a/.changelog/44414.txt
+++ b/.changelog/44414.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_acm_certificate: Added write-only support for the `private_key` argument, via the `private_key_wo` and `private_key_wo_version` arguments.
+resource/aws_acm_certificate: Add `private_key_wo` write-only argument and `private_key_wo_version` argument
 ```

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/acm"
 	"github.com/aws/aws-sdk-go-v2/service/acm/types"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	sdkid "github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
@@ -90,7 +91,6 @@ func resourceCertificate() *schema.Resource {
 			"certificate_body": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				RequiredWith:  []string{names.AttrPrivateKey},
 				ConflictsWith: []string{"certificate_authority_arn", names.AttrDomainName, "validation_method"},
 			},
 			names.AttrCertificateChain: {
@@ -104,7 +104,7 @@ func resourceCertificate() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ValidateFunc:  validation.StringDoesNotMatch(regexache.MustCompile(`\.$`), "cannot end with a period"),
-				ExactlyOneOf:  []string{names.AttrDomainName, names.AttrPrivateKey},
+				ExactlyOneOf:  []string{names.AttrDomainName, names.AttrPrivateKey, AttrPrivateKeyWo},
 				ConflictsWith: []string{"certificate_body", names.AttrCertificateChain, names.AttrPrivateKey},
 			},
 			"domain_validation_options": {
@@ -406,12 +406,10 @@ func resourceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta
 
 		d.SetId(aws.ToString(output.CertificateArn))
 	} else {
-		var privateKey string
-		_, ok := d.GetOk(AttrPrivateKeyWo)
-		if ok {
-			privateKey = d.Get(AttrPrivateKeyWo).(string)
-		} else {
-			privateKey = d.Get(names.AttrPrivateKey).(string)
+		privateKey := d.Get(names.AttrPrivateKey).(string)
+		privateKeyWo, _ := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath(AttrPrivateKeyWo))
+		if privateKeyWo != "" {
+			privateKey = privateKeyWo
 		}
 		input := acm.ImportCertificateInput{
 			Certificate: []byte(d.Get("certificate_body").(string)),
@@ -520,12 +518,10 @@ func resourceCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta
 		oPKRaw, nPKRaw := d.GetChange(names.AttrPrivateKey)
 
 		if !isChangeNormalizeCertRemoval(oCBRaw, nCBRaw) || !isChangeNormalizeCertRemoval(oCCRaw, nCCRaw) || !isChangeNormalizeCertRemoval(oPKRaw, nPKRaw) {
-			var privateKey string
-			_, ok := d.GetOk(AttrPrivateKeyWo)
-			if ok {
-				privateKey = d.Get(AttrPrivateKeyWo).(string)
-			} else {
-				privateKey = d.Get(names.AttrPrivateKey).(string)
+			privateKey := d.Get(names.AttrPrivateKey).(string)
+			privateKeyWo, _ := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath(AttrPrivateKeyWo))
+			if privateKeyWo != "" {
+				privateKey = privateKeyWo
 			}
 			input := acm.ImportCertificateInput{
 				Certificate:    []byte(d.Get("certificate_body").(string)),

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -399,6 +399,7 @@ func resourceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 		output, err := conn.RequestCertificate(ctx, &input)
+
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "requesting ACM Certificate (%s): %s", domainName, err)
 		}
@@ -422,6 +423,7 @@ func resourceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 		output, err := conn.ImportCertificate(ctx, &input)
+
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "importing ACM Certificate: %s", err)
 		}
@@ -535,6 +537,7 @@ func resourceCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta
 			}
 
 			_, err := conn.ImportCertificate(ctx, &input)
+
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "importing ACM Certificate (%s): %s", d.Id(), err)
 			}
@@ -544,6 +547,7 @@ func resourceCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta
 			CertificateArn: aws.String(d.Get(names.AttrARN).(string)),
 		}
 		_, err := conn.RenewCertificate(ctx, &input)
+
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "renewing ACM Certificate (%s): %s", d.Id(), err)
 		}
@@ -561,6 +565,7 @@ func resourceCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 		_, err := conn.UpdateCertificateOptions(ctx, &input)
+
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating ACM Certificate options (%s): %s", d.Id(), err)
 		}
@@ -844,6 +849,7 @@ func findCertificateByARN(ctx context.Context, conn *acm.Client, arn string) (*t
 	}
 
 	output, err := findCertificate(ctx, conn, &input)
+
 	if err != nil {
 		return nil, err
 	}
@@ -859,6 +865,7 @@ func findCertificateByARN(ctx context.Context, conn *acm.Client, arn string) (*t
 
 func findCertificateRenewalByARN(ctx context.Context, conn *acm.Client, arn string) (*types.RenewalSummary, error) {
 	certificate, err := findCertificateByARN(ctx, conn, arn)
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -86,7 +86,7 @@ func resourceCertificate() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ValidateFunc:  verify.ValidARN,
-				ConflictsWith: []string{"certificate_body", names.AttrPrivateKey, "validation_method"},
+				ConflictsWith: []string{"certificate_body", names.AttrPrivateKey, AttrPrivateKeyWo, "validation_method"},
 			},
 			"certificate_body": {
 				Type:          schema.TypeString,
@@ -197,7 +197,6 @@ func resourceCertificate() *schema.Resource {
 			AttrPrivateKeyWoVersion: {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ForceNew:     true,
 				RequiredWith: []string{AttrPrivateKeyWo},
 			},
 			"renewal_eligibility": {
@@ -407,7 +406,8 @@ func resourceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta
 		d.SetId(aws.ToString(output.CertificateArn))
 	} else {
 		privateKey := d.Get(names.AttrPrivateKey).(string)
-		privateKeyWo, _ := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath(AttrPrivateKeyWo))
+		privateKeyWo, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath(AttrPrivateKeyWo))
+		diags = append(diags, di...)
 		if privateKeyWo != "" {
 			privateKey = privateKeyWo
 		}
@@ -512,14 +512,15 @@ func resourceCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 	conn := meta.(*conns.AWSClient).ACMClient(ctx)
 
-	if d.HasChanges(names.AttrPrivateKey, "certificate_body", names.AttrCertificateChain) {
+	if d.HasChanges(names.AttrPrivateKey, "certificate_body", names.AttrCertificateChain, AttrPrivateKeyWoVersion) {
 		oCBRaw, nCBRaw := d.GetChange("certificate_body")
 		oCCRaw, nCCRaw := d.GetChange(names.AttrCertificateChain)
 		oPKRaw, nPKRaw := d.GetChange(names.AttrPrivateKey)
 
-		if !isChangeNormalizeCertRemoval(oCBRaw, nCBRaw) || !isChangeNormalizeCertRemoval(oCCRaw, nCCRaw) || !isChangeNormalizeCertRemoval(oPKRaw, nPKRaw) {
+		if !isChangeNormalizeCertRemoval(oCBRaw, nCBRaw) || !isChangeNormalizeCertRemoval(oCCRaw, nCCRaw) || !isChangeNormalizeCertRemoval(oPKRaw, nPKRaw) || d.HasChange(AttrPrivateKeyWoVersion) {
 			privateKey := d.Get(names.AttrPrivateKey).(string)
-			privateKeyWo, _ := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath(AttrPrivateKeyWo))
+			privateKeyWo, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath(AttrPrivateKeyWo))
+			diags = append(diags, di...)
 			if privateKeyWo != "" {
 				privateKey = privateKeyWo
 			}

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -56,11 +56,6 @@ const (
 	certificateValidationMethodNone = "NONE"
 )
 
-var (
-	AttrPrivateKeyWo        = fmt.Sprintf("%s_wo", names.AttrPrivateKey)
-	AttrPrivateKeyWoVersion = fmt.Sprintf("%s_wo_version", names.AttrPrivateKey)
-)
-
 // @SDKResource("aws_acm_certificate", name="Certificate")
 // @Tags(identifierAttribute="arn")
 // @ArnIdentity
@@ -86,7 +81,7 @@ func resourceCertificate() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ValidateFunc:  verify.ValidARN,
-				ConflictsWith: []string{"certificate_body", names.AttrPrivateKey, AttrPrivateKeyWo, "validation_method"},
+				ConflictsWith: []string{"certificate_body", names.AttrPrivateKey, "private_key_wo", "validation_method"},
 			},
 			"certificate_body": {
 				Type:          schema.TypeString,
@@ -104,7 +99,7 @@ func resourceCertificate() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ValidateFunc:  validation.StringDoesNotMatch(regexache.MustCompile(`\.$`), "cannot end with a period"),
-				ExactlyOneOf:  []string{names.AttrDomainName, names.AttrPrivateKey, AttrPrivateKeyWo},
+				ExactlyOneOf:  []string{names.AttrDomainName, names.AttrPrivateKey, "private_key_wo"},
 				ConflictsWith: []string{"certificate_body", names.AttrCertificateChain, names.AttrPrivateKey},
 			},
 			"domain_validation_options": {
@@ -185,19 +180,19 @@ func resourceCertificate() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Sensitive:    true,
-				ExactlyOneOf: []string{names.AttrDomainName, names.AttrPrivateKey, AttrPrivateKeyWo},
+				ExactlyOneOf: []string{names.AttrDomainName, names.AttrPrivateKey, "private_key_wo"},
 			},
-			AttrPrivateKeyWo: {
+			"private_key_wo": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				WriteOnly:    true,
-				ExactlyOneOf: []string{names.AttrDomainName, names.AttrPrivateKey, AttrPrivateKeyWo},
-				RequiredWith: []string{AttrPrivateKeyWoVersion},
+				ExactlyOneOf: []string{names.AttrDomainName, names.AttrPrivateKey, "private_key_wo"},
+				RequiredWith: []string{"private_key_wo_version"},
 			},
-			AttrPrivateKeyWoVersion: {
+			"private_key_wo_version": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				RequiredWith: []string{AttrPrivateKeyWo},
+				RequiredWith: []string{"private_key_wo"},
 			},
 			"renewal_eligibility": {
 				Type:     schema.TypeString,
@@ -407,7 +402,7 @@ func resourceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta
 		d.SetId(aws.ToString(output.CertificateArn))
 	} else {
 		privateKey := d.Get(names.AttrPrivateKey).(string)
-		privateKeyWo, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath(AttrPrivateKeyWo))
+		privateKeyWo, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath("private_key_wo"))
 		diags = append(diags, di...)
 		if privateKeyWo != "" {
 			privateKey = privateKeyWo
@@ -514,14 +509,14 @@ func resourceCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 	conn := meta.(*conns.AWSClient).ACMClient(ctx)
 
-	if d.HasChanges(names.AttrPrivateKey, "certificate_body", names.AttrCertificateChain, AttrPrivateKeyWoVersion) {
+	if d.HasChanges(names.AttrPrivateKey, "certificate_body", names.AttrCertificateChain, "private_key_wo_version") {
 		oCBRaw, nCBRaw := d.GetChange("certificate_body")
 		oCCRaw, nCCRaw := d.GetChange(names.AttrCertificateChain)
 		oPKRaw, nPKRaw := d.GetChange(names.AttrPrivateKey)
 
-		if !isChangeNormalizeCertRemoval(oCBRaw, nCBRaw) || !isChangeNormalizeCertRemoval(oCCRaw, nCCRaw) || !isChangeNormalizeCertRemoval(oPKRaw, nPKRaw) || d.HasChange(AttrPrivateKeyWoVersion) {
+		if !isChangeNormalizeCertRemoval(oCBRaw, nCBRaw) || !isChangeNormalizeCertRemoval(oCCRaw, nCCRaw) || !isChangeNormalizeCertRemoval(oPKRaw, nPKRaw) || d.HasChange("private_key_wo_version") {
 			privateKey := d.Get(names.AttrPrivateKey).(string)
-			privateKeyWo, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath(AttrPrivateKeyWo))
+			privateKeyWo, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath("private_key_wo"))
 			diags = append(diags, di...)
 			if privateKeyWo != "" {
 				privateKey = privateKeyWo

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -55,6 +55,11 @@ const (
 	certificateValidationMethodNone = "NONE"
 )
 
+var (
+	AttrPrivateKeyWo        = fmt.Sprintf("%s_wo", names.AttrPrivateKey)
+	AttrPrivateKeyWoVersion = fmt.Sprintf("%s_wo_version", names.AttrPrivateKey)
+)
+
 // @SDKResource("aws_acm_certificate", name="Certificate")
 // @Tags(identifierAttribute="arn")
 // @ArnIdentity
@@ -180,7 +185,20 @@ func resourceCertificate() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Sensitive:    true,
-				ExactlyOneOf: []string{names.AttrDomainName, names.AttrPrivateKey},
+				ExactlyOneOf: []string{names.AttrDomainName, names.AttrPrivateKey, AttrPrivateKeyWo},
+			},
+			AttrPrivateKeyWo: {
+				Type:         schema.TypeString,
+				Optional:     true,
+				WriteOnly:    true,
+				ExactlyOneOf: []string{names.AttrDomainName, names.AttrPrivateKey, AttrPrivateKeyWo},
+				RequiredWith: []string{AttrPrivateKeyWoVersion},
+			},
+			AttrPrivateKeyWoVersion: {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{AttrPrivateKeyWo},
 			},
 			"renewal_eligibility": {
 				Type:     schema.TypeString,
@@ -382,16 +400,22 @@ func resourceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 		output, err := conn.RequestCertificate(ctx, &input)
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "requesting ACM Certificate (%s): %s", domainName, err)
 		}
 
 		d.SetId(aws.ToString(output.CertificateArn))
 	} else {
+		var privateKey string
+		_, ok := d.GetOk(AttrPrivateKeyWo)
+		if ok {
+			privateKey = d.Get(AttrPrivateKeyWo).(string)
+		} else {
+			privateKey = d.Get(names.AttrPrivateKey).(string)
+		}
 		input := acm.ImportCertificateInput{
 			Certificate: []byte(d.Get("certificate_body").(string)),
-			PrivateKey:  []byte(d.Get(names.AttrPrivateKey).(string)),
+			PrivateKey:  []byte(privateKey),
 			Tags:        getTagsIn(ctx),
 		}
 
@@ -400,7 +424,6 @@ func resourceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 		output, err := conn.ImportCertificate(ctx, &input)
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "importing ACM Certificate: %s", err)
 		}
@@ -497,10 +520,17 @@ func resourceCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta
 		oPKRaw, nPKRaw := d.GetChange(names.AttrPrivateKey)
 
 		if !isChangeNormalizeCertRemoval(oCBRaw, nCBRaw) || !isChangeNormalizeCertRemoval(oCCRaw, nCCRaw) || !isChangeNormalizeCertRemoval(oPKRaw, nPKRaw) {
+			var privateKey string
+			_, ok := d.GetOk(AttrPrivateKeyWo)
+			if ok {
+				privateKey = d.Get(AttrPrivateKeyWo).(string)
+			} else {
+				privateKey = d.Get(names.AttrPrivateKey).(string)
+			}
 			input := acm.ImportCertificateInput{
 				Certificate:    []byte(d.Get("certificate_body").(string)),
 				CertificateArn: aws.String(d.Get(names.AttrARN).(string)),
-				PrivateKey:     []byte(d.Get(names.AttrPrivateKey).(string)),
+				PrivateKey:     []byte(privateKey),
 			}
 
 			if chain, ok := d.GetOk(names.AttrCertificateChain); ok {
@@ -508,7 +538,6 @@ func resourceCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta
 			}
 
 			_, err := conn.ImportCertificate(ctx, &input)
-
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "importing ACM Certificate (%s): %s", d.Id(), err)
 			}
@@ -518,7 +547,6 @@ func resourceCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta
 			CertificateArn: aws.String(d.Get(names.AttrARN).(string)),
 		}
 		_, err := conn.RenewCertificate(ctx, &input)
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "renewing ACM Certificate (%s): %s", d.Id(), err)
 		}
@@ -536,7 +564,6 @@ func resourceCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 		_, err := conn.UpdateCertificateOptions(ctx, &input)
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating ACM Certificate options (%s): %s", d.Id(), err)
 		}
@@ -820,7 +847,6 @@ func findCertificateByARN(ctx context.Context, conn *acm.Client, arn string) (*t
 	}
 
 	output, err := findCertificate(ctx, conn, &input)
-
 	if err != nil {
 		return nil, err
 	}
@@ -836,7 +862,6 @@ func findCertificateByARN(ctx context.Context, conn *acm.Client, arn string) (*t
 
 func findCertificateRenewalByARN(ctx context.Context, conn *acm.Client, arn string) (*types.RenewalSummary, error) {
 	certificate, err := findCertificateByARN(ctx, conn, arn)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -404,6 +404,9 @@ func resourceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta
 		privateKey := d.Get(names.AttrPrivateKey).(string)
 		privateKeyWo, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath("private_key_wo"))
 		diags = append(diags, di...)
+		if diags.HasError() {
+			return diags
+		}
 		if privateKeyWo != "" {
 			privateKey = privateKeyWo
 		}
@@ -518,6 +521,9 @@ func resourceCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta
 			privateKey := d.Get(names.AttrPrivateKey).(string)
 			privateKeyWo, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath("private_key_wo"))
 			diags = append(diags, di...)
+			if diags.HasError() {
+				return diags
+			}
 			if privateKeyWo != "" {
 				privateKey = privateKeyWo
 			}

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -1539,6 +1539,7 @@ func TestAccACMCertificate_PrivateKeyWo(t *testing.T) {
 				Config: testAccCertificateConfig_privateKeyWoUpdate(newCertificate, newKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, resourceName, &v2),
+					testAccCheckCertficateNotRecreated(&v1, &v2),
 					resource.TestCheckNoResourceAttr(resourceName, tfacm.AttrPrivateKeyWo),
 					resource.TestCheckResourceAttr(resourceName, tfacm.AttrPrivateKeyWoVersion, "2"),
 				),

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -1826,6 +1826,7 @@ func testAccCheckCertificateExists(ctx context.Context, t *testing.T, n string, 
 		conn := acctest.ProviderMeta(ctx, t).ACMClient(ctx)
 
 		output, err := tfacm.FindCertificateByARN(ctx, conn, rs.Primary.ID)
+
 		if err != nil {
 			return err
 		}

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -1539,7 +1539,7 @@ func TestAccACMCertificate_PrivateKeyWo(t *testing.T) {
 				Config: testAccCertificateConfig_privateKeyWoUpdate(newCertificate, newKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v2),
-					testAccCheckCertficateNotRecreated(&v1, &v2),
+					testAccCheckCertificateNotRecreated(&v1, &v2),
 					resource.TestCheckNoResourceAttr(resourceName, "private_key_wo"),
 					resource.TestCheckResourceAttr(resourceName, "private_key_wo_version", "2"),
 				),
@@ -1582,7 +1582,7 @@ func TestAccACMCertificate_Imported_domainName(t *testing.T) {
 				Config: testAccCertificateConfig_privateKey(newCertificate, key, newCaCertificate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v2),
-					testAccCheckCertficateNotRecreated(&v1, &v2),
+					testAccCheckCertificateNotRecreated(&v1, &v2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusIssued)),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, commonName),
@@ -1592,7 +1592,7 @@ func TestAccACMCertificate_Imported_domainName(t *testing.T) {
 				Config: testAccCertificateConfig_privateKeyNoChain(t, withoutChainDomain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v3),
-					testAccCheckCertficateNotRecreated(&v2, &v3),
+					testAccCheckCertificateNotRecreated(&v2, &v3),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusIssued)),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, withoutChainDomain),
@@ -1863,7 +1863,7 @@ func testAccCheckCertificateDestroy(ctx context.Context, t *testing.T) resource.
 	}
 }
 
-func testAccCheckCertficateNotRecreated(v1, v2 *types.CertificateDetail) resource.TestCheckFunc {
+func testAccCheckCertificateNotRecreated(v1, v2 *types.CertificateDetail) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if aws.ToString(v1.CertificateArn) != aws.ToString(v2.CertificateArn) {
 			return fmt.Errorf("ACM Certificate recreated")

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -1521,7 +1521,7 @@ func TestAccACMCertificate_PrivateKeyWo(t *testing.T) {
 	newCertificate := acctest.TLSRSAX509LocallySignedCertificatePEM(t, newCaKey, newCaCertificate, newKey, commonName)
 	var v1, v2 types.CertificateDetail
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -1525,12 +1525,12 @@ func TestAccACMCertificate_PrivateKeyWo(t *testing.T) {
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCertificateConfig_privateKeyWo(certificate, key),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckCertificateExists(ctx, resourceName, &v1),
+					testAccCheckCertificateExists(ctx, t, resourceName, &v1),
 					resource.TestCheckNoResourceAttr(resourceName, tfacm.AttrPrivateKeyWo),
 					resource.TestCheckResourceAttr(resourceName, tfacm.AttrPrivateKeyWoVersion, "1"),
 				),
@@ -1538,7 +1538,7 @@ func TestAccACMCertificate_PrivateKeyWo(t *testing.T) {
 			{
 				Config: testAccCertificateConfig_privateKeyWoUpdate(newCertificate, newKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckCertificateExists(ctx, resourceName, &v2),
+					testAccCheckCertificateExists(ctx, t, resourceName, &v2),
 					testAccCheckCertficateNotRecreated(&v1, &v2),
 					resource.TestCheckNoResourceAttr(resourceName, tfacm.AttrPrivateKeyWo),
 					resource.TestCheckResourceAttr(resourceName, tfacm.AttrPrivateKeyWoVersion, "2"),

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -1531,8 +1531,8 @@ func TestAccACMCertificate_PrivateKeyWo(t *testing.T) {
 				Config: testAccCertificateConfig_privateKeyWo(certificate, key),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v1),
-					resource.TestCheckNoResourceAttr(resourceName, tfacm.AttrPrivateKeyWo),
-					resource.TestCheckResourceAttr(resourceName, tfacm.AttrPrivateKeyWoVersion, "1"),
+					resource.TestCheckNoResourceAttr(resourceName, "private_key_wo"),
+					resource.TestCheckResourceAttr(resourceName, "private_key_wo_version", "1"),
 				),
 			},
 			{
@@ -1540,8 +1540,8 @@ func TestAccACMCertificate_PrivateKeyWo(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v2),
 					testAccCheckCertficateNotRecreated(&v1, &v2),
-					resource.TestCheckNoResourceAttr(resourceName, tfacm.AttrPrivateKeyWo),
-					resource.TestCheckResourceAttr(resourceName, tfacm.AttrPrivateKeyWoVersion, "2"),
+					resource.TestCheckNoResourceAttr(resourceName, "private_key_wo"),
+					resource.TestCheckResourceAttr(resourceName, "private_key_wo_version", "2"),
 				),
 			},
 		},

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -16,6 +16,8 @@ Amazon-issued, where AWS provides the certificate authority and automatically ma
 imported certificates, issued by another certificate authority;
 and private certificates, issued using an ACM Private Certificate Authority.
 
+-> **Note:** Write-Only argument `private_key_wo` is available to use in place of `private_key`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments).
+
 ## Amazon-Issued Certificates
 
 For Amazon-issued certificates, this resource deals with requesting certificates and managing their attributes and life-cycle.
@@ -113,6 +115,38 @@ resource "aws_acm_certificate" "cert" {
 }
 ```
 
+### Existing Certificate Body Import With Write-Only Private Key
+
+```terraform
+resource "tls_private_key" "example" {
+  algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "example" {
+  key_algorithm   = "RSA"
+  private_key_pem = tls_private_key.example.private_key_pem
+
+  subject {
+    common_name  = "example.com"
+    organization = "ACME Examples, Inc"
+  }
+
+  validity_period_hours = 12
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "aws_acm_certificate" "cert" {
+  private_key_wo         = tls_private_key.example.private_key_pem
+  private_key_wo_version = 1
+  certificate_body       = tls_self_signed_cert.example.cert_pem
+}
+```
+
 ### Referencing domain_validation_options With for_each Based Resources
 
 See the [`aws_acm_certificate_validation` resource](acm_certificate_validation.html) for a full example of performing DNS validation.
@@ -149,7 +183,9 @@ This resource supports the following arguments:
     * `options` - (Optional) Configuration block used to set certificate options. Detailed below.
     * `validation_option` - (Optional) Configuration block used to specify information about the initial validation of each domain name. Detailed below.
 * Importing an existing certificate
-    * `private_key` - (Required) Certificate's PEM-formatted private key
+    * `private_key` - (Required) Certificate's PEM-formatted private key. Conflicts with `private_key_wo`.
+    * `private_key_wo` - (Optional, Write-Only) Certificate's PEM-formatted private key. Conflicts with `private_key`. Must be used together with `private_key_wo_version`.
+    * `private_key_wo_version` - (Optional) Used together with `private_key_wo` to trigger an update. Increment this value when an update to `private_key_wo` is required.
     * `certificate_body` - (Required) Certificate's PEM-formatted public key
     * `certificate_chain` - (Optional) Certificate's PEM-formatted chain
 * Creating a private CA issued certificate

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -183,7 +183,7 @@ This resource supports the following arguments:
     * `options` - (Optional) Configuration block used to set certificate options. Detailed below.
     * `validation_option` - (Optional) Configuration block used to specify information about the initial validation of each domain name. Detailed below.
 * Importing an existing certificate
-    * `private_key` - (Required) Certificate's PEM-formatted private key. Conflicts with `private_key_wo`.
+    * `private_key` - (Optional) Certificate's PEM-formatted private key. Conflicts with `private_key_wo`.
     * `private_key_wo` - (Optional, Write-Only) Certificate's PEM-formatted private key. Conflicts with `private_key`. Must be used together with `private_key_wo_version`.
     * `private_key_wo_version` - (Optional) Used together with `private_key_wo` to trigger an update. Increment this value when an update to `private_key_wo` is required.
     * `certificate_body` - (Required) Certificate's PEM-formatted public key


### PR DESCRIPTION
## Rollback Plan

N/A

## Changes to Security Controls

N/A

### Description
Added [write-only](https://developer.hashicorp.com/terraform/language/manage-sensitive-data/write-only) support for the `private_key` argument, so that it can be used in combination with an [ephemeral resource](https://developer.hashicorp.com/terraform/language/manage-sensitive-data/ephemeral#ephemeral-resources) to avoid the private_key being written to terraform state.

This means two new agruments:
- `private_key_wo`: used to configure the actual value for the private key (not written to tfstate)
- `private_key_wo_version`: used to enforce changes on the `private_key_wo`, should always be set in combination.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/43945

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

**Acceptance test:**

```console
➜ make testacc TESTS=TestAccACMCertificate_PrivateKeyWo PKG=acm

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f/acm-certificate-private-key-wo 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/acm/... -v -count 1 -parallel 20 -run='TestAccACMCertificate_PrivateKeyWo'  -timeout 360m -vet=off
2025/09/23 15:15:33 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/23 15:15:33 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccACMCertificate_PrivateKeyWo
=== PAUSE TestAccACMCertificate_PrivateKeyWo
=== CONT  TestAccACMCertificate_PrivateKeyWo
--- PASS: TestAccACMCertificate_PrivateKeyWo (24.25s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/acm        27.935s
```
