### PR TITLE
Technical debt: Use `internal/retry.StateChangeConf` with `tfresource.Options`

### DIFF
--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -15,13 +15,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -593,7 +593,7 @@ func waitDBClusterInstanceAvailable(ctx context.Context, conn *rds.Client, id st
 			instanceStatusUpgrading,
 		},
 		Target:     []string{instanceStatusAvailable, instanceStatusStorageOptimization},
-		Refresh:    statusDBInstance(ctx, conn, id),
+		Refresh:    statusDBInstance(conn, id),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
@@ -617,7 +617,7 @@ func waitDBClusterInstanceDeleted(ctx context.Context, conn *rds.Client, id stri
 			instanceStatusModifying,
 		},
 		Target:     []string{},
-		Refresh:    statusDBInstance(ctx, conn, id),
+		Refresh:    statusDBInstance(conn, id),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -32,6 +32,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -2851,7 +2852,7 @@ func findDBInstances(ctx context.Context, conn *rds.Client, input *rds.DescribeD
 		page, err := pages.NextPage(ctx, optFns...)
 
 		if errs.IsA[*types.DBInstanceNotFoundFault](err) {
-			return nil, &retry.NotFoundError{
+			return nil, &sdkretry.NotFoundError{
 				LastError:   err,
 				LastRequest: input,
 			}
@@ -2871,8 +2872,8 @@ func findDBInstances(ctx context.Context, conn *rds.Client, input *rds.DescribeD
 	return output, nil
 }
 
-func statusDBInstance(ctx context.Context, conn *rds.Client, id string, optFns ...func(*rds.Options)) retry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusDBInstance(conn *rds.Client, id string, optFns ...func(*rds.Options)) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findDBInstanceByID(ctx, conn, id, optFns...)
 
 		if tfresource.NotFound(err) {
@@ -2916,7 +2917,7 @@ func waitDBInstanceAvailable(ctx context.Context, conn *rds.Client, id string, t
 			instanceStatusUpgrading,
 		},
 		Target:  []string{instanceStatusAvailable, instanceStatusStorageOptimization},
-		Refresh: statusDBInstance(ctx, conn, id),
+		Refresh: statusDBInstance(conn, id),
 		Timeout: timeout,
 	}
 	options.Apply(stateConf)
@@ -2950,7 +2951,7 @@ func waitDBInstanceStopped(ctx context.Context, conn *rds.Client, id string, tim
 			instanceStatusUpgrading,
 		},
 		Target:                    []string{instanceStatusStopped},
-		Refresh:                   statusDBInstance(ctx, conn, id),
+		Refresh:                   statusDBInstance(conn, id),
 		Timeout:                   timeout,
 		ContinuousTargetOccurence: 2,
 		Delay:                     10 * time.Second,
@@ -2994,7 +2995,7 @@ func waitDBInstanceDeleted(ctx context.Context, conn *rds.Client, id string, tim
 			instanceStatusStorageOptimization,
 		},
 		Target:  []string{},
-		Refresh: statusDBInstance(ctx, conn, id),
+		Refresh: statusDBInstance(conn, id),
 		Timeout: timeout,
 	}
 	options.Apply(stateConf)
@@ -3021,7 +3022,7 @@ func findBlueGreenDeploymentByID(ctx context.Context, conn *rds.Client, id strin
 
 	// Eventual consistency check.
 	if aws.ToString(output.BlueGreenDeploymentIdentifier) != id {
-		return nil, &retry.NotFoundError{
+		return nil, &sdkretry.NotFoundError{
 			LastRequest: input,
 		}
 	}
@@ -3047,7 +3048,7 @@ func findBlueGreenDeployments(ctx context.Context, conn *rds.Client, input *rds.
 		page, err := pages.NextPage(ctx)
 
 		if errs.IsA[*types.BlueGreenDeploymentNotFoundFault](err) {
-			return nil, &retry.NotFoundError{
+			return nil, &sdkretry.NotFoundError{
 				LastError:   err,
 				LastRequest: input,
 			}
@@ -3067,8 +3068,8 @@ func findBlueGreenDeployments(ctx context.Context, conn *rds.Client, input *rds.
 	return output, nil
 }
 
-func statusBlueGreenDeployment(ctx context.Context, conn *rds.Client, id string) retry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusBlueGreenDeployment(conn *rds.Client, id string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findBlueGreenDeploymentByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -3094,7 +3095,7 @@ func waitBlueGreenDeploymentAvailable(ctx context.Context, conn *rds.Client, id 
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{"PROVISIONING"},
 		Target:  []string{"AVAILABLE"},
-		Refresh: statusBlueGreenDeployment(ctx, conn, id),
+		Refresh: statusBlueGreenDeployment(conn, id),
 		Timeout: timeout,
 	}
 	options.Apply(stateConf)
@@ -3120,7 +3121,7 @@ func waitBlueGreenDeploymentSwitchoverCompleted(ctx context.Context, conn *rds.C
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{"AVAILABLE", "SWITCHOVER_IN_PROGRESS"},
 		Target:  []string{"SWITCHOVER_COMPLETED"},
-		Refresh: statusBlueGreenDeployment(ctx, conn, id),
+		Refresh: statusBlueGreenDeployment(conn, id),
 		Timeout: timeout,
 	}
 	options.Apply(stateConf)
@@ -3150,7 +3151,7 @@ func waitBlueGreenDeploymentDeleted(ctx context.Context, conn *rds.Client, id st
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{"PROVISIONING", "AVAILABLE", "SWITCHOVER_IN_PROGRESS", "SWITCHOVER_COMPLETED", "INVALID_CONFIGURATION", "SWITCHOVER_FAILED", "DELETING"},
 		Target:  []string{},
-		Refresh: statusBlueGreenDeployment(ctx, conn, id),
+		Refresh: statusBlueGreenDeployment(conn, id),
 		Timeout: timeout,
 	}
 	options.Apply(stateConf)

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -3065,7 +3065,6 @@ func TestAccRDSInstance_ReplicateSourceDB_mssqlDomain(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	sourceResourceName := "aws_db_instance.source"
 	resourceName := "aws_db_instance.test"
-
 	domain := acctest.RandomDomain().String()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -11112,11 +11111,10 @@ resource "aws_security_group_rule" "test" {
 }
 
 resource "aws_directory_service_directory" "directory" {
-  name                = %[2]q
-  password_wo         = ephemeral.aws_secretsmanager_random_password.test.random_password
-  password_wo_version = 1
-  type                = "MicrosoftAD"
-  edition             = "Standard"
+  name     = %[2]q
+  password = "SuperSecretPassw0rd"
+  type     = "MicrosoftAD"
+  edition  = "Standard"
 
   vpc_settings {
     vpc_id     = aws_vpc.test.id

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/backoff"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
@@ -158,7 +157,7 @@ type Options struct {
 	ContinuousTargetOccurence int           // Number of times the Target state has to occur continuously
 }
 
-func (o Options) Apply(c *sdkretry.StateChangeConf) {
+func (o Options) Apply(c *retry.StateChangeConf) {
 	if o.Delay > 0 {
 		c.Delay = o.Delay
 	}

--- a/internal/tfresource/retry_test.go
+++ b/internal/tfresource/retry_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
@@ -479,7 +478,7 @@ func TestOptionsApply(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			conf := sdkretry.StateChangeConf{}
+			conf := retry.StateChangeConf{}
 
 			testCase.options.Apply(&conf)
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Use `internal/retry.StateChangeConf` with `tfresource.Options`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/42554.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/44093.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% ACCTEST_TIMEOUT=720m make testacc TESTARGS='-run=TestAccRDSInstance_\|TestAccRDSClusterInstance_' PKG=rds ACCTEST_PARALLELISM=4
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-tfresource.Options-use-internal/retry 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/rds/... -v -count 1 -parallel 4  -run=TestAccRDSInstance_\|TestAccRDSClusterInstance_ -timeout 720m -vet=off
2025/09/24 13:36:28 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/24 13:36:28 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSClusterInstance_basic
=== PAUSE TestAccRDSClusterInstance_basic
=== RUN   TestAccRDSClusterInstance_disappears
=== PAUSE TestAccRDSClusterInstance_disappears
=== RUN   TestAccRDSClusterInstance_identifierGenerated
=== PAUSE TestAccRDSClusterInstance_identifierGenerated
=== RUN   TestAccRDSClusterInstance_identifierPrefix
=== PAUSE TestAccRDSClusterInstance_identifierPrefix
=== RUN   TestAccRDSClusterInstance_tags
=== PAUSE TestAccRDSClusterInstance_tags
=== RUN   TestAccRDSClusterInstance_isAlreadyBeingDeleted
=== PAUSE TestAccRDSClusterInstance_isAlreadyBeingDeleted
=== RUN   TestAccRDSClusterInstance_az
=== PAUSE TestAccRDSClusterInstance_az
=== RUN   TestAccRDSClusterInstance_kmsKey
=== PAUSE TestAccRDSClusterInstance_kmsKey
=== RUN   TestAccRDSClusterInstance_publiclyAccessible
=== PAUSE TestAccRDSClusterInstance_publiclyAccessible
=== RUN   TestAccRDSClusterInstance_copyTagsToSnapshot
=== PAUSE TestAccRDSClusterInstance_copyTagsToSnapshot
=== RUN   TestAccRDSClusterInstance_caCertificateIdentifier
=== PAUSE TestAccRDSClusterInstance_caCertificateIdentifier
=== RUN   TestAccRDSClusterInstance_monitoringInterval
=== PAUSE TestAccRDSClusterInstance_monitoringInterval
=== RUN   TestAccRDSClusterInstance_MonitoringRoleARN_enabledToDisabled
=== PAUSE TestAccRDSClusterInstance_MonitoringRoleARN_enabledToDisabled
=== RUN   TestAccRDSClusterInstance_MonitoringRoleARN_enabledToRemoved
=== PAUSE TestAccRDSClusterInstance_MonitoringRoleARN_enabledToRemoved
=== RUN   TestAccRDSClusterInstance_MonitoringRoleARN_removedToEnabled
=== PAUSE TestAccRDSClusterInstance_MonitoringRoleARN_removedToEnabled
=== RUN   TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraMySQL1
=== PAUSE TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraMySQL1
=== RUN   TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraPostgresql
=== PAUSE TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraPostgresql
=== RUN   TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraMySQL1
=== PAUSE TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraMySQL1
=== RUN   TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraMySQL1_defaultKeyToCustomKey
=== PAUSE TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraMySQL1_defaultKeyToCustomKey
=== RUN   TestAccRDSClusterInstance_performanceInsightsRetentionPeriod
=== PAUSE TestAccRDSClusterInstance_performanceInsightsRetentionPeriod
=== RUN   TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraPostgresql
=== PAUSE TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraPostgresql
=== RUN   TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraPostgresql_defaultKeyToCustomKey
=== PAUSE TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraPostgresql_defaultKeyToCustomKey
=== RUN   TestAccRDSClusterInstance_Replica_basic
=== PAUSE TestAccRDSClusterInstance_Replica_basic
=== RUN   TestAccRDSInstance_basic
=== PAUSE TestAccRDSInstance_basic
=== RUN   TestAccRDSInstance_identifierPrefix
=== PAUSE TestAccRDSInstance_identifierPrefix
=== RUN   TestAccRDSInstance_identifierGenerated
=== PAUSE TestAccRDSInstance_identifierGenerated
=== RUN   TestAccRDSInstance_disappears
=== PAUSE TestAccRDSInstance_disappears
=== RUN   TestAccRDSInstance_engineLifecycleSupport_disabled
=== PAUSE TestAccRDSInstance_engineLifecycleSupport_disabled
=== RUN   TestAccRDSInstance_Versions_onlyMajor
=== PAUSE TestAccRDSInstance_Versions_onlyMajor
=== RUN   TestAccRDSInstance_kmsKey
=== PAUSE TestAccRDSInstance_kmsKey
=== RUN   TestAccRDSInstance_customIAMInstanceProfile
=== PAUSE TestAccRDSInstance_customIAMInstanceProfile
=== RUN   TestAccRDSInstance_DBSubnetGroupName_basic
=== PAUSE TestAccRDSInstance_DBSubnetGroupName_basic
=== RUN   TestAccRDSInstance_networkType
=== PAUSE TestAccRDSInstance_networkType
=== RUN   TestAccRDSInstance_optionGroup
=== PAUSE TestAccRDSInstance_optionGroup
=== RUN   TestAccRDSInstance_iamAuth
=== PAUSE TestAccRDSInstance_iamAuth
=== RUN   TestAccRDSInstance_Versions_allowMajor
=== PAUSE TestAccRDSInstance_Versions_allowMajor
=== RUN   TestAccRDSInstance_db2
    instance_test.go:608: Environment variable RDS_DB2_CUSTOMER_ID is not set, skipping test
--- SKIP: TestAccRDSInstance_db2 (0.00s)
=== RUN   TestAccRDSInstance_DBSubnetGroupName_ramShared
=== PAUSE TestAccRDSInstance_DBSubnetGroupName_ramShared
=== RUN   TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs
=== PAUSE TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs
=== RUN   TestAccRDSInstance_deletionProtection
=== PAUSE TestAccRDSInstance_deletionProtection
=== RUN   TestAccRDSInstance_FinalSnapshotIdentifier_basic
=== PAUSE TestAccRDSInstance_FinalSnapshotIdentifier_basic
=== RUN   TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot
=== PAUSE TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot
=== RUN   TestAccRDSInstance_isAlreadyBeingDeleted
=== PAUSE TestAccRDSInstance_isAlreadyBeingDeleted
=== RUN   TestAccRDSInstance_Storage_maxAllocated
=== PAUSE TestAccRDSInstance_Storage_maxAllocated
=== RUN   TestAccRDSInstance_password
=== PAUSE TestAccRDSInstance_password
=== RUN   TestAccRDSInstance_passwordWriteOnly
=== PAUSE TestAccRDSInstance_passwordWriteOnly
=== RUN   TestAccRDSInstance_ManageMasterPassword_basic
=== PAUSE TestAccRDSInstance_ManageMasterPassword_basic
=== RUN   TestAccRDSInstance_ErrorOnConvertToManageOnStoppedInstance
=== PAUSE TestAccRDSInstance_ErrorOnConvertToManageOnStoppedInstance
=== RUN   TestAccRDSInstance_ManageMasterPassword_kmsKey
=== PAUSE TestAccRDSInstance_ManageMasterPassword_kmsKey
=== RUN   TestAccRDSInstance_ManageMasterPassword_convertToManaged
=== PAUSE TestAccRDSInstance_ManageMasterPassword_convertToManaged
=== RUN   TestAccRDSInstance_ReplicateSourceDB_basic
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_basic
=== RUN   TestAccRDSInstance_ReplicateSourceDB_promoteNull
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_promoteNull
=== RUN   TestAccRDSInstance_ReplicateSourceDB_promoteEmptyString
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_promoteEmptyString
=== RUN   TestAccRDSInstance_ReplicateSourceDB_sourceARN
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_sourceARN
=== RUN   TestAccRDSInstance_ReplicateSourceDB_upgradeStorageConfig
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_upgradeStorageConfig
=== RUN   TestAccRDSInstance_ReplicateSourceDB_namePrefix
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_namePrefix
=== RUN   TestAccRDSInstance_ReplicateSourceDB_nameGenerated
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_nameGenerated
=== RUN   TestAccRDSInstance_ReplicateSourceDB_addLater
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_addLater
=== RUN   TestAccRDSInstance_ReplicateSourceDB_allocatedStorage
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_allocatedStorage
=== RUN   TestAccRDSInstance_ReplicateSourceDB_iops
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_iops
=== RUN   TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops
=== RUN   TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade
=== RUN   TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade
=== RUN   TestAccRDSInstance_ReplicateSourceDB_availabilityZone
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_availabilityZone
=== RUN   TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod
=== RUN   TestAccRDSInstance_ReplicateSourceDB_backupWindow
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_backupWindow
=== RUN   TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_basic
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_basic
=== RUN   TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_sameAsSource
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_sameAsSource
=== RUN   TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_sameVPC
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_sameVPC
=== RUN   TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_crossRegion
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_crossRegion
=== RUN   TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupNameRAMShared
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupNameRAMShared
=== RUN   TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupNameVPCSecurityGroupIDs
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupNameVPCSecurityGroupIDs
=== RUN   TestAccRDSInstance_ReplicateSourceDB_deletionProtection
    instance_test.go:2168: CreateDBInstanceReadReplica API currently ignores DeletionProtection=true with SourceDBInstanceIdentifier set
--- SKIP: TestAccRDSInstance_ReplicateSourceDB_deletionProtection (0.00s)
=== RUN   TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled
=== RUN   TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow
=== RUN   TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage
=== RUN   TestAccRDSInstance_ReplicateSourceDB_monitoring
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_monitoring
=== RUN   TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists
=== RUN   TestAccRDSInstance_ReplicateSourceDB_multiAZ
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_multiAZ
=== RUN   TestAccRDSInstance_ReplicateSourceDB_networkType
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_networkType
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSameSetOnBoth
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSameSetOnBoth
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica
=== RUN   TestAccRDSInstance_ReplicateSourceDB_port
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_port
=== RUN   TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs
=== RUN   TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier
=== RUN   TestAccRDSInstance_ReplicateSourceDB_characterSet_Source
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_characterSet_Source
=== RUN   TestAccRDSInstance_ReplicateSourceDB_replicaMode
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_replicaMode
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep
=== RUN   TestAccRDSInstance_ReplicateSourceDB_CrossRegion_parameterGroupNameEquivalent
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_CrossRegion_parameterGroupNameEquivalent
=== RUN   TestAccRDSInstance_ReplicateSourceDB_CrossRegion_parameterGroupNamePostgres
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_CrossRegion_parameterGroupNamePostgres
=== RUN   TestAccRDSInstance_ReplicateSourceDB_CrossRegion_characterSet
    instance_test.go:3008: Skipping due to upstream error
--- SKIP: TestAccRDSInstance_ReplicateSourceDB_CrossRegion_characterSet (0.00s)
=== RUN   TestAccRDSInstance_ReplicateSourceDB_mssqlDomain
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_mssqlDomain
=== RUN   TestAccRDSInstance_s3Import
    instance_test.go:3106: RestoreDBInstanceFromS3 cannot restore from MySQL version 5.6
--- SKIP: TestAccRDSInstance_s3Import (0.00s)
=== RUN   TestAccRDSInstance_SnapshotIdentifier_basic
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_basic
=== RUN   TestAccRDSInstance_SnapshotIdentifier_ManageMasterPasswordKMSKey
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_ManageMasterPasswordKMSKey
=== RUN   TestAccRDSInstance_SnapshotIdentifier_namePrefix
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_namePrefix
=== RUN   TestAccRDSInstance_SnapshotIdentifier_nameGenerated
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_nameGenerated
=== RUN   TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved
=== RUN   TestAccRDSInstance_SnapshotIdentifier_allocatedStorage
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_allocatedStorage
=== RUN   TestAccRDSInstance_SnapshotIdentifier_io1Storage
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_io1Storage
=== RUN   TestAccRDSInstance_SnapshotIdentifier_io2Storage
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_io2Storage
=== RUN   TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade
=== RUN   TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade
=== RUN   TestAccRDSInstance_SnapshotIdentifier_availabilityZone
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_availabilityZone
=== RUN   TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride
=== RUN   TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset
=== RUN   TestAccRDSInstance_SnapshotIdentifier_backupWindow
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_backupWindow
=== RUN   TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName
=== RUN   TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameRAMShared
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameRAMShared
=== RUN   TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs
=== RUN   TestAccRDSInstance_SnapshotIdentifier_deletionProtection
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_deletionProtection
=== RUN   TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled
=== RUN   TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow
=== RUN   TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage
=== RUN   TestAccRDSInstance_SnapshotIdentifier_monitoring
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_monitoring
=== RUN   TestAccRDSInstance_SnapshotIdentifier_multiAZ
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_multiAZ
=== RUN   TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer
=== RUN   TestAccRDSInstance_SnapshotIdentifier_parameterGroupName
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_parameterGroupName
=== RUN   TestAccRDSInstance_SnapshotIdentifier_port
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_port
=== RUN   TestAccRDSInstance_SnapshotIdentifier_tags
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_tags
=== RUN   TestAccRDSInstance_SnapshotIdentifier_tagsRemove
    instance_test.go:4248: To be fixed: https://github.com/hashicorp/terraform-provider-aws/issues/26808
--- SKIP: TestAccRDSInstance_SnapshotIdentifier_tagsRemove (0.00s)
=== RUN   TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs
=== RUN   TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags
=== RUN   TestAccRDSInstance_monitoringInterval
=== PAUSE TestAccRDSInstance_monitoringInterval
=== RUN   TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled
=== PAUSE TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled
=== RUN   TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved
=== PAUSE TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved
=== RUN   TestAccRDSInstance_MonitoringRoleARN_removedToEnabled
=== PAUSE TestAccRDSInstance_MonitoringRoleARN_removedToEnabled
=== RUN   TestAccRDSInstance_portUpdate
=== PAUSE TestAccRDSInstance_portUpdate
=== RUN   TestAccRDSInstance_MSSQL_tz
=== PAUSE TestAccRDSInstance_MSSQL_tz
=== RUN   TestAccRDSInstance_MSSQL_domain
=== PAUSE TestAccRDSInstance_MSSQL_domain
=== RUN   TestAccRDSInstance_MSSQL_domainSnapshotRestore
=== PAUSE TestAccRDSInstance_MSSQL_domainSnapshotRestore
=== RUN   TestAccRDSInstance_MSSQL_selfManagedDomain
=== PAUSE TestAccRDSInstance_MSSQL_selfManagedDomain
=== RUN   TestAccRDSInstance_MSSQL_selfManagedDomainSingleDomainDNSIP
=== PAUSE TestAccRDSInstance_MSSQL_selfManagedDomainSingleDomainDNSIP
=== RUN   TestAccRDSInstance_MSSQL_selfManagedDomainSnapshotRestore
=== PAUSE TestAccRDSInstance_MSSQL_selfManagedDomainSnapshotRestore
=== RUN   TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion
=== PAUSE TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion
=== RUN   TestAccRDSInstance_Versions_minor
=== PAUSE TestAccRDSInstance_Versions_minor
=== RUN   TestAccRDSInstance_CloudWatchLogsExport_basic
=== PAUSE TestAccRDSInstance_CloudWatchLogsExport_basic
=== RUN   TestAccRDSInstance_CloudWatchLogsExport_db2
    instance_test.go:5009: Environment variable RDS_DB2_CUSTOMER_ID is not set, skipping test
--- SKIP: TestAccRDSInstance_CloudWatchLogsExport_db2 (0.00s)
=== RUN   TestAccRDSInstance_CloudWatchLogsExport_mySQL
=== PAUSE TestAccRDSInstance_CloudWatchLogsExport_mySQL
=== RUN   TestAccRDSInstance_CloudWatchLogsExport_msSQL
=== PAUSE TestAccRDSInstance_CloudWatchLogsExport_msSQL
=== RUN   TestAccRDSInstance_CloudWatchLogsExport_oracle
=== PAUSE TestAccRDSInstance_CloudWatchLogsExport_oracle
=== RUN   TestAccRDSInstance_CloudWatchLogsExport_postgresql
=== PAUSE TestAccRDSInstance_CloudWatchLogsExport_postgresql
=== RUN   TestAccRDSInstance_CloudWatchLogsExport_postgresql_iam_db_auth
=== PAUSE TestAccRDSInstance_CloudWatchLogsExport_postgresql_iam_db_auth
=== RUN   TestAccRDSInstance_dedicatedLogVolume_enableOnCreate
=== PAUSE TestAccRDSInstance_dedicatedLogVolume_enableOnCreate
=== RUN   TestAccRDSInstance_dedicatedLogVolume_enableOnUpdate
=== PAUSE TestAccRDSInstance_dedicatedLogVolume_enableOnUpdate
=== RUN   TestAccRDSInstance_noDeleteAutomatedBackups
=== PAUSE TestAccRDSInstance_noDeleteAutomatedBackups
=== RUN   TestAccRDSInstance_PerformanceInsights_disabledToEnabled
=== PAUSE TestAccRDSInstance_PerformanceInsights_disabledToEnabled
=== RUN   TestAccRDSInstance_PerformanceInsights_enabledToDisabled
=== PAUSE TestAccRDSInstance_PerformanceInsights_enabledToDisabled
=== RUN   TestAccRDSInstance_PerformanceInsights_kmsKeyID
=== PAUSE TestAccRDSInstance_PerformanceInsights_kmsKeyID
=== RUN   TestAccRDSInstance_PerformanceInsights_kmsKeyID_UpdateMode
=== PAUSE TestAccRDSInstance_PerformanceInsights_kmsKeyID_UpdateMode
=== RUN   TestAccRDSInstance_PerformanceInsights_retentionPeriod
=== PAUSE TestAccRDSInstance_PerformanceInsights_retentionPeriod
=== RUN   TestAccRDSInstance_PerformanceInsights_databaseInsightsMode
=== PAUSE TestAccRDSInstance_PerformanceInsights_databaseInsightsMode
=== RUN   TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled
=== RUN   TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled
=== RUN   TestAccRDSInstance_CACertificate_latest
=== PAUSE TestAccRDSInstance_CACertificate_latest
=== RUN   TestAccRDSInstance_CACertificate_update
=== PAUSE TestAccRDSInstance_CACertificate_update
=== RUN   TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier
=== PAUSE TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier
=== RUN   TestAccRDSInstance_RestoreToPointInTime_sourceResourceID
=== PAUSE TestAccRDSInstance_RestoreToPointInTime_sourceResourceID
=== RUN   TestAccRDSInstance_RestoreToPointInTime_monitoring
=== PAUSE TestAccRDSInstance_RestoreToPointInTime_monitoring
=== RUN   TestAccRDSInstance_RestoreToPointInTime_manageMasterPassword
=== PAUSE TestAccRDSInstance_RestoreToPointInTime_manageMasterPassword
=== RUN   TestAccRDSInstance_Oracle_nationalCharacterSet
=== PAUSE TestAccRDSInstance_Oracle_nationalCharacterSet
=== RUN   TestAccRDSInstance_Oracle_noNationalCharacterSet
=== PAUSE TestAccRDSInstance_Oracle_noNationalCharacterSet
=== RUN   TestAccRDSInstance_Outposts_coIPEnabled
=== PAUSE TestAccRDSInstance_Outposts_coIPEnabled
=== RUN   TestAccRDSInstance_Outposts_coIPDisabledToEnabled
=== PAUSE TestAccRDSInstance_Outposts_coIPDisabledToEnabled
=== RUN   TestAccRDSInstance_Outposts_coIPEnabledToDisabled
=== PAUSE TestAccRDSInstance_Outposts_coIPEnabledToDisabled
=== RUN   TestAccRDSInstance_Outposts_coIPRestoreToPointInTime
=== PAUSE TestAccRDSInstance_Outposts_coIPRestoreToPointInTime
=== RUN   TestAccRDSInstance_Outposts_coIPSnapshotIdentifier
=== PAUSE TestAccRDSInstance_Outposts_coIPSnapshotIdentifier
=== RUN   TestAccRDSInstance_Outposts_backupTarget
=== PAUSE TestAccRDSInstance_Outposts_backupTarget
=== RUN   TestAccRDSInstance_license
=== PAUSE TestAccRDSInstance_license
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup
=== RUN   TestAccRDSInstance_BlueGreenDeployment_tags
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_tags
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups
=== RUN   TestAccRDSInstance_BlueGreenDeployment_deletionProtectionBypassesBlueGreen
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_deletionProtectionBypassesBlueGreen
=== RUN   TestAccRDSInstance_BlueGreenDeployment_passwordBypassesBlueGreen
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_passwordBypassesBlueGreen
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection
=== RUN   TestAccRDSInstance_BlueGreenDeployment_outOfBand
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_outOfBand
=== RUN   TestAccRDSInstance_Storage_gp3MySQL
=== PAUSE TestAccRDSInstance_Storage_gp3MySQL
=== RUN   TestAccRDSInstance_Storage_gp3Postgres
=== PAUSE TestAccRDSInstance_Storage_gp3Postgres
=== RUN   TestAccRDSInstance_Storage_gp3SQLServer
=== PAUSE TestAccRDSInstance_Storage_gp3SQLServer
=== RUN   TestAccRDSInstance_Storage_changeThroughput
=== PAUSE TestAccRDSInstance_Storage_changeThroughput
=== RUN   TestAccRDSInstance_Storage_changeIOPSThroughput
=== PAUSE TestAccRDSInstance_Storage_changeIOPSThroughput
=== RUN   TestAccRDSInstance_Storage_changeIOPSGP3
=== PAUSE TestAccRDSInstance_Storage_changeIOPSGP3
=== RUN   TestAccRDSInstance_Storage_throughputSSE
=== PAUSE TestAccRDSInstance_Storage_throughputSSE
=== RUN   TestAccRDSInstance_Storage_postgres
=== PAUSE TestAccRDSInstance_Storage_postgres
=== RUN   TestAccRDSInstance_Storage_changeIOPSio1
=== PAUSE TestAccRDSInstance_Storage_changeIOPSio1
=== RUN   TestAccRDSInstance_Storage_changeIOPSio2
=== PAUSE TestAccRDSInstance_Storage_changeIOPSio2
=== RUN   TestAccRDSInstance_NewIdentifier_pending
=== PAUSE TestAccRDSInstance_NewIdentifier_pending
=== RUN   TestAccRDSInstance_NewIdentifier_immediately
=== PAUSE TestAccRDSInstance_NewIdentifier_immediately
=== CONT  TestAccRDSClusterInstance_basic
=== CONT  TestAccRDSInstance_SnapshotIdentifier_nameGenerated
=== CONT  TestAccRDSInstance_NewIdentifier_immediately
=== CONT  TestAccRDSInstance_noDeleteAutomatedBackups
--- PASS: TestAccRDSInstance_noDeleteAutomatedBackups (609.54s)
=== CONT  TestAccRDSInstance_license
--- PASS: TestAccRDSInstance_NewIdentifier_immediately (630.38s)
=== CONT  TestAccRDSInstance_NewIdentifier_pending
--- PASS: TestAccRDSClusterInstance_basic (897.80s)
=== CONT  TestAccRDSInstance_Storage_changeIOPSio2
--- PASS: TestAccRDSInstance_SnapshotIdentifier_nameGenerated (981.08s)
=== CONT  TestAccRDSInstance_Storage_changeIOPSio1
--- PASS: TestAccRDSInstance_NewIdentifier_pending (589.12s)
=== CONT  TestAccRDSInstance_Storage_postgres
--- PASS: TestAccRDSInstance_Storage_changeIOPSio2 (689.01s)
=== CONT  TestAccRDSInstance_Storage_throughputSSE
--- PASS: TestAccRDSInstance_Storage_changeIOPSio1 (699.32s)
=== CONT  TestAccRDSInstance_Storage_changeIOPSGP3
--- PASS: TestAccRDSInstance_license (1096.18s)
=== CONT  TestAccRDSInstance_Storage_changeIOPSThroughput
--- PASS: TestAccRDSInstance_Storage_postgres (816.73s)
=== CONT  TestAccRDSInstance_Storage_changeThroughput
--- PASS: TestAccRDSInstance_Storage_changeIOPSThroughput (576.61s)
=== CONT  TestAccRDSInstance_Storage_gp3SQLServer
--- PASS: TestAccRDSInstance_Storage_changeIOPSGP3 (698.80s)
=== CONT  TestAccRDSInstance_Storage_gp3Postgres
--- PASS: TestAccRDSInstance_Storage_throughputSSE (949.38s)
=== CONT  TestAccRDSInstance_Storage_gp3MySQL
--- PASS: TestAccRDSInstance_Storage_changeThroughput (577.71s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica
--- PASS: TestAccRDSInstance_Storage_gp3Postgres (704.96s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass
--- PASS: TestAccRDSInstance_Storage_gp3MySQL (755.97s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_tags
--- PASS: TestAccRDSInstance_Storage_gp3SQLServer (1146.53s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup
--- PASS: TestAccRDSInstance_BlueGreenDeployment_tags (633.95s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass (2090.66s)
=== CONT  TestAccRDSInstance_RestoreToPointInTime_sourceResourceID
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup (1813.02s)
=== CONT  TestAccRDSInstance_Outposts_backupTarget
    instance_test.go:6470: skipping since no Outposts found
--- SKIP: TestAccRDSInstance_Outposts_backupTarget (0.45s)
=== CONT  TestAccRDSInstance_Outposts_coIPSnapshotIdentifier
    instance_test.go:6436: skipping since no Outposts found
--- SKIP: TestAccRDSInstance_Outposts_coIPSnapshotIdentifier (0.16s)
=== CONT  TestAccRDSInstance_Outposts_coIPRestoreToPointInTime
    instance_test.go:6385: skipping since no Outposts found
--- SKIP: TestAccRDSInstance_Outposts_coIPRestoreToPointInTime (0.18s)
=== CONT  TestAccRDSInstance_Outposts_coIPEnabledToDisabled
    instance_test.go:6334: skipping since no Outposts found
--- SKIP: TestAccRDSInstance_Outposts_coIPEnabledToDisabled (0.18s)
=== CONT  TestAccRDSInstance_Outposts_coIPDisabledToEnabled
    instance_test.go:6284: skipping since no Outposts found
--- SKIP: TestAccRDSInstance_Outposts_coIPDisabledToEnabled (0.16s)
=== CONT  TestAccRDSInstance_Outposts_coIPEnabled
    instance_test.go:6250: skipping since no Outposts found
--- SKIP: TestAccRDSInstance_Outposts_coIPEnabled (0.19s)
=== CONT  TestAccRDSInstance_Oracle_noNationalCharacterSet
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica (2796.66s)
=== CONT  TestAccRDSInstance_Oracle_nationalCharacterSet
--- PASS: TestAccRDSInstance_Oracle_noNationalCharacterSet (1030.88s)
=== CONT  TestAccRDSInstance_RestoreToPointInTime_manageMasterPassword
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion (2376.37s)
=== CONT  TestAccRDSInstance_RestoreToPointInTime_monitoring
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceResourceID (1172.20s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups
--- PASS: TestAccRDSInstance_Oracle_nationalCharacterSet (1095.14s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection
--- PASS: TestAccRDSInstance_RestoreToPointInTime_manageMasterPassword (1368.07s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_outOfBand
--- PASS: TestAccRDSInstance_RestoreToPointInTime_monitoring (1341.86s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_passwordBypassesBlueGreen
--- PASS: TestAccRDSInstance_BlueGreenDeployment_passwordBypassesBlueGreen (750.87s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_deletionProtectionBypassesBlueGreen
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups (2137.63s)
=== CONT  TestAccRDSInstance_ManageMasterPassword_kmsKey
--- PASS: TestAccRDSInstance_ManageMasterPassword_kmsKey (509.35s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection (2488.31s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_namePrefix
--- PASS: TestAccRDSInstance_BlueGreenDeployment_deletionProtectionBypassesBlueGreen (729.15s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_ManageMasterPasswordKMSKey
--- PASS: TestAccRDSInstance_BlueGreenDeployment_outOfBand (2067.77s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_basic
--- PASS: TestAccRDSInstance_SnapshotIdentifier_namePrefix (1122.04s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_mssqlDomain
--- PASS: TestAccRDSInstance_ReplicateSourceDB_mssqlDomain (4439.01s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_CrossRegion_parameterGroupNamePostgres
--- PASS: TestAccRDSInstance_SnapshotIdentifier_ManageMasterPasswordKMSKey (1225.55s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_CrossRegion_parameterGroupNameEquivalent
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled (1413.93s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep
--- PASS: TestAccRDSInstance_SnapshotIdentifier_basic (792.15s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_replicaMode
--- PASS: TestAccRDSInstance_ReplicateSourceDB_CrossRegion_parameterGroupNamePostgres (845.65s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_characterSet_Source
--- PASS: TestAccRDSInstance_ReplicateSourceDB_CrossRegion_parameterGroupNameEquivalent (806.29s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep (1068.78s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs
--- PASS: TestAccRDSInstance_ReplicateSourceDB_replicaMode (1821.85s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_port
--- PASS: TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs (895.34s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica
--- PASS: TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier (1235.48s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue
--- PASS: TestAccRDSInstance_ReplicateSourceDB_characterSet_Source (1557.50s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth
--- PASS: TestAccRDSInstance_ReplicateSourceDB_port (517.10s)
=== CONT  TestAccRDSInstance_PerformanceInsights_databaseInsightsMode
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica (630.41s)
=== CONT  TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue (611.56s)
=== CONT  TestAccRDSInstance_CACertificate_update
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth (753.71s)
=== CONT  TestAccRDSInstance_CACertificate_latest
--- PASS: TestAccRDSInstance_PerformanceInsights_databaseInsightsMode (719.54s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled
--- PASS: TestAccRDSInstance_CACertificate_update (558.58s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier (611.48s)
=== CONT  TestAccRDSInstance_identifierPrefix
--- PASS: TestAccRDSInstance_CACertificate_latest (575.01s)
=== CONT  TestAccRDSInstance_ErrorOnConvertToManageOnStoppedInstance
--- PASS: TestAccRDSInstance_identifierPrefix (340.88s)
=== CONT  TestAccRDSInstance_ManageMasterPassword_basic
--- PASS: TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled (722.68s)
=== CONT  TestAccRDSInstance_passwordWriteOnly
--- PASS: TestAccRDSInstance_ManageMasterPassword_basic (344.80s)
=== CONT  TestAccRDSInstance_password
--- PASS: TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled (935.31s)
=== CONT  TestAccRDSInstance_Storage_maxAllocated
--- PASS: TestAccRDSInstance_ErrorOnConvertToManageOnStoppedInstance (889.22s)
=== CONT  TestAccRDSInstance_isAlreadyBeingDeleted
--- PASS: TestAccRDSInstance_passwordWriteOnly (614.59s)
=== CONT  TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot
--- PASS: TestAccRDSInstance_password (614.44s)
=== CONT  TestAccRDSInstance_FinalSnapshotIdentifier_basic
--- PASS: TestAccRDSInstance_isAlreadyBeingDeleted (336.94s)
=== CONT  TestAccRDSInstance_deletionProtection
--- PASS: TestAccRDSInstance_FinalSnapshotIdentifier_basic (242.21s)
=== CONT  TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs
--- PASS: TestAccRDSInstance_Storage_maxAllocated (661.03s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupNameVPCSecurityGroupIDs
--- PASS: TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot (258.81s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupNameRAMShared
    instance_test.go:2110: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupNameRAMShared (0.00s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_crossRegion
--- PASS: TestAccRDSInstance_deletionProtection (316.17s)
...
```

The remainder failed with `api error ExpiredToken: The security token included in the request is expired`, but I think we have a representative sample indicating success.
