### PR TITLE
[Docs] aws_ecs_cluster: Correct documentation to use KMS ARN instead of KMS ID in Fargate Storage configuration

### DIFF
--- a/website/docs/r/ecs_cluster.html.markdown
+++ b/website/docs/r/ecs_cluster.html.markdown
@@ -185,8 +185,8 @@ The `log_configuration` configuration block supports the following arguments:
 
 The `managed_storage_configuration` configuration block supports the following arguments:
 
-* `fargate_ephemeral_storage_kms_key_id` - (Optional) AWS Key Management Service key ID for the Fargate ephemeral storage.
-* `kms_key_id` - (Optional) AWS Key Management Service key ID to encrypt the managed storage.
+* `fargate_ephemeral_storage_kms_key_id` - (Optional) AWS Key Management Service key ARN for the Fargate ephemeral storage.
+* `kms_key_id` - (Optional) AWS Key Management Service key ARN to encrypt the managed storage.
 
 ### `service_connect_defaults` Block
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
According to the current acceptance test implementation, `configuration.managed_storage_configuration.fargate_ephemeral_storage_kms_key_id` in `aws_ecs_cluster` resource is expected to be a **KMS ARN**, not a **KMS ID**, as #45545 reported.

See:
https://github.com/hashicorp/terraform-provider-aws/blob/a4196fbc2f1d31dbbcae2ee8167a8e3500009d34/internal/service/ecs/cluster_test.go#L348-L357

The same applies to the `kms_key_id` attribute in this block as well:
https://github.com/hashicorp/terraform-provider-aws/blob/a4196fbc2f1d31dbbcae2ee8167a8e3500009d34/internal/service/ecs/cluster_test.go#L364-L373

This PR updates the documentation including the example and description of `fargate_ephemeral_storage_kms_key_id` and `kms_key_id` in `configuration.managed_storage_configuration` block.

### Relations
Closes #45545


