### PR TITLE
Avoid using d.Get("task") for each task in appflow_flow

### DIFF
--- a/internal/service/appflow/flow.go
+++ b/internal/service/appflow/flow.go
@@ -1208,16 +1208,12 @@ func resourceFlow() *schema.Resource {
 								ValidateFunc: validation.StringLenBetween(0, 2048),
 							},
 							DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
-								if v, ok := d.Get("task").(*schema.Set); ok && v.Len() == 1 {
-									if tl, ok := v.List()[0].(map[string]any); ok && len(tl) > 0 {
-										if sf, ok := tl["source_fields"].([]any); ok && len(sf) == 1 {
-											if sf[0] == "" {
-												return oldValue == "0" && newValue == "1"
-											}
-										}
-									}
+								marker, ok := d.Get("single_task_flag").(bool)
+								if !ok || !marker {
+									return false
 								}
-								return false
+
+								return oldValue == "0" && newValue == "1"
 							},
 						},
 						"task_properties": {
@@ -1234,6 +1230,16 @@ func resourceFlow() *schema.Resource {
 							ValidateDiagFunc: enum.Validate[types.TaskType](),
 						},
 					},
+				},
+			},
+			"single_task_flag": {
+				Type:     schema.TypeBool,
+				Computed: true,
+				Optional: true,
+				ForceNew: false,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// Ignore internal field
+					return true
 				},
 			},
 			"trigger_config": {
@@ -1415,8 +1421,12 @@ func resourceFlowRead(ctx context.Context, d *schema.ResourceData, meta any) dia
 	} else {
 		d.Set("source_flow_config", nil)
 	}
-	if err := d.Set("task", flattenTasks(output.Tasks)); err != nil {
+	tasks := flattenTasks(output.Tasks)
+	if err := d.Set("task", tasks); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting task: %s", err)
+	}
+	if err := d.Set("single_task_flag", len(tasks) == 1); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting single_task_flag: %s", err)
 	}
 	if output.TriggerConfig != nil {
 		if err := d.Set("trigger_config", []any{flattenTriggerConfig(output.TriggerConfig)}); err != nil {


### PR DESCRIPTION
## Rollback Plan

A new attribute has been added, but believe this can _just_ be reverted.

## Changes to Security Controls

No

### Description

The original implementation called d.Get("task") for each task's source_fields attribute. As a result, for each task, d.Get("task") is called - which turns out to be expensive. For example for ~350 tasks, this seemed to take about 15 minutes. Profiling for this original behavoir can be seen in the PR.

This change introduces a new single_task_flag attribute, which is computed once during the read operation and this is used to determine if a single task is present (which is what the original result of d.Get("task") was used for. From local testing of the use-case, this completely fixes the slow-down


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
