### PR TITLE
docs: remove unsupported `search_type` for resource `aws_bedrockagentcore_gateway`

### DIFF
--- a/website/docs/r/bedrockagentcore_gateway.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway.html.markdown
@@ -119,7 +119,7 @@ The `protocol_configuration` block supports the following:
 The `mcp` block supports the following:
 
 * `instructions` - (Optional) Instructions for the MCP protocol configuration.
-* `search_type` - (Optional) Search type for MCP. Valid values: `SEMANTIC`, `HYBRID`.
+* `search_type` - (Optional) Search type for MCP. Valid values: `SEMANTIC`.
 * `supported_versions` - (Optional) Set of supported MCP protocol versions.
 
 ## Attribute Reference


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None.

### Description

Remove the currently unsupported [`search_type`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagentcore_gateway#search_type-1)  `HYBRIB` from the [`aws_bedrockagentcore_gateway` resource documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagentcore_gateway).

### Relations

Closes #44966 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

-  [`search_type` in source dode](https://github.com/hashicorp/terraform-provider-aws/blob/c59ab029934b91a7466c2dedf3e9f2e2b0de9a67/internal/service/bedrockagentcore/gateway.go#L168) uses internally an enumeration from the AWS SDK Go V2. 
- [Referenced AWS SDK Go V2 enum](https://github.com/aws/aws-sdk-go-v2/blob/f4b68139280ee1873399b27d581ba128834c71c4/service/bedrockagentcorecontrol/types/enums.go#L542) contains at present only the value SEMANTIC.

### Output from Acceptance Testing

Not applicable. Only documentation is updated.