### PR TITLE
[DOCS] aws_networkflowmonitor_monitor: add EKS cluster in supported resources

### DIFF
--- a/website/docs/r/networkflowmonitor_monitor.html.markdown
+++ b/website/docs/r/networkflowmonitor_monitor.html.markdown
@@ -61,7 +61,7 @@ The following arguments are optional:
 
 The `local_resource` and `remote_resource` blocks support the following:
 
-* `type` - (Required) The type of the resource. Valid values are `AWS::EC2::VPC`, `AWS::EC2::Subnet`, `AWS::EC2::AvailabilityZone`, `AWS::EC2::Region, `AWS::EKS::Cluster`.
+* `type` - (Required) The type of the resource. Valid values are `AWS::EC2::VPC`, `AWS::EC2::Subnet`, `AWS::EC2::AvailabilityZone`, `AWS::EC2::Region`, and `AWS::EKS::Cluster`.
 * `identifier` - (Required) The identifier of the resource. For VPC resources, this is the VPC ARN.
 
 ## Attribute Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Update the documentation of aws_networkflowmonitor_monitor to support 'AWS::EKS::Cluster' in local resources.



### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/eks/latest/userguide/network-observability.html#_using_infrastructure_as_code_iac


<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


