### PR TITLE
feat: aws_sqs_queue's max_message_size increase to 1024kib

### DIFF
--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -92,7 +92,7 @@ var (
 			Type:         schema.TypeInt,
 			Optional:     true,
 			Default:      defaultQueueMaximumMessageSize,
-			ValidateFunc: validation.IntBetween(1024, 262_144),
+			ValidateFunc: validation.IntBetween(1024, 1_048_576),
 		},
 		"message_retention_seconds": {
 			Type:         schema.TypeInt,

--- a/internal/service/sqs/queue_test.go
+++ b/internal/service/sqs/queue_test.go
@@ -1304,7 +1304,7 @@ func testAccQueueConfig_managedEncryptionKMSDataKeyReusePeriodSeconds(rName stri
 	return fmt.Sprintf(`
 resource "aws_sqs_queue" "test" {
   kms_data_key_reuse_period_seconds = "60"
-  max_message_size                  = "261244"
+  max_message_size                  = "1048576"
   message_retention_seconds         = "60"
   name                              = %[1]q
   sqs_managed_sse_enabled           = true
@@ -1358,7 +1358,7 @@ func testAccQueueConfig_noManagedEncryptionKMSDataKeyReusePeriodSeconds(rName st
 resource "aws_sqs_queue" "test" {
   fifo_queue                        = true
   kms_data_key_reuse_period_seconds = "60"
-  max_message_size                  = "261244"
+  max_message_size                  = "1048576"
   message_retention_seconds         = "60"
   name                              = "%[1]s.fifo"
   receive_wait_time_seconds         = "10"


### PR DESCRIPTION
This pull request replicates a recent V6 provider change to the V5 branch.  Can a new V5 version be published with this change?  Please let me know.

Related: https://github.com/hashicorp/terraform-provider-aws/commit/f3db0be213a8a78cfaa2ff44e8c92a139694bd0b

**Note:** I did not include a changelog entry because I'm not really sure how the numbering scheme works (and what number should be used for a previous V5 release if one should happen).