### PR TITLE
r/aws_vpc: Add `Computed: true` to `ipv6_netmask_length` attribute

### DIFF
--- a/.changelog/45845.txt
+++ b/.changelog/45845.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpc: Fix perpetual diffs in `ipv6_netmask_length` when using IPAM-managed IPv6 pools
+```

--- a/internal/service/ec2/vpc_.go
+++ b/internal/service/ec2/vpc_.go
@@ -177,6 +177,7 @@ func resourceVPC() *schema.Resource {
 				"ipv6_netmask_length": {
 					Type:          schema.TypeInt,
 					Optional:      true,
+					Computed:      true,
 					ValidateFunc:  validation.IntInSlice(vpcCIDRValidIPv6Netmasks),
 					ConflictsWith: []string{"ipv6_cidr_block"},
 					RequiredWith:  []string{"ipv6_ipam_pool_id"},


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Add `Computed: true` to the `ipv6_netmask_length` attribute schema to fix perpetual diffs when using IPAM-managed IPv6 pools.

This is the same fix applied in #30795 for `ipv6_ipam_pool_id`.

### Relations

Closes #45844

### References

- #30795 - Similar fix for `ipv6_ipam_pool_id` attribute

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccVPC_IPAMIPv6 PKG=ec2
2026/01/07 18:11:48 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/07 18:11:48 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPC_IPAMIPv6
=== PAUSE TestAccVPC_IPAMIPv6
=== CONT  TestAccVPC_IPAMIPv6
--- PASS: TestAccVPC_IPAMIPv6 (1131.11s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	1131.307s
```
