### PR TITLE
Add tags to blue green deployment creation

### DIFF
--- a/internal/service/rds/blue_green.go
+++ b/internal/service/rds/blue_green.go
@@ -128,7 +128,7 @@ func (h *instanceHandler) precondition(ctx context.Context, d *schema.ResourceDa
 	return nil
 }
 
-func (h *instanceHandler) createBlueGreenInput(d *schema.ResourceData) *rds.CreateBlueGreenDeploymentInput {
+func (h *instanceHandler) createBlueGreenInput(ctx context.Context, d *schema.ResourceData) *rds.CreateBlueGreenDeploymentInput {
 	input := &rds.CreateBlueGreenDeploymentInput{
 		BlueGreenDeploymentName: aws.String(d.Get(names.AttrIdentifier).(string)),
 		Source:                  aws.String(d.Get(names.AttrARN).(string)),
@@ -140,6 +140,7 @@ func (h *instanceHandler) createBlueGreenInput(d *schema.ResourceData) *rds.Crea
 	if d.HasChange(names.AttrParameterGroupName) {
 		input.TargetDBParameterGroupName = aws.String(d.Get(names.AttrParameterGroupName).(string))
 	}
+	input.Tags = getTagsIn(ctx)
 
 	return input
 }

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -2170,7 +2170,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta an
 				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", d.Get(names.AttrIdentifier).(string), err)
 			}
 
-			createIn := handler.createBlueGreenInput(d)
+			createIn := handler.createBlueGreenInput(ctx, d)
 
 			log.Printf("[DEBUG] Updating RDS DB Instance (%s): Creating Blue/Green Deployment", d.Get(names.AttrIdentifier).(string))
 

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -14132,6 +14132,14 @@ func testAccInstanceConfig_BlueGreenDeployment_engineVersion(rName string, updat
 	return acctest.ConfigCompose(
 		acctest.ConfigRandomPassword(),
 		fmt.Sprintf(`
+provider "aws" {
+  default_tags {
+    tags = {
+      Terraform = "True"
+    }
+  }
+}
+
 resource "aws_db_instance" "test" {
   identifier              = %[1]q
   allocated_storage       = 10


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This fixes a bug where the blue green deployment did not have any tags attached to it since it wasn't set when creating the deployment.
In cases where IAM rights are based on resource tags this results in blue green deployments not working with the terraform provider.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
None


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

I currently ran a single test `TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion`, which I changed
to ensure the defaults tags from the provider where used.
I inspected the RDS blue green deployment in the AWS console, since I don't know how I can automate this in a test, since after terraform apply the blue green deployment resource is gone
 
```console
GOROOT=/Users/stijndehaes/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.8.darwin-arm64 #gosetup
GOPATH=/Users/stijndehaes/go #gosetup
/Users/stijndehaes/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.8.darwin-arm64/bin/go test -c -o /Users/stijndehaes/Library/Caches/JetBrains/GoLand2025.2/tmp/GoLand/___TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion_in_github_com_hashicorp_terraform_provider_aws_internal_service_rds.test github.com/hashicorp/terraform-provider-aws/internal/service/rds #gosetup
/Users/stijndehaes/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.8.darwin-arm64/bin/go tool test2json -t /Users/stijndehaes/Library/Caches/JetBrains/GoLand2025.2/tmp/GoLand/___TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion_in_github_com_hashicorp_terraform_provider_aws_internal_service_rds.test -test.v=test2json -test.paniconexit0 -test.run ^\QTestAccRDSInstance_BlueGreenDeployment_updateEngineVersion\E$ #gosetup
2025/11/14 12:04:56 Creating Terraform AWS Provider (SDKv2-style)...
2025/11/14 12:04:56 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion (1771.19s)
PASS
...
```
