### PR TITLE
fix: Remove aws_api_gateway_account reset_on_delete docs

### DIFF
--- a/website/docs/cdktf/python/r/api_gateway_account.html.markdown
+++ b/website/docs/cdktf/python/r/api_gateway_account.html.markdown
@@ -12,8 +12,6 @@ description: |-
 
 Provides a settings of an API Gateway Account. Settings is applied region-wide per `provider` block.
 
--> **Note:** By default, destroying this resource will keep your account settings intact. Set `reset_on_delete` to `true` to reset the account setttings to default. In a future major version of the provider, destroying the resource will reset account settings.
-
 ## Example Usage
 
 ```python
@@ -76,9 +74,6 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `cloudwatch_role_arn` - (Optional) ARN of an IAM role for CloudWatch (to allow logging & monitoring). See more [in AWS Docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-stage-settings.html#how-to-stage-settings-console). Logging & monitoring can be enabled/disabled and otherwise tuned on the API Gateway Stage level.
-* `reset_on_delete` - (Optional) If `true`, destroying the resource will reset account settings to default, otherwise account settings are not modified.
-  Defaults to `false`.
-  Will be removed in a future major version of the provider.
 
 ## Attribute Reference
 

--- a/website/docs/cdktf/typescript/r/api_gateway_account.html.markdown
+++ b/website/docs/cdktf/typescript/r/api_gateway_account.html.markdown
@@ -12,8 +12,6 @@ description: |-
 
 Provides a settings of an API Gateway Account. Settings is applied region-wide per `provider` block.
 
--> **Note:** By default, destroying this resource will keep your account settings intact. Set `reset_on_delete` to `true` to reset the account setttings to default. In a future major version of the provider, destroying the resource will reset account settings.
-
 ## Example Usage
 
 ```typescript
@@ -89,9 +87,6 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `cloudwatchRoleArn` - (Optional) ARN of an IAM role for CloudWatch (to allow logging & monitoring). See more [in AWS Docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-stage-settings.html#how-to-stage-settings-console). Logging & monitoring can be enabled/disabled and otherwise tuned on the API Gateway Stage level.
-* `reset_on_delete` - (Optional) If `true`, destroying the resource will reset account settings to default, otherwise account settings are not modified.
-  Defaults to `false`.
-  Will be removed in a future major version of the provider.
 
 ## Attribute Reference
 

--- a/website/docs/r/api_gateway_account.html.markdown
+++ b/website/docs/r/api_gateway_account.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Provides a settings of an API Gateway Account. Settings is applied region-wide per `provider` block.
 
--> **Note:** By default, destroying this resource will keep your account settings intact. Set `reset_on_delete` to `true` to reset the account setttings to default. In a future major version of the provider, destroying the resource will reset account settings.
-
 ## Example Usage
 
 ```terraform
@@ -67,9 +65,6 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `cloudwatch_role_arn` - (Optional) ARN of an IAM role for CloudWatch (to allow logging & monitoring). See more [in AWS Docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-stage-settings.html#how-to-stage-settings-console). Logging & monitoring can be enabled/disabled and otherwise tuned on the API Gateway Stage level.
-* `reset_on_delete` - (Optional) If `true`, destroying the resource will reset account settings to default, otherwise account settings are not modified.
-  Defaults to `false`.
-  Will be removed in a future major version of the provider.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan
Not applicable.

## Changes to Security Controls
Not applicable.

### Description
The argument was removed in https://github.com/hashicorp/terraform-provider-aws/pull/42226 so the docs should reflect this.


### Relations
Relates #42226 

### References

### Output from Acceptance Testing
Not applicable.
