### PR TITLE
identitytests: include `ExistingResource_NoRefresh` case in serialized tests

### DIFF
--- a/internal/generate/identitytests/resource_test.go.gtpl
+++ b/internal/generate/identitytests/resource_test.go.gtpl
@@ -227,8 +227,9 @@ func {{ template "testname" . }}_IdentitySerial(t *testing.T) {
 	{{- end }}
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    {{ template "testname" . }}_Identity_Basic,
-		"ExistingResource": {{ template "testname" . }}_Identity_ExistingResource,
+		acctest.CtBasic:             {{ template "testname" . }}_Identity_Basic,
+		"ExistingResource":          {{ template "testname" . }}_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": {{ template "testname" . }}_Identity_ExistingResource_NoRefresh_NoChange,
 		{{ if .GenerateRegionOverrideTest -}}
 			"RegionOverride": {{ template "testname" . }}_Identity_RegionOverride,
 		{{ end -}}

--- a/internal/service/appfabric/app_bundle_identity_gen_test.go
+++ b/internal/service/appfabric/app_bundle_identity_gen_test.go
@@ -24,9 +24,10 @@ func testAccAppFabricAppBundle_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccAppFabricAppBundle_Identity_Basic,
-		"ExistingResource": testAccAppFabricAppBundle_Identity_ExistingResource,
-		"RegionOverride":   testAccAppFabricAppBundle_Identity_RegionOverride,
+		acctest.CtBasic:             testAccAppFabricAppBundle_Identity_Basic,
+		"ExistingResource":          testAccAppFabricAppBundle_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccAppFabricAppBundle_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccAppFabricAppBundle_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/auditmanager/account_registration_identity_gen_test.go
+++ b/internal/service/auditmanager/account_registration_identity_gen_test.go
@@ -23,9 +23,10 @@ func testAccAuditManagerAccountRegistration_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccAuditManagerAccountRegistration_Identity_Basic,
-		"ExistingResource": testAccAuditManagerAccountRegistration_Identity_ExistingResource,
-		"RegionOverride":   testAccAuditManagerAccountRegistration_Identity_RegionOverride,
+		acctest.CtBasic:             testAccAuditManagerAccountRegistration_Identity_Basic,
+		"ExistingResource":          testAccAuditManagerAccountRegistration_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccAuditManagerAccountRegistration_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccAuditManagerAccountRegistration_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/backup/region_settings_identity_gen_test.go
+++ b/internal/service/backup/region_settings_identity_gen_test.go
@@ -24,9 +24,10 @@ func testAccBackupRegionSettings_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccBackupRegionSettings_Identity_Basic,
-		"ExistingResource": testAccBackupRegionSettings_Identity_ExistingResource,
-		"RegionOverride":   testAccBackupRegionSettings_Identity_RegionOverride,
+		acctest.CtBasic:             testAccBackupRegionSettings_Identity_Basic,
+		"ExistingResource":          testAccBackupRegionSettings_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccBackupRegionSettings_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccBackupRegionSettings_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/bedrock/custom_model_identity_gen_test.go
+++ b/internal/service/bedrock/custom_model_identity_gen_test.go
@@ -24,9 +24,10 @@ func testAccBedrockCustomModel_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccBedrockCustomModel_Identity_Basic,
-		"ExistingResource": testAccBedrockCustomModel_Identity_ExistingResource,
-		"RegionOverride":   testAccBedrockCustomModel_Identity_RegionOverride,
+		acctest.CtBasic:             testAccBedrockCustomModel_Identity_Basic,
+		"ExistingResource":          testAccBedrockCustomModel_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccBedrockCustomModel_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccBedrockCustomModel_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/bedrock/model_invocation_logging_configuration_identity_gen_test.go
+++ b/internal/service/bedrock/model_invocation_logging_configuration_identity_gen_test.go
@@ -24,9 +24,10 @@ func testAccBedrockModelInvocationLoggingConfiguration_IdentitySerial(t *testing
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccBedrockModelInvocationLoggingConfiguration_Identity_Basic,
-		"ExistingResource": testAccBedrockModelInvocationLoggingConfiguration_Identity_ExistingResource,
-		"RegionOverride":   testAccBedrockModelInvocationLoggingConfiguration_Identity_RegionOverride,
+		acctest.CtBasic:             testAccBedrockModelInvocationLoggingConfiguration_Identity_Basic,
+		"ExistingResource":          testAccBedrockModelInvocationLoggingConfiguration_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccBedrockModelInvocationLoggingConfiguration_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccBedrockModelInvocationLoggingConfiguration_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/cloudtrail/trail_identity_gen_test.go
+++ b/internal/service/cloudtrail/trail_identity_gen_test.go
@@ -24,9 +24,10 @@ func testAccCloudTrailTrail_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccCloudTrailTrail_Identity_Basic,
-		"ExistingResource": testAccCloudTrailTrail_Identity_ExistingResource,
-		"RegionOverride":   testAccCloudTrailTrail_Identity_RegionOverride,
+		acctest.CtBasic:             testAccCloudTrailTrail_Identity_Basic,
+		"ExistingResource":          testAccCloudTrailTrail_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccCloudTrailTrail_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccCloudTrailTrail_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/codeartifact/domain_identity_gen_test.go
+++ b/internal/service/codeartifact/domain_identity_gen_test.go
@@ -23,9 +23,10 @@ func testAccCodeArtifactDomain_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccCodeArtifactDomain_Identity_Basic,
-		"ExistingResource": testAccCodeArtifactDomain_Identity_ExistingResource,
-		"RegionOverride":   testAccCodeArtifactDomain_Identity_RegionOverride,
+		acctest.CtBasic:             testAccCodeArtifactDomain_Identity_Basic,
+		"ExistingResource":          testAccCodeArtifactDomain_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccCodeArtifactDomain_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccCodeArtifactDomain_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/codeartifact/domain_permissions_policy_identity_gen_test.go
+++ b/internal/service/codeartifact/domain_permissions_policy_identity_gen_test.go
@@ -23,9 +23,10 @@ func testAccCodeArtifactDomainPermissionsPolicy_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccCodeArtifactDomainPermissionsPolicy_Identity_Basic,
-		"ExistingResource": testAccCodeArtifactDomainPermissionsPolicy_Identity_ExistingResource,
-		"RegionOverride":   testAccCodeArtifactDomainPermissionsPolicy_Identity_RegionOverride,
+		acctest.CtBasic:             testAccCodeArtifactDomainPermissionsPolicy_Identity_Basic,
+		"ExistingResource":          testAccCodeArtifactDomainPermissionsPolicy_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccCodeArtifactDomainPermissionsPolicy_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccCodeArtifactDomainPermissionsPolicy_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/codeartifact/repository_identity_gen_test.go
+++ b/internal/service/codeartifact/repository_identity_gen_test.go
@@ -23,9 +23,10 @@ func testAccCodeArtifactRepository_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccCodeArtifactRepository_Identity_Basic,
-		"ExistingResource": testAccCodeArtifactRepository_Identity_ExistingResource,
-		"RegionOverride":   testAccCodeArtifactRepository_Identity_RegionOverride,
+		acctest.CtBasic:             testAccCodeArtifactRepository_Identity_Basic,
+		"ExistingResource":          testAccCodeArtifactRepository_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccCodeArtifactRepository_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccCodeArtifactRepository_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/codeartifact/repository_permissions_policy_identity_gen_test.go
+++ b/internal/service/codeartifact/repository_permissions_policy_identity_gen_test.go
@@ -23,9 +23,10 @@ func testAccCodeArtifactRepositoryPermissionsPolicy_IdentitySerial(t *testing.T)
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccCodeArtifactRepositoryPermissionsPolicy_Identity_Basic,
-		"ExistingResource": testAccCodeArtifactRepositoryPermissionsPolicy_Identity_ExistingResource,
-		"RegionOverride":   testAccCodeArtifactRepositoryPermissionsPolicy_Identity_RegionOverride,
+		acctest.CtBasic:             testAccCodeArtifactRepositoryPermissionsPolicy_Identity_Basic,
+		"ExistingResource":          testAccCodeArtifactRepositoryPermissionsPolicy_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccCodeArtifactRepositoryPermissionsPolicy_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccCodeArtifactRepositoryPermissionsPolicy_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/connect/instance_identity_gen_test.go
+++ b/internal/service/connect/instance_identity_gen_test.go
@@ -24,9 +24,10 @@ func testAccConnectInstance_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccConnectInstance_Identity_Basic,
-		"ExistingResource": testAccConnectInstance_Identity_ExistingResource,
-		"RegionOverride":   testAccConnectInstance_Identity_RegionOverride,
+		acctest.CtBasic:             testAccConnectInstance_Identity_Basic,
+		"ExistingResource":          testAccConnectInstance_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccConnectInstance_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccConnectInstance_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/connect/phone_number_identity_gen_test.go
+++ b/internal/service/connect/phone_number_identity_gen_test.go
@@ -24,9 +24,10 @@ func testAccConnectPhoneNumber_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccConnectPhoneNumber_Identity_Basic,
-		"ExistingResource": testAccConnectPhoneNumber_Identity_ExistingResource,
-		"RegionOverride":   testAccConnectPhoneNumber_Identity_RegionOverride,
+		acctest.CtBasic:             testAccConnectPhoneNumber_Identity_Basic,
+		"ExistingResource":          testAccConnectPhoneNumber_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccConnectPhoneNumber_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccConnectPhoneNumber_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/devopsguru/event_sources_config_identity_gen_test.go
+++ b/internal/service/devopsguru/event_sources_config_identity_gen_test.go
@@ -24,9 +24,10 @@ func testAccDevOpsGuruEventSourcesConfig_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccDevOpsGuruEventSourcesConfig_Identity_Basic,
-		"ExistingResource": testAccDevOpsGuruEventSourcesConfig_Identity_ExistingResource,
-		"RegionOverride":   testAccDevOpsGuruEventSourcesConfig_Identity_RegionOverride,
+		acctest.CtBasic:             testAccDevOpsGuruEventSourcesConfig_Identity_Basic,
+		"ExistingResource":          testAccDevOpsGuruEventSourcesConfig_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccDevOpsGuruEventSourcesConfig_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccDevOpsGuruEventSourcesConfig_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/devopsguru/service_integration_identity_gen_test.go
+++ b/internal/service/devopsguru/service_integration_identity_gen_test.go
@@ -23,9 +23,10 @@ func testAccDevOpsGuruServiceIntegration_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccDevOpsGuruServiceIntegration_Identity_Basic,
-		"ExistingResource": testAccDevOpsGuruServiceIntegration_Identity_ExistingResource,
-		"RegionOverride":   testAccDevOpsGuruServiceIntegration_Identity_RegionOverride,
+		acctest.CtBasic:             testAccDevOpsGuruServiceIntegration_Identity_Basic,
+		"ExistingResource":          testAccDevOpsGuruServiceIntegration_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccDevOpsGuruServiceIntegration_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccDevOpsGuruServiceIntegration_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/ec2/ebs_snapshot_block_public_access_identity_gen_test.go
+++ b/internal/service/ec2/ebs_snapshot_block_public_access_identity_gen_test.go
@@ -23,9 +23,10 @@ func testAccEC2EBSEBSSnapshotBlockPublicAccess_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccEC2EBSEBSSnapshotBlockPublicAccess_Identity_Basic,
-		"ExistingResource": testAccEC2EBSEBSSnapshotBlockPublicAccess_Identity_ExistingResource,
-		"RegionOverride":   testAccEC2EBSEBSSnapshotBlockPublicAccess_Identity_RegionOverride,
+		acctest.CtBasic:             testAccEC2EBSEBSSnapshotBlockPublicAccess_Identity_Basic,
+		"ExistingResource":          testAccEC2EBSEBSSnapshotBlockPublicAccess_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccEC2EBSEBSSnapshotBlockPublicAccess_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccEC2EBSEBSSnapshotBlockPublicAccess_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/ec2/ec2_image_block_public_access_identity_gen_test.go
+++ b/internal/service/ec2/ec2_image_block_public_access_identity_gen_test.go
@@ -22,8 +22,9 @@ func testAccEC2ImageBlockPublicAccess_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccEC2ImageBlockPublicAccess_Identity_Basic,
-		"ExistingResource": testAccEC2ImageBlockPublicAccess_Identity_ExistingResource,
+		acctest.CtBasic:             testAccEC2ImageBlockPublicAccess_Identity_Basic,
+		"ExistingResource":          testAccEC2ImageBlockPublicAccess_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccEC2ImageBlockPublicAccess_Identity_ExistingResource_NoRefresh_NoChange,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/ec2/ec2_serial_console_access_identity_gen_test.go
+++ b/internal/service/ec2/ec2_serial_console_access_identity_gen_test.go
@@ -22,8 +22,9 @@ func testAccEC2SerialConsoleAccess_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccEC2SerialConsoleAccess_Identity_Basic,
-		"ExistingResource": testAccEC2SerialConsoleAccess_Identity_ExistingResource,
+		acctest.CtBasic:             testAccEC2SerialConsoleAccess_Identity_Basic,
+		"ExistingResource":          testAccEC2SerialConsoleAccess_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccEC2SerialConsoleAccess_Identity_ExistingResource_NoRefresh_NoChange,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/glue/resource_policy_identity_gen_test.go
+++ b/internal/service/glue/resource_policy_identity_gen_test.go
@@ -23,9 +23,10 @@ func testAccGlueResourcePolicy_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccGlueResourcePolicy_Identity_Basic,
-		"ExistingResource": testAccGlueResourcePolicy_Identity_ExistingResource,
-		"RegionOverride":   testAccGlueResourcePolicy_Identity_RegionOverride,
+		acctest.CtBasic:             testAccGlueResourcePolicy_Identity_Basic,
+		"ExistingResource":          testAccGlueResourcePolicy_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccGlueResourcePolicy_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccGlueResourcePolicy_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/iot/event_configurations_identity_gen_test.go
+++ b/internal/service/iot/event_configurations_identity_gen_test.go
@@ -23,9 +23,10 @@ func testAccIoTEventConfigurations_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccIoTEventConfigurations_Identity_Basic,
-		"ExistingResource": testAccIoTEventConfigurations_Identity_ExistingResource,
-		"RegionOverride":   testAccIoTEventConfigurations_Identity_RegionOverride,
+		acctest.CtBasic:             testAccIoTEventConfigurations_Identity_Basic,
+		"ExistingResource":          testAccIoTEventConfigurations_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccIoTEventConfigurations_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccIoTEventConfigurations_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/iot/indexing_configuration_identity_gen_test.go
+++ b/internal/service/iot/indexing_configuration_identity_gen_test.go
@@ -23,9 +23,10 @@ func testAccIoTIndexingConfiguration_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccIoTIndexingConfiguration_Identity_Basic,
-		"ExistingResource": testAccIoTIndexingConfiguration_Identity_ExistingResource,
-		"RegionOverride":   testAccIoTIndexingConfiguration_Identity_RegionOverride,
+		acctest.CtBasic:             testAccIoTIndexingConfiguration_Identity_Basic,
+		"ExistingResource":          testAccIoTIndexingConfiguration_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccIoTIndexingConfiguration_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccIoTIndexingConfiguration_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/iot/logging_options_identity_gen_test.go
+++ b/internal/service/iot/logging_options_identity_gen_test.go
@@ -24,9 +24,10 @@ func testAccIoTLoggingOptions_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccIoTLoggingOptions_Identity_Basic,
-		"ExistingResource": testAccIoTLoggingOptions_Identity_ExistingResource,
-		"RegionOverride":   testAccIoTLoggingOptions_Identity_RegionOverride,
+		acctest.CtBasic:             testAccIoTLoggingOptions_Identity_Basic,
+		"ExistingResource":          testAccIoTLoggingOptions_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccIoTLoggingOptions_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccIoTLoggingOptions_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/ivs/playback_key_pair_identity_gen_test.go
+++ b/internal/service/ivs/playback_key_pair_identity_gen_test.go
@@ -23,9 +23,10 @@ func testAccIVSPlaybackKeyPair_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccIVSPlaybackKeyPair_Identity_Basic,
-		"ExistingResource": testAccIVSPlaybackKeyPair_Identity_ExistingResource,
-		"RegionOverride":   testAccIVSPlaybackKeyPair_Identity_RegionOverride,
+		acctest.CtBasic:             testAccIVSPlaybackKeyPair_Identity_Basic,
+		"ExistingResource":          testAccIVSPlaybackKeyPair_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccIVSPlaybackKeyPair_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccIVSPlaybackKeyPair_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/macie2/classification_export_configuration_identity_gen_test.go
+++ b/internal/service/macie2/classification_export_configuration_identity_gen_test.go
@@ -24,9 +24,10 @@ func testAccMacie2ClassificationExportConfiguration_IdentitySerial(t *testing.T)
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccMacie2ClassificationExportConfiguration_Identity_Basic,
-		"ExistingResource": testAccMacie2ClassificationExportConfiguration_Identity_ExistingResource,
-		"RegionOverride":   testAccMacie2ClassificationExportConfiguration_Identity_RegionOverride,
+		acctest.CtBasic:             testAccMacie2ClassificationExportConfiguration_Identity_Basic,
+		"ExistingResource":          testAccMacie2ClassificationExportConfiguration_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccMacie2ClassificationExportConfiguration_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccMacie2ClassificationExportConfiguration_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/organizations/organization_identity_gen_test.go
+++ b/internal/service/organizations/organization_identity_gen_test.go
@@ -23,8 +23,9 @@ func testAccOrganizationsOrganization_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccOrganizationsOrganization_Identity_Basic,
-		"ExistingResource": testAccOrganizationsOrganization_Identity_ExistingResource,
+		acctest.CtBasic:             testAccOrganizationsOrganization_Identity_Basic,
+		"ExistingResource":          testAccOrganizationsOrganization_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccOrganizationsOrganization_Identity_ExistingResource_NoRefresh_NoChange,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/organizations/organizational_unit_identity_gen_test.go
+++ b/internal/service/organizations/organizational_unit_identity_gen_test.go
@@ -24,8 +24,9 @@ func testAccOrganizationsOrganizationalUnit_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccOrganizationsOrganizationalUnit_Identity_Basic,
-		"ExistingResource": testAccOrganizationsOrganizationalUnit_Identity_ExistingResource,
+		acctest.CtBasic:             testAccOrganizationsOrganizationalUnit_Identity_Basic,
+		"ExistingResource":          testAccOrganizationsOrganizationalUnit_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccOrganizationsOrganizationalUnit_Identity_ExistingResource_NoRefresh_NoChange,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/organizations/policy_attachment_identity_gen_test.go
+++ b/internal/service/organizations/policy_attachment_identity_gen_test.go
@@ -23,8 +23,9 @@ func testAccOrganizationsPolicyAttachment_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccOrganizationsPolicyAttachment_Identity_Basic,
-		"ExistingResource": testAccOrganizationsPolicyAttachment_Identity_ExistingResource,
+		acctest.CtBasic:             testAccOrganizationsPolicyAttachment_Identity_Basic,
+		"ExistingResource":          testAccOrganizationsPolicyAttachment_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccOrganizationsPolicyAttachment_Identity_ExistingResource_NoRefresh_NoChange,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/organizations/policy_identity_gen_test.go
+++ b/internal/service/organizations/policy_identity_gen_test.go
@@ -24,8 +24,9 @@ func testAccOrganizationsPolicy_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccOrganizationsPolicy_Identity_Basic,
-		"ExistingResource": testAccOrganizationsPolicy_Identity_ExistingResource,
+		acctest.CtBasic:             testAccOrganizationsPolicy_Identity_Basic,
+		"ExistingResource":          testAccOrganizationsPolicy_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccOrganizationsPolicy_Identity_ExistingResource_NoRefresh_NoChange,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/organizations/resource_policy_identity_gen_test.go
+++ b/internal/service/organizations/resource_policy_identity_gen_test.go
@@ -24,8 +24,9 @@ func testAccOrganizationsResourcePolicy_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccOrganizationsResourcePolicy_Identity_Basic,
-		"ExistingResource": testAccOrganizationsResourcePolicy_Identity_ExistingResource,
+		acctest.CtBasic:             testAccOrganizationsResourcePolicy_Identity_Basic,
+		"ExistingResource":          testAccOrganizationsResourcePolicy_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccOrganizationsResourcePolicy_Identity_ExistingResource_NoRefresh_NoChange,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/rds/certificate_identity_gen_test.go
+++ b/internal/service/rds/certificate_identity_gen_test.go
@@ -24,9 +24,10 @@ func testAccRDSCertificate_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccRDSCertificate_Identity_Basic,
-		"ExistingResource": testAccRDSCertificate_Identity_ExistingResource,
-		"RegionOverride":   testAccRDSCertificate_Identity_RegionOverride,
+		acctest.CtBasic:             testAccRDSCertificate_Identity_Basic,
+		"ExistingResource":          testAccRDSCertificate_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccRDSCertificate_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccRDSCertificate_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/resourceexplorer2/index_identity_gen_test.go
+++ b/internal/service/resourceexplorer2/index_identity_gen_test.go
@@ -22,9 +22,10 @@ func testAccResourceExplorer2Index_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccResourceExplorer2Index_Identity_Basic,
-		"ExistingResource": testAccResourceExplorer2Index_Identity_ExistingResource,
-		"RegionOverride":   testAccResourceExplorer2Index_Identity_RegionOverride,
+		acctest.CtBasic:             testAccResourceExplorer2Index_Identity_Basic,
+		"ExistingResource":          testAccResourceExplorer2Index_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccResourceExplorer2Index_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccResourceExplorer2Index_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/resourceexplorer2/view_identity_gen_test.go
+++ b/internal/service/resourceexplorer2/view_identity_gen_test.go
@@ -24,9 +24,10 @@ func testAccResourceExplorer2View_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccResourceExplorer2View_Identity_Basic,
-		"ExistingResource": testAccResourceExplorer2View_Identity_ExistingResource,
-		"RegionOverride":   testAccResourceExplorer2View_Identity_RegionOverride,
+		acctest.CtBasic:             testAccResourceExplorer2View_Identity_Basic,
+		"ExistingResource":          testAccResourceExplorer2View_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccResourceExplorer2View_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccResourceExplorer2View_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/s3control/account_public_access_block_identity_gen_test.go
+++ b/internal/service/s3control/account_public_access_block_identity_gen_test.go
@@ -23,8 +23,9 @@ func testAccS3ControlAccountPublicAccessBlock_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccS3ControlAccountPublicAccessBlock_Identity_Basic,
-		"ExistingResource": testAccS3ControlAccountPublicAccessBlock_Identity_ExistingResource,
+		acctest.CtBasic:             testAccS3ControlAccountPublicAccessBlock_Identity_Basic,
+		"ExistingResource":          testAccS3ControlAccountPublicAccessBlock_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccS3ControlAccountPublicAccessBlock_Identity_ExistingResource_NoRefresh_NoChange,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/sagemaker/servicecatalog_portfolio_status_identity_gen_test.go
+++ b/internal/service/sagemaker/servicecatalog_portfolio_status_identity_gen_test.go
@@ -24,9 +24,10 @@ func testAccSageMakerServicecatalogPortfolioStatus_IdentitySerial(t *testing.T) 
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccSageMakerServicecatalogPortfolioStatus_Identity_Basic,
-		"ExistingResource": testAccSageMakerServicecatalogPortfolioStatus_Identity_ExistingResource,
-		"RegionOverride":   testAccSageMakerServicecatalogPortfolioStatus_Identity_RegionOverride,
+		acctest.CtBasic:             testAccSageMakerServicecatalogPortfolioStatus_Identity_Basic,
+		"ExistingResource":          testAccSageMakerServicecatalogPortfolioStatus_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccSageMakerServicecatalogPortfolioStatus_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccSageMakerServicecatalogPortfolioStatus_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/sagemaker/user_profile_identity_gen_test.go
+++ b/internal/service/sagemaker/user_profile_identity_gen_test.go
@@ -24,9 +24,10 @@ func testAccSageMakerUserProfile_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccSageMakerUserProfile_Identity_Basic,
-		"ExistingResource": testAccSageMakerUserProfile_Identity_ExistingResource,
-		"RegionOverride":   testAccSageMakerUserProfile_Identity_RegionOverride,
+		acctest.CtBasic:             testAccSageMakerUserProfile_Identity_Basic,
+		"ExistingResource":          testAccSageMakerUserProfile_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccSageMakerUserProfile_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccSageMakerUserProfile_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/securityhub/automation_rule_identity_gen_test.go
+++ b/internal/service/securityhub/automation_rule_identity_gen_test.go
@@ -24,9 +24,10 @@ func testAccSecurityHubAutomationRule_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccSecurityHubAutomationRule_Identity_Basic,
-		"ExistingResource": testAccSecurityHubAutomationRule_Identity_ExistingResource,
-		"RegionOverride":   testAccSecurityHubAutomationRule_Identity_RegionOverride,
+		acctest.CtBasic:             testAccSecurityHubAutomationRule_Identity_Basic,
+		"ExistingResource":          testAccSecurityHubAutomationRule_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccSecurityHubAutomationRule_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccSecurityHubAutomationRule_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/ssmcontacts/contact_channel_identity_gen_test.go
+++ b/internal/service/ssmcontacts/contact_channel_identity_gen_test.go
@@ -23,8 +23,9 @@ func testAccSSMContactsContactChannel_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccSSMContactsContactChannel_Identity_Basic,
-		"ExistingResource": testAccSSMContactsContactChannel_Identity_ExistingResource,
+		acctest.CtBasic:             testAccSSMContactsContactChannel_Identity_Basic,
+		"ExistingResource":          testAccSSMContactsContactChannel_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccSSMContactsContactChannel_Identity_ExistingResource_NoRefresh_NoChange,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/ssmcontacts/rotation_identity_gen_test.go
+++ b/internal/service/ssmcontacts/rotation_identity_gen_test.go
@@ -23,8 +23,9 @@ func testAccSSMContactsRotation_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccSSMContactsRotation_Identity_Basic,
-		"ExistingResource": testAccSSMContactsRotation_Identity_ExistingResource,
+		acctest.CtBasic:             testAccSSMContactsRotation_Identity_Basic,
+		"ExistingResource":          testAccSSMContactsRotation_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccSSMContactsRotation_Identity_ExistingResource_NoRefresh_NoChange,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/ssmcontacts/ssmcontacts_test.go
+++ b/internal/service/ssmcontacts/ssmcontacts_test.go
@@ -35,8 +35,6 @@ func TestAccSSMContacts_serial(t *testing.T) {
 			acctest.CtName:       testAccContactChannel_name,
 			"type":               testAccContactChannel_type,
 			"identity":           testAccSSMContactsContactChannel_IdentitySerial,
-			// TODO: this should be included in the generated _IdentitySerial
-			"identityExistingResourceNoRefresh": testAccSSMContactsContactChannel_Identity_ExistingResource_NoRefresh_NoChange,
 		},
 		"ContactChannelDataSource": {
 			acctest.CtBasic: testAccContactChannelDataSource_basic,
@@ -56,17 +54,15 @@ func TestAccSSMContacts_serial(t *testing.T) {
 			"channelTargetInfo": testAccPlanDataSource_channelTargetInfo,
 		},
 		"RotationResource": {
-			acctest.CtBasic:      testAccRotation_basic,
-			acctest.CtDisappears: testAccRotation_disappears,
-			"update":             testAccRotation_updateRequiredFields,
-			"startTime":          testAccRotation_startTime,
-			"contactIds":         testAccRotation_contactIds,
-			"recurrence":         testAccRotation_recurrence,
-			"tags":               testAccSSMContactsRotation_tagsSerial,
-			"identity":           testAccSSMContactsRotation_IdentitySerial,
-			// TODO: these should be included in the generated _IdentitySerial
-			"identityExistingResourceNoRefresh": testAccSSMContactsRotation_Identity_ExistingResource_NoRefresh_NoChange,
-			"identityRegionOverride":            testAccSSMContactsRotation_Identity_RegionOverride,
+			acctest.CtBasic:          testAccRotation_basic,
+			acctest.CtDisappears:     testAccRotation_disappears,
+			"update":                 testAccRotation_updateRequiredFields,
+			"startTime":              testAccRotation_startTime,
+			"contactIds":             testAccRotation_contactIds,
+			"recurrence":             testAccRotation_recurrence,
+			"tags":                   testAccSSMContactsRotation_tagsSerial,
+			"identity":               testAccSSMContactsRotation_IdentitySerial,
+			"identityRegionOverride": testAccSSMContactsRotation_Identity_RegionOverride,
 		},
 		"RotationDataSource": {
 			acctest.CtBasic:   testAccRotationDataSource_basic,

--- a/internal/service/ssoadmin/trusted_token_issuer_identity_gen_test.go
+++ b/internal/service/ssoadmin/trusted_token_issuer_identity_gen_test.go
@@ -24,9 +24,10 @@ func testAccSSOAdminTrustedTokenIssuer_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccSSOAdminTrustedTokenIssuer_Identity_Basic,
-		"ExistingResource": testAccSSOAdminTrustedTokenIssuer_Identity_ExistingResource,
-		"RegionOverride":   testAccSSOAdminTrustedTokenIssuer_Identity_RegionOverride,
+		acctest.CtBasic:             testAccSSOAdminTrustedTokenIssuer_Identity_Basic,
+		"ExistingResource":          testAccSSOAdminTrustedTokenIssuer_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccSSOAdminTrustedTokenIssuer_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccSSOAdminTrustedTokenIssuer_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/xray/encryption_config_identity_gen_test.go
+++ b/internal/service/xray/encryption_config_identity_gen_test.go
@@ -24,9 +24,10 @@ func testAccXRayEncryptionConfig_IdentitySerial(t *testing.T) {
 	t.Helper()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:    testAccXRayEncryptionConfig_Identity_Basic,
-		"ExistingResource": testAccXRayEncryptionConfig_Identity_ExistingResource,
-		"RegionOverride":   testAccXRayEncryptionConfig_Identity_RegionOverride,
+		acctest.CtBasic:             testAccXRayEncryptionConfig_Identity_Basic,
+		"ExistingResource":          testAccXRayEncryptionConfig_Identity_ExistingResource,
+		"ExistingResourceNoRefresh": testAccXRayEncryptionConfig_Identity_ExistingResource_NoRefresh_NoChange,
+		"RegionOverride":            testAccXRayEncryptionConfig_Identity_RegionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Includes the recently added `_ExistingResource_NoRefresh_NoChange` test case in subtests when generated identity tests are serialized.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #44392
Relates #44393
Relates #44395
Realtes #44369