### PR TITLE
[BUG] Suppress diff for lambda target group attributes 

### DIFF
--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -258,10 +258,11 @@ func resourceTargetGroup() *schema.Resource {
 				),
 			},
 			"stickiness": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
+				Type:             schema.TypeList,
+				Optional:         true,
+				Computed:         true,
+				MaxItems:         1,
+				DiffSuppressFunc: suppressIfTargetType(awstypes.TargetTypeEnumLambda),
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cookie_duration": {
@@ -297,9 +298,10 @@ func resourceTargetGroup() *schema.Resource {
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"target_failover": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
+				Type:             schema.TypeList,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: suppressIfTargetType(awstypes.TargetTypeEnumLambda),
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"on_deregistration": {
@@ -316,10 +318,11 @@ func resourceTargetGroup() *schema.Resource {
 				},
 			},
 			"target_group_health": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
+				Type:             schema.TypeList,
+				Optional:         true,
+				Computed:         true,
+				MaxItems:         1,
+				DiffSuppressFunc: suppressIfTargetType(awstypes.TargetTypeEnumLambda),
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"dns_failover": {


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to security controls.

### Description

Fixes perpetual diff issue for Lambda target groups with stickiness, target_failover, and target_group_health attributes.

Lambda target type only supports `lambda.multi_value_headers.enabled` attribute. AWS API silently ignores stickiness, target_failover, and target_group_health configuration for Lambda target groups, but Terraform was detecting them as diffs. Detecting diffs in the plan for changes that are not actually applied is undesirable.

This change adds `DiffSuppressFunc` to these three attributes to suppress diffs when `target_type` is lambda, using the existing `suppressIfTargetType()` helper function.

#### Before
```
  ~ update in-place
...
  ~ resource "aws_lb_target_group" "test" {
...
      ~ stickiness {
          + cookie_duration = 86400
          + enabled         = false
          + type            = "lb_cookie"
        }

      ~ target_failover {
          + on_deregistration = "no_rebalance"
          + on_unhealthy      = "no_rebalance"
        }

      ~ target_group_health {
          ~ dns_failover {
              + minimum_healthy_targets_count      = "off"
              + minimum_healthy_targets_percentage = "off"
            }
          ~ unhealthy_state_routing {
              + minimum_healthy_targets_count      = 1
              + minimum_healthy_targets_percentage = "off"
            }
        }
...
Plan: 0 to add, 1 to change, 0 to destroy.
```

#### After
```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes
are needed.
```

### Relations

None

### References

> The following target group attributes are supported if the target group type is instance or ip:
(omitted)

> The following target group attribute is supported if the target group type is lambda:
(omitted)

- [AWS ELBv2 Target Group Attributes Documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#target-group-attributes)