### PR TITLE
Add data source 'aws_vpc_endpoints'

### DIFF
--- a/.changelog/44997.txt
+++ b/.changelog/44997.txt
@@ -1,0 +1,4 @@
+```release-note:new-data-source
+aws_vpc_endpoints
+```
+

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -753,6 +753,12 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*inttypes.Service
 			Region:   unique.Make(inttypes.ResourceRegionDisabled()),
 		},
 		{
+			Factory:  dataSourceVPCEndpoints,
+			TypeName: "aws_vpc_endpoints",
+			Name:     "Endpoints",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+		{
 			Factory:  dataSourceIPAMPool,
 			TypeName: "aws_vpc_ipam_pool",
 			Name:     "IPAM Pool",

--- a/internal/service/ec2/vpc_endpoints_data_source.go
+++ b/internal/service/ec2/vpc_endpoints_data_source.go
@@ -1,0 +1,295 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_vpc_endpoints", name="Endpoints")
+func dataSourceVPCEndpoints() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceVPCEndpointsRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			names.AttrFilter: customFiltersSchema(),
+			names.AttrIDs: {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			names.AttrIPAddressType: {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			names.AttrServiceName: {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"service_region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			names.AttrState: {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			names.AttrTags: tftags.TagsSchemaComputed(),
+			"vpc_endpoint_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"vpc_endpoint_type": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: enum.Validate[awstypes.VpcEndpointType](),
+			},
+			names.AttrVPCID: {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vpc_endpoints": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						names.AttrARN: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cidr_blocks": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"dns_entry": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									names.AttrDNSName: {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									names.AttrHostedZoneID: {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"dns_options": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"dns_record_ip_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"private_dns_only_for_inbound_resolver_endpoint": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+								},
+							},
+						},
+						names.AttrID: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrIPAddressType: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"network_interface_ids": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						names.AttrOwnerID: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrPolicy: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"prefix_list_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"private_dns_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"requester_managed": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"route_table_ids": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						names.AttrSecurityGroupIDs: {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						names.AttrServiceName: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrState: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrSubnetIDs: {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						names.AttrTags: tftags.TagsSchemaComputed(),
+						"vpc_endpoint_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrVPCID: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceVPCEndpointsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).EC2Client(ctx)
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)
+
+	input := &ec2.DescribeVpcEndpointsInput{}
+
+	if v, ok := d.GetOk("vpc_endpoint_ids"); ok && v.(*schema.Set).Len() > 0 {
+		input.VpcEndpointIds = flex.ExpandStringValueSet(v.(*schema.Set))
+	}
+
+	input.Filters = append(input.Filters, newAttributeFilterList(
+		map[string]string{
+			"ip-address-type":    d.Get(names.AttrIPAddressType).(string),
+			"service-name":       d.Get(names.AttrServiceName).(string),
+			"service-region":     d.Get("service_region").(string),
+			"vpc-endpoint-state": d.Get(names.AttrState).(string),
+			"vpc-endpoint-type":  d.Get("vpc_endpoint_type").(string),
+			"vpc-id":             d.Get(names.AttrVPCID).(string),
+		},
+	)...)
+
+	input.Filters = append(input.Filters, newTagFilterList(
+		svcTags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
+	)...)
+	input.Filters = append(input.Filters, newCustomFilterList(
+		d.Get(names.AttrFilter).(*schema.Set),
+	)...)
+	if len(input.Filters) == 0 {
+		// Don't send an empty filters list; the EC2 API won't accept it.
+		input.Filters = nil
+	}
+
+	vpces, err := findVPCEndpoints(ctx, conn, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading EC2 VPC Endpoints: %s", err)
+	}
+
+	var vpcEndpointIDs []string
+	var vpcEndpoints []map[string]any
+
+	for _, vpce := range vpces {
+		vpcEndpointID := aws.ToString(vpce.VpcEndpointId)
+		vpcEndpointIDs = append(vpcEndpointIDs, vpcEndpointID)
+
+		ownerID := aws.ToString(vpce.OwnerId)
+		vpcEndpointData := map[string]any{
+			names.AttrARN:              vpcEndpointARN(ctx, meta.(*conns.AWSClient), ownerID, vpcEndpointID),
+			"dns_entry":                flattenDNSEntries(vpce.DnsEntries),
+			names.AttrID:               vpcEndpointID,
+			names.AttrIPAddressType:    vpce.IpAddressType,
+			"network_interface_ids":    vpce.NetworkInterfaceIds,
+			names.AttrOwnerID:          ownerID,
+			"private_dns_enabled":      vpce.PrivateDnsEnabled,
+			"requester_managed":        vpce.RequesterManaged,
+			"route_table_ids":          vpce.RouteTableIds,
+			names.AttrSecurityGroupIDs: flattenSecurityGroupIdentifiers(vpce.Groups),
+			names.AttrServiceName:      aws.ToString(vpce.ServiceName),
+			names.AttrState:            vpce.State,
+			names.AttrSubnetIDs:        vpce.SubnetIds,
+			names.AttrVPCID:            aws.ToString(vpce.VpcId),
+		}
+
+		if vpce.DnsOptions != nil {
+			vpcEndpointData["dns_options"] = []any{flattenDNSOptions(vpce.DnsOptions)}
+		} else {
+			vpcEndpointData["dns_options"] = nil
+		}
+
+		// VPC endpoints don't have types in GovCloud, so set type to default if empty
+		if v := string(vpce.VpcEndpointType); v == "" {
+			vpcEndpointData["vpc_endpoint_type"] = awstypes.VpcEndpointTypeGateway
+		} else {
+			vpcEndpointData["vpc_endpoint_type"] = v
+		}
+
+		serviceName := aws.ToString(vpce.ServiceName)
+		if pl, err := findPrefixListByName(ctx, conn, serviceName); err != nil {
+			if !retry.NotFound(err) {
+				return sdkdiag.AppendErrorf(diags, "reading EC2 Prefix List (%s): %s", serviceName, err)
+			}
+			vpcEndpointData["cidr_blocks"] = nil
+			vpcEndpointData["prefix_list_id"] = nil
+		} else {
+			vpcEndpointData["cidr_blocks"] = pl.Cidrs
+			vpcEndpointData["prefix_list_id"] = aws.ToString(pl.PrefixListId)
+		}
+
+		if policy, err := structure.NormalizeJsonString(aws.ToString(vpce.PolicyDocument)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "policy contains invalid JSON: %s", err)
+		} else {
+			vpcEndpointData[names.AttrPolicy] = policy
+		}
+
+		vpcEndpointData[names.AttrTags] = keyValueTags(ctx, vpce.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()
+
+		vpcEndpoints = append(vpcEndpoints, vpcEndpointData)
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region(ctx))
+	d.Set(names.AttrIDs, vpcEndpointIDs)
+	d.Set("vpc_endpoints", vpcEndpoints)
+
+	return diags
+}

--- a/internal/service/ec2/vpc_endpoints_data_source_test.go
+++ b/internal/service/ec2/vpc_endpoints_data_source_test.go
@@ -1,0 +1,242 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccVPCEndpointsDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	datasourceName := "data.aws_vpc_endpoints.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCEndpointsDataSourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(datasourceName, "ids.#", 0),
+					acctest.CheckResourceAttrGreaterThanValue(datasourceName, "vpc_endpoints.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVPCEndpointsDataSource_filter(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_vpc_endpoint.test"
+	datasourceName := "data.aws_vpc_endpoints.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCEndpointsDataSourceConfig_filter(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(datasourceName, "ids.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "vpc_endpoints.#", "1"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ids.0", resourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(datasourceName, "vpc_endpoints.0.id", resourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(datasourceName, "vpc_endpoints.0.arn", resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(datasourceName, "vpc_endpoints.0.service_name", resourceName, names.AttrServiceName),
+					resource.TestCheckResourceAttrPair(datasourceName, "vpc_endpoints.0.vpc_id", resourceName, names.AttrVPCID),
+					resource.TestCheckResourceAttrPair(datasourceName, "vpc_endpoints.0.state", resourceName, names.AttrState),
+					resource.TestCheckResourceAttrPair(datasourceName, "vpc_endpoints.0.vpc_endpoint_type", resourceName, "vpc_endpoint_type"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVPCEndpointsDataSource_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_vpc_endpoint.test"
+	datasourceName := "data.aws_vpc_endpoints.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCEndpointsDataSourceConfig_tags(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(datasourceName, "ids.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "vpc_endpoints.#", "1"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ids.0", resourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(datasourceName, "vpc_endpoints.0.id", resourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(datasourceName, "vpc_endpoints.0.tags.%", resourceName, acctest.CtTagsPercent),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVPCEndpointsDataSource_serviceName(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_vpc_endpoint.test"
+	datasourceName := "data.aws_vpc_endpoints.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCEndpointsDataSourceConfig_serviceName(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(datasourceName, "ids.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "vpc_endpoints.#", "1"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ids.0", resourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(datasourceName, "vpc_endpoints.0.id", resourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(datasourceName, "vpc_endpoints.0.service_name", resourceName, names.AttrServiceName),
+				),
+			},
+		},
+	})
+}
+
+func testAccVPCEndpointsDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_region" "current" {}
+
+resource "aws_vpc_endpoint" "test" {
+  vpc_id       = aws_vpc.test.id
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_vpc_endpoints" "test" {
+  depends_on = [aws_vpc_endpoint.test]
+}
+`, rName)
+}
+
+func testAccVPCEndpointsDataSourceConfig_filter(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_region" "current" {}
+
+resource "aws_vpc_endpoint" "test" {
+  vpc_id       = aws_vpc.test.id
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_vpc_endpoints" "test" {
+  vpc_id = aws_vpc.test.id
+
+  depends_on = [aws_vpc_endpoint.test]
+}
+`, rName)
+}
+
+func testAccVPCEndpointsDataSourceConfig_tags(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_region" "current" {}
+
+resource "aws_vpc_endpoint" "test" {
+  vpc_id       = aws_vpc.test.id
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+
+  tags = {
+    Name = %[1]q
+    TestTag = "test-value"
+  }
+}
+
+data "aws_vpc_endpoints" "test" {
+  tags = {
+    TestTag = "test-value"
+  }
+
+  depends_on = [aws_vpc_endpoint.test]
+}
+`, rName)
+}
+
+func testAccVPCEndpointsDataSourceConfig_serviceName(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_region" "current" {}
+
+resource "aws_vpc_endpoint" "test" {
+  vpc_id       = aws_vpc.test.id
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc_endpoint" "kms" {
+  vpc_id       = aws_vpc.test.id
+  service_name = "com.amazonaws.${data.aws_region.current.name}.kms"
+  vpc_endpoint_type = "Interface"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_vpc_endpoints" "test" {
+  vpc_id = aws_vpc.test.id
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+
+  depends_on = [aws_vpc_endpoint.test, aws_vpc_endpoint.kms]
+}
+`, rName)
+}

--- a/website/docs/d/vpc_endpoints.html.markdown
+++ b/website/docs/d/vpc_endpoints.html.markdown
@@ -1,0 +1,119 @@
+---
+subcategory: "VPC (Virtual Private Cloud)"
+layout: "aws"
+page_title: "AWS: aws_vpc_endpoints"
+description: |-
+  Provides information about VPC endpoints.
+---
+
+# Data Source: aws_vpc_endpoints
+
+Provides information about VPC endpoints.
+
+## Example Usage
+
+The following shows getting all VPC endpoints.
+
+```terraform
+data "aws_vpc_endpoints" "example" {}
+```
+
+The following example retrieves a list of all VPC endpoints with a custom tag of `Service` set to a value of `web-service`.
+
+```terraform
+data "aws_vpc_endpoints" "example" {
+  tags = {
+    Service = "web-service"
+  }
+}
+```
+
+The following example retrieves a list of all VPC endpoints in a specific VPC.
+
+```terraform
+data "aws_vpc_endpoints" "example" {
+  vpc_id = var.vpc_id
+}
+```
+
+The following example shows filtering by service name and state.
+
+```terraform
+data "aws_vpc_endpoints" "s3_endpoints" {
+  service_name = "com.amazonaws.us-west-2.s3"
+  state        = "available"
+}
+```
+
+The following example shows filtering by VPC endpoint type.
+
+```terraform
+data "aws_vpc_endpoints" "gateway_endpoints" {
+  vpc_endpoint_type = "Gateway"
+  vpc_id            = var.vpc_id
+}
+```
+
+## Argument Reference
+
+* `filter` - (Optional) Custom filter block as described below.
+* `ip_address_type` - (Optional) IP address type (`ipv4` or `ipv6`).
+* `service_name` - (Optional) Service name. For AWS services the service name is usually in the form `com.amazonaws.<region>.<service>` (e.g., `com.amazonaws.us-west-2.s3`).
+* `service_region` - (Optional) Region where the service is offered.
+* `state` - (Optional) State of the VPC endpoint. Valid values are `pendingAcceptance`, `pending`, `available`, `deleting`, `deleted`, `rejected`, `failed`.
+* `tags` - (Optional) Map of tags, each pair of which must exactly match a pair on the desired VPC endpoints.
+* `vpc_endpoint_ids` - (Optional) Set of VPC endpoint IDs to retrieve.
+* `vpc_endpoint_type` - (Optional) Type of VPC endpoint. Valid values are `Gateway`, `GatewayLoadBalancer`, `Interface`, `Resource`, `ServiceNetwork`.
+* `vpc_id` - (Optional) ID of the VPC in which the endpoint resides.
+
+More complex filters can be expressed using one or more `filter` sub-blocks, which take the following arguments:
+
+* `name` - (Required) Name of the field to filter by, as defined by [the underlying AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVpcEndpoints.html).
+* `values` - (Required) Set of values that are accepted for the given field. A VPC endpoint will be selected if any one of the given values matches.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `ids` - List of VPC endpoint IDs.
+* `vpc_endpoints` - List of VPC endpoints. Each VPC endpoint object contains the following attributes:
+    * `arn` - ARN of the VPC endpoint.
+    * `cidr_blocks` - List of CIDR blocks for the exposed AWS service. Applicable for endpoints of type Gateway.
+    * `dns_entry` - DNS entries for the VPC endpoint. [DNS entry blocks are documented below](#dns_entry-block).
+    * `dns_options` - DNS options for the VPC endpoint. [DNS options blocks are documented below](#dns_options-block).
+    * `id` - ID of the VPC endpoint.
+    * `ip_address_type` - IP address type for the VPC endpoint.
+    * `network_interface_ids` - List of network interface IDs associated with the VPC endpoint.
+    * `owner_id` - ID of the AWS account that owns the VPC endpoint.
+    * `policy` - Policy document associated with the VPC endpoint. Applicable for endpoints of type Gateway.
+    * `prefix_list_id` - Prefix list ID of the exposed AWS service. Applicable for endpoints of type Gateway.
+    * `private_dns_enabled` - Whether private DNS is enabled for the VPC endpoint.
+    * `requester_managed` - Whether the VPC endpoint is being managed by its service.
+    * `route_table_ids` - List of route table IDs associated with the VPC endpoint.
+    * `security_group_ids` - List of security group IDs associated with the network interfaces.
+    * `service_name` - Service name that is specified when creating the VPC endpoint.
+    * `state` - State of the VPC endpoint.
+    * `subnet_ids` - List of subnet IDs associated with the VPC endpoint.
+    * `tags` - Map of tags assigned to the VPC endpoint.
+    * `vpc_endpoint_type` - VPC endpoint type, `Gateway`, `GatewayLoadBalancer`, or `Interface`.
+    * `vpc_id` - ID of the VPC in which the endpoint is used.
+
+### `dns_entry` Block
+
+DNS blocks (for `dns_entry`) support the following attributes:
+
+* `dns_name` - DNS name.
+* `hosted_zone_id` - ID of the private hosted zone.
+
+### `dns_options` Block
+
+DNS options (for `dns_options`) support the following attributes:
+
+* `dns_record_ip_type` - The DNS records created for the endpoint.
+* `private_dns_only_for_inbound_resolver_endpoint` - Indicates whether to enable private DNS only for inbound endpoints.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `read` - (Default `20m`)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The new datasource `aws_vpc_endpoints` returns a list of zero or more DescribeVpcEndpoints results given the configured filters. This is similar to the existing `aws_vpc_endpoint` data source, but does not require exactly one result.

### Relations

Closes #43472
Closes #20192

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVpcEndpoints.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccVPCEndpointsDataSource PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 bm/vpc_endpoints_data_source 🌿...
TF_ACC=1 go1.24.10 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCEndpointsDataSource'  -timeout 360m -vet=off
2025/11/07 11:54:41 Creating Terraform AWS Provider (SDKv2-style)...
2025/11/07 11:54:41 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCEndpointsDataSource_basic
=== PAUSE TestAccVPCEndpointsDataSource_basic
=== RUN   TestAccVPCEndpointsDataSource_filter
=== PAUSE TestAccVPCEndpointsDataSource_filter
=== RUN   TestAccVPCEndpointsDataSource_tags
=== PAUSE TestAccVPCEndpointsDataSource_tags
=== RUN   TestAccVPCEndpointsDataSource_serviceName
=== PAUSE TestAccVPCEndpointsDataSource_serviceName
=== CONT  TestAccVPCEndpointsDataSource_basic
=== CONT  TestAccVPCEndpointsDataSource_tags
=== CONT  TestAccVPCEndpointsDataSource_filter
=== CONT  TestAccVPCEndpointsDataSource_serviceName
--- PASS: TestAccVPCEndpointsDataSource_filter (39.70s)
--- PASS: TestAccVPCEndpointsDataSource_tags (39.80s)
--- PASS: TestAccVPCEndpointsDataSource_basic (47.89s)
--- PASS: TestAccVPCEndpointsDataSource_serviceName (69.29s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	74.901s
```
