### PR TITLE
speed up ci

### DIFF
--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -148,7 +148,7 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
       - name: Go Test
-        run: go test ./...
+        run: go test -parallel 16 ./...
 
   import-lint:
     needs: [go_build]
@@ -276,7 +276,7 @@ jobs:
 
   tfproviderdocs:
     needs: [terraform_providers_schema]
-    runs-on: ubuntu-latest
+    runs-on: custom-ubuntu-22.04-large
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -142,45 +142,40 @@ jobs:
 
       - run: tflint --config .ci/.tflint.hcl --init
 
-      - run: |
-          exit_code=0
+      - run: sudo apt-get update && sudo apt-get install -y parallel
 
-          # Configure the rules for tflint.
-          # The *_invalid_* rules disabled here prevent evaluation of expressions.
-          # Do not disable *_invalid_name rules, since these are good checks for e.g. "%s" formatting verbs
-          # being carried over from test cases.
-          shared_rules=(
-              "--disable-rule=aws_cloudwatch_event_target_invalid_arn"
-              "--disable-rule=aws_db_instance_default_parameter_group"
-              "--disable-rule=aws_elasticache_cluster_default_parameter_group"
-              "--disable-rule=aws_elasticache_replication_group_default_parameter_group"
-              "--disable-rule=aws_iam_policy_sid_invalid_characters"
-              "--disable-rule=aws_iam_saml_provider_invalid_saml_metadata_document"
-              "--disable-rule=aws_iam_server_certificate_invalid_certificate_body"
-              "--disable-rule=aws_iam_server_certificate_invalid_private_key"
-              "--disable-rule=aws_iot_certificate_invalid_csr"
-              "--disable-rule=aws_lb_invalid_load_balancer_type"
-              "--disable-rule=aws_lb_target_group_invalid_protocol"
-              "--disable-rule=aws_networkfirewall_rule_group_invalid_rules"
-              "--disable-rule=aws_s3_object_copy_invalid_source"
-              "--disable-rule=aws_servicecatalog_portfolio_share_invalid_type"
-              "--disable-rule=aws_transfer_ssh_key_invalid_body"
-              "--disable-rule=terraform_unused_declarations"
-              "--disable-rule=terraform_typed_variables"
-          )
-          while read -r filename; do
+      - run: |
+          validate_file() {
+            filename=$1
+
+            # Configure the rules for tflint.
+            shared_rules=(
+                "--disable-rule=aws_cloudwatch_event_target_invalid_arn"
+                "--disable-rule=aws_db_instance_default_parameter_group"
+                "--disable-rule=aws_elasticache_cluster_default_parameter_group"
+                "--disable-rule=aws_elasticache_replication_group_default_parameter_group"
+                "--disable-rule=aws_iam_policy_sid_invalid_characters"
+                "--disable-rule=aws_iam_saml_provider_invalid_saml_metadata_document"
+                "--disable-rule=aws_iam_server_certificate_invalid_certificate_body"
+                "--disable-rule=aws_iam_server_certificate_invalid_private_key"
+                "--disable-rule=aws_iot_certificate_invalid_csr"
+                "--disable-rule=aws_lb_invalid_load_balancer_type"
+                "--disable-rule=aws_lb_target_group_invalid_protocol"
+                "--disable-rule=aws_networkfirewall_rule_group_invalid_rules"
+                "--disable-rule=aws_s3_object_copy_invalid_source"
+                "--disable-rule=aws_servicecatalog_portfolio_share_invalid_type"
+                "--disable-rule=aws_transfer_ssh_key_invalid_body"
+                "--disable-rule=terraform_unused_declarations"
+                "--disable-rule=terraform_typed_variables"
+            )
+
             rules=("${shared_rules[@]}")
             if [[ "$filename" == "./website/docs/guides/version-2-upgrade.html.markdown" ]]; then
-                # ./website/docs/guides/version-2-upgrade.html.markdown should still include pre-0.12 syntax,
-                # since v1.0 does not support Terraform 0.12.
                 rules+=(
                 "--disable-rule=terraform_deprecated_index"
                 "--disable-rule=terraform_deprecated_interpolation"
                 )
             elif [[ "$filename" == "./website/docs/guides/version-3-upgrade.html.markdown" ]]; then
-                # ./website/docs/guides/version-3-upgrade.html.markdown has one example showing migration from
-                # pre-0.12 syntax to 0.12 syntax. We can't customize rules per block, and adding a
-                # tflint-ignore directive to documentation is not ideal.
                 rules+=(
                 "--enable-rule=terraform_deprecated_index"
                 "--disable-rule=terraform_deprecated_interpolation"
@@ -192,10 +187,10 @@ jobs:
                 )
             fi
 
-            # We need to capture the output and error code here. We don't want to exit on the first error
-            set +e
-            ./.ci/scripts/validate-terraform-file.sh "$filename" "${rules[@]}" || exit_code=1
-            set -e
-          done < <(find ./website/docs -not \( -path ./website/docs/cdktf -prune \) -type f -name '*.markdown' | sort -u)
+            ./.ci/scripts/validate-terraform-file.sh "$filename" "${rules[@]}"
+          }
+          export -f validate_file
 
-          exit $exit_code
+          find ./website/docs -not \( -path ./website/docs/cdktf -prune \) -type f -name '*.markdown' | \
+            sort -u | \
+            parallel -j 16 --halt soon,fail=1 validate_file {}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Drops 3 of our longest running CI checks to manageable times:

* `Provider Checks / tfproviderdocs` - from 20-30m and failing for lack of disk space **-> 1m**
* `Website Checks / tflint` - from ~30m **-> 5m**
* `Provider Checks / go test` - from 25-40m **-> 12-15m**

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Extracted from #45401 and #45400

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
n/a
```
