### PR TITLE
r/aws_iam_user: switch tag identifier to `id`

### DIFF
--- a/.changelog/45608.txt
+++ b/.changelog/45608.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iam_user: Fix `NoSuchEntity` errors when `name` and `tags` arguments are both updated
+```

--- a/internal/service/iam/service_package_gen.go
+++ b/internal/service/iam/service_package_gen.go
@@ -396,7 +396,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			TypeName: "aws_iam_user",
 			Name:     "User",
 			Tags: unique.Make(inttypes.ServicePackageResourceTags{
-				IdentifierAttribute: names.AttrName,
+				IdentifierAttribute: names.AttrID,
 				ResourceType:        "User",
 			}),
 			Region: unique.Make(inttypes.ResourceRegionDisabled()),

--- a/internal/service/iam/user.go
+++ b/internal/service/iam/user.go
@@ -28,7 +28,7 @@ import (
 )
 
 // @SDKResource("aws_iam_user", name="User")
-// @Tags(identifierAttribute="name", resourceType="User")
+// @Tags(identifierAttribute="id", resourceType="User")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/iam/types;types.User", importIgnore="force_destroy")
 func resourceUser() *schema.Resource {
 	return &schema.Resource{


### PR DESCRIPTION

<!-- Copyright IBM Corp. 2014, 2025 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
IAM user tag operations rely on the user name as the identifier. When the `name` argument is used as the identifier attribute, an update which changes both `name` and `tag` arguments causes transparent tagging to fail. Transparent tagging operations run _before_ the update operation, meaning the updated `name` value is passed to the [`TagUser`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_TagUser.html) API before the [`UpdateUser`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateUser.html) API is called to update it.

By switching the tag identifier to `id`, we allow the `TagUser` API to reference the "old" user name, via `d.GetId()`, before the update operation executes and changes the name along with resource identifier. As `id` tracks the user name, this change does not break any existing tagging workflows, just enables the "name and tag" update case to behave as expected.

Before:

```console
% make t K=iam T=TestAccIAMUser_nameAndTags
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-iam_user-tag-and-name-update 🌿...
TF_ACC=1 go1.24.11 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMUser_nameAndTags'  -timeout 360m -vet=off
2025/12/15 16:39:45 Creating Terraform AWS Provider (SDKv2-style)...
2025/12/15 16:39:45 Initializing Terraform AWS Provider (SDKv2-style)...

=== CONT  TestAccIAMUser_nameAndTags
    user_test.go:538: Step 2/2 error: Error running apply: exit status 1

        Error: updating tags for IAM (Identity & Access Management) User (tf-acc-test-1187392722609479887-updated): tagging resource (tf-acc-test-1187392722609479887-updated): operation error IAM: TagUser, https response error StatusCode: 404, RequestID: 5651011a-12db-4b23-9199-24d6672641bf, NoSuchEntity: The user with name tf-acc-test-1187392722609479887-updated cannot be found.

          with aws_iam_user.user,
          on terraform_plugin_test.tf line 12, in resource "aws_iam_user" "user":
          12: resource "aws_iam_user" "user" {

--- FAIL: TestAccIAMUser_nameAndTags (15.18s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/iam        21.693s
```

After:

```console
% make t K=iam T=TestAccIAMUser_nameAndTags
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-iam_user-tag-and-name-update 🌿...
TF_ACC=1 go1.24.11 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMUser_nameAndTags'  -timeout 360m -vet=off
2025/12/16 10:20:19 Creating Terraform AWS Provider (SDKv2-style)...
2025/12/16 10:20:19 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccIAMUser_nameAndTags (21.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        27.774s
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #45607


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=iam T=TestAccIAMUser_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-iam_user-tag-and-name-update 🌿...
TF_ACC=1 go1.24.11 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMUser_'  -timeout 360m -vet=off
2025/12/16 10:25:18 Creating Terraform AWS Provider (SDKv2-style)...
2025/12/16 10:25:18 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccIAMUser_ForceDestroy_policyInline (34.73s)
=== CONT  TestAccIAMUser_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccIAMUser_ForceDestroy_policyAttached (36.71s)
=== CONT  TestAccIAMUser_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccIAMUser_ForceDestroy_policyInlineAttached (36.82s)
=== CONT  TestAccIAMUser_basic
--- PASS: TestAccIAMUser_ForceDestroy_accessKey (43.86s)
=== CONT  TestAccIAMUser_disappears
--- PASS: TestAccIAMUser_ForceDestroy_signingCertificate (45.67s)
=== CONT  TestAccIAMUser_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccIAMUser_ForceDestroy_serviceSpecificCred (45.80s)
=== CONT  TestAccIAMUser_ForceDestroy_sshKey
--- PASS: TestAccIAMUser_ForceDestroy_mfaDevice (45.97s)
=== CONT  TestAccIAMUser_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccIAMUser_tags_DefaultTags_nullNonOverlappingResourceTag (49.78s)
=== CONT  TestAccIAMUser_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccIAMUser_tags_DefaultTags_nullOverlappingResourceTag (51.79s)
=== CONT  TestAccIAMUser_tags_DefaultTags_nonOverlapping
--- PASS: TestAccIAMUser_tags_DefaultTags_emptyProviderOnlyTag (52.16s)
=== CONT  TestAccIAMUser_tags_DefaultTags_providerOnly
--- PASS: TestAccIAMUser_tags_DefaultTags_emptyResourceTag (54.09s)
=== CONT  TestAccIAMUser_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccIAMUser_tags_ComputedTag_OnCreate (56.57s)
=== CONT  TestAccIAMUser_tags_AddOnUpdate
--- PASS: TestAccIAMUser_pathChange (69.16s)
=== CONT  TestAccIAMUser_tags_EmptyTag_OnCreate
--- PASS: TestAccIAMUser_nameChange (73.24s)
=== CONT  TestAccIAMUser_ForceDestroy_loginProfile
--- PASS: TestAccIAMUser_nameAndTags (75.08s)
=== CONT  TestAccIAMUser_tags_EmptyMap
--- PASS: TestAccIAMUser_disappears (37.71s)
=== CONT  TestAccIAMUser_tags_null
--- PASS: TestAccIAMUser_tags_ComputedTag_OnUpdate_Replace (88.28s)
--- PASS: TestAccIAMUser_tags_ComputedTag_OnUpdate_Add (91.48s)
--- PASS: TestAccIAMUser_ForceDestroy_sshKey (46.05s)
--- PASS: TestAccIAMUser_basic (71.99s)
--- PASS: TestAccIAMUser_ForceDestroy_loginProfile (40.51s)
--- PASS: TestAccIAMUser_tags_DefaultTags_updateToResourceOnly (79.26s)
--- PASS: TestAccIAMUser_tags_DefaultTags_updateToProviderOnly (78.40s)
--- PASS: TestAccIAMUser_tags_EmptyTag_OnUpdate_Replace (72.19s)
--- PASS: TestAccIAMUser_tags_AddOnUpdate (70.56s)
--- PASS: TestAccIAMUser_tags_DefaultTags_overlapping (131.10s)
--- PASS: TestAccIAMUser_tags_EmptyMap (57.29s)
--- PASS: TestAccIAMUser_tags_IgnoreTags_Overlap_DefaultTag (88.51s)
--- PASS: TestAccIAMUser_tags_null (53.51s)
--- PASS: TestAccIAMUser_tags_EmptyTag_OnCreate (69.51s)
--- PASS: TestAccIAMUser_tags_IgnoreTags_Overlap_ResourceTag (94.78s)
--- PASS: TestAccIAMUser_tags_EmptyTag_OnUpdate_Add (93.17s)
--- PASS: TestAccIAMUser_tags (142.97s)
--- PASS: TestAccIAMUser_tags_DefaultTags_nonOverlapping (93.90s)
--- PASS: TestAccIAMUser_permissionsBoundary (147.57s)
--- PASS: TestAccIAMUser_tags_DefaultTags_providerOnly (105.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        164.605s
```
