### PR TITLE
fix: Corrects grammar in EMR and KMS validation messages

### DIFF
--- a/.changelog/44478.txt
+++ b/.changelog/44478.txt
@@ -1,4 +1,0 @@
-```release-note:note
-resource/aws_emr_service: Updates validation messages from `be comprised of only` to `only contain`
-resource/aws_kms_service: Updates validation messages from `be comprised of only` to `only contain`
-```

--- a/.changelog/44478.txt
+++ b/.changelog/44478.txt
@@ -1,0 +1,4 @@
+```release-note:note
+resource/aws_emr_service: Corrects grammar of validation messages from `be comprised of` to `comprise`
+resource/aws_kms_service: Corrects grammar of validation messages from `be comprised of` to `comprise`
+```

--- a/.changelog/44478.txt
+++ b/.changelog/44478.txt
@@ -1,4 +1,4 @@
 ```release-note:note
-resource/aws_emr_service: Corrects grammar of validation messages from `be comprised of` to `comprise`
-resource/aws_kms_service: Corrects grammar of validation messages from `be comprised of` to `comprise`
+resource/aws_emr_service: Updates validation messages from `be comprised of only` to `only contain`
+resource/aws_kms_service: Updates validation messages from `be comprised of only` to `only contain`
 ```

--- a/internal/service/emr/validate.go
+++ b/internal/service/emr/validate.go
@@ -19,7 +19,7 @@ func validCustomAMIID(v any, k string) (ws []string, errors []error) {
 
 	if !regexache.MustCompile(`^ami\-[0-9a-z]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"%q must begin with 'ami-' and comprise only [0-9a-z]: %v", k, value))
+			"%q must begin with 'ami-' and only contain [0-9a-z]: %v", k, value))
 	}
 
 	return

--- a/internal/service/emr/validate.go
+++ b/internal/service/emr/validate.go
@@ -19,7 +19,7 @@ func validCustomAMIID(v any, k string) (ws []string, errors []error) {
 
 	if !regexache.MustCompile(`^ami\-[0-9a-z]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"%q must begin with 'ami-' and be comprised of only [0-9a-z]: %v", k, value))
+			"%q must begin with 'ami-' and comprise only [0-9a-z]: %v", k, value))
 	}
 
 	return

--- a/internal/service/kms/validate.go
+++ b/internal/service/kms/validate.go
@@ -42,7 +42,7 @@ func validNameForDataSource(v any, k string) (ws []string, es []error) {
 
 	if !aliasNameRegex.MatchString(value) {
 		es = append(es, fmt.Errorf(
-			"%q must begin with 'alias/' and be comprised of only [0-9A-Za-z_/-]", k))
+			"%q must begin with 'alias/' and comprise only [0-9A-Za-z_/-]", k))
 	}
 	return
 }
@@ -56,7 +56,7 @@ func validNameForResource(v any, k string) (ws []string, es []error) {
 
 	if !aliasNameRegex.MatchString(value) {
 		es = append(es, fmt.Errorf(
-			"%q must begin with 'alias/' and be comprised of only [0-9A-Za-z_/-]", k))
+			"%q must begin with 'alias/' and comprise only [0-9A-Za-z_/-]", k))
 	}
 	return
 }

--- a/internal/service/kms/validate.go
+++ b/internal/service/kms/validate.go
@@ -42,7 +42,7 @@ func validNameForDataSource(v any, k string) (ws []string, es []error) {
 
 	if !aliasNameRegex.MatchString(value) {
 		es = append(es, fmt.Errorf(
-			"%q must begin with 'alias/' and comprise only [0-9A-Za-z_/-]", k))
+			"%q must begin with 'alias/' and only contain [0-9A-Za-z_/-]", k))
 	}
 	return
 }
@@ -56,7 +56,7 @@ func validNameForResource(v any, k string) (ws []string, es []error) {
 
 	if !aliasNameRegex.MatchString(value) {
 		es = append(es, fmt.Errorf(
-			"%q must begin with 'alias/' and comprise only [0-9A-Za-z_/-]", k))
+			"%q must begin with 'alias/' and only contain [0-9A-Za-z_/-]", k))
 	}
 	return
 }

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -330,7 +330,7 @@ func ValidLaunchTemplateID(v any, k string) (ws []string, errors []error) {
 		errors = append(errors, fmt.Errorf("%q cannot be longer than 255 characters", k))
 	} else if !regexache.MustCompile(`^lt\-[0-9a-z]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"%q must begin with 'lt-' and be comprised of only alphanumeric characters: %v", k, value))
+			"%q must begin with 'lt-' and comprise only alphanumeric characters: %v", k, value))
 	}
 	return
 }

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -330,7 +330,7 @@ func ValidLaunchTemplateID(v any, k string) (ws []string, errors []error) {
 		errors = append(errors, fmt.Errorf("%q cannot be longer than 255 characters", k))
 	} else if !regexache.MustCompile(`^lt\-[0-9a-z]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"%q must begin with 'lt-' and comprise only alphanumeric characters: %v", k, value))
+			"%q must begin with 'lt-' and only contain alphanumeric characters: %v", k, value))
 	}
 	return
 }


### PR DESCRIPTION
This PR fixes an admittedly minor grammar error in the validation messages for the EMR and KMS services.

`be comprised of only` -> `only contain`

## Rollback Plan

I don't think this needs one, as it's just a message fix. The actual text also isn't checked for in the tests.

## Changes to Security Controls

None.
