### PR TITLE
docs: Add note re. needing to specify setting defaults to avoid perpetual diff + add ref to AWS doc w/ the values for r/aws_backup_global_settings

### DIFF
--- a/website/docs/r/backup_global_settings.html.markdown
+++ b/website/docs/r/backup_global_settings.html.markdown
@@ -10,12 +10,16 @@ description: |-
 
 Provides an AWS Backup Global Settings resource.
 
+~> **Note:** This resource will show perpetual differences for any supported settings not explicitly configured in the `global_settings` configuration block. To avoid this, specify all supported options with their default values (typically `"false"`, but check the plan diff for the actual value). See [UpdateGlobalSettings](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_UpdateGlobalSettings.html) in the AWS Backup Developer Guide for available settings.
+
 ## Example Usage
 
 ```terraform
 resource "aws_backup_global_settings" "test" {
   global_settings = {
-    "isCrossAccountBackupEnabled" = "true"
+    "isCrossAccountBackupEnabled"     = "true"
+    "isMpaEnabled"                    = "false"
+    "isDelegatedAdministratorEnabled" = "false"
   }
 }
 ```
@@ -24,7 +28,7 @@ resource "aws_backup_global_settings" "test" {
 
 This resource supports the following arguments:
 
-* `global_settings` - (Required) A list of resources along with the opt-in preferences for the account.
+* `global_settings` - (Required) A list of resources along with the opt-in preferences for the account. For a list of inputs, see [UpdateGlobalSettings](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_UpdateGlobalSettings.html) in the AWS Backup Developer Guide.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2025 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is for updating the `aws_backup_global_settings` resource documentation with a note about the perpetual diffs unless all settings and their default values (if not explicitly used) are set in the resource. Links to the API doc that includes the list of all settings have also been added.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #43514

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [UpdateGlobalSettings](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_UpdateGlobalSettings.html) for specs.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
n/a
```
