### PR TITLE
opensearch: Remove 10-minute delays from domain creation and deletion

### DIFF
--- a/.changelog/45245.txt
+++ b/.changelog/45245.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_opensearch_domain: Remove hardcoded 10-minute delay before polling domain state during creation and deletion
+```

--- a/.changelog/45245.txt
+++ b/.changelog/45245.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_opensearch_domain: Remove hardcoded 10-minute delay before polling domain state during creation and deletion
+resource/aws_opensearch_domain: Remove hardcoded delays before polling domain state during creation, update, and deletion operations
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,6 @@ ENHANCEMENTS:
 * resource/aws_fis_experiment_template: Add support for `Functions` to `action.*.target` ([#41209](https://github.com/hashicorp/terraform-provider-aws/issues/41209))
 * resource/aws_lambda_invocation: Add import support ([#41240](https://github.com/hashicorp/terraform-provider-aws/issues/41240))
 * resource/aws_lb_listener: Support `jwt-validation` as a valid `default_action.type` and add `default_action.jwt_validation` configuration block ([#45089](https://github.com/hashicorp/terraform-provider-aws/issues/45089))
-* resource/aws_opensearch_domain: Remove hardcoded 10-minute delay before polling domain state during creation and deletion ([#45244](https://github.com/hashicorp/terraform-provider-aws/issues/45244))
 * resource/aws_lb_listener_rule: Support `jwt-validation` as a valid `action.type` and add `action.jwt_validation` configuration block ([#45089](https://github.com/hashicorp/terraform-provider-aws/issues/45089))
 * resource/aws_odb_cloud_vm_cluster: vm cluster creation using odb network ARN and exadata infrastructure ARN for resource sharing model. ([#45003](https://github.com/hashicorp/terraform-provider-aws/issues/45003))
 * resource/aws_organizations_organization: Add `SECURITYHUB_POLICY` as a valid value for `enabled_policy_types` argument ([#45135](https://github.com/hashicorp/terraform-provider-aws/issues/45135))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ ENHANCEMENTS:
 * resource/aws_fis_experiment_template: Add support for `Functions` to `action.*.target` ([#41209](https://github.com/hashicorp/terraform-provider-aws/issues/41209))
 * resource/aws_lambda_invocation: Add import support ([#41240](https://github.com/hashicorp/terraform-provider-aws/issues/41240))
 * resource/aws_lb_listener: Support `jwt-validation` as a valid `default_action.type` and add `default_action.jwt_validation` configuration block ([#45089](https://github.com/hashicorp/terraform-provider-aws/issues/45089))
+* resource/aws_opensearch_domain: Remove hardcoded 10-minute delay before polling domain state during creation and deletion ([#45244](https://github.com/hashicorp/terraform-provider-aws/issues/45244))
 * resource/aws_lb_listener_rule: Support `jwt-validation` as a valid `action.type` and add `action.jwt_validation` configuration block ([#45089](https://github.com/hashicorp/terraform-provider-aws/issues/45089))
 * resource/aws_odb_cloud_vm_cluster: vm cluster creation using odb network ARN and exadata infrastructure ARN for resource sharing model. ([#45003](https://github.com/hashicorp/terraform-provider-aws/issues/45003))
 * resource/aws_organizations_organization: Add `SECURITYHUB_POLICY` as a valid value for `enabled_policy_types` argument ([#45135](https://github.com/hashicorp/terraform-provider-aws/issues/45135))

--- a/internal/service/opensearch/wait.go
+++ b/internal/service/opensearch/wait.go
@@ -82,7 +82,7 @@ func waitForDomainUpdate(ctx context.Context, conn *opensearch.Client, domainNam
 
 		return tfresource.RetryableError(
 			fmt.Errorf("%q: Timeout while waiting for changes to be processed", domainName))
-	}, tfresource.WithDelay(1*time.Minute), tfresource.WithPollInterval(10*time.Second))
+	}, tfresource.WithPollInterval(10*time.Second))
 
 	if err != nil {
 		return fmt.Errorf("waiting for OpenSearch Domain changes to be processed: %w", err)

--- a/internal/service/opensearch/wait.go
+++ b/internal/service/opensearch/wait.go
@@ -58,7 +58,7 @@ func waitForDomainCreation(ctx context.Context, conn *opensearch.Client, domainN
 
 		return tfresource.RetryableError(
 			fmt.Errorf("%q: Timeout while waiting for OpenSearch Domain to be created", domainName))
-	}, tfresource.WithDelay(10*time.Minute), tfresource.WithPollInterval(10*time.Second))
+	}, tfresource.WithPollInterval(10*time.Second))
 
 	if err != nil {
 		return fmt.Errorf("waiting for OpenSearch Domain to be created: %w", err)
@@ -109,7 +109,7 @@ func waitForDomainDelete(ctx context.Context, conn *opensearch.Client, domainNam
 		}
 
 		return tfresource.RetryableError(fmt.Errorf("timeout while waiting for the OpenSearch Domain %q to be deleted", domainName))
-	}, tfresource.WithDelay(10*time.Minute), tfresource.WithPollInterval(10*time.Second))
+	}, tfresource.WithPollInterval(10*time.Second))
 
 	if err != nil {
 		return fmt.Errorf("waiting for OpenSearch Domain to be deleted: %w", err)


### PR DESCRIPTION
Closes #45244

Removes hardcoded delays before polling domain state during creation, update, and deletion operations. The provider will now begin polling immediately with a 10-second interval for all operations.

This significantly reduces wait times for:
- Fast AWS provisioning scenarios
- Local testing with LocalStack (lightweight AWS emulator)

**Changes:**
- Removed `tfresource.WithDelay(10*time.Minute)` from `waitForDomainCreation()`
- Removed `tfresource.WithDelay(1*time.Minute)` from `waitForDomainUpdate()` (for consistency)
- Removed `tfresource.WithDelay(10*time.Minute)` from `waitForDomainDelete()`
- Kept `tfresource.WithPollInterval(10*time.Second)` to prevent API rate limiting
- Updated changelog entry in `.changelog/45245.txt`

**Domain Creation Performance Test (LocalStack):**
- Before: 600+ seconds (10+ minutes minimum)
- After: ~19 seconds
- **Improvement: ~30x faster**

**Note on Consistency:**
PR #32209 reduced the update delay from 10 minutes to 1 minute. This PR goes further by removing delays entirely from all operations (create/update/delete) for consistency and maximum performance improvement.

**Related:**
- #32189 - Original update delay issue
- #32209 - Update delay fix (reduced to 1 min)
- #28523 - LocalStack timeout discussion
- #44925 - Similar delay issues with RDS