### PR TITLE
Technical debt: Pin `modernize` until Go 1.25 upgrade

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -364,11 +364,11 @@ misspell: changelog-misspell docs-misspell website-misspell go-misspell ## [CI] 
 
 modern-check: prereq-go ## [CI] Check for modern Go code (best run in individual services)
 	@echo "make: Checking for modern Go code..."
-	@$(GO_VER) run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test $(TEST)
+	@$(GO_VER) run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@v0.20.0 -test $(TEST)
 
 modern-fix: prereq-go ## [CI] Fix checks for modern Go code (best run in individual services)
 	@echo "make: Fixing checks for modern Go code..."
-	@$(GO_VER) run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test $(TEST)
+	@$(GO_VER) run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@v0.20.0 -fix -test $(TEST)
 
 pr-target-check: ## [CI] Check for pull request target
 	@echo "make: Checking for pull request target..."


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

```
make TEST=./... modern-check
  make TEST=./... modern-check
  shell: /usr/bin/bash -e {0}
  env:
    GOTOOLCHAIN: local
    GOCACHE: /home/runner/.cache/go-build
make: go1.24.11 not found
make: installing go1.24.11...
make: if you get an error, see https://go.dev/doc/manage-install to locally install various Go versions
go: downloading golang.org/dl v0.0.0-20251202160438-22e1a22285f8
Downloaded   0.0% (   16384 / 78702669 bytes) ...
Downloaded 100.0% (78702669 / 78702669 bytes)
Unpacking /home/runner/sdk/go1.24.11/go1.24.11.linux-amd64.tar.gz ...
Success. You may now run 'go1.24.11'
make: go1.24.11 ready
make: Checking for modern Go code...
go: downloading golang.org/x/tools v0.40.0
go: downloading golang.org/x/tools/gopls v0.21.0
go: golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest: golang.org/x/tools/gopls@v0.21.0 requires go >= 1.25 (running go 1.24.11; GOTOOLCHAIN=local)
make: *** [GNUmakefile:367: modern-check] Error 1
```