### PR TITLE
list-resource: Updates EC2 resource display names

### DIFF
--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -4125,7 +4125,7 @@ func (l *instanceListResource) List(ctx context.Context, request list.ListReques
 			}
 
 			if v, ok := tags["Name"]; ok {
-				result.DisplayName = v.ValueString()
+				result.DisplayName = fmt.Sprintf("%s (%s)", v.ValueString(), aws.ToString(instance.InstanceId))
 			} else {
 				result.DisplayName = aws.ToString(instance.InstanceId)
 			}

--- a/internal/service/ec2/vpc_.go
+++ b/internal/service/ec2/vpc_.go
@@ -905,7 +905,7 @@ func (l *vpcListResource) List(ctx context.Context, request list.ListRequest, st
 				}
 
 				if v, ok := tags["Name"]; ok {
-					result.DisplayName = v.ValueString()
+					result.DisplayName = fmt.Sprintf("%s (%s)", v.ValueString(), aws.ToString(vpc.VpcId))
 				} else {
 					result.DisplayName = aws.ToString(vpc.VpcId)
 				}

--- a/internal/service/ec2/vpc_subnet.go
+++ b/internal/service/ec2/vpc_subnet.go
@@ -844,7 +844,7 @@ func (l *subnetListResource) List(ctx context.Context, request list.ListRequest,
 				}
 
 				if v, ok := tags["Name"]; ok {
-					result.DisplayName = v.ValueString()
+					result.DisplayName = fmt.Sprintf("%s (%s)", v.ValueString(), aws.ToString(subnet.SubnetId))
 				} else {
 					result.DisplayName = aws.ToString(subnet.SubnetId)
 				}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Adds `id` to list resource display names for more clarity. If the resource has a `Name` tag, the display name is now `<Name tag> (<id>)`
