### PR TITLE
docs: update database type in dms endpoint documentation

### DIFF
--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -137,7 +137,7 @@ The following arguments are optional:
 
 ### mysql_settings
 
--> Additional information can be found in the [Using MongoDB as a Source for AWS DMS documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html).
+-> Additional information can be found in the [Using MySQL as a Source for AWS DMS documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html).
 
 * `after_connect_script` - (Optional) Script to run immediately after AWS DMS connects to the endpoint.
 * `authentication_method` - (Optional) Authentication method to use. Valid values: `password`, `iam`.


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

(copied from #45328, slightly modified)


The documentation for `aws_dms_endpoint` contains a section [`mysql_settings`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_endpoint#mysql_settings). In this section there is a note that mentions

> Additional information can be found in the [Using MongoDB as a Source for AWS DMS documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html). 

here _MongoDB_ needs to change to _MySQL_. 


I additionally checked tha the link used in that note is correct, it points to the description for MySQL.

> https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html

### Relations

Closes #45328 

### References


### Output from Acceptance Testing

Not applicable. Only documentation is updated.