### PR TITLE
docs: Fix exported attribute name in bedrockagentcore_memory_strategy

### DIFF
--- a/website/docs/r/bedrockagentcore_memory_strategy.html.markdown
+++ b/website/docs/r/bedrockagentcore_memory_strategy.html.markdown
@@ -169,7 +169,7 @@ The `extraction` block supports the following:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - Unique identifier of the Memory Strategy.
+* `memory_strategy_id` - Unique identifier of the Memory Strategy. This corresponds to the service `strategyId` identifier (AWS API / CloudFormation terminology).
 
 ## Timeouts
 


### PR DESCRIPTION
Fixes #45721

Updated attribute reference for Memory Strategy to clarify identifier terminology.

<!-- Copyright IBM Corp. 2014, 2025 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

This is a documentation-only change with no functional impact. No rollback is necessary.