### PR TITLE
Fix `acctest.CheckACMPCACertificateAuthorityActivateRootCA`

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1958,21 +1958,21 @@ func CheckACMPCACertificateAuthorityActivateSubordinateCA(ctx context.Context, r
 			return fmt.Errorf("attempting to activate ACM PCA %s Certificate Authority", v)
 		}
 
-		arn := aws.ToString(certificateAuthority.Arn)
+		caARN := aws.ToString(certificateAuthority.Arn)
 
 		getCSRInput := acmpca.GetCertificateAuthorityCsrInput{
-			CertificateAuthorityArn: aws.String(arn),
+			CertificateAuthorityArn: aws.String(caARN),
 		}
 		getCsrOutput, err := conn.GetCertificateAuthorityCsr(ctx, &getCSRInput)
 
 		if err != nil {
-			return fmt.Errorf("getting ACM PCA Certificate Authority (%s) CSR: %w", arn, err)
+			return fmt.Errorf("getting ACM PCA Certificate Authority (%s) CSR: %w", caARN, err)
 		}
 
-		rootCertificateAuthorityArn := aws.ToString(rootCertificateAuthority.Arn)
+		rootCAARN := aws.ToString(rootCertificateAuthority.Arn)
 
 		issueCertInput := acmpca.IssueCertificateInput{
-			CertificateAuthorityArn: aws.String(rootCertificateAuthorityArn),
+			CertificateAuthorityArn: aws.String(rootCAARN),
 			Csr:                     []byte(aws.ToString(getCsrOutput.Csr)),
 			IdempotencyToken:        aws.String(id.UniqueId()),
 			SigningAlgorithm:        certificateAuthority.CertificateAuthorityConfiguration.SigningAlgorithm,
@@ -1984,27 +1984,29 @@ func CheckACMPCACertificateAuthorityActivateSubordinateCA(ctx context.Context, r
 		}
 		issueCertOutput, err := conn.IssueCertificate(ctx, &issueCertInput)
 		if err != nil {
-			return fmt.Errorf("issuing ACM PCA Certificate Authority (%s) Subordinate CA certificate from CSR: %w", arn, err)
+			return fmt.Errorf("issuing ACM PCA Certificate Authority (%s) Subordinate CA certificate from CSR: %w", caARN, err)
 		}
+
+		caCertARN := aws.ToString(issueCertOutput.CertificateArn)
 
 		// Wait for certificate status to become ISSUED.
 		getCertOutput, err := tfresource.RetryWhenIsA[*acmpca.GetCertificateOutput, *acmpcatypes.RequestInProgressException](ctx, CertificateIssueTimeout, func(ctx context.Context) (*acmpca.GetCertificateOutput, error) {
-			return tfacmpca.FindCertificateByTwoPartKey(ctx, conn, rootCertificateAuthorityArn, aws.ToString(issueCertOutput.CertificateArn))
+			return tfacmpca.FindCertificateByTwoPartKey(ctx, conn, caCertARN, rootCAARN)
 		})
 
 		if err != nil {
-			return fmt.Errorf("waiting for ACM PCA Certificate Authority (%s) Subordinate CA certificate (%s) to become ISSUED: %w", arn, aws.ToString(issueCertOutput.CertificateArn), err)
+			return fmt.Errorf("waiting for ACM PCA Certificate Authority (%s) Subordinate CA certificate (%s) to become ISSUED: %w", caARN, caCertARN, err)
 		}
 
 		importCACertificateInput := acmpca.ImportCertificateAuthorityCertificateInput{
-			CertificateAuthorityArn: aws.String(arn),
+			CertificateAuthorityArn: aws.String(caARN),
 			Certificate:             []byte(aws.ToString(getCertOutput.Certificate)),
 			CertificateChain:        []byte(aws.ToString(getCertOutput.CertificateChain)),
 		}
 		_, err = conn.ImportCertificateAuthorityCertificate(ctx, &importCACertificateInput)
 
 		if err != nil {
-			return fmt.Errorf("importing ACM PCA Certificate Authority (%s) Subordinate CA certificate: %w", arn, err)
+			return fmt.Errorf("importing ACM PCA Certificate Authority (%s) Subordinate CA certificate: %w", caARN, err)
 		}
 
 		return err


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Arguments to `tfacmpca.FindCertificateByTwoPartKey` were in the wrong order.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/45137.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/36338.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccAppMesh_serial/VirtualGateway/listenerTls' PKG=appmesh
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-fix-acctest.CheckACMPCACertificateAuthorityActivateRootCA 🌿...
TF_ACC=1 go1.24.10 test ./internal/service/appmesh/... -v -count 1 -parallel 20  -run=TestAccAppMesh_serial/VirtualGateway/listenerTls -timeout 360m -vet=off
2025/11/20 15:34:16 Creating Terraform AWS Provider (SDKv2-style)...
2025/11/20 15:34:16 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAppMesh_serial
=== PAUSE TestAccAppMesh_serial
=== CONT  TestAccAppMesh_serial
=== RUN   TestAccAppMesh_serial/VirtualGateway
=== RUN   TestAccAppMesh_serial/VirtualGateway/listenerTls
--- PASS: TestAccAppMesh_serial (63.99s)
    --- PASS: TestAccAppMesh_serial/VirtualGateway (63.99s)
        --- PASS: TestAccAppMesh_serial/VirtualGateway/listenerTls (63.99s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appmesh	69.632s
```
```console
% make testacc TESTARGS='-run=TestAccSiteVPNCustomerGateway_certificate' PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-fix-acctest.CheckACMPCACertificateAuthorityActivateRootCA 🌿...
TF_ACC=1 go1.24.10 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccSiteVPNCustomerGateway_certificate -timeout 360m -vet=off
2025/11/20 15:55:48 Creating Terraform AWS Provider (SDKv2-style)...
2025/11/20 15:55:48 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSiteVPNCustomerGateway_certificate
=== PAUSE TestAccSiteVPNCustomerGateway_certificate
=== CONT  TestAccSiteVPNCustomerGateway_certificate
--- PASS: TestAccSiteVPNCustomerGateway_certificate (77.63s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	83.275s
```