### PR TITLE
[DOCS] Fix the resource name to align with the `depends_on` argument

### DIFF
--- a/website/docs/r/ssoadmin_account_assignment.html.markdown
+++ b/website/docs/r/ssoadmin_account_assignment.html.markdown
@@ -63,7 +63,7 @@ resource "aws_identitystore_group" "example" {
   description       = "Admin Group"
 }
 
-resource "aws_ssoadmin_account_assignment" "account_assignment" {
+resource "aws_ssoadmin_account_assignment" "example" {
   instance_arn       = tolist(data.aws_ssoadmin_instances.example.arns)[0]
   permission_set_arn = aws_ssoadmin_permission_set.example.arn
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR fixes the resource name for `aws_ssoadmin_account_assignment` resource. The resource is named `account_assignment`, however, in the next resource the `depends_on` argument refers to `aws_ssoadmin_account_assignment.example`. Since all other resources are named example, 

### Relations
Re-Closes: #[40720](https://github.com/hashicorp/terraform-provider-aws/issues/40720)