### PR TITLE
fix: fix interface conversion panic

### DIFF
--- a/.changelog/44459.txt
+++ b/.changelog/44459.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_instance: Fix `interface conversion: interface {} is nil, not map[string]interface {}` panics when `capacity_reservation_target ` is empty
+```

--- a/.changelog/44459.txt
+++ b/.changelog/44459.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_instance: Fix `interface conversion: interface {} is nil, not map[string]interface {}` panics when `capacity_reservation_target ` is empty
+resource/aws_instance: Fix `interface conversion: interface {} is nil, not map[string]interface {}` panics when `capacity_reservation_target` is empty
 ```

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -3815,7 +3815,7 @@ func expandCapacityReservationSpecification(tfMap map[string]any) *awstypes.Capa
 		apiObject.CapacityReservationPreference = awstypes.CapacityReservationPreference(v)
 	}
 
-	if v, ok := tfMap["capacity_reservation_target"].([]any); ok && len(v) > 0 {
+	if v, ok := tfMap["capacity_reservation_target"].([]any); ok && len(v) > 0 && v[0] != nil {
 		apiObject.CapacityReservationTarget = expandCapacityReservationTarget(v[0].(map[string]any))
 	}
 

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -10048,7 +10048,7 @@ resource "aws_instance" "test" {
 resource "aws_ec2_capacity_reservation" "test" {
   instance_type     = data.aws_ec2_instance_type_offering.available.instance_type
   instance_platform = %[2]q
-  availability_zone = data.aws_availability_zones.available.names[0]
+  availability_zone = data.aws_availability_zones.available.names[1]
   instance_count    = 10
 
   tags = {


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls are implemented.

### Description

* Terraform version 1.13.2
* AWS Provider version 6.14.1

When setting up EC2 instances in combination with capacity reservations we ran into a panic. The stack trace is below

```plain
Stack trace from the terraform-provider-aws_v6.14.1_x5 plugin:

panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 89 [running]:
github.com/hashicorp/terraform-provider-aws/internal/service/ec2.expandCapacityReservationSpecification(0xc004afb920)
        github.com/hashicorp/terraform-provider-aws/internal/service/ec2/ec2_instance.go:3819 +0x2ba
github.com/hashicorp/terraform-provider-aws/internal/service/ec2.buildInstanceOpts({0x22b47f28, 0xc004afb350}, 0xc0036a6750, {0x1fe24a20?, 0xc0003c51d0?})
        github.com/hashicorp/terraform-provider-aws/internal/service/ec2/ec2_instance.go:2915 +0x1df6
github.com/hashicorp/terraform-provider-aws/internal/service/ec2.resourceInstanceCreate({0x22b47f28, 0xc004afb350}, 0xc0036a6750, {0x1fe24a20, 0xc0003c51d0})
        github.com/hashicorp/terraform-provider-aws/internal/service/ec2/ec2_instance.go:1087 +0xba
github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2.wrapResource.(*wrappedResource).create.interceptedCRUDHandler[...].func2(0xc0036a6750, {0x1fe24a20, 0xc0003c51d0})
        github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2/intercept.go:177 +0x5b7
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0x22b47f28?, {0x22b47f28?, 0xc004aa8570?}, 0xd?, {0x1fe24a20?, 0xc0003c51d0?})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.38.1/helper/schema/resource.go:844 +0x7a
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc001cfbb00, {0x22b47f28, 0xc004aa8570}, 0xc004aaef70, 0xc0036a6630, {0x1fe24a20, 0xc0003c51d0})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.38.1/helper/schema/resource.go:980 +0xb47
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc0036a10b0, {0x22b47f28?, 0xc004aa84b0?}, 0xc0049b5ae0)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.38.1/helper/schema/grpc_provider.go:1499 +0x1085
github.com/hashicorp/terraform-plugin-mux/tf5muxserver.(*muxServer).ApplyResourceChange(0xc0036a7dd0, {0x22b47f28?, 0xc004aa81e0?}, 0xc0049b5ae0)
        github.com/hashicorp/terraform-plugin-mux@v0.21.0/tf5muxserver/mux_server_ApplyResourceChange.go:36 +0x18d
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc0036a8dc0, {0x22b47f28?, 0xc004a99620?}, 0xc00498f080)
        github.com/hashicorp/terraform-plugin-go@v0.29.0/tfprotov5/tf5server/server.go:944 +0x3b9
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x1fcf4140, 0xc0036a8dc0}, {0x22b47f28, 0xc004a99620}, 0xc00498f000, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.29.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:789 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0036b8200, {0x22b47f28, 0xc004a99590}, 0xc004691bc0, 0xc00375f1a0, 0x3138d928, 0x0)
        google.golang.org/grpc@v1.75.1/server.go:1431 +0x1036
google.golang.org/grpc.(*Server).handleStream(0xc0036b8200, {0x22b48a38, 0xc003868000}, 0xc004691bc0)
        google.golang.org/grpc@v1.75.1/server.go:1842 +0xb88
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        google.golang.org/grpc@v1.75.1/server.go:1061 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 55
        google.golang.org/grpc@v1.75.1/server.go:1072 +0x11d

Error: The terraform-provider-aws_v6.14.1_x5 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

The panic can be reproduced using below configuration

```hcl
terraform {
  required_version = "~> 1.13.2"
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "6.14.1"
    }
  }
}

provider "aws" {
  region = "eu-central-1"
}

data "aws_ami" "windows_2019" {
  most_recent = true
  owners      = ["amazon"]
  filter {
    name   = "name"
    values = ["Windows_Server-2019-English-Full-Base-*"]
  }
  filter {
    name   = "architecture"
    values = ["x86_64"]
  }
  filter {
    name   = "root-device-type"
    values = ["ebs"]
  }
  filter {
    name   = "virtualization-type"
    values = ["hvm"]
  }
}


resource "aws_instance" "windows_2019" {
  ami                         = data.aws_ami.windows_2019.id
  instance_type               = "t3.large"
  availability_zone           = "eu-central-1a"
  capacity_reservation_specification {
    capacity_reservation_target {
    }
  }
}
```

The relevant part of the code is 

```hcl
capacity_reservation_specification {
    capacity_reservation_target {
    }
  }
```

which is (based on our understanding and feedback in #43008) causing the trouble. Typically you would not declare `capacity_reservation_specification` at all.  Nevertheless the provider should not panic here.

The pull request adds a missing check to prevent the panic.

In addition, I updated `testAccInstanceConfig_capacityReservationSpecificationTargetID`: The EC2 instance shows up in `us-west-2b` and the capacity reservation in `us-west-2a`  - causing the test utilizing `testAccInstanceConfig_capacityReservationSpecificationTargetID` to fail as the EC2 instance is not able to target the capacity reservation.

### Relations

Relates #43008

### References


### Output from Acceptance Testing

Focusing only on the capacity reservation related tests

```console
❯ make test TESTS=TestAccEC2Instance_CapacityReservation_ PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running unit tests on branch: 🌿 b-aws_instance-capacity-reservation 🌿...
go1.24.6 test ./internal/service/ec2/... -v -count 1 -parallel 2 -run='TestAccEC2Instance_CapacityReservation_'  -timeout 15m -vet=off
2025/09/26 19:08:35 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/26 19:08:35 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEC2Instance_CapacityReservation_unspecifiedDefaultsToOpen
=== PAUSE TestAccEC2Instance_CapacityReservation_unspecifiedDefaultsToOpen
=== RUN   TestAccEC2Instance_CapacityReservation_targetID
=== PAUSE TestAccEC2Instance_CapacityReservation_targetID
=== RUN   TestAccEC2Instance_CapacityReservation_modifyPreference
=== PAUSE TestAccEC2Instance_CapacityReservation_modifyPreference
=== RUN   TestAccEC2Instance_CapacityReservation_modifyTarget
=== PAUSE TestAccEC2Instance_CapacityReservation_modifyTarget
=== CONT  TestAccEC2Instance_CapacityReservation_unspecifiedDefaultsToOpen
=== CONT  TestAccEC2Instance_CapacityReservation_modifyPreference
--- PASS: TestAccEC2Instance_CapacityReservation_unspecifiedDefaultsToOpen (126.87s)
=== CONT  TestAccEC2Instance_CapacityReservation_modifyTarget
--- PASS: TestAccEC2Instance_CapacityReservation_modifyPreference (219.04s)
=== CONT  TestAccEC2Instance_CapacityReservation_targetID
--- PASS: TestAccEC2Instance_CapacityReservation_targetID (104.25s)
--- PASS: TestAccEC2Instance_CapacityReservation_modifyTarget (199.07s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        326.163s
``
