### PR TITLE
docs: Remove unsupported multiple subnet_mapping blocks in example for r/aws_networkfirewall_vpc_endpoint_association

### DIFF
--- a/website/docs/r/networkfirewall_vpc_endpoint_association.html.markdown
+++ b/website/docs/r/networkfirewall_vpc_endpoint_association.html.markdown
@@ -25,10 +25,6 @@ resource "aws_networkfirewall_vpc_endpoint_association" "example" {
     subnet_id = aws_subnet.example.id
   }
 
-  subnet_mapping {
-    subnet_id = aws_subnet.example_two.id
-  }
-
   tags = {
     Name = "example endpoint"
   }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2025 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to remove the extra `subnet_mapping` block from the `aws_networkfirewall_vpc_endpoint_association` resource usage example. The resource supports only one block and multiple subnets must be handled with `for_each` to create multiple `aws_networkfirewall_vpc_endpoint_association` resource instances.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #45595

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [CreateVpcEndpointAssociation](https://docs.aws.amazon.com/network-firewall/latest/APIReference/API_CreateVpcEndpointAssociation.html) to confirm the API specs taking only one `subnet_mapping` block.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
n/a
```
