### PR TITLE
feat(bedrock): add aws_bedrock_prompt_router resource and data sources

### DIFF
--- a/.changelog/45124.txt
+++ b/.changelog/45124.txt
@@ -1,0 +1,11 @@
+```release-note:new-resource
+aws_bedrock_prompt_router
+```
+
+```release-note:new-data-source
+aws_bedrock_prompt_router
+```
+
+```release-note:new-data-source
+aws_bedrock_prompt_routers
+```

--- a/internal/service/bedrock/exports_test.go
+++ b/internal/service/bedrock/exports_test.go
@@ -8,13 +8,15 @@ var (
 	ResourceCustomModel                         = newCustomModelResource
 	ResourceGuardrail                           = newGuardrailResource
 	ResourceGuardrailVersion                    = newGuardrailVersionResource
-	ResourceModelInvocationLoggingConfiguration = newModelInvocationLoggingConfigurationResource
 	ResourceInferenceProfile                    = newInferenceProfileResource
+	ResourceModelInvocationLoggingConfiguration = newModelInvocationLoggingConfigurationResource
+	ResourcePromptRouter                        = newPromptRouterResource
 
 	FindCustomModelByID                     = findCustomModelByID
 	FindGuardrailByTwoPartKey               = findGuardrailByTwoPartKey
 	FindModelCustomizationJobByID           = findModelCustomizationJobByID
 	FindModelInvocationLoggingConfiguration = findModelInvocationLoggingConfiguration
+	FindPromptRouterByARN                   = findPromptRouterByARN
 	FindProvisionedModelThroughputByID      = findProvisionedModelThroughputByID
 
 	WaitModelCustomizationJobCompleted = waitModelCustomizationJobCompleted

--- a/internal/service/bedrock/prompt_router.go
+++ b/internal/service/bedrock/prompt_router.go
@@ -1,0 +1,301 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package bedrock
+
+import (
+	"context"
+
+	"github.com/YakDriver/regexache"
+	"github.com/YakDriver/smarterr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrock"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	sdkid "github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+const (
+	responseQualityDifferenceMin float64 = 0
+	responseQualityDifferenceMax float64 = 100
+)
+
+// @FrameworkResource("aws_bedrock_prompt_router", name="Prompt Router")
+// @Tags(identifierAttribute="prompt_router_arn")
+// @Testing(tagsTest=false)
+func newPromptRouterResource(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &promptRouterResource{}
+
+	return r, nil
+}
+
+type promptRouterResource struct {
+	framework.ResourceWithModel[promptRouterResourceModel]
+}
+
+func (r *promptRouterResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrDescription: schema.StringAttribute{
+				Optional: true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 200),
+					stringvalidator.RegexMatches(regexache.MustCompile(`^([0-9a-zA-Z:.][ _-]?)+$`), ""),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"prompt_router_arn": framework.ARNAttributeComputedOnly(),
+			"prompt_router_name": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 64),
+					stringvalidator.RegexMatches(regexache.MustCompile(`^([0-9a-zA-Z][ _-]?)+$`), ""),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			names.AttrTags:    tftags.TagsAttribute(),
+			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+		},
+		Blocks: map[string]schema.Block{
+			"fallback_model": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[promptRouterTargetModel](ctx),
+				Validators: []validator.List{
+					listvalidator.IsRequired(),
+					listvalidator.SizeAtMost(1),
+					listvalidator.SizeAtLeast(1),
+				},
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"model_arn": schema.StringAttribute{
+							CustomType: fwtypes.ARNType,
+							Required:   true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
+						},
+					},
+				},
+			},
+			"models": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[promptRouterTargetModel](ctx),
+				Validators: []validator.List{
+					listvalidator.IsRequired(),
+					listvalidator.SizeAtLeast(1),
+				},
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"model_arn": schema.StringAttribute{
+							CustomType: fwtypes.ARNType,
+							Required:   true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
+						},
+					},
+				},
+			},
+			"routing_criteria": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[routingCriteriaModel](ctx),
+				Validators: []validator.List{
+					listvalidator.IsRequired(),
+					listvalidator.SizeAtMost(1),
+					listvalidator.SizeAtLeast(1),
+				},
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"response_quality_difference": schema.Float64Attribute{
+							Required: true,
+							Validators: []validator.Float64{
+								float64validator.Between(responseQualityDifferenceMin, responseQualityDifferenceMax),
+							},
+							PlanModifiers: []planmodifier.Float64{
+								float64planmodifier.RequiresReplace(),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *promptRouterResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	var data promptRouterResourceModel
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.Plan.Get(ctx, &data))
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().BedrockClient(ctx)
+
+	var input bedrock.CreatePromptRouterInput
+	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Expand(ctx, data, &input))
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	input.ClientRequestToken = aws.String(sdkid.UniqueId())
+	input.Tags = getTagsIn(ctx)
+
+	out, err := conn.CreatePromptRouter(ctx, &input)
+	if err != nil {
+		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, data.PromptRouterName.String())
+		return
+	}
+
+	promptRouterARN := aws.ToString(out.PromptRouterArn)
+
+	router, err := findPromptRouterByARN(ctx, conn, promptRouterARN)
+	if err != nil {
+		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, promptRouterARN)
+		return
+	}
+
+	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, router, &data))
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, data))
+}
+
+func (r *promptRouterResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	var data promptRouterResourceModel
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.State.Get(ctx, &data))
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().BedrockClient(ctx)
+
+	promptRouterARN := fwflex.StringValueFromFramework(ctx, data.PromptRouterARN)
+	out, err := findPromptRouterByARN(ctx, conn, promptRouterARN)
+	if retry.NotFound(err) {
+		smerr.AddOne(ctx, &response.Diagnostics, fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		response.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, promptRouterARN)
+		return
+	}
+
+	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, out, &data))
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, &data))
+}
+
+func (r *promptRouterResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	var data promptRouterResourceModel
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.State.Get(ctx, &data))
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().BedrockClient(ctx)
+
+	promptRouterARN := fwflex.StringValueFromFramework(ctx, data.PromptRouterARN)
+	input := bedrock.DeletePromptRouterInput{
+		PromptRouterArn: aws.String(promptRouterARN),
+	}
+
+	_, err := conn.DeletePromptRouter(ctx, &input)
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return
+	}
+	if err != nil {
+		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, promptRouterARN)
+		return
+	}
+}
+
+func (r *promptRouterResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("prompt_router_arn"), request, response)
+}
+
+func findPromptRouterByARN(ctx context.Context, conn *bedrock.Client, arn string) (*bedrock.GetPromptRouterOutput, error) {
+	input := bedrock.GetPromptRouterInput{
+		PromptRouterArn: aws.String(arn),
+	}
+
+	return findPromptRouter(ctx, conn, &input)
+}
+
+func findPromptRouter(ctx context.Context, conn *bedrock.Client, input *bedrock.GetPromptRouterInput) (*bedrock.GetPromptRouterOutput, error) {
+	out, err := conn.GetPromptRouter(ctx, input)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, smarterr.NewError(&sdkretry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		})
+	}
+
+	if err != nil {
+		return nil, smarterr.NewError(err)
+	}
+
+	if out == nil {
+		return nil, smarterr.NewError(tfresource.NewEmptyResultError(input))
+	}
+
+	return out, nil
+}
+
+type promptRouterResourceModel struct {
+	framework.WithRegionModel
+	Description      types.String                                             `tfsdk:"description"`
+	FallbackModel    fwtypes.ListNestedObjectValueOf[promptRouterTargetModel] `tfsdk:"fallback_model"`
+	Models           fwtypes.ListNestedObjectValueOf[promptRouterTargetModel] `tfsdk:"models"`
+	PromptRouterARN  types.String                                             `tfsdk:"prompt_router_arn"`
+	PromptRouterName types.String                                             `tfsdk:"prompt_router_name"`
+	RoutingCriteria  fwtypes.ListNestedObjectValueOf[routingCriteriaModel]    `tfsdk:"routing_criteria"`
+	Tags             tftags.Map                                               `tfsdk:"tags"`
+	TagsAll          tftags.Map                                               `tfsdk:"tags_all"`
+}
+
+type promptRouterTargetModel struct {
+	ModelARN fwtypes.ARN `tfsdk:"model_arn"`
+}
+
+type routingCriteriaModel struct {
+	ResponseQualityDifference types.Float64 `tfsdk:"response_quality_difference"`
+}

--- a/internal/service/bedrock/prompt_router_data_source.go
+++ b/internal/service/bedrock/prompt_router_data_source.go
@@ -1,0 +1,102 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package bedrock
+
+import (
+	"context"
+	"fmt"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_bedrock_prompt_router", name="Prompt Router")
+func newPromptRouterDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &promptRouterDataSource{}, nil
+}
+
+type promptRouterDataSource struct {
+	framework.DataSourceWithModel[promptRouterDataSourceModel]
+}
+
+func (d *promptRouterDataSource) Schema(ctx context.Context, request datasource.SchemaRequest, response *datasource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrCreatedAt: schema.StringAttribute{
+				CustomType: timetypes.RFC3339Type{},
+				Computed:   true,
+			},
+			names.AttrDescription: schema.StringAttribute{
+				Computed: true,
+			},
+			"fallback_model": framework.DataSourceComputedListOfObjectAttribute[promptRouterTargetModel](ctx),
+			"models":         framework.DataSourceComputedListOfObjectAttribute[promptRouterTargetModel](ctx),
+			"prompt_router_arn": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Required:   true,
+			},
+			"prompt_router_name": schema.StringAttribute{
+				Computed: true,
+			},
+			"routing_criteria": framework.DataSourceComputedListOfObjectAttribute[routingCriteriaModel](ctx),
+			names.AttrStatus: schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.PromptRouterStatus](),
+				Computed:   true,
+			},
+			names.AttrType: schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.PromptRouterType](),
+				Computed:   true,
+			},
+			"updated_at": schema.StringAttribute{
+				CustomType: timetypes.RFC3339Type{},
+				Computed:   true,
+			},
+		},
+	}
+}
+
+func (d *promptRouterDataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+	var data promptRouterDataSourceModel
+	response.Diagnostics.Append(request.Config.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := d.Meta().BedrockClient(ctx)
+
+	output, err := findPromptRouterByARN(ctx, conn, data.PromptRouterARN.ValueString())
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("reading Bedrock Prompt Router (%s)", data.PromptRouterARN.ValueString()), err.Error())
+		return
+	}
+
+	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+type promptRouterDataSourceModel struct {
+	framework.WithRegionModel
+	CreatedAt        timetypes.RFC3339                                        `tfsdk:"created_at"`
+	Description      types.String                                             `tfsdk:"description"`
+	FallbackModel    fwtypes.ListNestedObjectValueOf[promptRouterTargetModel] `tfsdk:"fallback_model"`
+	Models           fwtypes.ListNestedObjectValueOf[promptRouterTargetModel] `tfsdk:"models"`
+	PromptRouterARN  fwtypes.ARN                                              `tfsdk:"prompt_router_arn"`
+	PromptRouterName types.String                                             `tfsdk:"prompt_router_name"`
+	RoutingCriteria  fwtypes.ListNestedObjectValueOf[routingCriteriaModel]    `tfsdk:"routing_criteria"`
+	Status           fwtypes.StringEnum[awstypes.PromptRouterStatus]          `tfsdk:"status"`
+	Type             fwtypes.StringEnum[awstypes.PromptRouterType]            `tfsdk:"type"`
+	UpdatedAt        timetypes.RFC3339                                        `tfsdk:"updated_at"`
+}

--- a/internal/service/bedrock/prompt_router_data_source_test.go
+++ b/internal/service/bedrock/prompt_router_data_source_test.go
@@ -1,0 +1,46 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package bedrock_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccBedrockPromptRouterDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	datasourceName := "data.aws_bedrock_prompt_router.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPromptRouterDataSourceConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceName, "prompt_router_arn"),
+					resource.TestCheckResourceAttrSet(datasourceName, "prompt_router_name"),
+					resource.TestCheckResourceAttrSet(datasourceName, names.AttrStatus),
+					resource.TestCheckResourceAttrSet(datasourceName, names.AttrType),
+					resource.TestCheckResourceAttrSet(datasourceName, names.AttrCreatedAt),
+					resource.TestCheckResourceAttrSet(datasourceName, "updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func testAccPromptRouterDataSourceConfig_basic() string {
+	return `
+data "aws_bedrock_prompt_routers" "test" {}
+
+data "aws_bedrock_prompt_router" "test" {
+  prompt_router_arn = data.aws_bedrock_prompt_routers.test.prompt_router_summaries[0].prompt_router_arn
+}
+`
+}

--- a/internal/service/bedrock/prompt_router_test.go
+++ b/internal/service/bedrock/prompt_router_test.go
@@ -1,0 +1,326 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package bedrock_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrock"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tfbedrock "github.com/hashicorp/terraform-provider-aws/internal/service/bedrock"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+const (
+	promptRouterFallbackModelID = "anthropic.claude-3-5-sonnet-20240620-v1:0" // lintignore:AWSAT003,AWSAT005
+	promptRouterModelID1        = "anthropic.claude-3-5-sonnet-20240620-v1:0" // lintignore:AWSAT003,AWSAT005
+	promptRouterModelID2        = "anthropic.claude-3-haiku-20240307-v1:0"    // lintignore:AWSAT003,AWSAT005
+)
+
+func TestAccBedrockPromptRouter_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var promptRouter bedrock.GetPromptRouterOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_bedrock_prompt_router.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPromptRouterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPromptRouterConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPromptRouterExists(ctx, resourceName, &promptRouter),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("prompt_router_arn"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("prompt_router_name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("fallback_model"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("models"), knownvalue.ListSizeExact(2)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("routing_criteria"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "prompt_router_arn"),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "prompt_router_arn",
+			},
+		},
+	})
+}
+
+func TestAccBedrockPromptRouter_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	var promptRouter bedrock.GetPromptRouterOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_bedrock_prompt_router.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPromptRouterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPromptRouterConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPromptRouterExists(ctx, resourceName, &promptRouter),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfbedrock.ResourcePromptRouter, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccBedrockPromptRouter_description(t *testing.T) {
+	ctx := acctest.Context(t)
+	var promptRouter bedrock.GetPromptRouterOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_bedrock_prompt_router.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPromptRouterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPromptRouterConfig_description(rName, "Test description"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPromptRouterExists(ctx, resourceName, &promptRouter),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrDescription), knownvalue.StringExact("Test description")),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "prompt_router_arn"),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "prompt_router_arn",
+			},
+		},
+	})
+}
+
+func TestAccBedrockPromptRouter_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	var promptRouter bedrock.GetPromptRouterOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_bedrock_prompt_router.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPromptRouterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPromptRouterConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPromptRouterExists(ctx, resourceName, &promptRouter),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+						acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+					})),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "prompt_router_arn"),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "prompt_router_arn",
+			},
+		},
+	})
+}
+
+func testAccCheckPromptRouterDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).BedrockClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_bedrock_prompt_router" {
+				continue
+			}
+
+			_, err := tfbedrock.FindPromptRouterByARN(ctx, conn, rs.Primary.Attributes["prompt_router_arn"])
+			if retry.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("Bedrock Prompt Router %s still exists", rs.Primary.Attributes["prompt_router_arn"])
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckPromptRouterExists(ctx context.Context, n string, v *bedrock.GetPromptRouterOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).BedrockClient(ctx)
+
+		resp, err := tfbedrock.FindPromptRouterByARN(ctx, conn, rs.Primary.Attributes["prompt_router_arn"])
+		if err != nil {
+			return err
+		}
+
+		*v = *resp
+
+		return nil
+	}
+}
+
+func testAccPromptRouterConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_bedrock_prompt_router" "test" {
+  prompt_router_name = %[1]q
+
+  fallback_model {
+    model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[2]s"
+  }
+
+  models {
+    model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[3]s"
+  }
+
+  models {
+    model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[4]s"
+  }
+
+  routing_criteria {
+    response_quality_difference = 25
+  }
+}
+`, rName, promptRouterFallbackModelID, promptRouterModelID1, promptRouterModelID2)
+}
+
+func testAccPromptRouterConfig_description(rName, description string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_bedrock_prompt_router" "test" {
+  prompt_router_name = %[1]q
+  description        = %[2]q
+
+  fallback_model {
+    model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[3]s"
+  }
+
+  models {
+    model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[4]s"
+  }
+
+  models {
+    model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[5]s"
+  }
+
+  routing_criteria {
+    response_quality_difference = 25
+  }
+}
+`, rName, description, promptRouterFallbackModelID, promptRouterModelID1, promptRouterModelID2)
+}
+
+func testAccPromptRouterConfig_tags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_bedrock_prompt_router" "test" {
+  prompt_router_name = %[1]q
+
+  fallback_model {
+    model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[4]s"
+  }
+
+  models {
+    model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[5]s"
+  }
+
+  models {
+    model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[6]s"
+  }
+
+  routing_criteria {
+    response_quality_difference = 25
+  }
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1, promptRouterFallbackModelID, promptRouterModelID1, promptRouterModelID2)
+}

--- a/internal/service/bedrock/prompt_routers_data_source.go
+++ b/internal/service/bedrock/prompt_routers_data_source.go
@@ -1,0 +1,104 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package bedrock
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrock"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+)
+
+// @FrameworkDataSource("aws_bedrock_prompt_routers", name="Prompt Routers")
+func newPromptRoutersDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &promptRoutersDataSource{}, nil
+}
+
+type promptRoutersDataSource struct {
+	framework.DataSourceWithModel[promptRoutersDataSourceModel]
+}
+
+func (d *promptRoutersDataSource) Schema(ctx context.Context, request datasource.SchemaRequest, response *datasource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"prompt_router_summaries": framework.DataSourceComputedListOfObjectAttribute[promptRouterSummaryModel](ctx),
+		},
+	}
+}
+
+func (d *promptRoutersDataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+	var data promptRoutersDataSourceModel
+	response.Diagnostics.Append(request.Config.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := d.Meta().BedrockClient(ctx)
+
+	input := &bedrock.ListPromptRoutersInput{}
+
+	response.Diagnostics.Append(fwflex.Expand(ctx, data, input)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	promptRouters, err := findPromptRouters(ctx, conn, input)
+
+	if err != nil {
+		response.Diagnostics.AddError("listing Bedrock Prompt Routers", err.Error())
+		return
+	}
+
+	output := &bedrock.ListPromptRoutersOutput{
+		PromptRouterSummaries: promptRouters,
+	}
+	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+func findPromptRouters(ctx context.Context, conn *bedrock.Client, input *bedrock.ListPromptRoutersInput) ([]awstypes.PromptRouterSummary, error) {
+	var output = make([]awstypes.PromptRouterSummary, 0)
+
+	pages := bedrock.NewListPromptRoutersPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, page.PromptRouterSummaries...)
+	}
+
+	return output, nil
+}
+
+type promptRoutersDataSourceModel struct {
+	framework.WithRegionModel
+	PromptRouterSummaries fwtypes.ListNestedObjectValueOf[promptRouterSummaryModel] `tfsdk:"prompt_router_summaries"`
+}
+
+type promptRouterSummaryModel struct {
+	CreatedAt        timetypes.RFC3339                                        `tfsdk:"created_at"`
+	Description      types.String                                             `tfsdk:"description"`
+	FallbackModel    fwtypes.ListNestedObjectValueOf[promptRouterTargetModel] `tfsdk:"fallback_model"`
+	Models           fwtypes.ListNestedObjectValueOf[promptRouterTargetModel] `tfsdk:"models"`
+	PromptRouterARN  fwtypes.ARN                                              `tfsdk:"prompt_router_arn"`
+	PromptRouterName types.String                                             `tfsdk:"prompt_router_name"`
+	RoutingCriteria  fwtypes.ListNestedObjectValueOf[routingCriteriaModel]    `tfsdk:"routing_criteria"`
+	Status           fwtypes.StringEnum[awstypes.PromptRouterStatus]          `tfsdk:"status"`
+	Type             fwtypes.StringEnum[awstypes.PromptRouterType]            `tfsdk:"type"`
+	UpdatedAt        timetypes.RFC3339                                        `tfsdk:"updated_at"`
+}

--- a/internal/service/bedrock/prompt_routers_data_source_test.go
+++ b/internal/service/bedrock/prompt_routers_data_source_test.go
@@ -1,0 +1,37 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package bedrock_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccBedrockPromptRoutersDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	datasourceName := "data.aws_bedrock_prompt_routers.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPromptRoutersDataSourceConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanOrEqualValue(datasourceName, "prompt_router_summaries.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func testAccPromptRoutersDataSourceConfig_basic() string {
+	return `
+data "aws_bedrock_prompt_routers" "test" {}
+`
+}

--- a/internal/service/bedrock/service_package_gen.go
+++ b/internal/service/bedrock/service_package_gen.go
@@ -55,6 +55,18 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 			Name:     "Inference Profiles",
 			Region:   unique.Make(inttypes.ResourceRegionDefault()),
 		},
+		{
+			Factory:  newPromptRouterDataSource,
+			TypeName: "aws_bedrock_prompt_router",
+			Name:     "Prompt Router",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+		{
+			Factory:  newPromptRoutersDataSource,
+			TypeName: "aws_bedrock_prompt_routers",
+			Name:     "Prompt Routers",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
 	}
 }
 
@@ -106,6 +118,15 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			Import: inttypes.FrameworkImport{
 				WrappedImport: true,
 			},
+		},
+		{
+			Factory:  newPromptRouterResource,
+			TypeName: "aws_bedrock_prompt_router",
+			Name:     "Prompt Router",
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: "prompt_router_arn",
+			}),
+			Region: unique.Make(inttypes.ResourceRegionDefault()),
 		},
 		{
 			Factory:  newProvisionedModelThroughputResource,

--- a/internal/service/bedrock/sweep.go
+++ b/internal/service/bedrock/sweep.go
@@ -1,0 +1,88 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package bedrock
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrock"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func RegisterSweepers() {
+	awsv2.Register("aws_bedrock_guardrail", sweepGuardrails)
+	awsv2.Register("aws_bedrock_inference_profile", sweepInferenceProfiles)
+	awsv2.Register("aws_bedrock_prompt_router", sweepPromptRouters)
+}
+
+func sweepGuardrails(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	input := &bedrock.ListGuardrailsInput{}
+	conn := client.BedrockClient(ctx)
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	pages := bedrock.NewListGuardrailsPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, v := range page.Guardrails {
+			sweepResources = append(sweepResources, framework.NewSweepResource(newGuardrailResource, client,
+				framework.NewAttribute("guardrail_id", aws.ToString(v.Id))))
+		}
+	}
+
+	return sweepResources, nil
+}
+
+func sweepInferenceProfiles(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	input := &bedrock.ListInferenceProfilesInput{}
+	conn := client.BedrockClient(ctx)
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	pages := bedrock.NewListInferenceProfilesPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, v := range page.InferenceProfileSummaries {
+			sweepResources = append(sweepResources, framework.NewSweepResource(newInferenceProfileResource, client,
+				framework.NewAttribute(names.AttrID, aws.ToString(v.InferenceProfileId))))
+		}
+	}
+
+	return sweepResources, nil
+}
+
+func sweepPromptRouters(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	input := &bedrock.ListPromptRoutersInput{}
+	conn := client.BedrockClient(ctx)
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	pages := bedrock.NewListPromptRoutersPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, v := range page.PromptRouterSummaries {
+			sweepResources = append(sweepResources, framework.NewSweepResource(newPromptRouterResource, client,
+				framework.NewAttribute("prompt_router_arn", aws.ToString(v.PromptRouterArn))))
+		}
+	}
+
+	return sweepResources, nil
+}

--- a/internal/sweep/register_gen_test.go
+++ b/internal/sweep/register_gen_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/service/backup"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/batch"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/bcmdataexports"
+	"github.com/hashicorp/terraform-provider-aws/internal/service/bedrock"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/billing"
@@ -210,6 +211,7 @@ func registerSweepers() {
 	backup.RegisterSweepers()
 	batch.RegisterSweepers()
 	bcmdataexports.RegisterSweepers()
+	bedrock.RegisterSweepers()
 	bedrockagent.RegisterSweepers()
 	bedrockagentcore.RegisterSweepers()
 	billing.RegisterSweepers()

--- a/website/docs/d/bedrock_prompt_router.html.markdown
+++ b/website/docs/d/bedrock_prompt_router.html.markdown
@@ -1,0 +1,56 @@
+---
+subcategory: "Bedrock"
+layout: "aws"
+page_title: "AWS: aws_bedrock_prompt_router"
+description: |-
+  Terraform data source for managing an AWS Bedrock Prompt Router.
+---
+
+# Data Source: aws_bedrock_prompt_router
+
+Terraform data source for managing an AWS Bedrock Prompt Router.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_bedrock_prompt_routers" "example" {}
+
+data "aws_bedrock_prompt_router" "example" {
+  prompt_router_arn = data.aws_bedrock_prompt_routers.example.prompt_router_summaries[0].prompt_router_arn
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `prompt_router_arn` - (Required) ARN of the prompt router.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+- `created_at` - Time at which the prompt router was created.
+- `description` - Description of the prompt router.
+- `fallback_model` - List of information about the fallback model. See [`fallback_model`](#fallback_model).
+- `models` - List of information about each model in the prompt router. See [`models`](#models).
+- `prompt_router_name` - Name of the prompt router.
+- `routing_criteria` - Routing criteria for the prompt router. See [`routing_criteria`](#routing_criteria).
+- `status` - Status of the prompt router. `AVAILABLE` means that the prompt router is ready to route requests.
+- `type` - Type of the prompt router.
+- `updated_at` - Time at which the prompt router was last updated.
+
+### `fallback_model`
+
+- `model_arn` - Amazon Resource Name (ARN) of the fallback model.
+
+### `models`
+
+- `model_arn` - Amazon Resource Name (ARN) of the model.
+
+### `routing_criteria`
+
+- `response_quality_difference` - Threshold for the difference in quality between model responses.

--- a/website/docs/d/bedrock_prompt_routers.html.markdown
+++ b/website/docs/d/bedrock_prompt_routers.html.markdown
@@ -1,0 +1,56 @@
+---
+subcategory: "Bedrock"
+layout: "aws"
+page_title: "AWS: aws_bedrock_prompt_routers"
+description: |-
+  Terraform data source for managing AWS Bedrock Prompt Routers.
+---
+
+# Data Source: aws_bedrock_prompt_routers
+
+Terraform data source for managing AWS Bedrock Prompt Routers.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_bedrock_prompt_routers" "example" {}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+- `prompt_router_summaries` - List of prompt router summary objects. See [`prompt_router_summaries`](#prompt_router_summaries).
+
+### `prompt_router_summaries`
+
+- `created_at` - Time at which the prompt router was created.
+- `description` - Description of the prompt router.
+- `fallback_model` - List of information about the fallback model. See [`fallback_model`](#fallback_model).
+- `models` - List of information about each model in the prompt router. See [`models`](#models).
+- `prompt_router_arn` - Amazon Resource Name (ARN) of the prompt router.
+- `prompt_router_name` - Name of the prompt router.
+- `routing_criteria` - Routing criteria for the prompt router. See [`routing_criteria`](#routing_criteria).
+- `status` - Status of the prompt router. `AVAILABLE` means that the prompt router is ready to route requests.
+- `type` - Type of the prompt router.
+- `updated_at` - Time at which the prompt router was last updated.
+
+### `fallback_model`
+
+- `model_arn` - Amazon Resource Name (ARN) of the fallback model.
+
+### `models`
+
+- `model_arn` - Amazon Resource Name (ARN) of the model.
+
+### `routing_criteria`
+
+- `response_quality_difference` - Threshold for the difference in quality between model responses.

--- a/website/docs/r/bedrock_prompt_router.html.markdown
+++ b/website/docs/r/bedrock_prompt_router.html.markdown
@@ -1,0 +1,94 @@
+---
+subcategory: "Bedrock"
+layout: "aws"
+page_title: "AWS: aws_bedrock_prompt_router"
+description: |-
+  Manages an AWS Bedrock Prompt Router.
+---
+
+# Resource: aws_bedrock_prompt_router
+
+Manages an AWS Bedrock Prompt Router that routes requests between multiple foundation models based on routing criteria.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_region" "current" {}
+
+resource "aws_bedrock_prompt_router" "example" {
+  prompt_router_name = "example-router"
+  description        = "Example prompt router for intelligent routing"
+
+  fallback_model {
+    model_arn = "arn:aws:bedrock:${data.aws_region.current.name}::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0"
+  }
+
+  models {
+    model_arn = "arn:aws:bedrock:${data.aws_region.current.name}::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0"
+  }
+
+  models {
+    model_arn = "arn:aws:bedrock:${data.aws_region.current.name}::foundation-model/anthropic.claude-3-5-haiku-20241022-v1:0"
+  }
+
+  routing_criteria {
+    response_quality_difference = 25
+  }
+
+  tags = {
+    Environment = "production"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `prompt_router_name` - (Required) Name of the prompt router. Must be unique within your AWS account in the current region. Must be between 1 and 64 characters.
+* `fallback_model` - (Required) Default model to use when the routing criteria is not met. See [`fallback_model`](#fallback_model).
+* `models` - (Required) List of foundation models that the prompt router can route requests to. At least one model must be specified. See [`models`](#models).
+* `routing_criteria` - (Required) Criteria used to determine how incoming requests are routed to different models. See [`routing_criteria`](#routing_criteria).
+
+The following arguments are optional:
+
+* `description` - (Optional) Description of the prompt router to help identify its purpose. Must be between 1 and 200 characters.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `tags` - (Optional) Key-value mapping of resource tags for the prompt router.
+
+### `fallback_model`
+
+* `model_arn` - (Required) Amazon Resource Name (ARN) of the fallback model.
+
+### `models`
+
+* `model_arn` - (Required) Amazon Resource Name (ARN) of the model.
+
+### `routing_criteria`
+
+* `response_quality_difference` - (Required) Threshold for the difference in quality between model responses. Must be a value between 0 and 100, and must be a multiple of 5 (e.g., 0, 5, 10, 15, ..., 100).
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `prompt_router_arn` - Amazon Resource Name (ARN) of the prompt router.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Bedrock Prompt Router using the `prompt_router_arn`. For example:
+
+```terraform
+import {
+  to = aws_bedrock_prompt_router.example
+  id = "arn:aws:bedrock:us-east-1:123456789012:default-prompt-router/example-router"
+}
+```
+
+Using `terraform import`, import Bedrock Prompt Router using the `prompt_router_arn`. For example:
+
+```console
+% terraform import aws_bedrock_prompt_router.example arn:aws:bedrock:us-east-1:123456789012:default-prompt-router/example-router
+```


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls (access controls, encryption, logging) in this pull request.

### Description

This PR adds support for AWS Bedrock Prompt Router:

**New Resource:**
- **aws_bedrock_prompt_router** - Manages custom prompt routers that intelligently route prompts to the most suitable foundation model based on configurable routing criteria

**New Data Sources:**
- **aws_bedrock_prompt_router** - Retrieves detailed information about a specific prompt router by ARN
- **aws_bedrock_prompt_routers** - Lists all available prompt routers in an AWS account/region

**Additional Changes:**
- Added sweepers for bedrock package (first sweeper file in this package) covering:
  - `aws_bedrock_guardrail`
  - `aws_bedrock_inference_profile`
  - `aws_bedrock_prompt_router`

The prompt router resource supports:
- Creating custom prompt routers with fallback model and target models
- Configuring response quality difference threshold (0-100, must be multiple of 5) for routing decisions
- Optional description
- Tagging support

Note: The AWS API does not support updates for prompt routers, so all attribute changes require resource replacement.

### Relations

Closes #45125

### References

* AWS SDK Go v2 - [CreatePromptRouter](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/bedrock#Client.CreatePromptRouter)
* AWS SDK Go v2 - [GetPromptRouter](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/bedrock#Client.GetPromptRouter)
* AWS SDK Go v2 - [DeletePromptRouter](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/bedrock#Client.DeletePromptRouter)
* AWS SDK Go v2 - [ListPromptRouters](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/bedrock#Client.ListPromptRouters)
* AWS Bedrock API Reference - [Prompt Router APIs](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_Operations_Amazon_Bedrock.html)

### Output from Acceptance Testing

```console
% PKG_NAME=internal/service/bedrock TESTARGS='-run=TestAccBedrockPromptRouter' TF_ACC=1 AWS_PROFILE=octo-devenablement-nonprod AWS_REGION=eu-central-1 AWS_DEFAULT_REGION=eu-central-1 make testacc

=== RUN   TestAccBedrockPromptRoutersDataSource_basic
=== PAUSE TestAccBedrockPromptRoutersDataSource_basic
=== RUN   TestAccBedrockPromptRouterDataSource_basic
=== PAUSE TestAccBedrockPromptRouterDataSource_basic
=== RUN   TestAccBedrockPromptRouter_basic
=== PAUSE TestAccBedrockPromptRouter_basic
=== RUN   TestAccBedrockPromptRouter_disappears
=== PAUSE TestAccBedrockPromptRouter_disappears
=== RUN   TestAccBedrockPromptRouter_description
=== PAUSE TestAccBedrockPromptRouter_description
=== RUN   TestAccBedrockPromptRouter_tags
=== PAUSE TestAccBedrockPromptRouter_tags
=== CONT  TestAccBedrockPromptRoutersDataSource_basic
=== CONT  TestAccBedrockPromptRouter_tags
=== CONT  TestAccBedrockPromptRouter_description
=== CONT  TestAccBedrockPromptRouter_disappears
=== CONT  TestAccBedrockPromptRouterDataSource_basic
=== CONT  TestAccBedrockPromptRouter_basic
--- PASS: TestAccBedrockPromptRoutersDataSource_basic (13.00s)
--- PASS: TestAccBedrockPromptRouterDataSource_basic (13.27s)
--- PASS: TestAccBedrockPromptRouter_disappears (16.89s)
--- PASS: TestAccBedrockPromptRouter_tags (20.55s)
--- PASS: TestAccBedrockPromptRouter_basic (20.67s)
--- PASS: TestAccBedrockPromptRouter_description (20.67s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrock	28.229s
```
