### PR TITLE
Eventual Task Definition consistency

### DIFF
--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -655,89 +655,91 @@ func resourceTaskDefinitionRead(ctx context.Context, d *schema.ResourceData, met
 		familyOrARN = d.Get(names.AttrFamily).(string)
 	}
 
-    // Wrap the read in a retry that only triggers for brand-new resources.
-    type taskDefWithTags struct {
-        Task *awstypes.TaskDefinition
-        Tags []awstypes.Tag
-    }
+	// Wrap the read in a retry that only triggers for brand-new resources.
+	type taskDefWithTags struct {
+		Task *awstypes.TaskDefinition
+		Tags []awstypes.Tag
+	}
 
-    output, err := tfresource.RetryWhenNewResourceNotFound(
-        ctx,
-        taskDefinitionPropagationTimeout,
-        func(ctx context.Context) (taskDefWithTags, error) {
-            td, tags, err := findTaskDefinitionByFamilyOrARN(ctx, conn, familyOrARN)
-            if err != nil {
-                return taskDefWithTags{}, err
-            }
-            return taskDefWithTags{
-                Task: td,
-                Tags: tags,
-            }, nil
-        },
-        d.IsNewResource(),
-    )
+	output, err := tfresource.RetryWhenNewResourceNotFound(
+		ctx,
+		taskDefinitionPropagationTimeout,
+		func(ctx context.Context) (taskDefWithTags, error) {
+			td, tags, err := findTaskDefinitionByFamilyOrARN(ctx, conn, familyOrARN)
+			if err != nil {
+				return taskDefWithTags{}, err
+			}
+			return taskDefWithTags{
+				Task: td,
+				Tags: tags,
+			}, nil
+		},
+		d.IsNewResource(),
+	)
 
-    // For existing resources: if it’s really gone, drop from state.
-    if !d.IsNewResource() && retry.NotFound(err) {
-        log.Printf("[WARN] ECS Task Definition (%s) not found, removing from state", d.Id())
-        d.SetId("")
-        return diags
-    }
+	// For existing resources: if it’s really gone, drop from state.
+	if !d.IsNewResource() && retry.NotFound(err) {
+		log.Printf("[WARN] ECS Task Definition (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
+	}
 
-    // Any other error (including exhausted retries for new resources) is fatal.
-    if err != nil {
-        return sdkdiag.AppendErrorf(diags, "reading ECS Task Definition (%s): %s", familyOrARN, err)
-    }
+	// Any other error (including exhausted retries for new resources) is fatal.
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading ECS Task Definition (%s): %s", familyOrARN, err)
+	}
 
-    taskDefinition := output.Task
-    tags := output.Tags
+	taskDefinition := output.Task
+	tags := output.Tags
 
-    d.SetId(aws.ToString(taskDefinition.Family))
-    arn := aws.ToString(taskDefinition.TaskDefinitionArn)
-    d.Set(names.AttrARN, arn)
-    d.Set("arn_without_revision", taskDefinitionARNStripRevision(arn))
-    d.Set("cpu", taskDefinition.Cpu)
-    d.Set("enable_fault_injection", taskDefinition.EnableFaultInjection)
-    if err := d.Set("ephemeral_storage", flattenEphemeralStorage(taskDefinition.EphemeralStorage)); err != nil {
-        return sdkdiag.AppendErrorf(diags, "setting ephemeral_storage: %s", err)
-    }
-    d.Set(names.AttrExecutionRoleARN, taskDefinition.ExecutionRoleArn)
-    d.Set(names.AttrFamily, taskDefinition.Family)
-    d.Set("ipc_mode", taskDefinition.IpcMode)
-    d.Set("memory", taskDefinition.Memory)
-    d.Set("network_mode", taskDefinition.NetworkMode)
-    d.Set("pid_mode", taskDefinition.PidMode)
-    if err := d.Set("placement_constraints", flattenTaskDefinitionPlacementConstraints(taskDefinition.PlacementConstraints)); err != nil {
-        return sdkdiag.AppendErrorf(diags, "setting placement_constraints: %s", err)
-    }
-    if err := d.Set("proxy_configuration", flattenProxyConfiguration(taskDefinition.ProxyConfiguration)); err != nil {
-        return sdkdiag.AppendErrorf(diags, "setting proxy_configuration: %s", err)
-    }
-    d.Set("requires_compatibilities", taskDefinition.RequiresCompatibilities)
-    d.Set("revision", taskDefinition.Revision)
-    if err := d.Set("runtime_platform", flattenRuntimePlatform(taskDefinition.RuntimePlatform)); err != nil {
-        return sdkdiag.AppendErrorf(diags, "setting runtime_platform: %s", err)
-    }
-    d.Set("task_role_arn", taskDefinition.TaskRoleArn)
-    d.Set("track_latest", d.Get("track_latest"))
-    if err := d.Set("volume", flattenVolumes(taskDefinition.Volumes)); err != nil {
-        return sdkdiag.AppendErrorf(diags, "setting volume: %s", err)
-    }
+	d.SetId(aws.ToString(taskDefinition.Family))
+	arn := aws.ToString(taskDefinition.TaskDefinitionArn)
+	d.Set(names.AttrARN, arn)
+	d.Set("arn_without_revision", taskDefinitionARNStripRevision(arn))
+	d.Set("cpu", taskDefinition.Cpu)
+	d.Set("enable_fault_injection", taskDefinition.EnableFaultInjection)
+	if err := d.Set("ephemeral_storage", flattenEphemeralStorage(taskDefinition.EphemeralStorage)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting ephemeral_storage: %s", err)
+	}
+	d.Set(names.AttrExecutionRoleARN, taskDefinition.ExecutionRoleArn)
+	d.Set(names.AttrFamily, taskDefinition.Family)
+	d.Set("ipc_mode", taskDefinition.IpcMode)
+	d.Set("memory", taskDefinition.Memory)
+	d.Set("network_mode", taskDefinition.NetworkMode)
+	d.Set("pid_mode", taskDefinition.PidMode)
+	if err := d.Set("placement_constraints", flattenTaskDefinitionPlacementConstraints(taskDefinition.PlacementConstraints)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting placement_constraints: %s", err)
+	}
+	if err := d.Set("proxy_configuration", flattenProxyConfiguration(taskDefinition.ProxyConfiguration)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting proxy_configuration: %s", err)
+	}
+	d.Set("requires_compatibilities", taskDefinition.RequiresCompatibilities)
+	d.Set("revision", taskDefinition.Revision)
+	if err := d.Set("runtime_platform", flattenRuntimePlatform(taskDefinition.RuntimePlatform)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting runtime_platform: %s", err)
+	}
+	d.Set("task_role_arn", taskDefinition.TaskRoleArn)
+	d.Set("track_latest", d.Get("track_latest"))
+	if err := d.Set("volume", flattenVolumes(taskDefinition.Volumes)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting volume: %s", err)
+	}
 
-    // keep the existing container_definitions normalization
-    containerDefinitions(taskDefinition.ContainerDefinitions).orderContainers()
-    containerDefinitions(taskDefinition.ContainerDefinitions).orderEnvironmentVariables()
-    containerDefinitions(taskDefinition.ContainerDefinitions).orderSecrets()
+	// Sort the lists of environment variables as they come in, so we won't get spurious reorderings in plans
+	// (diff is suppressed if the environment variables haven't changed, but they still show in the plan if
+	// some other property changes).
+	containerDefinitions(taskDefinition.ContainerDefinitions).orderContainers()
+	containerDefinitions(taskDefinition.ContainerDefinitions).orderEnvironmentVariables()
+	containerDefinitions(taskDefinition.ContainerDefinitions).orderSecrets()
 
-    defs, err := flattenContainerDefinitions(taskDefinition.ContainerDefinitions)
-    if err != nil {
-        return sdkdiag.AppendFromErr(diags, err)
-    }
-    d.Set("container_definitions", defs)
+	defs, err := flattenContainerDefinitions(taskDefinition.ContainerDefinitions)
+	if err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
+	}
+	d.Set("container_definitions", defs)
 
-    setTagsOut(ctx, tags)
+	setTagsOut(ctx, tags)
 
-    return diags
+	return diags
 }
 
 func resourceTaskDefinitionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {


### PR DESCRIPTION
I've been personally suffering from 

```
aws_ecs_task_definition.somesystem_task: Creating...
╷
│ Error: reading ECS Task Definition (arn:aws:ecs:REGION:ACCOUNT_ID:task-definition/somesystem_task:20): couldn't find resource

```
The task definition in question is being updated, but the system is immediately attempting to read it and failing.  I poked around and saw how it was being solved with other systems.

It'd be nice if newly created resources were implicitly retried in any context where they're queried vs this specific error handling in each case.

I still need to run acceptance testing and such, this is more of a rough draft of 'bug report by way of PR'

But to reiterate,

it finds the existing task, updates it, but then immediately cant find the brand new revision which definitely exists now (or will soon) in aws fashion.