### PR TITLE
Allows passing non-pointer types to `types.IsZero`

### DIFF
--- a/internal/types/zero.go
+++ b/internal/types/zero.go
@@ -7,13 +7,16 @@ import (
 	"reflect"
 )
 
-// IsZero returns true if `v` is `nil`, is a pointer to `nil`, or points to the zero value of `T`.
-func IsZero[T any](v *T) bool {
-	if v == nil {
-		return true
+// IsZero returns true if `v` is the zero value of `T`, `nil`, is a pointer to `nil`, or points to the zero value of `T`.
+func IsZero[T any](v T) bool {
+	val := reflect.ValueOf(v)
+	val = reflect.Indirect(val)
+
+	if val.Kind() == reflect.Interface {
+		val = val.Elem()
 	}
 
-	if val := reflect.ValueOf(*v); !val.IsValid() || val.IsZero() {
+	if !val.IsValid() || val.IsZero() {
 		return true
 	}
 

--- a/internal/types/zero_test.go
+++ b/internal/types/zero_test.go
@@ -12,7 +12,7 @@ type AIsZero struct {
 	Value int
 }
 
-func TestIsZero(t *testing.T) {
+func TestIsZeroPtr(t *testing.T) {
 	t.Parallel()
 
 	zero := Zero[AIsZero]()
@@ -45,6 +45,36 @@ func TestIsZero(t *testing.T) {
 			t.Parallel()
 
 			got := IsZero(testCase.Ptr)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+func TestIsZeroStructValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		Value    AIsZero
+		Expected bool
+	}{
+		"zero value struct": {
+			Value:    AIsZero{},
+			Expected: true,
+		},
+		"non-zero value struct": {
+			Value:    AIsZero{Value: 42},
+			Expected: false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := IsZero(testCase.Value)
 
 			if got != testCase.Expected {
 				t.Errorf("got %t, expected %t", got, testCase.Expected)
@@ -91,6 +121,47 @@ func TestIsZeroPointerToAny(t *testing.T) {
 			t.Parallel()
 
 			got := IsZero(testCase.Ptr)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+func TestIsZeroAnyValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		Value    any
+		Expected bool
+	}{
+		"nil value": {
+			Expected: true,
+		},
+		"zero int value": {
+			Value:    0,
+			Expected: true,
+		},
+		"zero string value": {
+			Value:    "",
+			Expected: true,
+		},
+		"non-zero int value": {
+			Value:    1,
+			Expected: false,
+		},
+		"non-zero string value": {
+			Value:    "string",
+			Expected: false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := IsZero(testCase.Value)
 
 			if got != testCase.Expected {
 				t.Errorf("got %t, expected %t", got, testCase.Expected)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Allows passing non-pointer types to `types.IsZero`
