### PR TITLE
docs(elasticache_replication_group): clarify auth_token_update_strategy

### DIFF
--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -232,7 +232,7 @@ The following arguments are optional:
   When `engine` is `redis`, default is `false`.
   When `engine` is `valkey`, default is `true`.
 * `auth_token` - (Optional) Password used to access a password protected server. Can be specified only if `transit_encryption_enabled = true`.
-* `auth_token_update_strategy` - (Optional) Strategy to use when updating the `auth_token`. Valid values are `SET`, `ROTATE`, and `DELETE`. Required if `auth_token` is set.
+* `auth_token_update_strategy` - (Optional) Strategy used when modifying `auth_token` on an existing replication group. Not used during initial create. Valid values are `SET`, `ROTATE`, and `DELETE`. If omitted during an auth token change, AWS defaults to `ROTATE`.
 * `auto_minor_version_upgrade` - (Optional) Specifies whether minor version engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window.
   Only supported for engine types `"redis"` and `"valkey"` and if the engine version is 6 or higher.
   Defaults to `true`.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2025 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

Revert this commit (or follow up with a PR) to restore the prior documentation wording.

## Changes to Security Controls

No. Documentation-only change; no provider behavior changes.

### Description

Clarifies the `auth_token_update_strategy` argument documentation for `aws_elasticache_replication_group`.

The previous text implied `auth_token_update_strategy` is required whenever `auth_token` is set. AWS only applies an auth token update strategy when modifying an existing replication group’s auth token (ModifyReplicationGroup). Initial create uses CreateReplicationGroup, which supports `AuthToken` but does not accept an `AuthTokenUpdateStrategy` parameter.

### Relations

Closes #45310

### References

- AWS API Reference: ModifyReplicationGroup (AuthTokenUpdateStrategy semantics/defaults)  
  https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_ModifyReplicationGroup.html
- AWS API Reference: CreateReplicationGroup (AuthToken; no AuthTokenUpdateStrategy)  
  https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateReplicationGroup.html
- (Optional) ElastiCache AUTH user guide  
  https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/auth.html

### Output from Acceptance Testing

Docs-only change.

```console
% make website-lint
# (pass)

% make website-link-check
# (pass)   # or: not run locally (docker not available); CI will validate
