### PR TITLE
Provider: Fix required tag validation regressions

### DIFF
--- a/.changelog/45201.txt
+++ b/.changelog/45201.txt
@@ -1,3 +1,6 @@
 ```release-note:bug
 provider: Fix early return logic in the required tag validation interceptor. This addresses a performance regression introduced in [v6.22.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#6220-november-20-2025).
 ```
+```release-note:bug
+provider: Fix crash in required tag validation interceptor when tag values are unknown. This addresses a regression introduced in [v6.22.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#6220-november-20-2025).
+```

--- a/internal/provider/framework/tags_interceptor.go
+++ b/internal/provider/framework/tags_interceptor.go
@@ -301,6 +301,10 @@ func (r resourceValidateRequiredTagsInterceptor) modifyPlan(ctx context.Context,
 			return
 		}
 
+		if !planTags.IsWhollyKnown() {
+			return
+		}
+
 		allPlanTags := c.DefaultTagsConfig(ctx).MergeTags(tftags.New(ctx, planTags))
 		allStateTags := c.DefaultTagsConfig(ctx).MergeTags(tftags.New(ctx, stateTags))
 

--- a/internal/provider/sdkv2/tags_interceptor.go
+++ b/internal/provider/sdkv2/tags_interceptor.go
@@ -329,6 +329,10 @@ func validateRequiredTags() customizeDiffInterceptor {
 					return nil
 				}
 
+				if !d.GetRawPlan().GetAttr(names.AttrTags).IsWhollyKnown() {
+					return nil
+				}
+
 				cfgTags := tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))
 				allTags := c.DefaultTagsConfig(ctx).MergeTags(cfgTags)
 				if allTags.ContainsAllKeys(reqTags) {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This includes fixes for two regressions introduced in `v6.22.0`:

1. The validate required tags interceptor would crash when the planned value for the `tags` attribute included unknown tag values. Validation now skips when planned values are not wholly known.
1. The check for whether tag policy compliance was enabled and included required tags for the current resource type was nested in the middle of the required tag validation logic. It is now moved to the start to exit as early as possible and prevent unnecessary processing of tag values.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #45143
Closes #45187


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% TF_ACC_REQUIRED_TAG_KEY=Owner make t K=iot T=TestAccIoTBillingGroup_requiredTags
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-tag-policy-interceptor 🌿...
TF_ACC=1 go1.24.10 test ./internal/service/iot/... -v -count 1 -parallel 20 -run='TestAccIoTBillingGroup_requiredTags'  -timeout 360m -vet=off
2025/11/21 10:54:23 Creating Terraform AWS Provider (SDKv2-style)...
2025/11/21 10:54:23 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccIoTBillingGroup_requiredTags_defaultTags (21.24s)
--- PASS: TestAccIoTBillingGroup_requiredTags (21.25s)
--- PASS: TestAccIoTBillingGroup_requiredTags_disabled (35.96s)
--- PASS: TestAccIoTBillingGroup_requiredTags_warning (39.28s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iot        45.913s
```

```console
% TF_ACC_REQUIRED_TAG_KEY=Owner make t K=logs T=TestAccLogsLogGroup_requiredTags
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-tag-policy-interceptor 🌿...
TF_ACC=1 go1.24.10 test ./internal/service/logs/... -v -count 1 -parallel 20 -run='TestAccLogsLogGroup_requiredTags'  -timeout 360m -vet=off
2025/11/21 10:57:30 Creating Terraform AWS Provider (SDKv2-style)...
2025/11/21 10:57:30 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccLogsLogGroup_requiredTags (19.66s)
--- PASS: TestAccLogsLogGroup_requiredTags_defaultTags (19.75s)
--- PASS: TestAccLogsLogGroup_requiredTags_disabled (35.51s)
--- PASS: TestAccLogsLogGroup_requiredTags_warning (38.56s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       45.089s
```
