### PR TITLE
chore: `v6.22.1` release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.23.0 (Unreleased)
+## 6.22.1 (November 21, 2025)
 
 ENHANCEMENTS:
 


### PR DESCRIPTION
Preparing for the `v6.22.1` patch release. `version/VERSION` is already tracking the correct patch number.