### PR TITLE
feat: Add serial_number attr for r/aws_iam_virtual_mfa_device

### DIFF
--- a/.changelog/45751.txt
+++ b/.changelog/45751.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_iam_virtual_mfa_device: Add `serial_number` attribute
+```

--- a/internal/service/iam/virtual_mfa_device.go
+++ b/internal/service/iam/virtual_mfa_device.go
@@ -66,6 +66,10 @@ func resourceVirtualMFADevice() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"serial_number": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			names.AttrUserName: {
@@ -151,6 +155,7 @@ func resourceVirtualMFADeviceRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	d.Set(names.AttrARN, vMFA.SerialNumber)
+	d.Set("serial_number", vMFA.SerialNumber)
 
 	path, name, err := parseVirtualMFADeviceARN(aws.ToString(vMFA.SerialNumber))
 	if err != nil {

--- a/internal/service/iam/virtual_mfa_device_test.go
+++ b/internal/service/iam/virtual_mfa_device_test.go
@@ -38,6 +38,7 @@ func TestAccIAMVirtualMFADevice_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &conf),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("mfa/%s", rName)),
+					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, "serial_number", "iam", fmt.Sprintf("mfa/%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "base_32_string_seed"),
 					resource.TestCheckNoResourceAttr(resourceName, "enable_date"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/"),
@@ -78,6 +79,7 @@ func TestAccIAMVirtualMFADevice_path(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &conf),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("mfa%s%s", path, rName)),
+					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, "serial_number", "iam", fmt.Sprintf("mfa%s%s", path, rName)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, path),
 				),
 			},

--- a/website/docs/r/iam_virtual_mfa_device.html.markdown
+++ b/website/docs/r/iam_virtual_mfa_device.html.markdown
@@ -31,20 +31,22 @@ resource "aws_iam_virtual_mfa_device" "example" {
 
 This resource supports the following arguments:
 
-* `virtual_mfa_device_name` - (Required) The name of the virtual MFA device. Use with path to uniquely identify a virtual MFA device.
-* `path` - (Optional) The path for the virtual MFA device.
+* `virtual_mfa_device_name` - (Required) Name of the virtual MFA device. Use with path to uniquely identify a virtual MFA device.
+* `path` - (Optional) Path for the virtual MFA device.
 * `tags` - (Optional) Map of resource tags for the virtual mfa device. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `arn` - The Amazon Resource Name (ARN) specifying the virtual mfa device.
-* `base_32_string_seed` - The base32 seed defined as specified in [RFC3548](https://tools.ietf.org/html/rfc3548.txt). The `base_32_string_seed` is base64-encoded.
-* `enable_date` - The date and time when the virtual MFA device was enabled.
-* `qr_code_png` -  A QR code PNG image that encodes `otpauth://totp/$virtualMFADeviceName@$AccountName?secret=$Base32String` where `$virtualMFADeviceName` is one of the create call arguments. AccountName is the user name if set (otherwise, the account ID), and Base32String is the seed in base32 format.
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
-* `user_name` - The associated IAM User name if the virtual MFA device is enabled.
+* `id` - Serial number associated with the virtual MFA device.
+* `arn` - Amazon Resource Name (ARN), which is also the serial number, of the virtual MFA device.
+* `base_32_string_seed` - Base32 seed defined as specified in [RFC3548](https://tools.ietf.org/html/rfc3548.txt). The `base_32_string_seed` is base64-encoded.
+* `enable_date` - Date and time when the virtual MFA device was enabled.
+* `qr_code_png` -  QR code PNG image that encodes `otpauth://totp/$virtualMFADeviceName@$AccountName?secret=$Base32String` where `$virtualMFADeviceName` is one of the create call arguments. `AccountName` is the user name if set (otherwise, the account ID), and `Base32String` is the seed in base32 format.
+* `serial_number` - Serial number associated with the virtual MFA device.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+* `user_name` - Name of the IAM user associated with this virtual MFA device.
 
 ## Import
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2025 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the `serial_number` attribute to the `aws_iam_virtual_mfa_device` resource. Although there would be now three attributes for the same field (`id`, `arn`, and `serial_number`), having `serial_number` would match the resource to the AWS API more closely.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #45616

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [VirtualMFADevice](https://docs.aws.amazon.com/IAM/latest/APIReference/API_VirtualMFADevice.html) for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS="TestAccIAMVirtualMFADevice_" PKG=iam
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: ðŸŒ¿ main ðŸŒ¿...
TF_ACC=1 go1.25.5 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMVirtualMFADevice_'  -timeout 360m -vet=off
2025/12/28 23:16:15 Creating Terraform AWS Provider (SDKv2-style)...
2025/12/28 23:16:15 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIAMVirtualMFADevice_tags
=== PAUSE TestAccIAMVirtualMFADevice_tags
=== RUN   TestAccIAMVirtualMFADevice_tags_null
=== PAUSE TestAccIAMVirtualMFADevice_tags_null
=== RUN   TestAccIAMVirtualMFADevice_tags_EmptyMap
=== PAUSE TestAccIAMVirtualMFADevice_tags_EmptyMap
=== RUN   TestAccIAMVirtualMFADevice_tags_AddOnUpdate
=== PAUSE TestAccIAMVirtualMFADevice_tags_AddOnUpdate
=== RUN   TestAccIAMVirtualMFADevice_tags_EmptyTag_OnCreate
=== PAUSE TestAccIAMVirtualMFADevice_tags_EmptyTag_OnCreate
=== RUN   TestAccIAMVirtualMFADevice_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccIAMVirtualMFADevice_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccIAMVirtualMFADevice_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccIAMVirtualMFADevice_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccIAMVirtualMFADevice_tags_DefaultTags_providerOnly
=== PAUSE TestAccIAMVirtualMFADevice_tags_DefaultTags_providerOnly
=== RUN   TestAccIAMVirtualMFADevice_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccIAMVirtualMFADevice_tags_DefaultTags_nonOverlapping
=== RUN   TestAccIAMVirtualMFADevice_tags_DefaultTags_overlapping
=== PAUSE TestAccIAMVirtualMFADevice_tags_DefaultTags_overlapping
=== RUN   TestAccIAMVirtualMFADevice_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccIAMVirtualMFADevice_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccIAMVirtualMFADevice_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccIAMVirtualMFADevice_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccIAMVirtualMFADevice_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccIAMVirtualMFADevice_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccIAMVirtualMFADevice_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccIAMVirtualMFADevice_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccIAMVirtualMFADevice_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccIAMVirtualMFADevice_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccIAMVirtualMFADevice_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccIAMVirtualMFADevice_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccIAMVirtualMFADevice_tags_ComputedTag_OnCreate
=== PAUSE TestAccIAMVirtualMFADevice_tags_ComputedTag_OnCreate
=== RUN   TestAccIAMVirtualMFADevice_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccIAMVirtualMFADevice_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccIAMVirtualMFADevice_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccIAMVirtualMFADevice_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccIAMVirtualMFADevice_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccIAMVirtualMFADevice_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccIAMVirtualMFADevice_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccIAMVirtualMFADevice_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccIAMVirtualMFADevice_basic
=== PAUSE TestAccIAMVirtualMFADevice_basic
=== RUN   TestAccIAMVirtualMFADevice_path
=== PAUSE TestAccIAMVirtualMFADevice_path
=== RUN   TestAccIAMVirtualMFADevice_disappears
=== PAUSE TestAccIAMVirtualMFADevice_disappears
=== CONT  TestAccIAMVirtualMFADevice_tags
=== CONT  TestAccIAMVirtualMFADevice_tags_DefaultTags_emptyResourceTag
=== CONT  TestAccIAMVirtualMFADevice_tags_EmptyMap
=== CONT  TestAccIAMVirtualMFADevice_tags_IgnoreTags_Overlap_DefaultTag
=== CONT  TestAccIAMVirtualMFADevice_tags_EmptyTag_OnUpdate_Replace
=== CONT  TestAccIAMVirtualMFADevice_tags_DefaultTags_nonOverlapping
=== CONT  TestAccIAMVirtualMFADevice_tags_DefaultTags_providerOnly
=== CONT  TestAccIAMVirtualMFADevice_tags_DefaultTags_overlapping
=== CONT  TestAccIAMVirtualMFADevice_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccIAMVirtualMFADevice_tags_EmptyTag_OnUpdate_Add
=== CONT  TestAccIAMVirtualMFADevice_tags_AddOnUpdate
=== CONT  TestAccIAMVirtualMFADevice_tags_DefaultTags_updateToProviderOnly
=== CONT  TestAccIAMVirtualMFADevice_basic
=== CONT  TestAccIAMVirtualMFADevice_disappears
=== CONT  TestAccIAMVirtualMFADevice_tags_ComputedTag_OnUpdate_Replace
=== CONT  TestAccIAMVirtualMFADevice_tags_IgnoreTags_Overlap_ResourceTag
=== CONT  TestAccIAMVirtualMFADevice_tags_EmptyTag_OnCreate
=== CONT  TestAccIAMVirtualMFADevice_tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccIAMVirtualMFADevice_tags_ComputedTag_OnUpdate_Add
=== CONT  TestAccIAMVirtualMFADevice_path
--- PASS: TestAccIAMVirtualMFADevice_disappears (53.61s)
=== CONT  TestAccIAMVirtualMFADevice_tags_ComputedTag_OnCreate
--- PASS: TestAccIAMVirtualMFADevice_path (63.69s)
=== CONT  TestAccIAMVirtualMFADevice_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccIAMVirtualMFADevice_basic (64.72s)
=== CONT  TestAccIAMVirtualMFADevice_tags_null
--- PASS: TestAccIAMVirtualMFADevice_tags_DefaultTags_emptyResourceTag (70.16s)
=== CONT  TestAccIAMVirtualMFADevice_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccIAMVirtualMFADevice_tags_DefaultTags_nullNonOverlappingResourceTag (73.02s)
--- PASS: TestAccIAMVirtualMFADevice_tags_EmptyMap (102.90s)
--- PASS: TestAccIAMVirtualMFADevice_tags_DefaultTags_updateToResourceOnly (105.91s)
--- PASS: TestAccIAMVirtualMFADevice_tags_DefaultTags_updateToProviderOnly (109.81s)
--- PASS: TestAccIAMVirtualMFADevice_tags_EmptyTag_OnUpdate_Replace (109.86s)
--- PASS: TestAccIAMVirtualMFADevice_tags_AddOnUpdate (115.35s)
--- PASS: TestAccIAMVirtualMFADevice_tags_ComputedTag_OnUpdate_Add (120.20s)
--- PASS: TestAccIAMVirtualMFADevice_tags_ComputedTag_OnCreate (67.64s)
--- PASS: TestAccIAMVirtualMFADevice_tags_ComputedTag_OnUpdate_Replace (122.36s)
--- PASS: TestAccIAMVirtualMFADevice_tags_DefaultTags_nullOverlappingResourceTag (60.04s)
--- PASS: TestAccIAMVirtualMFADevice_tags_EmptyTag_OnCreate (124.95s)
--- PASS: TestAccIAMVirtualMFADevice_tags_DefaultTags_emptyProviderOnlyTag (58.68s)
--- PASS: TestAccIAMVirtualMFADevice_tags_IgnoreTags_Overlap_DefaultTag (130.03s)
--- PASS: TestAccIAMVirtualMFADevice_tags_EmptyTag_OnUpdate_Add (140.38s)
--- PASS: TestAccIAMVirtualMFADevice_tags_null (75.87s)
--- PASS: TestAccIAMVirtualMFADevice_tags_IgnoreTags_Overlap_ResourceTag (142.67s)
--- PASS: TestAccIAMVirtualMFADevice_tags_DefaultTags_nonOverlapping (147.25s)
--- PASS: TestAccIAMVirtualMFADevice_tags_DefaultTags_overlapping (148.00s)
--- PASS: TestAccIAMVirtualMFADevice_tags (167.44s)
--- PASS: TestAccIAMVirtualMFADevice_tags_DefaultTags_providerOnly (171.22s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        171.583s

$
```
