### PR TITLE
DOC: update 'aws_ssm_default_patch_baseline' to include 'AMAZON_LINUX_2023'

### DIFF
--- a/website/docs/r/ssm_default_patch_baseline.html.markdown
+++ b/website/docs/r/ssm_default_patch_baseline.html.markdown
@@ -38,6 +38,7 @@ The following arguments are required:
   `AMAZON_LINUX`,
   `AMAZON_LINUX_2`,
   `AMAZON_LINUX_2022`,
+  `AMAZON_LINUX_2023`,
   `CENTOS`,
   `DEBIAN`,
   `MACOS`,


### PR DESCRIPTION
- **DOC: update 'aws_ssm_default_patch_baseline' doc to include 'AMAZON_LINUX_2023' as valid value for 'operating_system'**

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan


## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

N/A

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Updating documentation to reflect that `AMAZON_LINUX_2023` is a valid value for the `operating_system` argument in the
`aws_ssm_default_patch_baseline` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #31993

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
