### PR TITLE
feat(imagebuilder): support image pipeline executions

### DIFF
--- a/.changelog/45544.txt
+++ b/.changelog/45544.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_imagebuilder_image: Add `image_pipeline_execution_settings` configuration block to support invoking image pipelines directly for image creation
+```

--- a/website/docs/r/imagebuilder_image.html.markdown
+++ b/website/docs/r/imagebuilder_image.html.markdown
@@ -12,6 +12,8 @@ Manages an Image Builder Image.
 
 ## Example Usage
 
+### Building an Image from a Recipe
+
 ```terraform
 resource "aws_imagebuilder_image" "example" {
   distribution_configuration_arn   = aws_imagebuilder_distribution_configuration.example.arn
@@ -20,24 +22,50 @@ resource "aws_imagebuilder_image" "example" {
 }
 ```
 
+### Building an Image by Invoking a Pipeline
+
+```terraform
+resource "aws_imagebuilder_image_pipeline" "example" {
+  image_recipe_arn                 = aws_imagebuilder_image_recipe.example.arn
+  infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.example.arn
+  name                             = "example"
+}
+
+resource "aws_imagebuilder_image" "example" {
+  image_pipeline_execution_settings {
+    image_pipeline_arn = aws_imagebuilder_image_pipeline.example.arn
+  }
+
+  tags = {
+    Name = "example"
+  }
+}
+```
+
 ## Argument Reference
 
-The following arguments are required:
-
-* `infrastructure_configuration_arn` - (Required) Amazon Resource Name (ARN) of the Image Builder Infrastructure Configuration.
+~> **NOTE:** You must specify one of the following: (`image_recipe_arn` or `container_recipe_arn` with `infrastructure_configuration_arn`) OR `image_pipeline_execution_settings`. These approaches are mutually exclusive.
 
 The following arguments are optional:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `container_recipe_arn` - (Optional) - Amazon Resource Name (ARN) of the container recipe.
+* `container_recipe_arn` - (Optional) Amazon Resource Name (ARN) of the container recipe.
 * `distribution_configuration_arn` - (Optional) Amazon Resource Name (ARN) of the Image Builder Distribution Configuration.
 * `enhanced_image_metadata_enabled` - (Optional) Whether additional information about the image being created is collected. Defaults to `true`.
 * `execution_role` - (Optional) Amazon Resource Name (ARN) of the service-linked role to be used by Image Builder to [execute workflows](https://docs.aws.amazon.com/imagebuilder/latest/userguide/manage-image-workflows.html).
+* `image_pipeline_execution_settings` - (Optional) Configuration block to trigger an image build by invoking an existing image pipeline. Detailed below.
 * `image_recipe_arn` - (Optional) Amazon Resource Name (ARN) of the image recipe.
-* `image_tests_configuration` - (Optional) Configuration block with image tests configuration. Detailed below.
 * `image_scanning_configuration` - (Optional) Configuration block with image scanning configuration. Detailed below.
+* `image_tests_configuration` - (Optional) Configuration block with image tests configuration. Detailed below.
+* `infrastructure_configuration_arn` - (Optional) Amazon Resource Name (ARN) of the Image Builder Infrastructure Configuration. Required when using `image_recipe_arn` or `container_recipe_arn`.
 * `workflow` - (Optional) Configuration block with the workflow configuration. Detailed below.
 * `tags` - (Optional) Key-value map of resource tags for the Image Builder Image. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### image_pipeline_execution_settings
+
+The following arguments are required:
+
+* `image_pipeline_arn` - (Required) Amazon Resource Name (ARN) of the Image Builder Image Pipeline to invoke for creating the image.
 
 ### image_tests_configuration
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None

### Description

Adds support for invoking Image Builder pipelines directly when creating `aws_imagebuilder_image` resources through a new `image_pipeline_execution_settings` configuration block.

This enhancement provides an alternative method for creating images by triggering an existing image pipeline execution, rather than requiring users to specify individual recipe and infrastructure configurations. When `image_pipeline_execution_settings` is used, the resource calls the `StartImagePipelineExecution` API to invoke the pipeline and create the image.

**Key changes:**
- Added `image_pipeline_execution_settings` configuration block to `aws_imagebuilder_image` resource
  - Contains `image_pipeline_arn` parameter to reference the pipeline to invoke
- Modified resource creation logic to use `StartImagePipelineExecution` API when pipeline execution settings are provided
- Made `infrastructure_configuration_arn` optional (only required for recipe-based creation)
- Added mutual exclusivity validation between pipeline execution settings and recipe-based parameters
- Updated documentation with examples showing both creation methods

**Usage example:**
```terraform
resource "aws_imagebuilder_image_pipeline" "example" {
  image_recipe_arn                 = aws_imagebuilder_image_recipe.example.arn
  infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.example.arn
  name                             = "example"
}

resource "aws_imagebuilder_image" "example" {
  image_pipeline_execution_settings {
    image_pipeline_arn = aws_imagebuilder_image_pipeline.example.arn
  }

  tags = {
    Name = "example"
  }
}
```

### Relations

Closes #33212

### References

- API Documentation: [StartImagePipelineExecution](https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_StartImagePipelineExecution.html)

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccImageBuilderImage_pipelineExecutionSettings PKG=imagebuilder                                    
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_imagebuilder_image-start-pipeline 🌿...
TF_ACC=1 go1.24.11 test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderImage_pipelineExecutionSettings'  -timeout 360m -vet=off
2025/12/10 22:48:14 Creating Terraform AWS Provider (SDKv2-style)...
2025/12/10 22:48:14 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccImageBuilderImage_pipelineExecutionSettings
=== PAUSE TestAccImageBuilderImage_pipelineExecutionSettings
=== RUN   TestAccImageBuilderImage_pipelineExecutionSettings_tags
=== PAUSE TestAccImageBuilderImage_pipelineExecutionSettings_tags
=== RUN   TestAccImageBuilderImage_pipelineExecutionSettings_disappears
=== PAUSE TestAccImageBuilderImage_pipelineExecutionSettings_disappears
=== CONT  TestAccImageBuilderImage_pipelineExecutionSettings
=== CONT  TestAccImageBuilderImage_pipelineExecutionSettings_disappears
=== CONT  TestAccImageBuilderImage_pipelineExecutionSettings_tags
--- PASS: TestAccImageBuilderImage_pipelineExecutionSettings_disappears (783.18s)
--- PASS: TestAccImageBuilderImage_pipelineExecutionSettings (911.17s)
--- PASS: TestAccImageBuilderImage_pipelineExecutionSettings_tags (1081.31s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       1081.521s
```