### PR TITLE
Add aws_rdsdata_query action

### DIFF
--- a/internal/service/rdsdata/query_action.go
+++ b/internal/service/rdsdata/query_action.go
@@ -1,0 +1,180 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package rdsdata
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/rdsdata"
+	"github.com/aws/aws-sdk-go-v2/service/rdsdata/types"
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/action/schema"
+	fwtypes2 "github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @Action(aws_rdsdata_query, name="RDS Data Query")
+func newQueryAction(_ context.Context) (action.ActionWithConfigure, error) {
+	return &queryAction{}, nil
+}
+
+// NewQueryAction creates a new query action for testing
+func NewQueryAction(ctx context.Context) (action.ActionWithConfigure, error) {
+	return newQueryAction(ctx)
+}
+
+var (
+	_ action.Action = (*queryAction)(nil)
+)
+
+type queryAction struct {
+	framework.ActionWithModel[queryActionModel]
+	client *rdsdata.Client
+}
+
+type queryActionModel struct {
+	framework.WithRegionModel
+	ResourceArn           fwtypes2.String                                    `tfsdk:"resource_arn"`
+	SecretArn             fwtypes2.String                                    `tfsdk:"secret_arn"`
+	SQL                   fwtypes2.String                                    `tfsdk:"sql"`
+	Database              fwtypes2.String                                    `tfsdk:"database"`
+	Parameters            fwtypes.ListNestedObjectValueOf[sqlParameterModel] `tfsdk:"parameters"`
+	IncludeResultMetadata fwtypes2.Bool                                      `tfsdk:"include_result_metadata"`
+}
+
+type sqlParameterModel struct {
+	Name  fwtypes2.String `tfsdk:"name"`
+	Value fwtypes2.String `tfsdk:"value"`
+}
+
+func (a *queryAction) Schema(ctx context.Context, req action.SchemaRequest, resp *action.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Executes SQL queries against Aurora Serverless clusters using RDS Data API",
+		Attributes: map[string]schema.Attribute{
+			names.AttrResourceARN: schema.StringAttribute{
+				Description: "ARN of the Aurora Serverless cluster",
+				Required:    true,
+			},
+			"secret_arn": schema.StringAttribute{
+				Description: "ARN of the Secrets Manager secret containing database credentials",
+				Required:    true,
+			},
+			"sql": schema.StringAttribute{
+				Description: "SQL statement to execute",
+				Required:    true,
+			},
+			names.AttrDatabase: schema.StringAttribute{
+				Description: "Name of the database",
+				Optional:    true,
+			},
+			"include_result_metadata": schema.BoolAttribute{
+				Description: "Include column metadata in query results",
+				Optional:    true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrParameters: schema.ListNestedBlock{
+				Description: "SQL parameters for prepared statements",
+				CustomType:  fwtypes.NewListNestedObjectTypeOf[sqlParameterModel](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrName: schema.StringAttribute{
+							Description: "Parameter name",
+							Required:    true,
+						},
+						names.AttrValue: schema.StringAttribute{
+							Description: "Parameter value",
+							Required:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (a *queryAction) Configure(ctx context.Context, req action.ConfigureRequest, resp *action.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	meta, ok := req.ProviderData.(*conns.AWSClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Action Configure Type",
+			fmt.Sprintf("Expected *conns.AWSClient, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	a.client = meta.RDSDataClient(ctx)
+}
+
+func (a *queryAction) Invoke(ctx context.Context, req action.InvokeRequest, resp *action.InvokeResponse) {
+	var model queryActionModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "Starting RDS Data query execution", map[string]any{
+		names.AttrResourceARN: model.ResourceArn.ValueString(),
+		"sql_length":          len(model.SQL.ValueString()),
+	})
+
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: "Executing SQL query...",
+	})
+
+	input := rdsdata.ExecuteStatementInput{
+		ResourceArn: model.ResourceArn.ValueStringPointer(),
+		SecretArn:   model.SecretArn.ValueStringPointer(),
+		Sql:         model.SQL.ValueStringPointer(),
+	}
+
+	if !model.Database.IsNull() {
+		input.Database = model.Database.ValueStringPointer()
+	}
+
+	if !model.IncludeResultMetadata.IsNull() {
+		input.IncludeResultMetadata = model.IncludeResultMetadata.ValueBool()
+	}
+
+	if !model.Parameters.IsNull() {
+		var params []sqlParameterModel
+		resp.Diagnostics.Append(model.Parameters.ElementsAs(ctx, &params, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		var sqlParams []types.SqlParameter
+		for _, param := range params {
+			sqlParams = append(sqlParams, types.SqlParameter{
+				Name:  param.Name.ValueStringPointer(),
+				Value: &types.FieldMemberStringValue{Value: param.Value.ValueString()},
+			})
+		}
+		input.Parameters = sqlParams
+	}
+
+	output, err := a.client.ExecuteStatement(ctx, &input)
+	if err != nil {
+		resp.Diagnostics.AddError("SQL Execution Failed", err.Error())
+		return
+	}
+
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: fmt.Sprintf("Query executed successfully. Records affected: %d", output.NumberOfRecordsUpdated),
+	})
+
+	tflog.Info(ctx, "RDS Data query completed successfully", map[string]any{
+		"records_updated": output.NumberOfRecordsUpdated,
+		"has_records":     len(output.Records) > 0,
+	})
+}

--- a/internal/service/rdsdata/query_action_test.go
+++ b/internal/service/rdsdata/query_action_test.go
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package rdsdata_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccRDSDataQueryAction_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSDataServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueryActionConfig_basic(rName),
+			},
+		},
+	})
+}
+
+func testAccQueryActionConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccQueryDataSourceConfig_base(rName), `
+resource "aws_rdsdata_query" "test" {
+  depends_on   = [aws_rds_cluster_instance.test]
+  resource_arn = aws_rds_cluster.test.arn
+  secret_arn   = aws_secretsmanager_secret_version.test.arn
+  sql          = "SELECT 1"
+}
+`)
+}

--- a/internal/service/rdsdata/query_data_source.go
+++ b/internal/service/rdsdata/query_data_source.go
@@ -1,0 +1,168 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package rdsdata
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/aws/aws-sdk-go-v2/service/rdsdata"
+	rdsdatatypes "github.com/aws/aws-sdk-go-v2/service/rdsdata/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_rdsdata_query", name="Query")
+func newDataSourceQuery(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceQuery{}, nil
+}
+
+type dataSourceQuery struct {
+	framework.DataSourceWithModel[dataSourceQueryModel]
+}
+
+func (d *dataSourceQuery) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: framework.IDAttribute(),
+			names.AttrDatabase: schema.StringAttribute{
+				Optional: true,
+			},
+			names.AttrResourceARN: schema.StringAttribute{
+				Required: true,
+			},
+			"secret_arn": schema.StringAttribute{
+				Required: true,
+			},
+			"sql": schema.StringAttribute{
+				Required: true,
+			},
+			"records": schema.StringAttribute{
+				Computed: true,
+			},
+			"number_of_records_updated": schema.Int64Attribute{
+				Computed: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrParameters: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrName: schema.StringAttribute{
+							Required: true,
+						},
+						names.AttrValue: schema.StringAttribute{
+							Required: true,
+						},
+						"type_hint": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type dataSourceQueryModel struct {
+	framework.WithRegionModel
+	ID                     types.String                    `tfsdk:"id"`
+	Database               types.String                    `tfsdk:"database"`
+	ResourceARN            types.String                    `tfsdk:"resource_arn"`
+	SecretARN              types.String                    `tfsdk:"secret_arn"`
+	SQL                    types.String                    `tfsdk:"sql"`
+	Parameters             []dataSourceQueryParameterModel `tfsdk:"parameters"`
+	Records                types.String                    `tfsdk:"records"`
+	NumberOfRecordsUpdated types.Int64                     `tfsdk:"number_of_records_updated"`
+}
+
+type dataSourceQueryParameterModel struct {
+	Name     types.String `tfsdk:"name"`
+	Value    types.String `tfsdk:"value"`
+	TypeHint types.String `tfsdk:"type_hint"`
+}
+
+func (d *dataSourceQuery) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data dataSourceQueryModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := d.Meta().RDSDataClient(ctx)
+
+	input := rdsdata.ExecuteStatementInput{
+		ResourceArn:     data.ResourceARN.ValueStringPointer(),
+		SecretArn:       data.SecretARN.ValueStringPointer(),
+		Sql:             data.SQL.ValueStringPointer(),
+		FormatRecordsAs: rdsdatatypes.RecordsFormatTypeJson,
+	}
+
+	if !data.Database.IsNull() {
+		input.Database = data.Database.ValueStringPointer()
+	}
+
+	if len(data.Parameters) > 0 {
+		input.Parameters = expandSQLParameters(data.Parameters)
+	}
+
+	output, err := conn.ExecuteStatement(ctx, &input)
+	if err != nil {
+		resp.Diagnostics.AddError("executing RDS Data API statement", err.Error())
+		return
+	}
+
+	data.ID = types.StringValue(data.ResourceARN.ValueString() + ":" + data.SQL.ValueString())
+	data.Records = types.StringPointerValue(output.FormattedRecords)
+	data.NumberOfRecordsUpdated = types.Int64Value(output.NumberOfRecordsUpdated)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func expandSQLParameters(tfList []dataSourceQueryParameterModel) []rdsdatatypes.SqlParameter {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []rdsdatatypes.SqlParameter
+
+	for _, tfObj := range tfList {
+		apiObject := rdsdatatypes.SqlParameter{
+			Name: tfObj.Name.ValueStringPointer(),
+		}
+
+		if !tfObj.TypeHint.IsNull() {
+			apiObject.TypeHint = rdsdatatypes.TypeHint(tfObj.TypeHint.ValueString())
+		}
+
+		// Convert value to Field type
+		valueStr := tfObj.Value.ValueString()
+		var field rdsdatatypes.Field
+
+		// Try to parse as JSON first, otherwise treat as string
+		var jsonValue any
+		if err := json.Unmarshal([]byte(valueStr), &jsonValue); err == nil {
+			switch v := jsonValue.(type) {
+			case string:
+				field = &rdsdatatypes.FieldMemberStringValue{Value: v}
+			case float64:
+				field = &rdsdatatypes.FieldMemberDoubleValue{Value: v}
+			case bool:
+				field = &rdsdatatypes.FieldMemberBooleanValue{Value: v}
+			default:
+				field = &rdsdatatypes.FieldMemberStringValue{Value: valueStr}
+			}
+		} else {
+			field = &rdsdatatypes.FieldMemberStringValue{Value: valueStr}
+		}
+
+		apiObject.Value = field
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}

--- a/internal/service/rdsdata/query_data_source_test.go
+++ b/internal/service/rdsdata/query_data_source_test.go
@@ -1,0 +1,126 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package rdsdata_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccRDSDataQueryDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_rdsdata_query.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueryDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "records"),
+					resource.TestCheckResourceAttr(dataSourceName, "sql", "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA LIMIT 1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRDSDataQueryDataSource_withParameters(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_rdsdata_query.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueryDataSourceConfig_withParameters(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "records"),
+					resource.TestCheckResourceAttr(dataSourceName, "sql", "SELECT :param1 as test_column"),
+					resource.TestCheckResourceAttr(dataSourceName, "parameters.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "parameters.0.name", "param1"),
+					resource.TestCheckResourceAttr(dataSourceName, "parameters.0.value", "test_value"),
+				),
+			},
+		},
+	})
+}
+
+func testAccQueryDataSourceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccQueryDataSourceConfig_base(rName), `
+data "aws_rdsdata_query" "test" {
+  depends_on   = [aws_rds_cluster_instance.test]
+  resource_arn = aws_rds_cluster.test.arn
+  secret_arn   = aws_secretsmanager_secret.test.arn
+  sql          = "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA LIMIT 1"
+}
+`)
+}
+
+func testAccQueryDataSourceConfig_withParameters(rName string) string {
+	return acctest.ConfigCompose(testAccQueryDataSourceConfig_base(rName), `
+data "aws_rdsdata_query" "test" {
+  depends_on   = [aws_rds_cluster_instance.test]
+  resource_arn = aws_rds_cluster.test.arn
+  secret_arn   = aws_secretsmanager_secret.test.arn
+  sql          = "SELECT :param1 as test_column"
+
+  parameters {
+    name  = "param1"
+    value = "test_value"
+  }
+}
+`)
+}
+
+func testAccQueryDataSourceConfig_base(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster" "test" {
+  cluster_identifier           = %[1]q
+  engine                       = "aurora-mysql"
+  database_name                = "test"
+  master_username              = "username"
+  master_password              = "mustbeeightcharacters"
+  backup_retention_period      = 7
+  preferred_backup_window      = "07:00-09:00"
+  preferred_maintenance_window = "tue:04:00-tue:04:30"
+  skip_final_snapshot          = true
+  enable_http_endpoint         = true
+
+  serverlessv2_scaling_configuration {
+    max_capacity = 8
+    min_capacity = 0.5
+  }
+}
+
+resource "aws_rds_cluster_instance" "test" {
+  cluster_identifier = aws_rds_cluster.test.id
+  instance_class     = "db.serverless"
+  engine             = aws_rds_cluster.test.engine
+  engine_version     = aws_rds_cluster.test.engine_version
+}
+
+resource "aws_secretsmanager_secret" "test" {
+  name = %[1]q
+}
+
+resource "aws_secretsmanager_secret_version" "test" {
+  secret_id = aws_secretsmanager_secret.test.id
+  secret_string = jsonencode({
+    username = aws_rds_cluster.test.master_username
+    password = aws_rds_cluster.test.master_password
+  })
+}
+`, rName)
+}

--- a/internal/service/rdsdata/query_resource.go
+++ b/internal/service/rdsdata/query_resource.go
@@ -1,0 +1,154 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package rdsdata
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/rdsdata"
+	rdsdatatypes "github.com/aws/aws-sdk-go-v2/service/rdsdata/types"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_rdsdata_query", name="Query")
+func newResourceQuery(context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceQuery{}, nil
+}
+
+type resourceQuery struct {
+	framework.ResourceWithModel[resourceQueryModel]
+}
+
+func (r *resourceQuery) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: framework.IDAttribute(),
+			names.AttrDatabase: schema.StringAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			names.AttrResourceARN: schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"secret_arn": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"sql": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"records": schema.StringAttribute{
+				Computed: true,
+			},
+			"number_of_records_updated": schema.Int64Attribute{
+				Computed: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrParameters: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrName: schema.StringAttribute{
+							Required: true,
+						},
+						names.AttrValue: schema.StringAttribute{
+							Required: true,
+						},
+						"type_hint": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type resourceQueryModel struct {
+	framework.WithRegionModel
+	ID                     types.String                  `tfsdk:"id"`
+	Database               types.String                  `tfsdk:"database"`
+	ResourceARN            types.String                  `tfsdk:"resource_arn"`
+	SecretARN              types.String                  `tfsdk:"secret_arn"`
+	SQL                    types.String                  `tfsdk:"sql"`
+	Parameters             []resourceQueryParameterModel `tfsdk:"parameters"`
+	Records                types.String                  `tfsdk:"records"`
+	NumberOfRecordsUpdated types.Int64                   `tfsdk:"number_of_records_updated"`
+}
+
+type resourceQueryParameterModel struct {
+	Name     types.String `tfsdk:"name"`
+	Value    types.String `tfsdk:"value"`
+	TypeHint types.String `tfsdk:"type_hint"`
+}
+
+func (r *resourceQuery) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data resourceQueryModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().RDSDataClient(ctx)
+
+	input := rdsdata.ExecuteStatementInput{
+		ResourceArn:     data.ResourceARN.ValueStringPointer(),
+		SecretArn:       data.SecretARN.ValueStringPointer(),
+		Sql:             data.SQL.ValueStringPointer(),
+		FormatRecordsAs: rdsdatatypes.RecordsFormatTypeJson,
+	}
+
+	if !data.Database.IsNull() {
+		input.Database = data.Database.ValueStringPointer()
+	}
+
+	if len(data.Parameters) > 0 {
+		// Convert resource parameter model to data source parameter model for compatibility
+		var params []dataSourceQueryParameterModel
+		for _, p := range data.Parameters {
+			params = append(params, dataSourceQueryParameterModel(p))
+		}
+		input.Parameters = expandSQLParameters(params)
+	}
+
+	output, err := conn.ExecuteStatement(ctx, &input)
+	if err != nil {
+		resp.Diagnostics.AddError("executing RDS Data API statement", err.Error())
+		return
+	}
+
+	data.ID = types.StringValue(data.ResourceARN.ValueString() + ":" + data.SQL.ValueString())
+	data.Records = types.StringPointerValue(output.FormattedRecords)
+	data.NumberOfRecordsUpdated = types.Int64Value(output.NumberOfRecordsUpdated)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *resourceQuery) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// No-op: query results are stored in state and don't need to be refreshed
+}
+
+func (r *resourceQuery) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// No-op: all changes require replacement
+}
+
+func (r *resourceQuery) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// No-op: no API call needed, just remove from state
+}

--- a/internal/service/rdsdata/query_resource_test.go
+++ b/internal/service/rdsdata/query_resource_test.go
@@ -1,0 +1,84 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package rdsdata_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccRDSDataQueryResource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rdsdata_query.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSDataServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueryResourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
+					resource.TestCheckResourceAttr(resourceName, "records", "[{\"1\":1}]"),
+					resource.TestCheckResourceAttr(resourceName, "number_of_records_updated", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRDSDataQueryResource_withParameters(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rdsdata_query.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSDataServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueryResourceConfig_withParameters(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
+					resource.TestCheckResourceAttrSet(resourceName, "records"),
+					resource.TestCheckResourceAttr(resourceName, "number_of_records_updated", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccQueryResourceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccQueryDataSourceConfig_base(rName), `
+resource "aws_rdsdata_query" "test" {
+  depends_on   = [aws_rds_cluster_instance.test]
+  resource_arn = aws_rds_cluster.test.arn
+  secret_arn   = aws_secretsmanager_secret_version.test.arn
+  sql          = "SELECT 1"
+}
+`)
+}
+
+func testAccQueryResourceConfig_withParameters(rName string) string {
+	return acctest.ConfigCompose(testAccQueryDataSourceConfig_base(rName), `
+resource "aws_rdsdata_query" "test" {
+  depends_on   = [aws_rds_cluster_instance.test]
+  resource_arn = aws_rds_cluster.test.arn
+  secret_arn   = aws_secretsmanager_secret_version.test.arn
+  sql          = "SELECT * FROM information_schema.tables WHERE table_name = :table_name"
+  database     = aws_rds_cluster.test.database_name
+
+  parameters {
+    name  = "table_name"
+    value = "test_table"
+  }
+}
+`)
+}

--- a/internal/service/rdsdata/service_package_gen.go
+++ b/internal/service/rdsdata/service_package_gen.go
@@ -7,6 +7,7 @@ package rdsdata
 
 import (
 	"context"
+	"unique"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rdsdata"
@@ -20,7 +21,14 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
-	return []*inttypes.ServicePackageFrameworkDataSource{}
+	return []*inttypes.ServicePackageFrameworkDataSource{
+		{
+			Factory:  newDataSourceQuery,
+			TypeName: "aws_rdsdata_query",
+			Name:     "Query",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.ServicePackageFrameworkResource {

--- a/internal/service/rdsdata/service_package_gen.go
+++ b/internal/service/rdsdata/service_package_gen.go
@@ -32,7 +32,14 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.ServicePackageFrameworkResource {
-	return []*inttypes.ServicePackageFrameworkResource{}
+	return []*inttypes.ServicePackageFrameworkResource{
+		{
+			Factory:  newResourceQuery,
+			TypeName: "aws_rdsdata_query",
+			Name:     "Query",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*inttypes.ServicePackageSDKDataSource {

--- a/internal/service/rdsdata/service_package_gen.go
+++ b/internal/service/rdsdata/service_package_gen.go
@@ -20,6 +20,17 @@ import (
 
 type servicePackage struct{}
 
+func (p *servicePackage) Actions(ctx context.Context) []*inttypes.ServicePackageAction {
+	return []*inttypes.ServicePackageAction{
+		{
+			Factory:  newQueryAction,
+			TypeName: "aws_rdsdata_query",
+			Name:     "RDS Data Query",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+	}
+}
+
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
 	return []*inttypes.ServicePackageFrameworkDataSource{
 		{

--- a/website/docs/actions/rdsdata_query.html.markdown
+++ b/website/docs/actions/rdsdata_query.html.markdown
@@ -1,0 +1,128 @@
+---
+subcategory: "RDS Data"
+layout: "aws"
+page_title: "AWS: aws_rdsdata_query"
+description: |-
+  Executes SQL queries against Aurora Serverless databases using the RDS Data API.
+---
+
+# Action: aws_rdsdata_query
+
+~> **Note:** `aws_rdsdata_query` is in beta. Its interface and behavior may change as the feature evolves, and breaking changes are possible. It is offered as a technical preview without compatibility guarantees until Terraform 1.14 is generally available.
+
+Executes SQL queries against Aurora Serverless databases using the RDS Data API. This action allows for imperative SQL execution with support for parameterized queries and transaction management.
+
+For information about the RDS Data API, see the [RDS Data API Developer Guide](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html). For specific information about executing statements, see the [ExecuteStatement](https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_ExecuteStatement.html) page in the RDS Data Service API Reference.
+
+## Example Usage
+
+### Basic Query
+
+```terraform
+resource "aws_rds_cluster" "example" {
+  cluster_identifier   = "example-cluster"
+  engine               = "aurora-mysql"
+  database_name        = "example"
+  master_username      = "admin"
+  master_password      = "password123"
+  enable_http_endpoint = true
+  skip_final_snapshot  = true
+
+  serverlessv2_scaling_configuration {
+    max_capacity = 1
+    min_capacity = 0.5
+  }
+}
+
+resource "aws_secretsmanager_secret" "example" {
+  name = "example-db-credentials"
+}
+
+resource "aws_secretsmanager_secret_version" "example" {
+  secret_id = aws_secretsmanager_secret.example.id
+  secret_string = jsonencode({
+    username = aws_rds_cluster.example.master_username
+    password = aws_rds_cluster.example.master_password
+  })
+}
+
+action "aws_rdsdata_query" "example" {
+  config {
+    resource_arn = aws_rds_cluster.example.arn
+    secret_arn   = aws_secretsmanager_secret_version.example.arn
+    sql          = "SELECT COUNT(*) FROM users"
+  }
+}
+
+resource "terraform_data" "example" {
+  input = "trigger-query"
+
+  lifecycle {
+    action_trigger {
+      events  = [before_create]
+      actions = [action.aws_rdsdata_query.example]
+    }
+  }
+}
+```
+
+### Parameterized Query
+
+```terraform
+action "aws_rdsdata_query" "user_lookup" {
+  config {
+    resource_arn = aws_rds_cluster.example.arn
+    secret_arn   = aws_secretsmanager_secret_version.example.arn
+    database     = "example"
+    sql          = "SELECT * FROM users WHERE status = :status AND created_date > :date"
+
+    parameters {
+      name  = "status"
+      value = "active"
+    }
+
+    parameters {
+      name  = "date"
+      value = "2024-01-01"
+    }
+  }
+}
+```
+
+### Data Modification Query
+
+```terraform
+action "aws_rdsdata_query" "update_status" {
+  config {
+    resource_arn = aws_rds_cluster.example.arn
+    secret_arn   = aws_secretsmanager_secret_version.example.arn
+    database     = "example"
+    sql          = "UPDATE users SET last_login = NOW() WHERE user_id = :user_id"
+
+    parameters {
+      name  = "user_id"
+      value = "12345"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `resource_arn` - (Required) The Amazon Resource Name (ARN) of the Aurora Serverless DB cluster.
+* `secret_arn` - (Required) The ARN of the secret that enables access to the DB cluster. The secret must contain the database credentials.
+* `sql` - (Required) The SQL statement to execute.
+
+The following arguments are optional:
+
+* `database` - (Optional) The name of the database to execute the SQL statement against.
+* `parameters` - (Optional) Parameters for the SQL statement. See [Parameters](#parameters) below.
+
+### Parameters
+
+The `parameters` block supports the following:
+
+* `name` - (Required) The name of the parameter.
+* `value` - (Required) The value of the parameter.

--- a/website/docs/d/rdsdata_query.html.markdown
+++ b/website/docs/d/rdsdata_query.html.markdown
@@ -1,0 +1,93 @@
+---
+subcategory: "RDS Data"
+layout: "aws"
+page_title: "AWS: aws_rdsdata_query"
+description: |-
+  Executes SQL queries against RDS Aurora Serverless clusters using the RDS Data API.
+---
+
+# Data Source: aws_rdsdata_query
+
+Executes SQL queries against RDS Aurora Serverless clusters using the RDS Data API. This data source allows you to run SQL statements and retrieve results in JSON format.
+
+## Example Usage
+
+### Basic Query
+
+```terraform
+data "aws_rdsdata_query" "example" {
+  resource_arn = aws_rds_cluster.example.arn
+  secret_arn   = aws_secretsmanager_secret.example.arn
+  sql          = "SELECT * FROM users LIMIT 10"
+}
+```
+
+### Query with Parameters
+
+```terraform
+data "aws_rdsdata_query" "example" {
+  resource_arn = aws_rds_cluster.example.arn
+  secret_arn   = aws_secretsmanager_secret.example.arn
+  sql          = "SELECT * FROM users WHERE status = :status"
+  database     = "myapp"
+
+  parameters {
+    name  = "status"
+    value = "active"
+  }
+}
+```
+
+### Query with Multiple Parameters
+
+```terraform
+data "aws_rdsdata_query" "example" {
+  resource_arn = aws_rds_cluster.example.arn
+  secret_arn   = aws_secretsmanager_secret.example.arn
+  sql          = "SELECT * FROM orders WHERE user_id = :user_id AND created_at > :date"
+
+  parameters {
+    name  = "user_id"
+    value = "123"
+  }
+
+  parameters {
+    name  = "date"
+    value = "2023-01-01"
+  }
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `resource_arn` - (Required) The Amazon Resource Name (ARN) of the Aurora Serverless DB cluster.
+* `secret_arn` - (Required) The ARN of the secret that enables access to the DB cluster. The secret must contain the database credentials.
+* `sql` - (Required) The SQL statement to execute.
+* `database` - (Optional) The name of the database to execute the statement against.
+* `parameters` - (Optional) Parameters for the SQL statement. See [Parameters](#parameters) below.
+* `region` - (Optional) The AWS region where the RDS cluster is located. If not specified, the provider region is used.
+
+### Parameters
+
+The `parameters` block supports the following:
+
+* `name` - (Required) The name of the parameter.
+* `value` - (Required) The value of the parameter as a string.
+* `type_hint` - (Optional) A hint that specifies the correct object type for the parameter value. Valid values: `DATE`, `DECIMAL`, `JSON`, `TIME`, `TIMESTAMP`, `UUID`.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `records` - The records returned by the SQL statement in JSON format.
+* `number_of_records_updated` - The number of records updated by the request (for DML statements).
+
+## Notes
+
+* This data source requires the Aurora Serverless cluster to have the Data API enabled.
+* The secret must be created in AWS Secrets Manager and contain the database credentials in the correct format.
+* Results are returned in JSON format when using `SELECT` statements.
+* For non-SELECT statements (INSERT, UPDATE, DELETE), the `number_of_records_updated` attribute will contain the count of affected rows.
+* The Data API has a 1MB limit for response data. Large result sets may be truncated.

--- a/website/docs/d/rdsdata_query.html.markdown
+++ b/website/docs/d/rdsdata_query.html.markdown
@@ -3,12 +3,14 @@ subcategory: "RDS Data"
 layout: "aws"
 page_title: "AWS: aws_rdsdata_query"
 description: |-
-  Executes SQL queries against RDS Aurora Serverless clusters using the RDS Data API.
+  Executes SQL queries against RDS clusters using the RDS Data API.
 ---
 
 # Data Source: aws_rdsdata_query
 
-Executes SQL queries against RDS Aurora Serverless clusters using the RDS Data API. This data source allows you to run SQL statements and retrieve results in JSON format.
+Executes SQL queries against RDS clusters using the RDS Data API. This data source allows you to run SQL statements and retrieve results in JSON format.
+
+~> **Note:** This data source is ideal for SELECT queries that need to be executed multiple times during Terraform operations. For one-time operations like DDL statements, INSERT, UPDATE, or DELETE operations, consider using the [`aws_rdsdata_query` resource](/docs/providers/aws/r/rdsdata_query.html) instead.
 
 ## Example Usage
 

--- a/website/docs/r/rdsdata_query.html.markdown
+++ b/website/docs/r/rdsdata_query.html.markdown
@@ -1,0 +1,76 @@
+---
+subcategory: "RDS Data"
+layout: "aws"
+page_title: "AWS: aws_rdsdata_query"
+description: |-
+  Executes a SQL query against an RDS cluster using the RDS Data API.
+---
+
+# Resource: aws_rdsdata_query
+
+Executes a SQL query against an RDS cluster using the RDS Data API. The query is executed once during resource creation, and any changes to the query or parameters will trigger a replacement.
+
+~> **Note:** For queries that need to be executed multiple times or for retrieving data (SELECT queries), consider using the [`aws_rdsdata_query` data source](/docs/providers/aws/d/rdsdata_query.html) instead. Use this resource for one-time operations like DDL statements, INSERT, UPDATE, or DELETE operations.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_rdsdata_query" "example" {
+  resource_arn = aws_rds_cluster.example.arn
+  secret_arn   = aws_secretsmanager_secret.example.arn
+  sql          = "SELECT * FROM users WHERE active = true"
+  database     = "mydb"
+}
+```
+
+### With Parameters
+
+```terraform
+resource "aws_rdsdata_query" "example" {
+  resource_arn = aws_rds_cluster.example.arn
+  secret_arn   = aws_secretsmanager_secret.example.arn
+  sql          = "INSERT INTO users (name, email) VALUES (:name, :email)"
+  database     = "mydb"
+
+  parameters {
+    name  = "name"
+    value = "John Doe"
+  }
+
+  parameters {
+    name  = "email"
+    value = "john@example.com"
+  }
+}
+```
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `resource_arn` - (Required) The Amazon Resource Name (ARN) of the RDS cluster.
+* `secret_arn` - (Required) The ARN of the secret that enables access to the DB cluster.
+* `sql` - (Required) The SQL statement to execute.
+* `database` - (Optional) The name of the database.
+* `parameters` - (Optional) Parameters for the SQL statement. See [parameters](#parameters) below.
+* `region` - (Optional) The AWS region.
+
+### parameters
+
+* `name` - (Required) The name of the parameter.
+* `value` - (Required) The value of the parameter.
+* `type_hint` - (Optional) A hint that specifies the correct object type for the parameter value.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - The resource identifier.
+* `records` - The records returned by the SQL statement in JSON format.
+* `number_of_records_updated` - The number of records updated by the statement.
+
+## Import
+
+You cannot import this resource.


### PR DESCRIPTION
### Description
Adds support for RDS Data Query, with the Terraform action workflow.

Simple usage:
```terraform
action "aws_rdsdata_query" "example" {
  config {
    resource_arn = aws_rds_cluster.example.arn
    secret_arn   = aws_secretsmanager_secret_version.example.arn
    sql          = "SELECT COUNT(*) FROM users"
  }
}
```

Parameterized query
```terraform
action "aws_rdsdata_query" "user_lookup" {
  config {
    resource_arn = aws_rds_cluster.example.arn
    secret_arn   = aws_secretsmanager_secret_version.example.arn
    database     = "example"
    sql          = "SELECT * FROM users WHERE status = :status AND created_date > :date"

    parameters {
      name  = "status"
      value = "active"
    }

    parameters {
      name  = "date"
      value = "2024-01-01"
    }
  }
}
```

### Relations
On top of #44629 ( Add RDS Data Service) #44630 (aws_rdsdata_query datasource) #44643 (aws_rdsdata_query resource)

Closes #44472

### References
https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html
https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_ExecuteStatement.html

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccRDSDataQueryAction_basic PKG=rdsdata

2025/10/16 16:26:40 Creating Terraform AWS Provider (SDKv2-style)...
2025/10/16 16:26:40 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSDataQueryAction_basic
=== PAUSE TestAccRDSDataQueryAction_basic
=== CONT  TestAccRDSDataQueryAction_basic
--- PASS: TestAccRDSDataQueryAction_basic (1218.59s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rdsdata    1223.308s
```
