### PR TITLE
chore: fix `v6.18.0` changelog entry formatting

### DIFF
--- a/.changelog/44327.txt
+++ b/.changelog/44327.txt
@@ -6,28 +6,28 @@ resource/aws_organizations_account: The `status` attribute is deprecated. Use `s
 ```
 
 ```release-note:enhancement
-resource/aws_organizations_organization: Add `state`, `joined_method`, and 'joined_timestamp` attributes to the `accounts` and `non_master_accounts` blocks
+resource/aws_organizations_organization: Add `state`, `joined_method`, and `joined_timestamp` attributes to the `accounts` and `non_master_accounts` blocks
 ```
 ```release-note:note
 resource/aws_organizations_organization: The `accounts.status` and `non_master_accounts.status` attributes are deprecated. Use the `accounts.state` and `non_master_accounts.state` attributes instead.
 ```
 
 ```release-note:enhancement
-data-source/aws_organizations_organization: Add `state`, `joined_method`, and 'joined_timestamp` attributes to the `accounts` and `non_master_accounts` blocks
+data-source/aws_organizations_organization: Add `state`, `joined_method`, and `joined_timestamp` attributes to the `accounts` and `non_master_accounts` blocks
 ```
 ```release-note:note
 data-source/aws_organizations_organization: The `accounts.status` and `non_master_accounts.status` attributes are deprecated. Use the `accounts.state` and `non_master_accounts.state` attributes instead.
 ```
 
 ```release-note:enhancement
-data-source/aws_organizations_organizational_unit_child_accounts: Add `state`, `joined_method`, and 'joined_timestamp` attributes to the `accounts` block
+data-source/aws_organizations_organizational_unit_child_accounts: Add `state`, `joined_method`, and `joined_timestamp` attributes to the `accounts` block
 ```
 ```release-note:note
 data-source/aws_organizations_organizational_unit_child_accounts: The `accounts.status` attribute is deprecated. Use `accounts.state` instead.
 ```
 
 ```release-note:enhancement
-data-source/aws_organizations_organizational_unit_descendant_accounts: Add `state`, `joined_method`, and 'joined_timestamp` attributes to the `accounts` block
+data-source/aws_organizations_organizational_unit_descendant_accounts: Add `state`, `joined_method`, and `joined_timestamp` attributes to the `accounts` block
 ```
 ```release-note:note
 data-source/aws_organizations_organizational_unit_descendant_accounts: The `accounts.status` attribute is deprecated. Use `accounts.state` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,16 +21,16 @@ FEATURES:
 ENHANCEMENTS:
 
 * data-source/aws_iam_policy: Adds validation for `path_prefix` attribute ([#44703](https://github.com/hashicorp/terraform-provider-aws/issues/44703))
-* data-source/aws_organizations_organization: Add `state`, `joined_method`, and 'joined_timestamp` attributes to the `accounts` and `non_master_accounts` blocks ([#44327](https://github.com/hashicorp/terraform-provider-aws/issues/44327))
-* data-source/aws_organizations_organizational_unit_child_accounts: Add `state`, `joined_method`, and 'joined_timestamp` attributes to the `accounts` block ([#44327](https://github.com/hashicorp/terraform-provider-aws/issues/44327))
-* data-source/aws_organizations_organizational_unit_descendant_accounts: Add `state`, `joined_method`, and 'joined_timestamp` attributes to the `accounts` block ([#44327](https://github.com/hashicorp/terraform-provider-aws/issues/44327))
+* data-source/aws_organizations_organization: Add `state`, `joined_method`, and `joined_timestamp` attributes to the `accounts` and `non_master_accounts` blocks ([#44327](https://github.com/hashicorp/terraform-provider-aws/issues/44327))
+* data-source/aws_organizations_organizational_unit_child_accounts: Add `state`, `joined_method`, and `joined_timestamp` attributes to the `accounts` block ([#44327](https://github.com/hashicorp/terraform-provider-aws/issues/44327))
+* data-source/aws_organizations_organizational_unit_descendant_accounts: Add `state`, `joined_method`, and `joined_timestamp` attributes to the `accounts` block ([#44327](https://github.com/hashicorp/terraform-provider-aws/issues/44327))
 * resource/aws_appstream_directory_config: Add `certificate_based_auth_properties` argument ([#44679](https://github.com/hashicorp/terraform-provider-aws/issues/44679))
 * resource/aws_iam_policy: Adds List support ([#44703](https://github.com/hashicorp/terraform-provider-aws/issues/44703))
 * resource/aws_iam_policy: Adds validation for `path` attribute ([#44703](https://github.com/hashicorp/terraform-provider-aws/issues/44703))
 * resource/aws_iam_role_policy_attachment: Adds List support ([#44739](https://github.com/hashicorp/terraform-provider-aws/issues/44739))
 * resource/aws_odb_network: Add `delete_associated_resources` attribute to enable practitioner to delete associated oci resource. ([#44754](https://github.com/hashicorp/terraform-provider-aws/issues/44754))
 * resource/aws_organizations_account: Add `state` attribute ([#44327](https://github.com/hashicorp/terraform-provider-aws/issues/44327))
-* resource/aws_organizations_organization: Add `state`, `joined_method`, and 'joined_timestamp` attributes to the `accounts` and `non_master_accounts` blocks ([#44327](https://github.com/hashicorp/terraform-provider-aws/issues/44327))
+* resource/aws_organizations_organization: Add `state`, `joined_method`, and `joined_timestamp` attributes to the `accounts` and `non_master_accounts` blocks ([#44327](https://github.com/hashicorp/terraform-provider-aws/issues/44327))
 
 BUG FIXES:
 


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Replaces some errant single quotes that should have been backticks in the changelog entries for #44327. I've also manually updated the published changelog on the releases page.
https://github.com/hashicorp/terraform-provider-aws/releases/tag/v6.18.0

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #44327

