### PR TITLE
fix(aws_bedrockagentcore_gateway): config for AWS_IAM authorizer type

### DIFF
--- a/.changelog/44826.txt
+++ b/.changelog/44826.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_gateway: Add validator to ensure correct `authorizer_configuration` and `authorizer_type` config
+```


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None

### Description

PR allows provisioning AWS_IAM protected AgentCore Gateways.

### Relations

Closes #44825

### References

[CreateGateway API Request](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_CreateGateway.html#bedrockagentcorecontrol-CreateGateway-request-authorizerConfiguration)

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccBedrockAgentCoreGateway PKG=bedrockagentcore

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws-iam-protected-gateway 🌿...
TF_ACC=1 go1.24.8 test ./internal/service/bedrockagentcore/... -v -count 1 -parallel 20 -run='TestAccBedrockAgentCoreGateway_'  -timeout 360m -vet=off
2025/10/27 17:40:57 Creating Terraform AWS Provider (SDKv2-style)...
2025/10/27 17:40:57 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockAgentCoreGateway_basic
=== PAUSE TestAccBedrockAgentCoreGateway_basic
=== RUN   TestAccBedrockAgentCoreGateway_disappears
=== PAUSE TestAccBedrockAgentCoreGateway_disappears
=== RUN   TestAccBedrockAgentCoreGateway_tags
=== PAUSE TestAccBedrockAgentCoreGateway_tags
=== RUN   TestAccBedrockAgentCoreGateway_description
=== PAUSE TestAccBedrockAgentCoreGateway_description
=== RUN   TestAccBedrockAgentCoreGateway_kmsKey
    gateway_test.go:242: KMS key returns HTTP 500
--- SKIP: TestAccBedrockAgentCoreGateway_kmsKey (0.00s)
=== RUN   TestAccBedrockAgentCoreGateway_protocolConfiguration
=== PAUSE TestAccBedrockAgentCoreGateway_protocolConfiguration
=== RUN   TestAccBedrockAgentCoreGateway_awsIamAuthorizer
=== PAUSE TestAccBedrockAgentCoreGateway_awsIamAuthorizer
=== CONT  TestAccBedrockAgentCoreGateway_basic
=== CONT  TestAccBedrockAgentCoreGateway_description
=== CONT  TestAccBedrockAgentCoreGateway_awsIamAuthorizer
=== CONT  TestAccBedrockAgentCoreGateway_protocolConfiguration
=== CONT  TestAccBedrockAgentCoreGateway_tags
=== CONT  TestAccBedrockAgentCoreGateway_disappears
--- PASS: TestAccBedrockAgentCoreGateway_disappears (23.55s)
--- PASS: TestAccBedrockAgentCoreGateway_awsIamAuthorizer (26.30s)
--- PASS: TestAccBedrockAgentCoreGateway_basic (26.99s)
--- PASS: TestAccBedrockAgentCoreGateway_protocolConfiguration (40.02s)
--- PASS: TestAccBedrockAgentCoreGateway_description (40.67s)
--- PASS: TestAccBedrockAgentCoreGateway_tags (52.21s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore	59.690s
```
