### PR TITLE
Docs: Clarify deprecations in `aws_service_discovery_service`

### DIFF
--- a/website/docs/r/service_discovery_service.html.markdown
+++ b/website/docs/r/service_discovery_service.html.markdown
@@ -39,7 +39,7 @@ resource "aws_service_discovery_service" "example" {
     routing_policy = "MULTIVALUE"
   }
 
-  health_check_custom_config {
+  health_check_config {
     failure_threshold = 1
   }
 }
@@ -79,9 +79,9 @@ This resource supports the following arguments:
 * `name` - (Required, Forces new resource) The name of the service.
 * `description` - (Optional) The description of the service.
 * `dns_config` - (Optional) A complex type that contains information about the resource record sets that you want Amazon Route 53 to create when you register an instance. See [`dns_config` Block](#dns_config-block) for details.
-* `health_check_config` - (Optional) A complex type that contains settings for an optional health check. Only for Public DNS namespaces. See [`health_check_config` Block](#health_check_config-block) for details.
 * `force_destroy` - (Optional) A boolean that indicates all instances should be deleted from the service so that the service can be destroyed without error. These instances are not recoverable. Defaults to `false`.
-* `health_check_custom_config` - (Optional, Forces new resource) A complex type that contains settings for ECS managed health checks. See [`health_check_custom_config` Block](#health_check_custom_config-block) for details.
+* `health_check_config` - (Optional) A complex type that contains settings for an optional health check. Only for Public DNS namespaces. See [`health_check_config` Block](#health_check_config-block) for details.
+* `health_check_custom_config` - (Optional, **Deprecated**, Forces new resource) Please use `health_check_config` instead. See [`health_check_custom_config` Block](#health_check_custom_config-block) for details.
 * `namespace_id` - (Optional) The ID of the namespace that you want to use to create the service.
 * `type` - (Optional) If present, specifies that the service instances are only discoverable using the `DiscoverInstances` API operation. No DNS records is registered for the service instances. The only valid value is `HTTP`.
 * `tags` - (Optional) A map of tags to assign to the service. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
@@ -110,6 +110,8 @@ The `health_check_config` configuration block supports the following arguments:
 * `type` - (Optional, Forces new resource) The type of health check that you want to create, which indicates how Route 53 determines whether an endpoint is healthy. Valid Values: HTTP, HTTPS, TCP
 
 ### `health_check_custom_config` Block
+
+~> The `health_check_custom_config` argument is deprecated. Use [`health_check_config`](#health_check_config-block) instead, which supports additional attributes.
 
 The `health_check_custom_config` configuration block supports the following arguments:
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls
n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change adapts the example usage to use the non-deprecated block `health_check_config` instead of `health_check_custom_config`. 
Additionally, a note regarding the deprecation of `health_check_custom_config` is added.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

n/a
