### PR TITLE
aws_bedrockagentcore_agent_runtime:  Fix `lifecycle_configuration` attributes to be properly computed when not specified

### DIFF
--- a/.changelog/45289.txt
+++ b/.changelog/45289.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bedrockagentcore_agent_runtime: Fix `lifecycle_configuration` attributes to be properly computed when not specified
+```

--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -87,7 +87,6 @@ func (r *agentRuntimeResource) Schema(ctx context.Context, request resource.Sche
 				CustomType: fwtypes.MapOfStringType,
 				Optional:   true,
 			},
-			"lifecycle_configuration": framework.ResourceOptionalComputedListOfObjectsAttribute[lifecycleConfigurationModel](ctx, 1, nil, listplanmodifier.UseStateForUnknown()),
 			names.AttrRoleARN: schema.StringAttribute{
 				CustomType: fwtypes.ARNType,
 				Required:   true,
@@ -98,6 +97,24 @@ func (r *agentRuntimeResource) Schema(ctx context.Context, request resource.Sche
 		},
 
 		Blocks: map[string]schema.Block{
+			"lifecycle_configuration": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[lifecycleConfigurationModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"idle_runtime_session_timeout": schema.Int32Attribute{
+							Optional: true,
+							Computed: true,
+						},
+						"max_lifetime": schema.Int32Attribute{
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"agent_runtime_artifact": schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[agentRuntimeArtifactModel](ctx),
 				Validators: []validator.List{


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Fixes the `aws_bedrockagentcore_agent_runtime` resource to properly handle computed default values for `lifecycle_configuration` attributes.

When using `lifecycle_configuration` with only `max_lifetime` specified (without `idle_runtime_session_timeout`), AWS automatically computes a default value for `idle_runtime_session_timeout`. The previous implementation used `schema.ListAttribute` which only marked the list as Optional+Computed, but the nested attributes were not marked as Computed. This caused Terraform to report "Provider produced inconsistent result after apply" when the API returned computed values.

The fix converts `lifecycle_configuration` from a `schema.ListAttribute` to a `schema.ListNestedBlock` where both `idle_runtime_session_timeout` and `max_lifetime` are explicitly marked as `Optional: true, Computed: true`. This allows the AWS API to return computed default values without triggering the inconsistent result error.

### Relations

Closes #45290

### References

- [Terraform Plugin Framework - Computed Attributes](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/attributes#computed)

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccBedrockAgentCoreAgentRuntime_lifecycleConfiguration PKG=bedrockagentcore

=== RUN   TestAccBedrockAgentCoreAgentRuntime_lifecycleConfiguration
=== PAUSE TestAccBedrockAgentCoreAgentRuntime_lifecycleConfiguration
=== RUN   TestAccBedrockAgentCoreAgentRuntime_lifecycleConfigurationMaxLifetimeOnly
=== PAUSE TestAccBedrockAgentCoreAgentRuntime_lifecycleConfigurationMaxLifetimeOnly
=== CONT  TestAccBedrockAgentCoreAgentRuntime_lifecycleConfiguration
=== CONT  TestAccBedrockAgentCoreAgentRuntime_lifecycleConfigurationMaxLifetimeOnly
--- PASS: TestAccBedrockAgentCoreAgentRuntime_lifecycleConfigurationMaxLifetimeOnly (32.96s)
--- PASS: TestAccBedrockAgentCoreAgentRuntime_lifecycleConfiguration (48.21s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore   55.494s
```
