### PR TITLE
docs: [aws_workspaces_workspace] update some attributes from "Argument Reference" to "Attribute Reference"

### DIFF
--- a/website/docs/d/workspaces_workspace.html.markdown
+++ b/website/docs/d/workspaces_workspace.html.markdown
@@ -42,22 +42,22 @@ This data source supports the following arguments:
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `bundle_id` - (Optional) ID of the bundle for the WorkSpace.
+* `bundle_id` - ID of the bundle for the WorkSpace.
 * `computer_name` - Name of the WorkSpace, as seen by the operating system.
 * `id` - Workspaces ID.
 * `ip_address` - IP address of the WorkSpace.
-* `root_volume_encryption_enabled` - (Optional) Indicates whether the data stored on the root volume is encrypted.
+* `root_volume_encryption_enabled` - Indicates whether the data stored on the root volume is encrypted.
 * `state` - Operational state of the WorkSpace.
-* `tags` - (Optional) Tags for the WorkSpace.
-* `user_volume_encryption_enabled` - (Optional) Indicates whether the data stored on the user volume
+* `tags` - Tags for the WorkSpace.
+* `user_volume_encryption_enabled` - Indicates whether the data stored on the user volume
 is encrypted.
-* `volume_encryption_key` - (Optional) Symmetric AWS KMS customer master key (CMK) used to encrypt data stored on your WorkSpace. Amazon WorkSpaces does not support asymmetric CMKs.
-* `workspace_properties` - (Optional) WorkSpace properties.
+* `volume_encryption_key` - Symmetric AWS KMS customer master key (CMK) used to encrypt data stored on your WorkSpace. Amazon WorkSpaces does not support asymmetric CMKs.
+* `workspace_properties` - WorkSpace properties.
 
-`workspace_properties` supports the following:
+### `workspace_properties` Attribute Reference
 
-* `compute_type_name` - (Optional) Compute type. For more information, see [Amazon WorkSpaces Bundles](http://aws.amazon.com/workspaces/details/#Amazon_WorkSpaces_Bundles). Valid values are `VALUE`, `STANDARD`, `PERFORMANCE`, `POWER`, `GRAPHICS`, `POWERPRO` and `GRAPHICSPRO`.
-* `root_volume_size_gib` - (Optional) Size of the root volume.
-* `running_mode` - (Optional) Running mode. For more information, see [Manage the WorkSpace Running Mode](https://docs.aws.amazon.com/workspaces/latest/adminguide/running-mode.html). Valid values are `AUTO_STOP` and `ALWAYS_ON`.
-* `running_mode_auto_stop_timeout_in_minutes` - (Optional) Time after a user logs off when WorkSpaces are automatically stopped. Configured in 60-minute intervals.
-* `user_volume_size_gib` - (Optional) Size of the user storage.
+* `compute_type_name` - Compute type. For more information, see [Amazon WorkSpaces Bundles](http://aws.amazon.com/workspaces/details/#Amazon_WorkSpaces_Bundles). Valid values are `VALUE`, `STANDARD`, `PERFORMANCE`, `POWER`, `GRAPHICS`, `POWERPRO` and `GRAPHICSPRO`.
+* `root_volume_size_gib` - Size of the root volume.
+* `running_mode` - Running mode. For more information, see [Manage the WorkSpace Running Mode](https://docs.aws.amazon.com/workspaces/latest/adminguide/running-mode.html). Valid values are `AUTO_STOP` and `ALWAYS_ON`.
+* `running_mode_auto_stop_timeout_in_minutes` - Time after a user logs off when WorkSpaces are automatically stopped. Configured in 60-minute intervals.
+* `user_volume_size_gib` - Size of the user storage.


### PR DESCRIPTION
### Description

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/workspaces_workspace

In the aws_workspaces_workspace data source, several fields defined as arguments currently either cause errors or are ignored when specified.
Based on verification, these fields appear to function as attributes rather than arguments.
The following table summarizes the observed behavior for each field.

Verified with Terraform Provider version 6.17.0.

#### Argument-to-Attribute Changes

|Attribute Name|Changed (Arg → Attr)|Notes|
|:----|:----|:----|
|region|–| |
|bundle_id|◯|Causes error if used as argument|
|directory_id|–| |
|root_volume_encryption_enabled|◯|Causes error if used as argument|
|tags|◯|Argument input is ignored|
|user_name|–| |
|user_volume_encryption_enabled|◯|Causes error if used as argument|
|volume_encryption_key|◯|Causes error if used as argument|
|workspace_id|–| |
|workspace_properties|◯|Causes error if used as argument|
|compute_type_name|◯|Inside workspace_properties|
|root_volume_size_gib|◯|Inside workspace_properties|
|running_mode|◯|Inside workspace_properties|
|running_mode_auto_stop_timeout_in_minutes|◯|Inside workspace_properties|
|user_volume_size_gib|◯|Inside workspace_properties|
|id|–| |
|ip_address|–| |
|compute_name|–| |
|state|–| |

### Reproduction Steps

Steps to reproduce for fields that cause an error when used as arguments (e.g. bundle_id)

#### main.tf

```terraform
data "aws_workspaces_workspace" "ws1" {
  workspace_id = "ws-xxxxxxxxx"
  bundle_id = "wsb-xxxxxxxxx"
}

output "ws1" {
  value = data.aws_workspaces_workspace.ws1
}
```

#### CLI

```sh
$ terraform apply                                                                                                   
╷
│ Error: Value for unconfigurable attribute
│ 
│   with data.aws_workspaces_workspace.w,
│   on main.tf line 19, in data "aws_workspaces_workspace" "ws1":
│   19:   bundle_id = "wsb-xxxxxxxxx"
│ 
│ Can't configure a value for "bundle_id": its value will be decided automatically based on the result of applying this
│ configuration.
```

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://github.com/hashicorp/terraform-provider-aws/pull/14135
https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/workspaces/workspace_data_source.go
