### PR TITLE
Handle 64bit on 32bit, broken builds

### DIFF
--- a/internal/service/networkmanager/connect_peer.go
+++ b/internal/service/networkmanager/connect_peer.go
@@ -6,6 +6,7 @@ package networkmanager
 import (
 	"context"
 	"log"
+	"math"
 	"time"
 
 	"github.com/YakDriver/regexache"
@@ -64,7 +65,7 @@ func resourceConnectPeer() *schema.Resource {
 						"peer_asn": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: verify.IntBetween64(1, 1<<32-1), // 4294967295
+							ValidateFunc: verify.IntBetween64(1, math.MaxUint32),
 						},
 					},
 				},

--- a/internal/service/networkmanager/connect_peer.go
+++ b/internal/service/networkmanager/connect_peer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -63,7 +64,7 @@ func resourceConnectPeer() *schema.Resource {
 						"peer_asn": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IntBetween(1, 4294967295),
+							ValidateFunc: verify.IntBetween64(1, 1<<32-1), // 4294967295
 						},
 					},
 				},

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -45,6 +45,26 @@ func StringIsInt32(v any, k string) (ws []string, errors []error) {
 	return
 }
 
+// IntBetween64 validates that an integer value is within the specified range,
+// supporting int64 min/max values that may exceed the platform's int size.
+// This is useful for values like ASNs that can be up to 4294967295.
+func IntBetween64(min, max int64) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(int)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		val := int64(v)
+		if val < min || val > max {
+			errors = append(errors, fmt.Errorf("expected %s to be in the range (%d - %d), got %d", k, min, max, val))
+		}
+
+		return warnings, errors
+	}
+}
+
 func Valid4ByteASN(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -49,7 +49,7 @@ func StringIsInt32(v any, k string) (ws []string, errors []error) {
 // supporting int64 min/max values that may exceed the platform's int size.
 // This is useful for values like ASNs that can be up to 4294967295.
 func IntBetween64(min, max int64) schema.SchemaValidateFunc {
-	return func(i interface{}, k string) (warnings []string, errors []error) {
+	return func(i any, k string) (warnings []string, errors []error) {
 		v, ok := i.(int)
 		if !ok {
 			errors = append(errors, fmt.Errorf("expected type of %s to be int", k))


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2025 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The build error occurred because `validation.IntBetween(1, 4294967295)` was trying to pass the literal `4294967295` (which equals 2^32- 1, the maximum 32-bit unsigned integer value) as an `int` parameter to the validation function. On 32-bit architectures, Go's `int` type is only 32 bits and has a maximum value of 2^31 - 1 (2147483647), so the literal `4294967295` overflows when used as an `int` argument. The fix creates a new `IntBetween64` validation function that accepts `int64` parameters instead of `int` parameters, allowing it to handle the full 32-bit ASN range (1-4294967295) without overflow issues. The function still validates `int` values from the schema, but internally converts them to `int64` for range checking, maintaining backward compatibility while supporting the complete ASN value range on all architectures.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Problem introduced by #45246

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
