### PR TITLE
[Docs] aws_bedrockagentcore_memory: Fix naming convention of `name` argument in examples and units of `event_expiry_duration`

### DIFF
--- a/website/docs/r/bedrockagentcore_memory.html.markdown
+++ b/website/docs/r/bedrockagentcore_memory.html.markdown
@@ -37,7 +37,7 @@ resource "aws_iam_role_policy_attachment" "example" {
 }
 
 resource "aws_bedrockagentcore_memory" "example" {
-  name                  = "example-memory"
+  name                  = "example_memory"
   event_expiry_duration = 30
 }
 ```
@@ -50,7 +50,7 @@ resource "aws_kms_key" "example" {
 }
 
 resource "aws_bedrockagentcore_memory" "example" {
-  name                      = "example-memory"
+  name                      = "example_memory"
   description               = "Memory for customer service agent"
   event_expiry_duration     = 60
   encryption_key_arn        = aws_kms_key.example.arn
@@ -64,7 +64,7 @@ resource "aws_bedrockagentcore_memory" "example" {
 The following arguments are required:
 
 * `name` - (Required) Name of the memory.
-* `event_expiry_duration` - (Required) Number of minutes after which memory events expire. Must be a positive integer.
+* `event_expiry_duration` - (Required) Number of days after which memory events expire. Must be a positive integer in the range of 7 to 365.
 
 The following arguments are optional:
 


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Update the documentation for `aws_bedrockagentcore_memory`:

  * Fix the naming convention of the `name` argument in examples, replacing `-` with `_`

    * `-` is not allowed in `name` arguments.

* `event_expiry_duration`:

  * Correct the units to "days" (not "minutes").
  * Add the valid range.

    * The current AWS Provider implements validation for `event_expiry_duration` requiring a range of 7 to 365.
    * The [AWS documentation](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_Memory.html) describes the valid range as 1 to 365.
    * Based on [my verification](https://github.com/hashicorp/terraform-provider-aws/issues/44904#issuecomment-3480236787), the current AWS Provider implementation is correct.



### Relations

Closes #44905
Closes #44904

### References
https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_Memory.html

The documented valid range for `eventExpiryDuration` appears to be incorrect.

