### PR TITLE
data.aws_ecr_images add tag status filter, max results and describe image

### DIFF
--- a/.changelog/44621.txt
+++ b/.changelog/44621.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_ecr_images: Add `tag_status`, `max_results`, and `describe_images` arguments with `image_details` attribute
+```

--- a/internal/service/ecr/images_data_source_test.go
+++ b/internal/service/ecr/images_data_source_test.go
@@ -5,10 +5,12 @@ package ecr_test
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -100,6 +102,141 @@ data "aws_ecr_images" "test" {
   repository_name = aws_ecr_repository.test.name
 }
 `, rName)
+}
+
+func TestAccECRImagesDataSource_describeImages(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_ecr_images.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImagesDataSourceConfig_describeImages(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrRepositoryName, rName),
+					resource.TestCheckResourceAttr(dataSourceName, "describe_images", acctest.CtTrue),
+				),
+			},
+		},
+	})
+}
+
+func TestAccECRImagesDataSource_maxResults(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_ecr_images.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImagesDataSourceConfig_maxResults(rName, 5),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrRepositoryName, rName),
+					resource.TestCheckResourceAttr(dataSourceName, "max_results", "5"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccECRImagesDataSource_tagStatus(t *testing.T) {
+	ctx := acctest.Context(t)
+	registryID := "137112412989"
+	repositoryName := "amazonlinux"
+	dataSourceName := "data.aws_ecr_images.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImagesDataSourceConfig_tagStatusPublic(registryID, repositoryName, "TAGGED"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrRepositoryName, repositoryName),
+					resource.TestCheckResourceAttr(dataSourceName, "tag_status", "TAGGED"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "image_ids.#"),
+					// Verify all returned images have tags
+					testAccCheckImagesAllHaveTags(dataSourceName),
+				),
+			},
+			{
+				Config: testAccImagesDataSourceConfig_tagStatusPublic(registryID, repositoryName, "ANY"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrRepositoryName, repositoryName),
+					resource.TestCheckResourceAttr(dataSourceName, "tag_status", "ANY"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "image_ids.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccImagesDataSourceConfig_describeImages(rName string, describeImages bool) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_repository" "test" {
+  name = %[1]q
+}
+
+data "aws_ecr_images" "test" {
+  repository_name = aws_ecr_repository.test.name
+  describe_images = %[2]t
+}
+`, rName, describeImages)
+}
+
+func testAccImagesDataSourceConfig_maxResults(rName string, maxResults int) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_repository" "test" {
+  name = %[1]q
+}
+
+data "aws_ecr_images" "test" {
+  repository_name = aws_ecr_repository.test.name
+  max_results     = %[2]d
+}
+`, rName, maxResults)
+}
+
+func testAccCheckImagesAllHaveTags(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		imageCount := rs.Primary.Attributes["image_ids.#"]
+		count, err := strconv.Atoi(imageCount)
+		if err != nil {
+			return err
+		}
+
+		for i := range count {
+			tagKey := fmt.Sprintf("image_ids.%d.image_tag", i)
+			if tag := rs.Primary.Attributes[tagKey]; tag == "" {
+				return fmt.Errorf("Image at index %d has no tag when TAGGED filter was used", i)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccImagesDataSourceConfig_tagStatusPublic(registryID, repositoryName, tagStatus string) string {
+	return fmt.Sprintf(`
+data "aws_ecr_images" "test" {
+  registry_id     = %[1]q
+  repository_name = %[2]q
+  tag_status      = %[3]q
+}
+`, registryID, repositoryName, tagStatus)
 }
 
 func testAccImagesDataSourceConfig_registryID(registryID, repositoryName string) string {

--- a/website/docs/d/ecr_images.html.markdown
+++ b/website/docs/d/ecr_images.html.markdown
@@ -26,6 +26,37 @@ output "image_tags" {
 }
 ```
 
+### Filter by Tag Status
+
+```terraform
+data "aws_ecr_images" "tagged_only" {
+  repository_name = "my-repository"
+  tag_status      = "TAGGED"
+}
+```
+
+### Limit Results
+
+```terraform
+data "aws_ecr_images" "limited" {
+  repository_name = "my-repository"
+  max_results     = 10
+}
+```
+
+### Get Detailed Image Information
+
+```terraform
+data "aws_ecr_images" "detailed" {
+  repository_name = "my-repository"
+  describe_images = true
+}
+
+output "image_details" {
+  value = data.aws_ecr_images.detailed.image_details
+}
+```
+
 ## Argument Reference
 
 This data source supports the following arguments:
@@ -33,6 +64,9 @@ This data source supports the following arguments:
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `registry_id` - (Optional) ID of the Registry where the repository resides.
 * `repository_name` - (Required) Name of the ECR Repository.
+* `tag_status` - (Optional) Filter images by tag status. Valid values: `TAGGED`, `UNTAGGED`, `ANY`.
+* `max_results` - (Optional) Maximum number of images to return.
+* `describe_images` - (Optional) Whether to call DescribeImages API to get detailed image information. Defaults to `false`.
 
 ## Attribute Reference
 
@@ -41,3 +75,10 @@ This data source exports the following attributes in addition to the arguments a
 * `image_ids` - List of image objects containing image digest and tags. Each object has the following attributes:
     * `image_digest` - The sha256 digest of the image manifest.
     * `image_tag` - The tag associated with the image.
+* `image_details` - List of detailed image information (only populated when `describe_images` is `true`). Each object has the following attributes:
+    * `image_digest` - The sha256 digest of the image manifest.
+    * `image_pushed_at` - The date and time when the image was pushed to the repository.
+    * `image_size_in_bytes` - The size of the image in bytes.
+    * `image_tags` - List of tags associated with the image.
+    * `registry_id` - The AWS account ID associated with the registry.
+    * `repository_name` - The name of the repository.


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

N/A

### Description

Improves data aws_ecr_images:
* Filter image by tag status 
* MaxResults
* Describe images

### Relations

Fixes #40025 

### References


### Output from Acceptance Testing

```console
2025/10/10 23:57:57 Creating Terraform AWS Provider (SDKv2-style)...
2025/10/10 23:57:57 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECRImagesDataSource_basic
=== PAUSE TestAccECRImagesDataSource_basic
=== RUN   TestAccECRImagesDataSource_registryID
=== PAUSE TestAccECRImagesDataSource_registryID
=== RUN   TestAccECRImagesDataSource_describeImages
=== PAUSE TestAccECRImagesDataSource_describeImages
=== RUN   TestAccECRImagesDataSource_maxResults
=== PAUSE TestAccECRImagesDataSource_maxResults
=== RUN   TestAccECRImagesDataSource_tagStatus
=== PAUSE TestAccECRImagesDataSource_tagStatus
=== CONT  TestAccECRImagesDataSource_basic
=== CONT  TestAccECRImagesDataSource_maxResults
=== CONT  TestAccECRImagesDataSource_tagStatus
=== CONT  TestAccECRImagesDataSource_registryID
=== CONT  TestAccECRImagesDataSource_describeImages
--- PASS: TestAccECRImagesDataSource_describeImages (23.40s)
--- PASS: TestAccECRImagesDataSource_maxResults (23.45s)
--- PASS: TestAccECRImagesDataSource_basic (23.93s)
--- PASS: TestAccECRImagesDataSource_registryID (28.57s)
--- PASS: TestAccECRImagesDataSource_tagStatus (48.69s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        53.520s

...
```
