### PR TITLE
r/aws_lambda_function: make `code_sha256` optional and computed

### DIFF
--- a/.changelog/45618.txt
+++ b/.changelog/45618.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lambda_function: `code_sha256` is now optional and computed
+```

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -124,6 +124,7 @@ func resourceFunction() *schema.Resource {
 			},
 			"code_sha256": {
 				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
 			},
 			"code_signing_config_arn": {
@@ -1780,6 +1781,7 @@ func updateComputedAttributesOnPublish(_ context.Context, d *schema.ResourceDiff
 
 func needsFunctionCodeUpdate(d sdkv2.ResourceDiffer) bool {
 	return d.HasChange("filename") ||
+		d.HasChange("code_sha256") ||
 		d.HasChange("source_code_hash") ||
 		d.HasChange(names.AttrS3Bucket) ||
 		d.HasChange("s3_key") ||

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -1945,7 +1945,7 @@ func TestAccLambdaFunction_s3(t *testing.T) {
 	})
 }
 
-func TestAccLambdaFunction_localUpdate(t *testing.T) {
+func TestAccLambdaFunction_LocalUpdate_sourceCodeHash(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -2002,6 +2002,146 @@ func TestAccLambdaFunction_localUpdate(t *testing.T) {
 						return testAccCheckAttributeIsDateAfter(s, resourceName, "last_modified", timeBeforeUpdate)
 					},
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccLambdaFunction_LocalUpdate_codeSha256(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	path, zipFile, err := createTempFile("lambda_localUpdate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(path)
+
+	var conf lambda.GetFunctionOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lambda_function.test"
+
+	var timeBeforeUpdate time.Time
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFunctionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					if err := testAccCreateZipFromFiles(map[string]string{"test-fixtures/lambda_func.js": "lambda.js"}, zipFile); err != nil {
+						t.Fatalf("error creating zip from files: %s", err)
+					}
+				},
+				Config: testAccFunctionConfig_local_codeSHA256(path, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFunctionExists(ctx, resourceName, &conf),
+					testAccCheckSourceCodeHash(&conf, "MbW0T1Pcy1QPtrFC9dT7hUfircj1NXss2uXgakqzAbk="),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish", "source_code_hash"},
+			},
+			{
+				PreConfig: func() {
+					if err := testAccCreateZipFromFiles(map[string]string{"test-fixtures/lambda_func_modified.js": "lambda.js"}, zipFile); err != nil {
+						t.Fatalf("error creating zip from files: %s", err)
+					}
+					timeBeforeUpdate = time.Now()
+				},
+				Config: testAccFunctionConfig_local_codeSHA256(path, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFunctionExists(ctx, resourceName, &conf),
+					testAccCheckSourceCodeHash(&conf, "7qn3LZOWCpWK5nm49qjw+VrbPQHfdu2ZrDjBsSUveKM="),
+					func(s *terraform.State) error {
+						return testAccCheckAttributeIsDateAfter(s, resourceName, "last_modified", timeBeforeUpdate)
+					},
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccLambdaFunction_LocalUpdate_sourceCodeHashToCodeSha256(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	path, zipFile, err := createTempFile("lambda_localUpdate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(path)
+
+	var conf lambda.GetFunctionOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lambda_function.test"
+
+	var timeBeforeUpdate time.Time
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFunctionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					if err := testAccCreateZipFromFiles(map[string]string{"test-fixtures/lambda_func.js": "lambda.js"}, zipFile); err != nil {
+						t.Fatalf("error creating zip from files: %s", err)
+					}
+				},
+				Config: testAccFunctionConfig_local(path, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFunctionExists(ctx, resourceName, &conf),
+					testAccCheckSourceCodeHash(&conf, "MbW0T1Pcy1QPtrFC9dT7hUfircj1NXss2uXgakqzAbk="),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish", "source_code_hash"},
+			},
+			// Switch from source_code_hash to code_sha256 for tracking source code changes
+			{
+				PreConfig: func() {
+					if err := testAccCreateZipFromFiles(map[string]string{"test-fixtures/lambda_func_modified.js": "lambda.js"}, zipFile); err != nil {
+						t.Fatalf("error creating zip from files: %s", err)
+					}
+					timeBeforeUpdate = time.Now()
+				},
+				Config: testAccFunctionConfig_local_codeSHA256(path, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFunctionExists(ctx, resourceName, &conf),
+					testAccCheckSourceCodeHash(&conf, "7qn3LZOWCpWK5nm49qjw+VrbPQHfdu2ZrDjBsSUveKM="),
+					func(s *terraform.State) error {
+						return testAccCheckAttributeIsDateAfter(s, resourceName, "last_modified", timeBeforeUpdate)
+					},
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})
@@ -2809,6 +2949,42 @@ func testAccCheckFunctionExists(ctx context.Context, n string, v *lambda.GetFunc
 
 		return nil
 	}
+}
+
+func testAccPreCheckSignerSigningProfile(ctx context.Context, t *testing.T, platformID string) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).SignerClient(ctx)
+
+	input := &signer.ListSigningPlatformsInput{}
+
+	pages := signer.NewListSigningPlatformsPaginator(conn, input)
+
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if acctest.PreCheckSkipError(err) {
+			t.Skipf("skipping acceptance testing: %s", err)
+		}
+
+		if err != nil {
+			t.Fatalf("unexpected PreCheck error: %s", err)
+		}
+
+		if page == nil {
+			t.Skip("skipping acceptance testing: empty response")
+		}
+
+		for _, platform := range page.Platforms {
+			if platform == (signertypes.SigningPlatform{}) {
+				continue
+			}
+
+			if aws.ToString(platform.PlatformId) == platformID {
+				return
+			}
+		}
+	}
+
+	t.Skipf("skipping acceptance testing: Signing Platform (%s) not found", platformID)
 }
 
 func testAccCheckFunctionQualifiedInvokeARN(name string, function *lambda.GetFunctionOutput) resource.TestCheckFunc {
@@ -4245,18 +4421,8 @@ resource "aws_lambda_function" "test" {
 `, rName))
 }
 
-func testAccFunctionConfig_s3Simple(rName string) string {
+func testAccFunctionConfigBase_iamRole(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_s3_bucket" "lambda_bucket" {
-  bucket = %[1]q
-}
-
-resource "aws_s3_object" "lambda_code" {
-  bucket = aws_s3_bucket.lambda_bucket.bucket
-  key    = "lambdatest.zip"
-  source = "test-fixtures/lambdatest.zip"
-}
-
 resource "aws_iam_role" "iam_for_lambda" {
   name = %[1]q
 
@@ -4276,6 +4442,22 @@ resource "aws_iam_role" "iam_for_lambda" {
 }
 EOF
 }
+`, rName)
+}
+
+func testAccFunctionConfig_s3Simple(rName string) string {
+	return acctest.ConfigCompose(
+		testAccFunctionConfigBase_iamRole(rName),
+		fmt.Sprintf(`
+resource "aws_s3_bucket" "lambda_bucket" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_object" "lambda_code" {
+  bucket = aws_s3_bucket.lambda_bucket.bucket
+  key    = "lambdatest.zip"
+  source = "test-fixtures/lambdatest.zip"
+}
 
 resource "aws_lambda_function" "test" {
   s3_bucket     = aws_s3_object.lambda_code.bucket
@@ -4285,31 +4467,13 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   runtime       = "nodejs20.x"
 }
-`, rName)
+`, rName))
 }
 
 func testAccFunctionConfig_local(filePath, rName string) string {
-	return fmt.Sprintf(`
-resource "aws_iam_role" "iam_for_lambda" {
-  name = %[2]q
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
+	return acctest.ConfigCompose(
+		testAccFunctionConfigBase_iamRole(rName),
+		fmt.Sprintf(`
 resource "aws_lambda_function" "test" {
   filename         = %[1]q
   source_code_hash = filebase64sha256(%[1]q)
@@ -4318,31 +4482,13 @@ resource "aws_lambda_function" "test" {
   handler          = "exports.example"
   runtime          = "nodejs20.x"
 }
-`, filePath, rName)
+`, filePath, rName))
 }
 
 func testAccFunctionConfig_localNameOnly(filePath, rName string) string {
-	return fmt.Sprintf(`
-resource "aws_iam_role" "iam_for_lambda" {
-  name = %[2]q
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
+	return acctest.ConfigCompose(
+		testAccFunctionConfigBase_iamRole(rName),
+		fmt.Sprintf(`
 resource "aws_lambda_function" "test" {
   filename      = %[1]q
   function_name = %[2]q
@@ -4350,31 +4496,13 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   runtime       = "nodejs20.x"
 }
-`, filePath, rName)
+`, filePath, rName))
 }
 
 func testAccFunctionConfig_localPublish(filePath, rName string) string {
-	return fmt.Sprintf(`
-resource "aws_iam_role" "iam_for_lambda" {
-  name = %[2]q
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
+	return acctest.ConfigCompose(
+		testAccFunctionConfigBase_iamRole(rName),
+		fmt.Sprintf(`
 resource "aws_lambda_function" "test" {
   filename         = %[1]q
   source_code_hash = filebase64sha256(%[1]q)
@@ -4388,11 +4516,28 @@ resource "aws_lambda_function" "test" {
     apply_on = "PublishedVersions"
   }
 }
-`, filePath, rName)
+`, filePath, rName))
+}
+
+func testAccFunctionConfig_local_codeSHA256(filePath, rName string) string {
+	return acctest.ConfigCompose(
+		testAccFunctionConfigBase_iamRole(rName),
+		fmt.Sprintf(`
+resource "aws_lambda_function" "test" {
+  filename      = %[1]q
+  code_sha256   = filebase64sha256(%[1]q)
+  function_name = %[2]q
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "exports.example"
+  runtime       = "nodejs20.x"
+}
+`, filePath, rName))
 }
 
 func testAccFunctionConfig_s3(key, path, rName string) string {
-	return fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		testAccFunctionConfigBase_iamRole(rName),
+		fmt.Sprintf(`
 resource "aws_s3_bucket" "artifacts" {
   bucket        = %[3]q
   force_destroy = true
@@ -4415,26 +4560,6 @@ resource "aws_s3_object" "o" {
   etag   = filemd5(%[2]q)
 }
 
-resource "aws_iam_role" "iam_for_lambda" {
-  name = %[3]q
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
 resource "aws_lambda_function" "test" {
   s3_bucket         = aws_s3_object.o.bucket
   s3_key            = aws_s3_object.o.key
@@ -4444,11 +4569,13 @@ resource "aws_lambda_function" "test" {
   handler           = "exports.example"
   runtime           = "nodejs20.x"
 }
-`, key, path, rName)
+`, key, path, rName))
 }
 
 func testAccFunctionConfig_s3UnversionedTPL(rName, key, path string) string {
-	return fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		testAccFunctionConfigBase_iamRole(rName),
+		fmt.Sprintf(`
 resource "aws_s3_bucket" "artifacts" {
   bucket        = %[1]q
   force_destroy = true
@@ -4461,26 +4588,6 @@ resource "aws_s3_object" "o" {
   etag   = filemd5(%[3]q)
 }
 
-resource "aws_iam_role" "iam_for_lambda" {
-  name = %[1]q
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
 resource "aws_lambda_function" "test" {
   s3_bucket     = aws_s3_object.o.bucket
   s3_key        = aws_s3_object.o.key
@@ -4489,7 +4596,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   runtime       = "nodejs20.x"
 }
-`, rName, key, path)
+`, rName, key, path))
 }
 
 func testAccFunctionConfig_runtime(rName, runtime string) string {
@@ -4653,7 +4760,9 @@ resource "aws_lambda_function" "test" {
 }
 
 func testAccFunctionConfig_skipDestroy(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigLambdaBase(rName, rName, rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		acctest.ConfigLambdaBase(rName, rName, rName),
+		fmt.Sprintf(`
 resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = %[1]q
@@ -4690,7 +4799,9 @@ resource "aws_lambda_function" "test" {
 }
 
 func testAccFunctionConfig_resetNonRefreshableAttributesAfterUpdateFailure(rName, zipFileS3, zipFileLambda string) string {
-	return acctest.ConfigCompose(acctest.ConfigLambdaBase(rName, rName, rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		acctest.ConfigLambdaBase(rName, rName, rName),
+		fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
@@ -4740,40 +4851,4 @@ resource "aws_lambda_function" "test" {
   }
 }
 `, rName, descriptionLine, executionTimeout, retentionPeriod))
-}
-
-func testAccPreCheckSignerSigningProfile(ctx context.Context, t *testing.T, platformID string) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).SignerClient(ctx)
-
-	input := &signer.ListSigningPlatformsInput{}
-
-	pages := signer.NewListSigningPlatformsPaginator(conn, input)
-
-	for pages.HasMorePages() {
-		page, err := pages.NextPage(ctx)
-
-		if acctest.PreCheckSkipError(err) {
-			t.Skipf("skipping acceptance testing: %s", err)
-		}
-
-		if err != nil {
-			t.Fatalf("unexpected PreCheck error: %s", err)
-		}
-
-		if page == nil {
-			t.Skip("skipping acceptance testing: empty response")
-		}
-
-		for _, platform := range page.Platforms {
-			if platform == (signertypes.SigningPlatform{}) {
-				continue
-			}
-
-			if aws.ToString(platform.PlatformId) == platformID {
-				return
-			}
-		}
-	}
-
-	t.Skipf("skipping acceptance testing: Signing Platform (%s) not found", platformID)
 }

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -51,11 +51,11 @@ data "archive_file" "example" {
 
 # Lambda function
 resource "aws_lambda_function" "example" {
-  filename         = data.archive_file.example.output_path
-  function_name    = "example_lambda_function"
-  role             = aws_iam_role.example.arn
-  handler          = "index.handler"
-  source_code_hash = data.archive_file.example.output_base64sha256
+  filename      = data.archive_file.example.output_path
+  function_name = "example_lambda_function"
+  role          = aws_iam_role.example.arn
+  handler       = "index.handler"
+  code_sha256   = data.archive_file.example.output_base64sha256
 
   runtime = "nodejs20.x"
 
@@ -566,6 +566,7 @@ The following arguments are optional:
 
 * `architectures` - (Optional) Instruction set architecture for your Lambda function. Valid values are `["x86_64"]` and `["arm64"]`. Default is `["x86_64"]`. Removing this attribute, function's architecture stays the same.
 * `capacity_provider_config` - (Optional) Configuration block for Lambda Capacity Provider. [See below](#capacity_provider_config-configuration).
+* `code_sha256` - (Optional) Base64-encoded representation the source code package file. Use this argument to trigger updates when the function source code changes. For OCI, this value is relayed directly from the image digest. For zip files, this value is the Base64 encoded SHA-256 hash of the `.zip` file. Layers are not included in the calculation. To trigger updates using a non-standard hashing algorithm, use the `source_code_hash` argument instead.
 * `code_signing_config_arn` - (Optional) ARN of a code-signing configuration to enable code signing for this function.
 * `dead_letter_config` - (Optional) Configuration block for dead letter queue. [See below](#dead_letter_config-configuration-block).
 * `description` - (Optional) Description of what your Lambda Function does.
@@ -594,7 +595,7 @@ The following arguments are optional:
 * `s3_object_version` - (Optional) Object version containing the function's deployment package. Conflicts with `filename` and `image_uri`.
 * `skip_destroy` - (Optional) Whether to retain the old version of a previously deployed Lambda Layer. Default is `false`.
 * `snap_start` - (Optional) Configuration block for snap start settings. [See below](#snap_start-configuration-block).
-* `source_code_hash` - (Optional) Base64-encoded SHA256 hash of the package file. Used to trigger updates when source code changes.
+* `source_code_hash` - (Optional) User-defined hash of the source code package file. Use this argument to trigger updates when the local function source code changes. This is a synthetic argument tracked only by the AWS provider and does not need to match the hashing algorithm used by Lambda to compute the `CodeSha256` response value. Out-of-band changes to the source code _will not_ be captured by this argument. To include out-of-band source code changes as an update trigger, use the `code_sha256` argument instead.
 * `source_kms_key_arn` - (Optional) ARN of the AWS Key Management Service key used to encrypt the function's `.zip` deployment package. Conflicts with `image_uri`.
 * `tags` - (Optional) Key-value map of tags for the Lambda function. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `timeout` - (Optional) Amount of time your Lambda Function has to run in seconds. Defaults to 3. Valid between 1 and 900.
@@ -674,7 +675,6 @@ The following arguments are optional:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN identifying your Lambda Function.
-* `code_sha256` - Base64-encoded representation of raw SHA-256 sum of the zip file.
 * `invoke_arn` - ARN to be used for invoking Lambda Function from API Gateway - to be used in [`aws_api_gateway_integration`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_integration)'s `uri`.
 * `last_modified` - Date this resource was last modified.
 * `qualified_arn` - ARN identifying your Lambda Function Version (if versioning is enabled via `publish = true`).


### PR DESCRIPTION

<!-- Copyright IBM Corp. 2014, 2025 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Making `code_sha256` optional and computed will allow the value to track against the base64 encoded SHA-256 hash returned by the AWS API, triggering updates when the function source code is changed out-of-band. This is similar to the behavior of the `source_code_hash` argument prior `v5.51.0` when it was changed to a synthetic argument.

The registry documentation has been updated to more accurately describe the behavior of both arguments, including which scenarios are appropriate for each.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/42826#issuecomment-3407777596
Closes #41092
Closes #42838 (No longer necessary with the approach taken here)

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/lambda/latest/api/API_FunctionConfiguration.html#lambda-Type-FunctionConfiguration-CodeSha256

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->



```console
% make t K=lambda T=TestAccLambdaFunction_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-lambda_function-code_sha_256 🌿...
TF_ACC=1 go1.24.11 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunction_'  -timeout 360m -vet=off
2025/12/16 15:11:03 Creating Terraform AWS Provider (SDKv2-style)...
2025/12/16 15:11:03 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccLambdaFunction_Zip_validation (9.75s)
=== CONT  TestAccLambdaFunction_versioned
--- PASS: TestAccLambdaFunction_nilDeadLetter (58.19s)
=== CONT  TestAccLambdaFunction_nameValidation
--- PASS: TestAccLambdaFunction_nameValidation (0.88s)
=== CONT  TestAccLambdaFunction_encryptedEnvVariables
--- PASS: TestAccLambdaFunction_Identity_Basic (60.64s)
=== CONT  TestAccLambdaFunction_EnvironmentVariables_noValue
--- PASS: TestAccLambdaFunction_emptyVPC (71.69s)
=== CONT  TestAccLambdaFunction_envVariables
--- PASS: TestAccLambdaFunction_disablePublish (77.29s)
=== CONT  TestAccLambdaFunction_expectFilenameAndS3Attributes
--- PASS: TestAccLambdaFunction_expectFilenameAndS3Attributes (0.86s)
=== CONT  TestAccLambdaFunction_concurrencyCycle
--- PASS: TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Add (93.68s)
=== CONT  TestAccLambdaFunction_concurrency
--- PASS: TestAccLambdaFunction_deadLetter (102.39s)
=== CONT  TestAccLambdaFunction_codeSigning
--- PASS: TestAccLambdaFunction_versioned (93.28s)
=== CONT  TestAccLambdaFunction_unpublishedCodeUpdate
--- PASS: TestAccLambdaFunction_deadLetterUpdated (108.87s)
=== CONT  TestAccLambdaFunction_disappears
--- PASS: TestAccLambdaFunction_enablePublish (124.29s)
=== CONT  TestAccLambdaFunction_basic
--- PASS: TestAccLambdaFunction_layersUpdate (126.45s)
=== CONT  TestAccLambdaFunction_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccLambdaFunction_VPC_properIAMDependencies (514.42s)
=== CONT  TestAccLambdaFunction_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccLambdaFunction_VPC_replaceSGWithDefault (544.17s)
=== CONT  TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccLambdaFunction_VPC_replaceSGWithCustom (940.45s)
=== CONT  TestAccLambdaFunction_loggingConfig
--- PASS: TestAccLambdaFunction_VPCPublishNo_changes (1098.52s)
=== CONT  TestAccLambdaFunction_layers
--- PASS: TestAccLambdaFunction_VPC_withInvocation (1290.85s)
=== CONT  TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables
--- PASS: TestAccLambdaFunction_vpc (1493.58s)
=== CONT  TestAccLambdaFunction_tracing
--- PASS: TestAccLambdaFunction_vpcRemoval (1688.58s)
=== CONT  TestAccLambdaFunction_loggingConfigWithPublish
--- PASS: TestAccLambdaFunction_EnvironmentVariables_noValue (1750.99s)
=== CONT  TestAccLambdaFunction_LocalUpdate_publish
--- PASS: TestAccLambdaFunction_versionedUpdate (1828.96s)
=== CONT  TestAccLambdaFunction_runtimes
--- PASS: TestAccLambdaFunction_disappears (1746.80s)
=== CONT  TestAccLambdaFunction_snapStart
--- PASS: TestAccLambdaFunction_encryptedEnvVariables (1796.75s)
=== CONT  TestAccLambdaFunction_S3Update_unversioned
--- PASS: TestAccLambdaFunction_concurrencyCycle (1778.57s)
=== CONT  TestAccLambdaFunction_S3Update_basic
--- PASS: TestAccLambdaFunction_basic (1738.80s)
=== CONT  TestAccLambdaFunction_LocalUpdate_codeSha256
--- PASS: TestAccLambdaFunction_concurrency (1775.04s)
=== CONT  TestAccLambdaFunction_LocalUpdate_nameOnly
--- PASS: TestAccLambdaFunction_codeSigning (1773.42s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_providerOnly
--- PASS: TestAccLambdaFunction_envVariables (1809.38s)
=== CONT  TestAccLambdaFunction_tags_ComputedTag_OnCreate
--- PASS: TestAccLambdaFunction_layers (797.11s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccLambdaFunction_tags_IgnoreTags_Overlap_DefaultTag (1384.27s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccLambdaFunction_tags_IgnoreTags_Overlap_ResourceTag (1772.45s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Replace (1354.79s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables (612.62s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccLambdaFunction_S3Update_unversioned (61.39s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccLambdaFunction_S3Update_basic (66.21s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_overlapping
--- PASS: TestAccLambdaFunction_tracing (431.14s)
=== CONT  TestAccLambdaFunction_tags_DefaultTags_nonOverlapping
--- PASS: TestAccLambdaFunction_unpublishedCodeUpdate (1827.60s)
=== CONT  TestAccLambdaFunction_tags_EmptyMap
--- PASS: TestAccLambdaFunction_loggingConfig (996.34s)
=== CONT  TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccLambdaFunction_snapStart (99.82s)
=== CONT  TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccLambdaFunction_tags_ComputedTag_OnCreate (81.70s)
=== CONT  TestAccLambdaFunction_tags_EmptyTag_OnCreate
--- PASS: TestAccLambdaFunction_tags_DefaultTags_nullNonOverlappingResourceTag (72.29s)
=== CONT  TestAccLambdaFunction_tags_AddOnUpdate
--- PASS: TestAccLambdaFunction_tags_DefaultTags_nullOverlappingResourceTag (75.88s)
=== CONT  TestAccLambdaFunction_Identity_ExistingResource_NoRefresh_NoChange
--- PASS: TestAccLambdaFunction_tags_DefaultTags_emptyProviderOnlyTag (81.39s)
=== CONT  TestAccLambdaFunction_tags_null
--- PASS: TestAccLambdaFunction_tags_DefaultTags_emptyResourceTag (87.76s)
=== CONT  TestAccLambdaFunction_tags
--- PASS: TestAccLambdaFunction_tags_DefaultTags_updateToResourceOnly (101.89s)
=== CONT  TestAccLambdaFunction_LocalUpdate_sourceCodeHash
--- PASS: TestAccLambdaFunction_tags_DefaultTags_providerOnly (130.19s)
=== CONT  TestAccLambdaFunction_Identity_ExistingResource
--- PASS: TestAccLambdaFunction_Identity_ExistingResource_NoRefresh_NoChange (62.12s)
=== CONT  TestAccLambdaFunction_architecturesUpdate
--- PASS: TestAccLambdaFunction_loggingConfigWithPublish (350.83s)
=== CONT  TestAccLambdaFunction_ephemeralStorage
--- PASS: TestAccLambdaFunction_LocalUpdate_publish (261.68s)
=== CONT  TestAccLambdaFunction_architecturesWithLayer
--- PASS: TestAccLambdaFunction_Identity_ExistingResource (70.19s)
=== CONT  TestAccLambdaFunction_Identity_RegionOverride
--- PASS: TestAccLambdaFunction_tags_DefaultTags_updateToProviderOnly (178.65s)
=== CONT  TestAccLambdaFunction_s3
--- PASS: TestAccLambdaFunction_LocalUpdate_codeSha256 (242.16s)
=== CONT  TestAccLambdaFunction_architectures
=== CONT  TestAccLambdaFunction_durableConfig
--- PASS: TestAccLambdaFunction_tags_EmptyMap (181.60s)
=== NAME  TestAccLambdaFunction_durableConfig
    function_test.go:2608: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-2]
--- SKIP: TestAccLambdaFunction_durableConfig (0.00s)
=== CONT  TestAccLambdaFunction_capacityProvider
--- PASS: TestAccLambdaFunction_LocalUpdate_nameOnly (248.85s)
=== CONT  TestAccLambdaFunction_skipDestroy
--- PASS: TestAccLambdaFunction_tags_DefaultTags_overlapping (202.01s)
=== CONT  TestAccLambdaFunction_resetNonRefreshableAttributesAfterUpdateFailure
--- PASS: TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Replace (191.89s)
=== CONT  TestAccLambdaFunction_durableConfigForceNew
    function_test.go:2666: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-2]
--- SKIP: TestAccLambdaFunction_durableConfigForceNew (0.00s)
=== CONT  TestAccLambdaFunction_tenancyConfig
--- PASS: TestAccLambdaFunction_tags_DefaultTags_nonOverlapping (206.03s)
=== CONT  TestAccLambdaFunction_tenancyConfigForceNew
=== CONT  TestAccLambdaFunction_fileSystem
--- PASS: TestAccLambdaFunction_s3 (42.43s)
--- PASS: TestAccLambdaFunction_tags_EmptyTag_OnCreate (188.86s)
=== CONT  TestAccLambdaFunction_sourceKMSKeyARN
--- PASS: TestAccLambdaFunction_tags_AddOnUpdate (186.11s)
=== CONT  TestAccLambdaFunction_ipv6AllowedForDualStack
--- PASS: TestAccLambdaFunction_tags_null (176.31s)
--- PASS: TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Add (203.24s)
--- PASS: TestAccLambdaFunction_Identity_RegionOverride (107.43s)
--- PASS: TestAccLambdaFunction_skipDestroy (70.58s)
--- PASS: TestAccLambdaFunction_ephemeralStorage (150.77s)
--- PASS: TestAccLambdaFunction_architectures (95.21s)
--- PASS: TestAccLambdaFunction_tags (214.19s)
--- PASS: TestAccLambdaFunction_tenancyConfig (72.82s)
--- PASS: TestAccLambdaFunction_resetNonRefreshableAttributesAfterUpdateFailure (86.54s)
--- PASS: TestAccLambdaFunction_LocalUpdate_sourceCodeHash (210.87s)
--- PASS: TestAccLambdaFunction_architecturesUpdate (186.59s)
--- PASS: TestAccLambdaFunction_architecturesWithLayer (162.50s)
--- PASS: TestAccLambdaFunction_capacityProvider (208.80s)
--- PASS: TestAccLambdaFunction_tenancyConfigForceNew (304.02s)
--- PASS: TestAccLambdaFunction_runtimes (607.59s)
--- PASS: TestAccLambdaFunction_sourceKMSKeyARN (289.28s)
--- PASS: TestAccLambdaFunction_ipv6AllowedForDualStack (770.29s)
--- PASS: TestAccLambdaFunction_vpcUpdate (3076.70s)
--- PASS: TestAccLambdaFunction_VPCPublishHas_changes (3077.17s)
--- PASS: TestAccLambdaFunction_fileSystem (1116.10s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     3260.953s
```
