### PR TITLE
docs: add note for optional argument instruction

### DIFF
--- a/website/docs/r/bedrockagent_agent.html.markdown
+++ b/website/docs/r/bedrockagent_agent.html.markdown
@@ -63,6 +63,7 @@ resource "aws_bedrockagent_agent" "example" {
   agent_name                  = "my-agent-name"
   agent_resource_role_arn     = aws_iam_role.example.arn
   idle_session_ttl_in_seconds = 500
+  instruction                 = "You are a friendly assistant who helps answer questions."
   foundation_model            = "anthropic.claude-v2"
 }
 ```


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None

### Description

Based on the feedback/ comments in the referenced issues it makes sense to update the documentation of argument `instruction` of resource [`aws_bedrockagent_agent`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagent_agent). The `instruction` (listed as `Optional`) are actually required if `prepare_agent` is `true`.

### Relations

- [Bedrock Agent instruction is mandatory](https://github.com/hashicorp/terraform-provider-aws/issues/40255)
- [BedRock Agent aws_bedrock_agent Resource - Agent Instruction cannot be null](https://github.com/hashicorp/terraform-provider-aws/issues/44758)
- [fix(aws_bedrockagent_agent): argument instruction is mandatory ](https://github.com/hashicorp/terraform-provider-aws/pull/40256)

### References


### Output from Acceptance Testing

Not applicable. Only documentation is updated.
