### PR TITLE
Fix persistent diffs in aws_controltower_landing_zone manifest_json

### DIFF
--- a/.changelog/44902.txt
+++ b/.changelog/44902.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_controltower_landing_zone: Fix persistent diffs in `manifest_json` caused by array ordering and type inconsistencies
+```

--- a/internal/service/controltower/exports_test.go
+++ b/internal/service/controltower/exports_test.go
@@ -9,7 +9,9 @@ var (
 	ResourceLandingZone = resourceLandingZone
 	ResourceBaseline    = newResourceBaseline
 
-	FindBaselineByID               = findBaselineByID
-	FindEnabledControlByTwoPartKey = findEnabledControlByTwoPartKey
-	FindLandingZoneByID            = findLandingZoneByID
+	FindBaselineByID                           = findBaselineByID
+	FindEnabledControlByTwoPartKey             = findEnabledControlByTwoPartKey
+	FindLandingZoneByID                        = findLandingZoneByID
+	NormalizeManifestJSON                      = normalizeManifestJSON
+	SuppressEquivalentLandingZoneManifestDiffs = suppressEquivalentLandingZoneManifestDiffs
 )

--- a/internal/service/controltower/landing_zone.go
+++ b/internal/service/controltower/landing_zone.go
@@ -7,8 +7,11 @@ package controltower
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,7 +33,6 @@ import (
 	tfsmithy "github.com/hashicorp/terraform-provider-aws/internal/smithy"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
-	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -87,7 +89,7 @@ func resourceLandingZone() *schema.Resource {
 					Type:                  schema.TypeString,
 					Required:              true,
 					ValidateFunc:          validation.StringIsJSON,
-					DiffSuppressFunc:      verify.SuppressEquivalentJSONDiffs,
+					DiffSuppressFunc:      suppressEquivalentLandingZoneManifestDiffs,
 					DiffSuppressOnRefresh: true,
 					StateFunc: func(v any) string {
 						json, _ := structure.NormalizeJsonString(v)
@@ -181,7 +183,15 @@ func resourceLandingZoneRead(ctx context.Context, d *schema.ResourceData, meta a
 			return sdkdiag.AppendFromErr(diags, err)
 		}
 
-		d.Set("manifest_json", v)
+		// Normalize the manifest before setting it in state
+		// This ensures that governedRegions order and retentionDays type are consistent
+		normalizedManifest, err := normalizeManifestJSON(v)
+		if err != nil {
+			log.Printf("[WARN] Failed to normalize manifest JSON: %s", err)
+			d.Set("manifest_json", v) // Fall back to original if normalization fails
+		} else {
+			d.Set("manifest_json", normalizedManifest)
+		}
 	} else {
 		d.Set("manifest_json", nil)
 	}
@@ -350,4 +360,115 @@ func flattenLandingZoneDriftStatusSummary(apiObject *types.LandingZoneDriftStatu
 	}
 
 	return tfMap
+}
+
+// suppressEquivalentLandingZoneManifestDiffs provides custom diff suppression for Landing Zone manifests.
+// It normalizes the JSON to handle two specific issues:
+// 1. AWS API returns numeric fields (like retentionDays) as strings, but they should be accepted as numbers
+// 2. AWS API may return arrays (like governedRegions) in different order
+func suppressEquivalentLandingZoneManifestDiffs(k, old, new string, d *schema.ResourceData) bool {
+	if strings.TrimSpace(old) == "" && strings.TrimSpace(new) == "" {
+		return true
+	}
+
+	if strings.TrimSpace(old) == "" || strings.TrimSpace(new) == "" {
+		return false
+	}
+
+	// Normalize both JSON strings and compare
+	normalizedOld, err := normalizeManifestJSON(old)
+	if err != nil {
+		log.Printf("[WARN] Failed to normalize old manifest JSON: %s", err)
+		return false
+	}
+
+	normalizedNew, err := normalizeManifestJSON(new)
+	if err != nil {
+		log.Printf("[WARN] Failed to normalize new manifest JSON: %s", err)
+		return false
+	}
+
+	return normalizedOld == normalizedNew
+}
+
+// normalizeManifest recursively normalizes a manifest for comparison:
+// - Converts numeric strings to numbers where appropriate (retentionDays)
+// - Sorts arrays that should be order-independent (governedRegions)
+func normalizeManifest(manifest map[string]interface{}) {
+	for key, value := range manifest {
+		switch key {
+		case "governedRegions":
+			// Sort the regions array to ignore order differences
+			if regions, ok := value.([]interface{}); ok {
+				strRegions := make([]string, 0, len(regions))
+				for _, r := range regions {
+					if str, ok := r.(string); ok {
+						strRegions = append(strRegions, str)
+					}
+				}
+				sort.Strings(strRegions)
+				newRegions := make([]interface{}, len(strRegions))
+				for i, r := range strRegions {
+					newRegions[i] = r
+				}
+				manifest[key] = newRegions
+			}
+		case "centralizedLogging":
+			// Handle nested configurations
+			if logging, ok := value.(map[string]interface{}); ok {
+				if configs, ok := logging["configurations"].(map[string]interface{}); ok {
+					// Normalize retentionDays in loggingBucket and accessLoggingBucket
+					for _, bucketKey := range []string{"loggingBucket", "accessLoggingBucket"} {
+						if bucket, ok := configs[bucketKey].(map[string]interface{}); ok {
+							normalizeRetentionDays(bucket)
+						}
+					}
+				}
+			}
+		default:
+			// Recursively normalize nested objects
+			if nested, ok := value.(map[string]interface{}); ok {
+				normalizeManifest(nested)
+			}
+		}
+	}
+}
+
+// normalizeRetentionDays converts string retentionDays to numbers for comparison
+func normalizeRetentionDays(bucket map[string]interface{}) {
+	if retention, ok := bucket["retentionDays"]; ok {
+		// Convert string to number if it's a numeric string
+		if strVal, ok := retention.(string); ok {
+			// Parse as float64 (JSON numbers are float64)
+			if numVal, err := strconv.ParseFloat(strVal, 64); err == nil {
+				bucket["retentionDays"] = numVal
+			}
+		}
+		// If it's already a number, leave it as is
+	}
+}
+
+// normalizeManifestJSON takes a JSON string, normalizes it (sorting governedRegions and
+// converting retentionDays strings to numbers), and returns the normalized JSON string.
+func normalizeManifestJSON(manifestJSON string) (string, error) {
+	if strings.TrimSpace(manifestJSON) == "" {
+		return manifestJSON, nil
+	}
+
+	var manifest map[string]interface{}
+	if err := json.Unmarshal([]byte(manifestJSON), &manifest); err != nil {
+		return "", err
+	}
+
+	// Normalize the manifest
+	normalizeManifest(manifest)
+
+	// Convert back to JSON string
+	normalized, err := json.Marshal(manifest)
+	if err != nil {
+		return "", err
+	}
+
+	// Use structure.NormalizeJsonString to ensure consistent formatting
+	return structure.NormalizeJsonString(string(normalized))
 }

--- a/internal/service/controltower/landing_zone_test.go
+++ b/internal/service/controltower/landing_zone_test.go
@@ -299,3 +299,167 @@ resource "aws_controltower_landing_zone" "test" {
 }
 `, acctest.Region(), landingZoneVersion, tagKey1, tagValue1, tagKey2, tagValue2)
 }
+
+func TestSuppressEquivalentLandingZoneManifestDiffs(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		old      string
+		new      string
+		expected bool
+	}{
+		{
+			name: "identical manifests",
+			old: `{
+				"governedRegions": ["us-east-1", "us-west-2"],
+				"centralizedLogging": {
+					"configurations": {
+						"loggingBucket": {
+							"retentionDays": 365
+						},
+						"accessLoggingBucket": {
+							"retentionDays": 365
+						}
+					}
+				}
+			}`,
+			new: `{
+				"governedRegions": ["us-east-1", "us-west-2"],
+				"centralizedLogging": {
+					"configurations": {
+						"loggingBucket": {
+							"retentionDays": 365
+						},
+						"accessLoggingBucket": {
+							"retentionDays": 365
+						}
+					}
+				}
+			}`,
+			expected: true,
+		},
+		{
+			name: "retentionDays number vs string",
+			old: `{
+				"governedRegions": ["us-east-1"],
+				"centralizedLogging": {
+					"configurations": {
+						"loggingBucket": {
+							"retentionDays": "365"
+						},
+						"accessLoggingBucket": {
+							"retentionDays": "90"
+						}
+					}
+				}
+			}`,
+			new: `{
+				"governedRegions": ["us-east-1"],
+				"centralizedLogging": {
+					"configurations": {
+						"loggingBucket": {
+							"retentionDays": 365
+						},
+						"accessLoggingBucket": {
+							"retentionDays": 90
+						}
+					}
+				}
+			}`,
+			expected: true,
+		},
+		{
+			name: "governedRegions different order",
+			old: `{
+				"governedRegions": ["us-east-1", "eu-west-2", "us-west-2"]
+			}`,
+			new: `{
+				"governedRegions": ["eu-west-2", "us-east-1", "us-west-2"]
+			}`,
+			expected: true,
+		},
+		{
+			name: "governedRegions different order with nested config",
+			old: `{
+				"governedRegions": ["us-east-1", "eu-west-2", "us-west-2"],
+				"centralizedLogging": {
+					"configurations": {
+						"loggingBucket": {
+							"retentionDays": 365
+						}
+					}
+				}
+			}`,
+			new: `{
+				"governedRegions": ["eu-west-2", "us-east-1", "us-west-2"],
+				"centralizedLogging": {
+					"configurations": {
+						"loggingBucket": {
+							"retentionDays": 365
+						}
+					}
+				}
+			}`,
+			expected: true,
+		},
+		{
+			name: "different governedRegions",
+			old: `{
+				"governedRegions": ["us-east-1", "us-west-2"]
+			}`,
+			new: `{
+				"governedRegions": ["us-east-1"]
+			}`,
+			expected: false,
+		},
+		{
+			name: "different retentionDays values",
+			old: `{
+				"governedRegions": ["us-east-1"],
+				"centralizedLogging": {
+					"configurations": {
+						"loggingBucket": {
+							"retentionDays": 365
+						}
+					}
+				}
+			}`,
+			new: `{
+				"governedRegions": ["us-east-1"],
+				"centralizedLogging": {
+					"configurations": {
+						"loggingBucket": {
+							"retentionDays": 90
+						}
+					}
+				}
+			}`,
+			expected: false,
+		},
+		{
+			name:     "both empty",
+			old:      "",
+			new:      "",
+			expected: true,
+		},
+		{
+			name:     "one empty",
+			old:      "",
+			new:      `{"governedRegions": ["us-east-1"]}`,
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := tfcontroltower.SuppressEquivalentLandingZoneManifestDiffs("manifest_json", tc.old, tc.new, nil)
+			if actual != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Rollback Plan

In case of any issues, users can rollback to the previous version of the provider. The changes are isolated to the `aws_controltower_landing_zone` resource's diff suppression logic.

## Changes to Security Controls

No changes to security controls. This PR only affects diff suppression and state normalization for the `manifest_json` attribute.

## Description

Fixes #35763

This PR resolves persistent diffs in the `aws_controltower_landing_zone` resource's `manifest_json` attribute caused by:

1. **Array ordering differences**: AWS API may return `governedRegions` in a different order than specified in configuration
2. **Type inconsistencies**: AWS API returns `retentionDays` as strings, but users may specify them as numbers

The fix implements a two-part solution:

1. **Custom diff suppression function** (`suppressEquivalentLandingZoneManifestDiffs`) that normalizes and compares manifests semantically
2. **State normalization during read** to ensure consistent representation in state

**Implementation details:**

- Added `normalizeManifestJSON()` function to:
  - Sort `governedRegions` array alphabetically for order-independent comparison
  - Convert `retentionDays` string values to numbers in `loggingBucket` and `accessLoggingBucket` configurations
- Added unit tests covering 7 scenarios including edge cases
- Applied normalization in both `Read` function (state refresh) and diff suppression

**Testing:**

Unit tests verify the normalization handles:
- Identical manifests (should suppress diff)
- `retentionDays` as number vs string (should suppress diff)
- `governedRegions` in different order (should suppress diff)
- Different `governedRegions` values (should NOT suppress diff)
- Different `retentionDays` values (should NOT suppress diff)
- Empty manifest edge cases

## Relations

N/A

## References

- Closes #35763

## Output from Acceptance Testing

N/A - Unit tests only at this stage. The affected resource requires AWS Organizations management account which is not available in standard acceptance testing.
