### PR TITLE
resource/aws_apprunner_service: Adds `region` to ignored changes in `Update`

### DIFF
--- a/.changelog/45050.txt
+++ b/.changelog/45050.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/aws_acmpca_certificate_authority: Prevents error when upgrading from provider pre-v6.0 without refreshing
-```

--- a/.changelog/45051.txt
+++ b/.changelog/45051.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_apprunner_service: Prevents error when upgrading from provider pre-v6.0 without refreshing
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Adds `region` to ignored changes in `aws_apprunner_service ` `Update`. Prevents `Either RevocationConfiguration or Status should be present` validation errors when upgrading from pre-v6.0 provider versions without refreshing.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=apprunner TESTS=_Identity_

--- PASS: TestAccAppRunnerAutoScalingConfigurationVersion_Identity_Basic (55.85s)
--- PASS: TestAccAppRunnerObservabilityConfiguration_Identity_Basic (56.79s)
--- PASS: TestAccAppRunnerAutoScalingConfigurationVersion_Identity_RegionOverride (64.79s)
--- PASS: TestAccAppRunnerObservabilityConfiguration_Identity_RegionOverride (65.84s)
--- PASS: TestAccAppRunnerVPCConnector_Identity_Basic (75.60s)
--- PASS: TestAccAppRunnerVPCConnector_Identity_RegionOverride (92.38s)
--- PASS: TestAccAppRunnerAutoScalingConfigurationVersion_Identity_ExistingResource_NoRefresh_NoChange (155.88s)
--- PASS: TestAccAppRunnerObservabilityConfiguration_Identity_ExistingResource_NoRefresh_NoChange (183.62s)
--- PASS: TestAccAppRunnerVPCConnector_Identity_ExistingResource_NoRefresh_NoChange (189.22s)
--- PASS: TestAccAppRunnerAutoScalingConfigurationVersion_Identity_ExistingResource (229.76s)
--- PASS: TestAccAppRunnerObservabilityConfiguration_Identity_ExistingResource (237.37s)
--- PASS: TestAccAppRunnerService_Identity_Basic (244.34s)
--- PASS: TestAccAppRunnerService_Identity_RegionOverride (247.30s)
--- PASS: TestAccAppRunnerVPCConnector_Identity_ExistingResource (254.20s)
--- PASS: TestAccAppRunnerService_Identity_ExistingResource_NoRefresh_NoChange (346.86s)
--- PASS: TestAccAppRunnerService_Identity_ExistingResource (377.98s)
--- PASS: TestAccAppRunnerVPCIngressConnection_Identity_RegionOverride (390.20s)
--- PASS: TestAccAppRunnerVPCIngressConnection_Identity_Basic (421.29s)
--- PASS: TestAccAppRunnerVPCIngressConnection_Identity_ExistingResource_NoRefresh_NoChange (491.42s)
--- PASS: TestAccAppRunnerVPCIngressConnection_Identity_ExistingResource (634.67s)
```
