### PR TITLE
route53domains: make privacy fields optional/computed to avoid forced…

### DIFF
--- a/internal/service/route53domains/registered_domain.go
+++ b/internal/service/route53domains/registered_domain.go
@@ -158,7 +158,7 @@ func resourceRegisteredDomain() *schema.Resource {
 				"admin_privacy": {
 					Type:     schema.TypeBool,
 					Optional: true,
-					Default:  true,
+					Computed:  true,
 				},
 				"auto_renew": {
 					Type:     schema.TypeBool,
@@ -169,7 +169,7 @@ func resourceRegisteredDomain() *schema.Resource {
 				"billing_privacy": {
 					Type:     schema.TypeBool,
 					Optional: true,
-					Default:  true,
+					Computed:  true,
 				},
 				names.AttrCreationDate: {
 					Type:     schema.TypeString,
@@ -214,7 +214,7 @@ func resourceRegisteredDomain() *schema.Resource {
 				"registrant_privacy": {
 					Type:     schema.TypeBool,
 					Optional: true,
-					Default:  true,
+					Computed:  true,
 				},
 				"registrar_name": {
 					Type:     schema.TypeString,
@@ -239,7 +239,7 @@ func resourceRegisteredDomain() *schema.Resource {
 				"tech_privacy": {
 					Type:     schema.TypeBool,
 					Optional: true,
-					Default:  true,
+					Computed:  true,
 				},
 				"transfer_lock": {
 					Type:     schema.TypeBool,


### PR DESCRIPTION
## Title
route53domains: make privacy fields optional/computed to avoid forced API calls

## Description

Removes `Default=true` from `admin_privacy`, `billing_privacy`, `registrant_privacy`, and `tech_privacy` in the `aws_route53domains_registered_domain` resource.

Previously, these attributes always defaulted to `true`, which forced Terraform to call `UpdateDomainContactPrivacy` even when privacy is not supported by the TLD (e.g. `.cz`, `.eu`). This resulted in `400 InvalidInput` errors during apply.

With this change, the privacy fields are now `Optional+Computed`. Terraform will:
- Only manage privacy if a value is explicitly set in configuration.
- Otherwise, treat AWS as the source of truth and skip unsupported API calls.

This prevents errors for unsupported TLDs while preserving full functionality for TLDs that allow privacy management.

## Relations

Closes #44538

## References

- AWS CZ route 53 docs: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/cz.html
- AWS Route 53 Domains docs: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/domain-privacy-protection.html  
- Provider PR guidelines: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/

## Rollback Plan

If needed, revert this commit and reintroduce `Default=true` for the privacy fields. This will restore prior behavior (always managing privacy), but may reintroduce errors for unsupported TLDs.

## Changes to Security Controls

No changes to access controls, encryption, or logging. This change only affects how Terraform decides whether to call `UpdateDomainContactPrivacy`.

## Output from Acceptance Testing
N/A