### PR TITLE
Update EBS gp3 throughput maximum from 1000 to 2000 MiB/s

### DIFF
--- a/internal/service/ec2/ebs_volume.go
+++ b/internal/service/ec2/ebs_volume.go
@@ -114,7 +114,7 @@ func resourceEBSVolume() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.IntBetween(125, 1000),
+				ValidateFunc: validation.IntBetween(125, 2000),
 			},
 			names.AttrType: {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Updates the throughput validation for EBS gp3 volumes to reflect AWS's new maximum of 2000 MiB/s (increased from 1000 MiB/s).

Reference: https://aws.amazon.com/ebs/general-purpose/

Changes:
- Updated validation.IntBetween(125, 1000) to validation.IntBetween(125, 2000) in internal/service/ec2/ebs_volume.go