### PR TITLE
[Enhancement] aws_cloudfront_distribution: Add `ip_address_type` argument to `origin.custom_origin_config` block

### DIFF
--- a/.changelog/44463.txt
+++ b/.changelog/44463.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudfront_distribution: Add `ip_address_type` argument to `origin.custom_origin_config` block
+```

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -628,6 +628,11 @@ func resourceDistribution() *schema.Resource {
 										Type:     schema.TypeInt,
 										Required: true,
 									},
+									names.AttrIPAddressType: {
+										Type:             schema.TypeString,
+										Optional:         true,
+										ValidateDiagFunc: enum.Validate[awstypes.IpAddressType](),
+									},
 									"origin_keepalive_timeout": {
 										Type:         schema.TypeInt,
 										Optional:     true,
@@ -2446,6 +2451,10 @@ func expandCustomOriginConfig(tfMap map[string]any) *awstypes.CustomOriginConfig
 		OriginSslProtocols:     expandCustomOriginConfigSSL(tfMap["origin_ssl_protocols"].(*schema.Set).List()),
 	}
 
+	if v, ok := tfMap[names.AttrIPAddressType]; ok && v.(string) != "" {
+		apiObject.IpAddressType = awstypes.IpAddressType(v.(string))
+	}
+
 	return apiObject
 }
 
@@ -2461,6 +2470,10 @@ func flattenCustomOriginConfig(apiObject *awstypes.CustomOriginConfig) map[strin
 		"origin_protocol_policy":   apiObject.OriginProtocolPolicy,
 		"origin_read_timeout":      aws.ToInt32(apiObject.OriginReadTimeout),
 		"origin_ssl_protocols":     flattenCustomOriginConfigSSL(apiObject.OriginSslProtocols),
+	}
+
+	if apiObject.IpAddressType != "" {
+		tfMap[names.AttrIPAddressType] = apiObject.IpAddressType
 	}
 
 	return tfMap

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -549,6 +549,7 @@ argument should not be specified.
 
 * `http_port` (Required) - HTTP port the custom origin listens on.
 * `https_port` (Required) - HTTPS port the custom origin listens on.
+* `ip_address_type` (Optional) - IP protocol CloudFront uses when connecting to your origin. Valid values: `ipv4`, `ipv6`, `dualstack`.
 * `origin_protocol_policy` (Required) - Origin protocol policy to apply to your origin. One of `http-only`, `https-only`, or `match-viewer`.
 * `origin_ssl_protocols` (Required) - List of SSL/TLS protocols that CloudFront can use when connecting to your origin over HTTPS. Valid values: `SSLv3`, `TLSv1`, `TLSv1.1`, `TLSv1.2`. For more information, see [Minimum Origin SSL Protocol](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesOriginSSLProtocols) in the Amazon CloudFront Developer Guide.
 * `origin_keepalive_timeout` - (Optional) The Custom KeepAlive timeout, in seconds. By default, AWS enforces an upper limit of `60`. But you can request an [increase](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-request-timeout). Defaults to `5`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* Added `ip_address_type` to `origin.custom_origin_config` configuration block

### Relations

Closes #44458

### References
https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CustomOriginConfig.html#cloudfront-Type-CustomOriginConfig-IpAddressType

### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccCloudFrontDistribution_' PKG=cloudfront 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_cloudfront_distribution-add_custom_origin_config_ip_address_type 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontDistribution_'  -timeout 360m -vet=off
2025/09/26 07:39:45 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/26 07:39:45 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudFrontDistribution_basic
=== PAUSE TestAccCloudFrontDistribution_basic
=== RUN   TestAccCloudFrontDistribution_disappears
=== PAUSE TestAccCloudFrontDistribution_disappears
=== RUN   TestAccCloudFrontDistribution_tags
=== PAUSE TestAccCloudFrontDistribution_tags
=== RUN   TestAccCloudFrontDistribution_s3Origin
=== PAUSE TestAccCloudFrontDistribution_s3Origin
=== RUN   TestAccCloudFrontDistribution_customOrigin
=== PAUSE TestAccCloudFrontDistribution_customOrigin
=== RUN   TestAccCloudFrontDistribution_customOriginIPAddressType
=== PAUSE TestAccCloudFrontDistribution_customOriginIPAddressType
=== RUN   TestAccCloudFrontDistribution_originPolicyDefault
=== PAUSE TestAccCloudFrontDistribution_originPolicyDefault
=== RUN   TestAccCloudFrontDistribution_originPolicyOrdered
=== PAUSE TestAccCloudFrontDistribution_originPolicyOrdered
=== RUN   TestAccCloudFrontDistribution_multiOrigin
=== PAUSE TestAccCloudFrontDistribution_multiOrigin
=== RUN   TestAccCloudFrontDistribution_orderedCacheBehavior
=== PAUSE TestAccCloudFrontDistribution_orderedCacheBehavior
=== RUN   TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== PAUSE TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== RUN   TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy
=== PAUSE TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy
=== RUN   TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
=== PAUSE TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
=== RUN   TestAccCloudFrontDistribution_Origin_emptyDomainName
=== PAUSE TestAccCloudFrontDistribution_Origin_emptyDomainName
=== RUN   TestAccCloudFrontDistribution_Origin_emptyOriginID
=== PAUSE TestAccCloudFrontDistribution_Origin_emptyOriginID
=== RUN   TestAccCloudFrontDistribution_Origin_connectionAttempts
=== PAUSE TestAccCloudFrontDistribution_Origin_connectionAttempts
=== RUN   TestAccCloudFrontDistribution_Origin_connectionTimeout
=== PAUSE TestAccCloudFrontDistribution_Origin_connectionTimeout
=== RUN   TestAccCloudFrontDistribution_Origin_originShield
=== PAUSE TestAccCloudFrontDistribution_Origin_originShield
=== RUN   TestAccCloudFrontDistribution_Origin_originAccessControl
=== PAUSE TestAccCloudFrontDistribution_Origin_originAccessControl
=== RUN   TestAccCloudFrontDistribution_noOptionalItems
=== PAUSE TestAccCloudFrontDistribution_noOptionalItems
=== RUN   TestAccCloudFrontDistribution_http11
=== PAUSE TestAccCloudFrontDistribution_http11
=== RUN   TestAccCloudFrontDistribution_isIPV6Enabled
=== PAUSE TestAccCloudFrontDistribution_isIPV6Enabled
=== RUN   TestAccCloudFrontDistribution_noCustomErrorResponse
=== PAUSE TestAccCloudFrontDistribution_noCustomErrorResponse
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
=== RUN   TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
=== PAUSE TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
=== RUN   TestAccCloudFrontDistribution_enabled
=== PAUSE TestAccCloudFrontDistribution_enabled
=== RUN   TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
=== PAUSE TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
=== RUN   TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
=== PAUSE TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
=== RUN   TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
=== PAUSE TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
=== RUN   TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate
=== PAUSE TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate
=== RUN   TestAccCloudFrontDistribution_waitForDeployment
=== PAUSE TestAccCloudFrontDistribution_waitForDeployment
=== RUN   TestAccCloudFrontDistribution_preconditionFailed
=== PAUSE TestAccCloudFrontDistribution_preconditionFailed
=== RUN   TestAccCloudFrontDistribution_originGroups
=== PAUSE TestAccCloudFrontDistribution_originGroups
=== RUN   TestAccCloudFrontDistribution_vpcOriginConfig
=== PAUSE TestAccCloudFrontDistribution_vpcOriginConfig
=== RUN   TestAccCloudFrontDistribution_responseCompletionTimeout
=== PAUSE TestAccCloudFrontDistribution_responseCompletionTimeout
=== RUN   TestAccCloudFrontDistribution_grpcConfig
=== PAUSE TestAccCloudFrontDistribution_grpcConfig
=== CONT  TestAccCloudFrontDistribution_basic
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
=== CONT  TestAccCloudFrontDistribution_Origin_connectionAttempts
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
=== CONT  TestAccCloudFrontDistribution_Origin_emptyOriginID
=== CONT  TestAccCloudFrontDistribution_preconditionFailed
=== CONT  TestAccCloudFrontDistribution_grpcConfig
=== CONT  TestAccCloudFrontDistribution_responseCompletionTimeout
=== CONT  TestAccCloudFrontDistribution_vpcOriginConfig
=== CONT  TestAccCloudFrontDistribution_originGroups
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
=== CONT  TestAccCloudFrontDistribution_multiOrigin
=== CONT  TestAccCloudFrontDistribution_enabled
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
=== CONT  TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate
=== CONT  TestAccCloudFrontDistribution_waitForDeployment
=== CONT  TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
--- PASS: TestAccCloudFrontDistribution_Origin_emptyOriginID (5.90s)
=== CONT  TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers (250.51s)
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames (250.73s)
=== CONT  TestAccCloudFrontDistribution_Origin_emptyDomainName
--- PASS: TestAccCloudFrontDistribution_Origin_emptyDomainName (0.70s)
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners (254.15s)
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames (255.11s)
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehavior
--- PASS: TestAccCloudFrontDistribution_grpcConfig (265.58s)
=== CONT  TestAccCloudFrontDistribution_customOrigin
--- PASS: TestAccCloudFrontDistribution_basic (269.44s)
=== CONT  TestAccCloudFrontDistribution_noOptionalItems
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups (273.10s)
=== CONT  TestAccCloudFrontDistribution_Origin_originShield
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN (281.12s)
=== CONT  TestAccCloudFrontDistribution_originPolicyOrdered
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN (289.80s)
=== CONT  TestAccCloudFrontDistribution_noCustomErrorResponse
--- PASS: TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN (297.94s)
=== CONT  TestAccCloudFrontDistribution_Origin_originAccessControl
--- PASS: TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate (312.22s)
=== CONT  TestAccCloudFrontDistribution_originPolicyDefault
=== CONT  TestAccCloudFrontDistribution_isIPV6Enabled
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers (222.92s)
--- PASS: TestAccCloudFrontDistribution_originGroups (505.13s)
=== CONT  TestAccCloudFrontDistribution_http11
--- PASS: TestAccCloudFrontDistribution_Origin_connectionAttempts (513.46s)
=== CONT  TestAccCloudFrontDistribution_tags
--- PASS: TestAccCloudFrontDistribution_responseCompletionTimeout (515.63s)
=== CONT  TestAccCloudFrontDistribution_customOriginIPAddressType
--- PASS: TestAccCloudFrontDistribution_multiOrigin (515.85s)
=== CONT  TestAccCloudFrontDistribution_disappears
--- PASS: TestAccCloudFrontDistribution_waitForDeployment (521.11s)
=== CONT  TestAccCloudFrontDistribution_s3Origin
=== CONT  TestAccCloudFrontDistribution_Origin_connectionTimeout
--- PASS: TestAccCloudFrontDistribution_preconditionFailed (609.90s)
--- PASS: TestAccCloudFrontDistribution_forwardedValuesToCachePolicy (608.35s)
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy (436.86s)
--- PASS: TestAccCloudFrontDistribution_customOrigin (462.66s)
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy (474.64s)
--- PASS: TestAccCloudFrontDistribution_noOptionalItems (460.11s)
--- PASS: TestAccCloudFrontDistribution_enabled (730.31s)
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehavior (477.22s)
--- PASS: TestAccCloudFrontDistribution_noCustomErrorResponse (458.91s)
--- PASS: TestAccCloudFrontDistribution_disappears (233.52s)
--- PASS: TestAccCloudFrontDistribution_originPolicyOrdered (469.77s)
--- PASS: TestAccCloudFrontDistribution_tags (262.36s)
--- PASS: TestAccCloudFrontDistribution_Origin_originShield (514.26s)
--- PASS: TestAccCloudFrontDistribution_originPolicyDefault (476.91s)
--- PASS: TestAccCloudFrontDistribution_Origin_originAccessControl (567.29s)
--- PASS: TestAccCloudFrontDistribution_isIPV6Enabled (564.80s)
--- PASS: TestAccCloudFrontDistribution_http11 (536.91s)
--- PASS: TestAccCloudFrontDistribution_s3Origin (524.22s)
--- PASS: TestAccCloudFrontDistribution_Origin_connectionTimeout (497.49s)
--- PASS: TestAccCloudFrontDistribution_customOriginIPAddressType (600.17s)
--- PASS: TestAccCloudFrontDistribution_vpcOriginConfig (1288.26s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 1293.639s



```
