### PR TITLE
Fix a problem that aws_rds_instance_state can't start a stopped RDS instance

### DIFF
--- a/.changelog/45791.txt
+++ b/.changelog/45791.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_instance_state: Fix aws_rds_instance_state can not start a stopped RDS instance
+```

--- a/internal/service/rds/instance_state_test.go
+++ b/internal/service/rds/instance_state_test.go
@@ -80,6 +80,41 @@ func TestAccRDSInstanceState_update(t *testing.T) {
 	})
 }
 
+func TestAccRDSInstanceState_update_start(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_rds_instance_state.test"
+	stateAvailable := "available"
+	stateStopped := "stopped"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceStateConfig_basic(rName, stateStopped),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceStateExists(ctx, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrIdentifier),
+					resource.TestCheckResourceAttr(resourceName, names.AttrState, stateStopped),
+				),
+			},
+			{
+				Config: testAccInstanceStateConfig_basic(rName, stateAvailable),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceStateExists(ctx, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrIdentifier),
+					resource.TestCheckResourceAttr(resourceName, names.AttrState, stateAvailable),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckInstanceStateExists(ctx context.Context, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2025 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

no changes to security controls.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

As explained in issue #40785, an RDS instance must be in the `available` (or `storage-optimization`) state
to apply changes to the `state` attribute.

This precondition causes a problem: a stopped RDS instance cannot be started.

To fix this issue, this PR changes the precondition to allow RDS instances in either the `available`
or `stopped` state.

### Relations

Closes #40785

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccRDSInstanceState_ PKG=rds
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 fix-cant-start-stopped-rds-instance 🌿...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstanceState_'  -timeout 360m -vet=off
2026/01/03 23:05:33 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/03 23:05:33 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSInstanceState_basic
=== PAUSE TestAccRDSInstanceState_basic
=== RUN   TestAccRDSInstanceState_update
=== PAUSE TestAccRDSInstanceState_update
=== RUN   TestAccRDSInstanceState_update_start
=== PAUSE TestAccRDSInstanceState_update_start
=== RUN   TestAccRDSInstanceState_disappears_Instance
=== PAUSE TestAccRDSInstanceState_disappears_Instance
=== CONT  TestAccRDSInstanceState_basic
=== CONT  TestAccRDSInstanceState_update_start
=== CONT  TestAccRDSInstanceState_update
=== CONT  TestAccRDSInstanceState_disappears_Instance
--- PASS: TestAccRDSInstanceState_basic (659.86s)
--- PASS: TestAccRDSInstanceState_disappears_Instance (660.90s)
--- PASS: TestAccRDSInstanceState_update (1208.52s)
--- PASS: TestAccRDSInstanceState_update_start (1496.58s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        1496.675s
```
