### PR TITLE
Revert "Bump github.com/hashicorp/terraform-plugin-framework from 1.16.0 to 1.16.1 in the terraform-devex group across 1 directory"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -291,7 +291,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/terraform-json v0.27.2
-	github.com/hashicorp/terraform-plugin-framework v1.16.1
+	github.com/hashicorp/terraform-plugin-framework v1.16.0
 	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.6.0
 	github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -669,8 +669,8 @@ github.com/hashicorp/terraform-exec v0.24.0 h1:mL0xlk9H5g2bn0pPF6JQZk5YlByqSqrO5
 github.com/hashicorp/terraform-exec v0.24.0/go.mod h1:lluc/rDYfAhYdslLJQg3J0oDqo88oGQAdHR+wDqFvo4=
 github.com/hashicorp/terraform-json v0.27.2 h1:BwGuzM6iUPqf9JYM/Z4AF1OJ5VVJEEzoKST/tRDBJKU=
 github.com/hashicorp/terraform-json v0.27.2/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
-github.com/hashicorp/terraform-plugin-framework v1.16.1 h1:1+zwFm3MEqd/0K3YBB2v9u9DtyYHyEuhVOfeIXbteWA=
-github.com/hashicorp/terraform-plugin-framework v1.16.1/go.mod h1:0xFOxLy5lRzDTayc4dzK/FakIgBhNf/lC4499R9cV4Y=
+github.com/hashicorp/terraform-plugin-framework v1.16.0 h1:tP0f+yJg0Z672e7levixDe5EpWwrTrNryPM9kDMYIpE=
+github.com/hashicorp/terraform-plugin-framework v1.16.0/go.mod h1:0xFOxLy5lRzDTayc4dzK/FakIgBhNf/lC4499R9cV4Y=
 github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0 h1:SJXL5FfJJm17554Kpt9jFXngdM6fXbnUnZ6iT2IeiYA=
 github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0/go.mod h1:p0phD0IYhsu9bR4+6OetVvvH59I6LwjXGnTVEr8ox6E=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.6.0 h1:Vv16e7EW4nT9668IV0RhdpEmnLl0im7BZx6J+QMlUkg=


### PR DESCRIPTION
Reverts hashicorp/terraform-provider-aws#44493

The additional error diagnostics added in this version have uncovered some discrepancies between how the AWS provider implemented resource identity support for Plugin Framework resources, and the expectations held by the upstream library. Specifically, the library assumes that a resource implements the `ResourceWithIdentity` interface when identity is fully supported, and always returns a non-nil schema. 

In versions `v6.0.0` to current, the provider has implemented an `IdentitySchema` method on all Plugin Framework resources by wrapping the base resource implementation, therefore satisfying the `ResourceWithIdentity` interface. A resource was only considered supported when the schema contained greater than 0 attributes. 

This difference in assumptions went undetected to this point because the upstream library allowed null identities to be written to state, as would be the case with any resource which the provider considered "unimplemented" but plugin framework would treat as implemented with an empty identity schema (0 attributes). With the introduction of new error diagnostics for this case, the provider will need to refactor how Plugin Framework resources are wrapped before proceeding with the upgrade of this package.

---

Example of a newly failing test with this library upgrade.

```console
% make t K=lambda T=TestAccLambdaFunctionRecursionConfig_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-identity-interceptor-fw 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunctionRecursionConfig_basic'  -timeout 360m -vet=off
2025/10/01 15:26:04 Creating Terraform AWS Provider (SDKv2-style)...
2025/10/01 15:26:04 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaFunctionRecursionConfig_basic
=== PAUSE TestAccLambdaFunctionRecursionConfig_basic
=== CONT  TestAccLambdaFunctionRecursionConfig_basic
    function_recursion_config_test.go:36: Step 1/2 error: Error running apply: exit status 1

        Error: Missing Resource Identity After Create

          with aws_lambda_function_recursion_config.test,
          on terraform_plugin_test.tf line 41, in resource "aws_lambda_function_recursion_config" "test":
          41: resource "aws_lambda_function_recursion_config" "test" {

        The Terraform Provider unexpectedly returned no resource identity data after
        having no errors in the resource create. This is always an issue in the
        Terraform Provider and should be reported to the provider developers.
--- FAIL: TestAccLambdaFunctionRecursionConfig_basic (30.13s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/lambda     36.818s
```