### PR TITLE
Add `WithError` functions to `internal/slices`

### DIFF
--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -409,12 +409,10 @@ func findInstanceByID(ctx context.Context, conn *ec2.Client, id string) (*awstyp
 }
 
 func findInstance(ctx context.Context, conn *ec2.Client, input *ec2.DescribeInstancesInput) (*awstypes.Instance, error) {
-	var output []awstypes.Instance
-	for v, err := range listInstances(ctx, conn, input) {
-		if err != nil {
-			return nil, err
-		}
-		output = append(output, v)
+	output, err := tfslices.CollectWithError(listInstances(ctx, conn, input))
+
+	if err != nil {
+		return nil, err
 	}
 
 	return tfresource.AssertSingleValueResult(output, func(v *awstypes.Instance) bool { return v.State != nil })

--- a/internal/slices/slices.go
+++ b/internal/slices/slices.go
@@ -4,6 +4,7 @@
 package slices
 
 import (
+	"iter"
 	"slices"
 )
 
@@ -166,4 +167,24 @@ func Strings[S ~[]E, E stringable](s S) []string {
 	return ApplyToAll(s, func(e E) string {
 		return string(e)
 	})
+}
+
+// CollectWithError collects values from seq into a new slice and returns it.
+// The first non-nil error in seq is returned.
+// If seq is empty, the result is nil.
+func CollectWithError[E any](seq iter.Seq2[E, error]) ([]E, error) {
+	return AppendSeqWithError([]E(nil), seq)
+}
+
+// AppendSeqWithError appends the values from seq to the slice and returns the extended slice.
+// The first non-nil error in seq is returned.
+// If seq is empty, the result preserves the nilness of s.
+func AppendSeqWithError[S ~[]E, E any](s S, seq iter.Seq2[E, error]) (S, error) {
+	for v, err := range seq {
+		if err != nil {
+			return nil, err
+		}
+		s = append(s, v)
+	}
+	return s, nil
 }

--- a/internal/slices/slices_test.go
+++ b/internal/slices/slices_test.go
@@ -4,6 +4,8 @@
 package slices
 
 import (
+	"errors"
+	"maps"
 	"strings"
 	"testing"
 
@@ -361,6 +363,49 @@ func TestRange(t *testing.T) {
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestCollectWithError(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input   map[int]error
+		wantErr bool
+	}
+	tests := map[string]testCase{
+		"no error": {
+			input: map[int]error{
+				1: nil,
+				2: nil,
+				3: nil,
+			},
+		},
+		"has error": {
+			input: map[int]error{
+				1: nil,
+				2: errors.New("test error"),
+				3: nil,
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := CollectWithError(maps.All(test.input))
+
+			if got, want := err != nil, test.wantErr; !cmp.Equal(got, want) {
+				t.Errorf("CollectWithError() err %t, want %t", got, want)
+			}
+			if err == nil {
+				if got, want := len(got), len(test.input); !cmp.Equal(got, want) {
+					t.Errorf("CollectWithError() len %d, want %d", got, want)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds `internal/slices.CollectWithError` to act on `iter.Seq2[E, error]`.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccEC2Instance_basic$$' PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-iter-funcs 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2Instance_basic$ -timeout 360m -vet=off
2025/09/26 16:21:52 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/26 16:21:52 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEC2Instance_basic
=== PAUSE TestAccEC2Instance_basic
=== CONT  TestAccEC2Instance_basic
--- PASS: TestAccEC2Instance_basic (117.09s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	122.748s
```
