### PR TITLE
docs: Fix typo in `aws_ecs_capacity_provider` docs

### DIFF
--- a/website/docs/r/ecs_capacity_provider.html.markdown
+++ b/website/docs/r/ecs_capacity_provider.html.markdown
@@ -55,7 +55,7 @@ resource "aws_ecs_capacity_provider" "example" {
 
   managed_instances_provider {
     infrastructure_role_arn = aws_iam_role.ecs_infrastructure.arn
-    propagate_tags          = "TASK_DEFINITION"
+    propagate_tags          = "CAPACITY_PROVIDER"
 
     instance_launch_template {
       ec2_instance_profile_arn = aws_iam_instance_profile.ecs_instance.arn


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR fixes a typo in the `managed_instances_provider` usage example. According to the ECS API, [managed_instances_provider.propagate_tags](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateManagedInstancesProviderConfiguration.html#ECS-Type-CreateManagedInstancesProviderConfiguration-propagateTags) allowed values are: `CAPACITY_PROVIDER`, `NONE`. 