### PR TITLE
[bugfix] aws_rds_cluster: Fix inability to update `serverlessv2_scaling_configuration.min_capacity` argument from `1` to `0`

### DIFF
--- a/.changelog/44545.txt
+++ b/.changelog/44545.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_cluster: Fix inability to update `serverlessv2_scaling_configuration.min_capacity` argument from `1` to `0`
+```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -583,10 +583,15 @@ func resourceCluster() *schema.Resource {
 				},
 			},
 			"serverlessv2_scaling_configuration": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				MaxItems:         1,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if k == "serverlessv2_scaling_configuration.#" {
+						return verify.SuppressMissingOptionalConfigurationBlock(k, old, new, d)
+					}
+					return false
+				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						names.AttrMaxCapacity: {

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -2203,12 +2203,12 @@ func TestAccRDSCluster_serverlessV2ScalingConfiguration(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_serverlessV2ScalingConfiguration(rName, 64.0, 2.5),
+				Config: testAccClusterConfig_serverlessV2ScalingConfiguration(rName, 64.0, 1.0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
 					resource.TestCheckResourceAttr(resourceName, "serverlessv2_scaling_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "serverlessv2_scaling_configuration.0.max_capacity", "64"),
-					resource.TestCheckResourceAttr(resourceName, "serverlessv2_scaling_configuration.0.min_capacity", "2.5"),
+					resource.TestCheckResourceAttr(resourceName, "serverlessv2_scaling_configuration.0.min_capacity", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "serverlessv2_scaling_configuration.0.seconds_until_auto_pause"),
 				),
 			},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* #44468 reported an issue where `min_capacity` could not be changed from `1` to `0`.
* The function `verify.SuppressMissingOptionalConfigurationBlock`, configured as the `DiffSuppressFunc` for the `serverlessv2_scaling_configuration` block, is invoked not only for the block itself but also for its elements, including `min_capacity`.
  * This function suppresses the diff when the new value is `0` and the old value is `1`, which exactly matches the behavior observed for `min_capacity` in this issue.
* To fix the issue, the function is now invoked only when the argument name is `serverlessv2_scaling_configuration.#`, which excludes `min_capacity`.
* Update the acceptance test to cover a case where `min_capacity` is changed from `1` to `0`.
  * Without this modification, it is confirmed that the updated acceptance fails.

### Relations

Closes #44468
Closes #40685

### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccRDSCluster_serverlessV2Scaling' PKG=rds 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws_rds_cluster-fix_serverlessv2_scaling_min_capacity_from_1_to_0 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSCluster_serverlessV2Scaling'  -timeout 360m -vet=off
2025/10/05 01:54:09 Creating Terraform AWS Provider (SDKv2-style)...
2025/10/05 01:54:09 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSCluster_serverlessV2ScalingConfiguration
=== PAUSE TestAccRDSCluster_serverlessV2ScalingConfiguration
=== RUN   TestAccRDSCluster_serverlessV2ScalingRemoved
=== PAUSE TestAccRDSCluster_serverlessV2ScalingRemoved
=== CONT  TestAccRDSCluster_serverlessV2ScalingConfiguration
=== CONT  TestAccRDSCluster_serverlessV2ScalingRemoved
--- PASS: TestAccRDSCluster_serverlessV2ScalingRemoved (175.22s)
--- PASS: TestAccRDSCluster_serverlessV2ScalingConfiguration (295.63s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        299.866s


```
