### PR TITLE
docs: add note about IP address range usage to aws_fsx_ontap_file_system

### DIFF
--- a/website/docs/r/fsx_ontap_file_system.html.markdown
+++ b/website/docs/r/fsx_ontap_file_system.html.markdown
@@ -72,6 +72,9 @@ This resource supports the following arguments:
 * `daily_automatic_backup_start_time` - (Optional) A recurring daily time, in the format HH:MM. HH is the zero-padded hour of the day (0-23), and MM is the zero-padded minute of the hour. For example, 05:00 specifies 5 AM daily. Requires `automatic_backup_retention_days` to be set.
 * `disk_iops_configuration` - (Optional) The SSD IOPS configuration for the Amazon FSx for NetApp ONTAP file system. See [Disk Iops Configuration](#disk-iops-configuration) below.
 * `endpoint_ip_address_range` - (Optional) Specifies the IP address range in which the endpoints to access your file system will be created. By default, Amazon FSx selects an unused IP address range for you from the 198.19.* range.
+
+~>  **Note:** The 198.19.* range is also used by AWS services such as WorkSpaces and AppStream 2.0 for their [management network interfaces](https://docs.aws.amazon.com/appstream2/latest/developerguide/management_ports.html).
+
 * `ha_pairs` - (Optional) - The number of ha_pairs to deploy for the file system. Valid value is 1 for `SINGLE_AZ_1` or `MULTI_AZ_1` and `MULTI_AZ_2`. Valid values are 1 through 12 for `SINGLE_AZ_2`.
 * `storage_type` - (Optional) - The filesystem storage type. defaults to `SSD`.
 * `fsx_admin_password` - (Optional) The ONTAP administrative password for the fsxadmin user that you can use to administer your file system using the ONTAP CLI and REST API.


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Add a note to the [`aws_fsx_ontap_file_system`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fsx_ontap_file_system) documentation. It highlights that the  [`endpoint IP address range`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fsx_ontap_file_system#endpoint_ip_address_range-1) used by FSx ONTAP file systems is potentially in conflict with other AWS services like WorkSpaces and AppStream 2.0.


### Relations

Closes #44594 

### References

- [Management Network Interface IP Address Range and Ports in Amazon WorkSpaces Applications
](https://docs.aws.amazon.com/appstream2/latest/developerguide/management_ports.html)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.