### PR TITLE
Fix updating tags of ECS service during update

### DIFF
--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -1600,6 +1600,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta any) 
 func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
+	partition := meta.(*conns.AWSClient).Partition(ctx)
 
 	if d.HasChangesExcept(names.AttrForceDelete, names.AttrTags, names.AttrTagsAll) {
 		cluster := d.Get("cluster").(string)
@@ -1818,6 +1819,17 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta any
 			}
 		} else if _, err := waitServiceActive(ctx, conn, d.Id(), cluster, d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for ECS Service (%s) update: %s", d.Id(), err)
+		}
+	}
+
+	// Update tags, as this isn't supported in UpdateService
+	newTags := getTagsIn(ctx)
+	err := updateTags(ctx, conn, d.Id(), d.Get(names.AttrTags), newTags)
+
+	// If default tags only, continue. Otherwise, error.
+	if err != nil {
+		if v, ok := d.GetOk(names.AttrTags); !((!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err)) {
+			return sdkdiag.AppendErrorf(diags, "setting ECS Service (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -5327,6 +5327,73 @@ resource "aws_ecs_service" "test" {
 `, rName)
 }
 
+func TestAccECSService_Tags_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	var service awstypes.Service
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ecs_service.test"
+
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckServiceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceConfig_tags(rName, map[string]string{"env": "dev"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "tags.env", "dev"),
+				),
+			},
+			{
+				Config: testAccServiceConfig_tags(rName, map[string]string{"env": "prod"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "tags.env", "prod"),
+				),
+			},
+			{
+				Config: testAccServiceConfig_tags(rName, map[string]string{}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
+				),
+			},
+		},
+	})
+}
+func testAccServiceConfig_tags(rName string, tags map[string]string) string {
+	tagsHCL := ""
+	if len(tags) > 0 {
+		tagsHCL = "tags = {\n"
+		for k, v := range tags {
+			tagsHCL += fmt.Sprintf("%q = %q\n", k, v)
+		}
+		tagsHCL += "}\n"
+	}
+
+	return fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+  name = %[1]q
+}
+
+resource "aws_ecs_service" "test" {
+  name            = %[1]q
+  cluster         = aws_ecs_cluster.test.id
+  task_definition = aws_ecs_task_definition.test.arn
+  desired_count   = 1
+  %s
+}
+`, rName, tagsHCL)
+}
+
 func testAccServiceConfig_clusterName(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

No rollback plan necessary

## Changes to Security Controls

None

### Description

The resource explicitly ignored changes to tags and did not make use of the UpdateTags SDK method. This means that tags of aws_ecs_service resources could not be modified.

This implements a call to update tags during resource updates.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
