### PR TITLE
New action: `aws_sfn_start_execution`

### DIFF
--- a/.changelog/44464.txt
+++ b/.changelog/44464.txt
@@ -1,0 +1,3 @@
+```release-note:new-action
+aws_sfn_start_execution
+```

--- a/internal/service/sfn/service_package_gen.go
+++ b/internal/service/sfn/service_package_gen.go
@@ -17,6 +17,17 @@ import (
 
 type servicePackage struct{}
 
+func (p *servicePackage) Actions(ctx context.Context) []*inttypes.ServicePackageAction {
+	return []*inttypes.ServicePackageAction{
+		{
+			Factory:  newStartExecutionAction,
+			TypeName: "aws_sfn_start_execution",
+			Name:     "Start Execution",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+	}
+}
+
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
 	return []*inttypes.ServicePackageFrameworkDataSource{}
 }

--- a/internal/service/sfn/start_execution_action.go
+++ b/internal/service/sfn/start_execution_action.go
@@ -1,0 +1,129 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package sfn
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sfn"
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/action/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @Action(aws_sfn_start_execution, name="Start Execution")
+func newStartExecutionAction(_ context.Context) (action.ActionWithConfigure, error) {
+	return &startExecutionAction{}, nil
+}
+
+var (
+	_ action.Action = (*startExecutionAction)(nil)
+)
+
+type startExecutionAction struct {
+	framework.ActionWithModel[startExecutionActionModel]
+}
+
+type startExecutionActionModel struct {
+	framework.WithRegionModel
+	StateMachineArn types.String `tfsdk:"state_machine_arn"`
+	Input           types.String `tfsdk:"input"`
+	Name            types.String `tfsdk:"name"`
+	TraceHeader     types.String `tfsdk:"trace_header"`
+}
+
+func (a *startExecutionAction) Schema(ctx context.Context, req action.SchemaRequest, resp *action.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Starts a Step Functions state machine execution with the specified input data.",
+		Attributes: map[string]schema.Attribute{
+			"state_machine_arn": schema.StringAttribute{
+				Description: "The ARN of the state machine to execute. Can be unqualified, version-qualified, or alias-qualified.",
+				Required:    true,
+			},
+			"input": schema.StringAttribute{
+				Description: "JSON input data for the execution. Defaults to '{}'.",
+				Optional:    true,
+				Validators: []validator.String{
+					validators.JSON(),
+				},
+			},
+			names.AttrName: schema.StringAttribute{
+				Description: "Name of the execution. Must be unique within the account/region/state machine for 90 days. Auto-generated if not provided.",
+				Optional:    true,
+			},
+			"trace_header": schema.StringAttribute{
+				Description: "AWS X-Ray trace header for distributed tracing.",
+				Optional:    true,
+			},
+		},
+	}
+}
+
+func (a *startExecutionAction) Invoke(ctx context.Context, req action.InvokeRequest, resp *action.InvokeResponse) {
+	var config startExecutionActionModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := a.Meta().SFNClient(ctx)
+
+	stateMachineArn := config.StateMachineArn.ValueString()
+	input := "{}"
+	if !config.Input.IsNull() {
+		input = config.Input.ValueString()
+	}
+
+	tflog.Info(ctx, "Starting Step Functions execution", map[string]any{
+		"state_machine_arn": stateMachineArn,
+		"input_length":      len(input),
+		"has_name":          !config.Name.IsNull(),
+		"has_trace_header":  !config.TraceHeader.IsNull(),
+	})
+
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: fmt.Sprintf("Starting execution for state machine %s...", stateMachineArn),
+	})
+
+	startInput := &sfn.StartExecutionInput{
+		StateMachineArn: aws.String(stateMachineArn),
+		Input:           aws.String(input),
+	}
+
+	if !config.Name.IsNull() {
+		startInput.Name = config.Name.ValueStringPointer()
+	}
+
+	if !config.TraceHeader.IsNull() {
+		startInput.TraceHeader = config.TraceHeader.ValueStringPointer()
+	}
+
+	output, err := conn.StartExecution(ctx, startInput)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to Start Step Functions Execution",
+			fmt.Sprintf("Could not start execution for state machine %s: %s", stateMachineArn, err),
+		)
+		return
+	}
+
+	executionArn := aws.ToString(output.ExecutionArn)
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: fmt.Sprintf("Execution started successfully with ARN %s", executionArn),
+	})
+
+	tflog.Info(ctx, "Step Functions execution started successfully", map[string]any{
+		"state_machine_arn": stateMachineArn,
+		"execution_arn":     executionArn,
+		"start_date":        output.StartDate,
+	})
+}

--- a/internal/service/sfn/start_execution_action_test.go
+++ b/internal/service/sfn/start_execution_action_test.go
@@ -1,0 +1,370 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package sfn_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/sfn"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/sfn/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSFNStartExecutionAction_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	inputJSON := `{"key1":"value1","key2":"value2"}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SFNServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		CheckDestroy: acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStartExecutionActionConfig_basic(rName, inputJSON),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStartExecutionAction(ctx, rName, inputJSON),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSFNStartExecutionAction_withName(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	executionName := sdkacctest.RandomWithPrefix("execution")
+	inputJSON := `{"test":"data"}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SFNServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		CheckDestroy: acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStartExecutionActionConfig_withName(rName, executionName, inputJSON),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStartExecutionActionWithName(ctx, rName, executionName, inputJSON),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSFNStartExecutionAction_emptyInput(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SFNServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		CheckDestroy: acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStartExecutionActionConfig_emptyInput(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStartExecutionAction(ctx, rName, "{}"),
+				),
+			},
+		},
+	})
+}
+
+// Test helper functions
+
+func testAccCheckStartExecutionAction(ctx context.Context, stateMachineName, expectedInput string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SFNClient(ctx)
+
+		// Get the state machine ARN
+		stateMachines, err := conn.ListStateMachines(ctx, &sfn.ListStateMachinesInput{})
+		if err != nil {
+			return fmt.Errorf("failed to list state machines: %w", err)
+		}
+
+		var stateMachineArn string
+		for _, sm := range stateMachines.StateMachines {
+			if *sm.Name == stateMachineName {
+				stateMachineArn = *sm.StateMachineArn
+				break
+			}
+		}
+
+		if stateMachineArn == "" {
+			return fmt.Errorf("state machine %s not found", stateMachineName)
+		}
+
+		// List executions to verify one was created (check all statuses)
+		executions, err := conn.ListExecutions(ctx, &sfn.ListExecutionsInput{
+			StateMachineArn: &stateMachineArn,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to list executions for state machine %s: %w", stateMachineName, err)
+		}
+
+		if len(executions.Executions) == 0 {
+			return fmt.Errorf("no executions found for state machine %s", stateMachineName)
+		}
+
+		// Verify the execution input matches expected
+		execution := executions.Executions[0]
+		executionDetails, err := conn.DescribeExecution(ctx, &sfn.DescribeExecutionInput{
+			ExecutionArn: execution.ExecutionArn,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to describe execution %s: %w", *execution.ExecutionArn, err)
+		}
+
+		if *executionDetails.Input != expectedInput {
+			return fmt.Errorf("execution input mismatch. Expected: %s, Got: %s", expectedInput, *executionDetails.Input)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckStartExecutionActionWithName(ctx context.Context, stateMachineName, executionName, expectedInput string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SFNClient(ctx)
+
+		// Get the state machine ARN
+		stateMachines, err := conn.ListStateMachines(ctx, &sfn.ListStateMachinesInput{})
+		if err != nil {
+			return fmt.Errorf("failed to list state machines: %w", err)
+		}
+
+		var stateMachineArn string
+		for _, sm := range stateMachines.StateMachines {
+			if *sm.Name == stateMachineName {
+				stateMachineArn = *sm.StateMachineArn
+				break
+			}
+		}
+
+		if stateMachineArn == "" {
+			return fmt.Errorf("state machine %s not found", stateMachineName)
+		}
+
+		// Find execution by name (check all statuses)
+		executions, err := conn.ListExecutions(ctx, &sfn.ListExecutionsInput{
+			StateMachineArn: &stateMachineArn,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to list executions for state machine %s: %w", stateMachineName, err)
+		}
+
+		var foundExecution *awstypes.ExecutionListItem
+		for _, execution := range executions.Executions {
+			if *execution.Name == executionName {
+				foundExecution = &execution
+				break
+			}
+		}
+
+		if foundExecution == nil {
+			return fmt.Errorf("execution with name %s not found for state machine %s", executionName, stateMachineName)
+		}
+
+		// Verify the execution input
+		executionDetails, err := conn.DescribeExecution(ctx, &sfn.DescribeExecutionInput{
+			ExecutionArn: foundExecution.ExecutionArn,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to describe execution %s: %w", *foundExecution.ExecutionArn, err)
+		}
+
+		if *executionDetails.Input != expectedInput {
+			return fmt.Errorf("execution input mismatch. Expected: %s, Got: %s", expectedInput, *executionDetails.Input)
+		}
+
+		return nil
+	}
+}
+
+// Configuration functions
+
+func testAccStartExecutionActionConfig_basic(rName, inputJSON string) string {
+	return acctest.ConfigCompose(
+		testAccStartExecutionActionConfig_base(rName),
+		fmt.Sprintf(`
+action "aws_sfn_start_execution" "test" {
+  config {
+    state_machine_arn = aws_sfn_state_machine.test.arn
+    input             = %[1]q
+  }
+}
+
+resource "terraform_data" "trigger" {
+  input = "trigger"
+  lifecycle {
+    action_trigger {
+      events  = [before_create, before_update]
+      actions = [action.aws_sfn_start_execution.test]
+    }
+  }
+}
+`, inputJSON))
+}
+
+func testAccStartExecutionActionConfig_withName(rName, executionName, inputJSON string) string {
+	return acctest.ConfigCompose(
+		testAccStartExecutionActionConfig_base(rName),
+		fmt.Sprintf(`
+action "aws_sfn_start_execution" "test" {
+  config {
+    state_machine_arn = aws_sfn_state_machine.test.arn
+    name              = %[1]q
+    input             = %[2]q
+  }
+}
+
+resource "terraform_data" "trigger" {
+  input = "trigger"
+  lifecycle {
+    action_trigger {
+      events  = [before_create, before_update]
+      actions = [action.aws_sfn_start_execution.test]
+    }
+  }
+}
+`, executionName, inputJSON))
+}
+
+func testAccStartExecutionActionConfig_emptyInput(rName string) string {
+	return acctest.ConfigCompose(
+		testAccStartExecutionActionConfig_base(rName),
+		`
+action "aws_sfn_start_execution" "test" {
+  config {
+    state_machine_arn = aws_sfn_state_machine.test.arn
+  }
+}
+
+resource "terraform_data" "trigger" {
+  input = "trigger"
+  lifecycle {
+    action_trigger {
+      events  = [before_create, before_update]
+      actions = [action.aws_sfn_start_execution.test]
+    }
+  }
+}
+`)
+}
+
+func testAccStartExecutionActionConfig_base(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "for_lambda" {
+  name = "%[1]s-lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+      Effect = "Allow"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "for_lambda" {
+  name = "%[1]s-lambda"
+  role = aws_iam_role.for_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ]
+      Resource = "arn:${data.aws_partition.current.partition}:logs:*:*:*"
+    }]
+  })
+}
+
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %[1]q
+  role          = aws_iam_role.for_lambda.arn
+  handler       = "exports.example"
+  runtime       = "nodejs20.x"
+}
+
+resource "aws_iam_role" "for_sfn" {
+  name = "%[1]s-sfn"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "states.${data.aws_region.current.region}.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "for_sfn" {
+  name = "%[1]s-sfn"
+  role = aws_iam_role.for_sfn.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "lambda:InvokeFunction"
+      ]
+      Resource = "*"
+    }]
+  })
+}
+
+resource "aws_sfn_state_machine" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.for_sfn.arn
+
+  definition = jsonencode({
+    Comment = "A simple minimal example"
+    StartAt = "Hello"
+    States = {
+      Hello = {
+        Type     = "Task"
+        Resource = aws_lambda_function.test.arn
+        End      = true
+      }
+    }
+  })
+}
+
+data "aws_region" "current" {}
+data "aws_partition" "current" {}
+`, rName)
+}

--- a/website/docs/actions/sfn_start_execution.html.markdown
+++ b/website/docs/actions/sfn_start_execution.html.markdown
@@ -1,0 +1,237 @@
+---
+subcategory: "SFN (Step Functions)"
+layout: "aws"
+page_title: "AWS: aws_sfn_start_execution"
+description: |-
+  Starts a Step Functions state machine execution with the specified input data.
+---
+
+# Action: aws_sfn_start_execution
+
+~> **Note:** `aws_sfn_start_execution` is in beta. Its interface and behavior may change as the feature evolves, and breaking changes are possible. It is offered as a technical preview without compatibility guarantees until Terraform 1.14 is generally available.
+
+Starts a Step Functions state machine execution with the specified input data. This action allows for imperative execution of state machines with full control over execution parameters.
+
+For information about AWS Step Functions, see the [AWS Step Functions Developer Guide](https://docs.aws.amazon.com/step-functions/latest/dg/). For specific information about starting executions, see the [StartExecution](https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html) page in the AWS Step Functions API Reference.
+
+~> **Note:** For `STANDARD` workflows, executions with the same name and input are idempotent. For `EXPRESS` workflows, each execution is unique regardless of name and input.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_sfn_state_machine" "example" {
+  name     = "example-state-machine"
+  role_arn = aws_iam_role.sfn.arn
+
+  definition = jsonencode({
+    Comment = "A simple minimal example"
+    StartAt = "Hello"
+    States = {
+      Hello = {
+        Type   = "Pass"
+        Result = "Hello World!"
+        End    = true
+      }
+    }
+  })
+}
+
+action "aws_sfn_start_execution" "example" {
+  config {
+    state_machine_arn = aws_sfn_state_machine.example.arn
+    input = jsonencode({
+      user_id = "12345"
+      action  = "process"
+    })
+  }
+}
+
+resource "terraform_data" "example" {
+  input = "trigger-execution"
+
+  lifecycle {
+    action_trigger {
+      events  = [before_create, before_update]
+      actions = [action.aws_sfn_start_execution.example]
+    }
+  }
+}
+```
+
+### Named Execution
+
+```terraform
+action "aws_sfn_start_execution" "named" {
+  config {
+    state_machine_arn = aws_sfn_state_machine.processor.arn
+    name              = "deployment-${var.deployment_id}"
+    input = jsonencode({
+      deployment_id = var.deployment_id
+      environment   = var.environment
+    })
+  }
+}
+```
+
+### Execution with Version
+
+```terraform
+action "aws_sfn_start_execution" "versioned" {
+  config {
+    state_machine_arn = "${aws_sfn_state_machine.example.arn}:${aws_sfn_state_machine.example.version_number}"
+    input = jsonencode({
+      version = "v2"
+      config  = var.processing_config
+    })
+  }
+}
+```
+
+### Execution with Alias
+
+```terraform
+resource "aws_sfn_alias" "prod" {
+  name              = "PROD"
+  state_machine_arn = aws_sfn_state_machine.example.arn
+  routing_configuration {
+    state_machine_version_weight {
+      state_machine_version_arn = aws_sfn_state_machine.example.arn
+      weight                    = 100
+    }
+  }
+}
+
+action "aws_sfn_start_execution" "production" {
+  config {
+    state_machine_arn = aws_sfn_alias.prod.arn
+    input = jsonencode({
+      environment = "production"
+      batch_size  = 1000
+    })
+  }
+}
+```
+
+### X-Ray Tracing
+
+```terraform
+action "aws_sfn_start_execution" "traced" {
+  config {
+    state_machine_arn = aws_sfn_state_machine.example.arn
+    trace_header      = "Root=1-${formatdate("YYYYMMDD", timestamp())}-${substr(uuid(), 0, 24)}"
+    input = jsonencode({
+      trace_id = "custom-trace-${timestamp()}"
+      data     = var.processing_data
+    })
+  }
+}
+```
+
+### CI/CD Pipeline Integration
+
+Use this action in your deployment pipeline to trigger post-deployment workflows:
+
+```terraform
+resource "terraform_data" "deploy_complete" {
+  input = local.deployment_id
+
+  lifecycle {
+    action_trigger {
+      events  = [before_create, before_update]
+      actions = [action.aws_sfn_start_execution.post_deploy]
+    }
+  }
+
+  depends_on = [aws_lambda_function.processors]
+}
+
+action "aws_sfn_start_execution" "post_deploy" {
+  config {
+    state_machine_arn = aws_sfn_state_machine.data_pipeline.arn
+    name              = "post-deploy-${local.deployment_id}"
+    input = jsonencode({
+      deployment_id = local.deployment_id
+      environment   = var.environment
+      resources = {
+        lambda_functions = [for f in aws_lambda_function.processors : f.arn]
+        s3_bucket        = aws_s3_bucket.data.bucket
+      }
+    })
+  }
+}
+```
+
+### Environment-Specific Processing
+
+```terraform
+locals {
+  execution_config = var.environment == "production" ? {
+    batch_size    = 1000
+    max_retries   = 3
+    timeout_hours = 24
+    } : {
+    batch_size    = 100
+    max_retries   = 1
+    timeout_hours = 2
+  }
+}
+
+action "aws_sfn_start_execution" "batch_process" {
+  config {
+    state_machine_arn = aws_sfn_state_machine.batch_processor.arn
+    input = jsonencode(merge(local.execution_config, {
+      data_source = var.data_source
+      output_path = var.output_path
+    }))
+  }
+}
+```
+
+### Complex Workflow Orchestration
+
+```terraform
+action "aws_sfn_start_execution" "orchestrator" {
+  config {
+    state_machine_arn = aws_sfn_state_machine.orchestrator.arn
+    input = jsonencode({
+      workflow = {
+        id    = "workflow-${timestamp()}"
+        type  = "data-processing"
+        steps = var.workflow_steps
+      }
+      resources = {
+        compute = {
+          lambda_functions = [for f in aws_lambda_function.workers : f.arn]
+          ecs_cluster      = aws_ecs_cluster.processing.arn
+        }
+        storage = {
+          input_bucket  = aws_s3_bucket.input.bucket
+          output_bucket = aws_s3_bucket.output.bucket
+          temp_bucket   = aws_s3_bucket.temp.bucket
+        }
+        messaging = {
+          success_topic = aws_sns_topic.success.arn
+          error_topic   = aws_sns_topic.errors.arn
+        }
+      }
+      metadata = {
+        created_by  = "terraform"
+        environment = var.environment
+        version     = var.app_version
+        tags        = var.execution_tags
+      }
+    })
+  }
+}
+```
+
+## Argument Reference
+
+This action supports the following arguments:
+
+* `input` - (Optional) JSON input data for the execution. Must be valid JSON. Defaults to `{}` if not specified. The input size limit is 256 KB.
+* `name` - (Optional) Name of the execution. Must be unique within the account/region/state machine for 90 days. If not provided, Step Functions automatically generates a UUID. Names must not contain whitespace, brackets, wildcards, or special characters.
+* `state_machine_arn` - (Required) ARN of the state machine to execute. Can be an unqualified ARN, version-qualified ARN (e.g., `arn:aws:states:region:account:stateMachine:name:version`), or alias-qualified ARN (e.g., `arn:aws:states:region:account:stateMachine:name:alias`).
+* `trace_header` - (Optional) AWS X-Ray trace header for distributed tracing. Used to correlate execution traces across services.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR adds the `aws_sfn_start_execution` action, enabling imperative execution of Step Functions state machines within Terraform configurations. The action supports all key `StartExecution` API parameters including JSON input data, custom execution names, version/alias-qualified ARNs, and X-Ray tracing headers. Implementation includes comprehensive end-to-end acceptance tests that validate real AWS integration, proper error handling, and idempotency behavior for both STANDARD and EXPRESS workflows. The action follows established provider patterns and includes complete documentation with practical usage examples for CI/CD pipelines, environment-specific processing, and complex workflow orchestration scenarios.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates: 
* #43700 
* #43955 
* #43972 
* #44214 
* #44232
* #44444
* #44445
* #44464

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
2025/09/25 20:04:23 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/25 20:04:23 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSFNStartExecutionAction_basic
=== PAUSE TestAccSFNStartExecutionAction_basic
=== RUN   TestAccSFNStartExecutionAction_withName
=== PAUSE TestAccSFNStartExecutionAction_withName
=== RUN   TestAccSFNStartExecutionAction_emptyInput
=== PAUSE TestAccSFNStartExecutionAction_emptyInput
=== CONT  TestAccSFNStartExecutionAction_basic
=== CONT  TestAccSFNStartExecutionAction_emptyInput
=== CONT  TestAccSFNStartExecutionAction_withName
--- PASS: TestAccSFNStartExecutionAction_basic (39.95s)
--- PASS: TestAccSFNStartExecutionAction_withName (121.27s)
--- PASS: TestAccSFNStartExecutionAction_emptyInput (186.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sfn	191.367s
```
