### PR TITLE
r/aws_cloudwatch_event_rule: Do not retry on `LimitExceededException`

### DIFF
--- a/internal/service/events/service_package.go
+++ b/internal/service/events/service_package.go
@@ -1,0 +1,41 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package events
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
+)
+
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*eventbridge.Options) {
+	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
+
+	return []func(*eventbridge.Options){
+		func(o *eventbridge.Options) {
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					if errs.IsAErrorMessageContains[*awstypes.LimitExceededException](err, "The requested resource exceeds the maximum number allowed") {
+						return aws.FalseTernary
+					}
+					return aws.UnknownTernary // Delegate to configured Retryer.
+				}),
+			}
+			// Include go-vcr retryable to prevent generated client retryer from being overridden
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, vcr.InteractionNotFoundRetryableFunc)
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
+		},
+	}
+}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

N/A

### Description
This PR updates the EventBridge options to prevent infinite retries on `LimitExceededException` which indicates that no more resoures can be created. There can be [maximum 100 or 300 rules per region by default](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-quota.html) (depending on the region).

### Relations
Closes #44477.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
