### PR TITLE
[Enhancement] feat: add bedrock agentcore observability support

### DIFF
--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -218,6 +218,19 @@ func (r *agentRuntimeResource) Schema(ctx context.Context, request resource.Sche
 					},
 				},
 			},
+			"observability": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[observabilityConfigurationModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"enabled": schema.BoolAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
 			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
 				Create: true,
 				Update: true,
@@ -285,11 +298,34 @@ func (r *agentRuntimeResource) Create(ctx context.Context, request resource.Crea
 		return
 	}
 
+	if !data.Observability.IsNull() {
+		obsConfig, d := data.Observability.ToPtr(ctx)
+		smerr.EnrichAppend(ctx, &response.Diagnostics, d)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		if obsConfig != nil && obsConfig.Enabled.ValueBool() {
+			if err := configureObservability(ctx, conn, r.Meta().XRayClient(ctx), runtime, data.EnvironmentVariables); err != nil {
+				smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+				return
+			}
+
+			runtime, err = findAgentRuntimeByID(ctx, conn, agentRuntimeID)
+			if err != nil {
+				smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+				return
+			}
+		}
+	}
+
 	// Set values for unknowns.
+	userEnvVars := data.EnvironmentVariables
 	smerr.EnrichAppend(ctx, &response.Diagnostics, fwflex.Flatten(ctx, runtime, &data, fwflex.WithFieldNamePrefix("AgentRuntime")))
 	if response.Diagnostics.HasError() {
 		return
 	}
+	data.EnvironmentVariables = userEnvVars
 
 	smerr.EnrichAppend(ctx, &response.Diagnostics, response.State.Set(ctx, data))
 }
@@ -315,9 +351,18 @@ func (r *agentRuntimeResource) Read(ctx context.Context, request resource.ReadRe
 		return
 	}
 
+	userEnvVars := data.EnvironmentVariables
 	smerr.EnrichAppend(ctx, &response.Diagnostics, fwflex.Flatten(ctx, out, &data, fwflex.WithFieldNamePrefix("AgentRuntime")))
 	if response.Diagnostics.HasError() {
 		return
+	}
+
+	if !data.Observability.IsNull() {
+		obsConfig, d := data.Observability.ToPtr(ctx)
+		smerr.EnrichAppend(ctx, &response.Diagnostics, d)
+		if !response.Diagnostics.HasError() && obsConfig != nil && obsConfig.Enabled.ValueBool() {
+			data.EnvironmentVariables = userEnvVars
+		}
 	}
 
 	smerr.EnrichAppend(ctx, &response.Diagnostics, response.State.Set(ctx, &data))
@@ -518,10 +563,15 @@ type agentRuntimeResourceModel struct {
 	TagsAll                    tftags.Map                                                       `tfsdk:"tags_all"`
 	Timeouts                   timeouts.Value                                                   `tfsdk:"timeouts"`
 	WorkloadIdentityDetails    fwtypes.ListNestedObjectValueOf[workloadIdentityDetailsModel]    `tfsdk:"workload_identity_details"`
+	Observability              fwtypes.ListNestedObjectValueOf[observabilityConfigurationModel] `tfsdk:"observability"`
 }
 
 type agentRuntimeArtifactModel struct {
 	ContainerConfiguration fwtypes.ListNestedObjectValueOf[containerConfigurationModel] `tfsdk:"container_configuration"`
+}
+
+type observabilityConfigurationModel struct {
+	Enabled types.Bool `tfsdk:"enabled"`
 }
 
 var (
@@ -679,6 +729,75 @@ func (m requestHeaderConfigurationModel) Expand(ctx context.Context) (any, diag.
 		return &r, diags
 	}
 	return nil, diags
+}
+
+func configureObservability(ctx context.Context, conn *bedrockagentcorecontrol.Client, xrayConn *xray.Client, runtime *bedrockagentcorecontrol.GetAgentRuntimeOutput, existingEnvVars fwtypes.MapOfString) error {
+	runtimeID := aws.ToString(runtime.AgentRuntimeId)
+	runtimeName := aws.ToString(runtime.AgentRuntimeName)
+	logGroup := fmt.Sprintf("/aws/bedrock-agentcore/runtimes/%s", runtimeID)
+
+	obsEnvVars := map[string]string{
+		"AGENT_OBSERVABILITY_ENABLED":     "true",
+		"OTEL_PYTHON_DISTRO":              "aws_distro",
+		"OTEL_PYTHON_CONFIGURATOR":        "aws_configurator",
+		"OTEL_RESOURCE_ATTRIBUTES":        fmt.Sprintf("service.name=%s,aws.log.group.names=%s", runtimeName, logGroup),
+		"OTEL_EXPORTER_OTLP_LOGS_HEADERS": fmt.Sprintf("x-aws-log-group=%s,x-aws-log-stream=runtime-logs,x-aws-metric-namespace=bedrock-agentcore", logGroup),
+		"OTEL_EXPORTER_OTLP_PROTOCOL":     "http/protobuf",
+		"OTEL_TRACES_EXPORTER":            "otlp",
+	}
+
+	mergedEnvVars := make(map[string]string)
+
+	if !existingEnvVars.IsNull() {
+		for k, v := range existingEnvVars.Elements() {
+			if strVal, ok := v.(types.String); ok {
+				mergedEnvVars[k] = strVal.ValueString()
+			}
+		}
+	}
+
+	for k, v := range obsEnvVars {
+		mergedEnvVars[k] = v
+	}
+
+	updateInput := &bedrockagentcorecontrol.UpdateAgentRuntimeInput{
+		AgentRuntimeId:          aws.String(runtimeID),
+		AgentRuntimeArtifact:    runtime.AgentRuntimeArtifact,
+		RoleArn:                 runtime.RoleArn,
+		NetworkConfiguration:    runtime.NetworkConfiguration,
+		EnvironmentVariables:    mergedEnvVars,
+		AuthorizerConfiguration: runtime.AuthorizerConfiguration,
+		Description:             runtime.Description,
+		ProtocolConfiguration:   runtime.ProtocolConfiguration,
+	}
+
+	if _, err := conn.UpdateAgentRuntime(ctx, updateInput); err != nil {
+		return fmt.Errorf("updating runtime with observability env vars: %w", err)
+	}
+
+	if err := configureXRayForObservability(ctx, xrayConn, runtimeID); err != nil {
+		return fmt.Errorf("configuring XRay: %w", err)
+	}
+
+	return nil
+}
+
+func configureXRayForObservability(ctx context.Context, xrayConn *xray.Client, runtimeName string) error {
+	getOutput, err := xrayConn.GetTraceSegmentDestination(ctx, &xray.GetTraceSegmentDestinationInput{})
+	if err != nil {
+		return fmt.Errorf("getting trace segment destination: %w", err)
+	}
+
+	if getOutput.Destination != xraytypes.TraceSegmentDestinationCloudWatchLogs {
+		_, err = xrayConn.UpdateTraceSegmentDestination(ctx, &xray.UpdateTraceSegmentDestinationInput{
+			Destination: xraytypes.TraceSegmentDestinationCloudWatchLogs,
+		})
+		if err != nil {
+			return fmt.Errorf("updating trace segment destination: %w", err)
+		}
+	}
+
+	return nil
 }
 
 type workloadIdentityDetailsModel struct {

--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -13,6 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
+	"github.com/aws/aws-sdk-go-v2/service/xray"
+	xraytypes "github.com/aws/aws-sdk-go-v2/service/xray/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"

--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -13,6 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	logstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/aws/aws-sdk-go-v2/service/xray"
 	xraytypes "github.com/aws/aws-sdk-go-v2/service/xray/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Resolve https://github.com/hashicorp/terraform-provider-aws/issues/44742

Add `aws_bedrockagentcore_agent_runtime.observability` block which enables agentcore observability option by addeing runtime id as an env vars after creating new runtime.


```terraform
terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "~>6.17"
    }
  }
}

provider "aws" {
  region = "us-west-2"
}

resource "aws_bedrockagentcore_agent_runtime" "test" {
  
  agent_runtime_name = "example_agent_runtime_2"
  role_arn           = "role_arn"
  
  agent_runtime_artifact {
    container_configuration {
      container_uri = "container_uri"
    }
  }
  
  network_configuration {
    network_mode = "PUBLIC"
  }
  
  observability {
    enabled = true
  }
}
```

There are 2 types of updating features:
- Enable CloudWatch Transaction Search  & Modifying destination of trace segments (xray UpdateTraceSegmentDestination): global setting (only activate once). This code checks and update if those options are unavailable.
- Changing environment variables with generated Runtime ID and redeploy: needed to each runtimes.

This code automatically enables cloudwatch transaction search. But it would takes a few minutes to be fully activated.
After then, we can check full traces & sessions of AgentCore Agent.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example: 

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/44742

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bedrockagentcore TESTS='^TestAccBedrockAgentCoreAgentRuntime'
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go1.24.8 test ./internal/service/bedrockagentcore/... -v -count 1 -parallel 20 -run='^TestAccBedrockAgentCoreAgentRuntime'  -timeout 360m -vet=off
2025/10/23 17:21:07 Creating Terraform AWS Provider (SDKv2-style)...
2025/10/23 17:21:07 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockAgentCoreAgentRuntimeEndpoint_basic
=== PAUSE TestAccBedrockAgentCoreAgentRuntimeEndpoint_basic
=== RUN   TestAccBedrockAgentCoreAgentRuntimeEndpoint_disappears
=== PAUSE TestAccBedrockAgentCoreAgentRuntimeEndpoint_disappears
=== RUN   TestAccBedrockAgentCoreAgentRuntimeEndpoint_update
=== PAUSE TestAccBedrockAgentCoreAgentRuntimeEndpoint_update
=== RUN   TestAccBedrockAgentCoreAgentRuntimeEndpoint_tags
=== PAUSE TestAccBedrockAgentCoreAgentRuntimeEndpoint_tags
=== RUN   TestAccBedrockAgentCoreAgentRuntime_basic
=== PAUSE TestAccBedrockAgentCoreAgentRuntime_basic
=== RUN   TestAccBedrockAgentCoreAgentRuntime_disappears
=== PAUSE TestAccBedrockAgentCoreAgentRuntime_disappears
=== RUN   TestAccBedrockAgentCoreAgentRuntime_tags
=== PAUSE TestAccBedrockAgentCoreAgentRuntime_tags
=== RUN   TestAccBedrockAgentCoreAgentRuntime_description
=== PAUSE TestAccBedrockAgentCoreAgentRuntime_description
=== RUN   TestAccBedrockAgentCoreAgentRuntime_environmentVariables
=== PAUSE TestAccBedrockAgentCoreAgentRuntime_environmentVariables
=== RUN   TestAccBedrockAgentCoreAgentRuntime_authorizerConfiguration
=== PAUSE TestAccBedrockAgentCoreAgentRuntime_authorizerConfiguration
=== RUN   TestAccBedrockAgentCoreAgentRuntime_protocolConfiguration
=== PAUSE TestAccBedrockAgentCoreAgentRuntime_protocolConfiguration
=== RUN   TestAccBedrockAgentCoreAgentRuntime_artifact
=== PAUSE TestAccBedrockAgentCoreAgentRuntime_artifact
=== CONT  TestAccBedrockAgentCoreAgentRuntimeEndpoint_basic
=== CONT  TestAccBedrockAgentCoreAgentRuntime_tags
=== CONT  TestAccBedrockAgentCoreAgentRuntimeEndpoint_tags
=== CONT  TestAccBedrockAgentCoreAgentRuntime_artifact
=== CONT  TestAccBedrockAgentCoreAgentRuntime_environmentVariables
=== CONT  TestAccBedrockAgentCoreAgentRuntime_disappears
=== CONT  TestAccBedrockAgentCoreAgentRuntimeEndpoint_update
=== CONT  TestAccBedrockAgentCoreAgentRuntime_protocolConfiguration
=== CONT  TestAccBedrockAgentCoreAgentRuntime_authorizerConfiguration
=== CONT  TestAccBedrockAgentCoreAgentRuntime_basic
=== CONT  TestAccBedrockAgentCoreAgentRuntime_description
=== CONT  TestAccBedrockAgentCoreAgentRuntimeEndpoint_disappears
--- PASS: TestAccBedrockAgentCoreAgentRuntime_disappears (72.54s)
--- PASS: TestAccBedrockAgentCoreAgentRuntimeEndpoint_disappears (78.02s)
--- PASS: TestAccBedrockAgentCoreAgentRuntime_basic (80.31s)
--- PASS: TestAccBedrockAgentCoreAgentRuntimeEndpoint_basic (86.83s)
--- PASS: TestAccBedrockAgentCoreAgentRuntime_description (108.19s)
--- PASS: TestAccBedrockAgentCoreAgentRuntime_artifact (113.92s)
--- PASS: TestAccBedrockAgentCoreAgentRuntime_environmentVariables (114.36s)
--- PASS: TestAccBedrockAgentCoreAgentRuntime_protocolConfiguration (114.85s)
--- PASS: TestAccBedrockAgentCoreAgentRuntime_authorizerConfiguration (116.02s)
--- PASS: TestAccBedrockAgentCoreAgentRuntimeEndpoint_update (118.53s)
--- PASS: TestAccBedrockAgentCoreAgentRuntime_tags (129.74s)
--- PASS: TestAccBedrockAgentCoreAgentRuntimeEndpoint_tags (136.87s)
PASS
ok  	[github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore](http://github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore)	143.835s
```
