### PR TITLE
resource/aws_lakeformation_permissions: Encapsulates assigning Resource to API inputs

### DIFF
--- a/internal/service/lakeformation/permissions_data_source.go
+++ b/internal/service/lakeformation/permissions_data_source.go
@@ -292,17 +292,7 @@ func dataSourcePermissionsRead(ctx context.Context, d *schema.ResourceData, meta
 		input.CatalogId = aws.String(v.(string))
 	}
 
-	resource := expandResource(d)
-	if resource != nil {
-		input.Resource = resource
-	} else {
-		input.Resource = &awstypes.Resource{}
-
-		if v, ok := d.GetOk("table_with_columns"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
-			// can't ListPermissions for TableWithColumns, so use Table instead
-			input.Resource.Table = ExpandTableWithColumnsResourceAsTable(v.([]any)[0].(map[string]any))
-		}
-	}
+	populateResourceForRead(&input, d)
 
 	filter := permissionsFilter(d)
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Encapsulates assigning Resource to API inputs. Handles special case for Read operation

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=lakeformation TESTS='TestAccLakeFormation_serial/Permission'

--- PASS: TestAccLakeFormation_serial (1035.50s)
    --- PASS: TestAccLakeFormation_serial/PermissionsBasic (357.92s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/lfTagPolicyMultiple (21.75s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/nonIAMPrincipals (16.35s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/basic (21.09s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/database (21.68s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/databaseIAMAllowed (59.73s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/databaseMultiple (22.24s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/dataLocation (22.56s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/disappears (92.10s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/lfTag (21.63s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/lfTagPolicy (21.39s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/databaseIAMPrincipals (13.20s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/dataCellsFilter (24.21s)
    --- PASS: TestAccLakeFormation_serial/PermissionsTable (288.07s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/iamAllowed (61.23s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/implicit (31.06s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/multipleRoles (22.83s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/selectOnly (22.69s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/wildcardSelectOnly (22.72s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/iamPrincipals (13.85s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/selectPlus (22.48s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/wildcardNoSelect (22.15s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/wildcardSelectPlus (30.75s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/nonIAMPrincipals (15.91s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/basic (22.40s)
    --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns (190.86s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardSelectOnly (22.70s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardSelectPlus (23.53s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/basic (86.19s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/implicit (34.07s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardExcludedColumns (24.36s)
    --- PASS: TestAccLakeFormation_serial/PermissionsDataSource (198.65s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/basic (22.64s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/dataCellsFilter (23.59s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/lfTag (22.37s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/tableWithColumns (23.18s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/nonIAMPrincipals (17.77s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/database (21.22s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/dataLocation (23.34s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/lfTagPolicy (21.61s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/table (22.92s)
```
