### PR TITLE
New action: `aws_codebuild_start_build`

### DIFF
--- a/.changelog/44444.txt
+++ b/.changelog/44444.txt
@@ -1,0 +1,3 @@
+```release-note:new-action
+aws_codebuild_start_build
+```

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -28,7 +28,7 @@ jobs:
     name: Validate Code Quality Rules
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:1.52.0"
+      image: "semgrep/semgrep:1.110.0"
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: |
@@ -43,7 +43,7 @@ jobs:
     needs: [semgrep-validate]
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:1.52.0"
+      image: "semgrep/semgrep:1.110.0"
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: |
@@ -54,7 +54,7 @@ jobs:
     needs: [semgrep-test]
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:1.52.0"
+      image: "semgrep/semgrep:1.110.0"
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: |
@@ -74,7 +74,7 @@ jobs:
     name: Naming Scan Caps/AWS/EC2
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:1.52.0"
+      image: "semgrep/semgrep:1.110.0"
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -85,7 +85,7 @@ jobs:
     name: Test Configs Scan
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:1.52.0"
+      image: "semgrep/semgrep:1.110.0"
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -96,7 +96,7 @@ jobs:
     name: Service Name Scan A-C
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:1.52.0"
+      image: "semgrep/semgrep:1.110.0"
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -107,7 +107,7 @@ jobs:
     name: Service Name Scan C-I
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:1.52.0"
+      image: "semgrep/semgrep:1.110.0"
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -118,7 +118,7 @@ jobs:
     name: Service Name Scan I-Q
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:1.52.0"
+      image: "semgrep/semgrep:1.110.0"
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -129,7 +129,7 @@ jobs:
     name: Service Name Scan Q-Z
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:1.52.0"
+      image: "semgrep/semgrep:1.110.0"
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -414,6 +414,7 @@ provider-lint: ## [CI] ProviderLint Checks / providerlint
 
 quick-fix-heading: ## Just a heading for quick-fix
 	@echo "make: Quick fixes..."
+	@echo "make: Multiple runs are needed if it finds errors (later targets not reached)"
 
 quick-fix: quick-fix-heading fmt testacc-lint-fix fix-imports modern-fix semgrep-fix website-terrafmt-fix ## Some quick fixes
 

--- a/internal/service/codebuild/service_package_gen.go
+++ b/internal/service/codebuild/service_package_gen.go
@@ -17,6 +17,16 @@ import (
 
 type servicePackage struct{}
 
+func (p *servicePackage) Actions(ctx context.Context) []*inttypes.ServicePackageAction {
+	return []*inttypes.ServicePackageAction{
+		{
+			Factory:  newStartBuildAction,
+			TypeName: "aws_codebuild_start_build",
+			Name:     "CodeBuild Start Build",
+		},
+	}
+}
+
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
 	return []*inttypes.ServicePackageFrameworkDataSource{}
 }

--- a/internal/service/codebuild/service_package_gen.go
+++ b/internal/service/codebuild/service_package_gen.go
@@ -23,6 +23,7 @@ func (p *servicePackage) Actions(ctx context.Context) []*inttypes.ServicePackage
 			Factory:  newStartBuildAction,
 			TypeName: "aws_codebuild_start_build",
 			Name:     "CodeBuild Start Build",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
 		},
 	}
 }

--- a/internal/service/codebuild/start_build_action.go
+++ b/internal/service/codebuild/start_build_action.go
@@ -1,0 +1,192 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package codebuild
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/codebuild"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/codebuild/types"
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/action/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @Action(aws_codebuild_start_build, name="CodeBuild Start Build")
+func newStartBuildAction(context.Context) (action.ActionWithConfigure, error) {
+	return &startBuildAction{}, nil
+}
+
+type startBuildAction struct {
+	framework.ActionWithModel[startBuildActionModel]
+}
+
+type startBuildActionModel struct {
+	ProjectName                    types.String                                                `tfsdk:"project_name"`
+	SourceVersion                  types.String                                                `tfsdk:"source_version"`
+	Timeout                        types.Int64                                                 `tfsdk:"timeout"`
+	EnvironmentVariablesOverride   fwtypes.ListNestedObjectValueOf[environmentVariableModel]   `tfsdk:"environment_variables_override"`
+	BuildID                        types.String                                                `tfsdk:"build_id"`
+}
+
+type environmentVariableModel struct {
+	Name  types.String `tfsdk:"name"`
+	Value types.String `tfsdk:"value"`
+	Type  types.String `tfsdk:"type"`
+}
+
+func (a *startBuildAction) Schema(ctx context.Context, req action.SchemaRequest, resp *action.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Starts a CodeBuild project build",
+		Attributes: map[string]schema.Attribute{
+			"project_name": schema.StringAttribute{
+				Description: "Name of the CodeBuild project",
+				Required:    true,
+			},
+			"source_version": schema.StringAttribute{
+				Description: "Version of the build input to be built",
+				Optional:    true,
+			},
+			names.AttrTimeout: schema.Int64Attribute{
+				Description: "Timeout in seconds for the build operation",
+				Optional:    true,
+			},
+			"build_id": schema.StringAttribute{
+				Description: "ID of the started build",
+				Optional:    true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"environment_variables_override": schema.ListNestedBlock{
+				CustomType:  fwtypes.NewListNestedObjectTypeOf[environmentVariableModel](ctx),
+				Description: "Environment variables to override for this build",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrName: schema.StringAttribute{
+							Description: "Environment variable name",
+							Required:    true,
+						},
+						names.AttrValue: schema.StringAttribute{
+							Description: "Environment variable value",
+							Required:    true,
+						},
+						names.AttrType: schema.StringAttribute{
+							Description: "Environment variable type",
+							Optional:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (a *startBuildAction) Invoke(ctx context.Context, req action.InvokeRequest, resp *action.InvokeResponse) {
+	var model startBuildActionModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := a.Meta().CodeBuildClient(ctx)
+
+	timeout := 30 * time.Minute
+	if !model.Timeout.IsNull() {
+		timeout = time.Duration(model.Timeout.ValueInt64()) * time.Second
+	}
+
+	tflog.Info(ctx, "Starting CodeBuild project build", map[string]interface{}{
+		"project_name": model.ProjectName.ValueString(),
+	})
+
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: "Starting CodeBuild project build...",
+	})
+
+	var input codebuild.StartBuildInput
+	resp.Diagnostics.Append(fwflex.Expand(ctx, model, &input)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	output, err := conn.StartBuild(ctx, &input)
+	if err != nil {
+		resp.Diagnostics.AddError("Starting CodeBuild project build", err.Error())
+		return
+	}
+
+	buildID := *output.Build.Id
+	model.BuildID = types.StringValue(buildID)
+
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: "Build started, waiting for completion...",
+	})
+
+	// Poll for build completion
+	deadline := time.Now().Add(timeout)
+	pollInterval := 30 * time.Second
+	progressInterval := 2 * time.Minute
+	lastProgressUpdate := time.Now()
+
+	for {
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Build monitoring cancelled", "Context was cancelled")
+			return
+		default:
+		}
+
+		if time.Now().After(deadline) {
+			resp.Diagnostics.AddError("Build timeout", "Build did not complete within the specified timeout")
+			return
+		}
+
+		batchGetBuildsOutput, err := conn.BatchGetBuilds(ctx, &codebuild.BatchGetBuildsInput{
+			Ids: []string{buildID},
+		})
+		if err != nil {
+			resp.Diagnostics.AddError("Getting build status", err.Error())
+			return
+		}
+
+		if len(batchGetBuildsOutput.Builds) == 0 {
+			resp.Diagnostics.AddError("Build not found", "Build was not found in BatchGetBuilds response")
+			return
+		}
+
+		build := batchGetBuildsOutput.Builds[0]
+		status := build.BuildStatus
+
+		if time.Since(lastProgressUpdate) >= progressInterval {
+			resp.SendProgress(action.InvokeProgressEvent{
+				Message: "Build currently in state: " + string(status),
+			})
+			lastProgressUpdate = time.Now()
+		}
+
+		switch status {
+		case awstypes.StatusTypeSucceeded:
+			resp.SendProgress(action.InvokeProgressEvent{
+				Message: "Build completed successfully",
+			})
+			return
+		case awstypes.StatusTypeFailed, awstypes.StatusTypeFault, awstypes.StatusTypeStopped, awstypes.StatusTypeTimedOut:
+			resp.Diagnostics.AddError("Build failed", "Build completed with status: "+string(status))
+			return
+		case awstypes.StatusTypeInProgress:
+			// Continue polling
+		default:
+			resp.Diagnostics.AddError("Unexpected build status", "Received unexpected build status: "+string(status))
+			return
+		}
+
+		time.Sleep(pollInterval)
+	}
+}

--- a/internal/service/codebuild/start_build_action.go
+++ b/internal/service/codebuild/start_build_action.go
@@ -152,7 +152,7 @@ func (a *startBuildAction) Invoke(ctx context.Context, req action.InvokeRequest,
 		input := codebuild.BatchGetBuildsInput{
 			Ids: []string{buildID},
 		}
-batchGetBuildsOutput, err := conn.BatchGetBuilds(ctx, &input)
+		batchGetBuildsOutput, err := conn.BatchGetBuilds(ctx, &input)
 		if err != nil {
 			resp.Diagnostics.AddError("Getting build status", err.Error())
 			return

--- a/internal/service/codebuild/start_build_action.go
+++ b/internal/service/codebuild/start_build_action.go
@@ -30,6 +30,7 @@ type startBuildAction struct {
 }
 
 type startBuildActionModel struct {
+	framework.WithRegionModel
 	ProjectName                  types.String                                              `tfsdk:"project_name"`
 	SourceVersion                types.String                                              `tfsdk:"source_version"`
 	Timeout                      types.Int64                                               `tfsdk:"timeout"`

--- a/internal/service/codebuild/start_build_action_test.go
+++ b/internal/service/codebuild/start_build_action_test.go
@@ -114,6 +114,8 @@ func testAccCheckBuildStarted(ctx context.Context, projectName string) resource.
 
 func testAccStartBuildActionConfig_basic(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -144,7 +146,7 @@ resource "aws_iam_role_policy" "test" {
           "logs:CreateLogStream",
           "logs:PutLogEvents"
         ]
-        Resource = "arn:aws:logs:*:*:*"
+        Resource = "arn:${data.aws_partition.current.partition}:logs:*:*:*"
       }
     ]
   })
@@ -191,6 +193,8 @@ resource "terraform_data" "trigger" {
 
 func testAccStartBuildActionConfig_withEnvironmentVariables(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -221,7 +225,7 @@ resource "aws_iam_role_policy" "test" {
           "logs:CreateLogStream",
           "logs:PutLogEvents"
         ]
-        Resource = "arn:aws:logs:*:*:*"
+        Resource = "arn:${data.aws_partition.current.partition}:logs:*:*:*"
       }
     ]
   })

--- a/internal/service/codebuild/start_build_action_test.go
+++ b/internal/service/codebuild/start_build_action_test.go
@@ -165,7 +165,7 @@ resource "aws_codebuild_project" "test" {
   }
 
   source {
-    type = "NO_SOURCE"
+    type      = "NO_SOURCE"
     buildspec = "version: 0.2\nphases:\n  build:\n    commands:\n      - echo 'Hello World'"
   }
 }
@@ -242,7 +242,7 @@ resource "aws_codebuild_project" "test" {
   }
 
   source {
-    type = "NO_SOURCE"
+    type      = "NO_SOURCE"
     buildspec = "version: 0.2\nphases:\n  build:\n    commands:\n      - echo \"TEST_VAR is $TEST_VAR\""
   }
 }
@@ -250,7 +250,7 @@ resource "aws_codebuild_project" "test" {
 action "aws_codebuild_start_build" "test" {
   config {
     project_name = aws_codebuild_project.test.name
-    
+
     environment_variables_override {
       name  = "TEST_VAR"
       value = "test_value"

--- a/internal/service/codebuild/start_build_action_test.go
+++ b/internal/service/codebuild/start_build_action_test.go
@@ -1,0 +1,273 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package codebuild_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/codebuild"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccCodeBuildStartBuildAction_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeBuildServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		CheckDestroy: testAccCheckProjectDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStartBuildActionConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBuildStarted(ctx, rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCodeBuildStartBuildAction_withEnvironmentVariables(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeBuildServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		CheckDestroy: testAccCheckProjectDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStartBuildActionConfig_withEnvironmentVariables(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBuildStarted(ctx, rName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckBuildStarted(ctx context.Context, projectName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CodeBuildClient(ctx)
+
+		// List builds for the project
+		input := &codebuild.ListBuildsForProjectInput{
+			ProjectName: &projectName,
+		}
+
+		timeout := time.After(5 * time.Minute)
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-timeout:
+				return fmt.Errorf("timeout waiting for build to be started for project %s", projectName)
+			case <-ticker.C:
+				output, err := conn.ListBuildsForProject(ctx, input)
+				if err != nil {
+					continue
+				}
+
+				if len(output.Ids) == 0 {
+					continue
+				}
+
+				// Get build details
+				batchInput := &codebuild.BatchGetBuildsInput{
+					Ids: output.Ids[:1], // Check most recent build
+				}
+				batchOutput, err := conn.BatchGetBuilds(ctx, batchInput)
+				if err != nil {
+					continue
+				}
+
+				if len(batchOutput.Builds) > 0 {
+					build := batchOutput.Builds[0]
+					// Verify build was started (any status other than not found)
+					if build.BuildStatus != "" {
+						return nil
+					}
+				}
+			}
+		}
+	}
+}
+
+func testAccStartBuildActionConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "codebuild.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "test" {
+  role = aws_iam_role.test.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+}
+
+resource "aws_codebuild_project" "test" {
+  name         = %[1]q
+  service_role = aws_iam_role.test.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "aws/codebuild/amazonlinux2-x86_64-standard:3.0"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    type = "NO_SOURCE"
+    buildspec = "version: 0.2\nphases:\n  build:\n    commands:\n      - echo 'Hello World'"
+  }
+}
+
+action "aws_codebuild_start_build" "test" {
+  config {
+    project_name = aws_codebuild_project.test.name
+  }
+}
+
+resource "terraform_data" "trigger" {
+  lifecycle {
+    action_trigger {
+      events  = [after_create]
+      actions = [action.aws_codebuild_start_build.test]
+    }
+  }
+
+  depends_on = [aws_codebuild_project.test]
+}
+`, rName)
+}
+
+func testAccStartBuildActionConfig_withEnvironmentVariables(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "codebuild.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "test" {
+  role = aws_iam_role.test.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+}
+
+resource "aws_codebuild_project" "test" {
+  name         = %[1]q
+  service_role = aws_iam_role.test.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "aws/codebuild/amazonlinux2-x86_64-standard:3.0"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    type = "NO_SOURCE"
+    buildspec = "version: 0.2\nphases:\n  build:\n    commands:\n      - echo \"TEST_VAR is $TEST_VAR\""
+  }
+}
+
+action "aws_codebuild_start_build" "test" {
+  config {
+    project_name = aws_codebuild_project.test.name
+    
+    environment_variables_override {
+      name  = "TEST_VAR"
+      value = "test_value"
+      type  = "PLAINTEXT"
+    }
+  }
+}
+
+resource "terraform_data" "trigger" {
+  lifecycle {
+    action_trigger {
+      events  = [after_create]
+      actions = [action.aws_codebuild_start_build.test]
+    }
+  }
+
+  depends_on = [aws_codebuild_project.test]
+}
+`, rName)
+}

--- a/website/docs/actions/codebuild_start_build.html.markdown
+++ b/website/docs/actions/codebuild_start_build.html.markdown
@@ -1,0 +1,100 @@
+---
+subcategory: "CodeBuild"
+layout: "aws"
+page_title: "AWS: aws_codebuild_start_build"
+description: |-
+  Starts a CodeBuild project build.
+---
+
+# Action: aws_codebuild_start_build
+
+~> **Note:** `aws_codebuild_start_build` is in beta. Its interface and behavior may change as the feature evolves, and breaking changes are possible. It is offered as a technical preview without compatibility guarantees until Terraform 1.14 is generally available.
+
+Starts a CodeBuild project build. This action will initiate a build and wait for it to complete, providing progress updates during execution.
+
+For information about AWS CodeBuild, see the [AWS CodeBuild User Guide](https://docs.aws.amazon.com/codebuild/latest/userguide/). For specific information about starting builds, see the [StartBuild](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_StartBuild.html) page in the AWS CodeBuild API Reference.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_codebuild_project" "example" {
+  name         = "example-project"
+  service_role = aws_iam_role.example.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "aws/codebuild/amazonlinux2-x86_64-standard:3.0"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    type = "NO_SOURCE"
+    buildspec = "version: 0.2\nphases:\n  build:\n    commands:\n      - echo 'Hello World'"
+  }
+}
+
+action "aws_codebuild_start_build" "example" {
+  config {
+    project_name = aws_codebuild_project.example.name
+  }
+}
+
+resource "terraform_data" "build_trigger" {
+  input = "trigger-build"
+
+  lifecycle {
+    action_trigger {
+      events  = [after_create]
+      actions = [action.aws_codebuild_start_build.example]
+    }
+  }
+}
+```
+
+### Build with Environment Variables
+
+```terraform
+action "aws_codebuild_start_build" "deploy" {
+  config {
+    project_name = aws_codebuild_project.deploy.name
+    source_version = "main"
+    timeout = 1800
+
+    environment_variables_override {
+      name  = "ENVIRONMENT"
+      value = "production"
+      type  = "PLAINTEXT"
+    }
+
+    environment_variables_override {
+      name  = "API_KEY"
+      value = "/prod/api-key"
+      type  = "PARAMETER_STORE"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `project_name` - (Required) Name of the CodeBuild project to build.
+
+The following arguments are optional:
+
+* `source_version` - (Optional) Version of the build input to be built. For GitHub, this can be a commit SHA, branch name, or tag name.
+* `timeout` - (Optional) Timeout in seconds for the build operation. Defaults to 1800 seconds (30 minutes).
+* `environment_variables_override` - (Optional) Environment variables to override for this build. See [Environment Variables Override](#environment-variables-override) below.
+
+### Environment Variables Override
+
+* `name` - (Required) Environment variable name.
+* `value` - (Required) Environment variable value.
+* `type` - (Optional) Environment variable type. Valid values are `PLAINTEXT`, `PARAMETER_STORE`, or `SECRETS_MANAGER`. Defaults to `PLAINTEXT`.

--- a/website/docs/actions/codebuild_start_build.html.markdown
+++ b/website/docs/actions/codebuild_start_build.html.markdown
@@ -34,7 +34,7 @@ resource "aws_codebuild_project" "example" {
   }
 
   source {
-    type = "NO_SOURCE"
+    type      = "NO_SOURCE"
     buildspec = "version: 0.2\nphases:\n  build:\n    commands:\n      - echo 'Hello World'"
   }
 }
@@ -62,9 +62,9 @@ resource "terraform_data" "build_trigger" {
 ```terraform
 action "aws_codebuild_start_build" "deploy" {
   config {
-    project_name = aws_codebuild_project.deploy.name
+    project_name   = aws_codebuild_project.deploy.name
     source_version = "main"
-    timeout = 1800
+    timeout        = 1800
 
     environment_variables_override {
       name  = "ENVIRONMENT"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
## Add aws_codebuild_start_build Terraform Action

Implements a new Terraform action to start AWS CodeBuild project builds imperatively within Terraform configurations.

### Features
• **Start builds** for any CodeBuild project by name
• **Environment variable overrides** for build-specific configuration
• **Source version control** (branch, commit, tag)
• **Configurable timeouts** with progress monitoring
• **Build completion tracking** with status updates

### Implementation
• Uses AutoFlex for clean data conversion
• Follows established action patterns from existing actions
• Proper polling with progress updates during build execution
• Comprehensive error handling for all build states

### Testing
• ✅ End-to-end acceptance tests with real infrastructure
• ✅ Basic build functionality 
• ✅ Environment variable override functionality
• ✅ Proper action trigger integration with terraform_data

### Documentation
• Complete user documentation following existing action patterns
• Usage examples for basic and advanced scenarios
• Full argument reference with nested block documentation

Enables Day-2 operations like triggering builds for deployments, testing, or maintenance workflows directly from Terraform.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates: 
* #43700 
* #43955 
* #43972 
* #44214 
* #44232

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
2025/09/24 17:41:50 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/24 17:41:50 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCodeBuildStartBuildAction_basic
=== PAUSE TestAccCodeBuildStartBuildAction_basic
=== RUN   TestAccCodeBuildStartBuildAction_withEnvironmentVariables
=== PAUSE TestAccCodeBuildStartBuildAction_withEnvironmentVariables
=== CONT  TestAccCodeBuildStartBuildAction_basic
=== CONT  TestAccCodeBuildStartBuildAction_withEnvironmentVariables
--- PASS: TestAccCodeBuildStartBuildAction_basic (66.84s)
--- PASS: TestAccCodeBuildStartBuildAction_withEnvironmentVariables (66.88s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codebuild	71.951s
```
