### PR TITLE
Add aws_ssm_send_command action

### DIFF
--- a/internal/service/ssm/service_package_gen.go
+++ b/internal/service/ssm/service_package_gen.go
@@ -17,6 +17,16 @@ import (
 
 type servicePackage struct{}
 
+func (p *servicePackage) Actions(ctx context.Context) []*inttypes.ServicePackageAction {
+	return []*inttypes.ServicePackageAction{
+		{
+			Factory:  newSendCommandAction,
+			TypeName: "aws_ssm_send_command",
+			Name:     "Send Command",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+	}
+}
 func (p *servicePackage) EphemeralResources(ctx context.Context) []*inttypes.ServicePackageEphemeralResource {
 	return []*inttypes.ServicePackageEphemeralResource{
 		{

--- a/internal/service/ssm/ssm_send_command_action.go
+++ b/internal/service/ssm/ssm_send_command_action.go
@@ -1,0 +1,330 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ssm
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/action/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	fwtypes "github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// sendCommandPollInterval defines polling cadence for send command action.
+const sendCommandPollInterval = 5 * time.Second
+
+// @Action(aws_ssm_send_command, name="Send Command")
+func newSendCommandAction(_ context.Context) (action.ActionWithConfigure, error) {
+	return &sendCommandAction{}, nil
+}
+
+var (
+	_ action.Action = (*sendCommandAction)(nil)
+)
+
+type sendCommandAction struct {
+	framework.ActionWithModel[sendCommandModel]
+}
+
+type sendCommandModel struct {
+	framework.WithRegionModel
+	InstanceIds    fwtypes.List   `tfsdk:"instance_ids"`
+	DocumentName   fwtypes.String `tfsdk:"document_name"`
+	Parameters     fwtypes.Map    `tfsdk:"parameters"`
+	OutputS3Bucket fwtypes.String `tfsdk:"output_s3_bucket"`
+	Timeout        fwtypes.Int64  `tfsdk:"timeout"`
+}
+
+func (a *sendCommandAction) Schema(ctx context.Context, req action.SchemaRequest, resp *action.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Executes commands on EC2 instances using AWS Systems Manager Run Command.",
+		Attributes: map[string]schema.Attribute{
+			"instance_ids": schema.ListAttribute{
+				Description: "List of EC2 instance IDs to execute the command on",
+				Required:    true,
+				ElementType: fwtypes.StringType,
+			},
+			"document_name": schema.StringAttribute{
+				Description: "Name of the SSM document to execute",
+				Required:    true,
+			},
+			"parameters": schema.MapAttribute{
+				Description: "Parameters to pass to the command document",
+				Optional:    true,
+				ElementType: fwtypes.ListType{ElemType: fwtypes.StringType},
+			},
+			"output_s3_bucket": schema.StringAttribute{
+				Description: "S3 bucket name to store command output",
+				Optional:    true,
+			},
+			names.AttrTimeout: schema.Int64Attribute{
+				Description: "Timeout in seconds to wait for command execution (default: 1800)",
+				Optional:    true,
+				Validators: []validator.Int64{
+					int64validator.Between(60, 7200),
+				},
+			},
+		},
+	}
+}
+
+func (a *sendCommandAction) Invoke(ctx context.Context, req action.InvokeRequest, resp *action.InvokeResponse) {
+	var config sendCommandModel
+
+	// Parse configuration
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get AWS client
+	conn := a.Meta().SSMClient(ctx)
+
+	var instanceIds []string
+	resp.Diagnostics.Append(config.InstanceIds.ElementsAs(ctx, &instanceIds, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	documentName := config.DocumentName.ValueString()
+
+	// Set default timeout if not provided
+	timeout := 1800 * time.Second
+	if !config.Timeout.IsNull() {
+		timeout = time.Duration(config.Timeout.ValueInt64()) * time.Second
+	}
+
+	tflog.Info(ctx, "Starting SSM send command action", map[string]any{
+		"instance_ids":    instanceIds,
+		"document_name":   documentName,
+		names.AttrTimeout: timeout.String(),
+	})
+
+	// Validate instances exist
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: "Validating instances...",
+	})
+
+	err := a.validateInstances(ctx, conn, instanceIds)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Instance Validation Failed",
+			fmt.Sprintf("Could not validate instances: %s", err),
+		)
+		return
+	}
+
+	// Validate document exists
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: fmt.Sprintf("Validating document '%s'...", documentName),
+	})
+
+	err = a.validateDocument(ctx, conn, documentName)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Document Validation Failed",
+			fmt.Sprintf("Could not validate document: %s", err),
+		)
+		return
+	}
+
+	// Send initial progress update
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: fmt.Sprintf("Sending command '%s' to %d instance(s)...", documentName, len(instanceIds)),
+	})
+
+	// Prepare SendCommand input
+	input := &ssm.SendCommandInput{
+		InstanceIds:  instanceIds,
+		DocumentName: aws.String(documentName),
+	}
+
+	// Add parameters if provided
+	if !config.Parameters.IsNull() {
+		parameters := make(map[string][]string)
+		diags := config.Parameters.ElementsAs(ctx, &parameters, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		input.Parameters = parameters
+	}
+
+	// Add S3 bucket if provided
+	if !config.OutputS3Bucket.IsNull() {
+		input.OutputS3BucketName = aws.String(config.OutputS3Bucket.ValueString())
+	}
+
+	// Send command
+	output, err := conn.SendCommand(ctx, input)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to Send Command",
+			fmt.Sprintf("Could not send SSM command: %s", err),
+		)
+		return
+	}
+
+	commandId := aws.ToString(output.Command.CommandId)
+	tflog.Debug(ctx, "Command sent", map[string]any{
+		"command_id": commandId,
+	})
+
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: fmt.Sprintf("Command sent (ID: %s), waiting for execution to complete...", commandId),
+	})
+
+	// Wait for command to complete on all instances
+	err = a.waitForCommandCompletion(ctx, conn, commandId, instanceIds, timeout, resp)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Command Execution Failed",
+			fmt.Sprintf("Error during command execution: %s", err),
+		)
+		return
+	}
+
+	// Final success message
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: fmt.Sprintf("Command '%s' completed successfully on all instances", documentName),
+	})
+
+	tflog.Info(ctx, "SSM send command action completed successfully", map[string]any{
+		"command_id": commandId,
+	})
+}
+
+// waitForCommandCompletion waits for the command to complete on all instances
+func (a *sendCommandAction) waitForCommandCompletion(ctx context.Context, conn *ssm.Client, commandId string, instanceIds []string, timeout time.Duration, resp *action.InvokeResponse) error {
+	startTime := time.Now()
+
+	for {
+		if time.Since(startTime) > timeout {
+			return fmt.Errorf("timeout waiting for command to complete after %s", timeout)
+		}
+
+		allComplete, err := a.areAllInvocationsComplete(ctx, conn, commandId, instanceIds)
+		if err != nil {
+			return err
+		}
+
+		if allComplete {
+			// Check for failures
+			for _, instanceId := range instanceIds {
+				invocation, err := a.getCommandInvocationStatus(ctx, conn, commandId, instanceId)
+				if err != nil {
+					return err
+				}
+
+				if invocation.Status != types.CommandInvocationStatusSuccess {
+					return fmt.Errorf("command failed on instance %s with status '%s' (exit code: %d): %s",
+						instanceId,
+						invocation.Status,
+						invocation.ResponseCode,
+						aws.ToString(invocation.StandardErrorContent))
+				}
+			}
+			return nil
+		}
+
+		// Send progress update
+		resp.SendProgress(action.InvokeProgressEvent{
+			Message: fmt.Sprintf("Command is still executing on instances, elapsed time: %s...", time.Since(startTime).Round(time.Second)),
+		})
+
+		time.Sleep(sendCommandPollInterval)
+	}
+}
+
+// getCommandInvocationStatus retrieves the status of a command invocation for a specific instance
+func (a *sendCommandAction) getCommandInvocationStatus(ctx context.Context, conn *ssm.Client, commandId, instanceId string) (*ssm.GetCommandInvocationOutput, error) {
+	input := &ssm.GetCommandInvocationInput{
+		CommandId:  aws.String(commandId),
+		InstanceId: aws.String(instanceId),
+	}
+
+	output, err := conn.GetCommandInvocation(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("getting command invocation for instance %s: %w", instanceId, err)
+	}
+
+	return output, nil
+}
+
+// areAllInvocationsComplete checks if all command invocations have completed
+func (a *sendCommandAction) areAllInvocationsComplete(ctx context.Context, conn *ssm.Client, commandId string, instanceIds []string) (bool, error) {
+	for _, instanceId := range instanceIds {
+		invocation, err := a.getCommandInvocationStatus(ctx, conn, commandId, instanceId)
+		if err != nil {
+			return false, err
+		}
+
+		// Check if still in progress
+		if invocation.Status == types.CommandInvocationStatusInProgress ||
+			invocation.Status == types.CommandInvocationStatusPending {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// validateInstances checks if all specified instances exist and are managed by SSM
+func (a *sendCommandAction) validateInstances(ctx context.Context, conn *ssm.Client, instanceIds []string) error {
+	input := &ssm.DescribeInstanceInformationInput{
+		Filters: []types.InstanceInformationStringFilter{
+			{
+				Key:    aws.String("InstanceIds"),
+				Values: instanceIds,
+			},
+		},
+	}
+
+	output, err := conn.DescribeInstanceInformation(ctx, input)
+	if err != nil {
+		return fmt.Errorf("describing instances: %w", err)
+	}
+
+	if len(output.InstanceInformationList) != len(instanceIds) {
+		foundIds := make(map[string]bool)
+		for _, info := range output.InstanceInformationList {
+			foundIds[aws.ToString(info.InstanceId)] = true
+		}
+
+		var missingIds []string
+		for _, id := range instanceIds {
+			if !foundIds[id] {
+				missingIds = append(missingIds, id)
+			}
+		}
+
+		return fmt.Errorf("instances not found or not managed by SSM: %v", missingIds)
+	}
+
+	return nil
+}
+
+// validateDocument checks if the specified document exists
+func (a *sendCommandAction) validateDocument(ctx context.Context, conn *ssm.Client, documentName string) error {
+	input := &ssm.DescribeDocumentInput{
+		Name: aws.String(documentName),
+	}
+
+	_, err := conn.DescribeDocument(ctx, input)
+	if err != nil {
+		return fmt.Errorf("document '%s' does not exist: %w", documentName, err)
+	}
+
+	return nil
+}

--- a/internal/service/ssm/ssm_send_command_action_test.go
+++ b/internal/service/ssm/ssm_send_command_action_test.go
@@ -1,0 +1,267 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ssm_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSSMSendCommandAction_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SSM)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSendCommandActionConfig_basic(rName),
+			},
+		},
+	})
+}
+
+func TestAccSSMSendCommandAction_withParameters(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SSM)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSendCommandActionConfig_withParameters(rName),
+			},
+		},
+	})
+}
+
+func TestAccSSMSendCommandAction_trigger(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SSM)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSendCommandActionConfig_trigger(rName),
+			},
+		},
+	})
+}
+
+func testAccSendCommandActionConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSendCommandActionConfig_base(rName),
+		`
+action "aws_ssm_send_command" "test" {
+  config {
+    instance_ids  = [aws_instance.test.id]
+    document_name = "AWS-RunShellScript"
+    parameters = {
+      commands = ["echo 'Hello World'"]
+    }
+  }
+}
+`)
+}
+
+func testAccSendCommandActionConfig_withParameters(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSendCommandActionConfig_base(rName),
+		`
+action "aws_ssm_send_command" "test" {
+  config {
+    instance_ids  = [aws_instance.test.id]
+    document_name = "AWS-RunShellScript"
+    parameters = {
+      commands = [
+        "echo 'Test command'",
+        "uptime"
+      ]
+    }
+    timeout = 600
+  }
+}
+`)
+}
+
+func testAccSendCommandActionConfig_trigger(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSendCommandActionConfig_base(rName),
+		`
+action "aws_ssm_send_command" "test" {
+  config {
+    instance_ids  = [aws_instance.test.id]
+    document_name = "AWS-RunShellScript"
+    parameters = {
+      commands = ["echo 'Triggered command'"]
+    }
+  }
+}
+
+resource "terraform_data" "trigger" {
+  input = "trigger"
+  lifecycle {
+    action_trigger {
+      events  = [after_create]
+      actions = [action.aws_ssm_send_command.test]
+    }
+  }
+}
+`)
+}
+
+func testAccSendCommandActionConfig_base(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		acctest.ConfigAvailableAZsNoOptIn(),
+		acctest.AvailableEC2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t3.micro", "t2.micro"),
+		fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.name
+}
+
+resource "aws_instance" "test" {
+  ami                  = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type        = data.aws_ec2_instance_type_offering.available.instance_type
+  iam_instance_profile = aws_iam_instance_profile.test.name
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
+// providerWithActions gets the AWS provider as a ProviderServerWithActions
+func providerWithActions(ctx context.Context, t *testing.T) tfprotov5.ProviderServerWithActions { //nolint:staticcheck // SA1019: Working in alpha situation
+	t.Helper()
+
+	factories := acctest.ProtoV5ProviderFactories
+	providerFactory, exists := factories["aws"]
+	if !exists {
+		t.Fatal("AWS provider factory not found in ProtoV5ProviderFactories")
+	}
+
+	providerServer, err := providerFactory()
+	if err != nil {
+		t.Fatalf("Failed to create provider server: %v", err)
+	}
+
+	providerWithActions, ok := providerServer.(tfprotov5.ProviderServerWithActions) //nolint:staticcheck // SA1019: Working in alpha situation
+	if !ok {
+		t.Fatal("Provider does not implement ProviderServerWithActions")
+	}
+
+	schemaResp, err := providerWithActions.GetProviderSchema(ctx, &tfprotov5.GetProviderSchemaRequest{})
+	if err != nil {
+		t.Fatalf("Failed to get provider schema: %v", err)
+	}
+
+	if len(schemaResp.ActionSchemas) == 0 {
+		t.Fatal("Expected to find action schemas but didn't find any!")
+	}
+
+	providerConfigValue, err := buildProviderConfiguration(t, schemaResp.Provider)
+	if err != nil {
+		t.Fatalf("Failed to build provider configuration: %v", err)
+	}
+
+	configureResp, err := providerWithActions.ConfigureProvider(ctx, &tfprotov5.ConfigureProviderRequest{
+		TerraformVersion: "1.0.0",
+		Config:           providerConfigValue,
+	})
+	if err != nil {
+		t.Fatalf("Failed to configure provider: %v", err)
+	}
+
+	if len(configureResp.Diagnostics) > 0 {
+		var diagMessages []string
+		for _, diag := range configureResp.Diagnostics {
+			diagMessages = append(diagMessages, fmt.Sprintf("Severity: %s, Summary: %s, Detail: %s", diag.Severity, diag.Summary, diag.Detail))
+		}
+		t.Fatalf("Provider configuration failed: %v", diagMessages)
+	}
+
+	return providerWithActions
+}
+
+// buildProviderConfiguration creates a minimal provider configuration from the schema
+func buildProviderConfiguration(t *testing.T, providerSchema *tfprotov5.Schema) (*tfprotov5.DynamicValue, error) {
+	t.Helper()
+
+	providerType := providerSchema.Block.ValueType()
+	configMap := make(map[string]tftypes.Value)
+
+	if objType, ok := providerType.(tftypes.Object); ok {
+		for attrName, attrType := range objType.AttributeTypes {
+			configMap[attrName] = tftypes.NewValue(attrType, nil)
+		}
+	}
+
+	configValue, err := tfprotov5.NewDynamicValue(
+		providerType,
+		tftypes.NewValue(providerType, configMap),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create config: %w", err)
+	}
+
+	return &configValue, nil
+}

--- a/website/docs/actions/ssm_send_command.html.markdown
+++ b/website/docs/actions/ssm_send_command.html.markdown
@@ -1,0 +1,173 @@
+---
+subcategory: "SSM (Systems Manager)"
+layout: "aws"
+page_title: "AWS: aws_ssm_send_command"
+description: |-
+  Executes commands on EC2 instances using AWS Systems Manager Run Command.
+---
+
+# Action: aws_ssm_send_command
+
+~> **Note:** `aws_ssm_send_command` is in alpha. Its interface and behavior may change as the feature evolves, and breaking changes are possible. It is offered as a technical preview without compatibility guarantees until Terraform 1.14 is generally available.
+
+!> **Warning:** This action may cause unintended consequences. When triggered, the `aws_ssm_send_command` action executes commands on EC2 instances, which can modify system state, install software, or perform other operations. Use caution—this preview action should be limited to development environments or carefully controlled production scenarios.
+
+Executes commands on EC2 instances using AWS Systems Manager Run Command. This action sends a command to one or more instances and waits for execution to complete.
+
+For information about AWS Systems Manager Run Command, see the [AWS Systems Manager User Guide](https://docs.aws.amazon.com/systems-manager/latest/userguide/execute-remote-commands.html). For specific information about the SendCommand API, see the [SendCommand](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_SendCommand.html) page in the AWS Systems Manager API Reference.
+
+~> **Note:** This action requires that target instances are managed by AWS Systems Manager and have the SSM Agent installed and running.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_instance" "example" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t3.micro"
+  iam_instance_profile = aws_iam_instance_profile.ssm.name
+
+  tags = {
+    Name = "example-instance"
+  }
+}
+
+action "aws_ssm_send_command" "example" {
+  config {
+    instance_ids  = [aws_instance.example.id]
+    document_name = "AWS-RunShellScript"
+    parameters = {
+      commands = ["echo 'Hello World'", "uptime"]
+    }
+  }
+}
+```
+
+### With Parameters
+
+```terraform
+action "aws_ssm_send_command" "update_packages" {
+  config {
+    instance_ids  = [aws_instance.web.id]
+    document_name = "AWS-RunShellScript"
+    parameters = {
+      commands = [
+        "sudo yum update -y",
+        "sudo systemctl restart httpd"
+      ]
+    }
+    timeout = 600
+  }
+}
+```
+
+### Multiple Instances with S3 Output
+
+```terraform
+action "aws_ssm_send_command" "deploy" {
+  config {
+    instance_ids = [
+      aws_instance.web1.id,
+      aws_instance.web2.id,
+      aws_instance.web3.id
+    ]
+    document_name      = "AWS-RunShellScript"
+    output_s3_bucket   = aws_s3_bucket.logs.id
+    parameters = {
+      commands = [
+        "cd /var/www/html",
+        "git pull origin main",
+        "sudo systemctl reload nginx"
+      ]
+    }
+    timeout = 900
+  }
+}
+```
+
+### Deployment Trigger
+
+```terraform
+resource "aws_instance" "app_server" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t3.micro"
+  iam_instance_profile = aws_iam_instance_profile.ssm.name
+
+  tags = {
+    Name = "app-server"
+  }
+}
+
+action "aws_ssm_send_command" "deploy_app" {
+  config {
+    instance_ids  = [aws_instance.app_server.id]
+    document_name = "AWS-RunShellScript"
+    parameters = {
+      commands = [
+        "aws s3 cp s3://my-app-bucket/app.zip /tmp/",
+        "unzip -o /tmp/app.zip -d /opt/app",
+        "sudo systemctl restart app"
+      ]
+    }
+    timeout = 1200
+  }
+}
+
+resource "terraform_data" "deployment_trigger" {
+  input = var.app_version
+
+  lifecycle {
+    action_trigger {
+      events  = [after_create, after_update]
+      actions = [action.aws_ssm_send_command.deploy_app]
+    }
+  }
+
+  depends_on = [aws_instance.app_server]
+}
+```
+
+## Argument Reference
+
+This action supports the following arguments:
+
+* `instance_ids` - (Required) List of EC2 instance IDs to execute the command on. All instances must be managed by AWS Systems Manager.
+* `document_name` - (Required) Name of the SSM document to execute. Can be an AWS-provided document (e.g., `AWS-RunShellScript`, `AWS-RunPowerShellScript`) or a custom document.
+* `parameters` - (Optional) Parameters to pass to the command document. The structure depends on the document being executed. For `AWS-RunShellScript`, use `commands` as a list of shell commands.
+* `output_s3_bucket` - (Optional) S3 bucket name to store command output. The SSM service must have permission to write to this bucket.
+* `region` - (Optional) Region where this action should be [run](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `timeout` - (Optional) Timeout in seconds to wait for command execution to complete. Must be between 60 and 7200 seconds. Default: `1800`.
+
+## Behavior
+
+The action performs the following steps:
+
+1. Validates that all specified instances exist and are managed by SSM
+2. Validates that the specified document exists
+3. Sends the command to all instances
+4. Polls command status every 5 seconds until all invocations complete
+5. Checks exit codes and reports any failures
+
+If any instance fails to execute the command successfully, the action fails and reports the error details including exit codes and stderr output.
+
+## Prerequisites
+
+To use this action, ensure:
+
+* Target EC2 instances have the SSM Agent installed and running
+* Instances have an IAM instance profile with the `AmazonSSMManagedInstanceCore` policy
+* Instances are registered with Systems Manager (visible in the SSM console)
+* If using `output_s3_bucket`, the SSM service has permission to write to the bucket
+
+## Common Documents
+
+AWS provides several built-in documents for common tasks:
+
+* `AWS-RunShellScript` - Run shell commands on Linux instances
+* `AWS-RunPowerShellScript` - Run PowerShell commands on Windows instances
+* `AWS-ConfigureAWSPackage` - Install or update AWS packages
+* `AWS-UpdateSSMAgent` - Update the SSM Agent
+* `AWS-RunPatchBaseline` - Apply patch baselines
+
+For a complete list, see the [AWS Systems Manager documents reference](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-ssm-docs.html).


### PR DESCRIPTION
- Implement SSM Send Command action for executing commands on EC2 instances
- Add comprehensive acceptance tests
- Include user documentation with examples
- Support parameters, timeout, and progress reporting

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
