### PR TITLE
F/aws dms data provider

### DIFF
--- a/.changelog/45516.txt
+++ b/.changelog/45516.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_dms_data_provider
+```

--- a/internal/service/dms/data_provider.go
+++ b/internal/service/dms/data_provider.go
@@ -1,0 +1,578 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dms
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	dms "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_dms_data_provider", name="Data Provider")
+// @Tags(identifierAttribute="data_provider_arn")
+func resourceDataProvider(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &dataProviderResource{}, nil
+}
+
+type dataProviderResource struct {
+	framework.ResourceWithModel[dataProviderResourceModel]
+}
+
+func (r *dataProviderResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"data_provider_arn": framework.ARNAttributeComputedOnly(),
+			"data_provider_name": schema.StringAttribute{
+				Optional: true,
+			},
+			names.AttrDescription: schema.StringAttribute{
+				Optional: true,
+			},
+			names.AttrEngine: schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			names.AttrTags:    tftags.TagsAttribute(),
+			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+			"virtual": schema.BoolAttribute{
+				Optional: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"settings": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[dataProviderSettingsModel](ctx),
+				Validators: []validator.List{
+					listvalidator.IsRequired(),
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"docdb_settings":                dataProviderSettingsBlock(ctx),
+						"ibm_db2_luw_settings":          dataProviderSettingsBlock(ctx),
+						"ibm_db2_zos_settings":          dataProviderSettingsBlock(ctx),
+						"mariadb_settings":              dataProviderSettingsBlock(ctx),
+						"microsoft_sql_server_settings": dataProviderSettingsBlock(ctx),
+						"mongodb_settings":              dataProviderSettingsBlock(ctx),
+						"mysql_settings":                dataProviderSettingsBlock(ctx),
+						"oracle_settings":               dataProviderSettingsBlock(ctx),
+						"postgres_settings":             dataProviderSettingsBlock(ctx),
+						"redshift_settings":             dataProviderSettingsBlock(ctx),
+						"sybase_ase_settings":           dataProviderSettingsBlock(ctx),
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataProviderSettingsBlock(ctx context.Context) schema.Block {
+	return schema.ListNestedBlock{
+		CustomType: fwtypes.NewListNestedObjectTypeOf[dataProviderDBSettingsModel](ctx),
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				names.AttrCertificateARN: schema.StringAttribute{
+					CustomType: fwtypes.ARNType,
+					Optional:   true,
+				},
+				names.AttrDatabaseName: schema.StringAttribute{
+					Optional: true,
+				},
+				names.AttrPort: schema.Int64Attribute{
+					Optional: true,
+				},
+				"server_name": schema.StringAttribute{
+					Optional: true,
+				},
+				"ssl_mode": schema.StringAttribute{
+					Optional: true,
+				},
+			},
+		},
+	}
+}
+
+func (r *dataProviderResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	var data dataProviderResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().DMSClient(ctx)
+
+	input := &dms.CreateDataProviderInput{
+		DataProviderName: fwflex.StringFromFramework(ctx, data.DataProviderName),
+		Description:      fwflex.StringFromFramework(ctx, data.Description),
+		Engine:           fwflex.StringFromFramework(ctx, data.Engine),
+		Tags:             getTagsIn(ctx),
+	}
+
+	if !data.Settings.IsNull() {
+		settings, diags := data.Settings.ToPtr(ctx)
+		response.Diagnostics.Append(diags...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+		input.Settings = expandDataProviderSettings(ctx, settings)
+	}
+
+	output, err := conn.CreateDataProvider(ctx, input)
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("creating DMS Data Provider (%s)", data.DataProviderName.ValueString()), err.Error())
+		return
+	}
+
+	data.DataProviderARN = fwflex.StringToFramework(ctx, output.DataProvider.DataProviderArn)
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+func (r *dataProviderResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	var data dataProviderResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().DMSClient(ctx)
+
+	output, err := findDataProviderByARN(ctx, conn, data.DataProviderARN.ValueString())
+	if errs.IsA[*retry.NotFoundError](err) {
+		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		response.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("reading DMS Data Provider (%s)", data.DataProviderARN.ValueString()), err.Error())
+		return
+	}
+
+	data.DataProviderName = fwflex.StringToFramework(ctx, output.DataProviderName)
+	data.Description = fwflex.StringToFramework(ctx, output.Description)
+	data.Engine = fwflex.StringToFramework(ctx, output.Engine)
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+func (r *dataProviderResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	var old, new dataProviderResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &old)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	response.Diagnostics.Append(request.Plan.Get(ctx, &new)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().DMSClient(ctx)
+
+	if !new.DataProviderName.Equal(old.DataProviderName) ||
+		!new.Description.Equal(old.Description) ||
+		!new.Settings.Equal(old.Settings) ||
+		!new.Virtual.Equal(old.Virtual) {
+		input := &dms.ModifyDataProviderInput{
+			DataProviderIdentifier: new.DataProviderARN.ValueStringPointer(),
+			DataProviderName:       fwflex.StringFromFramework(ctx, new.DataProviderName),
+			Description:            fwflex.StringFromFramework(ctx, new.Description),
+		}
+
+		if !new.Settings.IsNull() {
+			settings, diags := new.Settings.ToPtr(ctx)
+			response.Diagnostics.Append(diags...)
+			if response.Diagnostics.HasError() {
+				return
+			}
+			input.Settings = expandDataProviderSettings(ctx, settings)
+		}
+
+		_, err := conn.ModifyDataProvider(ctx, input)
+		if err != nil {
+			response.Diagnostics.AddError(fmt.Sprintf("updating DMS Data Provider (%s)", new.DataProviderARN.ValueString()), err.Error())
+			return
+		}
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, &new)...)
+}
+
+func (r *dataProviderResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	var data dataProviderResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().DMSClient(ctx)
+
+	input := &dms.DeleteDataProviderInput{
+		DataProviderIdentifier: data.DataProviderARN.ValueStringPointer(),
+	}
+	_, err := conn.DeleteDataProvider(ctx, input)
+
+	if errs.IsA[*awstypes.ResourceNotFoundFault](err) {
+		return
+	}
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("deleting DMS Data Provider (%s)", data.DataProviderARN.ValueString()), err.Error())
+	}
+}
+
+func (r *dataProviderResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("data_provider_arn"), request, response)
+}
+
+type dataProviderResourceModel struct {
+	framework.WithRegionModel
+	DataProviderARN  types.String                                               `tfsdk:"data_provider_arn"`
+	DataProviderName types.String                                               `tfsdk:"data_provider_name"`
+	Description      types.String                                               `tfsdk:"description"`
+	Engine           types.String                                               `tfsdk:"engine"`
+	Settings         fwtypes.ListNestedObjectValueOf[dataProviderSettingsModel] `tfsdk:"settings"`
+	Tags             tftags.Map                                                 `tfsdk:"tags"`
+	TagsAll          tftags.Map                                                 `tfsdk:"tags_all"`
+	Virtual          types.Bool                                                 `tfsdk:"virtual"`
+}
+
+type dataProviderSettingsModel struct {
+	DocDBSettings              fwtypes.ListNestedObjectValueOf[dataProviderDBSettingsModel] `tfsdk:"docdb_settings"`
+	IBMDB2LUWSettings          fwtypes.ListNestedObjectValueOf[dataProviderDBSettingsModel] `tfsdk:"ibm_db2_luw_settings"`
+	IBMDB2ZOSSettings          fwtypes.ListNestedObjectValueOf[dataProviderDBSettingsModel] `tfsdk:"ibm_db2_zos_settings"`
+	MariaDBSettings            fwtypes.ListNestedObjectValueOf[dataProviderDBSettingsModel] `tfsdk:"mariadb_settings"`
+	MicrosoftSQLServerSettings fwtypes.ListNestedObjectValueOf[dataProviderDBSettingsModel] `tfsdk:"microsoft_sql_server_settings"`
+	MongoDBSettings            fwtypes.ListNestedObjectValueOf[dataProviderDBSettingsModel] `tfsdk:"mongodb_settings"`
+	MySQLSettings              fwtypes.ListNestedObjectValueOf[dataProviderDBSettingsModel] `tfsdk:"mysql_settings"`
+	OracleSettings             fwtypes.ListNestedObjectValueOf[dataProviderDBSettingsModel] `tfsdk:"oracle_settings"`
+	PostgresSettings           fwtypes.ListNestedObjectValueOf[dataProviderDBSettingsModel] `tfsdk:"postgres_settings"`
+	RedshiftSettings           fwtypes.ListNestedObjectValueOf[dataProviderDBSettingsModel] `tfsdk:"redshift_settings"`
+	SybaseASESettings          fwtypes.ListNestedObjectValueOf[dataProviderDBSettingsModel] `tfsdk:"sybase_ase_settings"`
+}
+
+type dataProviderDBSettingsModel struct {
+	CertificateARN fwtypes.ARN  `tfsdk:"certificate_arn"`
+	DatabaseName   types.String `tfsdk:"database_name"`
+	Port           types.Int64  `tfsdk:"port"`
+	ServerName     types.String `tfsdk:"server_name"`
+	SSLMode        types.String `tfsdk:"ssl_mode"`
+}
+
+func findDataProviderByARN(ctx context.Context, conn *dms.Client, arn string) (*awstypes.DataProvider, error) {
+	input := &dms.DescribeDataProvidersInput{
+		Filters: []awstypes.Filter{
+			{
+				Name:   aws.String("data-provider-arn"),
+				Values: []string{arn},
+			},
+		},
+	}
+
+	output, err := conn.DescribeDataProviders(ctx, input)
+	if errs.IsA[*awstypes.ResourceNotFoundFault](err) {
+		return nil, &retry.NotFoundError{}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.DataProviders) == 0 {
+		return nil, &retry.NotFoundError{}
+	}
+
+	return &output.DataProviders[0], nil
+}
+
+func expandDataProviderSettings(ctx context.Context, settings *dataProviderSettingsModel) awstypes.DataProviderSettings { // nosemgrep:ci.semgrep.framework.manual-expander-functions
+	if settings == nil {
+		return nil
+	}
+
+	if !settings.PostgresSettings.IsNull() {
+		if s, diags := settings.PostgresSettings.ToPtr(ctx); diags == nil && s != nil {
+			return &awstypes.DataProviderSettingsMemberPostgreSqlSettings{
+				Value: *expandPostgreSQLDataProviderSettings(ctx, s),
+			}
+		}
+	}
+	if !settings.MySQLSettings.IsNull() {
+		if s, diags := settings.MySQLSettings.ToPtr(ctx); diags == nil && s != nil {
+			return &awstypes.DataProviderSettingsMemberMySqlSettings{
+				Value: *expandMySQLDataProviderSettings(ctx, s),
+			}
+		}
+	}
+	if !settings.OracleSettings.IsNull() {
+		if s, diags := settings.OracleSettings.ToPtr(ctx); diags == nil && s != nil {
+			return &awstypes.DataProviderSettingsMemberOracleSettings{
+				Value: *expandOracleDataProviderSettings(ctx, s),
+			}
+		}
+	}
+	if !settings.MariaDBSettings.IsNull() {
+		if s, diags := settings.MariaDBSettings.ToPtr(ctx); diags == nil && s != nil {
+			return &awstypes.DataProviderSettingsMemberMariaDbSettings{
+				Value: *expandMariaDBDataProviderSettings(ctx, s),
+			}
+		}
+	}
+	if !settings.MicrosoftSQLServerSettings.IsNull() {
+		if s, diags := settings.MicrosoftSQLServerSettings.ToPtr(ctx); diags == nil && s != nil {
+			return &awstypes.DataProviderSettingsMemberMicrosoftSqlServerSettings{
+				Value: *expandMicrosoftSQLServerDataProviderSettings(ctx, s),
+			}
+		}
+	}
+	if !settings.DocDBSettings.IsNull() {
+		if s, diags := settings.DocDBSettings.ToPtr(ctx); diags == nil && s != nil {
+			return &awstypes.DataProviderSettingsMemberDocDbSettings{
+				Value: *expandDocDBDataProviderSettings(ctx, s),
+			}
+		}
+	}
+	if !settings.MongoDBSettings.IsNull() {
+		if s, diags := settings.MongoDBSettings.ToPtr(ctx); diags == nil && s != nil {
+			return &awstypes.DataProviderSettingsMemberMongoDbSettings{
+				Value: *expandMongoDBDataProviderSettings(ctx, s),
+			}
+		}
+	}
+	if !settings.RedshiftSettings.IsNull() {
+		if s, diags := settings.RedshiftSettings.ToPtr(ctx); diags == nil && s != nil {
+			return &awstypes.DataProviderSettingsMemberRedshiftSettings{
+				Value: *expandRedshiftDataProviderSettings(ctx, s),
+			}
+		}
+	}
+	if !settings.IBMDB2LUWSettings.IsNull() {
+		if s, diags := settings.IBMDB2LUWSettings.ToPtr(ctx); diags == nil && s != nil {
+			return &awstypes.DataProviderSettingsMemberIbmDb2LuwSettings{
+				Value: *expandIBMDB2LUWDataProviderSettings(ctx, s),
+			}
+		}
+	}
+
+	return nil
+}
+
+func expandPostgreSQLDataProviderSettings(ctx context.Context, settings *dataProviderDBSettingsModel) *awstypes.PostgreSqlDataProviderSettings { // nosemgrep:ci.semgrep.framework.manual-expander-functions
+	if settings == nil {
+		return nil
+	}
+
+	result := &awstypes.PostgreSqlDataProviderSettings{
+		DatabaseName: fwflex.StringFromFramework(ctx, settings.DatabaseName),
+		ServerName:   fwflex.StringFromFramework(ctx, settings.ServerName),
+	}
+
+	if !settings.CertificateARN.IsNull() {
+		result.CertificateArn = settings.CertificateARN.ValueStringPointer()
+	}
+	if !settings.Port.IsNull() {
+		result.Port = aws.Int32(int32(settings.Port.ValueInt64()))
+	}
+	if !settings.SSLMode.IsNull() {
+		result.SslMode = awstypes.DmsSslModeValue(settings.SSLMode.ValueString())
+	}
+
+	return result
+}
+
+func expandMySQLDataProviderSettings(ctx context.Context, settings *dataProviderDBSettingsModel) *awstypes.MySqlDataProviderSettings { // nosemgrep:ci.semgrep.framework.manual-expander-functions
+	if settings == nil {
+		return nil
+	}
+
+	result := &awstypes.MySqlDataProviderSettings{
+		ServerName: fwflex.StringFromFramework(ctx, settings.ServerName),
+	}
+
+	if !settings.CertificateARN.IsNull() {
+		result.CertificateArn = settings.CertificateARN.ValueStringPointer()
+	}
+	if !settings.Port.IsNull() {
+		result.Port = aws.Int32(int32(settings.Port.ValueInt64()))
+	}
+	if !settings.SSLMode.IsNull() {
+		result.SslMode = awstypes.DmsSslModeValue(settings.SSLMode.ValueString())
+	}
+
+	return result
+}
+
+func expandOracleDataProviderSettings(ctx context.Context, settings *dataProviderDBSettingsModel) *awstypes.OracleDataProviderSettings { // nosemgrep:ci.semgrep.framework.manual-expander-functions
+	if settings == nil {
+		return nil
+	}
+
+	result := &awstypes.OracleDataProviderSettings{
+		DatabaseName: fwflex.StringFromFramework(ctx, settings.DatabaseName),
+		ServerName:   fwflex.StringFromFramework(ctx, settings.ServerName),
+	}
+
+	if !settings.CertificateARN.IsNull() {
+		result.CertificateArn = settings.CertificateARN.ValueStringPointer()
+	}
+	if !settings.Port.IsNull() {
+		result.Port = aws.Int32(int32(settings.Port.ValueInt64()))
+	}
+	if !settings.SSLMode.IsNull() {
+		result.SslMode = awstypes.DmsSslModeValue(settings.SSLMode.ValueString())
+	}
+
+	return result
+}
+
+func expandMariaDBDataProviderSettings(ctx context.Context, settings *dataProviderDBSettingsModel) *awstypes.MariaDbDataProviderSettings { // nosemgrep:ci.semgrep.framework.manual-expander-functions
+	if settings == nil {
+		return nil
+	}
+
+	result := &awstypes.MariaDbDataProviderSettings{
+		ServerName: fwflex.StringFromFramework(ctx, settings.ServerName),
+	}
+
+	if !settings.CertificateARN.IsNull() {
+		result.CertificateArn = settings.CertificateARN.ValueStringPointer()
+	}
+	if !settings.Port.IsNull() {
+		result.Port = aws.Int32(int32(settings.Port.ValueInt64()))
+	}
+	if !settings.SSLMode.IsNull() {
+		result.SslMode = awstypes.DmsSslModeValue(settings.SSLMode.ValueString())
+	}
+
+	return result
+}
+
+func expandMicrosoftSQLServerDataProviderSettings(ctx context.Context, settings *dataProviderDBSettingsModel) *awstypes.MicrosoftSqlServerDataProviderSettings { // nosemgrep:ci.semgrep.framework.manual-expander-functions
+	if settings == nil {
+		return nil
+	}
+
+	result := &awstypes.MicrosoftSqlServerDataProviderSettings{
+		DatabaseName: fwflex.StringFromFramework(ctx, settings.DatabaseName),
+		ServerName:   fwflex.StringFromFramework(ctx, settings.ServerName),
+	}
+
+	if !settings.CertificateARN.IsNull() {
+		result.CertificateArn = settings.CertificateARN.ValueStringPointer()
+	}
+	if !settings.Port.IsNull() {
+		result.Port = aws.Int32(int32(settings.Port.ValueInt64()))
+	}
+	if !settings.SSLMode.IsNull() {
+		result.SslMode = awstypes.DmsSslModeValue(settings.SSLMode.ValueString())
+	}
+
+	return result
+}
+
+func expandDocDBDataProviderSettings(ctx context.Context, settings *dataProviderDBSettingsModel) *awstypes.DocDbDataProviderSettings { // nosemgrep:ci.semgrep.framework.manual-expander-functions
+	if settings == nil {
+		return nil
+	}
+
+	result := &awstypes.DocDbDataProviderSettings{
+		DatabaseName: fwflex.StringFromFramework(ctx, settings.DatabaseName),
+		ServerName:   fwflex.StringFromFramework(ctx, settings.ServerName),
+	}
+
+	if !settings.CertificateARN.IsNull() {
+		result.CertificateArn = settings.CertificateARN.ValueStringPointer()
+	}
+	if !settings.Port.IsNull() {
+		result.Port = aws.Int32(int32(settings.Port.ValueInt64()))
+	}
+	if !settings.SSLMode.IsNull() {
+		result.SslMode = awstypes.DmsSslModeValue(settings.SSLMode.ValueString())
+	}
+
+	return result
+}
+
+func expandMongoDBDataProviderSettings(ctx context.Context, settings *dataProviderDBSettingsModel) *awstypes.MongoDbDataProviderSettings { // nosemgrep:ci.semgrep.framework.manual-expander-functions
+	if settings == nil {
+		return nil
+	}
+
+	result := &awstypes.MongoDbDataProviderSettings{
+		DatabaseName: fwflex.StringFromFramework(ctx, settings.DatabaseName),
+		ServerName:   fwflex.StringFromFramework(ctx, settings.ServerName),
+	}
+
+	if !settings.CertificateARN.IsNull() {
+		result.CertificateArn = settings.CertificateARN.ValueStringPointer()
+	}
+	if !settings.Port.IsNull() {
+		result.Port = aws.Int32(int32(settings.Port.ValueInt64()))
+	}
+	if !settings.SSLMode.IsNull() {
+		result.SslMode = awstypes.DmsSslModeValue(settings.SSLMode.ValueString())
+	}
+
+	return result
+}
+
+func expandRedshiftDataProviderSettings(ctx context.Context, settings *dataProviderDBSettingsModel) *awstypes.RedshiftDataProviderSettings { // nosemgrep:ci.semgrep.framework.manual-expander-functions
+	if settings == nil {
+		return nil
+	}
+
+	result := &awstypes.RedshiftDataProviderSettings{
+		DatabaseName: fwflex.StringFromFramework(ctx, settings.DatabaseName),
+		ServerName:   fwflex.StringFromFramework(ctx, settings.ServerName),
+	}
+
+	if !settings.Port.IsNull() {
+		result.Port = aws.Int32(int32(settings.Port.ValueInt64()))
+	}
+
+	return result
+}
+
+func expandIBMDB2LUWDataProviderSettings(ctx context.Context, settings *dataProviderDBSettingsModel) *awstypes.IbmDb2LuwDataProviderSettings { // nosemgrep:ci.semgrep.framework.manual-expander-functions
+	if settings == nil {
+		return nil
+	}
+
+	result := &awstypes.IbmDb2LuwDataProviderSettings{
+		DatabaseName: fwflex.StringFromFramework(ctx, settings.DatabaseName),
+		ServerName:   fwflex.StringFromFramework(ctx, settings.ServerName),
+	}
+
+	if !settings.CertificateARN.IsNull() {
+		result.CertificateArn = settings.CertificateARN.ValueStringPointer()
+	}
+	if !settings.Port.IsNull() {
+		result.Port = aws.Int32(int32(settings.Port.ValueInt64()))
+	}
+	if !settings.SSLMode.IsNull() {
+		result.SslMode = awstypes.DmsSslModeValue(settings.SSLMode.ValueString())
+	}
+
+	return result
+}

--- a/internal/service/dms/data_provider.go
+++ b/internal/service/dms/data_provider.go
@@ -11,6 +11,8 @@ import (
 	dms "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice/types"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -52,6 +54,13 @@ func (r *dataProviderResource) Schema(ctx context.Context, request resource.Sche
 				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						"aurora", "aurora-postgresql", "mysql", "oracle", "postgres",
+						"sqlserver", "redshift", "mariadb", "mongodb", "db2", "db2-zos",
+						"docdb", "sybase",
+					),
 				},
 			},
 			names.AttrTags:    tftags.TagsAttribute(),
@@ -110,6 +119,9 @@ func dataProviderSettingsBlock(ctx context.Context) schema.Block {
 				},
 				"ssl_mode": schema.StringAttribute{
 					Optional: true,
+					Validators: []validator.String{
+						stringvalidator.OneOf("none", "require", "verify-ca", "verify-full"),
+					},
 				},
 			},
 		},
@@ -130,6 +142,10 @@ func (r *dataProviderResource) Create(ctx context.Context, request resource.Crea
 		Description:      fwflex.StringFromFramework(ctx, data.Description),
 		Engine:           fwflex.StringFromFramework(ctx, data.Engine),
 		Tags:             getTagsIn(ctx),
+	}
+
+	if !data.Virtual.IsNull() {
+		input.Virtual = data.Virtual.ValueBoolPointer()
 	}
 
 	if !data.Settings.IsNull() {
@@ -174,6 +190,14 @@ func (r *dataProviderResource) Read(ctx context.Context, request resource.ReadRe
 	data.DataProviderName = fwflex.StringToFramework(ctx, output.DataProviderName)
 	data.Description = fwflex.StringToFramework(ctx, output.Description)
 	data.Engine = fwflex.StringToFramework(ctx, output.Engine)
+	data.Virtual = types.BoolPointerValue(output.Virtual)
+
+	settingsModel, diags := flattenDataProviderSettings(ctx, output.Settings)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	data.Settings = settingsModel
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
@@ -199,6 +223,10 @@ func (r *dataProviderResource) Update(ctx context.Context, request resource.Upda
 			DataProviderIdentifier: new.DataProviderARN.ValueStringPointer(),
 			DataProviderName:       fwflex.StringFromFramework(ctx, new.DataProviderName),
 			Description:            fwflex.StringFromFramework(ctx, new.Description),
+		}
+
+		if !new.Virtual.IsNull() {
+			input.Virtual = new.Virtual.ValueBoolPointer()
 		}
 
 		if !new.Settings.IsNull() {
@@ -371,6 +399,20 @@ func expandDataProviderSettings(ctx context.Context, settings *dataProviderSetti
 		if s, diags := settings.IBMDB2LUWSettings.ToPtr(ctx); diags == nil && s != nil {
 			return &awstypes.DataProviderSettingsMemberIbmDb2LuwSettings{
 				Value: *expandIBMDB2LUWDataProviderSettings(ctx, s),
+			}
+		}
+	}
+	if !settings.IBMDB2ZOSSettings.IsNull() {
+		if s, diags := settings.IBMDB2ZOSSettings.ToPtr(ctx); diags == nil && s != nil {
+			return &awstypes.DataProviderSettingsMemberIbmDb2zOsSettings{
+				Value: *expandIBMDB2ZOSDataProviderSettings(ctx, s),
+			}
+		}
+	}
+	if !settings.SybaseASESettings.IsNull() {
+		if s, diags := settings.SybaseASESettings.ToPtr(ctx); diags == nil && s != nil {
+			return &awstypes.DataProviderSettingsMemberSybaseAseSettings{
+				Value: *expandSybaseASEDataProviderSettings(ctx, s),
 			}
 		}
 	}
@@ -574,5 +616,131 @@ func expandIBMDB2LUWDataProviderSettings(ctx context.Context, settings *dataProv
 		result.SslMode = awstypes.DmsSslModeValue(settings.SSLMode.ValueString())
 	}
 
+	return result
+}
+
+func expandIBMDB2ZOSDataProviderSettings(ctx context.Context, settings *dataProviderDBSettingsModel) *awstypes.IbmDb2zOsDataProviderSettings { // nosemgrep:ci.semgrep.framework.manual-expander-functions
+	if settings == nil {
+		return nil
+	}
+
+	result := &awstypes.IbmDb2zOsDataProviderSettings{
+		DatabaseName: fwflex.StringFromFramework(ctx, settings.DatabaseName),
+		ServerName:   fwflex.StringFromFramework(ctx, settings.ServerName),
+	}
+
+	if !settings.CertificateARN.IsNull() {
+		result.CertificateArn = settings.CertificateARN.ValueStringPointer()
+	}
+	if !settings.Port.IsNull() {
+		result.Port = aws.Int32(int32(settings.Port.ValueInt64()))
+	}
+	if !settings.SSLMode.IsNull() {
+		result.SslMode = awstypes.DmsSslModeValue(settings.SSLMode.ValueString())
+	}
+
+	return result
+}
+
+func expandSybaseASEDataProviderSettings(ctx context.Context, settings *dataProviderDBSettingsModel) *awstypes.SybaseAseDataProviderSettings { // nosemgrep:ci.semgrep.framework.manual-expander-functions
+	if settings == nil {
+		return nil
+	}
+
+	result := &awstypes.SybaseAseDataProviderSettings{
+		DatabaseName: fwflex.StringFromFramework(ctx, settings.DatabaseName),
+		ServerName:   fwflex.StringFromFramework(ctx, settings.ServerName),
+	}
+
+	if !settings.CertificateARN.IsNull() {
+		result.CertificateArn = settings.CertificateARN.ValueStringPointer()
+	}
+	if !settings.Port.IsNull() {
+		result.Port = aws.Int32(int32(settings.Port.ValueInt64()))
+	}
+	if !settings.SSLMode.IsNull() {
+		result.SslMode = awstypes.DmsSslModeValue(settings.SSLMode.ValueString())
+	}
+
+	return result
+}
+
+func flattenDataProviderSettings(ctx context.Context, settings awstypes.DataProviderSettings) (fwtypes.ListNestedObjectValueOf[dataProviderSettingsModel], diag.Diagnostics) { // nosemgrep:ci.semgrep.framework.manual-flattener-functions
+	var diags diag.Diagnostics
+
+	if settings == nil {
+		return fwtypes.NewListNestedObjectValueOfNull[dataProviderSettingsModel](ctx), diags
+	}
+
+	model := &dataProviderSettingsModel{
+		DocDBSettings:              fwtypes.NewListNestedObjectValueOfNull[dataProviderDBSettingsModel](ctx),
+		IBMDB2LUWSettings:          fwtypes.NewListNestedObjectValueOfNull[dataProviderDBSettingsModel](ctx),
+		IBMDB2ZOSSettings:          fwtypes.NewListNestedObjectValueOfNull[dataProviderDBSettingsModel](ctx),
+		MariaDBSettings:            fwtypes.NewListNestedObjectValueOfNull[dataProviderDBSettingsModel](ctx),
+		MicrosoftSQLServerSettings: fwtypes.NewListNestedObjectValueOfNull[dataProviderDBSettingsModel](ctx),
+		MongoDBSettings:            fwtypes.NewListNestedObjectValueOfNull[dataProviderDBSettingsModel](ctx),
+		MySQLSettings:              fwtypes.NewListNestedObjectValueOfNull[dataProviderDBSettingsModel](ctx),
+		OracleSettings:             fwtypes.NewListNestedObjectValueOfNull[dataProviderDBSettingsModel](ctx),
+		PostgresSettings:           fwtypes.NewListNestedObjectValueOfNull[dataProviderDBSettingsModel](ctx),
+		RedshiftSettings:           fwtypes.NewListNestedObjectValueOfNull[dataProviderDBSettingsModel](ctx),
+		SybaseASESettings:          fwtypes.NewListNestedObjectValueOfNull[dataProviderDBSettingsModel](ctx),
+	}
+
+	switch v := settings.(type) {
+	case *awstypes.DataProviderSettingsMemberDocDbSettings:
+		model.DocDBSettings = flattenDBSettings(ctx, v.Value.CertificateArn, v.Value.DatabaseName, v.Value.Port, v.Value.ServerName, string(v.Value.SslMode))
+	case *awstypes.DataProviderSettingsMemberIbmDb2LuwSettings:
+		model.IBMDB2LUWSettings = flattenDBSettings(ctx, v.Value.CertificateArn, v.Value.DatabaseName, v.Value.Port, v.Value.ServerName, string(v.Value.SslMode))
+	case *awstypes.DataProviderSettingsMemberIbmDb2zOsSettings:
+		model.IBMDB2ZOSSettings = flattenDBSettings(ctx, v.Value.CertificateArn, v.Value.DatabaseName, v.Value.Port, v.Value.ServerName, string(v.Value.SslMode))
+	case *awstypes.DataProviderSettingsMemberMariaDbSettings:
+		model.MariaDBSettings = flattenDBSettings(ctx, v.Value.CertificateArn, nil, v.Value.Port, v.Value.ServerName, string(v.Value.SslMode))
+	case *awstypes.DataProviderSettingsMemberMicrosoftSqlServerSettings:
+		model.MicrosoftSQLServerSettings = flattenDBSettings(ctx, v.Value.CertificateArn, v.Value.DatabaseName, v.Value.Port, v.Value.ServerName, string(v.Value.SslMode))
+	case *awstypes.DataProviderSettingsMemberMongoDbSettings:
+		model.MongoDBSettings = flattenDBSettings(ctx, v.Value.CertificateArn, v.Value.DatabaseName, v.Value.Port, v.Value.ServerName, string(v.Value.SslMode))
+	case *awstypes.DataProviderSettingsMemberMySqlSettings:
+		model.MySQLSettings = flattenDBSettings(ctx, v.Value.CertificateArn, nil, v.Value.Port, v.Value.ServerName, string(v.Value.SslMode))
+	case *awstypes.DataProviderSettingsMemberOracleSettings:
+		model.OracleSettings = flattenDBSettings(ctx, v.Value.CertificateArn, v.Value.DatabaseName, v.Value.Port, v.Value.ServerName, string(v.Value.SslMode))
+	case *awstypes.DataProviderSettingsMemberPostgreSqlSettings:
+		model.PostgresSettings = flattenDBSettings(ctx, v.Value.CertificateArn, v.Value.DatabaseName, v.Value.Port, v.Value.ServerName, string(v.Value.SslMode))
+	case *awstypes.DataProviderSettingsMemberRedshiftSettings:
+		model.RedshiftSettings = flattenDBSettings(ctx, nil, v.Value.DatabaseName, v.Value.Port, v.Value.ServerName, "")
+	case *awstypes.DataProviderSettingsMemberSybaseAseSettings:
+		model.SybaseASESettings = flattenDBSettings(ctx, v.Value.CertificateArn, v.Value.DatabaseName, v.Value.Port, v.Value.ServerName, string(v.Value.SslMode))
+	}
+
+	result, d := fwtypes.NewListNestedObjectValueOfPtr(ctx, model)
+	diags.Append(d...)
+	return result, diags
+}
+
+func flattenDBSettings(ctx context.Context, certARN, dbName *string, port *int32, serverName *string, sslMode string) fwtypes.ListNestedObjectValueOf[dataProviderDBSettingsModel] { // nosemgrep:ci.semgrep.framework.manual-flattener-functions
+	model := &dataProviderDBSettingsModel{
+		CertificateARN: fwtypes.ARNNull(),
+		DatabaseName:   types.StringNull(),
+		Port:           types.Int64Null(),
+		ServerName:     types.StringNull(),
+		SSLMode:        types.StringNull(),
+	}
+
+	if certARN != nil {
+		model.CertificateARN = fwtypes.ARNValue(aws.ToString(certARN))
+	}
+	if dbName != nil {
+		model.DatabaseName = types.StringValue(aws.ToString(dbName))
+	}
+	if port != nil {
+		model.Port = types.Int64Value(int64(aws.ToInt32(port)))
+	}
+	if serverName != nil {
+		model.ServerName = types.StringValue(aws.ToString(serverName))
+	}
+	if sslMode != "" {
+		model.SSLMode = types.StringValue(sslMode)
+	}
+
+	result, _ := fwtypes.NewListNestedObjectValueOfPtr(ctx, model)
 	return result
 }

--- a/internal/service/dms/data_provider_test.go
+++ b/internal/service/dms/data_provider_test.go
@@ -1,0 +1,183 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dms_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tfdms "github.com/hashicorp/terraform-provider-aws/internal/service/dms"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccDMSDataProvider_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_dms_data_provider.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataProviderDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataProviderConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDataProviderExists(ctx, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "data_provider_arn"),
+					resource.TestCheckResourceAttr(resourceName, "data_provider_name", rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "postgres"),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.postgres_settings.#", "1"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIgnore:              []string{"settings"},
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "data_provider_arn"),
+				ImportStateVerifyIdentifierAttribute: "data_provider_arn",
+			},
+		},
+	})
+}
+
+func TestAccDMSDataProvider_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_dms_data_provider.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataProviderDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataProviderConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataProviderExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.postgres_settings.0.port", "5432"),
+				),
+			},
+			{
+				Config: testAccDataProviderConfig_updated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataProviderExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.postgres_settings.0.port", "5433"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDMSDataProvider_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_dms_data_provider.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataProviderDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataProviderConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataProviderExists(ctx, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, t, tfdms.ResourceDataProvider, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDataProviderExists(ctx context.Context, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DMSClient(ctx)
+
+		_, err := tfdms.FindDataProviderByARN(ctx, conn, rs.Primary.Attributes["data_provider_arn"])
+
+		return err
+	}
+}
+
+func testAccCheckDataProviderDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DMSClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_dms_data_provider" {
+				continue
+			}
+
+			_, err := tfdms.FindDataProviderByARN(ctx, conn, rs.Primary.Attributes["data_provider_arn"])
+
+			if errs.IsA[*retry.NotFoundError](err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("DMS Data Provider %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccDataProviderConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dms_data_provider" "test" {
+  data_provider_name = %[1]q
+  engine             = "postgres"
+
+  settings {
+    postgres_settings {
+      server_name   = "%[1]s.example.com"
+      port          = 5432
+      database_name = "testdb"
+      ssl_mode      = "none"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccDataProviderConfig_updated(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dms_data_provider" "test" {
+  data_provider_name = %[1]q
+  engine             = "postgres"
+
+  settings {
+    postgres_settings {
+      server_name   = "%[1]s.example.com"
+      port          = 5433
+      database_name = "testdb"
+      ssl_mode      = "none"
+    }
+  }
+}
+`, rName)
+}

--- a/internal/service/dms/data_provider_test.go
+++ b/internal/service/dms/data_provider_test.go
@@ -8,11 +8,10 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfdms "github.com/hashicorp/terraform-provider-aws/internal/service/dms"
@@ -22,18 +21,18 @@ import (
 func TestAccDMSDataProvider_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_data_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDataProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckDataProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataProviderConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDataProviderExists(ctx, resourceName),
+					testAccCheckDataProviderExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "data_provider_arn"),
 					resource.TestCheckResourceAttr(resourceName, "data_provider_name", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "postgres"),
@@ -56,25 +55,25 @@ func TestAccDMSDataProvider_basic(t *testing.T) {
 func TestAccDMSDataProvider_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_data_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDataProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckDataProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataProviderConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataProviderExists(ctx, resourceName),
+					testAccCheckDataProviderExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.postgres_settings.0.port", "5432"),
 				),
 			},
 			{
 				Config: testAccDataProviderConfig_updated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataProviderExists(ctx, resourceName),
+					testAccCheckDataProviderExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.postgres_settings.0.port", "5433"),
 				),
 			},
@@ -85,34 +84,42 @@ func TestAccDMSDataProvider_update(t *testing.T) {
 func TestAccDMSDataProvider_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_data_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDataProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckDataProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataProviderConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataProviderExists(ctx, resourceName),
+					testAccCheckDataProviderExists(ctx, t, resourceName),
 					acctest.CheckFrameworkResourceDisappears(ctx, t, tfdms.ResourceDataProvider, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 		},
 	})
 }
 
-func testAccCheckDataProviderExists(ctx context.Context, n string) resource.TestCheckFunc {
+func testAccCheckDataProviderExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).DMSClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).DMSClient(ctx)
 
 		_, err := tfdms.FindDataProviderByARN(ctx, conn, rs.Primary.Attributes["data_provider_arn"])
 
@@ -120,9 +127,9 @@ func testAccCheckDataProviderExists(ctx context.Context, n string) resource.Test
 	}
 }
 
-func testAccCheckDataProviderDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckDataProviderDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).DMSClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).DMSClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_dms_data_provider" {

--- a/internal/service/dms/exports_test.go
+++ b/internal/service/dms/exports_test.go
@@ -6,6 +6,7 @@ package dms
 // Exports for use in tests only.
 var (
 	ResourceCertificate            = resourceCertificate
+	ResourceDataProvider           = resourceDataProvider
 	ResourceEndpoint               = resourceEndpoint
 	ResourceEventSubscription      = resourceEventSubscription
 	ResourceReplicationConfig      = resourceReplicationConfig
@@ -15,6 +16,7 @@ var (
 	ResourceS3Endpoint             = resourceS3Endpoint
 
 	FindCertificateByID            = findCertificateByID
+	FindDataProviderByARN          = findDataProviderByARN
 	FindEndpointByID               = findEndpointByID
 	FindEventSubscriptionByName    = findEventSubscriptionByName
 	FindReplicationConfigByARN     = findReplicationConfigByARN

--- a/internal/service/dms/service_package_gen.go
+++ b/internal/service/dms/service_package_gen.go
@@ -25,7 +25,17 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.ServicePackageFrameworkResource {
-	return []*inttypes.ServicePackageFrameworkResource{}
+	return []*inttypes.ServicePackageFrameworkResource{
+		{
+			Factory:  resourceDataProvider,
+			TypeName: "aws_dms_data_provider",
+			Name:     "Data Provider",
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: "data_provider_arn",
+			}),
+			Region: unique.Make(inttypes.ResourceRegionDefault()),
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*inttypes.ServicePackageSDKDataSource {

--- a/internal/service/dms/service_package_gen.go
+++ b/internal/service/dms/service_package_gen.go
@@ -36,7 +36,17 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.ServicePackageFrameworkResource {
-	return []*inttypes.ServicePackageFrameworkResource{}
+	return []*inttypes.ServicePackageFrameworkResource{
+		{
+			Factory:  resourceDataProvider,
+			TypeName: "aws_dms_data_provider",
+			Name:     "Data Provider",
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: "data_provider_arn",
+			}),
+			Region: unique.Make(inttypes.ResourceRegionDefault()),
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*inttypes.ServicePackageSDKDataSource {

--- a/internal/service/dms/service_package_gen.go
+++ b/internal/service/dms/service_package_gen.go
@@ -44,7 +44,7 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			Tags: unique.Make(inttypes.ServicePackageResourceTags{
 				IdentifierAttribute: "data_provider_arn",
 			}),
-			Region: unique.Make(inttypes.ResourceRegionDefault()),
+			Region: inttypes.ResourceRegionDefault(),
 		},
 	}
 }

--- a/internal/service/dms/testdata/tmpl/data_provider_basic.gtpl
+++ b/internal/service/dms/testdata/tmpl/data_provider_basic.gtpl
@@ -1,0 +1,13 @@
+resource "aws_dms_data_provider" "test" {
+  data_provider_name = var.rName
+  engine             = "postgres"
+
+  settings {
+    postgres_settings {
+      server_name   = "example.com"
+      port          = 5432
+      database_name = "testdb"
+      ssl_mode      = "none"
+    }
+  }
+}

--- a/internal/service/dms/testdata/tmpl/data_provider_tags.gtpl
+++ b/internal/service/dms/testdata/tmpl/data_provider_tags.gtpl
@@ -1,0 +1,15 @@
+resource "aws_dms_data_provider" "test" {
+  data_provider_name = var.rName
+  engine             = "postgres"
+
+  settings {
+    postgres_settings {
+      server_name   = "example.com"
+      port          = 5432
+      database_name = "testdb"
+      ssl_mode      = "none"
+    }
+  }
+
+{{- template "tags" . }}
+}

--- a/website/docs/r/dms_data_provider.html.markdown
+++ b/website/docs/r/dms_data_provider.html.markdown
@@ -1,0 +1,114 @@
+---
+subcategory: "DMS (Database Migration)"
+layout: "aws"
+page_title: "AWS: aws_dms_data_provider"
+description: |-
+  Provides a DMS (Data Migration Service) data provider resource.
+---
+
+# Resource: aws_dms_data_provider
+
+Provides a DMS (Data Migration Service) data provider resource. DMS data providers store database connection information.
+
+## Example Usage
+
+### PostgreSQL Data Provider
+
+```terraform
+resource "aws_dms_data_provider" "postgres" {
+  data_provider_name = "my-postgres-provider"
+  engine             = "postgres"
+
+  settings {
+    postgres_settings {
+      server_name   = "mydb.example.com"
+      port          = 5432
+      database_name = "mydb"
+      ssl_mode      = "require"
+    }
+  }
+
+  tags = {
+    Name = "postgres-provider"
+  }
+}
+```
+
+### MySQL Data Provider
+
+```terraform
+resource "aws_dms_data_provider" "mysql" {
+  data_provider_name = "my-mysql-provider"
+  engine             = "mysql"
+
+  settings {
+    mysql_settings {
+      server_name = "mydb.example.com"
+      port        = 3306
+      ssl_mode    = "require"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `engine` - (Required) Database engine type. Valid values: `aurora`, `aurora-postgresql`, `mysql`, `oracle`, `postgres`, `sqlserver`, `redshift`, `mariadb`, `mongodb`, `db2`, `db2-zos`, `docdb`, `sybase`.
+* `settings` - (Required) Configuration block for data provider settings. See [`settings`](#settings) below.
+* `data_provider_name` - (Optional) User-friendly name for the data provider.
+* `description` - (Optional) Description of the data provider.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `virtual` - (Optional) Indicates whether the data provider is virtual.
+* `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### settings
+
+The `settings` block supports one of the following:
+
+* `docdb_settings` - (Optional) Configuration for DocumentDB. See [common settings](#common-settings) below.
+* `ibm_db2_luw_settings` - (Optional) Configuration for IBM DB2 LUW. See [common settings](#common-settings) below.
+* `ibm_db2_zos_settings` - (Optional) Configuration for IBM DB2 for z/OS. See [common settings](#common-settings) below.
+* `mariadb_settings` - (Optional) Configuration for MariaDB. See [common settings](#common-settings) below.
+* `microsoft_sql_server_settings` - (Optional) Configuration for Microsoft SQL Server. See [common settings](#common-settings) below.
+* `mongodb_settings` - (Optional) Configuration for MongoDB. See [common settings](#common-settings) below.
+* `mysql_settings` - (Optional) Configuration for MySQL. See [common settings](#common-settings) below.
+* `oracle_settings` - (Optional) Configuration for Oracle. See [common settings](#common-settings) below.
+* `postgres_settings` - (Optional) Configuration for PostgreSQL. See [common settings](#common-settings) below.
+* `redshift_settings` - (Optional) Configuration for Redshift. See [common settings](#common-settings) below.
+* `sybase_ase_settings` - (Optional) Configuration for SAP ASE. See [common settings](#common-settings) below.
+
+### Common Settings
+
+All settings blocks support the following common attributes:
+
+* `server_name` - (Optional) Server name.
+* `port` - (Optional) Port number.
+* `database_name` - (Optional) Database name.
+* `ssl_mode` - (Optional) SSL mode. Valid values: `none`, `require`, `verify-ca`, `verify-full`.
+* `certificate_arn` - (Optional) ARN of the certificate for SSL connection.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `data_provider_arn` - ARN of the data provider.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import data providers using the `data_provider_arn`. For example:
+
+```terraform
+import {
+  to = aws_dms_data_provider.example
+  id = "arn:aws:dms:us-east-1:123456789012:data-provider:ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+}
+```
+
+Using `terraform import`, import data providers using the `data_provider_arn`. For example:
+
+```console
+% terraform import aws_dms_data_provider.example arn:aws:dms:us-east-1:123456789012:data-provider:ABCDEFGHIJKLMNOPQRSTUVWXYZ
+```

--- a/website/docs/r/dms_data_provider.html.markdown
+++ b/website/docs/r/dms_data_provider.html.markdown
@@ -55,39 +55,139 @@ resource "aws_dms_data_provider" "mysql" {
 
 This resource supports the following arguments:
 
-* `engine` - (Required) Database engine type. Valid values: `aurora`, `aurora-postgresql`, `mysql`, `oracle`, `postgres`, `sqlserver`, `redshift`, `mariadb`, `mongodb`, `db2`, `db2-zos`, `docdb`, `sybase`.
-* `settings` - (Required) Configuration block for data provider settings. See [`settings`](#settings) below.
 * `data_provider_name` - (Optional) User-friendly name for the data provider.
 * `description` - (Optional) Description of the data provider.
+* `engine` - (Required) Database engine type. Valid values: `aurora`, `aurora-postgresql`, `mysql`, `oracle`, `postgres`, `sqlserver`, `redshift`, `mariadb`, `mongodb`, `db2`, `db2-zos`, `docdb`, `sybase`.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `virtual` - (Optional) Indicates whether the data provider is virtual.
+* `settings` - (Required) Configuration block for data provider settings. See [`settings`](#settings-block) below.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `virtual` - (Optional) Whether the data provider is virtual.
 
-### settings
+### `settings` Block
 
 The `settings` block supports one of the following:
 
-* `docdb_settings` - (Optional) Configuration for DocumentDB. See [common settings](#common-settings) below.
-* `ibm_db2_luw_settings` - (Optional) Configuration for IBM DB2 LUW. See [common settings](#common-settings) below.
-* `ibm_db2_zos_settings` - (Optional) Configuration for IBM DB2 for z/OS. See [common settings](#common-settings) below.
-* `mariadb_settings` - (Optional) Configuration for MariaDB. See [common settings](#common-settings) below.
-* `microsoft_sql_server_settings` - (Optional) Configuration for Microsoft SQL Server. See [common settings](#common-settings) below.
-* `mongodb_settings` - (Optional) Configuration for MongoDB. See [common settings](#common-settings) below.
-* `mysql_settings` - (Optional) Configuration for MySQL. See [common settings](#common-settings) below.
-* `oracle_settings` - (Optional) Configuration for Oracle. See [common settings](#common-settings) below.
-* `postgres_settings` - (Optional) Configuration for PostgreSQL. See [common settings](#common-settings) below.
-* `redshift_settings` - (Optional) Configuration for Redshift. See [common settings](#common-settings) below.
-* `sybase_ase_settings` - (Optional) Configuration for SAP ASE. See [common settings](#common-settings) below.
+* `docdb_settings` - (Optional) Configuration for DocumentDB. See [`docdb_settings` Block](#docdb_settings-block) below.
+* `ibm_db2_luw_settings` - (Optional) Configuration for IBM DB2 LUW. See [`ibm_db2_luw_settings` Block](#ibm_db2_luw_settings-block) below.
+* `ibm_db2_zos_settings` - (Optional) Configuration for IBM DB2 for z/OS. See [`ibm_db2_zos_settings` Block](#ibm_db2_zos_settings-block) below.
+* `mariadb_settings` - (Optional) Configuration for MariaDB. See [`mariadb_settings` Block](#mariadb_settings-block) below.
+* `microsoft_sql_server_settings` - (Optional) Configuration for Microsoft SQL Server. See [`microsoft_sql_server_settings` Block](#microsoft_sql_server_settings-block) below.
+* `mongodb_settings` - (Optional) Configuration for MongoDB. See [`mongodb_settings` Block](#mongodb_settings-block) below.
+* `mysql_settings` - (Optional) Configuration for MySQL. See [`mysql_settings` Block](#mysql_settings-block) below.
+* `oracle_settings` - (Optional) Configuration for Oracle. See [`oracle_settings` Block](#oracle_settings-block) below.
+* `postgres_settings` - (Optional) Configuration for PostgreSQL. See [`postgres_settings` Block](#postgres_settings-block) below.
+* `redshift_settings` - (Optional) Configuration for Redshift. See [`redshift_settings` Block](#redshift_settings-block) below.
+* `sybase_ase_settings` - (Optional) Configuration for SAP ASE. See [`sybase_ase_settings` Block](#sybase_ase_settings-block) below.
 
-### Common Settings
+### `docdb_settings` Block
 
-All settings blocks support the following common attributes:
+The `docdb_settings` block supports the following:
 
-* `server_name` - (Optional) Server name.
-* `port` - (Optional) Port number.
-* `database_name` - (Optional) Database name.
-* `ssl_mode` - (Optional) SSL mode. Valid values: `none`, `require`, `verify-ca`, `verify-full`.
 * `certificate_arn` - (Optional) ARN of the certificate for SSL connection.
+* `database_name` - (Optional) Database name.
+* `port` - (Optional) Port number.
+* `server_name` - (Optional) Server name.
+* `ssl_mode` - (Optional) SSL mode. Valid values: `none`, `require`, `verify-ca`, `verify-full`.
+
+### `ibm_db2_luw_settings` Block
+
+The `ibm_db2_luw_settings` block supports the following:
+
+* `certificate_arn` - (Optional) ARN of the certificate for SSL connection.
+* `database_name` - (Optional) Database name.
+* `port` - (Optional) Port number.
+* `server_name` - (Optional) Server name.
+* `ssl_mode` - (Optional) SSL mode. Valid values: `none`, `require`, `verify-ca`, `verify-full`.
+
+### `ibm_db2_zos_settings` Block
+
+The `ibm_db2_zos_settings` block supports the following:
+
+* `certificate_arn` - (Optional) ARN of the certificate for SSL connection.
+* `database_name` - (Optional) Database name.
+* `port` - (Optional) Port number.
+* `server_name` - (Optional) Server name.
+* `ssl_mode` - (Optional) SSL mode. Valid values: `none`, `require`, `verify-ca`, `verify-full`.
+
+### `mariadb_settings` Block
+
+The `mariadb_settings` block supports the following:
+
+* `certificate_arn` - (Optional) ARN of the certificate for SSL connection.
+* `database_name` - (Optional) Database name.
+* `port` - (Optional) Port number.
+* `server_name` - (Optional) Server name.
+* `ssl_mode` - (Optional) SSL mode. Valid values: `none`, `require`, `verify-ca`, `verify-full`.
+
+### `microsoft_sql_server_settings` Block
+
+The `microsoft_sql_server_settings` block supports the following:
+
+* `certificate_arn` - (Optional) ARN of the certificate for SSL connection.
+* `database_name` - (Optional) Database name.
+* `port` - (Optional) Port number.
+* `server_name` - (Optional) Server name.
+* `ssl_mode` - (Optional) SSL mode. Valid values: `none`, `require`, `verify-ca`, `verify-full`.
+
+### `mongodb_settings` Block
+
+The `mongodb_settings` block supports the following:
+
+* `certificate_arn` - (Optional) ARN of the certificate for SSL connection.
+* `database_name` - (Optional) Database name.
+* `port` - (Optional) Port number.
+* `server_name` - (Optional) Server name.
+* `ssl_mode` - (Optional) SSL mode. Valid values: `none`, `require`, `verify-ca`, `verify-full`.
+
+### `mysql_settings` Block
+
+The `mysql_settings` block supports the following:
+
+* `certificate_arn` - (Optional) ARN of the certificate for SSL connection.
+* `database_name` - (Optional) Database name.
+* `port` - (Optional) Port number.
+* `server_name` - (Optional) Server name.
+* `ssl_mode` - (Optional) SSL mode. Valid values: `none`, `require`, `verify-ca`, `verify-full`.
+
+### `oracle_settings` Block
+
+The `oracle_settings` block supports the following:
+
+* `certificate_arn` - (Optional) ARN of the certificate for SSL connection.
+* `database_name` - (Optional) Database name.
+* `port` - (Optional) Port number.
+* `server_name` - (Optional) Server name.
+* `ssl_mode` - (Optional) SSL mode. Valid values: `none`, `require`, `verify-ca`, `verify-full`.
+
+### `postgres_settings` Block
+
+The `postgres_settings` block supports the following:
+
+* `certificate_arn` - (Optional) ARN of the certificate for SSL connection.
+* `database_name` - (Optional) Database name.
+* `port` - (Optional) Port number.
+* `server_name` - (Optional) Server name.
+* `ssl_mode` - (Optional) SSL mode. Valid values: `none`, `require`, `verify-ca`, `verify-full`.
+
+### `redshift_settings` Block
+
+The `redshift_settings` block supports the following:
+
+* `certificate_arn` - (Optional) ARN of the certificate for SSL connection.
+* `database_name` - (Optional) Database name.
+* `port` - (Optional) Port number.
+* `server_name` - (Optional) Server name.
+* `ssl_mode` - (Optional) SSL mode. Valid values: `none`, `require`, `verify-ca`, `verify-full`.
+
+### `sybase_ase_settings` Block
+
+The `sybase_ase_settings` block supports the following:
+
+* `certificate_arn` - (Optional) ARN of the certificate for SSL connection.
+* `database_name` - (Optional) Database name.
+* `port` - (Optional) Port number.
+* `server_name` - (Optional) Server name.
+* `ssl_mode` - (Optional) SSL mode. Valid values: `none`, `require`, `verify-ca`, `verify-full`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None

### Description
This PR introduces a new aws_dms_data_provider resource. This is the first step for managing new DMS migration projects

### Relations
refs #38004

### References
[API Reference](https://docs.aws.amazon.com/dms/latest/APIReference/API_CreateDataProvider.html)

### Output from Acceptance Testing

```console
% TF_ACC=1 go test -v -run=TestAccDMSDataProvider ./internal/service/dms -timeout 30m

2025/12/10 00:55:31 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDMSDataProvider_basic
=== PAUSE TestAccDMSDataProvider_basic
=== RUN   TestAccDMSDataProvider_update
=== PAUSE TestAccDMSDataProvider_update
=== RUN   TestAccDMSDataProvider_disappears
=== PAUSE TestAccDMSDataProvider_disappears
=== CONT  TestAccDMSDataProvider_basic
=== CONT  TestAccDMSDataProvider_disappears
=== CONT  TestAccDMSDataProvider_update
--- PASS: TestAccDMSDataProvider_disappears (23.12s)
--- PASS: TestAccDMSDataProvider_basic (26.31s)
--- PASS: TestAccDMSDataProvider_update (38.73s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dms        43.407s
```
