### PR TITLE
fix[ec2_instance]: Handle invalid utf8 in Read

### DIFF
--- a/.changelog/44506.txt
+++ b/.changelog/44506.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_instance: Don't store invalid string in user_data attribute
+```

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -3494,7 +3495,12 @@ func resourceInstanceFlatten(ctx context.Context, client *conns.AWSClient, insta
 				if err != nil {
 					return sdkdiag.AppendErrorf(diags, "decoding user_data: %s", err)
 				}
-				rd.Set("user_data", string(data))
+				if utf8.Valid(data) {
+					rd.Set("user_data", string(data))
+				} else {
+					// The user_data wasn't valid UTF-8, so we need to store it as base64 instead of as the raw string.
+					rd.Set("user_data_base64", attr.UserData.Value)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When reading the UserData for an instance, if the decoded user data isn't valid UTF-8, then store the base64 value in user_data_base64 instead of the raw value in user_data.

This ensures that we don't store an invalid string in the `user_data` field, resulting in invalid json.

In particular, this allows importing an aws_instance that has binary UserData without resulting in an invalid state.

## Relations

Fixes: #44506


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->



