### PR TITLE
fix(docs): Add `instruction` input to BedRock Agent example 

### DIFF
--- a/website/docs/r/bedrockagent_agent.html.markdown
+++ b/website/docs/r/bedrockagent_agent.html.markdown
@@ -63,6 +63,7 @@ resource "aws_bedrockagent_agent" "example" {
   agent_name                  = "my-agent-name"
   agent_resource_role_arn     = aws_iam_role.example.arn
   idle_session_ttl_in_seconds = 500
+  instruction                 = "You are a friendly assistant who helps answer questions."
   foundation_model            = "anthropic.claude-v2"
 }
 ```


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, simply revert the PR to remove documentation updates. 

## Changes to Security Controls

N/A

### Description

Opened in response to https://github.com/hashicorp/terraform-provider-aws/issues/44758. This is only a fix for docs to ensure that the example for the `aws_bedrockagent_agent` resource works; there are other underlying issues to fix regarding whether the `instructions` input should be optional. 


### Relations

Relates #44758

### References

Issue linked above

### Output from Acceptance Testing

```console
make docs
make: Documentation Checks / markdown-link-check...
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
/usr/local/lib
+-- corepack@0.29.3
`-- npm@10.8.2
  +-- @isaacs/string-locale-compare@1.1.0
  +-- @npmcli/arborist@7.5.4
  +-- @npmcli/config@8.3.4
  +-- @npmcli/fs@3.1.1
  +-- @npmcli/map-workspaces@3.0.6
  +-- @npmcli/package-json@5.2.0
  +-- @npmcli/promise-spawn@7.0.2
  +-- @npmcli/redact@2.0.1
  +-- @npmcli/run-script@8.1.0
  +-- @sigstore/tuf@2.3.4
  +-- abbrev@2.0.0
  +-- archy@1.0.0
  +-- cacache@18.0.3
  +-- chalk@5.3.0
  +-- ci-info@4.0.0
  +-- cli-columns@4.0.0
  +-- fastest-levenshtein@1.0.16
  +-- fs-minipass@3.0.3
  +-- glob@10.4.2
  +-- graceful-fs@4.2.11
  +-- hosted-git-info@7.0.2
  +-- ini@4.1.3
  +-- init-package-json@6.0.3
  +-- is-cidr@5.1.0
  +-- json-parse-even-better-errors@3.0.2
  +-- libnpmaccess@8.0.6
  +-- libnpmdiff@6.1.4
  +-- libnpmexec@8.1.3
  +-- libnpmfund@5.0.12
  +-- libnpmhook@10.0.5
  +-- libnpmorg@6.0.6
  +-- libnpmpack@7.0.4
  +-- libnpmpublish@9.0.9
  +-- libnpmsearch@7.0.6
  +-- libnpmteam@6.0.5
  +-- libnpmversion@6.0.3
  +-- make-fetch-happen@13.0.1
  +-- minimatch@9.0.5
  +-- minipass-pipeline@1.2.4
  +-- minipass@7.1.2
  +-- ms@2.1.3
  +-- node-gyp@10.1.0
  +-- nopt@7.2.1
  +-- normalize-package-data@6.0.2
  +-- npm-audit-report@5.0.0
  +-- npm-install-checks@6.3.0
  +-- npm-package-arg@11.0.2
  +-- npm-pick-manifest@9.1.0
  +-- npm-profile@10.0.0
  +-- npm-registry-fetch@17.1.0
  +-- npm-user-validate@2.0.1
  +-- p-map@4.0.0
  +-- pacote@18.0.6
  +-- parse-conflict-json@3.0.1
  +-- proc-log@4.2.0
  +-- qrcode-terminal@0.12.0
  +-- read@3.0.1
  +-- semver@7.6.2
  +-- spdx-expression-parse@4.0.0
  +-- ssri@10.0.6
  +-- supports-color@9.4.0
  +-- tar@6.2.1
  +-- text-table@0.2.0
  +-- tiny-relative-date@1.3.0
  +-- treeverse@3.0.0
  +-- validate-npm-package-name@5.0.1
  +-- which@4.0.0
  `-- write-file-atomic@5.0.1

::endgroup::
Using markdown-link-check configuration file: /markdown/.ci/.markdownlinkcheck.json
QUIET: yes
VERBOSE: yes
DIRECTORY: /markdown/docs
DEPTH: -1
MODIFIED: no
BRANCH: main
PREFIX: 
EXTENSION: .md
FILE: 
+ find /markdown/docs -name '*.md' -not -path './node_modules/*' -exec markdown-link-check '{}' --config /markdown/.ci/.markdownlinkcheck.json -q -v ';'
+ set +x
=========================> MARKDOWN LINK CHECK <=========================

[✔] All links are good!

=========================================================================
make: Documentation Checks / markdown-lint...
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
make: Documentation Checks / misspell...
make: misspell: No such file or directory
make: *** [docs-misspell] Error 1
```

I promise I double-checked for misspellings since I couldn't get the last test to work.
