### PR TITLE
Add test for lambda invoke action logging

### DIFF
--- a/internal/service/lambda/invoke_action_test.go
+++ b/internal/service/lambda/invoke_action_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/hashicorp/terraform-plugin-testing/actioncheck"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -138,13 +139,13 @@ func TestAccLambdaInvokeAction_logTypes(t *testing.T) {
 		CheckDestroy: acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInvokeActionConfig_logType(rName, testData, inputJSON, "None"),
+				Config: testAccInvokeActionConfig_logType(rName, testData, inputJSON, string(awstypes.LogTypeNone)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInvokeActionLogType(ctx, rName, inputJSON, awstypes.LogTypeNone),
 				),
 			},
 			{
-				Config: testAccInvokeActionConfig_logType(rName, testData, inputJSON, "Tail"),
+				Config: testAccInvokeActionConfig_logType(rName, testData, inputJSON, string(awstypes.LogTypeTail)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInvokeActionLogType(ctx, rName, inputJSON, awstypes.LogTypeTail),
 				),
@@ -176,6 +177,39 @@ func TestAccLambdaInvokeAction_clientContext(t *testing.T) {
 				Config: testAccInvokeActionConfig_clientContext(rName, testData, inputJSON, clientContext),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInvokeActionClientContext(ctx, rName, inputJSON, clientContext),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLambdaInvokeAction_logTypeTail(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	testData := "log_output_test"
+	inputJSON := `{"key1":"value1","key2":"value2"}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LambdaEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		CheckDestroy: acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInvokeActionConfig_logType(rName, testData, inputJSON, string(awstypes.LogTypeTail)),
+				ActionChecks: []actioncheck.ActionCheck{
+					resource.TestCheckProgressMessageContains("aws_lambda_invoke.test", "Lambda function logs:"),
+					resource.TestCheckProgressMessageContains("aws_lambda_invoke.test", "invoked successfully"),
+					resource.TestCheckProgressMessageCount("aws_lambda_invoke.test", 2),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInvokeActionLogType(ctx, rName, inputJSON, awstypes.LogTypeTail),
 				),
 			},
 		},
@@ -342,6 +376,46 @@ func testAccCheckInvokeActionLogType(ctx context.Context, functionName, inputJSO
 			if output.LogResult == nil {
 				return fmt.Errorf("Expected log result when log type is Tail, but got none")
 			}
+		}
+
+		return nil
+	}
+}
+
+// testAccCheckInvokeActionLogOutput verifies that log output is captured and can be decoded
+func testAccCheckInvokeActionLogOutput(ctx context.Context, functionName, inputJSON string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaClient(ctx)
+
+		input := &lambda.InvokeInput{
+			FunctionName:   &functionName,
+			InvocationType: awstypes.InvocationTypeRequestResponse,
+			Payload:        []byte(inputJSON),
+			LogType:        awstypes.LogTypeTail,
+		}
+
+		output, err := conn.Invoke(ctx, input)
+		if err != nil {
+			return fmt.Errorf("Failed to invoke Lambda function %s with log type Tail: %w", functionName, err)
+		}
+
+		if output.FunctionError != nil {
+			return fmt.Errorf("Lambda function %s returned an error: %s", functionName, string(output.Payload))
+		}
+
+		// Verify log result is present
+		if output.LogResult == nil {
+			return fmt.Errorf("Expected log result when log type is Tail, but got none")
+		}
+
+		logData, err := base64.StdEncoding.DecodeString(*output.LogResult)
+		if err != nil {
+			return fmt.Errorf("Failed to decode log result: %w", err)
+		}
+
+		logStr := string(logData)
+		if len(logStr) == 0 {
+			return fmt.Errorf("Decoded log result is empty")
 		}
 
 		return nil


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds ActionChecks to verify that logs are output as expected.

DO NOT MERGE until a version of `terraform-plugin-testing` containing hashicorp/terraform-plugin-testing#570 is available.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #44843
Depends on hashicorp/terraform-plugin-testing#570

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
