### PR TITLE
accessanalyzer: enable `go-vcr` support

### DIFF
--- a/internal/service/accessanalyzer/accessanalyzer_test.go
+++ b/internal/service/accessanalyzer/accessanalyzer_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
 // AccessAnalyzer is limited to one per region, so run serially locally and in TeamCity.
@@ -39,7 +38,7 @@ func TestAccAccessAnalyzer_serial(t *testing.T) {
 }
 
 func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerClient(ctx)
+	conn := acctest.ProviderMeta(ctx, t).AccessAnalyzerClient(ctx)
 
 	input := accessanalyzer.ListAnalyzersInput{}
 

--- a/internal/service/accessanalyzer/analyzer.go
+++ b/internal/service/accessanalyzer/analyzer.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -22,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -40,6 +40,8 @@ const (
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types;types.AnalyzerSummary", serialize="true")
 // @Testing(preCheck="testAccPreCheck")
+// @Testing(existsTakesT=true)
+// @Testing(destroyTakesT=true)
 func resourceAnalyzer() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAnalyzerCreate,
@@ -241,7 +243,7 @@ func resourceAnalyzerRead(ctx context.Context, d *schema.ResourceData, meta any)
 
 	analyzer, err := findAnalyzerByName(ctx, conn, d.Id())
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] IAM Access Analyzer Analyzer (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -306,8 +308,7 @@ func findAnalyzerByName(ctx context.Context, conn *accessanalyzer.Client, name s
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+			LastError: err,
 		}
 	}
 

--- a/internal/service/accessanalyzer/analyzer_tags_gen_test.go
+++ b/internal/service/accessanalyzer/analyzer_tags_gen_test.go
@@ -58,7 +58,7 @@ func testAccAccessAnalyzerAnalyzer_tags(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -70,7 +70,7 @@ func testAccAccessAnalyzerAnalyzer_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -114,7 +114,7 @@ func testAccAccessAnalyzerAnalyzer_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -162,7 +162,7 @@ func testAccAccessAnalyzerAnalyzer_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -203,7 +203,7 @@ func testAccAccessAnalyzerAnalyzer_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -244,7 +244,7 @@ func testAccAccessAnalyzerAnalyzer_tags_null(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -256,7 +256,7 @@ func testAccAccessAnalyzerAnalyzer_tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -315,7 +315,7 @@ func testAccAccessAnalyzerAnalyzer_tags_EmptyMap(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -325,7 +325,7 @@ func testAccAccessAnalyzerAnalyzer_tags_EmptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -382,7 +382,7 @@ func testAccAccessAnalyzerAnalyzer_tags_AddOnUpdate(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -392,7 +392,7 @@ func testAccAccessAnalyzerAnalyzer_tags_AddOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -416,7 +416,7 @@ func testAccAccessAnalyzerAnalyzer_tags_AddOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -467,7 +467,7 @@ func testAccAccessAnalyzerAnalyzer_tags_EmptyTag_OnCreate(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -479,7 +479,7 @@ func testAccAccessAnalyzerAnalyzer_tags_EmptyTag_OnCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -519,7 +519,7 @@ func testAccAccessAnalyzerAnalyzer_tags_EmptyTag_OnCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -560,7 +560,7 @@ func testAccAccessAnalyzerAnalyzer_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -572,7 +572,7 @@ func testAccAccessAnalyzerAnalyzer_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -604,7 +604,7 @@ func testAccAccessAnalyzerAnalyzer_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -650,7 +650,7 @@ func testAccAccessAnalyzerAnalyzer_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -701,7 +701,7 @@ func testAccAccessAnalyzerAnalyzer_tags_EmptyTag_OnUpdate_Replace(t *testing.T) 
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -713,7 +713,7 @@ func testAccAccessAnalyzerAnalyzer_tags_EmptyTag_OnUpdate_Replace(t *testing.T) 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -744,7 +744,7 @@ func testAccAccessAnalyzerAnalyzer_tags_EmptyTag_OnUpdate_Replace(t *testing.T) 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -794,7 +794,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_providerOnly(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy: testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy: testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -807,7 +807,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -851,7 +851,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -897,7 +897,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -937,7 +937,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -979,7 +979,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_nonOverlapping(t *testing.T)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy: testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy: testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -994,7 +994,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_nonOverlapping(t *testing.T)
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1048,7 +1048,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_nonOverlapping(t *testing.T)
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1101,7 +1101,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_nonOverlapping(t *testing.T)
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1143,7 +1143,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_overlapping(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy: testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy: testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1158,7 +1158,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1211,7 +1211,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1268,7 +1268,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1323,7 +1323,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_updateToProviderOnly(t *test
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy: testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy: testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1335,7 +1335,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_updateToProviderOnly(t *test
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1368,7 +1368,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_updateToProviderOnly(t *test
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1417,7 +1417,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_updateToResourceOnly(t *test
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy: testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy: testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1430,7 +1430,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_updateToResourceOnly(t *test
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1458,7 +1458,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_updateToResourceOnly(t *test
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1510,7 +1510,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_emptyResourceTag(t *testing.
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy: testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy: testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1525,7 +1525,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_emptyResourceTag(t *testing.
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1579,7 +1579,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_emptyProviderOnlyTag(t *test
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy: testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy: testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1592,7 +1592,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_emptyProviderOnlyTag(t *test
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1640,7 +1640,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_nullOverlappingResourceTag(t
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy: testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy: testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1655,7 +1655,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_nullOverlappingResourceTag(t
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1706,7 +1706,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_nullNonOverlappingResourceTa
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy: testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy: testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1721,7 +1721,7 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_nullNonOverlappingResourceTa
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1772,7 +1772,7 @@ func testAccAccessAnalyzerAnalyzer_tags_ComputedTag_OnCreate(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy: testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy: testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1782,7 +1782,7 @@ func testAccAccessAnalyzerAnalyzer_tags_ComputedTag_OnCreate(t *testing.T) {
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1831,7 +1831,7 @@ func testAccAccessAnalyzerAnalyzer_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy: testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy: testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1843,7 +1843,7 @@ func testAccAccessAnalyzerAnalyzer_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1875,7 +1875,7 @@ func testAccAccessAnalyzerAnalyzer_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1932,7 +1932,7 @@ func testAccAccessAnalyzerAnalyzer_tags_ComputedTag_OnUpdate_Replace(t *testing.
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy: testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy: testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1944,7 +1944,7 @@ func testAccAccessAnalyzerAnalyzer_tags_ComputedTag_OnUpdate_Replace(t *testing.
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1974,7 +1974,7 @@ func testAccAccessAnalyzerAnalyzer_tags_ComputedTag_OnUpdate_Replace(t *testing.
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2023,7 +2023,7 @@ func testAccAccessAnalyzerAnalyzer_tags_IgnoreTags_Overlap_DefaultTag(t *testing
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy: testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy: testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2042,7 +2042,7 @@ func testAccAccessAnalyzerAnalyzer_tags_IgnoreTags_Overlap_DefaultTag(t *testing
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2091,7 +2091,7 @@ func testAccAccessAnalyzerAnalyzer_tags_IgnoreTags_Overlap_DefaultTag(t *testing
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2140,7 +2140,7 @@ func testAccAccessAnalyzerAnalyzer_tags_IgnoreTags_Overlap_DefaultTag(t *testing
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2189,7 +2189,7 @@ func testAccAccessAnalyzerAnalyzer_tags_IgnoreTags_Overlap_ResourceTag(t *testin
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy: testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy: testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2206,7 +2206,7 @@ func testAccAccessAnalyzerAnalyzer_tags_IgnoreTags_Overlap_ResourceTag(t *testin
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2269,7 +2269,7 @@ func testAccAccessAnalyzerAnalyzer_tags_IgnoreTags_Overlap_ResourceTag(t *testin
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2332,7 +2332,7 @@ func testAccAccessAnalyzerAnalyzer_tags_IgnoreTags_Overlap_ResourceTag(t *testin
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/accessanalyzer/analyzer_test.go
+++ b/internal/service/accessanalyzer/analyzer_test.go
@@ -9,33 +9,31 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfaccessanalyzer "github.com/hashicorp/terraform-provider-aws/internal/service/accessanalyzer"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func testAccAnalyzer_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var analyzer types.AnalyzerSummary
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_accessanalyzer_analyzer.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAnalyzerConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &analyzer),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &analyzer),
 					resource.TestCheckResourceAttr(resourceName, "analyzer_name", rName),
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "access-analyzer", fmt.Sprintf("analyzer/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "0"),
@@ -55,19 +53,19 @@ func testAccAnalyzer_basic(t *testing.T) {
 func testAccAnalyzer_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var analyzer types.AnalyzerSummary
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_accessanalyzer_analyzer.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAnalyzerConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &analyzer),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &analyzer),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfaccessanalyzer.ResourceAnalyzer(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -79,10 +77,10 @@ func testAccAnalyzer_disappears(t *testing.T) {
 func testAccAnalyzer_typeOrganization(t *testing.T) {
 	ctx := acctest.Context(t)
 	var analyzer types.AnalyzerSummary
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_accessanalyzer_analyzer.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -90,12 +88,12 @@ func testAccAnalyzer_typeOrganization(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAnalyzerConfig_typeOrganization(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &analyzer),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &analyzer),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.TypeOrganization)),
 				),
 			},
@@ -111,20 +109,20 @@ func testAccAnalyzer_typeOrganization(t *testing.T) {
 func testAccAnalyzer_accountInternalAccess(t *testing.T) {
 	ctx := acctest.Context(t)
 	var analyzer types.AnalyzerSummary
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_accessanalyzer_analyzer.test"
 	s3BucketResourceName := "aws_s3_bucket.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAnalyzerConfig_accountInternalAccess_resourceARNs(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &analyzer),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &analyzer),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "ACCOUNT_INTERNAL_ACCESS"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.internal_access.#", "1"),
@@ -144,7 +142,7 @@ func testAccAnalyzer_accountInternalAccess(t *testing.T) {
 			{
 				Config: testAccAnalyzerConfig_accountInternalAccess_resourceTypes(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &analyzer),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &analyzer),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "ACCOUNT_INTERNAL_ACCESS"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.internal_access.#", "1"),
@@ -170,19 +168,19 @@ func testAccAnalyzer_accountInternalAccess(t *testing.T) {
 func testAccAnalyzer_accountUnusedAccess(t *testing.T) {
 	ctx := acctest.Context(t)
 	var analyzer types.AnalyzerSummary
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_accessanalyzer_analyzer.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAnalyzerConfig_accountUnusedAccess(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &analyzer),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &analyzer),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "ACCOUNT_UNUSED_ACCESS"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.unused_access.#", "1"),
@@ -202,11 +200,11 @@ func testAccAnalyzer_accountUnusedAccess(t *testing.T) {
 func testAccAnalyzer_organizationInternalAccess(t *testing.T) {
 	ctx := acctest.Context(t)
 	var analyzer types.AnalyzerSummary
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_accessanalyzer_analyzer.test"
 	s3BucketResourceName := "aws_s3_bucket.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -214,12 +212,12 @@ func testAccAnalyzer_organizationInternalAccess(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAnalyzerConfig_organizationInternalAccess_resourceARNs(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &analyzer),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &analyzer),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "ORGANIZATION_INTERNAL_ACCESS"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.internal_access.#", "1"),
@@ -240,7 +238,7 @@ func testAccAnalyzer_organizationInternalAccess(t *testing.T) {
 			{
 				Config: testAccAnalyzerConfig_organizationInternalAccess_multiple(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &analyzer),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &analyzer),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "ORGANIZATION_INTERNAL_ACCESS"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.internal_access.#", "1"),
@@ -271,10 +269,10 @@ func testAccAnalyzer_organizationInternalAccess(t *testing.T) {
 func testAccAnalyzer_organizationUnusedAccess(t *testing.T) {
 	ctx := acctest.Context(t)
 	var analyzer types.AnalyzerSummary
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_accessanalyzer_analyzer.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -282,12 +280,12 @@ func testAccAnalyzer_organizationUnusedAccess(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAnalyzerConfig_organizationUnusedAccess(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &analyzer),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &analyzer),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "ORGANIZATION_UNUSED_ACCESS"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.unused_access.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.unused_access.0.unused_access_age", "180"),
@@ -313,13 +311,13 @@ func testAccAnalyzer_organizationUnusedAccess(t *testing.T) {
 func testAccAnalyzer_upgradeV5_95_0(t *testing.T) {
 	ctx := acctest.Context(t)
 	var analyzer types.AnalyzerSummary
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_accessanalyzer_analyzer.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
-		CheckDestroy: testAccCheckAnalyzerDestroy(ctx),
+		CheckDestroy: testAccCheckAnalyzerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
@@ -330,7 +328,7 @@ func testAccAnalyzer_upgradeV5_95_0(t *testing.T) {
 				},
 				Config: testAccAnalyzerConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &analyzer),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &analyzer),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -342,7 +340,7 @@ func testAccAnalyzer_upgradeV5_95_0(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				Config:                   testAccAnalyzerConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAnalyzerExists(ctx, resourceName, &analyzer),
+					testAccCheckAnalyzerExists(ctx, t, resourceName, &analyzer),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -360,9 +358,9 @@ func testAccAnalyzer_upgradeV5_95_0(t *testing.T) {
 	})
 }
 
-func testAccCheckAnalyzerDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckAnalyzerDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).AccessAnalyzerClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_accessanalyzer_analyzer" {
@@ -371,7 +369,7 @@ func testAccCheckAnalyzerDestroy(ctx context.Context) resource.TestCheckFunc {
 
 			_, err := tfaccessanalyzer.FindAnalyzerByName(ctx, conn, rs.Primary.ID)
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 
@@ -386,14 +384,14 @@ func testAccCheckAnalyzerDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckAnalyzerExists(ctx context.Context, n string, v *types.AnalyzerSummary) resource.TestCheckFunc {
+func testAccCheckAnalyzerExists(ctx context.Context, t *testing.T, n string, v *types.AnalyzerSummary) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).AccessAnalyzerClient(ctx)
 
 		output, err := tfaccessanalyzer.FindAnalyzerByName(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/accessanalyzer/archive_rule.go
+++ b/internal/service/accessanalyzer/archive_rule.go
@@ -15,12 +15,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	sdkid "github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2/types/nullable"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -131,7 +131,7 @@ func resourceArchiveRuleRead(ctx context.Context, d *schema.ResourceData, meta a
 
 	archiveRule, err := findArchiveRuleByTwoPartKey(ctx, conn, analyzerName, ruleName)
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] IAM Access Analyzer Archive Rule (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -218,8 +218,7 @@ func findArchiveRuleByTwoPartKey(ctx context.Context, conn *accessanalyzer.Clien
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+			LastError: err,
 		}
 	}
 

--- a/internal/service/accessanalyzer/archive_rule_test.go
+++ b/internal/service/accessanalyzer/archive_rule_test.go
@@ -9,35 +9,33 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfaccessanalyzer "github.com/hashicorp/terraform-provider-aws/internal/service/accessanalyzer"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func testAccAnalyzerArchiveRule_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var archiveRule types.ArchiveRuleSummary
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_accessanalyzer_archive_rule.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.AccessAnalyzerEndpointID)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckArchiveRuleDestroy(ctx),
+		CheckDestroy:             testAccCheckArchiveRuleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccArchiveRuleConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckArchiveRuleExists(ctx, resourceName, &archiveRule),
+					testAccCheckArchiveRuleExists(ctx, t, resourceName, &archiveRule),
 					resource.TestCheckResourceAttr(resourceName, "filter.0.criteria", "isPublic"),
 				),
 			},
@@ -53,7 +51,7 @@ func testAccAnalyzerArchiveRule_basic(t *testing.T) {
 func testAccAnalyzerArchiveRule_updateFilters(t *testing.T) {
 	ctx := acctest.Context(t)
 	var archiveRule types.ArchiveRuleSummary
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_accessanalyzer_archive_rule.test"
 
 	filters := `
@@ -81,19 +79,19 @@ filter {
   eq       = ["true"]
 }
 `
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.AccessAnalyzerEndpointID)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckArchiveRuleDestroy(ctx),
+		CheckDestroy:             testAccCheckArchiveRuleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccArchiveRuleConfig_updateFilters(rName, filters),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckArchiveRuleExists(ctx, resourceName, &archiveRule),
+					testAccCheckArchiveRuleExists(ctx, t, resourceName, &archiveRule),
 					resource.TestCheckResourceAttr(resourceName, "filter.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "filter.0.criteria", "error"),
 					resource.TestCheckResourceAttr(resourceName, "filter.0.exists", acctest.CtTrue),
@@ -102,7 +100,7 @@ filter {
 			{
 				Config: testAccArchiveRuleConfig_updateFilters(rName, filtersUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckArchiveRuleExists(ctx, resourceName, &archiveRule),
+					testAccCheckArchiveRuleExists(ctx, t, resourceName, &archiveRule),
 					resource.TestCheckResourceAttr(resourceName, "filter.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "filter.0.criteria", "error"),
 					resource.TestCheckResourceAttr(resourceName, "filter.0.exists", acctest.CtTrue),
@@ -113,7 +111,7 @@ filter {
 			{
 				Config: testAccArchiveRuleConfig_updateFilters(rName, filtersRemoved),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckArchiveRuleExists(ctx, resourceName, &archiveRule),
+					testAccCheckArchiveRuleExists(ctx, t, resourceName, &archiveRule),
 					resource.TestCheckResourceAttr(resourceName, "filter.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "filter.0.criteria", "isPublic"),
 					resource.TestCheckResourceAttr(resourceName, "filter.0.eq.0", acctest.CtTrue),
@@ -126,22 +124,22 @@ filter {
 func testAccAnalyzerArchiveRule_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var archiveRule types.ArchiveRuleSummary
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_accessanalyzer_archive_rule.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.AccessAnalyzerEndpointID)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckArchiveRuleDestroy(ctx),
+		CheckDestroy:             testAccCheckArchiveRuleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccArchiveRuleConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckArchiveRuleExists(ctx, resourceName, &archiveRule),
+					testAccCheckArchiveRuleExists(ctx, t, resourceName, &archiveRule),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfaccessanalyzer.ResourceArchiveRule(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -150,9 +148,9 @@ func testAccAnalyzerArchiveRule_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckArchiveRuleDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckArchiveRuleDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).AccessAnalyzerClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_accessanalyzer_archive_rule" {
@@ -167,7 +165,7 @@ func testAccCheckArchiveRuleDestroy(ctx context.Context) resource.TestCheckFunc 
 
 			_, err = tfaccessanalyzer.FindArchiveRuleByTwoPartKey(ctx, conn, analyzerName, ruleName)
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 
@@ -182,7 +180,7 @@ func testAccCheckArchiveRuleDestroy(ctx context.Context) resource.TestCheckFunc 
 	}
 }
 
-func testAccCheckArchiveRuleExists(ctx context.Context, n string, v *types.ArchiveRuleSummary) resource.TestCheckFunc {
+func testAccCheckArchiveRuleExists(ctx context.Context, t *testing.T, n string, v *types.ArchiveRuleSummary) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -199,7 +197,7 @@ func testAccCheckArchiveRuleExists(ctx context.Context, n string, v *types.Archi
 			return err
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).AccessAnalyzerClient(ctx)
 
 		output, err := tfaccessanalyzer.FindArchiveRuleByTwoPartKey(ctx, conn, analyzerName, ruleName)
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Enables `go-vcr` for the `accessanalyzer` service.

**AI Disclosure:** AI agents were used to execute the migration workflow and run acceptance tests. All code changes and test results were subsequently hand reviewed for correctness.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/25602
Relates https://github.com/hashicorp/terraform-provider-aws/issues/43717

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=accessanalyzer VCR_MODE=RECORD_ONLY VCR_PATH=/tmp/accessanalyzer-vcr-testdata/
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-go-vcr-accessanalyzer 🌿...
TF_ACC=1 go1.24.8 test ./internal/service/accessanalyzer/... -v -count 1 -parallel 20   -timeout 360m -vet=off
2025/10/17 16:06:29 Creating Terraform AWS Provider (SDKv2-style)...
2025/10/17 16:06:29 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccAccessAnalyzer_serial (266.13s)
    --- PASS: TestAccAccessAnalyzer_serial/Analyzer (223.38s)
        --- PASS: TestAccAccessAnalyzer_serial/Analyzer/accountUnusedAccess (12.09s)
        --- SKIP: TestAccAccessAnalyzer_serial/Analyzer/organizationInternalAccess (0.45s)
        --- PASS: TestAccAccessAnalyzer_serial/Analyzer/disappears (9.44s)
        --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags (163.76s)
            --- SKIP: TestAccAccessAnalyzer_serial/Analyzer/tags/ComputedTag_OnUpdate_Replace (0.00s)
            --- SKIP: TestAccAccessAnalyzer_serial/Analyzer/tags/IgnoreTags_Overlap_DefaultTag (0.00s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/EmptyMap (16.88s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/EmptyTag_OnUpdate_Add (28.97s)
            --- SKIP: TestAccAccessAnalyzer_serial/Analyzer/tags/DefaultTags_providerOnly (0.00s)
            --- SKIP: TestAccAccessAnalyzer_serial/Analyzer/tags/DefaultTags_updateToProviderOnly (0.00s)
            --- SKIP: TestAccAccessAnalyzer_serial/Analyzer/tags/DefaultTags_emptyResourceTag (0.00s)
            --- SKIP: TestAccAccessAnalyzer_serial/Analyzer/tags/DefaultTags_nullNonOverlappingResourceTag (0.00s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/basic (40.18s)
            --- SKIP: TestAccAccessAnalyzer_serial/Analyzer/tags/DefaultTags_nonOverlapping (0.00s)
            --- SKIP: TestAccAccessAnalyzer_serial/Analyzer/tags/DefaultTags_updateToResourceOnly (0.00s)
            --- SKIP: TestAccAccessAnalyzer_serial/Analyzer/tags/ComputedTag_OnCreate (0.00s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/AddOnUpdate (19.28s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/EmptyTag_OnUpdate_Replace (19.83s)
            --- SKIP: TestAccAccessAnalyzer_serial/Analyzer/tags/DefaultTags_nullOverlappingResourceTag (0.00s)
            --- SKIP: TestAccAccessAnalyzer_serial/Analyzer/tags/IgnoreTags_Overlap_ResourceTag (0.00s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/null (17.08s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/EmptyTag_OnCreate (21.54s)
            --- SKIP: TestAccAccessAnalyzer_serial/Analyzer/tags/DefaultTags_overlapping (0.00s)
            --- SKIP: TestAccAccessAnalyzer_serial/Analyzer/tags/ComputedTag_OnUpdate_Add (0.00s)
        --- PASS: TestAccAccessAnalyzer_serial/Analyzer/accountInternalAccess (26.21s)
        --- SKIP: TestAccAccessAnalyzer_serial/Analyzer/organizationUnusedAccess (0.31s)
        --- SKIP: TestAccAccessAnalyzer_serial/Analyzer/type_Organization (0.30s)
        --- SKIP: TestAccAccessAnalyzer_serial/Analyzer/upgradeV5_95_0 (0.00s)
        --- PASS: TestAccAccessAnalyzer_serial/Analyzer/basic (10.83s)
    --- PASS: TestAccAccessAnalyzer_serial/ArchiveRule (42.75s)
        --- PASS: TestAccAccessAnalyzer_serial/ArchiveRule/basic (11.16s)
        --- PASS: TestAccAccessAnalyzer_serial/ArchiveRule/disappears (9.80s)
        --- PASS: TestAccAccessAnalyzer_serial/ArchiveRule/update_filters (21.79s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/accessanalyzer	273.460s
```
