### PR TITLE
resource/aws_placement_group: Remove hardcoded upper limit for partition_count

### DIFF
--- a/.changelog/9999.txt
+++ b/.changelog/9999.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_placement_group: Remove hardcoded upper limit for `partition_count`
+```

--- a/internal/service/ec2/ec2_placement_group.go
+++ b/internal/service/ec2/ec2_placement_group.go
@@ -53,7 +53,7 @@ func resourcePlacementGroup() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 				// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#placement-groups-limitations-partition.
-				ValidateFunc: validation.IntBetween(0, 7),
+				ValidateFunc: validation.IntBetween(0),
 			},
 			"placement_group_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
## Description

This PR removes the hardcoded upper limit (7) for the `partition_count` argument in the `aws_placement_group` resource.

AWS has mutable service limits for partition count, so Terraform should defer validation to the AWS API instead of enforcing a static upper bound. This change replaces `validation.IntBetween(0, 7)` with `validation.IntAtLeast(0)`.

## Motivation and Context

Deferring this validation to AWS allows Terraform to remain compatible with future updates without requiring provider releases whenever limits change.

This aligns with HashiCorp’s principle of avoiding hardcoded API limits that can change on the AWS side.

## Affected Resource(s)

- `aws_placement_group`

## Changes Made

```go
- ValidateFunc: validation.IntBetween(0, 7),
+ ValidateFunc: validation.IntAtLeast(0),
