### PR TITLE
Technical debt: Speed up `make test`

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -2196,8 +2196,8 @@ func SkipIfExeNotOnPath(t *testing.T, file string) string {
 	return v
 }
 
-// SkipIfNotAcceptanceTest skips the current test if it's not an acceptance test (TF_ACC is set in the environment).
-func SkipIfNotAcceptanceTest(t *testing.T) {
+// SkipIfNotRunningAcceptanceTests skips the current test if it's not an acceptance test (TF_ACC is set in the environment).
+func SkipIfNotRunningAcceptanceTests(t *testing.T) {
 	t.Helper()
 	SkipIfEnvVarNotSet(t, resource.EnvTfAcc)
 }
@@ -2205,7 +2205,7 @@ func SkipIfNotAcceptanceTest(t *testing.T) {
 // RunSerialTests1Level runs test cases in parallel, optionally sleeping between each.
 func RunSerialTests1Level(t *testing.T, testCases map[string]func(*testing.T), d time.Duration) {
 	t.Helper()
-	SkipIfNotAcceptanceTest(t)
+	SkipIfNotRunningAcceptanceTests(t)
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Speeds up `make test` (`go test`) when serial acceptance tests with an inter-test delay are being run.
e.g. https://github.com/hashicorp/terraform-provider-aws/actions/runs/20146695967/job/57829639326?pr=45534:

```
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/amplify	542.092s
```

##### After

```console
% go test ./internal/service/amplify 
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/amplify	6.259s
```

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccEC2SerialConsoleAccess_serial' PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-speed-up-make-test 🌿...
TF_ACC=1 go1.24.11 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2SerialConsoleAccess_serial -timeout 360m -vet=off
2025/12/15 08:27:54 Creating Terraform AWS Provider (SDKv2-style)...
2025/12/15 08:27:54 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEC2SerialConsoleAccess_serial
=== PAUSE TestAccEC2SerialConsoleAccess_serial
=== CONT  TestAccEC2SerialConsoleAccess_serial
=== RUN   TestAccEC2SerialConsoleAccess_serial/Resource
=== RUN   TestAccEC2SerialConsoleAccess_serial/Resource/basic
=== RUN   TestAccEC2SerialConsoleAccess_serial/Resource/Identity
=== RUN   TestAccEC2SerialConsoleAccess_serial/Resource/Identity/Upgrade
=== RUN   TestAccEC2SerialConsoleAccess_serial/Resource/Identity/UpgradeNoRefresh
=== RUN   TestAccEC2SerialConsoleAccess_serial/Resource/Identity/basic
=== RUN   TestAccEC2SerialConsoleAccess_serial/Resource/Identity/ExistingResource
=== RUN   TestAccEC2SerialConsoleAccess_serial/Resource/Identity/ExistingResourceNoRefresh
=== RUN   TestAccEC2SerialConsoleAccess_serial/Resource/Identity/RegionOverride
=== RUN   TestAccEC2SerialConsoleAccess_serial/DataSource
=== RUN   TestAccEC2SerialConsoleAccess_serial/DataSource/basic
--- PASS: TestAccEC2SerialConsoleAccess_serial (289.64s)
    --- PASS: TestAccEC2SerialConsoleAccess_serial/Resource (280.44s)
        --- PASS: TestAccEC2SerialConsoleAccess_serial/Resource/basic (22.51s)
        --- PASS: TestAccEC2SerialConsoleAccess_serial/Resource/Identity (257.93s)
            --- PASS: TestAccEC2SerialConsoleAccess_serial/Resource/Identity/Upgrade (47.18s)
            --- PASS: TestAccEC2SerialConsoleAccess_serial/Resource/Identity/UpgradeNoRefresh (47.70s)
            --- PASS: TestAccEC2SerialConsoleAccess_serial/Resource/Identity/basic (19.97s)
            --- PASS: TestAccEC2SerialConsoleAccess_serial/Resource/Identity/ExistingResource (77.39s)
            --- PASS: TestAccEC2SerialConsoleAccess_serial/Resource/Identity/ExistingResourceNoRefresh (41.94s)
            --- PASS: TestAccEC2SerialConsoleAccess_serial/Resource/Identity/RegionOverride (23.77s)
    --- PASS: TestAccEC2SerialConsoleAccess_serial/DataSource (9.20s)
        --- PASS: TestAccEC2SerialConsoleAccess_serial/DataSource/basic (9.20s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	295.035s
```
