### PR TITLE
[Docs] aws_pipes_pipe: Correct `starting_position` in `dynamodb_stream_parameters` from `Optional` to `Required`

### DIFF
--- a/website/docs/cdktf/python/r/pipes_pipe.html.markdown
+++ b/website/docs/cdktf/python/r/pipes_pipe.html.markdown
@@ -342,7 +342,7 @@ You can find out more about EventBridge Pipes Sources in the [User Guide](https:
 * `maximum_retry_attempts` - (Optional) Discard records after the specified number of retries. The default value is -1, which sets the maximum number of retries to infinite. When MaximumRetryAttempts is infinite, EventBridge retries failed records until the record expires in the event source. Maximum value of 10,000.
 * `on_partial_batch_item_failure` - (Optional) Define how to handle item process failures. AUTOMATIC_BISECT halves each batch and retry each half until all the records are processed or there is one failed message left in the batch. Valid values: AUTOMATIC_BISECT.
 * `parallelization_factor` - (Optional)The number of batches to process concurrently from each shard. The default value is 1. Maximum value of 10.
-* `starting_position` - (Optional) The position in a stream from which to start reading. Valid values: TRIM_HORIZON, LATEST.
+* `starting_position` - (Required) The position in a stream from which to start reading. Valid values: TRIM_HORIZON, LATEST.
 
 ##### source_parameters.dynamodb_stream_parameters.dead_letter_config Configuration Block
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* Fix the attribute description for `starting_position` in `source_parameters.dynamodb_stream_parameters` block from `Optional` to `Required`.
  * It is implemented as `Required` in the AWS Provider
    * https://github.com/hashicorp/terraform-provider-aws/blob/033da7288cd09f84fe227fccdf0688be4a18bc70/internal/service/pipes/source_parameters.go#L149-L154
  * The [AWS documentation](https://docs.aws.amazon.com/eventbridge/latest/pipes-reference/API_PipeSourceDynamoDBStreamParameters.html#eventbridge-Type-PipeSourceDynamoDBStreamParameters-StartingPosition) describes it `Required`.
 
### Relations

Closes #44450

### References
https://docs.aws.amazon.com/eventbridge/latest/pipes-reference/API_PipeSourceDynamoDBStreamParameters.html#eventbridge-Type-PipeSourceDynamoDBStreamParameters-StartingPosition

