### PR TITLE
docs: prefer `ImportStateIdFunc` helpers from `acctest` package

### DIFF
--- a/docs/id-attributes.md
+++ b/docs/id-attributes.md
@@ -44,25 +44,10 @@ func (r *resourceEndpointPrivateDNS) ImportState(ctx context.Context, req resour
 {
 	ResourceName:                         resourceName,
 	ImportState:                          true,
-	ImportStateIdFunc:                    testAccVPCEndpointPrivateDNSImportStateIdFunc(resourceName),
+	ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "vpc_endpoint_id"),
 	ImportStateVerify:                    true,
 	ImportStateVerifyIdentifierAttribute: "vpc_endpoint_id",
 },
-```
-
-`ImportStateIdFunc`:
-
-```go
-func testAccVPCEndpointPrivateDNSImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return "", fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		return rs.Primary.Attributes["vpc_endpoint_id"], nil
-	}
-}
 ```
 
 ### Multi-part Identifier
@@ -93,23 +78,8 @@ func (r *resourceRuntimeManagementConfig) ImportState(ctx context.Context, req r
 {
 	ResourceName:                         resourceName,
 	ImportState:                          true,
-	ImportStateIdFunc:                    testAccRuntimeManagementConfigImportStateIdFunc(resourceName),
+	ImportStateIdFunc:                    acctest.AttrsImportStateIdFunc(resourceName, ",", "function_name", "qualifier"),
 	ImportStateVerify:                    true,
 	ImportStateVerifyIdentifierAttribute: "function_name",
 },
-```
-
-`ImportStateIdFunc`:
-
-```go
-func testAccRuntimeManagementConfigImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return "", fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		return fmt.Sprintf("%s,%s", rs.Primary.Attributes["function_name"], rs.Primary.Attributes["qualifier"]), nil
-	}
-}
 ```


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2025 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Replace custom import state ID function examples with the `acctest.AttrImportStateIdFunc` and `acctest.AttrsImportStateIdFunc` functions as the preferred best practice.


