### PR TITLE
fix: update kms_key_id validation to accept all AWS-supported formats

### DIFF
--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -84,7 +84,7 @@ func resourceLaunchTemplate() *schema.Resource {
 									names.AttrKMSKeyID: {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: verify.ValidARN,
+										ValidateFunc: verify.ValidKMSKeyID,
 									},
 									names.AttrSnapshotID: {
 										Type:     schema.TypeString,


### PR DESCRIPTION
## Description
Updates `kms_key_id` validation in launch templates to accept all AWS-supported formats instead of only ARN.

## Problem
- Issue #44505: Documentation ambiguity between KMS Key ID and ARN
- Current validation (`verify.ValidARN`) only accepts ARN format
- AWS API actually supports: key ID, key alias, key ARN, and alias ARN

## Solution
- Changed `ValidateFunc` from `verify.ValidARN` to `verify.ValidKMSKeyID`
- Now accepts all AWS-supported KMS key identifier formats
- Aligns with AWS API documentation and other Terraform resources

## Verification
- Checked existing usage: RDS, Redshift resources already use `verify.ValidKMSKeyID`
- AWS API documentation confirms support for multiple formats
- Maintains backward compatibility while expanding functionality

Fixes: #44505 
