### PR TITLE
.ci/scripts: support for `new-list-resource` entry types

### DIFF
--- a/.ci/scripts/changelog.tmpl
+++ b/.ci/scripts/changelog.tmpl
@@ -15,7 +15,7 @@ NOTES:
 {{ end -}}
 {{- end -}}
 
-{{- $features := combineTypes .NotesByType.feature (index .NotesByType "new-resource" ) (index .NotesByType "new-data-source") (index .NotesByType "new-ephemeral") (index .NotesByType "new-function") (index .NotesByType "new-action") (index .NotesByType "new-guide") }}
+{{- $features := combineTypes .NotesByType.feature (index .NotesByType "new-resource" ) (index .NotesByType "new-data-source") (index .NotesByType "new-ephemeral") (index .NotesByType "new-list-resource") (index .NotesByType "new-function") (index .NotesByType "new-action") (index .NotesByType "new-guide") }}
 {{- if $features }}
 FEATURES:
 

--- a/.ci/scripts/release-note.tmpl
+++ b/.ci/scripts/release-note.tmpl
@@ -5,6 +5,8 @@
 * **New Data Source:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/hashicorp/terraform-provider-aws/issues/{{- .Issue -}}))
 {{- else if eq "new-ephemeral" .Type -}}
 * **New Ephemeral Resource:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/hashicorp/terraform-provider-aws/issues/{{- .Issue -}}))
+{{- else if eq "new-list-resource" .Type -}}
+* **New List Resource:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/hashicorp/terraform-provider-aws/issues/{{- .Issue -}}))
 {{- else if eq "new-function" .Type -}}
 * **New Function:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/hashicorp/terraform-provider-aws/issues/{{- .Issue -}}))
 {{- else if eq "new-action" .Type -}}


### PR DESCRIPTION

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds support for a new changelog entry type, `new-list-resource`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/go-changelog/pull/47
Relates #44352
Relates #40222