### PR TITLE
docs: Add note re. aws_db_proxy dep issue on replace for r/aws_db_proxy_default_target_group and r/aws_db_proxy_target

### DIFF
--- a/website/docs/r/db_proxy_default_target_group.html.markdown
+++ b/website/docs/r/db_proxy_default_target_group.html.markdown
@@ -12,6 +12,8 @@ Provides a resource to manage an RDS DB proxy default target group resource.
 
 The `aws_db_proxy_default_target_group` behaves differently from normal resources, in that Terraform does not _create_ or _destroy_ this resource, since it implicitly exists as part of an RDS DB Proxy. On Terraform resource creation it is automatically imported and on resource destruction, Terraform performs no actions in RDS.
 
+~> **NOTE:** When the associated `aws_db_proxy` resource is replaced, Terraform will lose track of this resource, causing unexpected differences on the next apply. To ensure proper dependency management, add a `lifecycle` block with `replace_triggered_by` referencing the `aws_db_proxy` resource's `id` attribute.
+
 ## Example Usage
 
 ```terraform
@@ -47,6 +49,10 @@ resource "aws_db_proxy_default_target_group" "example" {
     max_connections_percent      = 100
     max_idle_connections_percent = 50
     session_pinning_filters      = ["EXCLUDE_VARIABLE_SETS"]
+  }
+
+  lifecycle {
+    replace_triggered_by = [aws_db_proxy.example.id]
   }
 }
 ```

--- a/website/docs/r/db_proxy_target.html.markdown
+++ b/website/docs/r/db_proxy_target.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an RDS DB proxy target resource.
 
+~> **NOTE:** When the associated `aws_db_proxy` resource is replaced, Terraform will lose track of this resource, causing unexpected differences on the next apply. To ensure proper dependency management, add a `lifecycle` block with `replace_triggered_by` referencing the `aws_db_proxy` resource's `id` attribute.
+
 ## Example Usage
 
 ```terraform
@@ -46,12 +48,20 @@ resource "aws_db_proxy_default_target_group" "example" {
     max_idle_connections_percent = 50
     session_pinning_filters      = ["EXCLUDE_VARIABLE_SETS"]
   }
+
+  lifecycle {
+    replace_triggered_by = [aws_db_proxy.example.id]
+  }
 }
 
 resource "aws_db_proxy_target" "example" {
   db_instance_identifier = aws_db_instance.example.identifier
   db_proxy_name          = aws_db_proxy.example.name
   target_group_name      = aws_db_proxy_default_target_group.example.name
+
+  lifecycle {
+    replace_triggered_by = [aws_db_proxy.example.id]
+  }
 }
 ```
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2025 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add a note to the `aws_db_proxy_default_target_group` and `aws_db_proxy_target` documentation about the resource dependency issue where these two resource's states would be changed on AWS side when the dependent `aws_db_proxy` resource is recreated. To address the issue, the `replace_triggered_by` `lifecycle` meta-argument needs to be added to add a dependency against the `id` attribute of the `aws_db_proxy` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #45738

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
n/a
```
