### PR TITLE
data.aws_route53_resolver_rule: Add target_ips attribute

### DIFF
--- a/.changelog/45492.txt
+++ b/.changelog/45492.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_route53_resolver_rule: Add `target_ips` attribute
+```

--- a/internal/service/route53resolver/rule_data_source.go
+++ b/internal/service/route53resolver/rule_data_source.go
@@ -70,6 +70,30 @@ func dataSourceRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"target_ips": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ipv6": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrPort: {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						names.AttrProtocol: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			names.AttrTags: tftags.TagsSchemaComputed(),
 		},
 	}
@@ -134,6 +158,9 @@ func dataSourceRuleRead(ctx context.Context, d *schema.ResourceData, meta any) d
 	d.Set("rule_type", rule.RuleType)
 	shareStatus := rule.ShareStatus
 	d.Set("share_status", shareStatus)
+	if err := d.Set("target_ips", flattenRuleTargetIPs(rule.TargetIps)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting target_ips: %s", err)
+	}
 	// https://github.com/hashicorp/terraform-provider-aws/issues/10211
 	if shareStatus != awstypes.ShareStatusSharedWithMe {
 		tags, err := listTags(ctx, conn, arn)

--- a/website/docs/d/route53_resolver_rule.html.markdown
+++ b/website/docs/d/route53_resolver_rule.html.markdown
@@ -42,3 +42,11 @@ This data source exports the following attributes in addition to the arguments a
 * `share_status` - Whether the rules is shared and, if so, whether the current account is sharing the rule with another account, or another account is sharing the rule with the current account.
 Values are `NOT_SHARED`, `SHARED_BY_ME` or `SHARED_WITH_ME`
 * `tags` - Map of tags assigned to the resolver rule.
+* `target_ips` - List of configurations for target IP addresses. Only applicable for `FORWARD` rules. See [`target_ips`](#target_ips) below for details.
+
+### target_ips
+
+* `ip` - IPv4 address that you want to forward DNS queries to.
+* `ipv6` - IPv6 address that you want to forward DNS queries to.
+* `port` - Port at the IP address that you want to forward DNS queries to.
+* `protocol` - Protocol for the target IP address. Valid values are `Do53` (DNS over port 53), `DoH` (DNS over HTTPS), and `DoH-FIPS` (DNS over HTTPS with FIPS).


### PR DESCRIPTION
Adds the `target_ips` attribute to the `aws_route53_resolver_rule` data source.

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to security controls.

### Description

Exposes the target IP addresses configured for Route53 Resolver FORWARD rules. Each target includes `ip`, `ipv6`, `port`, and `protocol` fields.

This data is available from the AWS API and is already exposed in the corresponding resource, so this change brings the data source to feature parity for read operations.

The implementation reuses the existing `flattenRuleTargetIPs` function from the resource to maintain consistency.

**Note:** The `server_name_indication` field is not included in this PR as it is being added separately in #40127 to avoid conflicts and ensure proper implementation across both the resource and data source.

### References

- [AWS API Documentation - TargetAddress](https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53resolver_TargetAddress.html)
- Related PR for `server_name_indication`: #40127

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccRoute53ResolverRuleDataSource_targetIPs PKG=route53resolver

Pending - will update once available.