### PR TITLE
Add interceptor_configurations support to aws_bedrockagentcore_gateway

### DIFF
--- a/.changelog/45344.txt
+++ b/.changelog/45344.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_bedrockagentcore_gateway: Add `interceptor_configurations` argument
+resource/aws_bedrockagentcore_gateway: Add `interceptor_configuration` argument
 ```

--- a/internal/service/bedrockagentcore/gateway.go
+++ b/internal/service/bedrockagentcore/gateway.go
@@ -145,7 +145,7 @@ func (r *gatewayResource) Schema(ctx context.Context, request resource.SchemaReq
 					},
 				},
 			},
-			"interceptor_configurations": schema.ListNestedBlock{
+			"interceptor_configuration": schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[gatewayInterceptorConfigurationModel](ctx),
 				Validators: []validator.List{
 					listvalidator.SizeBetween(1, 2),
@@ -153,7 +153,7 @@ func (r *gatewayResource) Schema(ctx context.Context, request resource.SchemaReq
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"interception_points": schema.SetAttribute{
-							CustomType: fwtypes.SetOfStringType,
+							CustomType: fwtypes.SetOfStringEnumType[awstypes.GatewayInterceptionPoint](),
 							Required:   true,
 						},
 					},
@@ -515,7 +515,7 @@ type gatewayResourceModel struct {
 	GatewayARN                types.String                                                          `tfsdk:"gateway_arn"`
 	GatewayID                 types.String                                                          `tfsdk:"gateway_id"`
 	GatewayURL                types.String                                                          `tfsdk:"gateway_url"`
-	InterceptorConfigurations fwtypes.ListNestedObjectValueOf[gatewayInterceptorConfigurationModel] `tfsdk:"interceptor_configurations"`
+	InterceptorConfigurations fwtypes.ListNestedObjectValueOf[gatewayInterceptorConfigurationModel] `tfsdk:"interceptor_configuration"`
 	KMSKeyARN                 fwtypes.ARN                                                           `tfsdk:"kms_key_arn"`
 	Name                      types.String                                                          `tfsdk:"name"`
 	ProtocolConfiguration     fwtypes.ListNestedObjectValueOf[gatewayProtocolConfigurationModel]    `tfsdk:"protocol_configuration"`
@@ -583,7 +583,7 @@ type mcpGatewayConfigurationModel struct {
 
 type gatewayInterceptorConfigurationModel struct {
 	InputConfiguration fwtypes.ListNestedObjectValueOf[interceptorInputConfigurationModel] `tfsdk:"input_configuration"`
-	InterceptionPoints fwtypes.SetOfString                                                 `tfsdk:"interception_points"`
+	InterceptionPoints fwtypes.SetOfStringEnum[awstypes.GatewayInterceptionPoint]          `tfsdk:"interception_points"`
 	Interceptor        fwtypes.ListNestedObjectValueOf[interceptorConfigurationModel]      `tfsdk:"interceptor"`
 }
 

--- a/internal/service/bedrockagentcore/gateway_test.go
+++ b/internal/service/bedrockagentcore/gateway_test.go
@@ -241,7 +241,7 @@ func TestAccBedrockAgentCoreGateway_interceptorConfigurations(t *testing.T) {
 					testAccCheckGatewayExists(ctx, resourceName, &gateway),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("interceptor_configurations"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("interceptor_configuration"), knownvalue.ListSizeExact(1)),
 				},
 			},
 			{
@@ -765,7 +765,7 @@ resource "aws_bedrockagentcore_gateway" "test" {
   authorizer_type = "AWS_IAM"
   protocol_type   = "MCP"
 
-  interceptor_configurations {
+  interceptor_configuration {
     interception_points = ["REQUEST", "RESPONSE"]
 
     interceptor {

--- a/website/docs/r/bedrockagentcore_gateway.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway.html.markdown
@@ -93,7 +93,7 @@ resource "aws_bedrockagentcore_gateway" "example" {
   authorizer_type = "AWS_IAM"
   protocol_type   = "MCP"
 
-  interceptor_configurations {
+  interceptor_configuration {
     interception_points = ["REQUEST", "RESPONSE"]
 
     interceptor {
@@ -124,7 +124,7 @@ The following arguments are optional:
 * `authorizer_configuration` - (Optional) Configuration for request authorization. Required when `authorizer_type` is set to `CUSTOM_JWT`. See [`authorizer_configuration`](#authorizer_configuration) below.
 * `description` - (Optional) Description of the gateway.
 * `exception_level` - (Optional) Exception level for the gateway. Valid values: `INFO`, `WARN`, `ERROR`.
-* `interceptor_configurations` - (Optional) List of interceptor configurations for the gateway. Minimum of 1, maximum of 2. See [`interceptor_configurations`](#interceptor_configurations) below.
+* `interceptor_configuration` - (Optional) List of interceptor configurations for the gateway. Minimum of 1, maximum of 2. See [`interceptor_configuration`](#interceptor_configuration) below.
 * `kms_key_arn` - (Optional) ARN of the KMS key used to encrypt the gateway data.
 * `protocol_configuration` - (Optional) Protocol-specific configuration for the gateway. See [`protocol_configuration`](#protocol_configuration) below.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
@@ -143,9 +143,9 @@ The `custom_jwt_authorizer` block supports the following:
 * `allowed_audience` - (Optional) Set of allowed audience values for JWT token validation.
 * `allowed_clients` - (Optional) Set of allowed client IDs for JWT token validation.
 
-### `interceptor_configurations`
+### `interceptor_configuration`
 
-The `interceptor_configurations` block supports the following:
+The `interceptor_configuration` block supports the following:
 
 * `interception_points` - (Required) Set of interception points. Valid values: `REQUEST`, `RESPONSE`.
 * `interceptor` - (Required) Interceptor infrastructure configuration. See [`interceptor`](#interceptor) below.


### PR DESCRIPTION
Closes #45331

Adds support for gateway interceptor configurations which allow custom Lambda functions to be invoked during gateway invocations at REQUEST and/or RESPONSE interception points.

## Changes

- Added `interceptor_configurations` block to `aws_bedrockagentcore_gateway` resource schema
- Implemented proper expand/flatten logic for the `InterceptorConfiguration` union type
- Added documentation with examples
- Added acceptance test
- Supports 1-2 interceptor configurations per gateway
- Each interceptor can specify REQUEST and/or RESPONSE interception points
- Lambda function ARN configuration for interceptor execution
- Optional input configuration to pass request headers to interceptor

## Checklist

- [x] Code follows provider conventions
- [x] Documentation updated with examples
- [x] Acceptance test added
- [ ] Changelog entry (will add once PR number is assigned)