### PR TITLE
[bugfix] d/aws_servicequotas_service_quota: Fix panic when non-existing `quota_name` is specified

### DIFF
--- a/.changelog/44449.txt
+++ b/.changelog/44449.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_servicequotas_service_quota: Fixed a panic that occurred when a non-existing `quota_name` was provided
+```

--- a/internal/service/servicequotas/service_quota_data_source.go
+++ b/internal/service/servicequotas/service_quota_data_source.go
@@ -128,13 +128,16 @@ func dataSourceServiceQuotaRead(ctx context.Context, d *schema.ResourceData, met
 	// A Service Quota will always have a default value, but will only have a current value if it has been set.
 	if quotaName != "" {
 		defaultQuota, err = findDefaultServiceQuotaByServiceCodeAndQuotaName(ctx, conn, serviceCode, quotaName)
-		quotaCode = aws.ToString(defaultQuota.QuotaCode)
 	} else {
 		defaultQuota, err = findDefaultServiceQuotaByServiceCodeAndQuotaCode(ctx, conn, serviceCode, quotaCode)
 	}
 
 	if err != nil {
 		return sdkdiag.AppendFromErr(diags, tfresource.SingularDataSourceFindError("Service Quotas Service Quota", err))
+	}
+
+	if quotaName != "" {
+		quotaCode = aws.ToString(defaultQuota.QuotaCode)
 	}
 
 	arn := aws.ToString(defaultQuota.QuotaArn)

--- a/internal/service/servicequotas/service_quota_data_source_test.go
+++ b/internal/service/servicequotas/service_quota_data_source_test.go
@@ -152,6 +152,10 @@ func TestAccServiceQuotasServiceQuotaDataSource_quotaName(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				Config:      testAccServiceQuotaDataSourceConfig_name("vpc", setQuotaQuotaName+"nonexist"),
+				ExpectError: regexache.MustCompile(`Service Quotas Service Quota`),
+			},
+			{
 				Config: testAccServiceQuotaDataSourceConfig_name("vpc", setQuotaQuotaName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "adjustable", acctest.CtTrue),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* Fix panic of `aws_servicequotas_service_quota` caused by missing error handling when a `quota_code` is not found for a given `quota_name`.
  * The `err` returned from `findDefaultServiceQuotaByServiceCodeAndQuotaName` is now caught and properly handled.

### Relations
Related to the [comment](https://github.com/hashicorp/terraform-provider-aws/issues/44366#issuecomment-3333269231)

### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccServiceQuotasServiceQuotaDataSource_' PKG=servicequotas
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws_servicequotas_service_quota-add_error_handling 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/servicequotas/... -v -count 1 -parallel 20 -run='TestAccServiceQuotasServiceQuotaDataSource_'  -timeout 360m -vet=off
2025/09/25 21:38:49 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/25 21:38:49 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccServiceQuotasServiceQuotaDataSource_quotaCode
=== PAUSE TestAccServiceQuotasServiceQuotaDataSource_quotaCode
=== RUN   TestAccServiceQuotasServiceQuotaDataSource_quotaCode_Unset
=== PAUSE TestAccServiceQuotasServiceQuotaDataSource_quotaCode_Unset
=== RUN   TestAccServiceQuotasServiceQuotaDataSource_quotaCode_hasUsageMetric
=== PAUSE TestAccServiceQuotasServiceQuotaDataSource_quotaCode_hasUsageMetric
=== RUN   TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaCode
=== PAUSE TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaCode
=== RUN   TestAccServiceQuotasServiceQuotaDataSource_quotaName
=== PAUSE TestAccServiceQuotasServiceQuotaDataSource_quotaName
=== RUN   TestAccServiceQuotasServiceQuotaDataSource_quotaName_Unset
=== PAUSE TestAccServiceQuotasServiceQuotaDataSource_quotaName_Unset
=== RUN   TestAccServiceQuotasServiceQuotaDataSource_quotaName_hasUsageMetric
=== PAUSE TestAccServiceQuotasServiceQuotaDataSource_quotaName_hasUsageMetric
=== RUN   TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaName
=== PAUSE TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaName
=== CONT  TestAccServiceQuotasServiceQuotaDataSource_quotaCode
=== CONT  TestAccServiceQuotasServiceQuotaDataSource_quotaName
=== CONT  TestAccServiceQuotasServiceQuotaDataSource_quotaName_hasUsageMetric
=== CONT  TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaName
=== CONT  TestAccServiceQuotasServiceQuotaDataSource_quotaCode_hasUsageMetric
=== CONT  TestAccServiceQuotasServiceQuotaDataSource_quotaName_Unset
=== CONT  TestAccServiceQuotasServiceQuotaDataSource_quotaCode_Unset
=== CONT  TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaCode
    service_quota_data_source_test.go:127: skipping test; environment variable TF_ACC_ASSUME_ROLE_ARN must be set. Usage: Amazon Resource Name (ARN) of existing IAM Role to assume for testing restricted permissions
--- SKIP: TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaCode (4.69s)
=== NAME  TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaName
    service_quota_data_source_test.go:256: skipping test; environment variable TF_ACC_ASSUME_ROLE_ARN must be set. Usage: Amazon Resource Name (ARN) of existing IAM Role to assume for testing restricted permissions
--- SKIP: TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaName (4.79s)
--- PASS: TestAccServiceQuotasServiceQuotaDataSource_quotaCode (22.42s)
--- PASS: TestAccServiceQuotasServiceQuotaDataSource_quotaName_hasUsageMetric (22.48s)
--- PASS: TestAccServiceQuotasServiceQuotaDataSource_quotaCode_hasUsageMetric (22.55s)
--- PASS: TestAccServiceQuotasServiceQuotaDataSource_quotaName_Unset (22.57s)
--- PASS: TestAccServiceQuotasServiceQuotaDataSource_quotaCode_Unset (23.47s)
--- PASS: TestAccServiceQuotasServiceQuotaDataSource_quotaName (23.89s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas      28.759s

```
