### PR TITLE
[WIP] Inconsistent Final Plan when nested set values change

### DIFF
--- a/internal/service/elasticbeanstalk/environment.go
+++ b/internal/service/elasticbeanstalk/environment.go
@@ -334,19 +334,17 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta a
 		return sdkdiag.AppendErrorf(diags, "reading Elastic Beanstalk Environment (%s) resources: %s", d.Id(), err)
 	}
 
-	applicationName := aws.ToString(env.ApplicationName)
-	environmentName := aws.ToString(env.EnvironmentName)
-	input := &elasticbeanstalk.DescribeConfigurationSettingsInput{
-		ApplicationName: aws.String(applicationName),
-		EnvironmentName: aws.String(environmentName),
+	input := elasticbeanstalk.DescribeConfigurationSettingsInput{
+		ApplicationName: env.ApplicationName,
+		EnvironmentName: env.EnvironmentName,
 	}
-	configurationSettings, err := findConfigurationSettings(ctx, conn, input)
+	configurationSettings, err := findConfigurationSettings(ctx, conn, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading Elastic Beanstalk Environment (%s) configuration settings: %s", d.Id(), err)
 	}
 
-	d.Set("application", applicationName)
+	d.Set("application", env.ApplicationName)
 	d.Set(names.AttrARN, env.EnvironmentArn)
 	if err := d.Set("autoscaling_groups", flattenAutoScalingGroups(resources.EnvironmentResources.AutoScalingGroups)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting autoscaling_groups: %s", err)
@@ -375,7 +373,7 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta a
 	if err := d.Set("load_balancers", flattenLoadBalancers(resources.EnvironmentResources.LoadBalancers)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting load_balancers: %s", err)
 	}
-	d.Set(names.AttrName, environmentName)
+	d.Set(names.AttrName, env.EnvironmentName)
 	d.Set("platform_arn", env.PlatformArn)
 	if err := d.Set("queues", flattenQueues(resources.EnvironmentResources.Queues)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting queues: %s", err)

--- a/internal/service/elasticbeanstalk/environment.go
+++ b/internal/service/elasticbeanstalk/environment.go
@@ -95,7 +95,7 @@ func resourceEnvironment() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		MigrateState:  EnvironmentMigrateState,
+		MigrateState:  environmentMigrateState,
 
 		SchemaFunc: func() map[string]*schema.Schema {
 			return map[string]*schema.Schema{

--- a/internal/service/elasticbeanstalk/environment_migrate.go
+++ b/internal/service/elasticbeanstalk/environment_migrate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func EnvironmentMigrateState(v int, is *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
+func environmentMigrateState(v int, is *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
 	switch v {
 	case 0:
 		log.Println("[INFO] Found AWS Elastic Beanstalk Environment State v0; migrating to v1")

--- a/internal/service/elasticbeanstalk/environment_test.go
+++ b/internal/service/elasticbeanstalk/environment_test.go
@@ -445,10 +445,10 @@ func TestAccElasticBeanstalkEnvironment_platformARN(t *testing.T) {
 	var app awstypes.EnvironmentDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elastic_beanstalk_environment.test"
-	platformNameWithVersion1 := "Python 3.9 running on 64bit Amazon Linux 2023/4.0.9"
+	platformNameWithVersion1 := "Python 3.12 running on 64bit Amazon Linux 2023/4.7.2"
 	rValue1 := sdkacctest.RandIntRange(1000, 2000)
 	rValue1Str := strconv.Itoa(rValue1)
-	platformNameWithVersion2 := "Python 3.11 running on 64bit Amazon Linux 2023/4.1.3"
+	platformNameWithVersion2 := "Python 3.13 running on 64bit Amazon Linux 2023/4.7.2"
 	rValue2 := sdkacctest.RandIntRange(3000, 4000)
 	rValue2Str := strconv.Itoa(rValue2)
 

--- a/internal/service/elasticbeanstalk/environment_test.go
+++ b/internal/service/elasticbeanstalk/environment_test.go
@@ -516,6 +516,226 @@ func TestAccElasticBeanstalkEnvironment_platformARN(t *testing.T) {
 	})
 }
 
+func TestAccElasticBeanstalkEnvironment_taint(t *testing.T) {
+	ctx := acctest.Context(t)
+	var app awstypes.EnvironmentDescription
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	value1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	value2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_elastic_beanstalk_environment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElasticBeanstalkServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnvironmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentConfig_setting_ComputedValue(rName, value1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentExists(ctx, resourceName, &app),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("setting"), knownvalue.SetExact(settingsChecks_ValueChanged(value1))),
+				},
+			},
+			{
+				Taint:  []string{"terraform_data.test"},
+				Config: testAccEnvironmentConfig_setting_ComputedValue(rName, value2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentExists(ctx, resourceName, &app),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction("terraform_data.test", plancheck.ResourceActionReplace),
+
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("setting"), knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"namespace": knownvalue.StringExact("aws:ec2:vpc"),
+								"name":      knownvalue.StringExact("Subnets"),
+								"resource":  knownvalue.StringExact(""),
+								// "value":    Unknown value,
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"namespace": knownvalue.StringExact("aws:ec2:vpc"),
+								"name":      knownvalue.StringExact("AssociatePublicIpAddress"),
+								"resource":  knownvalue.Null(),
+								"value":     knownvalue.StringExact("true"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"namespace": knownvalue.StringExact("aws:autoscaling:launchconfiguration"),
+								"name":      knownvalue.StringExact("IamInstanceProfile"),
+								"resource":  knownvalue.Null(),
+								"value":     knownvalue.NotNull(), // Pair: aws_iam_instance_profile.test.name
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"namespace": knownvalue.StringExact("aws:elasticbeanstalk:application:environment"),
+								"name":      knownvalue.StringExact("ENV_TEST"),
+								"resource":  knownvalue.StringExact(""),
+								// "value":    Unknown value,
+							}),
+						})),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("setting"), knownvalue.SetExact(settingsChecks_ValueChanged(value2))),
+				},
+			},
+		},
+	})
+}
+
+func TestAccElasticBeanstalkEnvironment_setting_ComputedValue(t *testing.T) {
+	ctx := acctest.Context(t)
+	var app awstypes.EnvironmentDescription
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	value1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	value2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_elastic_beanstalk_environment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElasticBeanstalkServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnvironmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentConfig_setting_ComputedValue(rName, value1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentExists(ctx, resourceName, &app),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("setting"), knownvalue.SetExact(settingsChecks_ValueChanged(value1))),
+				},
+			},
+			{
+				Config: testAccEnvironmentConfig_setting_ComputedValue(rName, value2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentExists(ctx, resourceName, &app),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction("terraform_data.test", plancheck.ResourceActionUpdate),
+
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("setting"), knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"namespace": knownvalue.StringExact("aws:ec2:vpc"),
+								"name":      knownvalue.StringExact("Subnets"),
+								"resource":  knownvalue.StringExact(""),
+								// "value":    Unknown value,
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"namespace": knownvalue.StringExact("aws:ec2:vpc"),
+								"name":      knownvalue.StringExact("AssociatePublicIpAddress"),
+								"resource":  knownvalue.Null(),
+								"value":     knownvalue.StringExact("true"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"namespace": knownvalue.StringExact("aws:autoscaling:launchconfiguration"),
+								"name":      knownvalue.StringExact("IamInstanceProfile"),
+								"resource":  knownvalue.Null(),
+								"value":     knownvalue.NotNull(), // Pair: aws_iam_instance_profile.test.name
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"namespace": knownvalue.StringExact("aws:elasticbeanstalk:application:environment"),
+								"name":      knownvalue.StringExact("ENV_TEST"),
+								"resource":  knownvalue.StringExact(""),
+								// "value":    Unknown value,
+							}),
+						})),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("setting"), knownvalue.SetExact(settingsChecks_ValueChanged(value2))),
+				},
+			},
+		},
+	})
+}
+
+func TestAccElasticBeanstalkEnvironment_setting_ForceNew(t *testing.T) {
+	ctx := acctest.Context(t)
+	var app awstypes.EnvironmentDescription
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	value1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	value2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_elastic_beanstalk_environment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElasticBeanstalkServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnvironmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentConfig_setting_ForceNew(rName, value1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentExists(ctx, resourceName, &app),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("setting"), knownvalue.SetExact(settingsChecks_ValueChanged(value1))),
+				},
+			},
+			{
+				Config: testAccEnvironmentConfig_setting_ForceNew(rName, value2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentExists(ctx, resourceName, &app),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction("terraform_data.test", plancheck.ResourceActionReplace),
+
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("setting"), knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"namespace": knownvalue.StringExact("aws:ec2:vpc"),
+								"name":      knownvalue.StringExact("Subnets"),
+								"resource":  knownvalue.StringExact(""),
+								// "value":    Unknown value,
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"namespace": knownvalue.StringExact("aws:ec2:vpc"),
+								"name":      knownvalue.StringExact("AssociatePublicIpAddress"),
+								"resource":  knownvalue.Null(),
+								"value":     knownvalue.StringExact("true"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"namespace": knownvalue.StringExact("aws:autoscaling:launchconfiguration"),
+								"name":      knownvalue.StringExact("IamInstanceProfile"),
+								"resource":  knownvalue.Null(),
+								"value":     knownvalue.NotNull(), // Pair: aws_iam_instance_profile.test.name
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"namespace": knownvalue.StringExact("aws:elasticbeanstalk:application:environment"),
+								"name":      knownvalue.StringExact("ENV_TEST"),
+								"resource":  knownvalue.StringExact(""),
+								// "value":    Unknown value,
+							}),
+						})),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("setting"), knownvalue.SetExact(settingsChecks_ValueChanged(value2))),
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckEnvironmentDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ElasticBeanstalkClient(ctx)
@@ -828,35 +1048,35 @@ func settingsChecks_basic() []knownvalue.Check {
 			names.AttrValue:     knownvalue.NotNull(), // Pair: aws_vpc.test.id
 		}),
 
-		knownvalue.ObjectPartial(map[string]knownvalue.Check{
+		knownvalue.ObjectExact(map[string]knownvalue.Check{
 			names.AttrNamespace: knownvalue.StringExact("aws:ec2:vpc"),
 			names.AttrName:      knownvalue.StringExact("Subnets"),
 			"resource":          knownvalue.StringExact(""),
 			names.AttrValue:     knownvalue.NotNull(), // Pair: aws_subnet.test[0].id
 		}),
 
-		knownvalue.ObjectPartial(map[string]knownvalue.Check{
+		knownvalue.ObjectExact(map[string]knownvalue.Check{
 			names.AttrNamespace: knownvalue.StringExact("aws:ec2:vpc"),
 			names.AttrName:      knownvalue.StringExact("AssociatePublicIpAddress"),
 			"resource":          knownvalue.StringExact(""),
 			names.AttrValue:     knownvalue.StringExact("true"),
 		}),
 
-		knownvalue.ObjectPartial(map[string]knownvalue.Check{
+		knownvalue.ObjectExact(map[string]knownvalue.Check{
 			names.AttrNamespace: knownvalue.StringExact("aws:autoscaling:launchconfiguration"),
 			names.AttrName:      knownvalue.StringExact("SecurityGroups"),
 			"resource":          knownvalue.StringExact(""),
 			names.AttrValue:     knownvalue.NotNull(), // Pair: aws_security_group.test.id
 		}),
 
-		knownvalue.ObjectPartial(map[string]knownvalue.Check{
+		knownvalue.ObjectExact(map[string]knownvalue.Check{
 			names.AttrNamespace: knownvalue.StringExact("aws:autoscaling:launchconfiguration"),
 			names.AttrName:      knownvalue.StringExact("IamInstanceProfile"),
 			"resource":          knownvalue.StringExact(""),
 			names.AttrValue:     knownvalue.NotNull(), // Pair: aws_iam_instance_profile.test.name
 		}),
 
-		knownvalue.ObjectPartial(map[string]knownvalue.Check{
+		knownvalue.ObjectExact(map[string]knownvalue.Check{
 			names.AttrNamespace: knownvalue.StringExact("aws:elasticbeanstalk:environment"),
 			names.AttrName:      knownvalue.StringExact("ServiceRole"),
 			"resource":          knownvalue.StringExact(""),
@@ -1739,4 +1959,93 @@ EOF
   }
 }
 `, rName, publicKey, email))
+}
+
+func testAccEnvironmentConfig_setting_ComputedValue(rName, value string) string {
+	return acctest.ConfigCompose(
+		testAccEnvironmentConfig_setting_ValueChange(rName),
+		fmt.Sprintf(`
+resource "terraform_data" "test" {
+  input = %[1]q
+}
+`, value))
+}
+
+func testAccEnvironmentConfig_setting_ForceNew(rName, value string) string {
+	return acctest.ConfigCompose(
+		testAccEnvironmentConfig_setting_ValueChange(rName),
+		fmt.Sprintf(`
+resource "terraform_data" "test" {
+  input = %[2]q
+  triggers_replace = [%[2]q]
+}
+`, rName, value))
+}
+
+func testAccEnvironmentConfig_setting_ValueChange(rName string) string {
+	return acctest.ConfigCompose(
+		testAccEnvironmentConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_elastic_beanstalk_environment" "test" {
+  application         = aws_elastic_beanstalk_application.test.name
+  name                = %[1]q
+  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.test.name
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "Subnets"
+    value     = replace("${aws_subnet.test[0].id}${terraform_data.test.output}", terraform_data.test.output,"")
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "AssociatePublicIpAddress"
+    value     = "true"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = aws_iam_instance_profile.test.name
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "ENV_TEST"
+    value     = terraform_data.test.output
+  }
+}
+`, rName))
+}
+
+func settingsChecks_ValueChanged(envVal string) []knownvalue.Check {
+	return []knownvalue.Check{
+		knownvalue.ObjectExact(map[string]knownvalue.Check{
+			names.AttrNamespace: knownvalue.StringExact("aws:ec2:vpc"),
+			names.AttrName:      knownvalue.StringExact("Subnets"),
+			"resource":          knownvalue.StringExact(""),
+			names.AttrValue:     knownvalue.NotNull(), // Pair: aws_subnet.test[0].id
+		}),
+
+		knownvalue.ObjectExact(map[string]knownvalue.Check{
+			names.AttrNamespace: knownvalue.StringExact("aws:ec2:vpc"),
+			names.AttrName:      knownvalue.StringExact("AssociatePublicIpAddress"),
+			"resource":          knownvalue.StringExact(""),
+			names.AttrValue:     knownvalue.StringExact("true"),
+		}),
+
+		knownvalue.ObjectExact(map[string]knownvalue.Check{
+			names.AttrNamespace: knownvalue.StringExact("aws:autoscaling:launchconfiguration"),
+			names.AttrName:      knownvalue.StringExact("IamInstanceProfile"),
+			"resource":          knownvalue.StringExact(""),
+			names.AttrValue:     knownvalue.NotNull(), // Pair: aws_iam_instance_profile.test.name
+		}),
+
+		knownvalue.ObjectExact(map[string]knownvalue.Check{
+			names.AttrNamespace: knownvalue.StringExact("aws:elasticbeanstalk:application:environment"),
+			names.AttrName:      knownvalue.StringExact("ENV_TEST"),
+			"resource":          knownvalue.StringExact(""),
+			"value":             knownvalue.StringExact(envVal),
+		}),
+	}
 }

--- a/internal/service/elasticbeanstalk/environment_test.go
+++ b/internal/service/elasticbeanstalk/environment_test.go
@@ -47,7 +47,7 @@ func TestAccElasticBeanstalkEnvironment_basic(t *testing.T) {
 				Config: testAccEnvironmentConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentExists(ctx, resourceName, &app),
-					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "elasticbeanstalk", fmt.Sprintf("environment/%s/%s", rName, rName)),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticbeanstalk", "environment/{application}/{name}"),
 					resource.TestMatchResourceAttr(resourceName, "autoscaling_groups.0", beanstalkAsgNameRegexp),
 					resource.TestMatchResourceAttr(resourceName, "endpoint_url", beanstalkEndpointURL),
 					resource.TestMatchResourceAttr(resourceName, "instances.0", beanstalkInstancesNameRegexp),

--- a/internal/service/elasticbeanstalk/environment_test.go
+++ b/internal/service/elasticbeanstalk/environment_test.go
@@ -72,6 +72,17 @@ func TestAccElasticBeanstalkEnvironment_basic(t *testing.T) {
 					"wait_for_ready_timeout",
 				},
 			},
+			{
+				Config: testAccEnvironmentConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentExists(ctx, resourceName, &app),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
 		},
 	})
 }

--- a/internal/service/elasticbeanstalk/exports_test.go
+++ b/internal/service/elasticbeanstalk/exports_test.go
@@ -15,4 +15,6 @@ var (
 	FindConfigurationSettingsByTwoPartKey = findConfigurationSettingsByTwoPartKey
 	FindEnvironmentByID                   = findEnvironmentByID
 	HostedZoneIDs                         = hostedZoneIDs
+
+	EnvironmentMigrateState = environmentMigrateState
 )


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

WIP for fixing Inconsistent Final Plan error when nested set values change

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
