### PR TITLE
[Enhancement]: `aws_vpclattice_resource_gateway`:  add `ipv4_addresses_per_eni` argument

### DIFF
--- a/.changelog/44560.txt
+++ b/.changelog/44560.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_vpclattice_resource_gateway: Add `ipv4_addresses_per_eni` argument to `aws_vpclattice_resource_gateway`
+resource/aws_vpclattice_resource_gateway: Add `ipv4_addresses_per_eni` argument
 ```

--- a/.changelog/44560.txt
+++ b/.changelog/44560.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_vpclattice_resource_gateway: Add `ipv4_addresses_per_eni` argument to `aws_vpclattice_resource_gateway`
+```

--- a/internal/service/vpclattice/resource_gateway.go
+++ b/internal/service/vpclattice/resource_gateway.go
@@ -78,6 +78,7 @@ func (r *resourceGatewayResource) Schema(ctx context.Context, request resource.S
 				},
 				PlanModifiers: []planmodifier.Int32{
 					int32planmodifier.RequiresReplace(),
+					int32planmodifier.UseStateForUnknown(),
 				},
 			},
 			names.AttrName: schema.StringAttribute{

--- a/internal/service/vpclattice/resource_gateway.go
+++ b/internal/service/vpclattice/resource_gateway.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
@@ -72,6 +71,7 @@ func (r *resourceGatewayResource) Schema(ctx context.Context, request resource.S
 			},
 			"ipv4_addresses_per_eni": schema.Int32Attribute{
 				Optional: true,
+				Computed: true,
 				Validators: []validator.Int32{
 					int32validator.AtLeast(1),
 					int32validator.AtMost(62),
@@ -79,7 +79,6 @@ func (r *resourceGatewayResource) Schema(ctx context.Context, request resource.S
 				PlanModifiers: []planmodifier.Int32{
 					int32planmodifier.RequiresReplace(),
 				},
-				Default: int32default.StaticInt32(16),
 			},
 			names.AttrName: schema.StringAttribute{
 				Required: true,
@@ -152,7 +151,7 @@ func (r *resourceGatewayResource) Create(ctx context.Context, request resource.C
 
 	// Ipv4AddressesPerEni is irrelevant if IPAddressType is IPv6
 	if data.IPAddressType.ValueEnum() != awstypes.ResourceGatewayIpAddressTypeIpv6 {
-		input.Ipv4AddressesPerEni = fwflex.Int32FromFramework(ctx, data.Ipv4AddressesPerEni)
+		input.Ipv4AddressesPerEni = fwflex.Int32FromFramework(ctx, data.IPV4AddressesPerEni)
 	}
 
 	outputCRG, err := conn.CreateResourceGateway(ctx, &input)
@@ -376,7 +375,7 @@ type resourceGatewayResourceModel struct {
 	ARN                 types.String                                              `tfsdk:"arn"`
 	ID                  types.String                                              `tfsdk:"id"`
 	IPAddressType       fwtypes.StringEnum[awstypes.ResourceGatewayIpAddressType] `tfsdk:"ip_address_type"`
-	Ipv4AddressesPerEni types.Int32                                               `tfsdk:"ipv4_addresses_per_eni"`
+	IPV4AddressesPerEni types.Int32                                               `tfsdk:"ipv4_addresses_per_eni"`
 	Name                types.String                                              `tfsdk:"name"`
 	SecurityGroupIDs    fwtypes.SetOfString                                       `tfsdk:"security_group_ids"`
 	Status              fwtypes.StringEnum[awstypes.ResourceGatewayStatus]        `tfsdk:"status"`

--- a/internal/service/vpclattice/resource_gateway.go
+++ b/internal/service/vpclattice/resource_gateway.go
@@ -12,10 +12,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -66,6 +69,17 @@ func (r *resourceGatewayResource) Schema(ctx context.Context, request resource.S
 					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),
 				},
+			},
+			"ipv4_addresses_per_eni": schema.Int32Attribute{
+				Optional: true,
+				Validators: []validator.Int32{
+					int32validator.AtLeast(1),
+					int32validator.AtMost(62),
+				},
+				PlanModifiers: []planmodifier.Int32{
+					int32planmodifier.RequiresReplace(),
+				},
+				Default: int32default.StaticInt32(16),
 			},
 			names.AttrName: schema.StringAttribute{
 				Required: true,
@@ -135,6 +149,11 @@ func (r *resourceGatewayResource) Create(ctx context.Context, request resource.C
 	input.ClientToken = aws.String(sdkid.UniqueId())
 	input.Tags = getTagsIn(ctx)
 	input.VpcIdentifier = fwflex.StringFromFramework(ctx, data.VPCID)
+
+	// Ipv4AddressesPerEni is irrelevant if IPAddressType is IPv6
+	if data.IPAddressType.ValueEnum() != awstypes.ResourceGatewayIpAddressTypeIpv6 {
+		input.Ipv4AddressesPerEni = fwflex.Int32FromFramework(ctx, data.Ipv4AddressesPerEni)
+	}
 
 	outputCRG, err := conn.CreateResourceGateway(ctx, &input)
 
@@ -354,15 +373,16 @@ func waitResourceGatewayDeleted(ctx context.Context, conn *vpclattice.Client, id
 
 type resourceGatewayResourceModel struct {
 	framework.WithRegionModel
-	ARN              types.String                                              `tfsdk:"arn"`
-	ID               types.String                                              `tfsdk:"id"`
-	IPAddressType    fwtypes.StringEnum[awstypes.ResourceGatewayIpAddressType] `tfsdk:"ip_address_type"`
-	Name             types.String                                              `tfsdk:"name"`
-	SecurityGroupIDs fwtypes.SetOfString                                       `tfsdk:"security_group_ids"`
-	Status           fwtypes.StringEnum[awstypes.ResourceGatewayStatus]        `tfsdk:"status"`
-	SubnetIDs        fwtypes.SetOfString                                       `tfsdk:"subnet_ids"`
-	Tags             tftags.Map                                                `tfsdk:"tags"`
-	TagsAll          tftags.Map                                                `tfsdk:"tags_all"`
-	Timeouts         timeouts.Value                                            `tfsdk:"timeouts"`
-	VPCID            types.String                                              `tfsdk:"vpc_id"`
+	ARN                 types.String                                              `tfsdk:"arn"`
+	ID                  types.String                                              `tfsdk:"id"`
+	IPAddressType       fwtypes.StringEnum[awstypes.ResourceGatewayIpAddressType] `tfsdk:"ip_address_type"`
+	Ipv4AddressesPerEni types.Int32                                               `tfsdk:"ipv4_addresses_per_eni"`
+	Name                types.String                                              `tfsdk:"name"`
+	SecurityGroupIDs    fwtypes.SetOfString                                       `tfsdk:"security_group_ids"`
+	Status              fwtypes.StringEnum[awstypes.ResourceGatewayStatus]        `tfsdk:"status"`
+	SubnetIDs           fwtypes.SetOfString                                       `tfsdk:"subnet_ids"`
+	Tags                tftags.Map                                                `tfsdk:"tags"`
+	TagsAll             tftags.Map                                                `tfsdk:"tags_all"`
+	Timeouts            timeouts.Value                                            `tfsdk:"timeouts"`
+	VPCID               types.String                                              `tfsdk:"vpc_id"`
 }

--- a/internal/service/vpclattice/resource_gateway_test.go
+++ b/internal/service/vpclattice/resource_gateway_test.go
@@ -165,6 +165,43 @@ func TestAccVPCLatticeResourceGateway_multipleSubnets(t *testing.T) {
 	})
 }
 
+func TestAccVPCLatticeResourceGateway_ipv4AddressesPerEni(t *testing.T) {
+	ctx := acctest.Context(t)
+	var resourcegateway vpclattice.GetResourceGatewayOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_vpclattice_resource_gateway.test"
+	addressType := "IPV4"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.VPCLatticeEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckResourceGatewayDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceGatewayConfig_ipv4AddressesPerEni(rName, 5),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGatewayExists(ctx, resourceName, &resourcegateway),
+					resource.TestCheckResourceAttr(resourceName, names.AttrIPAddressType, addressType),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "ACTIVE"),
+					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ipv4_addresses_per_eni", "5"),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "vpc-lattice", regexache.MustCompile(`resourcegateway/rgw-.+`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccVPCLatticeResourceGateway_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	var resourcegateway vpclattice.GetResourceGatewayOutput
@@ -383,6 +420,18 @@ resource "aws_vpclattice_resource_gateway" "test" {
   ip_address_type    = "IPV4"
 }
 `, rName))
+}
+
+func testAccResourceGatewayConfig_ipv4AddressesPerEni(rName string, ipAddressesPerEni int32) string {
+	return acctest.ConfigCompose(testAccResourceGatewayConfig_base(rName), fmt.Sprintf(`
+resource "aws_vpclattice_resource_gateway" "test" {
+  name                   = %[1]q
+  vpc_id                 = aws_vpc.test.id
+  security_group_ids     = [aws_security_group.test.id]
+  subnet_ids             = [aws_subnet.test.id]
+  ipv4_addresses_per_eni = %[2]q
+}
+`, rName, ipAddressesPerEni))
 }
 
 func testAccResourceGatewayConfig_update1(rName string) string {

--- a/internal/service/vpclattice/resource_gateway_test.go
+++ b/internal/service/vpclattice/resource_gateway_test.go
@@ -429,7 +429,7 @@ resource "aws_vpclattice_resource_gateway" "test" {
   vpc_id                 = aws_vpc.test.id
   security_group_ids     = [aws_security_group.test.id]
   subnet_ids             = [aws_subnet.test.id]
-  ipv4_addresses_per_eni = %[2]q
+  ipv4_addresses_per_eni = %[2]d
 }
 `, rName, ipAddressesPerEni))
 }

--- a/website/docs/r/vpclattice_resource_gateway.html.markdown
+++ b/website/docs/r/vpclattice_resource_gateway.html.markdown
@@ -63,6 +63,7 @@ The following arguments are optional:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `ip_address_type` - (Optional) IP address type used by the resource gateway. Valid values are `IPV4`, `IPV6`, and `DUALSTACK`. The IP address type of a resource gateway must be compatible with the subnets of the resource gateway and the IP address type of the resource.
+* `ipv4_addresses_per_eni` - (Optional) The number of IPv4 addresses per ENI for your resource. This argument is only applicable to `IPV4` and `DUALSTACK` IP address types. Defaults to `16`.
 * `security_group_ids` - (Optional) Security group IDs associated with the resource gateway. The security groups must be in the same VPC.
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

- Add `ipv4_addresses_per_eni` argument to `aws_vpclattice_resource_gateway`.
  - This argument is optional, and defaults to `16`. According to 
  - It is only applicable to `IPV4` and `DUALSTACK` IP address types.
  - The number of addresses per ENI must range from 1 to 62.
  - The number of addresses per ENI cannot be edited after resource creation.

### Relations

Closes #44555

### References

- Create Resource Gateway docs now call out the new "Pv4 addresses per ENI" option: https://docs.aws.amazon.com/vpc/latest/privatelink/create-resource-gateway.html
- Latest go-sdk-v2: https://github.com/aws/aws-sdk-go-v2/blob/e9e5d66c8bb0f113fffc221bc3f38368c56c67c7/service/vpclattice/api_op_CreateResourceGateway.go#L68


### Output from Acceptance Testing

I will not be able to provision a testing environment immediately, if someone could help me run the tests, that would be appreciated!

```console
$ make testacc TESTS='TestAccVPCLatticeResourceGateway_' PKG=vpclattice

...
```
