### PR TITLE
d/aws_vpn_connection: properly set `tags`

### DIFF
--- a/.changelog/44761.txt
+++ b/.changelog/44761.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_vpn_connection: Properly set `tags` attribute
+```

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -79,6 +79,7 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 			Factory:  newDataSourceVPNConnection,
 			TypeName: "aws_vpn_connection",
 			Name:     "VPN Connection",
+			Tags:     unique.Make(inttypes.ServicePackageResourceTags{}),
 			Region:   unique.Make(inttypes.ResourceRegionDefault()),
 		},
 	}

--- a/internal/service/ec2/vpnsite_connection_data_source.go
+++ b/internal/service/ec2/vpnsite_connection_data_source.go
@@ -23,6 +23,8 @@ import (
 )
 
 // @FrameworkDataSource("aws_vpn_connection", name="VPN Connection")
+// @Tags
+// @Testing(tagsTest=false)
 func newDataSourceVPNConnection(context.Context) (datasource.DataSourceWithConfigure, error) {
 	return &dataSourceVPNConnection{}, nil
 }
@@ -112,6 +114,8 @@ func (d *dataSourceVPNConnection) Read(ctx context.Context, req datasource.ReadR
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	setTagsOut(ctx, out.Tags)
 	smerr.EnrichAppend(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data), smerr.ID, data.VpnConnectionId.String())
 }
 

--- a/internal/service/ec2/vpnsite_connection_data_source_test.go
+++ b/internal/service/ec2/vpnsite_connection_data_source_test.go
@@ -38,6 +38,8 @@ func TestAccSiteVPNConnectionDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "customer_gateway_configuration"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "category"),
 					resource.TestCheckResourceAttr(dataSourceName, "routes.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, acctest.CtTagsPercent, "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.Name", rName),
 					resource.TestCheckResourceAttr(dataSourceName, "vgw_telemetries.#", "2"),
 				),
 			},
@@ -127,6 +129,10 @@ resource "aws_vpn_connection" "test" {
   vpn_gateway_id      = aws_vpn_gateway.test.id
   customer_gateway_id = aws_customer_gateway.test.id
   type                = "ipsec.1"
+
+  tags = {
+    Name = %[1]q
+  }
 }
 `, rName, rBgpAsn)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously the `tags` attribute would always return an empty result.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #44622
Addresses https://github.com/hashicorp/terraform-provider-aws/pull/44622#issuecomment-3419491062


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=ec2 T=TestAccSiteVPNConnectionDataSource_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-vpn_connection-ds-tags 🌿...
TF_ACC=1 go1.24.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnectionDataSource_'  -timeout 360m -vet=off
2025/10/21 16:44:13 Creating Terraform AWS Provider (SDKv2-style)...
2025/10/21 16:44:14 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccSiteVPNConnectionDataSource_noInput (1.47s)
--- PASS: TestAccSiteVPNConnectionDataSource_nonExistentId (2.44s)
--- PASS: TestAccSiteVPNConnectionDataSource_byFilter (232.63s)
--- PASS: TestAccSiteVPNConnectionDataSource_basic (563.31s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        570.281s
```