### PR TITLE
[bugfix] d/aws_networkfirewall_firewall_policy: Fix failure to retrieve multiple `stateful_rule_group_reference` attributes due to missing `Computed` attributes

### DIFF
--- a/.changelog/44482.txt
+++ b/.changelog/44482.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_networkfirewall_firewall_policy: Fix failure to retrieve multiple `firewall_policy.stateful_rule_group_reference` attributes
+```

--- a/internal/service/networkfirewall/firewall_policy_data_source.go
+++ b/internal/service/networkfirewall/firewall_policy_data_source.go
@@ -121,12 +121,12 @@ func dataSourceFirewallPolicy() *schema.Resource {
 										},
 										"override": {
 											Type:     schema.TypeList,
-											Optional: true,
+											Computed: true,
 											Elem: &schema.Resource{
 												Schema: map[string]*schema.Schema{
 													names.AttrAction: {
 														Type:     schema.TypeString,
-														Optional: true,
+														Computed: true,
 													},
 												},
 											},

--- a/internal/service/networkfirewall/firewall_policy_data_source_test.go
+++ b/internal/service/networkfirewall/firewall_policy_data_source_test.go
@@ -223,6 +223,35 @@ func TestAccNetworkFirewallFirewallPolicyDataSource_statefulEngineOptions(t *tes
 	})
 }
 
+func TestAccNetworkFirewallFirewallPolicyDataSource_multipleStatefulRuleGroupReferences(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	resourceName := "aws_networkfirewall_firewall_policy.test"
+	datasourceName := "data.aws_networkfirewall_firewall_policy.test"
+	ruleGroupResourceName1 := "aws_networkfirewall_rule_group.test.0"
+	ruleGroupResourceName2 := "aws_networkfirewall_rule_group.test.1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkFirewallServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirewallPolicyDataSourceConfig_multipleStatefulRuleGroupReferences(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrARN, resourceName, names.AttrARN), resource.TestCheckResourceAttrPair(datasourceName, names.AttrDescription, resourceName, names.AttrDescription),
+					resource.TestCheckResourceAttrPair(datasourceName, "firewall_policy.#", resourceName, "firewall_policy.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "firewall_policy.0.stateful_rule_group_reference.#", resourceName, "firewall_policy.0.stateful_rule_group_reference.#"),
+					resource.TestCheckTypeSetElemAttrPair(datasourceName, "firewall_policy.0.stateful_rule_group_reference.*.resource_arn", ruleGroupResourceName1, names.AttrARN),
+					resource.TestCheckTypeSetElemAttrPair(datasourceName, "firewall_policy.0.stateful_rule_group_reference.*.resource_arn", ruleGroupResourceName2, names.AttrARN),
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrName, resourceName, names.AttrName),
+					resource.TestCheckResourceAttrPair(datasourceName, acctest.CtTagsPercent, resourceName, acctest.CtTagsPercent),
+				),
+			},
+		},
+	})
+}
+
 func testAccFirewallPolicyDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_networkfirewall_firewall_policy" "test" {
@@ -360,4 +389,12 @@ data "aws_networkfirewall_firewall_policy" "test" {
   arn = aws_networkfirewall_firewall_policy.test.arn
 }
 `, rName)
+}
+
+func testAccFirewallPolicyDataSourceConfig_multipleStatefulRuleGroupReferences(rName string) string {
+	return acctest.ConfigCompose(testAccFirewallPolicyConfig_multipleStatefulRuleGroupReferences(rName), `
+data "aws_networkfirewall_firewall_policy" "test" {
+  arn = aws_networkfirewall_firewall_policy.test.arn
+}
+`)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* #44475 reported a failure to retrieve multiple `firewall_policy.stateful_rule_group_reference` attributes.  
* This was caused by missing `Computed` attributes in the block.  
* This PR marks these attributes as `Computed`.
* The newly added acceptance test confirms that multiple `stateful_rule_group_reference` attributes are retrieved as expected.

### Relations

Closes #44475


### Output from Acceptance Testing
```console
$ make testacc TESTS='TestAccNetworkFirewallFirewallPolicyDataSource_' PKG=networkfirewall 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws_networkfirewall_firewall_policy_data_source-fix_attribute 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/networkfirewall/... -v -count 1 -parallel 20 -run='TestAccNetworkFirewallFirewallPolicyDataSource_'  -timeout 360m -vet=off
2025/09/29 20:23:00 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/29 20:23:00 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_arn
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_arn
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_name
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_name
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_nameAndARN
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_nameAndARN
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_withOverriddenManagedRuleGroup
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_withOverriddenManagedRuleGroup
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_withPolicyVariables
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_withPolicyVariables
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_activeThreatDefense
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_activeThreatDefense
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_statefulEngineOptions
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_statefulEngineOptions
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_multipleStatefulRuleGroupReferences
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_multipleStatefulRuleGroupReferences
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_arn
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_withPolicyVariables
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_statefulEngineOptions
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_multipleStatefulRuleGroupReferences
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_activeThreatDefense
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_nameAndARN
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_withOverriddenManagedRuleGroup
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_name
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_name (153.11s)
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_statefulEngineOptions (154.47s)
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_arn (154.85s)
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_withOverriddenManagedRuleGroup (155.59s)
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_activeThreatDefense (155.59s)
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_nameAndARN (162.13s)
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_withPolicyVariables (164.53s)
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_multipleStatefulRuleGroupReferences (203.31s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall    207.515s

```
