### PR TITLE
docs(s3vectors_index): use correct attribute name kms_key_arn

### DIFF
--- a/website/docs/r/s3vectors_index.html.markdown
+++ b/website/docs/r/s3vectors_index.html.markdown
@@ -46,7 +46,7 @@ The following arguments are optional:
 
 The `encryption_configuration` block supports the following attributes:
 
-* `kms_key_arn` - (Optional, Forces new resource) AWS Key Management Service (KMS) customer managed key ID to use for the encryption configuration. This parameter is allowed if and only if `sse_type` is set to `aws:kms`.
+* `kms_key_arn` - (Optional, Forces new resource) AWS Key Management Service (KMS) customer managed key ID to use for the encryption configuration. This parameter is allowed if and only if `sse_type` is set to `aws:kms`. To specify the KMS key, you must use the format of the KMS key Amazon Resource Name (ARN).
 * `sse_type` - (Optional, Forces new resource) Type of encryption to use. Valid values: `AES256`, `aws:kms`. Defaults to `AES256`.
 
 ### `metadata_configuration` block


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

### Description

Resolves an inconsistency between the documentation and implementation for the `encryption_configuration` block of the `aws_s3vectors_index` resource as introduced in v6.26.0.

The enhancement to the `aws_s3vectors_index` resource in https://github.com/hashicorp/terraform-provider-aws/pull/45470 includes an `encryption_configuration` block with a `kms_key_arn` attribute:

https://github.com/hashicorp/terraform-provider-aws/blob/b6c16ac16873c26d130e27e838155525d8c98ddf/internal/service/s3vectors/index.go#L297-L300

https://github.com/hashicorp/terraform-provider-aws/blob/b6c16ac16873c26d130e27e838155525d8c98ddf/internal/service/s3vectors/index_test.go#L418-L430

...but the corresponding documentation uses the attribute name "kms_key_id" instead:
https://github.com/hashicorp/terraform-provider-aws/blob/b6c16ac16873c26d130e27e838155525d8c98ddf/website/docs/r/s3vectors_index.html.markdown#L47-L50

### Relations
Relates #45470
