### PR TITLE
resource/aws_inspector2_filter: Deserializes acceptance tests

### DIFF
--- a/internal/service/inspector2/filter_test.go
+++ b/internal/service/inspector2/filter_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func testAccInspector2Filter_basic(t *testing.T) {
+func TestAccInspector2Filter_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	action_1 := string(awstypes.FilterActionNone)
 	description_1 := "TestDescription_1"
@@ -71,7 +71,7 @@ func testAccInspector2Filter_basic(t *testing.T) {
 	})
 }
 
-func testAccInspector2Filter_update(t *testing.T) {
+func TestAccInspector2Filter_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	action_1 := string(awstypes.FilterActionNone)
 	description_1 := "TestDescription_1"
@@ -147,7 +147,7 @@ func testAccInspector2Filter_update(t *testing.T) {
 	})
 }
 
-func testAccInspector2Filter_stringFilters(t *testing.T) {
+func TestAccInspector2Filter_stringFilters(t *testing.T) {
 	ctx := acctest.Context(t)
 	action_1 := string(awstypes.FilterActionNone)
 	description_1 := "TestDescription_1"
@@ -243,7 +243,7 @@ func testAccInspector2Filter_stringFilters(t *testing.T) {
 	})
 }
 
-func testAccInspector2Filter_numberFilters(t *testing.T) {
+func TestAccInspector2Filter_numberFilters(t *testing.T) {
 	ctx := acctest.Context(t)
 	action_1 := string(awstypes.FilterActionNone)
 	description_1 := "TestDescription_1"
@@ -329,7 +329,7 @@ func testAccInspector2Filter_numberFilters(t *testing.T) {
 	})
 }
 
-func testAccInspector2Filter_dateFilters(t *testing.T) {
+func TestAccInspector2Filter_dateFilters(t *testing.T) {
 	ctx := acctest.Context(t)
 	action_1 := string(awstypes.FilterActionNone)
 	description_1 := "TestDescription_1"
@@ -415,7 +415,7 @@ func testAccInspector2Filter_dateFilters(t *testing.T) {
 	})
 }
 
-func testAccInspector2Filter_mapFilters(t *testing.T) {
+func TestAccInspector2Filter_mapFilters(t *testing.T) {
 	ctx := acctest.Context(t)
 	comparison := string(awstypes.MapComparisonEquals)
 	action_1 := string(awstypes.FilterActionNone)
@@ -494,7 +494,7 @@ func testAccInspector2Filter_mapFilters(t *testing.T) {
 	})
 }
 
-func testAccInspector2Filter_portRangeFilters(t *testing.T) {
+func TestAccInspector2Filter_portRangeFilters(t *testing.T) {
 	ctx := acctest.Context(t)
 	action_1 := string(awstypes.FilterActionNone)
 	description_1 := "TestDescription_1"
@@ -566,7 +566,7 @@ func testAccInspector2Filter_portRangeFilters(t *testing.T) {
 	})
 }
 
-func testAccInspector2Filter_packageFilters(t *testing.T) {
+func TestAccInspector2Filter_packageFilters(t *testing.T) {
 	ctx := acctest.Context(t)
 	comparison := string(awstypes.MapComparisonEquals)
 	action_1 := string(awstypes.FilterActionNone)
@@ -728,7 +728,7 @@ func testAccInspector2Filter_packageFilters(t *testing.T) {
 	})
 }
 
-func testAccInspector2Filter_disappears(t *testing.T) {
+func TestAccInspector2Filter_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	action_1 := string(awstypes.FilterActionNone)
 	description_1 := "TestDescription_1"

--- a/internal/service/inspector2/inspector2_test.go
+++ b/internal/service/inspector2/inspector2_test.go
@@ -32,17 +32,6 @@ func TestAccInspector2_serial(t *testing.T) {
 			acctest.CtBasic:      testAccDelegatedAdminAccount_basic,
 			acctest.CtDisappears: testAccDelegatedAdminAccount_disappears,
 		},
-		"Filter": {
-			acctest.CtBasic:           testAccInspector2Filter_basic,
-			"update":                  testAccInspector2Filter_update,
-			acctest.CtDisappears:      testAccInspector2Filter_disappears,
-			"filter_stringFilters":    testAccInspector2Filter_stringFilters,
-			"filter_dateFilters":      testAccInspector2Filter_dateFilters,
-			"filter_numberFilters":    testAccInspector2Filter_numberFilters,
-			"filter_mapFilters":       testAccInspector2Filter_mapFilters,
-			"filter_portRangeFilters": testAccInspector2Filter_portRangeFilters,
-			"filter_packageFilters":   testAccInspector2Filter_packageFilters,
-		},
 		"MemberAssociation": {
 			acctest.CtBasic:      testAccMemberAssociation_basic,
 			acctest.CtDisappears: testAccMemberAssociation_disappears,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

The tests for `aws_inspector2_filter` do not need to be serialized.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=inspector2 TESTS=TestAccInspector2Filter_

--- PASS: TestAccInspector2Filter_disappears (65.73s)
--- PASS: TestAccInspector2Filter_basic (116.25s)
--- PASS: TestAccInspector2Filter_tags_DefaultTags_emptyProviderOnlyTag (131.98s)
--- PASS: TestAccInspector2Filter_tags_DefaultTags_emptyResourceTag (140.16s)
--- PASS: TestAccInspector2Filter_Identity_Basic (164.62s)
--- PASS: TestAccInspector2Filter_tags_DefaultTags_updateToProviderOnly (176.02s)
--- PASS: TestAccInspector2Filter_mapFilters (176.06s)
--- PASS: TestAccInspector2Filter_dateFilters (176.24s)
--- PASS: TestAccInspector2Filter_tags_DefaultTags_updateToResourceOnly (176.27s)
--- PASS: TestAccInspector2Filter_stringFilters (190.35s)
--- PASS: TestAccInspector2Filter_portRangeFilters (190.43s)
--- PASS: TestAccInspector2Filter_update (199.44s)
--- PASS: TestAccInspector2Filter_tags_EmptyTag_OnUpdate_Replace (199.60s)
--- PASS: TestAccInspector2Filter_packageFilters (199.79s)
--- PASS: TestAccInspector2Filter_tags_ComputedTag_OnUpdate_Add (199.82s)
--- PASS: TestAccInspector2Filter_numberFilters (199.85s)
--- PASS: TestAccInspector2Filter_tags_DefaultTags_nullNonOverlappingResourceTag (134.14s)
--- PASS: TestAccInspector2Filter_tags_ComputedTag_OnCreate (93.72s)
--- PASS: TestAccInspector2Filter_tags_null (83.33s)
--- PASS: TestAccInspector2Filter_tags_EmptyMap (71.78s)
--- PASS: TestAccInspector2Filter_tags_EmptyTag_OnUpdate_Add (248.08s)
--- PASS: TestAccInspector2Filter_tags_DefaultTags_nullOverlappingResourceTag (71.97s)
--- PASS: TestAccInspector2Filter_tags_DefaultTags_nonOverlapping (255.70s)
--- PASS: TestAccInspector2Filter_tags_DefaultTags_overlapping (266.68s)
--- PASS: TestAccInspector2Filter_tags_AddOnUpdate (109.19s)
--- PASS: TestAccInspector2Filter_tags_IgnoreTags_Overlap_DefaultTag (155.16s)
--- PASS: TestAccInspector2Filter_tags_IgnoreTags_Overlap_ResourceTag (149.24s)
--- PASS: TestAccInspector2Filter_tags_EmptyTag_OnCreate (116.64s)
--- PASS: TestAccInspector2Filter_Identity_ExistingResource_NoRefresh_NoChange (102.51s)
--- PASS: TestAccInspector2Filter_Identity_ExistingResource (94.94s)
--- PASS: TestAccInspector2Filter_tags_ComputedTag_OnUpdate_Replace (104.27s)
--- PASS: TestAccInspector2Filter_Identity_RegionOverride (98.77s)
--- PASS: TestAccInspector2Filter_tags_DefaultTags_providerOnly (298.95s)
--- PASS: TestAccInspector2Filter_tags (124.68s)
```
