### PR TITLE
Add autoscaling set desired capacity action

### DIFF
--- a/internal/service/autoscaling/autoscaling_set_desired_capacity_action.go
+++ b/internal/service/autoscaling/autoscaling_set_desired_capacity_action.go
@@ -1,0 +1,256 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package autoscaling
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/action/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/actionwait"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @Action(aws_autoscaling_set_desired_capacity, name="Set Desired Capacity")
+func newSetDesiredCapacityAction(_ context.Context) (action.ActionWithConfigure, error) {
+	return &setDesiredCapacityAction{}, nil
+}
+
+type setDesiredCapacityAction struct {
+	framework.ActionWithModel[setDesiredCapacityModel]
+}
+
+type setDesiredCapacityModel struct {
+	framework.WithRegionModel
+	AutoScalingGroupName types.String `tfsdk:"autoscaling_group_name"`
+	DesiredCapacity      types.Int64  `tfsdk:"desired_capacity"`
+	MinSize              types.Int64  `tfsdk:"min_size"`
+	MaxSize              types.Int64  `tfsdk:"max_size"`
+	Timeout              types.Int64  `tfsdk:"timeout"`
+}
+
+func (a *setDesiredCapacityAction) Schema(ctx context.Context, req action.SchemaRequest, resp *action.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Sets the desired capacity of an Auto Scaling group and optionally updates min/max sizes.",
+		Attributes: map[string]schema.Attribute{
+			"autoscaling_group_name": schema.StringAttribute{
+				Description: "The name of the Auto Scaling group",
+				Required:    true,
+			},
+			"desired_capacity": schema.Int64Attribute{
+				Description: "The desired capacity for the Auto Scaling group",
+				Required:    true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
+			},
+			"min_size": schema.Int64Attribute{
+				Description: "The minimum size of the Auto Scaling group",
+				Optional:    true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
+			},
+			"max_size": schema.Int64Attribute{
+				Description: "The maximum size of the Auto Scaling group",
+				Optional:    true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
+			},
+			names.AttrTimeout: schema.Int64Attribute{
+				Description: "Timeout in seconds (default: 900)",
+				Optional:    true,
+				Validators: []validator.Int64{
+					int64validator.Between(60, 3600),
+				},
+			},
+		},
+	}
+}
+
+func (a *setDesiredCapacityAction) Invoke(ctx context.Context, req action.InvokeRequest, resp *action.InvokeResponse) {
+	var config setDesiredCapacityModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := a.Meta().AutoScalingClient(ctx)
+
+	asgName := config.AutoScalingGroupName.ValueString()
+	desiredCapacity := config.DesiredCapacity.ValueInt64()
+
+	timeout := 900 * time.Second
+	if !config.Timeout.IsNull() {
+		timeout = time.Duration(config.Timeout.ValueInt64()) * time.Second
+	}
+
+	tflog.Info(ctx, "Starting Auto Scaling set desired capacity action", map[string]any{
+		"autoscaling_group_name": asgName,
+		"desired_capacity":       desiredCapacity,
+		names.AttrTimeout:        timeout.String(),
+	})
+
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: fmt.Sprintf("Setting desired capacity for Auto Scaling group %s to %d...", asgName, desiredCapacity),
+	})
+
+	// Get current ASG to validate bounds
+	asg, err := findAutoScalingGroupByName(ctx, conn, asgName)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Auto Scaling Group Not Found",
+			fmt.Sprintf("Auto Scaling group %s was not found: %s", asgName, err),
+		)
+		return
+	}
+
+	// Validate capacity bounds
+	minSize := aws.ToInt32(asg.MinSize)
+	maxSize := aws.ToInt32(asg.MaxSize)
+
+	if !config.MinSize.IsNull() {
+		minSize = int32(config.MinSize.ValueInt64())
+	}
+	if !config.MaxSize.IsNull() {
+		maxSize = int32(config.MaxSize.ValueInt64())
+	}
+
+	if int64(minSize) > desiredCapacity || desiredCapacity > int64(maxSize) {
+		resp.Diagnostics.AddError(
+			"Invalid Capacity",
+			fmt.Sprintf("Desired capacity %d must be between min_size %d and max_size %d", desiredCapacity, minSize, maxSize),
+		)
+		return
+	}
+
+	// Update min/max if specified
+	if !config.MinSize.IsNull() || !config.MaxSize.IsNull() {
+		updateInput := &autoscaling.UpdateAutoScalingGroupInput{
+			AutoScalingGroupName: aws.String(asgName),
+		}
+		if !config.MinSize.IsNull() {
+			updateInput.MinSize = aws.Int32(int32(config.MinSize.ValueInt64()))
+		}
+		if !config.MaxSize.IsNull() {
+			updateInput.MaxSize = aws.Int32(int32(config.MaxSize.ValueInt64()))
+		}
+
+		_, err = conn.UpdateAutoScalingGroup(ctx, updateInput)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Failed to Update Auto Scaling Group",
+				fmt.Sprintf("Could not update Auto Scaling group %s: %s", asgName, err),
+			)
+			return
+		}
+	}
+
+	// Set desired capacity
+	setCapacityInput := &autoscaling.SetDesiredCapacityInput{
+		AutoScalingGroupName: aws.String(asgName),
+		DesiredCapacity:      aws.Int32(int32(desiredCapacity)),
+		HonorCooldown:        aws.Bool(false),
+	}
+
+	_, err = conn.SetDesiredCapacity(ctx, setCapacityInput)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to Set Desired Capacity",
+			fmt.Sprintf("Could not set desired capacity for Auto Scaling group %s: %s", asgName, err),
+		)
+		return
+	}
+
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: fmt.Sprintf("Waiting for Auto Scaling group %s to reach desired capacity %d...", asgName, desiredCapacity),
+	})
+
+	// Wait for desired capacity to be reached
+	_, err = actionwait.WaitForStatus(ctx, func(ctx context.Context) (actionwait.FetchResult[struct{}], error) {
+		asg, gerr := findAutoScalingGroupByName(ctx, conn, asgName)
+		if gerr != nil {
+			return actionwait.FetchResult[struct{}]{}, fmt.Errorf("describing Auto Scaling group: %w", gerr)
+		}
+
+		// Count instances in service
+		inServiceCount := 0
+		for _, instance := range asg.Instances {
+			if instance.LifecycleState == awstypes.LifecycleStateInService {
+				inServiceCount++
+			}
+		}
+
+		if int64(inServiceCount) == desiredCapacity {
+			return actionwait.FetchResult[struct{}]{Status: "READY"}, nil
+		}
+		return actionwait.FetchResult[struct{}]{Status: "SCALING"}, nil
+	}, actionwait.Options[struct{}]{
+		Timeout:          timeout,
+		Interval:         actionwait.FixedInterval(15 * time.Second),
+		ProgressInterval: 30 * time.Second,
+		SuccessStates:    []actionwait.Status{"READY"},
+		TransitionalStates: []actionwait.Status{"SCALING"},
+		ProgressSink: func(fr actionwait.FetchResult[any], meta actionwait.ProgressMeta) {
+			resp.SendProgress(action.InvokeProgressEvent{
+				Message: fmt.Sprintf("Auto Scaling group %s is scaling to desired capacity %d...", asgName, desiredCapacity),
+			})
+		},
+	})
+
+	if err != nil {
+		var timeoutErr *actionwait.TimeoutError
+		if errors.As(err, &timeoutErr) {
+			resp.Diagnostics.AddError(
+				"Timeout Waiting for Desired Capacity",
+				fmt.Sprintf("Auto Scaling group %s did not reach desired capacity %d within %s", asgName, desiredCapacity, timeout),
+			)
+		} else {
+			resp.Diagnostics.AddError(
+				"Error Waiting for Desired Capacity",
+				fmt.Sprintf("Error while waiting for Auto Scaling group %s: %s", asgName, err),
+			)
+		}
+		return
+	}
+
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: fmt.Sprintf("Auto Scaling group %s successfully reached desired capacity %d", asgName, desiredCapacity),
+	})
+
+	tflog.Info(ctx, "Auto Scaling set desired capacity action completed successfully", map[string]any{
+		"autoscaling_group_name": asgName,
+		"desired_capacity":       desiredCapacity,
+	})
+}
+
+func findAutoScalingGroupByName(ctx context.Context, conn *autoscaling.Client, name string) (*awstypes.AutoScalingGroup, error) {
+	input := &autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []string{name},
+	}
+
+	output, err := conn.DescribeAutoScalingGroups(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output.AutoScalingGroups) == 0 {
+		return nil, fmt.Errorf("Auto Scaling group %s not found", name)
+	}
+
+	return &output.AutoScalingGroups[0], nil
+}

--- a/internal/service/autoscaling/autoscaling_set_desired_capacity_action_test.go
+++ b/internal/service/autoscaling/autoscaling_set_desired_capacity_action_test.go
@@ -1,0 +1,213 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package autoscaling_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccAutoScalingSetDesiredCapacityAction_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.AutoScaling)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AutoScalingServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		CheckDestroy: acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSetDesiredCapacityActionConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSetDesiredCapacityAction(ctx, rName, 2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAutoScalingSetDesiredCapacityAction_withMinMax(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.AutoScaling)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AutoScalingServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		CheckDestroy: acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSetDesiredCapacityActionConfig_withMinMax(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSetDesiredCapacityAction(ctx, rName, 3),
+					testAccCheckAutoScalingGroupMinMax(ctx, rName, 1, 5),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSetDesiredCapacityAction(ctx context.Context, asgName string, expectedCapacity int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AutoScalingClient(ctx)
+
+		input := &autoscaling.DescribeAutoScalingGroupsInput{
+			AutoScalingGroupNames: []string{asgName},
+		}
+
+		output, err := conn.DescribeAutoScalingGroups(ctx, input)
+		if err != nil {
+			return fmt.Errorf("failed to describe Auto Scaling group %s: %w", asgName, err)
+		}
+
+		if len(output.AutoScalingGroups) == 0 {
+			return fmt.Errorf("Auto Scaling group %s not found", asgName)
+		}
+
+		asg := output.AutoScalingGroups[0]
+		actualCapacity := int(*asg.DesiredCapacity)
+
+		if actualCapacity != expectedCapacity {
+			return fmt.Errorf("expected desired capacity %d, got %d", expectedCapacity, actualCapacity)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAutoScalingGroupMinMax(ctx context.Context, asgName string, expectedMin, expectedMax int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AutoScalingClient(ctx)
+
+		input := &autoscaling.DescribeAutoScalingGroupsInput{
+			AutoScalingGroupNames: []string{asgName},
+		}
+
+		output, err := conn.DescribeAutoScalingGroups(ctx, input)
+		if err != nil {
+			return fmt.Errorf("failed to describe Auto Scaling group %s: %w", asgName, err)
+		}
+
+		if len(output.AutoScalingGroups) == 0 {
+			return fmt.Errorf("Auto Scaling group %s not found", asgName)
+		}
+
+		asg := output.AutoScalingGroups[0]
+		actualMin := int(*asg.MinSize)
+		actualMax := int(*asg.MaxSize)
+
+		if actualMin != expectedMin {
+			return fmt.Errorf("expected min size %d, got %d", expectedMin, actualMin)
+		}
+
+		if actualMax != expectedMax {
+			return fmt.Errorf("expected max size %d, got %d", expectedMax, actualMax)
+		}
+
+		return nil
+	}
+}
+
+func testAccSetDesiredCapacityActionConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSetDesiredCapacityActionConfig_base(rName),
+		`
+action "aws_autoscaling_set_desired_capacity" "test" {
+  config {
+    autoscaling_group_name = aws_autoscaling_group.test.name
+    desired_capacity       = 2
+  }
+}
+
+resource "terraform_data" "trigger" {
+  input = "trigger"
+  lifecycle {
+    action_trigger {
+      events  = [before_create, before_update]
+      actions = [action.aws_autoscaling_set_desired_capacity.test]
+    }
+  }
+}
+`)
+}
+
+func testAccSetDesiredCapacityActionConfig_withMinMax(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSetDesiredCapacityActionConfig_base(rName),
+		`
+action "aws_autoscaling_set_desired_capacity" "test" {
+  config {
+    autoscaling_group_name = aws_autoscaling_group.test.name
+    desired_capacity       = 3
+    min_size              = 1
+    max_size              = 5
+  }
+}
+
+resource "terraform_data" "trigger" {
+  input = "trigger"
+  lifecycle {
+    action_trigger {
+      events  = [before_create, before_update]
+      actions = [action.aws_autoscaling_set_desired_capacity.test]
+    }
+  }
+}
+`)
+}
+
+func testAccSetDesiredCapacityActionConfig_base(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name_prefix   = %[1]q
+  image_id      = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type = "t3.micro"
+}
+
+resource "aws_autoscaling_group" "test" {
+  name                = %[1]q
+  availability_zones  = [data.aws_availability_zones.available.names[0]]
+  min_size            = 0
+  max_size            = 3
+  desired_capacity    = 1
+
+  launch_template {
+    id      = aws_launch_template.test.id
+    version = "$Latest"
+  }
+
+  tag {
+    key                 = "Name"
+    value               = %[1]q
+    propagate_at_launch = true
+  }
+}
+`, rName))
+}

--- a/internal/service/autoscaling/service_package.go
+++ b/internal/service/autoscaling/service_package.go
@@ -1,0 +1,20 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package autoscaling
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/types"
+)
+
+func (p *servicePackage) Actions(ctx context.Context) []*types.ServicePackageAction {
+	return []*types.ServicePackageAction{
+		{
+			Factory:  newSetDesiredCapacityAction,
+			TypeName: "aws_autoscaling_set_desired_capacity",
+			Name:     "Set Desired Capacity",
+		},
+	}
+}


### PR DESCRIPTION
- Implements aws_autoscaling_set_desired_capacity action
- Supports updating desired capacity, min_size, and max_size
- Includes capacity validation and timeout configuration
- Waits for Auto Scaling group to reach desired capacity

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
