### PR TITLE
docs: Change import ID from account ID to region for r/aws_glue_resource_policy

### DIFF
--- a/website/docs/r/glue_resource_policy.html.markdown
+++ b/website/docs/r/glue_resource_policy.html.markdown
@@ -51,17 +51,17 @@ This resource exports no additional attributes.
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Glue Resource Policy using the account ID. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Glue Resource Policy using the region where the resource resides. For example:
 
 ```terraform
 import {
   to = aws_glue_resource_policy.Test
-  id = "12356789012"
+  id = "us-east-1"
 }
 ```
 
-Using `terraform import`, import Glue Resource Policy using the account ID. For example:
+Using `terraform import`, import Glue Resource Policy using the region where the resource resides. For example:
 
 ```console
-% terraform import aws_glue_resource_policy.Test 12356789012
+% terraform import aws_glue_resource_policy.Test us-east-1
 ```


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2025 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to fix the import ID in the `aws_glue_resource_policy` resource documentation to use the region instead of the account ID as the import ID. This resource is a regional singleton as indicated by the `@SingletonIdentity` annotation, so the import ID must behave in a certain way.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #45568

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to the source code (such as `singleton.go`) to understand the import behavior.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
n/a
```