### PR TITLE
fix(elbv2): prevent duplicate listener creation on same port/protocol

### DIFF
--- a/.changelog/35121.txt
+++ b/.changelog/35121.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lb_listener: Prevent duplicate listener creation by checking for existing listeners with same port and protocol before creation
+```

--- a/internal/service/elbv2/listener.go
+++ b/internal/service/elbv2/listener.go
@@ -570,6 +570,44 @@ func resourceListenerCreate(ctx context.Context, d *schema.ResourceData, meta an
 	conn := meta.(*conns.AWSClient).ELBV2Client(ctx)
 
 	lbARN := d.Get("load_balancer_arn").(string)
+
+	// Check for duplicate listener on same load balancer with same port/protocol
+	if v, ok := d.GetOk(names.AttrPort); ok {
+		port := int32(v.(int))
+
+		// Determine protocol (using same logic as creation)
+		var protocol awstypes.ProtocolEnum
+		if v, ok := d.GetOk(names.AttrProtocol); ok {
+			protocol = awstypes.ProtocolEnum(v.(string))
+		} else if strings.Contains(lbARN, "loadbalancer/app/") {
+			// Default to HTTP for Application Load Balancers if no protocol specified
+			if _, ok := d.GetOk(names.AttrCertificateARN); ok {
+				protocol = awstypes.ProtocolEnumHttps
+			} else {
+				protocol = awstypes.ProtocolEnumHttp
+			}
+		}
+
+		// Only check for duplicates if we have a protocol to check
+		if protocol != "" {
+			// Query existing listeners on this load balancer
+			describeInput := &elasticloadbalancingv2.DescribeListenersInput{
+				LoadBalancerArn: aws.String(lbARN),
+			}
+			existingListener, err := findListener(ctx, conn, describeInput, func(listener *awstypes.Listener) bool {
+				return aws.ToInt32(listener.Port) == port && listener.Protocol == protocol
+			})
+
+			if err != nil && !tfresource.NotFound(err) {
+				return sdkdiag.AppendErrorf(diags, "reading ELBv2 Listeners for Load Balancer (%s): %s", lbARN, err)
+			}
+
+			if existingListener != nil {
+				return sdkdiag.AppendErrorf(diags, "ELBv2 Listener on port %d with protocol %s already exists on Load Balancer (%s)", port, protocol, lbARN)
+			}
+		}
+	}
+
 	input := &elasticloadbalancingv2.CreateListenerInput{
 		LoadBalancerArn: aws.String(lbARN),
 		Tags:            getTagsIn(ctx),

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -289,6 +289,24 @@ func TestAccELBV2Listener_disappears(t *testing.T) {
 	})
 }
 
+func TestAccELBV2Listener_duplicate(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccListenerConfig_duplicate(rName),
+				ExpectError: regexache.MustCompile(`already exists`),
+			},
+		},
+	})
+}
+
 func TestAccELBV2Listener_Forward_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Listener
@@ -4795,6 +4813,68 @@ resource "aws_lb_listener" "test" {
       protocol    = "HTTPS"
       status_code = "HTTP_301"
     }
+  }
+}
+
+resource "aws_lb" "test" {
+  name            = %[1]q
+  internal        = true
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
+
+  idle_timeout               = 30
+  enable_deletion_protection = false
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_lb_target_group" "test" {
+  name     = %[1]q
+  port     = 8080
+  protocol = "HTTP"
+  vpc_id   = aws_vpc.test.id
+
+  health_check {
+    path                = "/health"
+    interval            = 60
+    port                = 8081
+    protocol            = "HTTP"
+    timeout             = 3
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = "200-299"
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccListenerConfig_duplicate(rName string) string {
+	return acctest.ConfigCompose(testAccListenerConfig_base(rName), fmt.Sprintf(`
+resource "aws_lb_listener" "test" {
+  load_balancer_arn = aws_lb.test.id
+  protocol          = "HTTP"
+  port              = "80"
+
+  default_action {
+    target_group_arn = aws_lb_target_group.test.arn
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener" "duplicate" {
+  load_balancer_arn = aws_lb.test.id
+  protocol          = "HTTP"
+  port              = "80"
+
+  default_action {
+    target_group_arn = aws_lb_target_group.test.arn
+    type             = "forward"
   }
 }
 

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -307,6 +307,82 @@ func TestAccELBV2Listener_duplicate(t *testing.T) {
 	})
 }
 
+func TestAccELBV2Listener_duplicate_ALB_protocolDefaulting_HTTP(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccListenerConfig_duplicate_ALB_protocolDefaulting_HTTP(rName),
+				ExpectError: regexache.MustCompile(`already exists`),
+			},
+		},
+	})
+}
+
+func TestAccELBV2Listener_duplicate_ALB_protocolDefaulting_HTTPS(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccListenerConfig_duplicate_ALB_protocolDefaulting_HTTPS(rName, key, certificate),
+				ExpectError: regexache.MustCompile(`already exists`),
+			},
+		},
+	})
+}
+
+func TestAccELBV2Listener_duplicate_NLB_TCP(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccListenerConfig_duplicate_NLB_TCP(rName),
+				ExpectError: regexache.MustCompile(`already exists`),
+			},
+		},
+	})
+}
+
+func TestAccELBV2Listener_duplicate_NLB_TLS(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccListenerConfig_duplicate_NLB_TLS(rName, key, certificate),
+				ExpectError: regexache.MustCompile(`already exists`),
+			},
+		},
+	})
+}
+
 func TestAccELBV2Listener_Forward_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Listener
@@ -4914,4 +4990,256 @@ resource "aws_lb_target_group" "test" {
   }
 }
 `, rName))
+}
+
+func testAccListenerConfig_duplicate_ALB_protocolDefaulting_HTTP(rName string) string {
+	return acctest.ConfigCompose(testAccListenerConfig_base(rName), fmt.Sprintf(`
+resource "aws_lb_listener" "test" {
+  load_balancer_arn = aws_lb.test.id
+  port              = "80"
+
+  default_action {
+    target_group_arn = aws_lb_target_group.test.arn
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener" "duplicate" {
+  load_balancer_arn = aws_lb.test.id
+  port              = "80"
+
+  default_action {
+    target_group_arn = aws_lb_target_group.test.arn
+    type             = "forward"
+  }
+}
+
+resource "aws_lb" "test" {
+  name            = %[1]q
+  internal        = true
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
+
+  idle_timeout               = 30
+  enable_deletion_protection = false
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_lb_target_group" "test" {
+  name     = %[1]q
+  port     = 8080
+  protocol = "HTTP"
+  vpc_id   = aws_vpc.test.id
+
+  health_check {
+    path                = "/health"
+    interval            = 60
+    port                = 8081
+    protocol            = "HTTP"
+    timeout             = 3
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = "200-299"
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccListenerConfig_duplicate_ALB_protocolDefaulting_HTTPS(rName, key, certificate string) string {
+	return acctest.ConfigCompose(testAccListenerConfig_base(rName), fmt.Sprintf(`
+resource "aws_iam_server_certificate" "test" {
+  name             = %[1]q
+  certificate_body = "%[2]s"
+  private_key      = "%[3]s"
+}
+
+resource "aws_lb_listener" "test" {
+  load_balancer_arn = aws_lb.test.id
+  port              = "443"
+  certificate_arn   = aws_iam_server_certificate.test.arn
+
+  default_action {
+    target_group_arn = aws_lb_target_group.test.arn
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener" "duplicate" {
+  load_balancer_arn = aws_lb.test.id
+  port              = "443"
+  certificate_arn   = aws_iam_server_certificate.test.arn
+
+  default_action {
+    target_group_arn = aws_lb_target_group.test.arn
+    type             = "forward"
+  }
+}
+
+resource "aws_lb" "test" {
+  name            = %[1]q
+  internal        = true
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
+
+  idle_timeout               = 30
+  enable_deletion_protection = false
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_lb_target_group" "test" {
+  name     = %[1]q
+  port     = 8080
+  protocol = "HTTP"
+  vpc_id   = aws_vpc.test.id
+
+  health_check {
+    path                = "/health"
+    interval            = 60
+    port                = 8081
+    protocol            = "HTTP"
+    timeout             = 3
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = "200-299"
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key)))
+}
+
+func testAccListenerConfig_duplicate_NLB_TCP(rName string) string {
+	return acctest.ConfigCompose(testAccListenerConfig_base(rName), fmt.Sprintf(`
+resource "aws_lb_listener" "test" {
+  load_balancer_arn = aws_lb.test.id
+  protocol          = "TCP"
+  port              = "80"
+
+  default_action {
+    target_group_arn = aws_lb_target_group.test.arn
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener" "duplicate" {
+  load_balancer_arn = aws_lb.test.id
+  protocol          = "TCP"
+  port              = "80"
+
+  default_action {
+    target_group_arn = aws_lb_target_group.test.arn
+    type             = "forward"
+  }
+}
+
+resource "aws_lb" "test" {
+  name               = %[1]q
+  internal           = true
+  load_balancer_type = "network"
+  subnets            = aws_subnet.test[*].id
+
+  enable_deletion_protection = false
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_lb_target_group" "test" {
+  name     = %[1]q
+  port     = 8080
+  protocol = "TCP"
+  vpc_id   = aws_vpc.test.id
+
+  health_check {
+    protocol            = "TCP"
+    interval            = 30
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccListenerConfig_duplicate_NLB_TLS(rName, key, certificate string) string {
+	return acctest.ConfigCompose(testAccListenerConfig_base(rName), fmt.Sprintf(`
+resource "aws_iam_server_certificate" "test" {
+  name             = %[1]q
+  certificate_body = "%[2]s"
+  private_key      = "%[3]s"
+}
+
+resource "aws_lb_listener" "test" {
+  load_balancer_arn = aws_lb.test.id
+  protocol          = "TLS"
+  port              = "443"
+  certificate_arn   = aws_iam_server_certificate.test.arn
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+
+  default_action {
+    target_group_arn = aws_lb_target_group.test.arn
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener" "duplicate" {
+  load_balancer_arn = aws_lb.test.id
+  protocol          = "TLS"
+  port              = "443"
+  certificate_arn   = aws_iam_server_certificate.test.arn
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+
+  default_action {
+    target_group_arn = aws_lb_target_group.test.arn
+    type             = "forward"
+  }
+}
+
+resource "aws_lb" "test" {
+  name               = %[1]q
+  internal           = true
+  load_balancer_type = "network"
+  subnets            = aws_subnet.test[*].id
+
+  enable_deletion_protection = false
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_lb_target_group" "test" {
+  name     = %[1]q
+  port     = 8080
+  protocol = "TCP"
+  vpc_id   = aws_vpc.test.id
+
+  health_check {
+    protocol            = "TCP"
+    interval            = 30
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key)))
 }


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. This change adds defensive validation to prevent duplicate resource creation but does not modify access controls, encryption, or logging.

### Description

Adds defensive validation to prevent duplicate listener creation on AWS load balancers when the AWS API fails to raise a `DuplicateListener` error.

**Problem:** The AWS `CreateListener` API sometimes silently returns an existing listener instead of raising an error when attempting to create a listener with the same port and protocol combination. This causes Terraform/Pulumi to incorrectly treat the operation as successful, leading to state inconsistencies where multiple listener resources point to the same ARN. When one listener is subsequently deleted, all resources referencing that ARN are affected.

**Solution:** Before attempting to create a listener, query existing listeners on the load balancer and explicitly check for port/protocol conflicts. If a duplicate is detected, return an error immediately. This follows the same defensive pattern already implemented in `load_balancer.go` and `target_group.go`.

**Tradeoff:** Adds one `DescribeListeners` API call before each listener creation (~50-200ms additional latency), but prevents silent data corruption and state inconsistencies.

### Relations

Closes #35121

### References

- Original issue discussion:
https://github.com/hashicorp/terraform-provider-aws/issues/35121
- Similar defensive patterns in codebase:
  - `internal/service/elbv2/load_balancer.go:385-395`
  - `internal/service/elbv2/target_group.go:424-432`

### Output from Acceptance Testing

**Note:** Acceptance tests require AWS IAM permissions not available in contributor's account. Tests will need to be run by maintainers with appropriate access.

**Expected Test Results:**

The following tests should pass when run with proper AWS credentials:

```console
% make testacc TESTS=TestAccELBV2Listener_duplicate PKG=elbv2
% make testacc TESTS=TestAccELBV2Listener_duplicate_ALB_protocolDefaulting_HTTP PKG=elbv2
% make testacc TESTS=TestAccELBV2Listener_duplicate_ALB_protocolDefaulting_HTTPS PKG=elbv2
% make testacc TESTS=TestAccELBV2Listener_duplicate_NLB_TCP PKG=elbv2
% make testacc TESTS=TestAccELBV2Listener_duplicate_NLB_TLS PKG=elbv2
```
