### PR TITLE
Add aws_rdsdata_query datasource

### DIFF
--- a/internal/service/rdsdata/query_data_source.go
+++ b/internal/service/rdsdata/query_data_source.go
@@ -1,0 +1,168 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package rdsdata
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/aws/aws-sdk-go-v2/service/rdsdata"
+	rdsdatatypes "github.com/aws/aws-sdk-go-v2/service/rdsdata/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_rdsdata_query", name="Query")
+func newDataSourceQuery(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceQuery{}, nil
+}
+
+type dataSourceQuery struct {
+	framework.DataSourceWithModel[dataSourceQueryModel]
+}
+
+func (d *dataSourceQuery) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: framework.IDAttribute(),
+			names.AttrDatabase: schema.StringAttribute{
+				Optional: true,
+			},
+			names.AttrResourceARN: schema.StringAttribute{
+				Required: true,
+			},
+			"secret_arn": schema.StringAttribute{
+				Required: true,
+			},
+			"sql": schema.StringAttribute{
+				Required: true,
+			},
+			"records": schema.StringAttribute{
+				Computed: true,
+			},
+			"number_of_records_updated": schema.Int64Attribute{
+				Computed: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrParameters: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrName: schema.StringAttribute{
+							Required: true,
+						},
+						names.AttrValue: schema.StringAttribute{
+							Required: true,
+						},
+						"type_hint": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type dataSourceQueryModel struct {
+	framework.WithRegionModel
+	ID                     types.String                    `tfsdk:"id"`
+	Database               types.String                    `tfsdk:"database"`
+	ResourceARN            types.String                    `tfsdk:"resource_arn"`
+	SecretARN              types.String                    `tfsdk:"secret_arn"`
+	SQL                    types.String                    `tfsdk:"sql"`
+	Parameters             []dataSourceQueryParameterModel `tfsdk:"parameters"`
+	Records                types.String                    `tfsdk:"records"`
+	NumberOfRecordsUpdated types.Int64                     `tfsdk:"number_of_records_updated"`
+}
+
+type dataSourceQueryParameterModel struct {
+	Name     types.String `tfsdk:"name"`
+	Value    types.String `tfsdk:"value"`
+	TypeHint types.String `tfsdk:"type_hint"`
+}
+
+func (d *dataSourceQuery) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data dataSourceQueryModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := d.Meta().RDSDataClient(ctx)
+
+	input := rdsdata.ExecuteStatementInput{
+		ResourceArn:     data.ResourceARN.ValueStringPointer(),
+		SecretArn:       data.SecretARN.ValueStringPointer(),
+		Sql:             data.SQL.ValueStringPointer(),
+		FormatRecordsAs: rdsdatatypes.RecordsFormatTypeJson,
+	}
+
+	if !data.Database.IsNull() {
+		input.Database = data.Database.ValueStringPointer()
+	}
+
+	if len(data.Parameters) > 0 {
+		input.Parameters = expandSQLParameters(data.Parameters)
+	}
+
+	output, err := conn.ExecuteStatement(ctx, &input)
+	if err != nil {
+		resp.Diagnostics.AddError("executing RDS Data API statement", err.Error())
+		return
+	}
+
+	data.ID = types.StringValue(data.ResourceARN.ValueString() + ":" + data.SQL.ValueString())
+	data.Records = types.StringPointerValue(output.FormattedRecords)
+	data.NumberOfRecordsUpdated = types.Int64Value(output.NumberOfRecordsUpdated)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func expandSQLParameters(tfList []dataSourceQueryParameterModel) []rdsdatatypes.SqlParameter {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []rdsdatatypes.SqlParameter
+
+	for _, tfObj := range tfList {
+		apiObject := rdsdatatypes.SqlParameter{
+			Name: tfObj.Name.ValueStringPointer(),
+		}
+
+		if !tfObj.TypeHint.IsNull() {
+			apiObject.TypeHint = rdsdatatypes.TypeHint(tfObj.TypeHint.ValueString())
+		}
+
+		// Convert value to Field type
+		valueStr := tfObj.Value.ValueString()
+		var field rdsdatatypes.Field
+
+		// Try to parse as JSON first, otherwise treat as string
+		var jsonValue any
+		if err := json.Unmarshal([]byte(valueStr), &jsonValue); err == nil {
+			switch v := jsonValue.(type) {
+			case string:
+				field = &rdsdatatypes.FieldMemberStringValue{Value: v}
+			case float64:
+				field = &rdsdatatypes.FieldMemberDoubleValue{Value: v}
+			case bool:
+				field = &rdsdatatypes.FieldMemberBooleanValue{Value: v}
+			default:
+				field = &rdsdatatypes.FieldMemberStringValue{Value: valueStr}
+			}
+		} else {
+			field = &rdsdatatypes.FieldMemberStringValue{Value: valueStr}
+		}
+
+		apiObject.Value = field
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}

--- a/internal/service/rdsdata/query_data_source_test.go
+++ b/internal/service/rdsdata/query_data_source_test.go
@@ -1,0 +1,126 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package rdsdata_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccRDSDataQueryDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_rdsdata_query.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueryDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "records"),
+					resource.TestCheckResourceAttr(dataSourceName, "sql", "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA LIMIT 1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRDSDataQueryDataSource_withParameters(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_rdsdata_query.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueryDataSourceConfig_withParameters(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "records"),
+					resource.TestCheckResourceAttr(dataSourceName, "sql", "SELECT :param1 as test_column"),
+					resource.TestCheckResourceAttr(dataSourceName, "parameters.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "parameters.0.name", "param1"),
+					resource.TestCheckResourceAttr(dataSourceName, "parameters.0.value", "test_value"),
+				),
+			},
+		},
+	})
+}
+
+func testAccQueryDataSourceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccQueryDataSourceConfig_base(rName), `
+data "aws_rdsdata_query" "test" {
+  depends_on   = [aws_rds_cluster_instance.test]
+  resource_arn = aws_rds_cluster.test.arn
+  secret_arn   = aws_secretsmanager_secret.test.arn
+  sql          = "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA LIMIT 1"
+}
+`)
+}
+
+func testAccQueryDataSourceConfig_withParameters(rName string) string {
+	return acctest.ConfigCompose(testAccQueryDataSourceConfig_base(rName), `
+data "aws_rdsdata_query" "test" {
+  depends_on   = [aws_rds_cluster_instance.test]
+  resource_arn = aws_rds_cluster.test.arn
+  secret_arn   = aws_secretsmanager_secret.test.arn
+  sql          = "SELECT :param1 as test_column"
+
+  parameters {
+    name  = "param1"
+    value = "test_value"
+  }
+}
+`)
+}
+
+func testAccQueryDataSourceConfig_base(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster" "test" {
+  cluster_identifier           = %[1]q
+  engine                       = "aurora-mysql"
+  database_name                = "test"
+  master_username              = "username"
+  master_password              = "mustbeeightcharacters"
+  backup_retention_period      = 7
+  preferred_backup_window      = "07:00-09:00"
+  preferred_maintenance_window = "tue:04:00-tue:04:30"
+  skip_final_snapshot          = true
+  enable_http_endpoint         = true
+
+  serverlessv2_scaling_configuration {
+    max_capacity = 8
+    min_capacity = 0.5
+  }
+}
+
+resource "aws_rds_cluster_instance" "test" {
+  cluster_identifier = aws_rds_cluster.test.id
+  instance_class     = "db.serverless"
+  engine             = aws_rds_cluster.test.engine
+  engine_version     = aws_rds_cluster.test.engine_version
+}
+
+resource "aws_secretsmanager_secret" "test" {
+  name = %[1]q
+}
+
+resource "aws_secretsmanager_secret_version" "test" {
+  secret_id = aws_secretsmanager_secret.test.id
+  secret_string = jsonencode({
+    username = aws_rds_cluster.test.master_username
+    password = aws_rds_cluster.test.master_password
+  })
+}
+`, rName)
+}

--- a/internal/service/rdsdata/service_package_gen.go
+++ b/internal/service/rdsdata/service_package_gen.go
@@ -7,6 +7,7 @@ package rdsdata
 
 import (
 	"context"
+	"unique"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rdsdata"
@@ -20,7 +21,14 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
-	return []*inttypes.ServicePackageFrameworkDataSource{}
+	return []*inttypes.ServicePackageFrameworkDataSource{
+		{
+			Factory:  newDataSourceQuery,
+			TypeName: "aws_rdsdata_query",
+			Name:     "Query",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.ServicePackageFrameworkResource {

--- a/website/docs/d/rdsdata_query.html.markdown
+++ b/website/docs/d/rdsdata_query.html.markdown
@@ -1,0 +1,93 @@
+---
+subcategory: "RDS Data"
+layout: "aws"
+page_title: "AWS: aws_rdsdata_query"
+description: |-
+  Executes SQL queries against RDS Aurora Serverless clusters using the RDS Data API.
+---
+
+# Data Source: aws_rdsdata_query
+
+Executes SQL queries against RDS Aurora Serverless clusters using the RDS Data API. This data source allows you to run SQL statements and retrieve results in JSON format.
+
+## Example Usage
+
+### Basic Query
+
+```terraform
+data "aws_rdsdata_query" "example" {
+  resource_arn = aws_rds_cluster.example.arn
+  secret_arn   = aws_secretsmanager_secret.example.arn
+  sql          = "SELECT * FROM users LIMIT 10"
+}
+```
+
+### Query with Parameters
+
+```terraform
+data "aws_rdsdata_query" "example" {
+  resource_arn = aws_rds_cluster.example.arn
+  secret_arn   = aws_secretsmanager_secret.example.arn
+  sql          = "SELECT * FROM users WHERE status = :status"
+  database     = "myapp"
+
+  parameters {
+    name  = "status"
+    value = "active"
+  }
+}
+```
+
+### Query with Multiple Parameters
+
+```terraform
+data "aws_rdsdata_query" "example" {
+  resource_arn = aws_rds_cluster.example.arn
+  secret_arn   = aws_secretsmanager_secret.example.arn
+  sql          = "SELECT * FROM orders WHERE user_id = :user_id AND created_at > :date"
+
+  parameters {
+    name  = "user_id"
+    value = "123"
+  }
+
+  parameters {
+    name  = "date"
+    value = "2023-01-01"
+  }
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `resource_arn` - (Required) The Amazon Resource Name (ARN) of the Aurora Serverless DB cluster.
+* `secret_arn` - (Required) The ARN of the secret that enables access to the DB cluster. The secret must contain the database credentials.
+* `sql` - (Required) The SQL statement to execute.
+* `database` - (Optional) The name of the database to execute the statement against.
+* `parameters` - (Optional) Parameters for the SQL statement. See [Parameters](#parameters) below.
+* `region` - (Optional) The AWS region where the RDS cluster is located. If not specified, the provider region is used.
+
+### Parameters
+
+The `parameters` block supports the following:
+
+* `name` - (Required) The name of the parameter.
+* `value` - (Required) The value of the parameter as a string.
+* `type_hint` - (Optional) A hint that specifies the correct object type for the parameter value. Valid values: `DATE`, `DECIMAL`, `JSON`, `TIME`, `TIMESTAMP`, `UUID`.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `records` - The records returned by the SQL statement in JSON format.
+* `number_of_records_updated` - The number of records updated by the request (for DML statements).
+
+## Notes
+
+* This data source requires the Aurora Serverless cluster to have the Data API enabled.
+* The secret must be created in AWS Secrets Manager and contain the database credentials in the correct format.
+* Results are returned in JSON format when using `SELECT` statements.
+* For non-SELECT statements (INSERT, UPDATE, DELETE), the `number_of_records_updated` attribute will contain the count of affected rows.
+* The Data API has a 1MB limit for response data. Large result sets may be truncated.


### PR DESCRIPTION
### Description
Adds support for RDS Data Query

```
data "aws_rdsdata_query" "test" {
  depends_on   = [aws_rds_cluster_instance.test]
  resource_arn = aws_rds_cluster.test.arn
  secret_arn   = aws_secretsmanager_secret.test.arn
  sql          = "SELECT :param1 as test_column"
  
  parameters {
    name  = "param1"
    value = "test_value"
  }
}
```

### Relations
Closes #40901
Refs #44472

On top of #44629 ( Add RDS Data Service) - **To REVIEWER** only the last commit is specific to this branch/PR.

### References
https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html
https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_ExecuteStatement.html


### Output from Acceptance Testing

```console
% TF_ACC=1 go test ./internal/service/rdsdata/... -v -run="TestAccRDSDataQueryDataSource" -timeout=30m

2025/10/13 00:20:23 Creating Terraform AWS Provider (SDKv2-style)...
2025/10/13 00:20:23 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSDataQueryDataSource_basic
=== PAUSE TestAccRDSDataQueryDataSource_basic
=== RUN   TestAccRDSDataQueryDataSource_withParameters
=== PAUSE TestAccRDSDataQueryDataSource_withParameters
=== CONT  TestAccRDSDataQueryDataSource_basic
=== CONT  TestAccRDSDataQueryDataSource_withParameters
--- PASS: TestAccRDSDataQueryDataSource_basic (828.47s)
--- PASS: TestAccRDSDataQueryDataSource_withParameters (1219.22s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rdsdata    1224.054s
```
