### PR TITLE
aws_fsx_lustre_file_system: Fixed to update `metadata_configuration` first to allow simultaneous increase of `metadata_configuration.iops` and `storage_capacity`

### DIFF
--- a/.changelog/44456.txt
+++ b/.changelog/44456.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_fsx_lustre_file_system: Fixed to update `metadata_configuration` first to allow simultaneous increase of `metadata_configuration.iops` and `storage_capacity`
+```

--- a/internal/service/fsx/lustre_file_system_test.go
+++ b/internal/service/fsx/lustre_file_system_test.go
@@ -1010,7 +1010,7 @@ func TestAccFSxLustreFileSystem_metadataConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{names.AttrSecurityGroupIDs},
 			},
 			{
-				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 1500),
+				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 1500, 1200),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem2),
 					testAccCheckLustreFileSystemNotRecreated(&filesystem1, &filesystem2),
@@ -1036,7 +1036,7 @@ func TestAccFSxLustreFileSystem_metadataConfig_increase(t *testing.T) {
 		CheckDestroy:             testAccCheckLustreFileSystemDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 1500),
+				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 1500, 1200),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem1),
 					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
@@ -1051,7 +1051,7 @@ func TestAccFSxLustreFileSystem_metadataConfig_increase(t *testing.T) {
 				ImportStateVerifyIgnore: []string{names.AttrSecurityGroupIDs},
 			},
 			{
-				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 3000),
+				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 3000, 1200),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem2),
 					testAccCheckLustreFileSystemNotRecreated(&filesystem1, &filesystem2),
@@ -1077,7 +1077,7 @@ func TestAccFSxLustreFileSystem_metadataConfig_decrease(t *testing.T) {
 		CheckDestroy:             testAccCheckLustreFileSystemDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 3000),
+				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 3000, 1200),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem1),
 					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
@@ -1092,13 +1092,57 @@ func TestAccFSxLustreFileSystem_metadataConfig_decrease(t *testing.T) {
 				ImportStateVerifyIgnore: []string{names.AttrSecurityGroupIDs},
 			},
 			{
-				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 1500),
+				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 1500, 1200),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem2),
 					testAccCheckLustreFileSystemRecreated(&filesystem1, &filesystem2),
 					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.mode", "USER_PROVISIONED"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.iops", "1500"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFSxLustreFileSystem_metadataConfig_increaseWithStorageCapacity(t *testing.T) {
+	ctx := acctest.Context(t)
+	var filesystem1, filesystem2 awstypes.FileSystem
+	resourceName := "aws_fsx_lustre_file_system.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.FSxServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLustreFileSystemDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 1500, 1200),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem1),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.mode", "USER_PROVISIONED"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.iops", "1500"),
+					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "1200"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrSecurityGroupIDs},
+			},
+			{
+				// When storage_capacity is increased to 2400, IOPS must be increased to at least 3000.
+				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 3000, 2400),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem2),
+					testAccCheckLustreFileSystemNotRecreated(&filesystem1, &filesystem2),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.mode", "USER_PROVISIONED"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.iops", "3000"),
+					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "2400"),
 				),
 			},
 		},
@@ -2015,10 +2059,10 @@ resource "aws_fsx_lustre_file_system" "test" {
 `, rName, mode))
 }
 
-func testAccLustreFileSystemConfig_metadata_iops(rName, mode string, iops int) string {
+func testAccLustreFileSystemConfig_metadata_iops(rName, mode string, iops, storageCapacity int) string {
 	return acctest.ConfigCompose(testAccLustreFileSystemConfig_base(rName), fmt.Sprintf(`
 resource "aws_fsx_lustre_file_system" "test" {
-  storage_capacity            = 1200
+  storage_capacity            = %[4]d
   subnet_ids                  = aws_subnet.test[*].id
   deployment_type             = "PERSISTENT_2"
   per_unit_storage_throughput = 125
@@ -2032,7 +2076,7 @@ resource "aws_fsx_lustre_file_system" "test" {
     Name = %[1]q
   }
 }
-`, rName, mode, iops))
+`, rName, mode, iops, storageCapacity))
 }
 
 func testAccLustreFileSystemConfig_rootSquash(rName, uid string) string {

--- a/internal/service/fsx/lustre_file_system_test.go
+++ b/internal/service/fsx/lustre_file_system_test.go
@@ -1128,12 +1128,6 @@ func TestAccFSxLustreFileSystem_metadataConfig_increaseWithStorageCapacity(t *te
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrSecurityGroupIDs},
-			},
-			{
 				// When storage_capacity is increased to 2400, IOPS must be increased to at least 3000.
 				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 3000, 2400),
 				Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* As reported in #44432, when `storage_capacity` is increased, sometimes `metadata_configuration.iops` must be increased before increasing `storage_capacity`.
  * For example, if `storage_capacity` is increased from 1200 to 2400, `metadata_configuration.iops` must be at least 3000, and it must be increased before `storage_capacity`.
* To achieve this, this PR fixes the code to update `metadata_configuration` first if it has changed, and then update the other settings.
  * The newly added acceptance test confirms that `storage_capacity` can be increased from 1200 to 2400 and `metadata_configuration.iops` from 1500 to 3000 simultaneously in the configuration.

### Relations

Closes #44432

### Output from Acceptance Testing


```console
$ make testacc TESTS='TestAccFSxLustreFileSystem_' PKG=fsx
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws_fsx_lustre_file_system-fix_update_order 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/fsx/... -v -count 1 -parallel 20 -run='TestAccFSxLustreFileSystem_'  -timeout 360m -vet=off
2025/09/26 00:46:19 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/26 00:46:19 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccFSxLustreFileSystem_basic
=== PAUSE TestAccFSxLustreFileSystem_basic
=== RUN   TestAccFSxLustreFileSystem_disappears
=== PAUSE TestAccFSxLustreFileSystem_disappears
=== RUN   TestAccFSxLustreFileSystem_dataCompression
=== PAUSE TestAccFSxLustreFileSystem_dataCompression
=== RUN   TestAccFSxLustreFileSystem_deleteConfig
    lustre_file_system_test.go:162: Environment variable AWS_FSX_CREATE_FINAL_BACKUP is not set, skipping test
--- SKIP: TestAccFSxLustreFileSystem_deleteConfig (0.00s)
=== RUN   TestAccFSxLustreFileSystem_exportPath
=== PAUSE TestAccFSxLustreFileSystem_exportPath
=== RUN   TestAccFSxLustreFileSystem_importPath
=== PAUSE TestAccFSxLustreFileSystem_importPath
=== RUN   TestAccFSxLustreFileSystem_importedFileChunkSize
=== PAUSE TestAccFSxLustreFileSystem_importedFileChunkSize
=== RUN   TestAccFSxLustreFileSystem_securityGroupIDs
=== PAUSE TestAccFSxLustreFileSystem_securityGroupIDs
=== RUN   TestAccFSxLustreFileSystem_storageCapacity
=== PAUSE TestAccFSxLustreFileSystem_storageCapacity
=== RUN   TestAccFSxLustreFileSystem_storageCapacityUpdate
=== PAUSE TestAccFSxLustreFileSystem_storageCapacityUpdate
=== RUN   TestAccFSxLustreFileSystem_fileSystemTypeVersion
=== PAUSE TestAccFSxLustreFileSystem_fileSystemTypeVersion
=== RUN   TestAccFSxLustreFileSystem_tags
=== PAUSE TestAccFSxLustreFileSystem_tags
=== RUN   TestAccFSxLustreFileSystem_weeklyMaintenanceStartTime
=== PAUSE TestAccFSxLustreFileSystem_weeklyMaintenanceStartTime
=== RUN   TestAccFSxLustreFileSystem_automaticBackupRetentionDays
=== PAUSE TestAccFSxLustreFileSystem_automaticBackupRetentionDays
=== RUN   TestAccFSxLustreFileSystem_dailyAutomaticBackupStartTime
=== PAUSE TestAccFSxLustreFileSystem_dailyAutomaticBackupStartTime
=== RUN   TestAccFSxLustreFileSystem_deploymentTypePersistent1
=== PAUSE TestAccFSxLustreFileSystem_deploymentTypePersistent1
=== RUN   TestAccFSxLustreFileSystem_deploymentTypePersistent1_perUnitStorageThroughput
=== PAUSE TestAccFSxLustreFileSystem_deploymentTypePersistent1_perUnitStorageThroughput
=== RUN   TestAccFSxLustreFileSystem_deploymentTypePersistent2
=== PAUSE TestAccFSxLustreFileSystem_deploymentTypePersistent2
=== RUN   TestAccFSxLustreFileSystem_deploymentTypePersistent2_perUnitStorageThroughput
=== PAUSE TestAccFSxLustreFileSystem_deploymentTypePersistent2_perUnitStorageThroughput
=== RUN   TestAccFSxLustreFileSystem_efaEnabled
=== PAUSE TestAccFSxLustreFileSystem_efaEnabled
=== RUN   TestAccFSxLustreFileSystem_intelligentTiering
=== PAUSE TestAccFSxLustreFileSystem_intelligentTiering
=== RUN   TestAccFSxLustreFileSystem_logConfig
=== PAUSE TestAccFSxLustreFileSystem_logConfig
=== RUN   TestAccFSxLustreFileSystem_metadataConfig
=== PAUSE TestAccFSxLustreFileSystem_metadataConfig
=== RUN   TestAccFSxLustreFileSystem_metadataConfig_increase
=== PAUSE TestAccFSxLustreFileSystem_metadataConfig_increase
=== RUN   TestAccFSxLustreFileSystem_metadataConfig_decrease
=== PAUSE TestAccFSxLustreFileSystem_metadataConfig_decrease
=== RUN   TestAccFSxLustreFileSystem_metadataConfig_increaseWithStorageCapacity
=== PAUSE TestAccFSxLustreFileSystem_metadataConfig_increaseWithStorageCapacity
=== RUN   TestAccFSxLustreFileSystem_rootSquashConfig
=== PAUSE TestAccFSxLustreFileSystem_rootSquashConfig
=== RUN   TestAccFSxLustreFileSystem_fromBackup
=== PAUSE TestAccFSxLustreFileSystem_fromBackup
=== RUN   TestAccFSxLustreFileSystem_kmsKeyID
=== PAUSE TestAccFSxLustreFileSystem_kmsKeyID
=== RUN   TestAccFSxLustreFileSystem_deploymentTypeScratch2
=== PAUSE TestAccFSxLustreFileSystem_deploymentTypeScratch2
=== RUN   TestAccFSxLustreFileSystem_storageTypeHddDriveCacheRead
=== PAUSE TestAccFSxLustreFileSystem_storageTypeHddDriveCacheRead
=== RUN   TestAccFSxLustreFileSystem_storageTypeHddDriveCacheNone
=== PAUSE TestAccFSxLustreFileSystem_storageTypeHddDriveCacheNone
=== RUN   TestAccFSxLustreFileSystem_copyTagsToBackups
=== PAUSE TestAccFSxLustreFileSystem_copyTagsToBackups
=== RUN   TestAccFSxLustreFileSystem_autoImportPolicy
=== PAUSE TestAccFSxLustreFileSystem_autoImportPolicy
=== CONT  TestAccFSxLustreFileSystem_basic
=== CONT  TestAccFSxLustreFileSystem_deploymentTypePersistent2_perUnitStorageThroughput
=== CONT  TestAccFSxLustreFileSystem_fileSystemTypeVersion
=== CONT  TestAccFSxLustreFileSystem_rootSquashConfig
=== CONT  TestAccFSxLustreFileSystem_storageTypeHddDriveCacheRead
=== CONT  TestAccFSxLustreFileSystem_metadataConfig_increaseWithStorageCapacity
=== CONT  TestAccFSxLustreFileSystem_deploymentTypePersistent2
=== CONT  TestAccFSxLustreFileSystem_metadataConfig
=== CONT  TestAccFSxLustreFileSystem_intelligentTiering
=== CONT  TestAccFSxLustreFileSystem_kmsKeyID
=== CONT  TestAccFSxLustreFileSystem_deploymentTypeScratch2
=== CONT  TestAccFSxLustreFileSystem_importedFileChunkSize
=== CONT  TestAccFSxLustreFileSystem_storageCapacityUpdate
=== CONT  TestAccFSxLustreFileSystem_storageCapacity
=== CONT  TestAccFSxLustreFileSystem_securityGroupIDs
=== CONT  TestAccFSxLustreFileSystem_fromBackup
=== CONT  TestAccFSxLustreFileSystem_metadataConfig_decrease
=== CONT  TestAccFSxLustreFileSystem_efaEnabled
=== CONT  TestAccFSxLustreFileSystem_copyTagsToBackups
=== CONT  TestAccFSxLustreFileSystem_logConfig
--- PASS: TestAccFSxLustreFileSystem_deploymentTypePersistent2 (1044.99s)
=== CONT  TestAccFSxLustreFileSystem_autoImportPolicy
--- PASS: TestAccFSxLustreFileSystem_deploymentTypeScratch2 (1075.13s)
=== CONT  TestAccFSxLustreFileSystem_exportPath
--- PASS: TestAccFSxLustreFileSystem_copyTagsToBackups (1095.63s)
=== CONT  TestAccFSxLustreFileSystem_importPath
--- PASS: TestAccFSxLustreFileSystem_basic (1104.33s)
=== CONT  TestAccFSxLustreFileSystem_dataCompression
--- PASS: TestAccFSxLustreFileSystem_intelligentTiering (1125.17s)
=== CONT  TestAccFSxLustreFileSystem_disappears
--- PASS: TestAccFSxLustreFileSystem_storageTypeHddDriveCacheRead (1138.89s)
=== CONT  TestAccFSxLustreFileSystem_dailyAutomaticBackupStartTime
--- PASS: TestAccFSxLustreFileSystem_metadataConfig (1169.34s)
=== CONT  TestAccFSxLustreFileSystem_deploymentTypePersistent1_perUnitStorageThroughput
--- PASS: TestAccFSxLustreFileSystem_rootSquashConfig (1253.68s)
=== CONT  TestAccFSxLustreFileSystem_deploymentTypePersistent1
--- PASS: TestAccFSxLustreFileSystem_efaEnabled (1298.55s)
=== CONT  TestAccFSxLustreFileSystem_weeklyMaintenanceStartTime
--- PASS: TestAccFSxLustreFileSystem_logConfig (1462.63s)
=== CONT  TestAccFSxLustreFileSystem_automaticBackupRetentionDays
--- PASS: TestAccFSxLustreFileSystem_deploymentTypePersistent2_perUnitStorageThroughput (1726.13s)
=== CONT  TestAccFSxLustreFileSystem_storageTypeHddDriveCacheNone
--- PASS: TestAccFSxLustreFileSystem_kmsKeyID (2146.96s)
=== CONT  TestAccFSxLustreFileSystem_tags
--- PASS: TestAccFSxLustreFileSystem_securityGroupIDs (2175.22s)
=== CONT  TestAccFSxLustreFileSystem_metadataConfig_increase
--- PASS: TestAccFSxLustreFileSystem_storageCapacity (2176.47s)
--- PASS: TestAccFSxLustreFileSystem_fileSystemTypeVersion (2189.64s)
--- PASS: TestAccFSxLustreFileSystem_disappears (1082.39s)
--- PASS: TestAccFSxLustreFileSystem_dailyAutomaticBackupStartTime (1111.80s)
--- PASS: TestAccFSxLustreFileSystem_importedFileChunkSize (2287.83s)
--- PASS: TestAccFSxLustreFileSystem_metadataConfig_decrease (2310.93s)
--- PASS: TestAccFSxLustreFileSystem_deploymentTypePersistent1 (1073.51s)
--- PASS: TestAccFSxLustreFileSystem_weeklyMaintenanceStartTime (1089.42s)
--- PASS: TestAccFSxLustreFileSystem_dataCompression (1322.98s)
--- PASS: TestAccFSxLustreFileSystem_automaticBackupRetentionDays (1197.95s)
--- PASS: TestAccFSxLustreFileSystem_metadataConfig_increaseWithStorageCapacity (2666.62s)
--- PASS: TestAccFSxLustreFileSystem_autoImportPolicy (1632.95s)
--- PASS: TestAccFSxLustreFileSystem_deploymentTypePersistent1_perUnitStorageThroughput (1636.70s)
--- PASS: TestAccFSxLustreFileSystem_storageTypeHddDriveCacheNone (1104.18s)
--- PASS: TestAccFSxLustreFileSystem_fromBackup (3171.72s)
--- PASS: TestAccFSxLustreFileSystem_tags (1097.63s)
--- PASS: TestAccFSxLustreFileSystem_storageCapacityUpdate (3277.70s)
--- PASS: TestAccFSxLustreFileSystem_exportPath (2250.39s)
--- PASS: TestAccFSxLustreFileSystem_importPath (2260.54s)
--- PASS: TestAccFSxLustreFileSystem_metadataConfig_increase (1960.84s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fsx        4140.297s


```
