### PR TITLE
fix: segmentation fault in NullValueOf for custom Set types

### DIFF
--- a/internal/framework/types/null.go
+++ b/internal/framework/types/null.go
@@ -5,8 +5,10 @@ package types
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	tfmaps "github.com/hashicorp/terraform-provider-aws/internal/maps"
@@ -16,6 +18,15 @@ import (
 func NullValueOf(ctx context.Context, v any) (attr.Value, error) {
 	var attrType attr.Type
 	var tfType tftypes.Type
+
+	// Check for types that have their own NullValue method
+	if t, ok := v.(interface{ NullValue(context.Context) (attr.Value, diag.Diagnostics) }); ok {
+		val, diags := t.NullValue(ctx)
+		if diags.HasError() {
+			return nil, fmt.Errorf("error creating null value: %v", diags)
+		}
+		return val, nil
+	}
 
 	switch v := v.(type) {
 	case basetypes.BoolValuable:

--- a/internal/framework/types/setof.go
+++ b/internal/framework/types/setof.go
@@ -104,6 +104,11 @@ func (t setTypeOf[T]) ValueType(ctx context.Context) attr.Value {
 	return SetValueOf[T]{}
 }
 
+func (t setTypeOf[T]) NullValue(ctx context.Context) (attr.Value, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	return NewSetValueOfNull[T](ctx), diags
+}
+
 // SetValueOf represents a Terraform Plugin Framework Set value whose elements are of type `T`.
 type SetValueOf[T attr.Value] struct {
 	basetypes.SetValue


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2025 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
Root Cause
NullValueOf creates a zero-value SetValue via ValueFromTerraform(nil), which has uninitialized internal state. Calling IsNull() on this value causes a null pointer dereference.

Solution
Add NullValue() method to setTypeOf[T] to properly create null values
Update NullValueOf to check for types implementing NullValue() before using the generic path


### Relations
Closes #45624



### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
