### PR TITLE
docs: change ip_protocol from Optional to Required

### DIFF
--- a/website/docs/r/vpc_security_group_egress_rule.html.markdown
+++ b/website/docs/r/vpc_security_group_egress_rule.html.markdown
@@ -38,7 +38,7 @@ This resource supports the following arguments:
 * `cidr_ipv6` - (Optional) The destination IPv6 CIDR range.
 * `description` - (Optional) The security group rule description.
 * `from_port` - (Optional) The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 type.
-* `ip_protocol` - (Optional) The IP protocol name or number. Use `-1` to specify all protocols. Note that if `ip_protocol` is set to `-1`, it translates to all protocols, all port ranges, and `from_port` and `to_port` values should not be defined.
+* `ip_protocol` - (Required) The IP protocol name or number. Use `-1` to specify all protocols. Note that if `ip_protocol` is set to `-1`, it translates to all protocols, all port ranges, and `from_port` and `to_port` values should not be defined.
 * `prefix_list_id` - (Optional) The ID of the destination prefix list.
 * `referenced_security_group_id` - (Optional) The destination security group that is referenced in the rule.
 * `security_group_id` - (Required) The ID of the security group.


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

The argument `ip_protocol` of resource [`aws_vpc_security_group_rule`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc_security_group_rule) is not `Optional`, but `Required`.
(Similar to `ip_protocol` of `aws_vpc_security_group_ingress_rule`)



A `terraform plan` on below shows the issue.

```hcl
resource "aws_security_group" "example" {
  name        = "example"
  description = "Example security group"
  tags = {
    Name = "example"
  }
}

resource "aws_vpc_security_group_egress_rule" "example" {
  security_group_id = aws_security_group.example.id
  cidr_ipv4   = "10.0.0.0/8"
  from_port   = 80
  // ip_protocol = "tcp"
  to_port     = 80
}
```

results in

```shell
│ Error: Missing required argument
│ 
│   on main.tf line 40, in resource "aws_vpc_security_group_egress_rule" "example":
│   40: resource "aws_vpc_security_group_egress_rule" "example" {
│ 
│ The argument "ip_protocol" is required, but no definition was found.
╵
```

### Relations

Closes #44565  

### References

- [Argument definition in source code ](https://github.com/hashicorp/terraform-provider-aws/blob/90010dbcfcaa9cb4dca6614d6ed6c60e773c32a3/internal/service/ec2/vpc_security_group_ingress_rule.go#L208)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.