### PR TITLE
[bugfix] aws_elasticache_serverless_cache: stop recreating serverless cache if upgrading from valkey 7 to 8

### DIFF
--- a/.changelog/45087.txt
+++ b/.changelog/45087.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_elasticache_serverless_cache: Fixed, upgrading valkey major version and changing engine from valkey 7 to redis 7 . Earlier it was forced replacement now it will be in-place update.
+resource/aws_elasticache_serverless_cache: Fix forced replacement when upgrading Valkey major version or switching engine between redis and valkey
 ```

--- a/internal/service/elasticache/serverless_cache.go
+++ b/internal/service/elasticache/serverless_cache.go
@@ -94,7 +94,6 @@ func (r *serverlessCacheResource) Schema(ctx context.Context, request resource.S
 			names.AttrEngine: schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplaceIf(
 						func(ctx context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
 							// In-place update support for redis -> valkey
@@ -132,17 +131,20 @@ func (r *serverlessCacheResource) Schema(ctx context.Context, request resource.S
 					stringplanmodifier.RequiresReplaceIf(
 						func(ctx context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
 							var engineVal types.String
-							req.Config.GetAttribute(ctx, path.Root(names.AttrEngine), &engineVal)
+							resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root(names.AttrEngine), &engineVal)...)
+							if resp.Diagnostics.HasError() {
+								return
+							}
 
 							stateFloatVal, err := strconv.ParseFloat(req.StateValue.ValueString(), 64)
 							if err != nil {
-								response.Diagnostics.AddError("incorrect major_engine_version format", err.Error())
+								resp.Diagnostics.AddError("incorrect major_engine_version format", err.Error())
 								return
 							}
 
 							planFloatVal, err := strconv.ParseFloat(req.PlanValue.ValueString(), 64)
 							if err != nil {
-								response.Diagnostics.AddError("incorrect major_engine_version format", err.Error())
+								resp.Diagnostics.AddError("incorrect major_engine_version format", err.Error())
 								return
 							}
 

--- a/internal/service/elasticache/serverless_cache_test.go
+++ b/internal/service/elasticache/serverless_cache_test.go
@@ -763,14 +763,14 @@ resource "aws_elasticache_serverless_cache" "test" {
 `, rName, engine)
 }
 
-func testAccServerlessCacheConfig_majorEngineVersion(rName, engine, major_engine_version string) string {
+func testAccServerlessCacheConfig_majorEngineVersion(rName, engine, majorEngineVersion string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_serverless_cache" "test" {
   name                 = %[1]q
   engine               = %[2]q
   major_engine_version = %[3]q
 }
-`, rName, engine, major_engine_version)
+`, rName, engine, majorEngineVersion)
 }
 
 func testAccServerlessCacheConfig_full(rName string) string {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously these actions were forcing replacement of the elasticache serverless resource: 
1. upgrading valkey major version (example: 7 to 8)
2. changing engine from valkey 7 to redis 7 

After the current changes in the code, it will be in-place update without recreating resource that follows inteded behaviour of aws console.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41644
Closes #45204

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccElastiCacheServerlessCache PKG=elasticache ACCTEST_PARALLELISM=10 ACCTEST_TIMEOUT=3880m
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
xargs: gofmt: No such file or directory
make: Running acceptance tests on branch: 🌿 f-elasticache-serverless-valkey-version 🌿...
TF_ACC=1 go1.24.10 test ./internal/service/elasticache/... -v -count 1 -parallel 10 -run='TestAccElastiCacheServerlessCache'  -timeout 3880m -vet=off
go: downloading github.com/aws/aws-sdk-go-v2 v1.40.0
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticache v1.51.4
go: downloading github.com/aws/aws-sdk-go-v2/service/account v1.29.5
go: downloading github.com/aws/aws-sdk-go-v2/service/acmpca v1.46.3
go: downloading github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.57.14
go: downloading github.com/aws/aws-sdk-go-v2/service/amp v1.42.1
go: downloading github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.33.1
go: downloading github.com/aws/aws-sdk-go-v2/service/apigateway v1.37.1
go: downloading github.com/aws/aws-sdk-go-v2/service/appconfig v1.43.4
go: downloading github.com/aws/aws-sdk-go-v2/service/appfabric v1.16.13
go: downloading github.com/aws/aws-sdk-go-v2/service/appflow v1.51.4
go: downloading github.com/aws/aws-sdk-go-v2/service/appintegrations v1.36.13
go: downloading github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.5
go: downloading github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.12
go: downloading github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.4
go: downloading github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.18.0
go: downloading github.com/aws/aws-sdk-go-v2/service/apprunner v1.39.6
go: downloading github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.2.15
go: downloading github.com/aws/aws-sdk-go-v2/service/athena v1.55.13
go: downloading github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.4
go: downloading github.com/aws/aws-sdk-go-v2/service/autoscaling v1.62.0
go: downloading github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.6
go: downloading github.com/aws/aws-sdk-go-v2/service/backup v1.54.1
go: downloading github.com/aws/aws-sdk-go-v2/service/batch v1.58.7
go: downloading github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.12.6
go: downloading github.com/aws/aws-sdk-go-v2/service/bedrock v1.49.3
go: downloading github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.51.4
go: downloading github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.13.4
go: downloading github.com/aws/aws-sdk-go-v2/service/billing v1.9.1
go: downloading github.com/aws/aws-sdk-go-v2/service/budgets v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/chatbot v1.14.13
go: downloading github.com/aws/aws-sdk-go-v2/service/chime v1.41.4
go: downloading github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.26.13
go: downloading github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.7
go: downloading github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.5
go: downloading github.com/aws/aws-sdk-go-v2/service/ec2 v1.273.0
go: downloading github.com/aws/aws-sdk-go-v2/service/iam v1.52.1
go: downloading github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.14
go: downloading github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.45.3
go: downloading github.com/aws/aws-sdk-go-v2/service/acm v1.37.14
go: downloading github.com/aws/aws-sdk-go-v2/service/amplify v1.38.6
go: downloading github.com/aws/aws-sdk-go-v2/service/appstream v1.52.2
go: downloading github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.37.4
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.29.4
go: downloading github.com/aws/aws-sdk-go-v2/service/cloud9 v1.33.12
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudformation v1.70.1
go: downloading github.com/aws/aws-sdk-go-v2/service/appsync v1.52.4
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudfront v1.57.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.12
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.12.15
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.4
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.52.4
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.60.1
go: downloading github.com/aws/aws-sdk-go-v2/service/codeartifact v1.38.13
go: downloading github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.5
go: downloading github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.4
go: downloading github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.4
go: downloading github.com/aws/aws-sdk-go-v2/service/codeconnections v1.10.12
go: downloading github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.4
go: downloading github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.29.12
go: downloading github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.34.12
go: downloading github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.13
go: downloading github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.35.5
go: downloading github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.31.13
go: downloading github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.13
go: downloading github.com/aws/aws-sdk-go-v2/service/comprehend v1.40.13
go: downloading github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.48.4
go: downloading github.com/aws/aws-sdk-go-v2/service/configservice v1.59.5
go: downloading github.com/aws/aws-sdk-go-v2/service/connect v1.147.0
go: downloading github.com/aws/aws-sdk-go-v2/service/connectcases v1.34.4
go: downloading github.com/aws/aws-sdk-go-v2/service/controltower v1.27.3
go: downloading github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.5
go: downloading github.com/aws/aws-sdk-go-v2/service/costexplorer v1.60.1
go: downloading github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.21.1
go: downloading github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.54.6
go: downloading github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.61.0
go: downloading github.com/aws/aws-sdk-go-v2/service/databrew v1.39.6
go: downloading github.com/aws/aws-sdk-go-v2/service/dataexchange v1.40.6
go: downloading github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.12
go: downloading github.com/aws/aws-sdk-go-v2/service/datazone v1.48.1
go: downloading github.com/aws/aws-sdk-go-v2/service/datasync v1.56.0
go: downloading github.com/aws/aws-sdk-go-v2/service/dax v1.29.8
go: downloading github.com/aws/aws-sdk-go-v2/service/detective v1.38.5
go: downloading github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.0
go: downloading github.com/aws/aws-sdk-go-v2/service/devopsguru v1.40.4
go: downloading github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.6
go: downloading github.com/aws/aws-sdk-go-v2/service/dlm v1.35.7
go: downloading github.com/aws/aws-sdk-go-v2/service/docdb v1.48.4
go: downloading github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.20.5
go: downloading github.com/aws/aws-sdk-go-v2/service/drs v1.36.5
go: downloading github.com/aws/aws-sdk-go-v2/service/dsql v1.12.0
go: downloading github.com/aws/aws-sdk-go-v2/service/dynamodb v1.53.1
go: downloading github.com/aws/aws-sdk-go-v2/service/ecr v1.53.1
go: downloading golang.org/x/crypto v0.45.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.38.5
go: downloading github.com/aws/aws-sdk-go-v2/service/ecs v1.69.0
go: downloading github.com/aws/aws-sdk-go-v2/service/efs v1.41.5
go: downloading github.com/aws/aws-sdk-go-v2/service/eks v1.74.10
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.33.14
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.14
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.0
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.37.14
go: downloading github.com/aws/aws-sdk-go-v2/service/elastictranscoder v1.32.13
go: downloading github.com/aws/aws-sdk-go-v2/service/emr v1.57.0
go: downloading github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.40.9
go: downloading github.com/aws/aws-sdk-go-v2/service/emrserverless v1.37.4
go: downloading github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.13
go: downloading github.com/aws/aws-sdk-go-v2/service/evidently v1.28.12
go: downloading github.com/aws/aws-sdk-go-v2/service/evs v1.5.9
go: downloading github.com/aws/aws-sdk-go-v2/service/finspace v1.33.13
go: downloading github.com/aws/aws-sdk-go-v2/service/firehose v1.42.4
go: downloading github.com/aws/aws-sdk-go-v2/service/fis v1.37.12
go: downloading github.com/aws/aws-sdk-go-v2/service/fms v1.44.13
go: downloading github.com/aws/aws-sdk-go-v2/service/inspector2 v1.45.1
go: downloading github.com/aws/aws-sdk-go-v2/service/fsx v1.64.1
go: downloading github.com/aws/aws-sdk-go-v2/service/organizations v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/service/outposts v1.57.7
go: downloading github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.13
go: downloading github.com/aws/aws-sdk-go-v2/service/gamelift v1.48.3
go: downloading github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.1
go: downloading github.com/aws/aws-sdk-go-v2/service/glacier v1.31.13
go: downloading github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.36.9
go: downloading github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.35.6
go: downloading github.com/aws/aws-sdk-go-v2/service/glue v1.134.0
go: downloading github.com/aws/aws-sdk-go-v2/service/wafv2 v1.70.1
go: downloading github.com/aws/aws-sdk-go-v2/service/grafana v1.32.6
go: downloading github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.13
go: downloading github.com/aws/aws-sdk-go-v2/service/groundstation v1.39.3
go: downloading github.com/aws/aws-sdk-go-v2/service/guardduty v1.68.1
go: downloading github.com/aws/aws-sdk-go-v2/service/healthlake v1.36.5
go: downloading github.com/aws/aws-sdk-go-v2/service/identitystore v1.34.4
go: downloading github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.50.0
go: downloading github.com/aws/aws-sdk-go-v2/service/inspector v1.30.12
go: downloading github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.26.5
go: downloading github.com/aws/aws-sdk-go-v2/service/invoicing v1.8.1
go: downloading github.com/aws/aws-sdk-go-v2/service/iot v1.69.12
go: downloading github.com/aws/aws-sdk-go-v2/service/ivs v1.48.6
go: downloading github.com/aws/aws-sdk-go-v2/service/ivschat v1.21.12
go: downloading github.com/aws/aws-sdk-go-v2/service/kafka v1.46.1
go: downloading github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.27.13
go: downloading github.com/aws/aws-sdk-go-v2/service/kendra v1.60.13
go: downloading github.com/aws/aws-sdk-go-v2/service/keyspaces v1.24.6
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesis v1.42.5
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.13
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.36.14
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.32.12
go: downloading github.com/aws/aws-sdk-go-v2/service/kms v1.48.3
go: downloading github.com/aws/aws-sdk-go-v2/service/lakeformation v1.46.0
go: downloading github.com/aws/aws-sdk-go-v2/service/lambda v1.82.1
go: downloading github.com/aws/aws-sdk-go-v2/service/launchwizard v1.13.13
go: downloading github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.34.6
go: downloading github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.57.1
go: downloading github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.0
go: downloading github.com/aws/aws-sdk-go-v2/service/lightsail v1.50.7
go: downloading github.com/aws/aws-sdk-go-v2/service/location v1.50.5
go: downloading github.com/aws/aws-sdk-go-v2/service/m2 v1.26.6
go: downloading github.com/aws/aws-sdk-go-v2/service/macie2 v1.50.5
go: downloading github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.46.1
go: downloading github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.85.1
go: downloading github.com/aws/aws-sdk-go-v2/service/medialive v1.87.1
go: downloading github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.13
go: downloading github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.33.1
go: downloading github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.13
go: downloading github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.13
go: downloading github.com/aws/aws-sdk-go-v2/service/memorydb v1.33.6
go: downloading github.com/aws/aws-sdk-go-v2/service/mgn v1.38.5
go: downloading github.com/aws/aws-sdk-go-v2/service/mq v1.34.11
go: downloading github.com/aws/aws-sdk-go-v2/service/mwaa v1.39.13
go: downloading github.com/aws/aws-sdk-go-v2/service/neptune v1.43.4
go: downloading github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.21.12
go: downloading github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.58.1
go: downloading github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.1
go: downloading github.com/aws/aws-sdk-go-v2/service/networkmanager v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.13.5
go: downloading github.com/aws/aws-sdk-go-v2/service/notifications v1.7.11
go: downloading github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.5.15
go: downloading github.com/aws/aws-sdk-go-v2/service/oam v1.23.6
go: downloading github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.8.7
go: downloading github.com/aws/aws-sdk-go-v2/service/odb v1.5.7
go: downloading github.com/aws/aws-sdk-go-v2/service/opensearch v1.54.1
go: downloading github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.27.5
go: downloading github.com/aws/aws-sdk-go-v2/service/osis v1.21.6
go: downloading github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.26.4
go: downloading github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.15.13
go: downloading github.com/aws/aws-sdk-go-v2/service/pcs v1.15.1
go: downloading github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.26.3
go: downloading github.com/aws/aws-sdk-go-v2/service/pipes v1.23.12
go: downloading github.com/aws/aws-sdk-go-v2/service/polly v1.54.6
go: downloading github.com/aws/aws-sdk-go-v2/service/pricing v1.40.6
go: downloading github.com/aws/aws-sdk-go-v2/service/qbusiness v1.33.13
go: downloading github.com/aws/aws-sdk-go-v2/service/quicksight v1.97.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ram v1.34.14
go: downloading github.com/aws/aws-sdk-go-v2/service/rbin v1.27.0
go: downloading github.com/aws/aws-sdk-go-v2/service/rds v1.110.0
go: downloading github.com/aws/aws-sdk-go-v2/service/redshift v1.60.1
go: downloading github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.38.0
go: downloading github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.31.16
go: downloading github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.12
go: downloading github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.35.5
go: downloading github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.22.7
go: downloading github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.15
go: downloading github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.21.13
go: downloading github.com/aws/aws-sdk-go-v2/service/route53 v1.60.1
go: downloading github.com/aws/aws-sdk-go-v2/service/route53domains v1.34.11
go: downloading github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.13
go: downloading github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.32.6
go: downloading github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.13
go: downloading github.com/aws/aws-sdk-go-v2/service/route53resolver v1.41.1
go: downloading github.com/aws/aws-sdk-go-v2/service/rum v1.30.1
go: downloading github.com/aws/aws-sdk-go-v2/service/s3 v1.92.0
go: downloading github.com/aws/aws-sdk-go-v2/service/s3control v1.66.10
go: downloading github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.4
go: downloading github.com/aws/aws-sdk-go-v2/service/s3tables v1.12.1
go: downloading github.com/aws/aws-sdk-go-v2/service/s3vectors v1.5.3
go: downloading github.com/aws/aws-sdk-go-v2/service/sagemaker v1.225.0
go: downloading github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.13
go: downloading github.com/aws/aws-sdk-go-v2/service/schemas v1.34.4
go: downloading github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.40.1
go: downloading github.com/aws/aws-sdk-go-v2/service/securityhub v1.66.0
go: downloading github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.5
go: downloading github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.30.4
go: downloading github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.35.13
go: downloading github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.4
go: downloading github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.39.17
go: downloading github.com/aws/aws-sdk-go-v2/service/servicequotas v1.33.8
go: downloading github.com/aws/aws-sdk-go-v2/service/ses v1.34.12
go: downloading github.com/aws/aws-sdk-go-v2/service/sesv2 v1.54.5
go: downloading github.com/aws/aws-sdk-go-v2/service/sfn v1.40.1
go: downloading github.com/aws/aws-sdk-go-v2/service/shield v1.34.13
go: downloading github.com/aws/aws-sdk-go-v2/service/signer v1.31.13
go: downloading github.com/aws/aws-sdk-go-v2/service/sqs v1.42.16
go: downloading github.com/aws/aws-sdk-go-v2/service/sns v1.39.6
go: downloading github.com/aws/aws-sdk-go-v2/service/ssm v1.67.3
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.31.6
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.39.12
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.8.13
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmsap v1.25.12
go: downloading github.com/aws/aws-sdk-go-v2/service/sso v1.30.4
go: downloading github.com/aws/aws-sdk-go-v2/service/storagegateway v1.43.5
go: downloading github.com/aws/aws-sdk-go-v2/service/sts v1.41.1
go: downloading github.com/aws/aws-sdk-go-v2/service/swf v1.33.7
go: downloading github.com/aws/aws-sdk-go-v2/service/synthetics v1.42.5
go: downloading github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.13
go: downloading github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.17.7
go: downloading github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.6
go: downloading github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.12
go: downloading github.com/aws/aws-sdk-go-v2/service/transcribe v1.53.7
go: downloading github.com/aws/aws-sdk-go-v2/service/transfer v1.67.7
go: downloading github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.30.3
go: downloading github.com/aws/aws-sdk-go-v2/service/vpclattice v1.20.3
go: downloading github.com/aws/aws-sdk-go-v2/service/waf v1.30.12
go: downloading github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.13
go: downloading github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.39.13
go: downloading github.com/aws/aws-sdk-go-v2/service/workmail v1.36.11
go: downloading github.com/aws/aws-sdk-go-v2/service/workspaces v1.64.5
go: downloading github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.34.1
go: downloading github.com/aws/aws-sdk-go-v2/service/xray v1.36.12
go: downloading github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.14
go: downloading github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.14
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.14
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.14
go: downloading github.com/aws/aws-sdk-go-v2/config v1.32.0
go: downloading github.com/aws/aws-sdk-go-v2/credentials v1.19.0
go: downloading github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.20.10
go: downloading github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.14
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.14
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.5
go: downloading github.com/aws/aws-sdk-go-v2/service/signin v1.0.1
go: downloading github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.8
2025/11/21 23:12:36 Creating Terraform AWS Provider (SDKv2-style)...
2025/11/21 23:12:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccElastiCacheServerlessCacheDataSource_Redis_basic
=== PAUSE TestAccElastiCacheServerlessCacheDataSource_Redis_basic
=== RUN   TestAccElastiCacheServerlessCacheDataSource_Valkey_basic
=== PAUSE TestAccElastiCacheServerlessCacheDataSource_Valkey_basic
=== RUN   TestAccElastiCacheServerlessCache_basicRedis
=== PAUSE TestAccElastiCacheServerlessCache_basicRedis
=== RUN   TestAccElastiCacheServerlessCache_basicValkey
=== PAUSE TestAccElastiCacheServerlessCache_basicValkey
=== RUN   TestAccElastiCacheServerlessCache_full
=== PAUSE TestAccElastiCacheServerlessCache_full
=== RUN   TestAccElastiCacheServerlessCache_fullRedis
=== PAUSE TestAccElastiCacheServerlessCache_fullRedis
=== RUN   TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup
=== PAUSE TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup
=== RUN   TestAccElastiCacheServerlessCache_fullValkey
=== PAUSE TestAccElastiCacheServerlessCache_fullValkey
=== RUN   TestAccElastiCacheServerlessCache_description
=== PAUSE TestAccElastiCacheServerlessCache_description
=== RUN   TestAccElastiCacheServerlessCache_cacheUsageLimits
=== PAUSE TestAccElastiCacheServerlessCache_cacheUsageLimits
=== RUN   TestAccElastiCacheServerlessCache_engine
=== PAUSE TestAccElastiCacheServerlessCache_engine
=== RUN   TestAccElastiCacheServerlessCache_valkeyMajorEngineVersion
=== PAUSE TestAccElastiCacheServerlessCache_valkeyMajorEngineVersion
=== RUN   TestAccElastiCacheServerlessCache_disappears
=== PAUSE TestAccElastiCacheServerlessCache_disappears
=== RUN   TestAccElastiCacheServerlessCache_tags
=== PAUSE TestAccElastiCacheServerlessCache_tags
=== CONT  TestAccElastiCacheServerlessCacheDataSource_Redis_basic
=== CONT  TestAccElastiCacheServerlessCache_fullValkey
=== CONT  TestAccElastiCacheServerlessCache_full
=== CONT  TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup
=== CONT  TestAccElastiCacheServerlessCache_fullRedis
=== CONT  TestAccElastiCacheServerlessCache_valkeyMajorEngineVersion
=== CONT  TestAccElastiCacheServerlessCache_tags
=== CONT  TestAccElastiCacheServerlessCache_disappears
=== CONT  TestAccElastiCacheServerlessCache_basicValkey
=== CONT  TestAccElastiCacheServerlessCache_basicRedis
--- PASS: TestAccElastiCacheServerlessCache_full (365.50s)
=== CONT  TestAccElastiCacheServerlessCache_cacheUsageLimits
--- PASS: TestAccElastiCacheServerlessCacheDataSource_Redis_basic (385.01s)
=== CONT  TestAccElastiCacheServerlessCache_engine
--- PASS: TestAccElastiCacheServerlessCache_fullRedis (386.39s)
=== CONT  TestAccElastiCacheServerlessCache_description
--- PASS: TestAccElastiCacheServerlessCache_basicRedis (398.18s)
=== CONT  TestAccElastiCacheServerlessCacheDataSource_Valkey_basic
--- PASS: TestAccElastiCacheServerlessCache_basicValkey (418.50s)
--- PASS: TestAccElastiCacheServerlessCache_disappears (425.85s)
--- PASS: TestAccElastiCacheServerlessCache_fullValkey (446.31s)
--- PASS: TestAccElastiCacheServerlessCache_tags (492.93s)
--- PASS: TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup (580.87s)
--- PASS: TestAccElastiCacheServerlessCache_description (406.94s)
--- PASS: TestAccElastiCacheServerlessCacheDataSource_Valkey_basic (425.39s)
--- PASS: TestAccElastiCacheServerlessCache_cacheUsageLimits (568.10s)
--- PASS: TestAccElastiCacheServerlessCache_valkeyMajorEngineVersion (1119.70s)
--- PASS: TestAccElastiCacheServerlessCache_engine (1400.84s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	1786.017s
...
```
