### PR TITLE
aws_dynamodb_table: add delay to available waiter

### DIFF
--- a/internal/service/dynamodb/wait.go
+++ b/internal/service/dynamodb/wait.go
@@ -30,10 +30,12 @@ const (
 
 func waitTableActive(ctx context.Context, conn *dynamodb.Client, tableName string, timeout time.Duration) (*awstypes.TableDescription, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(awstypes.TableStatusCreating, awstypes.TableStatusUpdating),
-		Target:  enum.Slice(awstypes.TableStatusActive),
-		Refresh: statusTable(ctx, conn, tableName),
-		Timeout: max(createTableTimeout, timeout),
+		Pending:                   enum.Slice(awstypes.TableStatusCreating, awstypes.TableStatusUpdating),
+		Target:                    enum.Slice(awstypes.TableStatusActive),
+		Refresh:                   statusTable(ctx, conn, tableName),
+		Timeout:                   max(createTableTimeout, timeout),
+		Delay:                     5 * time.Second,
+		ContinuousTargetOccurence: 2,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When updating cross region replicas the table status can sometimes return as available before the update is complete. Adding a delay resolves the initial check.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Relates #41179

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccDynamoDBTable_basic\|TestAccDynamoDBTable_disappears' PKG=dynamodb

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-dynamodb_waiter 🌿...
TF_ACC=1 go1.24.8 test ./internal/service/dynamodb/... -v -count 1 -parallel 20  -run=TestAccDynamoDBTable_basic\|TestAccDynamoDBTable_disappears -timeout 360m -vet=off
2025/10/14 12:34:41 Creating Terraform AWS Provider (SDKv2-style)...
2025/10/14 12:34:41 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDynamoDBTable_basic
=== PAUSE TestAccDynamoDBTable_basic
=== RUN   TestAccDynamoDBTable_disappears
=== PAUSE TestAccDynamoDBTable_disappears
=== CONT  TestAccDynamoDBTable_basic
=== CONT  TestAccDynamoDBTable_disappears
--- PASS: TestAccDynamoDBTable_basic (30.06s)
--- PASS: TestAccDynamoDBTable_disappears (41.56s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	49.463s
```

