### PR TITLE
rds: Remove delays and ContinuousTargetOccurence from DB instance operations

### DIFF
--- a/.changelog/44925.txt
+++ b/.changelog/44925.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_db_instance: Remove hardcoded delays and continuous target occurrence checks before polling instance state during creation, stop, and deletion operations
+```

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -2890,9 +2890,7 @@ func statusDBInstance(conn *rds.Client, id string, optFns ...func(*rds.Options))
 
 func waitDBInstanceAvailable(ctx context.Context, conn *rds.Client, id string, timeout time.Duration, optFns ...tfresource.OptionsFunc) (*types.DBInstance, error) {
 	options := tfresource.Options{
-		PollInterval:              10 * time.Second,
-		Delay:                     1 * time.Minute,
-		ContinuousTargetOccurence: 3,
+		PollInterval: 10 * time.Second,
 	}
 	for _, fn := range optFns {
 		fn(&options)
@@ -2952,12 +2950,10 @@ func waitDBInstanceStopped(ctx context.Context, conn *rds.Client, id string, tim
 			instanceStatusStorageFull,
 			instanceStatusUpgrading,
 		},
-		Target:                    []string{instanceStatusStopped},
-		Refresh:                   statusDBInstance(conn, id),
-		Timeout:                   timeout,
-		ContinuousTargetOccurence: 2,
-		Delay:                     10 * time.Second,
-		MinTimeout:                3 * time.Second,
+		Target:     []string{instanceStatusStopped},
+		Refresh:    statusDBInstance(conn, id),
+		Timeout:    timeout,
+		MinTimeout: 3 * time.Second,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
@@ -2971,9 +2967,7 @@ func waitDBInstanceStopped(ctx context.Context, conn *rds.Client, id string, tim
 
 func waitDBInstanceDeleted(ctx context.Context, conn *rds.Client, id string, timeout time.Duration, optFns ...tfresource.OptionsFunc) (*types.DBInstance, error) {
 	options := tfresource.Options{
-		PollInterval:              10 * time.Second,
-		Delay:                     1 * time.Minute,
-		ContinuousTargetOccurence: 3,
+		PollInterval: 10 * time.Second,
 	}
 	for _, fn := range optFns {
 		fn(&options)


### PR DESCRIPTION
Closes #44925

Removes hardcoded delays and continuous target occurrence checks before polling instance state during creation, stop, and deletion operations. The provider will now begin polling immediately with a 10-second interval.

This significantly reduces wait times for:
- Fast AWS provisioning scenarios
- Local testing with LocalStack (lightweight AWS emulator)

**Background:**
These delays were introduced in 2014 without explanation (originally committed to terraform repo without a PR). When Blue/Green deployments were introduced, delays were increased further with no documented rationale.

The `ContinuousTargetOccurence` parameter was added in commit 4e1733ed9e9 (Nov 20, 2024) with only "Add ContinuousTargetOccurence" as the commit message, providing no context for why multiple consecutive checks are needed.

This change removes both the initial delays and the continuous target checks, allowing the provider to begin polling immediately whilst keeping the 10-second poll interval to prevent RDS API rate limiting.

**Related:**
- #28523 - LocalStack timeout discussion
- #32189 - OpenSearch update delay issue
- #32209 - OpenSearch update delay fix
- #45245 - OpenSearch creation/deletion delay fix