### PR TITLE
`aws_elasticache_replication_group`: Remove unneeded `waitReplicationGroupAvailable()` call inside `resourceReplicationGroupRead()`

### DIFF
--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -744,16 +744,6 @@ func resourceReplicationGroupRead(ctx context.Context, d *schema.ResourceData, m
 
 	d.Set("user_group_ids", rgp.UserGroupIds)
 
-	// Tags cannot be read when the replication group is not Available
-	log.Printf("[DEBUG] Waiting for ElastiCache Replication Group (%s) to become available", d.Id())
-
-	const (
-		delay = 0 * time.Second
-	)
-	if _, err := waitReplicationGroupAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate), delay); err != nil {
-		return sdkdiag.AppendErrorf(diags, "waiting for ElastiCache Replication Group (%s) create: %s", aws.ToString(rgp.ARN), err)
-	}
-
 	log.Printf("[DEBUG] ElastiCache Replication Group (%s): Checking underlying cache clusters", d.Id())
 
 	// This section reads settings that require checking the underlying cache clusters


### PR DESCRIPTION
### Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

### Changes to Security Controls

No security-related changes.

### Description

For `aws_elasticache_replication_group`, `resourceReplicationGroupRead()` has a call to `waitReplicationGroupAvailable()` that I think is now unneeded, which makes the provider stall for up to 40 minutes waiting for the replication group to enter state `available`, when that function's code doesn't require the replication group to be in that state.

This makes the operation timeout at that level, rather than passing through to the generated AWS tag handling code. The The latter:

- has a 15 minute timeout
- has clearer logging that returns the exact message from the AWS API
- will automatically handle the situation correctly in the future if I can get AWS to accept my feature request to not block `ListTagsForResource()` when the ElastiCache replication group is in state `snapshotting` (which is why my ElastiCache RGs are not in state `available` during the plan, which is how I noticed this entire situation)

Please review #44787, specifically:
- https://github.com/hashicorp/terraform-provider-aws/issues/44787#issuecomment-3448014481
and
- https://github.com/hashicorp/terraform-provider-aws/issues/44787#issuecomment-3448024258

### Relations

Relates #44787

### References

With a stock v6.16.0 provider, Terraform waits for 40 minutes, produces no WARNING log entries, and only says it's waiting for the replication group to become available, but not why:

```
$ head -1 LOG.stock-v6.16.0.refresh_true
2025-10-15T00:23:48.696-0700 [INFO]  Terraform version: 1.5.7

$ tail -1 LOG.stock-v6.16.0.refresh_true
2025-10-15T01:04:11.678-0700 [DEBUG] provider: plugin exited

$ grep -c WARNING LOG.stock-v6.16.0.refresh_true
0

$ grep ERROR LOG.stock-v6.16.0.refresh_true | sed <AWS identifier redactions>
2025-10-15T01:04:09.331-0700 [ERROR] provider.terraform-provider-aws_v6.16.0_x5: Response contains error diagnostic: diagnostic_detail= diagnostic_summary="waiting for ElastiCache Replication Group (arn:aws:elasticache:AWS_REGION_REDACTED:AWS_ACCOUNT_ID_REDACTED:replicationgroup:fragment-cache-g5-cluster) create: timeout while waiting for state to become 'available' (timeout: 40m0s): operation error ElastiCache: DescribeReplicationGroups, context deadline exceeded" tf_provider_addr=registry.terraform.io/hashicorp/aws tf_req_id=9cf419da-2bd0-03b1-ecce-48a9fc07f578 @caller=github.com/hashicorp/terraform-plugin-go@v0.29.0/tfprotov5/internal/diag/diagnostics.go:58 @module=sdk.proto tf_rpc=ReadResource diagnostic_severity=ERROR tf_proto_version=5.10 tf_resource_type=aws_elasticache_replication_group timestamp=2025-10-15T01:04:09.331-0700
2025-10-15T01:04:09.331-0700 [ERROR] vertex "module.cluster_region.aws_elasticache_replication_group.singleton[\"fragment-cache-g5-0\"]" error: waiting for ElastiCache Replication Group (arn:aws:elasticache:AWS_REGION_REDACTED:AWS_ACCOUNT_ID_REDACTED:replicationgroup:fragment-cache-g5-cluster) create: timeout while waiting for state to become 'available' (timeout: 40m0s): operation error ElastiCache: DescribeReplicationGroups, context deadline exceeded
2025-10-15T01:04:09.751-0700 [ERROR] provider.terraform-provider-aws_v6.16.0_x5: Response contains error diagnostic: @module=sdk.proto diagnostic_summary="waiting for ElastiCache Replication Group (arn:aws:elasticache:AWS_REGION_REDACTED:AWS_ACCOUNT_ID_REDACTED:replicationgroup:diff-cache-g5-cluster) create: timeout while waiting for state to become 'available' (timeout: 40m0s): operation error ElastiCache: DescribeReplicationGroups, context deadline exceeded" tf_provider_addr=registry.terraform.io/hashicorp/aws @caller=github.com/hashicorp/terraform-plugin-go@v0.29.0/tfprotov5/internal/diag/diagnostics.go:58 diagnostic_detail= diagnostic_severity=ERROR tf_proto_version=5.10 tf_req_id=a5a75980-1960-802a-5c8f-31b082ac4485 tf_resource_type=aws_elasticache_replication_group tf_rpc=ReadResource timestamp=2025-10-15T01:04:09.750-0700
2025-10-15T01:04:09.751-0700 [ERROR] vertex "module.cluster_region.aws_elasticache_replication_group.singleton[\"diff-cache-g5-0\"]" error: waiting for ElastiCache Replication Group (arn:aws:elasticache:AWS_REGION_REDACTED:AWS_ACCOUNT_ID_REDACTED:replicationgroup:diff-cache-g5-cluster) create: timeout while waiting for state to become 'available' (timeout: 40m0s): operation error ElastiCache: DescribeReplicationGroups, context deadline exceeded
2025-10-15T01:04:09.752-0700 [ERROR] vertex "module.cluster_region.aws_elasticache_replication_group.singleton (expand)" error: waiting for ElastiCache Replication Group (arn:aws:elasticache:AWS_REGION_REDACTED:AWS_ACCOUNT_ID_REDACTED:replicationgroup:fragment-cache-g5-cluster) create: timeout while waiting for state to become 'available' (timeout: 40m0s): operation error ElastiCache: DescribeReplicationGroups, context deadline exceeded
2025-10-15T01:04:09.752-0700 [ERROR] vertex "module.cluster_region.aws_elasticache_replication_group.singleton (expand)" error: waiting for ElastiCache Replication Group (arn:aws:elasticache:AWS_REGION_REDACTED:AWS_ACCOUNT_ID_REDACTED:replicationgroup:diff-cache-g5-cluster) create: timeout while waiting for state to become 'available' (timeout: 40m0s): operation error ElastiCache: DescribeReplicationGroups, context deadline exceeded
```

After this patch, Terraform waits for 15 minutes, produces no WARNING log entries, and the ERROR messages explain that it was failing to list tags, and returns the error message from the AWS API call: `InvalidReplicationGroupState: Cluster not in available state to perform tagging operations`

```
$ head -1 LOG.patched.refresh_true
2025-10-15T00:25:33.693-0700 [INFO]  Terraform version: 1.5.7

$ tail -1 LOG.patched.refresh_true
2025-10-15T00:41:02.269-0700 [DEBUG] provider: plugin exited

$ grep -c WARNING LOG.patched.refresh_true
0

$ grep ERROR LOG.patched.refresh_true | sed <AWS identifier redactions>
2025-10-15T00:41:00.109-0700 [ERROR] provider.terraform-provider-aws: Response contains error diagnostic: @module=sdk.proto diagnostic_detail= diagnostic_severity=ERROR tf_provider_addr=registry.terraform.io/hashicorp/aws tf_req_id=db1b693a-77e6-14b1-2e71-5732f566e8e2 @caller=/Users/mhandler/work/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.29.0/tfprotov5/internal/diag/diagnostics.go:58 diagnostic_summary="listing tags for ElastiCache Replication Group (arn:aws:elasticache:AWS_REGION_REDACTED:AWS_ACCOUNT_ID_REDACTED:replicationgroup:checksum-g3-cluster): operation error ElastiCache: ListTagsForResource, https response error StatusCode: 400, RequestID: c8576c1f-ecd9-42f7-a002-49e615d379bd, InvalidReplicationGroupState: Cluster not in available state to perform tagging operations." tf_proto_version=5.10 tf_resource_type=aws_elasticache_replication_group tf_rpc=ReadResource timestamp=2025-10-15T00:41:00.109-0700
2025-10-15T00:41:00.110-0700 [ERROR] vertex "module.cluster_region.aws_elasticache_replication_group.singleton[\"checksum-g3-0\"]" error: listing tags for ElastiCache Replication Group (arn:aws:elasticache:AWS_REGION_REDACTED:AWS_ACCOUNT_ID_REDACTED:replicationgroup:checksum-g3-cluster): operation error ElastiCache: ListTagsForResource, https response error StatusCode: 400, RequestID: c8576c1f-ecd9-42f7-a002-49e615d379bd, InvalidReplicationGroupState: Cluster not in available state to perform tagging operations.
2025-10-15T00:41:00.110-0700 [ERROR] provider.terraform-provider-aws: Response contains error diagnostic: diagnostic_detail= tf_proto_version=5.10 tf_req_id=36f28370-1f02-ac78-5c3f-10cf9d41e7c2 tf_resource_type=aws_elasticache_replication_group @module=sdk.proto tf_provider_addr=registry.terraform.io/hashicorp/aws tf_rpc=ReadResource @caller=/Users/mhandler/work/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.29.0/tfprotov5/internal/diag/diagnostics.go:58 diagnostic_severity=ERROR diagnostic_summary="listing tags for ElastiCache Replication Group (arn:aws:elasticache:AWS_REGION_REDACTED:AWS_ACCOUNT_ID_REDACTED:replicationgroup:fragment-cache-g4-cluster): operation error ElastiCache: ListTagsForResource, https response error StatusCode: 400, RequestID: 225db210-2a01-4365-9668-dd29cdba7d8e, InvalidReplicationGroupState: Cluster not in available state to perform tagging operations." timestamp=2025-10-15T00:41:00.110-0700
2025-10-15T00:41:00.110-0700 [ERROR] vertex "module.cluster_region.aws_elasticache_replication_group.singleton[\"fragment-cache-g4-0\"]" error: listing tags for ElastiCache Replication Group (arn:aws:elasticache:AWS_REGION_REDACTED:AWS_ACCOUNT_ID_REDACTED:replicationgroup:fragment-cache-g4-cluster): operation error ElastiCache: ListTagsForResource, https response error StatusCode: 400, RequestID: 225db210-2a01-4365-9668-dd29cdba7d8e, InvalidReplicationGroupState: Cluster not in available state to perform tagging operations.
2025-10-15T00:41:00.121-0700 [ERROR] provider.terraform-provider-aws: Response contains error diagnostic: diagnostic_severity=ERROR diagnostic_summary="listing tags for ElastiCache Replication Group (arn:aws:elasticache:AWS_REGION_REDACTED:AWS_ACCOUNT_ID_REDACTED:replicationgroup:diff-cache-g3-cluster): operation error ElastiCache: ListTagsForResource, https response error StatusCode: 400, RequestID: ea47fb9f-d06f-413c-8fbb-a503088aa08e, InvalidReplicationGroupState: Cluster not in available state to perform tagging operations." tf_proto_version=5.10 tf_rpc=ReadResource @caller=/Users/mhandler/work/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.29.0/tfprotov5/internal/diag/diagnostics.go:58 @module=sdk.proto diagnostic_detail= tf_provider_addr=registry.terraform.io/hashicorp/aws tf_req_id=0c2afc9c-8d67-5eaa-ba2c-d7532b375e53 tf_resource_type=aws_elasticache_replication_group timestamp=2025-10-15T00:41:00.121-0700
2025-10-15T00:41:00.121-0700 [ERROR] vertex "module.cluster_region.aws_elasticache_replication_group.singleton[\"diff-cache-g3-0\"]" error: listing tags for ElastiCache Replication Group (arn:aws:elasticache:AWS_REGION_REDACTED:AWS_ACCOUNT_ID_REDACTED:replicationgroup:diff-cache-g3-cluster): operation error ElastiCache: ListTagsForResource, https response error StatusCode: 400, RequestID: ea47fb9f-d06f-413c-8fbb-a503088aa08e, InvalidReplicationGroupState: Cluster not in available state to perform tagging operations.
2025-10-15T00:41:00.235-0700 [ERROR] vertex "module.cluster_region.aws_elasticache_replication_group.singleton[\"proto-threads-g9-0\"]" error: listing tags for ElastiCache Replication Group (arn:aws:elasticache:AWS_REGION_REDACTED:AWS_ACCOUNT_ID_REDACTED:replicationgroup:proto-threads-g9-cluster): operation error ElastiCache: ListTagsForResource, https response error StatusCode: 400, RequestID: c44c3ed5-9fa2-4e78-9e31-78a2023036dc, InvalidReplicationGroupState: Cluster not in available state to perform tagging operations.
2025-10-15T00:41:00.236-0700 [ERROR] vertex "module.cluster_region.aws_elasticache_replication_group.singleton (expand)" error: listing tags for ElastiCache Replication Group (arn:aws:elasticache:AWS_REGION_REDACTED:AWS_ACCOUNT_ID_REDACTED:replicationgroup:checksum-g3-cluster): operation error ElastiCache: ListTagsForResource, https response error StatusCode: 400, RequestID: c8576c1f-ecd9-42f7-a002-49e615d379bd, InvalidReplicationGroupState: Cluster not in available state to perform tagging operations.
2025-10-15T00:41:00.236-0700 [ERROR] vertex "module.cluster_region.aws_elasticache_replication_group.singleton (expand)" error: listing tags for ElastiCache Replication Group (arn:aws:elasticache:AWS_REGION_REDACTED:AWS_ACCOUNT_ID_REDACTED:replicationgroup:fragment-cache-g4-cluster): operation error ElastiCache: ListTagsForResource, https response error StatusCode: 400, RequestID: 225db210-2a01-4365-9668-dd29cdba7d8e, InvalidReplicationGroupState: Cluster not in available state to perform tagging operations.
2025-10-15T00:41:00.236-0700 [ERROR] vertex "module.cluster_region.aws_elasticache_replication_group.singleton (expand)" error: listing tags for ElastiCache Replication Group (arn:aws:elasticache:AWS_REGION_REDACTED:AWS_ACCOUNT_ID_REDACTED:replicationgroup:proto-threads-g9-cluster): operation error ElastiCache: ListTagsForResource, https response error StatusCode: 400, RequestID: c44c3ed5-9fa2-4e78-9e31-78a2023036dc, InvalidReplicationGroupState: Cluster not in available state to perform tagging operations.
2025-10-15T00:41:00.236-0700 [ERROR] vertex "module.cluster_region.aws_elasticache_replication_group.singleton (expand)" error: listing tags for ElastiCache Replication Group (arn:aws:elasticache:AWS_REGION_REDACTED:AWS_ACCOUNT_ID_REDACTED:replicationgroup:diff-cache-g3-cluster): operation error ElastiCache: ListTagsForResource, https response error StatusCode: 400, RequestID: ea47fb9f-d06f-413c-8fbb-a503088aa08e, InvalidReplicationGroupState: Cluster not in available state to perform tagging operations.
2025-10-15T00:41:00.237-0700 [ERROR] provider.terraform-provider-aws: Response contains error diagnostic: diagnostic_detail= diagnostic_severity=ERROR diagnostic_summary="listing tags for ElastiCache Replication Group (arn:aws:elasticache:AWS_REGION_REDACTED:AWS_ACCOUNT_ID_REDACTED:replicationgroup:proto-threads-g9-cluster): operation error ElastiCache: ListTagsForResource, https response error StatusCode: 400, RequestID: c44c3ed5-9fa2-4e78-9e31-78a2023036dc, InvalidReplicationGroupState: Cluster not in available state to perform tagging operations." tf_provider_addr=registry.terraform.io/hashicorp/aws tf_rpc=ReadResource @caller=/Users/mhandler/work/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.29.0/tfprotov5/internal/diag/diagnostics.go:58 tf_req_id=8b1ba5c4-066d-f368-a026-ee4d2935d054 tf_resource_type=aws_elasticache_replication_group @module=sdk.proto tf_proto_version=5.10 timestamp=2025-10-15T00:41:00.233-0700
```

### Output from Acceptance Testing

```console
$ make testacc PKG=elasticache TESTS=TestAccElastiCacheReplicationGroup
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-elasticache-rg-state-snapshotting-plan-stall 🌿...
TF_ACC=1 go1.24.8 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheReplicationGroup'  -timeout 360m -vet=off
2025/10/26 00:45:08 Creating Terraform AWS Provider (SDKv2-style)...
2025/10/26 00:45:08 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccElastiCacheReplicationGroupDataSource_basic
=== PAUSE TestAccElastiCacheReplicationGroupDataSource_basic
=== RUN   TestAccElastiCacheReplicationGroupDataSource_clusterMode
=== PAUSE TestAccElastiCacheReplicationGroupDataSource_clusterMode
=== RUN   TestAccElastiCacheReplicationGroupDataSource_multiAZ
=== PAUSE TestAccElastiCacheReplicationGroupDataSource_multiAZ
=== RUN   TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations
=== PAUSE TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations
=== RUN   TestAccElastiCacheReplicationGroup_Redis_basic
=== PAUSE TestAccElastiCacheReplicationGroup_Redis_basic
=== RUN   TestAccElastiCacheReplicationGroup_Redis_basic_v5
=== PAUSE TestAccElastiCacheReplicationGroup_Redis_basic_v5
=== RUN   TestAccElastiCacheReplicationGroup_Valkey_basic
=== PAUSE TestAccElastiCacheReplicationGroup_Valkey_basic
=== RUN   TestAccElastiCacheReplicationGroup_uppercase
=== PAUSE TestAccElastiCacheReplicationGroup_uppercase
=== RUN   TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7
=== PAUSE TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7
=== RUN   TestAccElastiCacheReplicationGroup_OutOfBandUpgrade
=== PAUSE TestAccElastiCacheReplicationGroup_OutOfBandUpgrade
=== RUN   TestAccElastiCacheReplicationGroup_EngineVersion_update
=== PAUSE TestAccElastiCacheReplicationGroup_EngineVersion_update
=== RUN   TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion
=== PAUSE TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion
=== RUN   TestAccElastiCacheReplicationGroup_Engine_RedisToValkey
=== PAUSE TestAccElastiCacheReplicationGroup_Engine_RedisToValkey
=== RUN   TestAccElastiCacheReplicationGroup_disappears
=== PAUSE TestAccElastiCacheReplicationGroup_disappears
=== RUN   TestAccElastiCacheReplicationGroup_updateDescription
=== PAUSE TestAccElastiCacheReplicationGroup_updateDescription
=== RUN   TestAccElastiCacheReplicationGroup_updateMaintenanceWindow
=== PAUSE TestAccElastiCacheReplicationGroup_updateMaintenanceWindow
=== RUN   TestAccElastiCacheReplicationGroup_updateUserGroups
=== PAUSE TestAccElastiCacheReplicationGroup_updateUserGroups
=== RUN   TestAccElastiCacheReplicationGroup_updateNodeSize
=== PAUSE TestAccElastiCacheReplicationGroup_updateNodeSize
=== RUN   TestAccElastiCacheReplicationGroup_updateParameterGroup
=== PAUSE TestAccElastiCacheReplicationGroup_updateParameterGroup
=== RUN   TestAccElastiCacheReplicationGroup_authToken
=== PAUSE TestAccElastiCacheReplicationGroup_authToken
=== RUN   TestAccElastiCacheReplicationGroup_upgrade_6_0_0
=== PAUSE TestAccElastiCacheReplicationGroup_upgrade_6_0_0
=== RUN   TestAccElastiCacheReplicationGroup_upgrade_5_27_0
=== PAUSE TestAccElastiCacheReplicationGroup_upgrade_5_27_0
=== RUN   TestAccElastiCacheReplicationGroup_upgrade_4_68_0
=== PAUSE TestAccElastiCacheReplicationGroup_upgrade_4_68_0
=== RUN   TestAccElastiCacheReplicationGroup_vpc
=== PAUSE TestAccElastiCacheReplicationGroup_vpc
=== RUN   TestAccElastiCacheReplicationGroup_multiAzNotInVPC
=== PAUSE TestAccElastiCacheReplicationGroup_multiAzNotInVPC
=== RUN   TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated
=== PAUSE TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated
=== RUN   TestAccElastiCacheReplicationGroup_multiAzInVPC
=== PAUSE TestAccElastiCacheReplicationGroup_multiAzInVPC
=== RUN   TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
=== PAUSE TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
=== RUN   TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover
=== PAUSE TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover
=== RUN   TestAccElastiCacheReplicationGroup_ipDiscovery
=== PAUSE TestAccElastiCacheReplicationGroup_ipDiscovery
=== RUN   TestAccElastiCacheReplicationGroup_networkType
=== PAUSE TestAccElastiCacheReplicationGroup_networkType
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_basic
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_basic
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_singleNode
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_singleNode
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled
=== RUN   TestAccElastiCacheReplicationGroup_cacheClustersConflictsWithReplicasPerNodeGroup
=== PAUSE TestAccElastiCacheReplicationGroup_cacheClustersConflictsWithReplicasPerNodeGroup
=== RUN   TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError
=== PAUSE TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError
=== RUN   TestAccElastiCacheReplicationGroup_enableSnapshotting
=== PAUSE TestAccElastiCacheReplicationGroup_enableSnapshotting
=== RUN   TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken
=== PAUSE TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken
=== RUN   TestAccElastiCacheReplicationGroup_transitEncryption5x
=== PAUSE TestAccElastiCacheReplicationGroup_transitEncryption5x
=== RUN   TestAccElastiCacheReplicationGroup_transitEncryption7x_basic
=== PAUSE TestAccElastiCacheReplicationGroup_transitEncryption7x_basic
=== RUN   TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable
=== PAUSE TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable
=== RUN   TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable
=== PAUSE TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable
=== RUN   TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption
=== PAUSE TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption
=== RUN   TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption
=== PAUSE TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption
=== RUN   TestAccElastiCacheReplicationGroup_useCMKKMSKeyID
=== PAUSE TestAccElastiCacheReplicationGroup_useCMKKMSKeyID
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled
=== RUN   TestAccElastiCacheReplicationGroup_autoFailoverEnabled_validateNumberCacheClusters
=== PAUSE TestAccElastiCacheReplicationGroup_autoFailoverEnabled_validateNumberCacheClusters
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown
=== RUN   TestAccElastiCacheReplicationGroup_tags
=== PAUSE TestAccElastiCacheReplicationGroup_tags
=== RUN   TestAccElastiCacheReplicationGroup_TagWithOtherModification_version
=== PAUSE TestAccElastiCacheReplicationGroup_TagWithOtherModification_version
=== RUN   TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheClusters
=== PAUSE TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheClusters
=== RUN   TestAccElastiCacheReplicationGroup_finalSnapshot
=== PAUSE TestAccElastiCacheReplicationGroup_finalSnapshot
=== RUN   TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade
=== PAUSE TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade
=== RUN   TestAccElastiCacheReplicationGroup_Validation_noNodeType
=== PAUSE TestAccElastiCacheReplicationGroup_Validation_noNodeType
=== RUN   TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType
=== PAUSE TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary
=== RUN   TestAccElastiCacheReplicationGroup_dataTiering
=== PAUSE TestAccElastiCacheReplicationGroup_dataTiering
=== RUN   TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled
=== PAUSE TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled
=== RUN   TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled
=== PAUSE TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled
=== CONT  TestAccElastiCacheReplicationGroupDataSource_basic
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_singleNode
=== CONT  TestAccElastiCacheReplicationGroup_authToken
=== CONT  TestAccElastiCacheReplicationGroup_EngineVersion_update
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster
=== CONT  TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled
=== CONT  TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled
=== CONT  TestAccElastiCacheReplicationGroup_dataTiering
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic
=== CONT  TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType
=== CONT  TestAccElastiCacheReplicationGroup_Validation_noNodeType
=== CONT  TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade
=== CONT  TestAccElastiCacheReplicationGroup_finalSnapshot
=== CONT  TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheClusters
=== CONT  TestAccElastiCacheReplicationGroup_TagWithOtherModification_version
=== CONT  TestAccElastiCacheReplicationGroup_tags
--- PASS: TestAccElastiCacheReplicationGroup_Validation_noNodeType (24.95s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_singleNode (641.71s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize
--- PASS: TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade (694.34s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption
--- PASS: TestAccElastiCacheReplicationGroupDataSource_basic (820.48s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange
--- PASS: TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType (1000.56s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled
--- PASS: TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheClusters (1169.85s)
=== CONT  TestAccElastiCacheReplicationGroup_autoFailoverEnabled_validateNumberCacheClusters
--- PASS: TestAccElastiCacheReplicationGroup_autoFailoverEnabled_validateNumberCacheClusters (2.53s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled (1280.81s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled
--- PASS: TestAccElastiCacheReplicationGroup_finalSnapshot (1396.18s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic
--- PASS: TestAccElastiCacheReplicationGroup_dataTiering (1477.85s)
=== CONT  TestAccElastiCacheReplicationGroup_useCMKKMSKeyID
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary (1642.49s)
=== CONT  TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster (1823.55s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7
--- PASS: TestAccElastiCacheReplicationGroup_TagWithOtherModification_version (1950.52s)
=== CONT  TestAccElastiCacheReplicationGroup_OutOfBandUpgrade
--- PASS: TestAccElastiCacheReplicationGroup_tags (2010.15s)
=== CONT  TestAccElastiCacheReplicationGroup_ipDiscovery
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled (2071.96s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown (2219.03s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp
--- PASS: TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption (1570.57s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_basic_v5
--- PASS: TestAccElastiCacheReplicationGroup_useCMKKMSKeyID (854.33s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange (1721.00s)
=== CONT  TestAccElastiCacheReplicationGroup_uppercase
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled (1597.84s)
=== CONT  TestAccElastiCacheReplicationGroup_Valkey_basic
--- PASS: TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7 (943.04s)
=== CONT  TestAccElastiCacheReplicationGroup_updateMaintenanceWindow
--- PASS: TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption (1125.55s)
=== CONT  TestAccElastiCacheReplicationGroup_updateParameterGroup
--- PASS: TestAccElastiCacheReplicationGroup_authToken (2850.43s)
=== CONT  TestAccElastiCacheReplicationGroup_updateNodeSize
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled (1611.25s)
=== CONT  TestAccElastiCacheReplicationGroup_updateUserGroups
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize (2288.23s)
=== CONT  TestAccElastiCacheReplicationGroup_multiAzNotInVPC
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic (2963.47s)
=== CONT  TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover
--- PASS: TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover (2.28s)
=== CONT  TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic (1581.65s)
=== CONT  TestAccElastiCacheReplicationGroup_multiAzInVPC
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled (1845.19s)
=== CONT  TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken
--- PASS: TestAccElastiCacheReplicationGroup_ipDiscovery (1040.95s)
--- PASS: TestAccElastiCacheReplicationGroup_Redis_basic_v5 (910.80s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears (3292.38s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full (3478.72s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption7x_basic
--- PASS: TestAccElastiCacheReplicationGroup_uppercase (947.67s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption5x
--- PASS: TestAccElastiCacheReplicationGroup_updateMaintenanceWindow (974.43s)
=== CONT  TestAccElastiCacheReplicationGroup_updateDescription
--- PASS: TestAccElastiCacheReplicationGroup_updateParameterGroup (986.61s)
=== CONT  TestAccElastiCacheReplicationGroup_upgrade_4_68_0
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC (952.94s)
=== CONT  TestAccElastiCacheReplicationGroup_disappears
--- PASS: TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC (918.83s)
=== CONT  TestAccElastiCacheReplicationGroup_vpc
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic (3889.45s)
=== CONT  TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError
--- PASS: TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError (1.61s)
=== CONT  TestAccElastiCacheReplicationGroup_cacheClustersConflictsWithReplicasPerNodeGroup
--- PASS: TestAccElastiCacheReplicationGroup_cacheClustersConflictsWithReplicasPerNodeGroup (1.50s)
=== CONT  TestAccElastiCacheReplicationGroup_enableSnapshotting
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken (897.42s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup
--- PASS: TestAccElastiCacheReplicationGroup_OutOfBandUpgrade (2123.03s)
=== CONT  TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated (1115.30s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp (1925.62s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_basic
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup (1841.24s)
=== CONT  TestAccElastiCacheReplicationGroup_Engine_RedisToValkey
--- PASS: TestAccElastiCacheReplicationGroup_updateUserGroups (1332.68s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_basic
--- PASS: TestAccElastiCacheReplicationGroup_Valkey_basic (1822.46s)
=== CONT  TestAccElastiCacheReplicationGroup_upgrade_5_27_0
--- PASS: TestAccElastiCacheReplicationGroup_updateDescription (751.19s)
=== CONT  TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion
--- PASS: TestAccElastiCacheReplicationGroup_updateNodeSize (1702.37s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled
--- PASS: TestAccElastiCacheReplicationGroup_upgrade_4_68_0 (800.27s)
=== CONT  TestAccElastiCacheReplicationGroupDataSource_multiAZ
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown (2533.33s)
=== CONT  TestAccElastiCacheReplicationGroupDataSource_clusterMode
--- PASS: TestAccElastiCacheReplicationGroup_vpc (837.11s)
=== CONT  TestAccElastiCacheReplicationGroup_networkType
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption7x_basic (1261.37s)
=== CONT  TestAccElastiCacheReplicationGroup_upgrade_6_0_0
--- PASS: TestAccElastiCacheReplicationGroup_Redis_basic (739.52s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup (961.18s)
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption5x (1782.21s)
--- PASS: TestAccElastiCacheReplicationGroup_disappears (1453.81s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_basic (1141.65s)
--- PASS: TestAccElastiCacheReplicationGroup_upgrade_5_27_0 (1175.47s)
--- PASS: TestAccElastiCacheReplicationGroup_multiAzInVPC (2768.70s)
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable (2573.99s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_clusterMode (1149.44s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_multiAZ (1252.01s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp (1711.20s)
--- PASS: TestAccElastiCacheReplicationGroup_enableSnapshotting (2076.82s)
--- PASS: TestAccElastiCacheReplicationGroup_upgrade_6_0_0 (1236.37s)
--- PASS: TestAccElastiCacheReplicationGroup_Engine_RedisToValkey (1864.04s)
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable (2768.24s)
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion (1789.34s)
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_update (6388.39s)
--- PASS: TestAccElastiCacheReplicationGroup_networkType (1667.83s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations (2356.45s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown (2136.43s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled (3007.15s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	7567.893s
...
```
