### PR TITLE
docs: fix typo in attribute name

### DIFF
--- a/website/docs/r/bedrockagentcore_agent_runtime_endpoint.html.markdown
+++ b/website/docs/r/bedrockagentcore_agent_runtime_endpoint.html.markdown
@@ -40,7 +40,7 @@ The following arguments are optional:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `agent_runtime_endoint_arn` - ARN of the Agent Runtime Endpoint.
+* `agent_runtime_endpoint_arn` - ARN of the Agent Runtime Endpoint.
 * `agent_runtime_arn` - ARN of the associated Agent Runtime.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None.

### Description
 
Fix a typo in one of the attribute names for resource [aws_bedrockagentcore_agent_runtime_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagentcore_agent_runtime_endpoint):

[`agent_runtime_endoint_arn`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagentcore_agent_runtime_endpoint#agent_runtime_endoint_arn-1)  -> `agent_runtime_endpoint_arn`

### Relations

Closes #44772 

### References

- [Attribute in Terraform Docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagentcore_agent_runtime_endpoint#agent_runtime_endoint_arn-1)
- [Attribute name in Source](https://github.com/hashicorp/terraform-provider-aws/blob/99d3a4628ecbf94bfaca4f249f8f274810ca9e10/internal/service/bedrockagentcore/agent_runtime_endpoint.go#L62)


### Output from Acceptance Testing

Not applicable. Only documentation is updated.