### PR TITLE
r/aws_cloudwatch_log_resource_policy: Do not retry on `LimitExceededException`

### DIFF
--- a/.changelog/44522.txt
+++ b/.changelog/44522.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_log_resource_policy: Do not retry on `LimitExceededException`
+```

--- a/internal/service/logs/service_package.go
+++ b/internal/service/logs/service_package.go
@@ -1,0 +1,41 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package logs
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
+)
+
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*cloudwatchlogs.Options) {
+	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
+
+	return []func(*cloudwatchlogs.Options){
+		func(o *cloudwatchlogs.Options) {
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					if errs.IsAErrorMessageContains[*awstypes.LimitExceededException](err, "Resource limit exceeded") {
+						return aws.FalseTernary
+					}
+					return aws.UnknownTernary // Delegate to configured Retryer.
+				}),
+			}
+			// Include go-vcr retryable to prevent generated client retryer from being overridden
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, vcr.InteractionNotFoundRetryableFunc)
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
+		},
+	}
+}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

N/A

### Description
This PR updates the CloudWatch Logs options to prevent infinite retries on `LimitExceededException` which indicates that no more resoures can be created.

### Relations
Closes #41503.

### References
Reproduce using:
```terraform
data "aws_caller_identity" "current" {}
data "aws_region" "current" {}

resource "aws_cloudwatch_log_resource_policy" "example" {
  count       = 11
  policy_name = "example-policy-${count.index}"
  policy_document = jsonencode({
    Version = "2012-10-17"
    Statement = [
      {
        Effect    = "Allow"
        Principal = { "AWS" = data.aws_caller_identity.current.account_id }
        Action    = "logs:PutLogEvents"
        Resource  = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/my-function:*"
      }
    ]
  })
}
```

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccLogsResourcePolicy_basic PKG=logs  
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws_cloudwatch_log_resource_policy-limit-exceeded-exception-infinite-retries 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/logs/... -v -count 1 -parallel 20 -run='TestAccLogsResourcePolicy_basic'  -timeout 360m -vet=off
2025/10/01 23:32:56 Creating Terraform AWS Provider (SDKv2-style)...
2025/10/01 23:32:56 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLogsResourcePolicy_basic
=== PAUSE TestAccLogsResourcePolicy_basic
=== CONT  TestAccLogsResourcePolicy_basic
--- PASS: TestAccLogsResourcePolicy_basic (32.53s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       37.634s
```
