### PR TITLE
r/aws_s3_bucket(test): add tagging fallback acceptance test

### DIFF
--- a/internal/acctest/configs.go
+++ b/internal/acctest/configs.go
@@ -295,6 +295,17 @@ provider "aws" {
 `, tag1, value1, tag2, value2))
 }
 
+func ConfigAssumeRole() string {
+	//lintignore:AT004
+	return fmt.Sprintf(`
+provider "aws" {
+  assume_role {
+    role_arn = %[1]q
+  }
+}
+`, os.Getenv(envvar.AccAssumeRoleARN))
+}
+
 func ConfigAssumeRolePolicy(policy string) string {
 	//lintignore:AT004
 	return fmt.Sprintf(`


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds an acceptance test to exercise the fallback behavior of the tagging APIs used by the `aws_s3_bucket` resource. This behavior was adjusted as part of #45251, and this PR ports the testing completed locally into a formal acceptance test.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #45251
Closes #45275 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

With `TF_ACC_ASSUME_ROLE_ARN` set:

```console
% TF_ACC_ASSUME_ROLE_ARN=arn:aws:iam::<redacted>:role/tfacctest-s3-bucket-no-tag-perms make testacc K=s3 T=TestAccS3Bucket_tags_fallbackS3API
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-s3-tagging-fallback 🌿...
TF_ACC=1 go1.24.10 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3Bucket_tags_fallbackS3API'  -timeout 360m -vet=off
2025/12/01 11:30:48 Creating Terraform AWS Provider (SDKv2-style)...
2025/12/01 11:30:48 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3Bucket_tags_fallbackS3API
=== PAUSE TestAccS3Bucket_tags_fallbackS3API
=== CONT  TestAccS3Bucket_tags_fallbackS3API
--- PASS: TestAccS3Bucket_tags_fallbackS3API (48.24s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 54.701s
```

Otherwise:

```console
% make testacc K=s3 T=TestAccS3Bucket_tags_fallbackS3API
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-s3-tagging-fallback 🌿...
TF_ACC=1 go1.24.10 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3Bucket_tags_fallbackS3API'  -timeout 360m -vet=off
2025/12/01 11:37:32 Creating Terraform AWS Provider (SDKv2-style)...
2025/12/01 11:37:32 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3Bucket_tags_fallbackS3API
=== PAUSE TestAccS3Bucket_tags_fallbackS3API
=== CONT  TestAccS3Bucket_tags_fallbackS3API
    bucket_test.go:856: skipping test; environment variable TF_ACC_ASSUME_ROLE_ARN must be set. Usage: Amazon Resource Name (ARN) of existing IAM Role to assume for testing restricted permissions
--- SKIP: TestAccS3Bucket_tags_fallbackS3API (0.36s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 6.807s
```