### PR TITLE
r/aws_bedrock_guardrail: `contextual_grounding_policy_config.filters_config` is repeated block, not list of objects

### DIFF
--- a/website/docs/r/bedrock_guardrail.html.markdown
+++ b/website/docs/r/bedrock_guardrail.html.markdown
@@ -121,7 +121,7 @@ The `tier_config` configuration block supports the following arguments:
 
 ### Contextual Grounding Policy Config
 
-* `filters_config` (Required) List of contextual grounding filter configs. See [Contextual Grounding Filters Config](#contextual-grounding-filters-config) for more information.
+* `filters_config` (Required) One or more blocks defining contextual grounding filter configs. See [Contextual Grounding Filters Config](#contextual-grounding-filters-config) for more information.
 
 #### Contextual Grounding Filters Config
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Documents that `contextual_grounding_policy_config.filters_config` is _ListNestedBlock_.