### PR TITLE
[Enhancement]: aws_networkfirewall_logging_configuration: Add `enable_monitoring_dashboard` argument

### DIFF
--- a/internal/service/networkfirewall/logging_configuration_test.go
+++ b/internal/service/networkfirewall/logging_configuration_test.go
@@ -36,6 +36,7 @@ func TestAccNetworkFirewallLoggingConfiguration_CloudWatchLogDestination_logGrou
 				Config: testAccLoggingConfigurationConfig_cloudWatch(logGroupName, rName, string(awstypes.LogDestinationTypeCloudwatchLogs), string(awstypes.LogTypeFlow)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLoggingConfigurationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_monitoring_dashboard", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.log_destination_config.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "logging_configuration.0.log_destination_config.*", map[string]string{
@@ -49,6 +50,7 @@ func TestAccNetworkFirewallLoggingConfiguration_CloudWatchLogDestination_logGrou
 				Config: testAccLoggingConfigurationConfig_cloudWatch(updatedLogGroupName, rName, string(awstypes.LogDestinationTypeCloudwatchLogs), string(awstypes.LogTypeFlow)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLoggingConfigurationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_monitoring_dashboard", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.log_destination_config.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "logging_configuration.0.log_destination_config.*", map[string]string{
@@ -62,6 +64,7 @@ func TestAccNetworkFirewallLoggingConfiguration_CloudWatchLogDestination_logGrou
 				Config: testAccLoggingConfigurationConfig_cloudWatch(updatedLogGroupName, rName, string(awstypes.LogDestinationTypeCloudwatchLogs), string(awstypes.LogTypeTls)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLoggingConfigurationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_monitoring_dashboard", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.log_destination_config.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "logging_configuration.0.log_destination_config.*", map[string]string{
@@ -742,6 +745,115 @@ func TestAccNetworkFirewallLoggingConfiguration_updateToSingleTLSTypeLogDestinat
 	})
 }
 
+func TestAccNetworkFirewallLoggingConfiguration_enableMonitoringDashboard(t *testing.T) {
+	ctx := acctest.Context(t)
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	logGroupName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_networkfirewall_logging_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkFirewallServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLoggingConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingConfigurationConfig_s3AndCloudWatchEnableMonitoringDashboard(bucketName, logGroupName, rName, string(awstypes.LogTypeAlert), string(awstypes.LogTypeFlow), true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoggingConfigurationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_monitoring_dashboard", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.log_destination_config.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "logging_configuration.0.log_destination_config.*", map[string]string{
+						"log_destination.%":        "1",
+						"log_destination.logGroup": logGroupName,
+						"log_destination_type":     string(awstypes.LogDestinationTypeCloudwatchLogs),
+						"log_type":                 string(awstypes.LogTypeFlow),
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "logging_configuration.0.log_destination_config.*", map[string]string{
+						"log_destination.%":          "1",
+						"log_destination.bucketName": bucketName,
+						"log_destination_type":       string(awstypes.LogDestinationTypeS3),
+						"log_type":                   string(awstypes.LogTypeAlert),
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Disable Monitoring Dashboard
+				Config: testAccLoggingConfigurationConfig_s3AndCloudWatchEnableMonitoringDashboard(bucketName, logGroupName, rName, string(awstypes.LogTypeAlert), string(awstypes.LogTypeFlow), false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoggingConfigurationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_monitoring_dashboard", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.log_destination_config.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "logging_configuration.0.log_destination_config.*", map[string]string{
+						"log_destination.%":        "1",
+						"log_destination.logGroup": logGroupName,
+						"log_destination_type":     string(awstypes.LogDestinationTypeCloudwatchLogs),
+						"log_type":                 string(awstypes.LogTypeFlow),
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "logging_configuration.0.log_destination_config.*", map[string]string{
+						"log_destination.%":          "1",
+						"log_destination.bucketName": bucketName,
+						"log_destination_type":       string(awstypes.LogDestinationTypeS3),
+						"log_type":                   string(awstypes.LogTypeAlert),
+					}),
+				),
+			},
+			{
+				// Re-Enable Monitoring Dashboard and change log types at the same time
+				Config: testAccLoggingConfigurationConfig_s3AndCloudWatchEnableMonitoringDashboard(bucketName, logGroupName, rName, string(awstypes.LogTypeTls), string(awstypes.LogTypeFlow), true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoggingConfigurationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_monitoring_dashboard", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.log_destination_config.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "logging_configuration.0.log_destination_config.*", map[string]string{
+						"log_destination.%":        "1",
+						"log_destination.logGroup": logGroupName,
+						"log_destination_type":     string(awstypes.LogDestinationTypeCloudwatchLogs),
+						"log_type":                 string(awstypes.LogTypeFlow),
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "logging_configuration.0.log_destination_config.*", map[string]string{
+						"log_destination.%":          "1",
+						"log_destination.bucketName": bucketName,
+						"log_destination_type":       string(awstypes.LogDestinationTypeS3),
+						"log_type":                   string(awstypes.LogTypeTls),
+					}),
+				),
+			},
+			{
+				// Omit enable_monitoring_dashboard (inherit previous value)
+				Config: testAccLoggingConfigurationConfig_s3AndCloudWatch(bucketName, logGroupName, rName, string(awstypes.LogTypeTls), string(awstypes.LogTypeFlow)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoggingConfigurationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_monitoring_dashboard", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.log_destination_config.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "logging_configuration.0.log_destination_config.*", map[string]string{
+						"log_destination.%":        "1",
+						"log_destination.logGroup": logGroupName,
+						"log_destination_type":     string(awstypes.LogDestinationTypeCloudwatchLogs),
+						"log_type":                 string(awstypes.LogTypeFlow),
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "logging_configuration.0.log_destination_config.*", map[string]string{
+						"log_destination.%":          "1",
+						"log_destination.bucketName": bucketName,
+						"log_destination_type":       string(awstypes.LogDestinationTypeS3),
+						"log_type":                   string(awstypes.LogTypeTls),
+					}),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNetworkFirewallLoggingConfiguration_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1150,4 +1262,36 @@ resource "aws_networkfirewall_logging_configuration" "test" {
   }
 }
 `, logTypeS3, logTypeCloudWatch))
+}
+
+func testAccLoggingConfigurationConfig_s3AndCloudWatchEnableMonitoringDashboard(bucketName, logGroupName, rName, logTypeS3, logTypeCloudWatch string, enableMonitoringDashboard bool) string {
+	return acctest.ConfigCompose(
+		testAccLoggingConfigurationConfig_base(rName),
+		testAccLoggingConfigurationConfig_baseS3Bucket(bucketName),
+		testAccLoggingConfigurationConfig_baseCloudWatch(logGroupName),
+		fmt.Sprintf(`
+resource "aws_networkfirewall_logging_configuration" "test" {
+  firewall_arn = aws_networkfirewall_firewall.test.arn
+  
+  enable_monitoring_dashboard = %[3]t
+
+  logging_configuration {
+    log_destination_config {
+      log_destination = {
+        bucketName = aws_s3_bucket.test.bucket
+      }
+      log_destination_type = "S3"
+      log_type             = %[1]q
+    }
+
+    log_destination_config {
+      log_destination = {
+        logGroup = aws_cloudwatch_log_group.test.name
+      }
+      log_destination_type = "CloudWatchLogs"
+      log_type             = %[2]q
+    }
+  }
+}
+`, logTypeS3, logTypeCloudWatch, enableMonitoringDashboard))
 }

--- a/website/docs/r/networkfirewall_logging_configuration.html.markdown
+++ b/website/docs/r/networkfirewall_logging_configuration.html.markdown
@@ -70,6 +70,7 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `firewall_arn` - (Required, Forces new resource) The Amazon Resource Name (ARN) of the Network Firewall firewall.
+* `enable_monitoring_dashboard` - (Optional) Whether to enable the detailed firewall monitoring dashboard on the firewall. Defaults to `false`.
 * `logging_configuration` - (Required) A configuration block describing how AWS Network Firewall performs logging for a firewall. See [Logging Configuration](#logging-configuration) below for details.
 
 ### Logging Configuration


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* Add `enable_monitoring_dashboard` argument to `aws_networkfirewall_logging_configuration`.
  * This argument is marked as `Computed` since the AWS API returns this even if it is not specified in the configuration. 
  * The `UpdateLoggingConfiguration` API accepts only one operation at a time. As the AWS Management Console does, first set `enable_monitoring_dashboard`, and then configure each `logging_configuration`.
  * When updating `enable_monitoring_dashboard`, the `UpdateLoggingConfiguration` API requires that no `logging_configuration` entries are set. Therefore, to update `enable_monitoring_dashboard`, first remove all `logging_configuration` entries, then change `enable_monitoring_dashboard`, and finally reapply the `logging_configuration`.




### Relations

Closes #44502

### References
https://docs.aws.amazon.com/ja_jp/network-firewall/latest/APIReference/API_UpdateLoggingConfiguration.html#networkfirewall-UpdateLoggingConfiguration-request-EnableMonitoringDashboard

### Output from Acceptance Testing
```console


```
