### PR TITLE
Update Go version in devcontainer.json to 1.24

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,5 +3,5 @@
 {
 	"name": "Go",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:1.23"
+	"image": "mcr.microsoft.com/devcontainers/go:1.24"
 }


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No.

### Description

The `terraform-provider-aws` project currently requires Go `1.24.8`, but `devcontainer.json` still specifies Go `1.23`. This PR updates the version to `1.24` to align with project needs.

