### PR TITLE
[Docs] aws_codebuild_project: Fix import identifier to `arn`

### DIFF
--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -586,7 +586,6 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `arn` - ARN of the CodeBuild project.
 * `badge_url` - URL of the build badge when `badge_enabled` is enabled.
-* `id` - ARN of the CodeBuild project.
 * `public_project_alias` - The project identifier used with the public build APIs.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [
   `default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -586,7 +586,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `arn` - ARN of the CodeBuild project.
 * `badge_url` - URL of the build badge when `badge_enabled` is enabled.
-* `id` - Name (if imported via `name`) or ARN (if created via Terraform or imported via ARN) of the CodeBuild project.
+* `id` - ARN of the CodeBuild project.
 * `public_project_alias` - The project identifier used with the public build APIs.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [
   `default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
@@ -615,17 +615,17 @@ resource "aws_codebuild_project" "example" {
 - `arn` (String) Amazon Resource Name (ARN) of the CodeBuild project.
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to
-import CodeBuild Project using the `name`. For example:
+import CodeBuild Project using the `arn`. For example:
 
 ```terraform
 import {
   to = aws_codebuild_project.name
-  id = "project-name"
+  id = "arn-of-project"
 }
 ```
 
-Using `terraform import`, import CodeBuild Project using the `name`. For example:
+Using `terraform import`, import CodeBuild Project using the `arn`. For example:
 
 ```console
-% terraform import aws_codebuild_project.name project-name
+% terraform import aws_codebuild_project.name arn-of-project
 ```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR fixes the documentation of `aws_codebuild_project` regarding the import identifier.

* In the current implementation, only the `arn` can be used as the import identifier. However, the previous documentation stated that `name` could be used.
  * Historically, both `name` and `arn` were accepted as identifiers during import, since the “Read” function uses `findProjectByNameOrARN`.
  * In addition, the documentation states:
    > [id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project#id-1) - Name (if imported via name) or ARN (if created via Terraform or imported via ARN) of the CodeBuild project.

* However, when resource identity was introduced, the `arn` was designated as the identifier, and the `name` can no longer be used, as verified in #44940.


### Relations

Closes #44940 

