### PR TITLE
[Enhancement] aws_dms_endpoint: Add `mysql_settings` configuration block

### DIFF
--- a/.changelog/44516.txt
+++ b/.changelog/44516.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_dms_endpoint: Add `mysql_settings` configuration block
+```
+
+```release-note:enhancement
+data-source/aws_dms_endpoint: Add `mysql_settings` attribute
+```

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -998,7 +998,7 @@ func resourceEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta an
 				if d.HasChanges(
 					names.AttrUsername, names.AttrPassword, "server_name", names.AttrPort, names.AttrDatabaseName,
 					"secrets_manager_access_role_arn", "secrets_manager_arn", "mysql_settings") {
-					settings := &awstypes.MySQLSettings{}
+					var settings *awstypes.MySQLSettings
 
 					if v, ok := d.GetOk("mysql_settings"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 						settings = expandMySQLSettings(v.([]any)[0].(map[string]any))

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -692,8 +692,8 @@ func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta an
 			settings.SecretsManagerAccessRoleArn = aws.String(d.Get("secrets_manager_access_role_arn").(string))
 			settings.SecretsManagerSecretId = aws.String(d.Get("secrets_manager_arn").(string))
 		} else {
-			settings.Username = aws.String(d.Get("username").(string))
-			settings.Password = aws.String(d.Get("password").(string))
+			settings.Username = aws.String(d.Get(names.AttrUsername).(string))
+			settings.Password = aws.String(d.Get(names.AttrPassword).(string))
 			settings.ServerName = aws.String(d.Get("server_name").(string))
 			settings.Port = aws.Int32(int32(d.Get(names.AttrPort).(int)))
 

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -345,6 +345,69 @@ func resourceEndpoint() *schema.Resource {
 					},
 				},
 			},
+			"mysql_settings": {
+				Type:             schema.TypeList,
+				Optional:         true,
+				MaxItems:         1,
+				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"after_connect_script": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"authentication_method": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							ValidateDiagFunc: enum.Validate[awstypes.MySQLAuthenticationMethod](),
+						},
+						"clean_source_metadata_on_mismatch": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+						"events_poll_interval": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+						"execute_timeout": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+						"max_file_size": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+						"parallel_load_threads": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+						"server_timezone": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"service_access_role_arn": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: verify.ValidARN,
+						},
+						"target_db_type": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							ValidateDiagFunc: enum.Validate[awstypes.TargetDbType](),
+						},
+					},
+				},
+			},
 			"oracle_settings": {
 				Type:             schema.TypeList,
 				Optional:         true,
@@ -621,23 +684,29 @@ func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta an
 
 	switch d.Get("engine_name").(string) {
 	case engineNameAurora, engineNameMariadb, engineNameMySQL:
+		settings := &awstypes.MySQLSettings{}
+		if _, ok := d.GetOk("mysql_settings"); ok {
+			settings = expandMySQLSettings(d.Get("mysql_settings").([]any)[0].(map[string]any))
+		}
 		if _, ok := d.GetOk("secrets_manager_arn"); ok {
-			input.MySQLSettings = &awstypes.MySQLSettings{
-				SecretsManagerAccessRoleArn: aws.String(d.Get("secrets_manager_access_role_arn").(string)),
-				SecretsManagerSecretId:      aws.String(d.Get("secrets_manager_arn").(string)),
-			}
+			settings.SecretsManagerAccessRoleArn = aws.String(d.Get("secrets_manager_access_role_arn").(string))
+			settings.SecretsManagerSecretId = aws.String(d.Get("secrets_manager_arn").(string))
 		} else {
-			input.MySQLSettings = &awstypes.MySQLSettings{
-				Username:     aws.String(d.Get(names.AttrUsername).(string)),
-				Password:     aws.String(d.Get(names.AttrPassword).(string)),
-				ServerName:   aws.String(d.Get("server_name").(string)),
-				Port:         aws.Int32(int32(d.Get(names.AttrPort).(int))),
-				DatabaseName: aws.String(d.Get(names.AttrDatabaseName).(string)),
+			settings.Username = aws.String(d.Get("username").(string))
+			settings.Password = aws.String(d.Get("password").(string))
+			settings.ServerName = aws.String(d.Get("server_name").(string))
+			settings.Port = aws.Int32(int32(d.Get(names.AttrPort).(int)))
+
+			// DatabaseName can be empty since it should not be specified
+			// when mysql_settings.target_db_type is `multiple-databases`
+			if v, ok := d.GetOk(names.AttrDatabaseName); ok {
+				settings.DatabaseName = aws.String(v.(string))
 			}
 
 			// Set connection info in top-level namespace as well
 			expandTopLevelConnectionInfo(d, &input)
 		}
+		input.MySQLSettings = settings
 	case engineNameAuroraPostgresql, engineNamePostgres:
 		var settings *awstypes.PostgreSQLSettings
 
@@ -928,24 +997,35 @@ func resourceEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta an
 			case engineNameAurora, engineNameMariadb, engineNameMySQL:
 				if d.HasChanges(
 					names.AttrUsername, names.AttrPassword, "server_name", names.AttrPort, names.AttrDatabaseName,
-					"secrets_manager_access_role_arn", "secrets_manager_arn") {
-					if _, ok := d.GetOk("secrets_manager_arn"); ok {
-						input.MySQLSettings = &awstypes.MySQLSettings{
-							SecretsManagerAccessRoleArn: aws.String(d.Get("secrets_manager_access_role_arn").(string)),
-							SecretsManagerSecretId:      aws.String(d.Get("secrets_manager_arn").(string)),
-						}
+					"secrets_manager_access_role_arn", "secrets_manager_arn", "mysql_settings") {
+					settings := &awstypes.MySQLSettings{}
+
+					if v, ok := d.GetOk("mysql_settings"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+						settings = expandMySQLSettings(v.([]any)[0].(map[string]any))
 					} else {
-						input.MySQLSettings = &awstypes.MySQLSettings{
-							Username:     aws.String(d.Get(names.AttrUsername).(string)),
-							Password:     aws.String(d.Get(names.AttrPassword).(string)),
-							ServerName:   aws.String(d.Get("server_name").(string)),
-							Port:         aws.Int32(int32(d.Get(names.AttrPort).(int))),
-							DatabaseName: aws.String(d.Get(names.AttrDatabaseName).(string)),
+						settings = &awstypes.MySQLSettings{}
+					}
+
+					if _, ok := d.GetOk("secrets_manager_arn"); ok {
+						settings.SecretsManagerAccessRoleArn = aws.String(d.Get("secrets_manager_access_role_arn").(string))
+						settings.SecretsManagerSecretId = aws.String(d.Get("secrets_manager_arn").(string))
+					} else {
+						settings.Username = aws.String(d.Get(names.AttrUsername).(string))
+						settings.Password = aws.String(d.Get(names.AttrPassword).(string))
+						settings.ServerName = aws.String(d.Get("server_name").(string))
+						settings.Port = aws.Int32(int32(d.Get(names.AttrPort).(int)))
+
+						// DatabaseName can be empty since it should not be specified
+						// when mysql_settings.target_db_type is `multiple-databases`
+						if v, ok := d.GetOk(names.AttrDatabaseName); ok {
+							settings.DatabaseName = aws.String(v.(string))
 						}
 
 						// Update connection info in top-level namespace as well
 						expandTopLevelConnectionInfoModify(d, &input)
 					}
+
+					input.MySQLSettings = settings
 				}
 			case engineNameAuroraPostgresql, engineNamePostgres:
 				if d.HasChanges(
@@ -1345,6 +1425,9 @@ func resourceEndpointSetState(d *schema.ResourceData, endpoint *awstypes.Endpoin
 			d.Set("secrets_manager_arn", endpoint.MySQLSettings.SecretsManagerSecretId)
 		} else {
 			flattenTopLevelConnectionInfo(d, endpoint)
+		}
+		if err := d.Set("mysql_settings", flattenMySQLSettings(endpoint.MySQLSettings)); err != nil {
+			return fmt.Errorf("setting mysql_settings: %w", err)
 		}
 	case engineNameAuroraPostgresql, engineNamePostgres:
 		if endpoint.PostgreSQLSettings != nil {
@@ -1955,6 +2038,47 @@ func flattenRedshiftSettings(settings *awstypes.RedshiftSettings) []map[string]a
 	return []map[string]any{m}
 }
 
+func expandMySQLSettings(tfMap map[string]any) *awstypes.MySQLSettings {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &awstypes.MySQLSettings{}
+
+	if v, ok := tfMap["after_connect_script"].(string); ok && v != "" {
+		apiObject.AfterConnectScript = aws.String(v)
+	}
+	if v, ok := tfMap["authentication_method"].(string); ok && v != "" {
+		apiObject.AuthenticationMethod = awstypes.MySQLAuthenticationMethod(v)
+	}
+	if v, ok := tfMap["clean_source_metadata_on_mismatch"].(bool); ok {
+		apiObject.CleanSourceMetadataOnMismatch = aws.Bool(v)
+	}
+	if v, ok := tfMap["events_poll_interval"].(int); ok && v != 0 {
+		apiObject.EventsPollInterval = aws.Int32(int32(v))
+	}
+	if v, ok := tfMap["execute_timeout"].(int); ok && v != 0 {
+		apiObject.ExecuteTimeout = aws.Int32(int32(v))
+	}
+	if v, ok := tfMap["max_file_size"].(int); ok && v != 0 {
+		apiObject.MaxFileSize = aws.Int32(int32(v))
+	}
+	if v, ok := tfMap["parallel_load_threads"].(int); ok && v != 0 {
+		apiObject.ParallelLoadThreads = aws.Int32(int32(v))
+	}
+	if v, ok := tfMap["server_timezone"].(string); ok && v != "" {
+		apiObject.ServerTimezone = aws.String(v)
+	}
+	if v, ok := tfMap["service_access_role_arn"].(string); ok && v != "" {
+		apiObject.ServiceAccessRoleArn = aws.String(v)
+	}
+	if v, ok := tfMap["target_db_type"].(string); ok && v != "" {
+		apiObject.TargetDbType = awstypes.TargetDbType(v)
+	}
+
+	return apiObject
+}
+
 func expandPostgreSQLSettings(tfMap map[string]any) *awstypes.PostgreSQLSettings {
 	if tfMap == nil {
 		return nil
@@ -2018,6 +2142,47 @@ func expandPostgreSQLSettings(tfMap map[string]any) *awstypes.PostgreSQLSettings
 	}
 
 	return apiObject
+}
+
+func flattenMySQLSettings(apiObject *awstypes.MySQLSettings) []map[string]any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if v := apiObject.AfterConnectScript; v != nil {
+		tfMap["after_connect_script"] = aws.ToString(v)
+	}
+	if v := apiObject.AuthenticationMethod; v != "" {
+		tfMap["authentication_method"] = string(v)
+	}
+	if v := apiObject.CleanSourceMetadataOnMismatch; v != nil {
+		tfMap["clean_source_metadata_on_mismatch"] = aws.ToBool(v)
+	}
+	if v := apiObject.EventsPollInterval; v != nil {
+		tfMap["events_poll_interval"] = aws.ToInt32(v)
+	}
+	if v := apiObject.ExecuteTimeout; v != nil {
+		tfMap["execute_timeout"] = aws.ToInt32(v)
+	}
+	if v := apiObject.MaxFileSize; v != nil {
+		tfMap["max_file_size"] = aws.ToInt32(v)
+	}
+	if v := apiObject.ParallelLoadThreads; v != nil {
+		tfMap["parallel_load_threads"] = aws.ToInt32(v)
+	}
+	if v := apiObject.ServerTimezone; v != nil {
+		tfMap["server_timezone"] = aws.ToString(v)
+	}
+	if v := apiObject.ServiceAccessRoleArn; v != nil {
+		tfMap["service_access_role_arn"] = aws.ToString(v)
+	}
+	if v := apiObject.TargetDbType; v != "" {
+		tfMap["target_db_type"] = string(v)
+	}
+
+	return []map[string]any{tfMap}
 }
 
 func flattenPostgreSQLSettings(apiObject *awstypes.PostgreSQLSettings) []map[string]any {

--- a/internal/service/dms/endpoint_data_source.go
+++ b/internal/service/dms/endpoint_data_source.go
@@ -245,6 +245,54 @@ func dataSourceEndpoint() *schema.Resource {
 					},
 				},
 			},
+			"mysql_settings": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"after_connect_script": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"authentication_method": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"clean_source_metadata_on_mismatch": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"events_poll_interval": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"execute_timeout": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"max_file_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"parallel_load_threads": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"server_timezone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"service_access_role_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"target_db_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			names.AttrPassword: {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -642,6 +690,9 @@ func resourceEndpointDataSourceSetState(d *schema.ResourceData, endpoint *awstyp
 			d.Set("secrets_manager_arn", endpoint.MySQLSettings.SecretsManagerSecretId)
 		} else {
 			flattenTopLevelConnectionInfo(d, endpoint)
+		}
+		if err := d.Set("mysql_settings", flattenMySQLSettings(endpoint.MySQLSettings)); err != nil {
+			return fmt.Errorf("setting mysql_settings: %w", err)
 		}
 	case engineNameAuroraPostgresql, engineNamePostgres:
 		if endpoint.PostgreSQLSettings != nil {

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -3331,7 +3331,7 @@ resource "aws_dms_endpoint" "test" {
 `, rName)
 }
 
-func testAccEndpointConfig_mySQLSourceSettingsBlock(eventPollInterval int) string {
+func testAccEndpointConfig_mySQLSourceSettingsBlock(eventsPollInterval int) string {
 	return fmt.Sprintf(`
   mysql_settings {
     after_connect_script              = "SELECT NOW();"
@@ -3342,7 +3342,7 @@ func testAccEndpointConfig_mySQLSourceSettingsBlock(eventPollInterval int) strin
     service_access_role_arn           = aws_iam_role.test.arn
 	server_timezone                   = "UTC"
   }
-`, eventPollInterval)
+`, eventsPollInterval)
 }
 
 func testAccEndpointConfig_certificateBase(rName string) string {
@@ -3354,10 +3354,10 @@ resource "aws_dms_certificate" "dms_certificate" {
 `, rName)
 }
 
-func testAccEndpointConfig_mySQLSourceSettings(rName string, outputMySQLSettings bool, eventPollInterval int) string {
+func testAccEndpointConfig_mySQLSourceSettings(rName string, outputMySQLSettings bool, eventsPollInterval int) string {
 	mysqlSettings := ""
 	if outputMySQLSettings {
-		mysqlSettings = testAccEndpointConfig_mySQLSourceSettingsBlock(eventPollInterval)
+		mysqlSettings = testAccEndpointConfig_mySQLSourceSettingsBlock(eventsPollInterval)
 	}
 	return acctest.ConfigCompose(testAccEndpointConfig_certificateBase(rName), fmt.Sprintf(`
 data "aws_region" "current" {}

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -1175,6 +1175,7 @@ func TestAccDMSEndpoint_MySQL_settings_source(t *testing.T) {
 				ImportStateVerifyIgnore: []string{names.AttrPassword},
 			},
 			{
+				// Change events_poll_interval from 5 to 10
 				Config: testAccEndpointConfig_mySQLSourceSettings(rName, true, 10),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointExists(ctx, resourceName),
@@ -1188,6 +1189,7 @@ func TestAccDMSEndpoint_MySQL_settings_source(t *testing.T) {
 				),
 			},
 			{
+				// Remove mysql_settings block (inherited the previous values)
 				Config: testAccEndpointConfig_mySQLSourceSettings(rName, false, 10),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointExists(ctx, resourceName),
@@ -1235,6 +1237,7 @@ func TestAccDMSEndpoint_MySQL_settings_target(t *testing.T) {
 				ImportStateVerifyIgnore: []string{names.AttrPassword},
 			},
 			{
+				// Change execute_timeout from 100 to 60
 				Config: testAccEndpointConfig_mySQLTargetSettings(rName, true, 60),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointExists(ctx, resourceName),
@@ -1248,6 +1251,7 @@ func TestAccDMSEndpoint_MySQL_settings_target(t *testing.T) {
 				),
 			},
 			{
+				// Remove mysql_settings block (inherited the previous values)
 				Config: testAccEndpointConfig_mySQLTargetSettings(rName, false, 60),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointExists(ctx, resourceName),

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -3345,7 +3345,7 @@ func testAccEndpointConfig_mySQLSourceSettingsBlock(eventPollInterval int) strin
 `, eventPollInterval)
 }
 
-func testAccEndpointConfig_dmsCertificateBase(rName string) string {
+func testAccEndpointConfig_certificateBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_dms_certificate" "dms_certificate" {
   certificate_id  = %[1]q
@@ -3359,7 +3359,7 @@ func testAccEndpointConfig_mySQLSourceSettings(rName string, outputMySQLSettings
 	if outputMySQLSettings {
 		mysqlSettings = testAccEndpointConfig_mySQLSourceSettingsBlock(eventPollInterval)
 	}
-	return acctest.ConfigCompose(testAccEndpointConfig_dmsCertificateBase(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfig_certificateBase(rName), fmt.Sprintf(`
 data "aws_region" "current" {}
 data "aws_partition" "current" {}
 
@@ -3418,7 +3418,7 @@ func testAccEndpointConfig_mySQLTargetSettings(rName string, outputMySQLSettings
 	if outputMySQLSettings {
 		mysqlSettings = testAccEndpointConfig_mySQLTargetSettingsBlock(executeTimeout)
 	}
-	return acctest.ConfigCompose(testAccEndpointConfig_dmsCertificateBase(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfig_certificateBase(rName), fmt.Sprintf(`
 resource "aws_dms_endpoint" "test" {
   certificate_arn             = aws_dms_certificate.dms_certificate.certificate_arn
   endpoint_id                 = %[1]q

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -1144,6 +1144,126 @@ func TestAccDMSEndpoint_PostgreSQL_kmsKey(t *testing.T) {
 	})
 }
 
+func TestAccDMSEndpoint_MySQL_settings_source(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_dms_endpoint.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfig_mySQLSourceSettings(rName, true, 5),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.after_connect_script", "SELECT NOW();"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.authentication_method", "iam"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.clean_source_metadata_on_mismatch", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.events_poll_interval", "5"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.execute_timeout", "100"),
+					resource.TestCheckResourceAttrPair(resourceName, "mysql_settings.0.service_access_role_arn", "aws_iam_role.test", "arn"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrPassword},
+			},
+			{
+				Config: testAccEndpointConfig_mySQLSourceSettings(rName, true, 10),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.after_connect_script", "SELECT NOW();"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.authentication_method", "iam"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.clean_source_metadata_on_mismatch", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.events_poll_interval", "10"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.execute_timeout", "100"),
+					resource.TestCheckResourceAttrPair(resourceName, "mysql_settings.0.service_access_role_arn", "aws_iam_role.test", "arn"),
+				),
+			},
+			{
+				Config: testAccEndpointConfig_mySQLSourceSettings(rName, false, 10),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.after_connect_script", "SELECT NOW();"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.authentication_method", "iam"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.clean_source_metadata_on_mismatch", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.events_poll_interval", "10"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.execute_timeout", "100"),
+					resource.TestCheckResourceAttrPair(resourceName, "mysql_settings.0.service_access_role_arn", "aws_iam_role.test", "arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDMSEndpoint_MySQL_settings_target(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_dms_endpoint.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfig_mySQLTargetSettings(rName, true, 100),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.after_connect_script", "SELECT NOW();"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.authentication_method", string(awstypes.MySQLAuthenticationMethodPassword)),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.execute_timeout", "100"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.max_file_size", "1024"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.parallel_load_threads", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.target_db_type", string(awstypes.TargetDbTypeMultipleDatabases)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrPassword},
+			},
+			{
+				Config: testAccEndpointConfig_mySQLTargetSettings(rName, true, 60),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.after_connect_script", "SELECT NOW();"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.authentication_method", string(awstypes.MySQLAuthenticationMethodPassword)),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.execute_timeout", "60"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.max_file_size", "1024"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.parallel_load_threads", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.target_db_type", string(awstypes.TargetDbTypeMultipleDatabases)),
+				),
+			},
+			{
+				Config: testAccEndpointConfig_mySQLTargetSettings(rName, false, 60),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.after_connect_script", "SELECT NOW();"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.authentication_method", string(awstypes.MySQLAuthenticationMethodPassword)),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.execute_timeout", "60"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.max_file_size", "1024"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.parallel_load_threads", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.target_db_type", string(awstypes.TargetDbTypeMultipleDatabases)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDMSEndpoint_PostgreSQL_settings_source(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
@@ -3209,6 +3329,111 @@ resource "aws_dms_endpoint" "test" {
   }
 }
 `, rName)
+}
+
+func testAccEndpointConfig_mySQLSourceSettingsBlock(eventPollInterval int) string {
+	return fmt.Sprintf(`
+  mysql_settings {
+    after_connect_script              = "SELECT NOW();"
+    authentication_method             = "iam"
+    clean_source_metadata_on_mismatch = true
+    events_poll_interval              = %[1]d
+    execute_timeout                   = 100
+    service_access_role_arn           = aws_iam_role.test.arn
+	server_timezone                   = "UTC"
+  }
+`, eventPollInterval)
+}
+
+func testAccEndpointConfig_dmsCertificateBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dms_certificate" "dms_certificate" {
+  certificate_id  = %[1]q
+  certificate_pem = "-----BEGIN CERTIFICATE-----\nMIID2jCCAsKgAwIBAgIJAJ58TJVjU7G1MA0GCSqGSIb3DQEBBQUAMFExCzAJBgNV\nBAYTAlVTMREwDwYDVQQIEwhDb2xvcmFkbzEPMA0GA1UEBxMGRGVudmVyMRAwDgYD\nVQQKEwdDaGFydGVyMQwwCgYDVQQLEwNDU0UwHhcNMTcwMTMwMTkyMDA4WhcNMjYx\nMjA5MTkyMDA4WjBRMQswCQYDVQQGEwJVUzERMA8GA1UECBMIQ29sb3JhZG8xDzAN\nBgNVBAcTBkRlbnZlcjEQMA4GA1UEChMHQ2hhcnRlcjEMMAoGA1UECxMDQ1NFMIIB\nIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv6dq6VLIImlAaTrckb5w3X6J\nWP7EGz2ChGAXlkEYto6dPCba0v5+f+8UlMOpeB25XGoai7gdItqNWVFpYsgmndx3\nvTad3ukO1zeElKtw5oHPH2plOaiv/gVJaDa9NTeINj0EtGZs74fCOclAzGFX5vBc\nb08ESWBceRgGjGv3nlij4JzHfqTkCKQz6P6pBivQBfk62rcOkkH5rKoaGltRHROS\nMbkwOhu2hN0KmSYTXRvts0LXnZU4N0l2ms39gmr7UNNNlKYINL2JoTs9dNBc7APD\ndZvlEHd+/FjcLCI8hC3t4g4AbfW0okIBCNG0+oVjqGb2DeONSJKsThahXt89MQID\nAQABo4G0MIGxMB0GA1UdDgQWBBQKq8JxjY1GmeZXJjfOMfW0kBIzPDCBgQYDVR0j\nBHoweIAUCqvCcY2NRpnmVyY3zjH1tJASMzyhVaRTMFExCzAJBgNVBAYTAlVTMREw\nDwYDVQQIEwhDb2xvcmFkbzEPMA0GA1UEBxMGRGVudmVyMRAwDgYDVQQKEwdDaGFy\ndGVyMQwwCgYDVQQLEwNDU0WCCQCefEyVY1OxtTAMBgNVHRMEBTADAQH/MA0GCSqG\nSIb3DQEBBQUAA4IBAQAWifoMk5kbv+yuWXvFwHiB4dWUUmMlUlPU/E300yVTRl58\np6DfOgJs7MMftd1KeWqTO+uW134QlTt7+jwI8Jq0uyKCu/O2kJhVtH/Ryog14tGl\n+wLcuIPLbwJI9CwZX4WMBrq4DnYss+6F47i8NCc+Z3MAiG4vtq9ytBmaod0dj2bI\ng4/Lac0e00dql9RnqENh1+dF0V+QgTJCoPkMqDNAlSB8vOodBW81UAb2z12t+IFi\n3X9J3WtCK2+T5brXL6itzewWJ2ALvX3QpmZx7fMHJ3tE+SjjyivE1BbOlzYHx83t\nTeYnm7pS9un7A/UzTDHbs7hPUezLek+H3xTPAnnq\n-----END CERTIFICATE-----\n"
+}
+`, rName)
+}
+
+func testAccEndpointConfig_mySQLSourceSettings(rName string, outputMySQLSettings bool, eventPollInterval int) string {
+	mysqlSettings := ""
+	if outputMySQLSettings {
+		mysqlSettings = testAccEndpointConfig_mySQLSourceSettingsBlock(eventPollInterval)
+	}
+	return acctest.ConfigCompose(testAccEndpointConfig_dmsCertificateBase(rName), fmt.Sprintf(`
+data "aws_region" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name               = %[1]q
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "dms.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_dms_endpoint" "test" {
+  certificate_arn             = aws_dms_certificate.dms_certificate.certificate_arn
+  endpoint_id                 = %[1]q
+  endpoint_type               = "source"
+  engine_name                 = "mysql"
+  server_name                 = "tftest"
+  port                        = 5432
+  username                    = "tftest"
+  password                    = "tftest"
+  database_name               = "tftest"
+  ssl_mode                    = "verify-full"
+  extra_connection_attributes = ""
+
+  %[2]s
+}
+`, rName, mysqlSettings))
+}
+
+func testAccEndpointConfig_mySQLTargetSettingsBlock(executeTimeout int) string {
+	return fmt.Sprintf(`
+  mysql_settings {
+    after_connect_script    = "SELECT NOW();"
+    authentication_method   = "password"
+    execute_timeout         = %[1]d
+    max_file_size           = 1024
+    parallel_load_threads   = 1
+    target_db_type          = "multiple-databases"
+  }
+`, executeTimeout)
+}
+
+func testAccEndpointConfig_mySQLTargetSettings(rName string, outputMySQLSettings bool, executeTimeout int) string {
+	mysqlSettings := ""
+	if outputMySQLSettings {
+		mysqlSettings = testAccEndpointConfig_mySQLTargetSettingsBlock(executeTimeout)
+	}
+	return acctest.ConfigCompose(testAccEndpointConfig_dmsCertificateBase(rName), fmt.Sprintf(`
+resource "aws_dms_endpoint" "test" {
+  certificate_arn             = aws_dms_certificate.dms_certificate.certificate_arn
+  endpoint_id                 = %[1]q
+  endpoint_type               = "target"
+  engine_name                 = "mysql"
+  server_name                 = "tftest"
+  port                        = 5432
+  username                    = "tftest"
+  password                    = "tftest"
+  ssl_mode                    = "verify-full"
+  extra_connection_attributes = ""
+
+  %[2]s
+}
+`, rName, mysqlSettings))
 }
 
 func testAccEndpointConfig_postgreSQLSourceSettings(rName string) string {

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -1165,7 +1165,7 @@ func TestAccDMSEndpoint_MySQL_settings_source(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.clean_source_metadata_on_mismatch", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.events_poll_interval", "5"),
 					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.execute_timeout", "100"),
-					resource.TestCheckResourceAttrPair(resourceName, "mysql_settings.0.service_access_role_arn", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "mysql_settings.0.service_access_role_arn", "aws_iam_role.test", names.AttrARN),
 				),
 			},
 			{
@@ -1185,7 +1185,7 @@ func TestAccDMSEndpoint_MySQL_settings_source(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.clean_source_metadata_on_mismatch", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.events_poll_interval", "10"),
 					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.execute_timeout", "100"),
-					resource.TestCheckResourceAttrPair(resourceName, "mysql_settings.0.service_access_role_arn", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "mysql_settings.0.service_access_role_arn", "aws_iam_role.test", names.AttrARN),
 				),
 			},
 			{
@@ -1199,7 +1199,7 @@ func TestAccDMSEndpoint_MySQL_settings_source(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.clean_source_metadata_on_mismatch", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.events_poll_interval", "10"),
 					resource.TestCheckResourceAttr(resourceName, "mysql_settings.0.execute_timeout", "100"),
-					resource.TestCheckResourceAttrPair(resourceName, "mysql_settings.0.service_access_role_arn", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "mysql_settings.0.service_access_role_arn", "aws_iam_role.test", names.AttrARN),
 				),
 			},
 		},

--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -57,6 +57,7 @@ The following arguments are optional:
 * `kafka_settings` - (Optional) Configuration block for Kafka settings. See below.
 * `kinesis_settings` - (Optional) Configuration block for Kinesis settings. See below.
 * `mongodb_settings` - (Optional) Configuration block for MongoDB settings. See below.
+* `mysql_settings` - (Optional) Configuration block for MySQL settings. See below.
 * `oracle_settings` - (Optional) Configuration block for Oracle settings. See below.
 * `password` - (Optional) Password to be used to login to the endpoint database.
 * `postgres_settings` - (Optional) Configuration block for Postgres settings. See below.
@@ -133,6 +134,21 @@ The following arguments are optional:
 * `docs_to_investigate` - (Optional) Number of documents to preview to determine the document organization. Use this setting when `nesting_level` is set to `one`. Default is `1000`.
 * `extract_doc_id` - (Optional) Document ID. Use this setting when `nesting_level` is set to `none`. Default is `false`.
 * `nesting_level` - (Optional) Specifies either document or table mode. Default is `none`. Valid values are `one` (table mode) and `none` (document mode).
+
+### mysql_settings
+
+-> Additional information can be found in the [Using MongoDB as a Source for AWS DMS documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html).
+
+* `after_connect_script` - (Optional) Script to run immediately after AWS DMS connects to the endpoint.
+* `authentication_method` - (Optional) Authentication method to use. Valid values: `password`, `iam`.
+* `clean_source_metadata_on_mismatch` - (Optional) Whether to clean and recreate table metadata information on the replication instance when a mismatch occurs.
+* `events_poll_interval` - (Optional) Time interval to check the binary log for new changes/events when the database is idle. Default is `5`.
+* `execute_timeout` - (Optional) Client statement timeout (in seconds) for a MySQL source endpoint.
+* `max_file_size` - (Optional) Maximum size (in KB) of any .csv file used to transfer data to a MySQL-compatible database.
+* `parallel_load_threads` - (Optional) Number of threads to use to load the data into the MySQL-compatible target database.
+* `server_timezone` - (Optional) Time zone for the source MySQL database.
+* `service_access_role_arn` - (Optional) ARN of the IAM role to authenticate when connecting to the endpoint.
+* `target_db_type` - (Optional) Where to migrate source tables on the target. Valid values are `specific-database` and `multiple-databases`.
 
 ### oracle_settings
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* Add `mysql_settings` configuration block to both the `aws_dms_endpoint` resource and data source.
  * The implementation follows the existing pattern for `postgres_settings`.
  * All arguments in the block are marked as `Computed`.
    * When updating, since [`ExactSettings`](https://docs.aws.amazon.com/ja_jp/dms/latest/APIReference/API_ModifyEndpoint.html#DMS-ModifyEndpoint-request-ExactSettings) is not specified (i.e., `false`) in the current implementation, removing arguments from the configuration has no effect and values are inherited from the previous configuration. This is why `Computed` is required.
* The two newly added acceptance tests cover all added arguments.
* `mysql_settings` is also added to the schema of the data source.
  * No update to the acceptance tests of the data source is needed, as the current tests only check basic attributes.
  * No update to the data source documentation is needed, as it refers to the resource documentation.



### Relations

Closes #44495

### References

https://docs.aws.amazon.com/ja_jp/dms/latest/APIReference/API_MySQLSettings.html

### Output from Acceptance Testing
One test failed, but it appears not to be related to the fix of this PR.

```console
$ make testacc TESTS='TestAccDMSEndpoint_' PKG=dms 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_dms_endpoint-support_mysql_settings 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/dms/... -v -count 1 -parallel 20 -run='TestAccDMSEndpoint_'  -timeout 360m -vet=off
2025/10/01 21:53:55 Creating Terraform AWS Provider (SDKv2-style)...
2025/10/01 21:53:55 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDMSEndpoint_tags
=== PAUSE TestAccDMSEndpoint_tags
=== RUN   TestAccDMSEndpoint_tags_null
=== PAUSE TestAccDMSEndpoint_tags_null
=== RUN   TestAccDMSEndpoint_tags_EmptyMap
=== PAUSE TestAccDMSEndpoint_tags_EmptyMap
=== RUN   TestAccDMSEndpoint_tags_AddOnUpdate
=== PAUSE TestAccDMSEndpoint_tags_AddOnUpdate
=== RUN   TestAccDMSEndpoint_tags_EmptyTag_OnCreate
=== PAUSE TestAccDMSEndpoint_tags_EmptyTag_OnCreate
=== RUN   TestAccDMSEndpoint_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccDMSEndpoint_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccDMSEndpoint_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccDMSEndpoint_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccDMSEndpoint_tags_DefaultTags_providerOnly
=== PAUSE TestAccDMSEndpoint_tags_DefaultTags_providerOnly
=== RUN   TestAccDMSEndpoint_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccDMSEndpoint_tags_DefaultTags_nonOverlapping
=== RUN   TestAccDMSEndpoint_tags_DefaultTags_overlapping
=== PAUSE TestAccDMSEndpoint_tags_DefaultTags_overlapping
=== RUN   TestAccDMSEndpoint_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccDMSEndpoint_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccDMSEndpoint_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccDMSEndpoint_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccDMSEndpoint_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccDMSEndpoint_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccDMSEndpoint_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccDMSEndpoint_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccDMSEndpoint_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccDMSEndpoint_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccDMSEndpoint_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccDMSEndpoint_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccDMSEndpoint_tags_ComputedTag_OnCreate
=== PAUSE TestAccDMSEndpoint_tags_ComputedTag_OnCreate
=== RUN   TestAccDMSEndpoint_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccDMSEndpoint_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccDMSEndpoint_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccDMSEndpoint_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccDMSEndpoint_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccDMSEndpoint_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccDMSEndpoint_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccDMSEndpoint_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccDMSEndpoint_basic
=== PAUSE TestAccDMSEndpoint_basic
=== RUN   TestAccDMSEndpoint_Aurora_basic
=== PAUSE TestAccDMSEndpoint_Aurora_basic
=== RUN   TestAccDMSEndpoint_Aurora_secretID
=== PAUSE TestAccDMSEndpoint_Aurora_secretID
=== RUN   TestAccDMSEndpoint_Aurora_update
=== PAUSE TestAccDMSEndpoint_Aurora_update
=== RUN   TestAccDMSEndpoint_AuroraPostgreSQL_basic
=== PAUSE TestAccDMSEndpoint_AuroraPostgreSQL_basic
=== RUN   TestAccDMSEndpoint_AuroraPostgreSQL_secretID
=== PAUSE TestAccDMSEndpoint_AuroraPostgreSQL_secretID
=== RUN   TestAccDMSEndpoint_AuroraPostgreSQL_update
=== PAUSE TestAccDMSEndpoint_AuroraPostgreSQL_update
=== RUN   TestAccDMSEndpoint_dynamoDB
=== PAUSE TestAccDMSEndpoint_dynamoDB
=== RUN   TestAccDMSEndpoint_OpenSearch_basic
=== PAUSE TestAccDMSEndpoint_OpenSearch_basic
=== RUN   TestAccDMSEndpoint_OpenSearch_extraConnectionAttributes
=== PAUSE TestAccDMSEndpoint_OpenSearch_extraConnectionAttributes
=== RUN   TestAccDMSEndpoint_OpenSearch_errorRetryDuration
=== PAUSE TestAccDMSEndpoint_OpenSearch_errorRetryDuration
=== RUN   TestAccDMSEndpoint_OpenSearch_UseNewMappingType
=== PAUSE TestAccDMSEndpoint_OpenSearch_UseNewMappingType
=== RUN   TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage
=== PAUSE TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage
=== RUN   TestAccDMSEndpoint_kafka
=== PAUSE TestAccDMSEndpoint_kafka
=== RUN   TestAccDMSEndpoint_kinesis
=== PAUSE TestAccDMSEndpoint_kinesis
=== RUN   TestAccDMSEndpoint_MongoDB_basic
=== PAUSE TestAccDMSEndpoint_MongoDB_basic
=== RUN   TestAccDMSEndpoint_MongoDB_secretID
=== PAUSE TestAccDMSEndpoint_MongoDB_secretID
=== RUN   TestAccDMSEndpoint_MongoDB_update
=== PAUSE TestAccDMSEndpoint_MongoDB_update
=== RUN   TestAccDMSEndpoint_MariaDB_basic
=== PAUSE TestAccDMSEndpoint_MariaDB_basic
=== RUN   TestAccDMSEndpoint_MariaDB_secretID
=== PAUSE TestAccDMSEndpoint_MariaDB_secretID
=== RUN   TestAccDMSEndpoint_MariaDB_update
=== PAUSE TestAccDMSEndpoint_MariaDB_update
=== RUN   TestAccDMSEndpoint_MySQL_basic
=== PAUSE TestAccDMSEndpoint_MySQL_basic
=== RUN   TestAccDMSEndpoint_MySQL_secretID
=== PAUSE TestAccDMSEndpoint_MySQL_secretID
=== RUN   TestAccDMSEndpoint_MySQL_update
=== PAUSE TestAccDMSEndpoint_MySQL_update
=== RUN   TestAccDMSEndpoint_Oracle_basic
=== PAUSE TestAccDMSEndpoint_Oracle_basic
=== RUN   TestAccDMSEndpoint_Oracle_secretID
=== PAUSE TestAccDMSEndpoint_Oracle_secretID
=== RUN   TestAccDMSEndpoint_Oracle_kerberos
=== PAUSE TestAccDMSEndpoint_Oracle_kerberos
=== RUN   TestAccDMSEndpoint_Oracle_update
=== PAUSE TestAccDMSEndpoint_Oracle_update
=== RUN   TestAccDMSEndpoint_PostgreSQL_basic
=== PAUSE TestAccDMSEndpoint_PostgreSQL_basic
=== RUN   TestAccDMSEndpoint_PostgreSQL_secretID
=== PAUSE TestAccDMSEndpoint_PostgreSQL_secretID
=== RUN   TestAccDMSEndpoint_PostgreSQL_update
=== PAUSE TestAccDMSEndpoint_PostgreSQL_update
=== RUN   TestAccDMSEndpoint_PostgreSQL_kmsKey
=== PAUSE TestAccDMSEndpoint_PostgreSQL_kmsKey
=== RUN   TestAccDMSEndpoint_MySQL_settings_source
=== PAUSE TestAccDMSEndpoint_MySQL_settings_source
=== RUN   TestAccDMSEndpoint_MySQL_settings_target
=== PAUSE TestAccDMSEndpoint_MySQL_settings_target
=== RUN   TestAccDMSEndpoint_PostgreSQL_settings_source
=== PAUSE TestAccDMSEndpoint_PostgreSQL_settings_source
=== RUN   TestAccDMSEndpoint_PostgreSQL_settings_target
=== PAUSE TestAccDMSEndpoint_PostgreSQL_settings_target
=== RUN   TestAccDMSEndpoint_PostgreSQL_settings_update
=== PAUSE TestAccDMSEndpoint_PostgreSQL_settings_update
=== RUN   TestAccDMSEndpoint_SQLServer_basic
=== PAUSE TestAccDMSEndpoint_SQLServer_basic
=== RUN   TestAccDMSEndpoint_SQLServer_secretID
=== PAUSE TestAccDMSEndpoint_SQLServer_secretID
=== RUN   TestAccDMSEndpoint_SQLServer_update
=== PAUSE TestAccDMSEndpoint_SQLServer_update
=== RUN   TestAccDMSEndpoint_babelfish
=== PAUSE TestAccDMSEndpoint_babelfish
=== RUN   TestAccDMSEndpoint_SQLServer_kmsKey
=== PAUSE TestAccDMSEndpoint_SQLServer_kmsKey
=== RUN   TestAccDMSEndpoint_Sybase_basic
=== PAUSE TestAccDMSEndpoint_Sybase_basic
=== RUN   TestAccDMSEndpoint_Sybase_secretID
=== PAUSE TestAccDMSEndpoint_Sybase_secretID
=== RUN   TestAccDMSEndpoint_Sybase_update
=== PAUSE TestAccDMSEndpoint_Sybase_update
=== RUN   TestAccDMSEndpoint_Sybase_kmsKey
=== PAUSE TestAccDMSEndpoint_Sybase_kmsKey
=== RUN   TestAccDMSEndpoint_docDB
=== PAUSE TestAccDMSEndpoint_docDB
=== RUN   TestAccDMSEndpoint_db2_basic
=== PAUSE TestAccDMSEndpoint_db2_basic
=== RUN   TestAccDMSEndpoint_db2zOS_basic
=== PAUSE TestAccDMSEndpoint_db2zOS_basic
=== RUN   TestAccDMSEndpoint_azureSQLManagedInstance
=== PAUSE TestAccDMSEndpoint_azureSQLManagedInstance
=== RUN   TestAccDMSEndpoint_db2_secretID
=== PAUSE TestAccDMSEndpoint_db2_secretID
=== RUN   TestAccDMSEndpoint_db2zOS_secretID
=== PAUSE TestAccDMSEndpoint_db2zOS_secretID
=== RUN   TestAccDMSEndpoint_redis
=== PAUSE TestAccDMSEndpoint_redis
=== RUN   TestAccDMSEndpoint_Redshift_basic
=== PAUSE TestAccDMSEndpoint_Redshift_basic
=== RUN   TestAccDMSEndpoint_Redshift_secretID
=== PAUSE TestAccDMSEndpoint_Redshift_secretID
=== RUN   TestAccDMSEndpoint_Redshift_update
=== PAUSE TestAccDMSEndpoint_Redshift_update
=== RUN   TestAccDMSEndpoint_Redshift_kmsKey
=== PAUSE TestAccDMSEndpoint_Redshift_kmsKey
=== RUN   TestAccDMSEndpoint_Redshift_SSEKMSKeyARN
=== PAUSE TestAccDMSEndpoint_Redshift_SSEKMSKeyARN
=== RUN   TestAccDMSEndpoint_Redshift_SSEKMSKeyId
=== PAUSE TestAccDMSEndpoint_Redshift_SSEKMSKeyId
=== RUN   TestAccDMSEndpoint_pauseReplicationTasks
=== PAUSE TestAccDMSEndpoint_pauseReplicationTasks
=== CONT  TestAccDMSEndpoint_tags
=== CONT  TestAccDMSEndpoint_MariaDB_update
=== CONT  TestAccDMSEndpoint_basic
=== CONT  TestAccDMSEndpoint_MongoDB_basic
=== CONT  TestAccDMSEndpoint_OpenSearch_errorRetryDuration
=== CONT  TestAccDMSEndpoint_MariaDB_secretID
=== CONT  TestAccDMSEndpoint_MariaDB_basic
=== CONT  TestAccDMSEndpoint_MongoDB_update
=== CONT  TestAccDMSEndpoint_MongoDB_secretID
=== CONT  TestAccDMSEndpoint_OpenSearch_extraConnectionAttributes
=== CONT  TestAccDMSEndpoint_OpenSearch_basic
=== CONT  TestAccDMSEndpoint_dynamoDB
=== CONT  TestAccDMSEndpoint_AuroraPostgreSQL_update
=== CONT  TestAccDMSEndpoint_AuroraPostgreSQL_secretID
=== CONT  TestAccDMSEndpoint_AuroraPostgreSQL_basic
=== CONT  TestAccDMSEndpoint_Aurora_update
=== CONT  TestAccDMSEndpoint_Aurora_secretID
=== CONT  TestAccDMSEndpoint_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccDMSEndpoint_Aurora_basic
=== CONT  TestAccDMSEndpoint_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccDMSEndpoint_Aurora_basic (148.25s)
=== CONT  TestAccDMSEndpoint_tags_ComputedTag_OnCreate
--- PASS: TestAccDMSEndpoint_AuroraPostgreSQL_basic (149.24s)
=== CONT  TestAccDMSEndpoint_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccDMSEndpoint_MariaDB_basic (150.13s)
=== CONT  TestAccDMSEndpoint_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccDMSEndpoint_AuroraPostgreSQL_secretID (155.68s)
=== CONT  TestAccDMSEndpoint_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccDMSEndpoint_Aurora_secretID (156.15s)
=== CONT  TestAccDMSEndpoint_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccDMSEndpoint_OpenSearch_extraConnectionAttributes (161.53s)
=== CONT  TestAccDMSEndpoint_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccDMSEndpoint_OpenSearch_errorRetryDuration (161.79s)
=== CONT  TestAccDMSEndpoint_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccDMSEndpoint_OpenSearch_basic (162.57s)
=== CONT  TestAccDMSEndpoint_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccDMSEndpoint_MongoDB_basic (164.41s)
=== CONT  TestAccDMSEndpoint_babelfish
--- PASS: TestAccDMSEndpoint_MongoDB_secretID (165.42s)
=== CONT  TestAccDMSEndpoint_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccDMSEndpoint_MariaDB_secretID (165.45s)
=== CONT  TestAccDMSEndpoint_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccDMSEndpoint_MariaDB_update (166.98s)
=== CONT  TestAccDMSEndpoint_pauseReplicationTasks
--- PASS: TestAccDMSEndpoint_Aurora_update (168.82s)
=== CONT  TestAccDMSEndpoint_tags_DefaultTags_overlapping
--- PASS: TestAccDMSEndpoint_basic (168.94s)
=== CONT  TestAccDMSEndpoint_Redshift_SSEKMSKeyId
--- PASS: TestAccDMSEndpoint_AuroraPostgreSQL_update (168.98s)
=== CONT  TestAccDMSEndpoint_Redshift_SSEKMSKeyARN
--- PASS: TestAccDMSEndpoint_tags_DefaultTags_updateToResourceOnly (170.06s)
=== CONT  TestAccDMSEndpoint_tags_DefaultTags_nonOverlapping
--- PASS: TestAccDMSEndpoint_MongoDB_update (170.45s)
=== CONT  TestAccDMSEndpoint_Redshift_kmsKey
--- PASS: TestAccDMSEndpoint_dynamoDB (178.89s)
=== CONT  TestAccDMSEndpoint_tags_DefaultTags_providerOnly
--- PASS: TestAccDMSEndpoint_tags_IgnoreTags_Overlap_ResourceTag (196.26s)
=== CONT  TestAccDMSEndpoint_Redshift_update
--- PASS: TestAccDMSEndpoint_tags (218.49s)
=== CONT  TestAccDMSEndpoint_kafka
--- PASS: TestAccDMSEndpoint_tags_DefaultTags_nullNonOverlappingResourceTag (126.98s)
=== CONT  TestAccDMSEndpoint_kinesis
--- PASS: TestAccDMSEndpoint_tags_ComputedTag_OnCreate (130.54s)
=== CONT  TestAccDMSEndpoint_Redshift_secretID
--- PASS: TestAccDMSEndpoint_tags_DefaultTags_emptyProviderOnlyTag (132.10s)
=== CONT  TestAccDMSEndpoint_Redshift_basic
--- PASS: TestAccDMSEndpoint_tags_DefaultTags_nullOverlappingResourceTag (140.98s)
=== CONT  TestAccDMSEndpoint_tags_AddOnUpdate
--- PASS: TestAccDMSEndpoint_tags_DefaultTags_emptyResourceTag (144.35s)
=== CONT  TestAccDMSEndpoint_redis
--- PASS: TestAccDMSEndpoint_tags_IgnoreTags_Overlap_DefaultTag (159.52s)
=== CONT  TestAccDMSEndpoint_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccDMSEndpoint_babelfish (149.33s)
=== CONT  TestAccDMSEndpoint_db2zOS_secretID
--- PASS: TestAccDMSEndpoint_tags_EmptyTag_OnUpdate_Replace (161.45s)
=== CONT  TestAccDMSEndpoint_tags_EmptyTag_OnCreate
--- PASS: TestAccDMSEndpoint_tags_ComputedTag_OnUpdate_Replace (165.72s)
=== CONT  TestAccDMSEndpoint_db2_secretID
--- PASS: TestAccDMSEndpoint_tags_ComputedTag_OnUpdate_Add (165.72s)
=== CONT  TestAccDMSEndpoint_tags_EmptyMap
--- PASS: TestAccDMSEndpoint_tags_DefaultTags_updateToProviderOnly (163.48s)
=== CONT  TestAccDMSEndpoint_azureSQLManagedInstance
--- PASS: TestAccDMSEndpoint_tags_DefaultTags_overlapping (172.39s)
=== CONT  TestAccDMSEndpoint_tags_null
--- PASS: TestAccDMSEndpoint_tags_DefaultTags_nonOverlapping (172.54s)
=== CONT  TestAccDMSEndpoint_db2zOS_basic
--- PASS: TestAccDMSEndpoint_kafka (141.54s)
=== CONT  TestAccDMSEndpoint_db2_basic
--- PASS: TestAccDMSEndpoint_tags_DefaultTags_providerOnly (195.08s)
=== CONT  TestAccDMSEndpoint_Sybase_update
--- PASS: TestAccDMSEndpoint_Redshift_secretID (124.42s)
=== CONT  TestAccDMSEndpoint_Sybase_secretID
--- PASS: TestAccDMSEndpoint_tags_AddOnUpdate (138.13s)
=== CONT  TestAccDMSEndpoint_docDB
--- PASS: TestAccDMSEndpoint_redis (140.09s)
=== CONT  TestAccDMSEndpoint_Sybase_basic
--- PASS: TestAccDMSEndpoint_db2zOS_secretID (132.73s)
=== CONT  TestAccDMSEndpoint_Sybase_kmsKey
--- PASS: TestAccDMSEndpoint_kinesis (182.16s)
=== CONT  TestAccDMSEndpoint_SQLServer_kmsKey
--- PASS: TestAccDMSEndpoint_db2_secretID (146.50s)
=== CONT  TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage
--- PASS: TestAccDMSEndpoint_tags_EmptyMap (148.16s)
=== CONT  TestAccDMSEndpoint_OpenSearch_UseNewMappingType
--- PASS: TestAccDMSEndpoint_azureSQLManagedInstance (148.16s)
=== CONT  TestAccDMSEndpoint_PostgreSQL_update
--- PASS: TestAccDMSEndpoint_tags_EmptyTag_OnUpdate_Add (170.38s)
=== CONT  TestAccDMSEndpoint_PostgreSQL_settings_target
--- PASS: TestAccDMSEndpoint_tags_EmptyTag_OnCreate (166.87s)
=== CONT  TestAccDMSEndpoint_PostgreSQL_settings_source
--- PASS: TestAccDMSEndpoint_tags_null (158.26s)
=== CONT  TestAccDMSEndpoint_SQLServer_update
--- PASS: TestAccDMSEndpoint_db2zOS_basic (157.22s)
=== CONT  TestAccDMSEndpoint_MySQL_settings_target
--- PASS: TestAccDMSEndpoint_Redshift_SSEKMSKeyId (350.32s)
=== CONT  TestAccDMSEndpoint_SQLServer_secretID
--- PASS: TestAccDMSEndpoint_Redshift_update (323.16s)
=== CONT  TestAccDMSEndpoint_MySQL_settings_source
--- PASS: TestAccDMSEndpoint_Sybase_secretID (148.78s)
=== CONT  TestAccDMSEndpoint_SQLServer_basic
--- PASS: TestAccDMSEndpoint_Sybase_update (179.71s)
=== CONT  TestAccDMSEndpoint_PostgreSQL_kmsKey
--- PASS: TestAccDMSEndpoint_db2_basic (196.47s)
=== CONT  TestAccDMSEndpoint_PostgreSQL_settings_update
--- PASS: TestAccDMSEndpoint_Sybase_basic (117.72s)
=== CONT  TestAccDMSEndpoint_Oracle_secretID
--- PASS: TestAccDMSEndpoint_docDB (129.78s)
=== CONT  TestAccDMSEndpoint_PostgreSQL_basic
--- PASS: TestAccDMSEndpoint_Sybase_kmsKey (132.86s)
=== CONT  TestAccDMSEndpoint_Oracle_update
--- PASS: TestAccDMSEndpoint_SQLServer_kmsKey (121.66s)
=== CONT  TestAccDMSEndpoint_PostgreSQL_secretID
--- PASS: TestAccDMSEndpoint_Redshift_kmsKey (415.95s)
=== CONT  TestAccDMSEndpoint_Oracle_kerberos
--- PASS: TestAccDMSEndpoint_PostgreSQL_settings_target (106.56s)
=== CONT  TestAccDMSEndpoint_MySQL_update
--- PASS: TestAccDMSEndpoint_PostgreSQL_settings_source (93.39s)
=== CONT  TestAccDMSEndpoint_MySQL_secretID
--- PASS: TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage (113.70s)
=== CONT  TestAccDMSEndpoint_Oracle_basic
--- PASS: TestAccDMSEndpoint_PostgreSQL_update (114.94s)
=== CONT  TestAccDMSEndpoint_MySQL_basic
--- PASS: TestAccDMSEndpoint_OpenSearch_UseNewMappingType (116.43s)
--- PASS: TestAccDMSEndpoint_SQLServer_update (102.66s)
--- PASS: TestAccDMSEndpoint_SQLServer_secretID (94.03s)
--- PASS: TestAccDMSEndpoint_MySQL_settings_target (115.14s)
--- PASS: TestAccDMSEndpoint_MySQL_settings_source (115.14s)
--- PASS: TestAccDMSEndpoint_PostgreSQL_kmsKey (85.89s)
--- PASS: TestAccDMSEndpoint_SQLServer_basic (87.76s)
--- PASS: TestAccDMSEndpoint_Redshift_SSEKMSKeyARN (488.73s)
--- PASS: TestAccDMSEndpoint_Redshift_basic (391.01s)
--- PASS: TestAccDMSEndpoint_PostgreSQL_basic (126.40s)
--- PASS: TestAccDMSEndpoint_Oracle_secretID (129.71s)
--- PASS: TestAccDMSEndpoint_PostgreSQL_settings_update (143.83s)
--- PASS: TestAccDMSEndpoint_Oracle_basic (122.49s)
--- PASS: TestAccDMSEndpoint_MySQL_basic (121.46s)
--- PASS: TestAccDMSEndpoint_MySQL_secretID (127.54s)
--- PASS: TestAccDMSEndpoint_Oracle_kerberos (133.35s)
--- PASS: TestAccDMSEndpoint_PostgreSQL_secretID (140.37s)
--- PASS: TestAccDMSEndpoint_MySQL_update (145.34s)
--- PASS: TestAccDMSEndpoint_Oracle_update (163.66s)
=== NAME  TestAccDMSEndpoint_pauseReplicationTasks
    endpoint_test.go:2165: Step 2/2 error: Error running apply: exit status 1
        
        Error: starting replication tasks after updating DMS Endpoint (tf-acc-test-5354772027055350500-target): starting replication task: starting DMS Replication Task (tf-acc-test-5354772027055350500): operation error Database Migration Service: StartReplicationTask, https response error StatusCode: 400, RequestID: 86731ef0-17ed-444a-bce5-e87c10577296, InvalidResourceStateFault: Replication Task cannot be started, invalid state
        
          with aws_dms_endpoint.target,
          on terraform_plugin_test.tf line 159, in resource "aws_dms_endpoint" "target":
         159: resource "aws_dms_endpoint" "target" {
        
--- FAIL: TestAccDMSEndpoint_pauseReplicationTasks (1878.26s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/dms        2049.465s
FAIL
make: *** [testacc] Error 1


```
