### PR TITLE
feat(bg-custom-param-group): add parameter_group_name for blue_green_update block

### DIFF
--- a/.changelog/44819.txt
+++ b/.changelog/44819.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_db_instance: Add validation requiring `blue_green_update.parameter_group_name` when performing major version upgrades with Blue/Green deployments
+```

--- a/internal/service/rds/blue_green.go
+++ b/internal/service/rds/blue_green.go
@@ -137,7 +137,12 @@ func (h *instanceHandler) createBlueGreenInput(d *schema.ResourceData) *rds.Crea
 	if d.HasChange(names.AttrEngineVersion) {
 		input.TargetEngineVersion = aws.String(d.Get(names.AttrEngineVersion).(string))
 	}
-	if d.HasChange(names.AttrParameterGroupName) {
+
+	// Check for parameter_group_name from blue_green_update block first
+	if v, ok := d.GetOk("blue_green_update.0.parameter_group_name"); ok && v.(string) != "" {
+		input.TargetDBParameterGroupName = aws.String(v.(string))
+	} else if d.HasChange(names.AttrParameterGroupName) {
+		// Fall back to the main parameter_group_name if not specified in blue_green_update
 		input.TargetDBParameterGroupName = aws.String(d.Get(names.AttrParameterGroupName).(string))
 	}
 

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -177,6 +177,10 @@ func resourceInstance() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						names.AttrParameterGroupName: {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -717,6 +721,21 @@ func resourceInstance() *schema.Resource {
 				source := d.Get("replicate_source_db").(string)
 				if source != "" {
 					return errors.New(`"blue_green_update.enabled" cannot be set when "replicate_source_db" is set.`)
+				}
+				return nil
+			},
+			func(_ context.Context, d *schema.ResourceDiff, meta any) error {
+				if !d.Get("blue_green_update.0.enabled").(bool) {
+					return nil
+				}
+
+				// If allow_major_version_upgrade is true and engine_version is changing,
+				// then parameter_group_name is required in blue_green_update
+				if d.Get(names.AttrAllowMajorVersionUpgrade).(bool) && d.HasChange(names.AttrEngineVersion) {
+					paramGroupName := d.Get("blue_green_update.0.parameter_group_name").(string)
+					if paramGroupName == "" {
+						return errors.New(`"blue_green_update.parameter_group_name" is required when performing a major version upgrade with blue/green deployment`)
+					}
 				}
 				return nil
 			},

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -7233,6 +7233,69 @@ func TestAccRDSInstance_BlueGreenDeployment_outOfBand(t *testing.T) {
 	})
 }
 
+func TestAccRDSInstance_BlueGreenDeployment_majorVersionUpgradeRequiresParameterGroupName(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	// All RDS Instance tests should skip for testing.Short() except the 20 shortest running tests.
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v1, v2 types.DBInstance
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_db_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_BlueGreenDeployment_majorVersionUpgrade(rName, false, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDBInstanceExists(ctx, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, "backup_retention_period", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.initial", names.AttrVersion),
+				),
+			},
+			{
+				// This should fail because parameter_group_name is missing in blue_green_update
+				Config:      testAccInstanceConfig_BlueGreenDeployment_majorVersionUpgrade(rName, true, false),
+				ExpectError: regexache.MustCompile(`"blue_green_update.parameter_group_name" is required when performing a major version upgrade`),
+			},
+			{
+				Config: testAccInstanceConfig_BlueGreenDeployment_majorVersionUpgrade(rName, true, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDBInstanceExists(ctx, resourceName, &v2),
+					testAccCheckDBInstanceRecreated(&v1, &v2),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.update", names.AttrVersion),
+					resource.TestCheckResourceAttr(resourceName, "blue_green_update.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttrSet(resourceName, "blue_green_update.0.parameter_group_name"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"allow_major_version_upgrade",
+					names.AttrApplyImmediately,
+					names.AttrFinalSnapshotIdentifier,
+					names.AttrPassword,
+					"skip_final_snapshot",
+					"delete_automated_backups",
+					"blue_green_update",
+					"latest_restorable_time",
+				},
+			},
+		},
+	})
+}
+
 func TestAccRDSInstance_Storage_gp3MySQL(t *testing.T) {
 	ctx := acctest.Context(t)
 
@@ -14508,6 +14571,85 @@ resource "aws_db_instance" "test" {
   }
 }
 `, rName, password))
+}
+
+func testAccInstanceConfig_BlueGreenDeployment_majorVersionUpgrade(rName string, upgrade, withParameterGroupName bool) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigRandomPassword(),
+		acctest.ConfigVPCWithSubnets(rName, 2),
+		fmt.Sprintf(`
+data "aws_rds_engine_version" "initial" {
+  engine = %[2]q
+  latest                    = true
+  preferred_upgrade_targets = [data.aws_rds_engine_version.update.version_actual]
+}
+
+data "aws_rds_engine_version" "update" {
+  engine = %[2]q
+}
+
+locals {
+  engine_version = %[3]t ? data.aws_rds_engine_version.update : data.aws_rds_engine_version.initial
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine         = local.engine_version.engine
+  engine_version = local.engine_version.version
+  license_model  = "general-public-license"
+  storage_type   = "standard"
+
+  preferred_instance_classes = [%[4]s]
+}
+
+resource "aws_db_subnet_group" "test" {
+  name       = %[1]q
+  subnet_ids = aws_subnet.test[*].id
+}
+
+resource "aws_db_parameter_group" "test" {
+  name   = %[1]q
+  family = data.aws_rds_engine_version.update.parameter_group_family
+
+  parameter {
+    name  = "character_set_server"
+    value = "utf8"
+  }
+}
+
+resource "aws_db_instance" "test" {
+  identifier                  = %[1]q
+  allocated_storage           = 10
+  backup_retention_period     = 1
+  engine                      = data.aws_rds_orderable_db_instance.test.engine
+  engine_version              = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class              = data.aws_rds_orderable_db_instance.test.instance_class
+  db_name                     = "test"
+  db_subnet_group_name        = aws_db_subnet_group.test.name
+  parameter_group_name        = %[5]s
+  skip_final_snapshot         = true
+  password_wo                 = ephemeral.aws_secretsmanager_random_password.test.random_password
+  password_wo_version         = 1
+  username                    = "tfacctest"
+  allow_major_version_upgrade = %[3]t
+
+  blue_green_update {
+    enabled = true
+    %[6]s
+  }
+}
+`, rName, tfrds.InstanceEngineMySQL, upgrade, mainInstanceClasses,
+			func() string {
+				if withParameterGroupName {
+					return "aws_db_parameter_group.test.name"
+				}
+				return `"default.${local.engine_version.parameter_group_family}"`
+			}(),
+			func() string {
+				if withParameterGroupName {
+					return "parameter_group_name = aws_db_parameter_group.test.name"
+				}
+				return ""
+			}()))
 }
 
 func testAccInstanceConfig_engineVersion(rName string, update bool) string {


### PR DESCRIPTION
**Small changes**  to `blue_green_update` block.

- Added `parameter_group_name` to specify a custom DB param group in the time of green creation 

## Description

I'm working as a DevOps engineer and trying to perform a `Major version upgrade` using B/G deployment via Terraform.
Spotted an issue when I performed such an update - green environmet has the same param group as the blue one(with rds.logical_replication and other params that need for B/G update - but this will cause the error while replication), so I decided to add the possibility to specify custom db param group

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
