### PR TITLE
internal/provider: fix crash setting overrideRegion

### DIFF
--- a/.changelog/44860.txt
+++ b/.changelog/44860.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+provider: Fix crash when setting override region during provider initialization
+```

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -744,7 +744,7 @@ func (p *sdkProvider) initialize(ctx context.Context) (map[string]conns.ServiceP
 					var overrideRegion string
 
 					if isRegionOverrideEnabled && getAttribute != nil {
-						if region, ok := getAttribute(names.AttrRegion); ok {
+						if region, ok := getAttribute(names.AttrRegion); ok && region != nil {
 							overrideRegion = region.(string)
 						}
 					}


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The step to set an override region was previously missing a check for `nil` region values, potentially triggering a crash due to a nil interface conversion.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #44855



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test ./internal/provider/...
ok      github.com/hashicorp/terraform-provider-aws/internal/provider   7.010s [no tests to run]
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 6.466s
?       github.com/hashicorp/terraform-provider-aws/internal/provider/framework/identity        [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework/importer        6.290s
?       github.com/hashicorp/terraform-provider-aws/internal/provider/framework/listresource    [no test files]
?       github.com/hashicorp/terraform-provider-aws/internal/provider/framework/listresourceattribute   [no test files]
?       github.com/hashicorp/terraform-provider-aws/internal/provider/framework/resourceattribute       [no test files]
?       github.com/hashicorp/terraform-provider-aws/internal/provider/interceptors      [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     9.097s
?       github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2/identity    [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2/importer    0.624s
?       github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2/internal/attribute  [no test files]
```
