### PR TITLE
[Docs] r/aws_codestarnotifications_notification_rule: Update `target` block description

### DIFF
--- a/website/docs/r/codestarnotifications_notification_rule.html.markdown
+++ b/website/docs/r/codestarnotifications_notification_rule.html.markdown
@@ -68,8 +68,8 @@ This resource supports the following arguments:
 
 An `target` block supports the following arguments:
 
-* `address` - (Required) The ARN of notification rule target. For example, a SNS Topic ARN.
-* `type` - (Optional) The type of the notification target. Default value is `SNS`.
+* `address` - (Required) The ARN of the Amazon Q Developer in chat applications topic or Amazon Q Developer in chat applications client.
+* `type` - (Optional) The type of the notification target. Valid values are `SNS`, `AWSChatbotSlack`, and `AWSChatbotMicrosoftTeams`. Default value is `SNS`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
Update the documentation for `target` block in `aws_codestarnotifications_notification_rule` resource.

### Relations

Closes #45114

### References

https://docs.aws.amazon.com/codestar-notifications/latest/APIReference/API_Target.html

