### PR TITLE
fix: resource/aws_efs_file_system: Fix perpetual drift 

### DIFF
--- a/.changelog/45343.txt
+++ b/.changelog/45343.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_efs_file_system: Fix perpetual drift when `protection.replication_overwrite` is in `REPLICATING` state for replication destination file systems
+```

--- a/internal/service/efs/exports_test.go
+++ b/internal/service/efs/exports_test.go
@@ -18,4 +18,6 @@ var (
 	FindFileSystemPolicyByID         = findFileSystemPolicyByID
 	FindMountTargetByID              = findMountTargetByID
 	FindReplicationConfigurationByID = findReplicationConfigurationByID
+
+	SuppressReplicationOverwriteProtectionDiff = suppressReplicationOverwriteProtectionDiff
 )

--- a/internal/service/efs/file_system.go
+++ b/internal/service/efs/file_system.go
@@ -141,7 +141,9 @@ func resourceFileSystem() *schema.Resource {
 								ValidateFunc: validation.StringInSlice(enum.Slice(
 									awstypes.ReplicationOverwriteProtectionEnabled,
 									awstypes.ReplicationOverwriteProtectionDisabled,
+									awstypes.ReplicationOverwriteProtectionReplicating,
 								), false),
+								DiffSuppressFunc: suppressReplicationOverwriteProtectionDiff,
 							},
 						},
 					},
@@ -610,4 +612,23 @@ func flattenFileSystemProtectionDescription(apiObject *awstypes.FileSystemProtec
 	tfMap["replication_overwrite"] = apiObject.ReplicationOverwriteProtection
 
 	return []any{tfMap}
+}
+
+func suppressReplicationOverwriteProtectionDiff(k, old, new string, d *schema.ResourceData) bool {
+	// When a file system becomes a replication destination, AWS automatically
+	// sets replication_overwrite to "REPLICATING". This is a read-only state
+	// that cannot be changed while replication is active. AWS rejects all
+	// update attempts with: "ReplicationOverwriteProtection cannot be changed
+	// while the file system is a replication destination."
+	//
+	// Suppress diff when current state is REPLICATING to prevent perpetual
+	// drift and failed update attempts. When replication is removed, AWS
+	// automatically allows the protection setting to be changed again.
+
+	if old == string(awstypes.ReplicationOverwriteProtectionReplicating) {
+		// REPLICATING is AWS-managed and read-only; suppress any attempted change
+		return true
+	}
+
+	return false
 }

--- a/internal/service/efs/file_system_test.go
+++ b/internal/service/efs/file_system_test.go
@@ -155,6 +155,77 @@ func TestAccEFSFileSystem_protection(t *testing.T) {
 	})
 }
 
+func TestSuppressReplicationOverwriteProtectionDiff(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		old      string
+		new      string
+		expected bool
+	}{
+		{
+			name:     "REPLICATING to DISABLED should be suppressed",
+			old:      "REPLICATING",
+			new:      "DISABLED",
+			expected: true,
+		},
+		{
+			name:     "REPLICATING to ENABLED should be suppressed",
+			old:      "REPLICATING",
+			new:      "ENABLED",
+			expected: true,
+		},
+		{
+			name:     "REPLICATING to REPLICATING should be suppressed",
+			old:      "REPLICATING",
+			new:      "REPLICATING",
+			expected: true,
+		},
+		{
+			name:     "DISABLED to ENABLED should not be suppressed",
+			old:      "DISABLED",
+			new:      "ENABLED",
+			expected: false,
+		},
+		{
+			name:     "ENABLED to DISABLED should not be suppressed",
+			old:      "ENABLED",
+			new:      "DISABLED",
+			expected: false,
+		},
+		{
+			name:     "DISABLED to DISABLED should not be suppressed",
+			old:      "DISABLED",
+			new:      "DISABLED",
+			expected: false,
+		},
+		{
+			name:     "ENABLED to REPLICATING should not be suppressed",
+			old:      "ENABLED",
+			new:      "REPLICATING",
+			expected: false,
+		},
+		{
+			name:     "DISABLED to REPLICATING should not be suppressed",
+			old:      "DISABLED",
+			new:      "REPLICATING",
+			expected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := tfefs.SuppressReplicationOverwriteProtectionDiff("protection.0.replication_overwrite", tc.old, tc.new, nil)
+			if actual != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, actual)
+			}
+		})
+	}
+}
+
 func TestAccEFSFileSystem_availabilityZoneName(t *testing.T) {
 	ctx := acctest.Context(t)
 	var desc awstypes.FileSystemDescription


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
Adds REPLICATING state support and diff suppression to prevent perpetual drift when AWS sets protection.replication_overwrite to REPLICATING for replication destination file systems.

### Relations
Closes #36811

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make: Running acceptance tests on branch: 🌿 rshade/efs-refresh 🌿...
TF_ACC=1 go1.24.10 test ./internal/service/efs/... -v -count 1 -parallel 20 -run='TestAccEFSFileSystem_'  -timeout 360m -vet=off
2025/12/01 16:03:48 Creating Terraform AWS Provider (SDKv2-style)...
2025/12/01 16:03:48 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEFSFileSystem_basic
=== PAUSE TestAccEFSFileSystem_basic
=== RUN   TestAccEFSFileSystem_disappears
=== PAUSE TestAccEFSFileSystem_disappears
=== RUN   TestAccEFSFileSystem_performanceMode
=== PAUSE TestAccEFSFileSystem_performanceMode
=== RUN   TestAccEFSFileSystem_protection
=== PAUSE TestAccEFSFileSystem_protection
=== RUN   TestAccEFSFileSystem_availabilityZoneName
=== PAUSE TestAccEFSFileSystem_availabilityZoneName
=== RUN   TestAccEFSFileSystem_tags
=== PAUSE TestAccEFSFileSystem_tags
=== RUN   TestAccEFSFileSystem_kmsKey
=== PAUSE TestAccEFSFileSystem_kmsKey
=== RUN   TestAccEFSFileSystem_kmsWithoutEncryption
=== PAUSE TestAccEFSFileSystem_kmsWithoutEncryption
=== RUN   TestAccEFSFileSystem_provisionedThroughputInMibps
=== PAUSE TestAccEFSFileSystem_provisionedThroughputInMibps
=== RUN   TestAccEFSFileSystem_throughputMode
=== PAUSE TestAccEFSFileSystem_throughputMode
=== RUN   TestAccEFSFileSystem_lifecyclePolicy
=== PAUSE TestAccEFSFileSystem_lifecyclePolicy
=== CONT  TestAccEFSFileSystem_basic
=== CONT  TestAccEFSFileSystem_kmsKey
=== CONT  TestAccEFSFileSystem_throughputMode
=== CONT  TestAccEFSFileSystem_provisionedThroughputInMibps
=== CONT  TestAccEFSFileSystem_kmsWithoutEncryption
=== CONT  TestAccEFSFileSystem_protection
=== CONT  TestAccEFSFileSystem_tags
=== CONT  TestAccEFSFileSystem_availabilityZoneName
=== CONT  TestAccEFSFileSystem_performanceMode
=== CONT  TestAccEFSFileSystem_lifecyclePolicy
=== CONT  TestAccEFSFileSystem_disappears
--- PASS: TestAccEFSFileSystem_kmsWithoutEncryption (57.33s)
--- PASS: TestAccEFSFileSystem_disappears (93.11s)
--- PASS: TestAccEFSFileSystem_performanceMode (110.45s)
--- PASS: TestAccEFSFileSystem_availabilityZoneName (122.22s)
--- PASS: TestAccEFSFileSystem_kmsKey (131.74s)
--- PASS: TestAccEFSFileSystem_basic (132.57s)
--- PASS: TestAccEFSFileSystem_protection (144.02s)
--- PASS: TestAccEFSFileSystem_provisionedThroughputInMibps (159.45s)
--- PASS: TestAccEFSFileSystem_throughputMode (159.56s)
--- PASS: TestAccEFSFileSystem_tags (215.18s)
--- PASS: TestAccEFSFileSystem_lifecyclePolicy (239.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/efs        239.197s
...
```
