### PR TITLE
add aws_ssoadmin_rename_application action

### DIFF
--- a/.changelog/45048.txt
+++ b/.changelog/45048.txt
@@ -1,0 +1,3 @@
+```release-note:new-action
+aws_ssoadmin_rename_application
+```

--- a/internal/service/ssoadmin/rename_application_action.go
+++ b/internal/service/ssoadmin/rename_application_action.go
@@ -1,0 +1,115 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ssoadmin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/action/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+)
+
+// @Action(aws_ssoadmin_rename_application, name="Rename Application")
+func newRenameApplicationAction(_ context.Context) (action.ActionWithConfigure, error) {
+	return &renameApplicationAction{}, nil
+}
+
+var (
+	_ action.Action = (*renameApplicationAction)(nil)
+)
+
+type renameApplicationAction struct {
+	framework.ActionWithModel[renameApplicationActionModel]
+}
+
+type renameApplicationActionModel struct {
+	framework.WithRegionModel
+	ApplicationArn types.String `tfsdk:"application_arn"`
+	NewName        types.String `tfsdk:"new_name"`
+}
+
+func (a *renameApplicationAction) Schema(ctx context.Context, req action.SchemaRequest, resp *action.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Renames an AWS SSO Admin application. This action allows for imperative renaming of SSO applications.",
+		Attributes: map[string]schema.Attribute{
+			"application_arn": schema.StringAttribute{
+				Description: "The ARN of the SSO application to rename.",
+				Required:    true,
+			},
+			"new_name": schema.StringAttribute{
+				Description: "The new name for the SSO application.",
+				Required:    true,
+			},
+		},
+	}
+}
+
+func (a *renameApplicationAction) Invoke(ctx context.Context, req action.InvokeRequest, resp *action.InvokeResponse) {
+	var config renameApplicationActionModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := a.Meta().SSOAdminClient(ctx)
+
+	applicationArn := config.ApplicationArn.ValueString()
+	newName := config.NewName.ValueString()
+
+	tflog.Info(ctx, "Starting SSO Admin rename application action", map[string]any{
+		"application_arn": applicationArn,
+		"new_name":        newName,
+	})
+
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: fmt.Sprintf("Renaming SSO application %s to %s...", applicationArn, newName),
+	})
+
+	// Get current application details
+	describeInput := &ssoadmin.DescribeApplicationInput{
+		ApplicationArn: aws.String(applicationArn),
+	}
+
+	describeOutput, err := conn.DescribeApplication(ctx, describeInput)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to Describe SSO Application",
+			fmt.Sprintf("Could not describe SSO application %s: %s", applicationArn, err),
+		)
+		return
+	}
+
+	// Update application with new name
+	updateInput := &ssoadmin.UpdateApplicationInput{
+		ApplicationArn: aws.String(applicationArn),
+		Name:           aws.String(newName),
+		Description:    describeOutput.Description,
+		Status:         describeOutput.Status,
+	}
+
+	_, err = conn.UpdateApplication(ctx, updateInput)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to Rename SSO Application",
+			fmt.Sprintf("Could not rename SSO application %s: %s", applicationArn, err),
+		)
+		return
+	}
+
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: fmt.Sprintf("SSO application %s renamed to %s successfully", applicationArn, newName),
+	})
+
+	tflog.Info(ctx, "SSO Admin rename application action completed successfully", map[string]any{
+		"application_arn": applicationArn,
+		"new_name":        newName,
+	})
+}

--- a/internal/service/ssoadmin/rename_application_action_test.go
+++ b/internal/service/ssoadmin/rename_application_action_test.go
@@ -1,0 +1,91 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ssoadmin_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSSOAdminRenameApplicationAction_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	newName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckSSOAdminInstances(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSOAdminServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRenameApplicationActionConfig_basic(rName, newName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRenameApplicationActionExecuted(ctx, "aws_ssoadmin_application.test", newName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckRenameApplicationActionExecuted(ctx context.Context, resourceName, expectedName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SSOAdminClient(ctx)
+
+		output, err := conn.DescribeApplication(ctx, &ssoadmin.DescribeApplicationInput{
+			ApplicationArn: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return fmt.Errorf("error describing SSO Admin Application (%s): %w", rs.Primary.ID, err)
+		}
+
+		if aws.ToString(output.Name) != expectedName {
+			return fmt.Errorf("SSO Admin Application name was not renamed. Expected: %s, Got: %s", expectedName, aws.ToString(output.Name))
+		}
+
+		return nil
+	}
+}
+
+func testAccRenameApplicationActionConfig_basic(rName, newName string) string {
+	return acctest.ConfigCompose(testAccApplicationConfig_basic(rName, testAccApplicationProviderARN), fmt.Sprintf(`
+action "aws_ssoadmin_rename_application" "test" {
+  config {
+    application_arn = aws_ssoadmin_application.test.application_arn
+    new_name        = %[1]q
+  }
+}
+
+resource "terraform_data" "trigger" {
+  lifecycle {
+    action_trigger {
+      events  = [after_create]
+      actions = [action.aws_ssoadmin_rename_application.test]
+    }
+  }
+
+  depends_on = [
+    aws_ssoadmin_application.test,
+  ]
+}
+`, newName))
+}

--- a/internal/service/ssoadmin/service_package_gen.go
+++ b/internal/service/ssoadmin/service_package_gen.go
@@ -20,6 +20,17 @@ import (
 
 type servicePackage struct{}
 
+func (p *servicePackage) Actions(ctx context.Context) []*inttypes.ServicePackageAction {
+	return []*inttypes.ServicePackageAction{
+		{
+			Factory:  newRenameApplicationAction,
+			TypeName: "aws_ssoadmin_rename_application",
+			Name:     "Rename Application",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+	}
+}
+
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
 	return []*inttypes.ServicePackageFrameworkDataSource{
 		{

--- a/website/docs/actions/ssoadmin_rename_application.html.markdown
+++ b/website/docs/actions/ssoadmin_rename_application.html.markdown
@@ -1,0 +1,76 @@
+---
+subcategory: "SSO Admin"
+layout: "aws"
+page_title: "AWS: aws_ssoadmin_rename_application"
+description: |-
+  Renames an AWS SSO Admin application.
+---
+
+# Action: aws_ssoadmin_rename_application
+
+~> **Note:** `aws_ssoadmin_rename_application` is in beta. Its interface and behavior may change as the feature evolves, and breaking changes are possible. It is offered as a technical preview without compatibility guarantees until Terraform 1.14 is generally available.
+
+Renames an AWS SSO Admin application. This action allows for imperative renaming of SSO applications.
+
+For information about AWS SSO Admin applications, see the [AWS SSO Admin User Guide](https://docs.aws.amazon.com/singlesignon/latest/userguide/). For specific information about updating applications, see the [UpdateApplication](https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_UpdateApplication.html) page in the AWS SSO Admin API Reference.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_ssoadmin_application" "example" {
+  name                     = "example-app"
+  description              = "Example SSO application"
+  instance_arn             = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+  application_provider_arn = data.aws_ssoadmin_application_providers.example.application_providers[0].application_provider_arn
+}
+
+action "aws_ssoadmin_rename_application" "example" {
+  config {
+    application_arn = aws_ssoadmin_application.example.application_arn
+    new_name        = "renamed-example-app"
+  }
+}
+
+resource "terraform_data" "example" {
+  input = "rename-application"
+
+  lifecycle {
+    action_trigger {
+      events  = [before_update]
+      actions = [action.aws_ssoadmin_rename_application.example]
+    }
+  }
+}
+```
+
+### Conditional Renaming
+
+```terraform
+action "aws_ssoadmin_rename_application" "conditional" {
+  config {
+    application_arn = aws_ssoadmin_application.example.application_arn
+    new_name        = var.environment == "production" ? "prod-${var.app_name}" : "dev-${var.app_name}"
+  }
+}
+```
+
+### Batch Renaming with Prefix
+
+```terraform
+action "aws_ssoadmin_rename_application" "batch_rename" {
+  config {
+    application_arn = aws_ssoadmin_application.example.application_arn
+    new_name        = "${var.naming_prefix}-${aws_ssoadmin_application.example.name}"
+  }
+}
+```
+
+## Argument Reference
+
+This action supports the following arguments:
+
+* `application_arn` - (Required) The ARN of the SSO application to rename. This uniquely identifies the application within your AWS account.
+* `new_name` - (Required) The new name for the SSO application. The name must be unique within the SSO instance and follow AWS naming conventions.
+* `region` - (Optional) Region where this action should be [run](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
```
action "aws_ssoadmin_rename_application" "test" {
  config {
    application_arn = aws_ssoadmin_application.test.application_arn
    new_name        = "my-name"
  }
}
```
will call [UpdateApplication](https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_UpdateApplication.html) API.

### Relations

Closes #45046

### References


### Output from Acceptance Testing
```console
%  TF_ACC=1 go test -v ./internal/service/ssoadmin/ -run TestAccSSOAdminRenameApplicationAction_basic                           

2025/11/12 23:31:15 Creating Terraform AWS Provider (SDKv2-style)...
2025/11/12 23:31:15 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSSOAdminRenameApplicationAction_basic
=== PAUSE TestAccSSOAdminRenameApplicationAction_basic
=== CONT  TestAccSSOAdminRenameApplicationAction_basic
--- PASS: TestAccSSOAdminRenameApplicationAction_basic (17.90s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin   22.824s
...
```
