### PR TITLE
[Enhancement] r/aws_lambda_event_source_mapping: Add `schema_registry_config` to both MSK and self-managed Kafka event sources

### DIFF
--- a/.changelog/44540.txt
+++ b/.changelog/44540.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lambda_event_source_mapping: Add `schema_registry_config` configuration blocks to `amazon_managed_kafka_event_source_config` and `self_managed_kafka_event_source_config` blocks
+```

--- a/internal/service/lambda/event_source_mapping_test.go
+++ b/internal/service/lambda/event_source_mapping_test.go
@@ -2734,7 +2734,7 @@ func testAccEventSourceMappingConfig_msk(rName, batchSize string) string {
 	return acctest.ConfigCompose(testAccEventSourceMappingConfig_kafkaBase(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
-  kafka_version          = "2.7.1"
+  kafka_version          = "3.8.x"
   number_of_broker_nodes = 2
 
   broker_node_group_info {
@@ -2771,7 +2771,7 @@ func testAccEventSourceMappingConfig_mskWithEventSourceConfig(rName, batchSize s
 	return acctest.ConfigCompose(testAccEventSourceMappingConfig_kafkaBase(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
-  kafka_version          = "2.7.1"
+  kafka_version          = "3.8.x"
   number_of_broker_nodes = 2
 
   broker_node_group_info {

--- a/internal/service/lambda/event_source_mapping_test.go
+++ b/internal/service/lambda/event_source_mapping_test.go
@@ -1028,6 +1028,78 @@ func TestAccLambdaEventSourceMapping_mskWithEventSourceConfig(t *testing.T) {
 	})
 }
 
+func TestAccLambdaEventSourceMapping_mskWithEventSourceConfigSchemaRegistry(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v lambda.GetEventSourceMappingOutput
+	resourceName := "aws_lambda_event_source_mapping.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckMSK(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID, "kafka"),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEventSourceMappingDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEventSourceMappingConfig_mskWithEventSourceConfigSchemaRegistryByConfluent(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEventSourceMappingExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "amazon_managed_kafka_event_source_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "amazon_managed_kafka_event_source_config.0.consumer_group_id", "amazon-managed-test-group-id"),
+					resource.TestCheckResourceAttr(resourceName, "amazon_managed_kafka_event_source_config.0.schema_registry_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "amazon_managed_kafka_event_source_config.0.schema_registry_config.0.access_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "amazon_managed_kafka_event_source_config.0.schema_registry_config.0.access_config.0.type", string(awstypes.KafkaSchemaRegistryAuthTypeBasicAuth)),
+					resource.TestCheckResourceAttrPair(resourceName, "amazon_managed_kafka_event_source_config.0.schema_registry_config.0.access_config.0.uri", "aws_secretsmanager_secret.test", names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "amazon_managed_kafka_event_source_config.0.schema_registry_config.0.event_record_format", string(awstypes.SchemaRegistryEventRecordFormatJson)),
+					resource.TestCheckResourceAttr(resourceName, "amazon_managed_kafka_event_source_config.0.schema_registry_config.0.schema_registry_uri", "https://test-schema-registry.com"),
+					resource.TestCheckResourceAttr(resourceName, "amazon_managed_kafka_event_source_config.0.schema_registry_config.0.schema_validation_config.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "amazon_managed_kafka_event_source_config.0.schema_registry_config.0.schema_validation_config.*", map[string]string{
+						"attribute": string(awstypes.KafkaSchemaValidationAttributeKey),
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "amazon_managed_kafka_event_source_config.0.schema_registry_config.0.schema_validation_config.*", map[string]string{
+						"attribute": string(awstypes.KafkaSchemaValidationAttributeValue),
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
+			},
+			{
+				Config: testAccEventSourceMappingConfig_mskWithEventSourceConfigSchemaRegistryByGlue(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEventSourceMappingExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "amazon_managed_kafka_event_source_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "amazon_managed_kafka_event_source_config.0.consumer_group_id", "amazon-managed-test-group-id"),
+					resource.TestCheckResourceAttr(resourceName, "amazon_managed_kafka_event_source_config.0.schema_registry_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "amazon_managed_kafka_event_source_config.0.schema_registry_config.0.access_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "amazon_managed_kafka_event_source_config.0.schema_registry_config.0.event_record_format", string(awstypes.SchemaRegistryEventRecordFormatJson)),
+					resource.TestCheckResourceAttrPair(resourceName, "amazon_managed_kafka_event_source_config.0.schema_registry_config.0.schema_registry_uri", "aws_glue_registry.test", names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "amazon_managed_kafka_event_source_config.0.schema_registry_config.0.schema_validation_config.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "amazon_managed_kafka_event_source_config.0.schema_registry_config.0.schema_validation_config.*", map[string]string{
+						"attribute": string(awstypes.KafkaSchemaValidationAttributeKey),
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "amazon_managed_kafka_event_source_config.0.schema_registry_config.0.schema_validation_config.*", map[string]string{
+						"attribute": string(awstypes.KafkaSchemaValidationAttributeValue),
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
+			},
+		},
+	})
+}
+
 func TestAccLambdaEventSourceMapping_selfManagedKafka(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetEventSourceMappingOutput
@@ -1113,6 +1185,79 @@ func TestAccLambdaEventSourceMapping_selfManagedKafkaWithEventSourceConfig(t *te
 					resource.TestCheckResourceAttr(resourceName, "source_access_configuration.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "topics.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "topics.*", "test"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
+			},
+		},
+	})
+}
+
+func TestAccLambdaEventSourceMapping_selfManagedKafkaWithEventSourceConfigSchemaRegistry(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v lambda.GetEventSourceMappingOutput
+	resourceName := "aws_lambda_event_source_mapping.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEventSourceMappingDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEventSourceMappingConfig_selfManagedKafkaWithEventSourceConfigSchemaRegistryByConfluent(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEventSourceMappingExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "self_managed_kafka_event_source_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "self_managed_kafka_event_source_config.0.consumer_group_id", "self-managed-test-group-id"),
+					resource.TestCheckResourceAttr(resourceName, "self_managed_kafka_event_source_config.0.schema_registry_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "self_managed_kafka_event_source_config.0.schema_registry_config.0.access_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "self_managed_kafka_event_source_config.0.schema_registry_config.0.access_config.0.type", string(awstypes.KafkaSchemaRegistryAuthTypeBasicAuth)),
+					resource.TestCheckResourceAttrPair(resourceName, "self_managed_kafka_event_source_config.0.schema_registry_config.0.access_config.0.uri", "aws_secretsmanager_secret.test", names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "self_managed_kafka_event_source_config.0.schema_registry_config.0.event_record_format", string(awstypes.SchemaRegistryEventRecordFormatJson)),
+					resource.TestCheckResourceAttr(resourceName, "self_managed_kafka_event_source_config.0.schema_registry_config.0.schema_registry_uri", "https://test-schema-registry.com"),
+					resource.TestCheckResourceAttr(resourceName, "self_managed_kafka_event_source_config.0.schema_registry_config.0.schema_validation_config.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "self_managed_kafka_event_source_config.0.schema_registry_config.0.schema_validation_config.*", map[string]string{
+						"attribute": string(awstypes.KafkaSchemaValidationAttributeKey),
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "self_managed_kafka_event_source_config.0.schema_registry_config.0.schema_validation_config.*", map[string]string{
+						"attribute": string(awstypes.KafkaSchemaValidationAttributeValue),
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
+			},
+			{
+				Config: testAccEventSourceMappingConfig_selfManagedKafkaWithEventSourceConfigSchemaRegistryByGlue(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEventSourceMappingExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "self_managed_kafka_event_source_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "self_managed_kafka_event_source_config.0.consumer_group_id", "self-managed-test-group-id"),
+					resource.TestCheckResourceAttr(resourceName, "self_managed_kafka_event_source_config.0.schema_registry_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "self_managed_kafka_event_source_config.0.schema_registry_config.0.access_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "self_managed_kafka_event_source_config.0.schema_registry_config.0.event_record_format", string(awstypes.SchemaRegistryEventRecordFormatJson)),
+					resource.TestCheckResourceAttrPair(resourceName, "self_managed_kafka_event_source_config.0.schema_registry_config.0.schema_registry_uri", "aws_glue_registry.test", names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "self_managed_kafka_event_source_config.0.schema_registry_config.0.schema_validation_config.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "self_managed_kafka_event_source_config.0.schema_registry_config.0.schema_validation_config.*", map[string]string{
+						"attribute": string(awstypes.KafkaSchemaValidationAttributeKey),
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "self_managed_kafka_event_source_config.0.schema_registry_config.0.schema_validation_config.*", map[string]string{
+						"attribute": string(awstypes.KafkaSchemaValidationAttributeValue),
+					}),
 				),
 			},
 			{
@@ -1923,7 +2068,9 @@ resource "aws_iam_policy" "test" {
         "ec2:DescribeVpcs",
         "logs:CreateLogGroup",
         "logs:CreateLogStream",
-        "logs:PutLogEvents"
+        "logs:PutLogEvents",
+        "glue:GetRegistry",
+        "glue:GetSchemaVersion"
       ],
       "Resource": "*"
     }
@@ -2239,6 +2386,43 @@ resource "aws_docdb_cluster" "test" {
   ]
 }
 `, rName))
+}
+
+func testAccEventSourceMappingConfig_kafkaSchemaRegistryByGlueBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_registry" "test" {
+  registry_name = %[1]q
+}
+
+resource "aws_glue_schema" "test" {
+  schema_name   = %[1]q
+  registry_arn  = aws_glue_registry.test.arn
+  data_format   = "JSON"
+  compatibility = "NONE"
+  schema_definition = jsonencode(
+    {
+      "$id" : "https://example.com/person.schema.json",
+      "$schema" : "http://json-schema.org/draft-07/schema#",
+      "title" : "Person",
+      "type" : "object",
+      "properties" : {
+        "firstName" : {
+          "type" : "string",
+          "description" : "The person's first name."
+        },
+        "lastName" : {
+          "type" : "string",
+          "description" : "The person's last name."
+        },
+        "age" : {
+          "description" : "Age in years which must be equal to or greater than zero.",
+          "type" : "integer",
+          "minimum" : 0
+        }
+      }
+  })
+}
+`, rName)
 }
 
 func testAccEventSourceMappingConfig_sqsKMSKeyARN(rName, pattern string) string {
@@ -2620,6 +2804,122 @@ resource "aws_lambda_event_source_mapping" "test" {
 `, rName, batchSize))
 }
 
+func testAccEventSourceMappingConfig_mskWithEventSourceConfigSchemaRegistryByConfluent(rName string) string {
+	return acctest.ConfigCompose(testAccEventSourceMappingConfig_kafkaBase(rName), fmt.Sprintf(`
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  kafka_version          = "3.8.x"
+  number_of_broker_nodes = 2
+
+  broker_node_group_info {
+    client_subnets  = aws_subnet.test[*].id
+    instance_type   = "kafka.m5.large"
+    security_groups = [aws_security_group.test.id]
+
+    storage_info {
+      ebs_storage_info {
+        volume_size = 10
+      }
+    }
+  }
+}
+
+resource "aws_secretsmanager_secret" "test" {
+  name                    = %[1]q
+  recovery_window_in_days = 7
+}
+
+resource "aws_lambda_event_source_mapping" "test" {
+  batch_size        = 100
+  event_source_arn  = aws_msk_cluster.test.arn
+  enabled           = true
+  function_name     = aws_lambda_function.test.arn
+  topics            = ["test"]
+  starting_position = "TRIM_HORIZON"
+
+  provisioned_poller_config {
+    maximum_pollers = 100
+    minimum_pollers = 1
+  }
+
+  amazon_managed_kafka_event_source_config {
+    consumer_group_id = "amazon-managed-test-group-id"
+    schema_registry_config {
+      access_config {
+        type = "BASIC_AUTH"
+        uri  = aws_secretsmanager_secret.test.arn
+      }
+      event_record_format = "JSON"
+      schema_registry_uri = "https://test-schema-registry.com"
+      schema_validation_config {
+        attribute = "KEY"
+      }
+      schema_validation_config {
+        attribute = "VALUE"
+      }
+    }
+  }
+
+  depends_on = [aws_iam_policy_attachment.test]
+}
+`, rName))
+}
+
+func testAccEventSourceMappingConfig_mskWithEventSourceConfigSchemaRegistryByGlue(rName string) string {
+	return acctest.ConfigCompose(
+		testAccEventSourceMappingConfig_kafkaBase(rName),
+		testAccEventSourceMappingConfig_kafkaSchemaRegistryByGlueBase(rName),
+		fmt.Sprintf(`
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  kafka_version          = "3.8.x"
+  number_of_broker_nodes = 2
+
+  broker_node_group_info {
+    client_subnets  = aws_subnet.test[*].id
+    instance_type   = "kafka.m5.large"
+    security_groups = [aws_security_group.test.id]
+
+    storage_info {
+      ebs_storage_info {
+        volume_size = 10
+      }
+    }
+  }
+}
+
+resource "aws_lambda_event_source_mapping" "test" {
+  batch_size        = 100
+  event_source_arn  = aws_msk_cluster.test.arn
+  enabled           = true
+  function_name     = aws_lambda_function.test.arn
+  topics            = ["test"]
+  starting_position = "TRIM_HORIZON"
+
+  provisioned_poller_config {
+    maximum_pollers = 100
+    minimum_pollers = 1
+  }
+
+  amazon_managed_kafka_event_source_config {
+    consumer_group_id = "amazon-managed-test-group-id"
+    schema_registry_config {
+      event_record_format = "JSON"
+      schema_registry_uri = aws_glue_registry.test.arn
+      schema_validation_config {
+        attribute = "KEY"
+      }
+      schema_validation_config {
+        attribute = "VALUE"
+      }
+    }
+  }
+
+  depends_on = [aws_iam_policy_attachment.test]
+}
+`, rName))
+}
+
 func testAccEventSourceMappingConfig_selfManagedKafka(rName, batchSize, kafkaBootstrapServers string) string {
 	if batchSize == "" {
 		batchSize = "null"
@@ -2692,6 +2992,117 @@ resource "aws_lambda_event_source_mapping" "test" {
   }
 }
 `, rName, batchSize, kafkaBootstrapServers))
+}
+
+func testAccEventSourceMappingConfig_selfManagedKafkaWithEventSourceConfigSchemaRegistryByConfluent(rName string) string {
+	return acctest.ConfigCompose(testAccEventSourceMappingConfig_kafkaBase(rName), fmt.Sprintf(`
+resource "aws_secretsmanager_secret" "test" {
+  name                    = %[1]q
+  recovery_window_in_days = 7
+}
+
+resource "aws_lambda_event_source_mapping" "test" {
+  batch_size        = 100
+  enabled           = false
+  function_name     = aws_lambda_function.test.arn
+  topics            = ["test"]
+  starting_position = "TRIM_HORIZON"
+
+  provisioned_poller_config {
+    maximum_pollers = 100
+    minimum_pollers = 1
+  }
+
+  self_managed_kafka_event_source_config {
+    consumer_group_id = "self-managed-test-group-id"
+    schema_registry_config {
+      access_config {
+        type = "BASIC_AUTH"
+        uri  = aws_secretsmanager_secret.test.arn
+      }
+      event_record_format = "JSON"
+      schema_registry_uri = "https://test-schema-registry.com"
+      schema_validation_config {
+        attribute = "KEY"
+      }
+      schema_validation_config {
+        attribute = "VALUE"
+      }
+    }
+  }
+
+  self_managed_event_source {
+    endpoints = {
+      KAFKA_BOOTSTRAP_SERVERS = "test1:9092,test2:9092"
+    }
+  }
+
+  dynamic "source_access_configuration" {
+    for_each = aws_subnet.test[*].id
+    content {
+      type = "VPC_SUBNET"
+      uri  = "subnet:${source_access_configuration.value}"
+    }
+  }
+
+  source_access_configuration {
+    type = "VPC_SECURITY_GROUP"
+    uri  = aws_security_group.test.id
+  }
+}
+`, rName))
+}
+
+func testAccEventSourceMappingConfig_selfManagedKafkaWithEventSourceConfigSchemaRegistryByGlue(rName string) string {
+	return acctest.ConfigCompose(
+		testAccEventSourceMappingConfig_kafkaBase(rName),
+		testAccEventSourceMappingConfig_kafkaSchemaRegistryByGlueBase(rName), `
+resource "aws_lambda_event_source_mapping" "test" {
+  batch_size        = 100
+  enabled           = false
+  function_name     = aws_lambda_function.test.arn
+  topics            = ["test"]
+  starting_position = "TRIM_HORIZON"
+
+  provisioned_poller_config {
+    maximum_pollers = 100
+    minimum_pollers = 1
+  }
+
+  self_managed_kafka_event_source_config {
+    consumer_group_id = "self-managed-test-group-id"
+    schema_registry_config {
+      event_record_format = "JSON"
+      schema_registry_uri = aws_glue_registry.test.arn
+      schema_validation_config {
+        attribute = "KEY"
+      }
+      schema_validation_config {
+        attribute = "VALUE"
+      }
+    }
+  }
+
+  self_managed_event_source {
+    endpoints = {
+      KAFKA_BOOTSTRAP_SERVERS = "test1:9092,test2:9092"
+    }
+  }
+
+  dynamic "source_access_configuration" {
+    for_each = aws_subnet.test[*].id
+    content {
+      type = "VPC_SUBNET"
+      uri  = "subnet:${source_access_configuration.value}"
+    }
+  }
+
+  source_access_configuration {
+    type = "VPC_SECURITY_GROUP"
+    uri  = aws_security_group.test.id
+  }
+}
+`)
 }
 
 func testAccEventSourceMappingConfig_selfManagedKafkaWithProvisionedPollerConfig(rName, batchSize, kafkaBootstrapServers, maxPollers, minPollers string) string {

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -234,6 +234,7 @@ The following arguments are optional:
 ### amazon_managed_kafka_event_source_config Configuration Block
 
 * `consumer_group_id` - (Optional) Kafka consumer group ID between 1 and 200 characters for use when creating this event source mapping. If one is not specified, this value will be automatically generated. See [AmazonManagedKafkaEventSourceConfig Syntax](https://docs.aws.amazon.com/lambda/latest/dg/API_AmazonManagedKafkaEventSourceConfig.html).
+* `schema_registry_config` - (Optional) Block for a Kafka schema registry setting. [See below](#schema_registry_config-configuration-block).
 
 ### destination_config Configuration Block
 
@@ -277,11 +278,22 @@ The following arguments are optional:
 ### self_managed_kafka_event_source_config Configuration Block
 
 * `consumer_group_id` - (Optional) Kafka consumer group ID between 1 and 200 characters for use when creating this event source mapping. If one is not specified, this value will be automatically generated. See [SelfManagedKafkaEventSourceConfig Syntax](https://docs.aws.amazon.com/lambda/latest/dg/API_SelfManagedKafkaEventSourceConfig.html).
+* `schema_registry_config` - (Optional) Block for a Kafka schema registry setting. [See below](#schema_registry_config-configuration-block).
 
 ### source_access_configuration Configuration Block
 
 * `type` - (Required) Type of authentication protocol, VPC components, or virtual host for your event source. For valid values, refer to the [AWS documentation](https://docs.aws.amazon.com/lambda/latest/api/API_SourceAccessConfiguration.html).
 * `uri` - (Required) URI for this configuration. For type `VPC_SUBNET` the value should be `subnet:subnet_id` where `subnet_id` is the value you would find in an aws_subnet resource's id attribute. For type `VPC_SECURITY_GROUP` the value should be `security_group:security_group_id` where `security_group_id` is the value you would find in an aws_security_group resource's id attribute.
+
+### schema_registry_config Configuration Block
+
+* `access_config` - (Optional) Configuration block for authentication Lambda uses to access the schema registry.
+    * `type` - (Optional) Authentication type Lambda uses to access the schema registry.
+    * `uri` - (Optional) URI of the secret (Secrets Manager secret ARN) used to authenticate with the schema registry.
+* `event_record_format` - (Optional) Record format that Lambda delivers to the function after schema validation. Valid values: `JSON`, `SOURCE`.
+* `schema_registry_uri` - (Optional) URI of the schema registry. For AWS Glue schema registries, use the ARN of the registry. For Confluent schema registries, use the registry URL.
+* `schema_validation_config` - (Optional) Repeatable block that defines schema validation settings. These specify the message attributes that Lambda should validate and filter using the schema registry.
+    * `attribute` - (Optional) Message attribute to validate. Valid values: `KEY`, `VALUE`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* Add `schema_registry_config` block to both `amazon_managed_kafka_event_source_config` and `self_managed_kafka_event_source_config`.
  * The AWS API uses the same object for `schema_registry_config` in both blocks, so the same schema definition applies to both.
* Update `kafka_version` in existing acceptance tests, as the previous version is no longer supported.

### Relations

Closes #43143 
Closes #44496 

### References
https://docs.aws.amazon.com/lambda/latest/api/API_KafkaSchemaRegistryConfig.html

### Output from Acceptance Testing
One test failed, but it appears not to be related to the fix in this PR.
```console
$ make testacc TESTS='TestAccLambdaEventSourceMapping_' PKG=lambda 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_lambda_event_source_mapping-add_schema_registry_config 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaEventSourceMapping_'  -timeout 360m -vet=off
2025/10/04 01:43:07 Creating Terraform AWS Provider (SDKv2-style)...
2025/10/04 01:43:07 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_basic
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_basic
=== RUN   TestAccLambdaEventSourceMapping_KMSKeyARN
=== PAUSE TestAccLambdaEventSourceMapping_KMSKeyARN
=== RUN   TestAccLambdaEventSourceMapping_tags
=== PAUSE TestAccLambdaEventSourceMapping_tags
=== RUN   TestAccLambdaEventSourceMapping_SQS_basic
=== PAUSE TestAccLambdaEventSourceMapping_SQS_basic
=== RUN   TestAccLambdaEventSourceMapping_DynamoDB_basic
=== PAUSE TestAccLambdaEventSourceMapping_DynamoDB_basic
=== RUN   TestAccLambdaEventSourceMapping_DynamoDB_functionResponseTypes
=== PAUSE TestAccLambdaEventSourceMapping_DynamoDB_functionResponseTypes
=== RUN   TestAccLambdaEventSourceMapping_DynamoDB_streamAdded
=== PAUSE TestAccLambdaEventSourceMapping_DynamoDB_streamAdded
=== RUN   TestAccLambdaEventSourceMapping_SQS_batchWindow
=== PAUSE TestAccLambdaEventSourceMapping_SQS_batchWindow
=== RUN   TestAccLambdaEventSourceMapping_disappears
=== PAUSE TestAccLambdaEventSourceMapping_disappears
=== RUN   TestAccLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== PAUSE TestAccLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_batchWindow
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_batchWindow
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_bisectBatch
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_bisectBatch
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_destination
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_destination
=== RUN   TestAccLambdaEventSourceMapping_msk
=== PAUSE TestAccLambdaEventSourceMapping_msk
=== RUN   TestAccLambdaEventSourceMapping_mskWithEventSourceConfig
=== PAUSE TestAccLambdaEventSourceMapping_mskWithEventSourceConfig
=== RUN   TestAccLambdaEventSourceMapping_mskWithEventSourceConfigSchemaRegistry
=== PAUSE TestAccLambdaEventSourceMapping_mskWithEventSourceConfigSchemaRegistry
=== RUN   TestAccLambdaEventSourceMapping_selfManagedKafka
=== PAUSE TestAccLambdaEventSourceMapping_selfManagedKafka
=== RUN   TestAccLambdaEventSourceMapping_selfManagedKafkaWithEventSourceConfig
=== PAUSE TestAccLambdaEventSourceMapping_selfManagedKafkaWithEventSourceConfig
=== RUN   TestAccLambdaEventSourceMapping_selfManagedKafkaWithEventSourceConfigSchemaRegistry
=== PAUSE TestAccLambdaEventSourceMapping_selfManagedKafkaWithEventSourceConfigSchemaRegistry
=== RUN   TestAccLambdaEventSourceMapping_selfManagedKafkaWithProvisionedPollerConfig
=== PAUSE TestAccLambdaEventSourceMapping_selfManagedKafkaWithProvisionedPollerConfig
=== RUN   TestAccLambdaEventSourceMapping_activeMQ
=== PAUSE TestAccLambdaEventSourceMapping_activeMQ
=== RUN   TestAccLambdaEventSourceMapping_rabbitMQ
=== PAUSE TestAccLambdaEventSourceMapping_rabbitMQ
=== RUN   TestAccLambdaEventSourceMapping_SQS_filterCriteria
=== PAUSE TestAccLambdaEventSourceMapping_SQS_filterCriteria
=== RUN   TestAccLambdaEventSourceMapping_SQS_scalingConfig
=== PAUSE TestAccLambdaEventSourceMapping_SQS_scalingConfig
=== RUN   TestAccLambdaEventSourceMapping_documentDB
=== PAUSE TestAccLambdaEventSourceMapping_documentDB
=== RUN   TestAccLambdaEventSourceMapping_SQS_metricsConfig
=== PAUSE TestAccLambdaEventSourceMapping_SQS_metricsConfig
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_basic
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds
=== CONT  TestAccLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_batchWindow
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp
=== CONT  TestAccLambdaEventSourceMapping_selfManagedKafkaWithEventSourceConfigSchemaRegistry
=== CONT  TestAccLambdaEventSourceMapping_SQS_metricsConfig
=== CONT  TestAccLambdaEventSourceMapping_rabbitMQ
=== CONT  TestAccLambdaEventSourceMapping_activeMQ
=== CONT  TestAccLambdaEventSourceMapping_selfManagedKafkaWithProvisionedPollerConfig
=== CONT  TestAccLambdaEventSourceMapping_documentDB
=== CONT  TestAccLambdaEventSourceMapping_SQS_scalingConfig
=== CONT  TestAccLambdaEventSourceMapping_mskWithEventSourceConfig
=== CONT  TestAccLambdaEventSourceMapping_selfManagedKafkaWithEventSourceConfig
=== CONT  TestAccLambdaEventSourceMapping_selfManagedKafka
--- PASS: TestAccLambdaEventSourceMapping_selfManagedKafkaWithEventSourceConfig (63.30s)
=== CONT  TestAccLambdaEventSourceMapping_mskWithEventSourceConfigSchemaRegistry
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts (79.45s)
=== CONT  TestAccLambdaEventSourceMapping_DynamoDB_functionResponseTypes
--- PASS: TestAccLambdaEventSourceMapping_SQS_changesInEnabledAreDetected (82.80s)
=== CONT  TestAccLambdaEventSourceMapping_disappears
--- PASS: TestAccLambdaEventSourceMapping_selfManagedKafkaWithProvisionedPollerConfig (103.92s)
=== CONT  TestAccLambdaEventSourceMapping_SQS_batchWindow
=== CONT  TestAccLambdaEventSourceMapping_DynamoDB_streamAdded
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds (107.97s)
--- PASS: TestAccLambdaEventSourceMapping_selfManagedKafkaWithEventSourceConfigSchemaRegistry (114.52s)
=== CONT  TestAccLambdaEventSourceMapping_SQS_basic
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne (118.09s)
=== CONT  TestAccLambdaEventSourceMapping_DynamoDB_basic
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp (118.78s)
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_destination
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero (145.33s)
=== CONT  TestAccLambdaEventSourceMapping_msk
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_batchWindow (149.20s)
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_bisectBatch
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds (162.24s)
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor (175.59s)
=== CONT  TestAccLambdaEventSourceMapping_tags
--- PASS: TestAccLambdaEventSourceMapping_SQS_scalingConfig (180.20s)
=== CONT  TestAccLambdaEventSourceMapping_KMSKeyARN
--- PASS: TestAccLambdaEventSourceMapping_selfManagedKafka (185.82s)
=== CONT  TestAccLambdaEventSourceMapping_SQS_filterCriteria
--- PASS: TestAccLambdaEventSourceMapping_SQS_metricsConfig (186.32s)
--- PASS: TestAccLambdaEventSourceMapping_DynamoDB_functionResponseTypes (130.26s)
--- PASS: TestAccLambdaEventSourceMapping_SQS_batchWindow (115.65s)
--- PASS: TestAccLambdaEventSourceMapping_disappears (138.87s)
--- PASS: TestAccLambdaEventSourceMapping_DynamoDB_basic (120.52s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_destination (138.38s)
--- PASS: TestAccLambdaEventSourceMapping_DynamoDB_streamAdded (155.29s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_bisectBatch (119.17s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne (112.75s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_basic (275.55s)
--- PASS: TestAccLambdaEventSourceMapping_KMSKeyARN (103.59s)
--- PASS: TestAccLambdaEventSourceMapping_tags (121.88s)
--- PASS: TestAccLambdaEventSourceMapping_SQS_basic (190.65s)
--- PASS: TestAccLambdaEventSourceMapping_SQS_filterCriteria (200.24s)
=== NAME  TestAccLambdaEventSourceMapping_rabbitMQ
    event_source_mapping_test.go:1385: Step 1/2 error: After applying this test step, the refresh plan was not empty.
        stdout
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_mq_broker.test will be updated in-place
          ~ resource "aws_mq_broker" "test" {
                id                            = "b-296777b8-be33-4294-902e-23c5a3844018"
                tags                          = {}
                # (18 unchanged attributes hidden)
        
                # (4 unchanged blocks hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccLambdaEventSourceMapping_rabbitMQ (756.64s)
--- PASS: TestAccLambdaEventSourceMapping_activeMQ (1154.14s)
--- PASS: TestAccLambdaEventSourceMapping_documentDB (1738.58s)
--- PASS: TestAccLambdaEventSourceMapping_mskWithEventSourceConfigSchemaRegistry (1755.13s)
--- PASS: TestAccLambdaEventSourceMapping_mskWithEventSourceConfig (2996.40s)
--- PASS: TestAccLambdaEventSourceMapping_msk (3020.32s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/lambda     3170.442s
FAIL
make: *** [testacc] Error 1

```
