### PR TITLE
docs: fix broken link to Non–region-aware resources section

### DIFF
--- a/website/docs/cdktf/python/guides/enhanced-region-support.html.markdown
+++ b/website/docs/cdktf/python/guides/enhanced-region-support.html.markdown
@@ -544,7 +544,7 @@ class MyConvertedCode(TerraformStack):
 </p>
 </details>
 
-## Non–region-aware resources
+## Non–region-aware resources {#nonregion-aware-resources}
 
 This section lists resources that are not Region-aware—meaning `region` has not been added to them.
 

--- a/website/docs/cdktf/typescript/guides/enhanced-region-support.html.markdown
+++ b/website/docs/cdktf/typescript/guides/enhanced-region-support.html.markdown
@@ -629,7 +629,7 @@ class MyConvertedCode extends TerraformStack {
 </p>
 </details>
 
-## Non–region-aware resources
+## Non–region-aware resources {#nonregion-aware-resources}
 
 This section lists resources that are not Region-aware—meaning `region` has not been added to them.
 

--- a/website/docs/guides/enhanced-region-support.html.markdown
+++ b/website/docs/guides/enhanced-region-support.html.markdown
@@ -496,7 +496,7 @@ resource "aws_s3_bucket_replication_configuration" "replication" {
 </p>
 </details>
 
-## Non–region-aware resources
+## Non–region-aware resources {#nonregion-aware-resources}
 
 This section lists resources that are not Region-aware—meaning `region` has not been added to them.
 


### PR DESCRIPTION
The link to the 'Non–region-aware resources' section in the Enhanced Region Support guide was not working because the heading contains an en-dash character (Unicode U+2013) which some markdown processors do not correctly convert to the expected anchor format.

This commit adds an explicit anchor ID {#nonregion-aware-resources} to the heading to ensure the link works correctly across all markdown processors.

Fixes the broken link in:
- 'Can I use region in every resource?' section
- Table of contents

Affected files:
- website/docs/guides/enhanced-region-support.html.markdown
- website/docs/cdktf/typescript/guides/enhanced-region-support.html.markdown
- website/docs/cdktf/python/guides/enhanced-region-support.html.markdown

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
