### PR TITLE
opensearch: Add error handling for domain change progress failures

### DIFF
--- a/internal/service/opensearch/wait.go
+++ b/internal/service/opensearch/wait.go
@@ -6,6 +6,7 @@ package opensearch
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -13,6 +14,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/opensearch/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	tfretry "github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -20,6 +22,49 @@ const (
 	domainUpgradeSuccessMinTimeout = 10 * time.Second
 	domainUpgradeSuccessDelay      = 30 * time.Second
 )
+
+func checkAndReturnChangeProgressError(ctx context.Context, conn *opensearch.Client, domainName string, details *awstypes.ChangeProgressDetails) error {
+	if details != nil && (details.ConfigChangeStatus == awstypes.ConfigChangeStatusValidationFailed || details.ConfigChangeStatus == awstypes.ConfigChangeStatusCancelled) {
+		return getChangeProgressError(ctx, conn, domainName, details.ChangeId)
+	}
+	return nil
+}
+
+func getChangeProgressError(ctx context.Context, conn *opensearch.Client, domainName string, changeId *string) error {
+	input := &opensearch.DescribeDomainChangeProgressInput{
+		DomainName: aws.String(domainName),
+	}
+	if changeId != nil {
+		input.ChangeId = changeId
+	}
+
+	output, err := conn.DescribeDomainChangeProgress(ctx, input)
+	if err != nil {
+		return fmt.Errorf("domain %s: unable to get change progress details: %w", domainName, err)
+	}
+
+	if output.ChangeProgressStatus == nil {
+		return fmt.Errorf("domain %s: unexpected API response, ChangeProgressStatus is nil", domainName)
+	}
+
+	status := output.ChangeProgressStatus
+	var failedStages []string
+	for _, stage := range status.ChangeProgressStages {
+		if stage.Status != nil && *stage.Status == "FAILED" {
+			desc := aws.ToString(stage.Description)
+			if desc == "" {
+				desc = aws.ToString(stage.Name)
+			}
+			failedStages = append(failedStages, desc)
+		}
+	}
+
+	if len(failedStages) > 0 {
+		return fmt.Errorf("domain %s: %s: %s", domainName, status.ConfigChangeStatus, strings.Join(failedStages, "; "))
+	}
+
+	return fmt.Errorf("domain %s: %s", domainName, status.ConfigChangeStatus)
+}
 
 func waitUpgradeSucceeded(ctx context.Context, conn *opensearch.Client, name string, timeout time.Duration) (*opensearch.GetUpgradeStatusOutput, error) {
 	stateConf := &retry.StateChangeConf{
@@ -52,6 +97,10 @@ func waitForDomainCreation(ctx context.Context, conn *opensearch.Client, domainN
 			return tfresource.NonRetryableError(err)
 		}
 
+		if err := checkAndReturnChangeProgressError(ctx, conn, domainName, out.ChangeProgressDetails); err != nil {
+			return tfresource.NonRetryableError(err)
+		}
+
 		if !aws.ToBool(out.Processing) && (out.Endpoint != nil || out.Endpoints != nil) {
 			return nil
 		}
@@ -73,6 +122,10 @@ func waitForDomainUpdate(ctx context.Context, conn *opensearch.Client, domainNam
 		var err error
 		out, err = findDomainByName(ctx, conn, domainName)
 		if err != nil {
+			return tfresource.NonRetryableError(err)
+		}
+
+		if err := checkAndReturnChangeProgressError(ctx, conn, domainName, out.ChangeProgressDetails); err != nil {
 			return tfresource.NonRetryableError(err)
 		}
 
@@ -98,9 +151,13 @@ func waitForDomainDelete(ctx context.Context, conn *opensearch.Client, domainNam
 		out, err = findDomainByName(ctx, conn, domainName)
 
 		if err != nil {
-			if tfresource.NotFound(err) {
+			if tfretry.NotFound(err) {
 				return nil
 			}
+			return tfresource.NonRetryableError(err)
+		}
+
+		if err := checkAndReturnChangeProgressError(ctx, conn, domainName, out.ChangeProgressDetails); err != nil {
 			return tfresource.NonRetryableError(err)
 		}
 


### PR DESCRIPTION
- Add checkAndReturnChangeProgressError to detect validation failures and cancellations
- Add getChangeProgressError to fetch detailed error information from DescribeDomainChangeProgress API
- Integrate error checks into waitForDomainCreation, waitForDomainUpdate, and waitForDomainDelete
- Replace deprecated tfresource.NotFound with retry.NotFound

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR adds additional state validation.
When a change validation check failed, it previously wasn't caught and would result in an infinite wait, while the OpenSearch Domain creation would have failed in the control plane.

Examples of such events are:
- Dedicated master node types not compatible with the cluster nodes and size.
- Insufficient capacity

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
