### PR TITLE
[bugfix] d/aws_lb: Fix panic caused by missing `secondary_ips_auto_assigned_per_subnet` in schema definition

### DIFF
--- a/.changelog/44485.txt
+++ b/.changelog/44485.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_lb: Fix panic caused by missing `secondary_ips_auto_assigned_per_subnet` attribute in schema definition
+```

--- a/.changelog/44485.txt
+++ b/.changelog/44485.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-data-source/aws_lb: Fix panic caused by missing `secondary_ips_auto_assigned_per_subnet` attribute in schema definition
+data-source/aws_lb: Fix `Invalid address to set: []string{"secondary_ips_auto_assigned_per_subnet"}` errors
 ```

--- a/internal/service/elbv2/load_balancer_data_source.go
+++ b/internal/service/elbv2/load_balancer_data_source.go
@@ -175,6 +175,10 @@ func dataSourceLoadBalancer() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"secondary_ips_auto_assigned_per_subnet": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			names.AttrSecurityGroups: {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* #44481 reported a panic error: `Invalid address to set: []string{"secondary_ips_auto_assigned_per_subnet"}`  
* The `secondary_ips_auto_assigned_per_subnet` argument was introduced to the resource in #43699.  
* Even though the same flattener is used in both the resource and the data source, this attribute had not yet been implemented for the data source.  
* This PR adds `secondary_ips_auto_assigned_per_subnet` to the data source schema.  
* The newly added acceptance test confirms that:  
  * Without this change, the reported panic can be reproduced.  
  * With this change, no panic occurs and the expected value of `secondary_ips_auto_assigned_per_subnet` is returned.  
* No need to update the documentation since it describes `See the LB Resource for details on the returned attributes - they are identical.`

### Relations

Closes #44481



### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccELBV2LoadBalancerDataSource_' PKG=elbv2 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws_lb-fix_panic_due_to_missing_attribute 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2LoadBalancerDataSource_'  -timeout 360m -vet=off
2025/09/29 21:44:52 Creating Terraform AWS Provider (SDKv2-style)...
2025/09/29 21:44:53 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccELBV2LoadBalancerDataSource_tags
=== PAUSE TestAccELBV2LoadBalancerDataSource_tags
=== RUN   TestAccELBV2LoadBalancerDataSource_tags_NullMap
=== PAUSE TestAccELBV2LoadBalancerDataSource_tags_NullMap
=== RUN   TestAccELBV2LoadBalancerDataSource_tags_EmptyMap
=== PAUSE TestAccELBV2LoadBalancerDataSource_tags_EmptyMap
=== RUN   TestAccELBV2LoadBalancerDataSource_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccELBV2LoadBalancerDataSource_tags_DefaultTags_nonOverlapping
=== RUN   TestAccELBV2LoadBalancerDataSource_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccELBV2LoadBalancerDataSource_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccELBV2LoadBalancerDataSource_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccELBV2LoadBalancerDataSource_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccELBV2LoadBalancerDataSource_basic
=== PAUSE TestAccELBV2LoadBalancerDataSource_basic
=== RUN   TestAccELBV2LoadBalancerDataSource_outpost
=== PAUSE TestAccELBV2LoadBalancerDataSource_outpost
=== RUN   TestAccELBV2LoadBalancerDataSource_backwardsCompatibility
=== PAUSE TestAccELBV2LoadBalancerDataSource_backwardsCompatibility
=== RUN   TestAccELBV2LoadBalancerDataSource_nlbSecondaryIPAddresses
=== PAUSE TestAccELBV2LoadBalancerDataSource_nlbSecondaryIPAddresses
=== CONT  TestAccELBV2LoadBalancerDataSource_tags
=== CONT  TestAccELBV2LoadBalancerDataSource_tags_IgnoreTags_Overlap_ResourceTag
=== CONT  TestAccELBV2LoadBalancerDataSource_backwardsCompatibility
=== CONT  TestAccELBV2LoadBalancerDataSource_tags_DefaultTags_nonOverlapping
=== CONT  TestAccELBV2LoadBalancerDataSource_tags_IgnoreTags_Overlap_DefaultTag
=== CONT  TestAccELBV2LoadBalancerDataSource_nlbSecondaryIPAddresses
=== CONT  TestAccELBV2LoadBalancerDataSource_tags_EmptyMap
=== CONT  TestAccELBV2LoadBalancerDataSource_outpost
=== CONT  TestAccELBV2LoadBalancerDataSource_tags_NullMap
=== CONT  TestAccELBV2LoadBalancerDataSource_basic
=== NAME  TestAccELBV2LoadBalancerDataSource_outpost
    load_balancer_data_source_test.go:105: skipping since no Outposts found
--- SKIP: TestAccELBV2LoadBalancerDataSource_outpost (5.18s)
--- PASS: TestAccELBV2LoadBalancerDataSource_nlbSecondaryIPAddresses (217.45s)
--- PASS: TestAccELBV2LoadBalancerDataSource_tags_EmptyMap (221.76s)
--- PASS: TestAccELBV2LoadBalancerDataSource_tags_DefaultTags_nonOverlapping (230.77s)
--- PASS: TestAccELBV2LoadBalancerDataSource_backwardsCompatibility (236.84s)
--- PASS: TestAccELBV2LoadBalancerDataSource_basic (239.74s)
--- PASS: TestAccELBV2LoadBalancerDataSource_tags_IgnoreTags_Overlap_DefaultTag (240.96s)
--- PASS: TestAccELBV2LoadBalancerDataSource_tags_IgnoreTags_Overlap_ResourceTag (243.50s)
--- PASS: TestAccELBV2LoadBalancerDataSource_tags_NullMap (248.31s)
--- PASS: TestAccELBV2LoadBalancerDataSource_tags (250.97s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      255.294s


```
