### PR TITLE
r/aws_wafv2_web_acl,r/aws_wafv2_rule_group: Fix spurious diffs on unchanged rules

### DIFF
--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -4,9 +4,11 @@
 package wafv2
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -2044,6 +2046,11 @@ func expandFieldToProtect(tfList []any) *awstypes.FieldToProtect {
 }
 
 func flattenRules(r []awstypes.Rule) any {
+	// Sort rules by priority to ensure consistent ordering and avoid spurious diffs
+	slices.SortFunc(r, func(a, b awstypes.Rule) int {
+		return cmp.Compare(a.Priority, b.Priority)
+	})
+
 	out := make([]map[string]any, len(r))
 	for i, rule := range r {
 		m := make(map[string]any)
@@ -2943,6 +2950,11 @@ func flattenWebACLStatement(s *awstypes.Statement) map[string]any {
 }
 
 func flattenWebACLRules(r []awstypes.Rule) any {
+	// Sort rules by priority to ensure consistent ordering and avoid spurious diffs
+	slices.SortFunc(r, func(a, b awstypes.Rule) int {
+		return cmp.Compare(a.Priority, b.Priority)
+	})
+
 	out := make([]map[string]any, len(r))
 	for i, rule := range r {
 		m := make(map[string]any)

--- a/internal/service/wafv2/flex_test.go
+++ b/internal/service/wafv2/flex_test.go
@@ -157,3 +157,145 @@ func Test_expandWebACLRulesJSON(t *testing.T) {
 		})
 	}
 }
+
+func Test_flattenWebACLRules_sortsByPriority(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    []awstypes.Rule
+		expected []int32
+	}{
+		"empty slice": {
+			input:    []awstypes.Rule{},
+			expected: []int32{},
+		},
+		"single rule": {
+			input: []awstypes.Rule{
+				{Name: aws.String("rule-1"), Priority: 10},
+			},
+			expected: []int32{10},
+		},
+		"already sorted": {
+			input: []awstypes.Rule{
+				{Name: aws.String("rule-1"), Priority: 1},
+				{Name: aws.String("rule-2"), Priority: 5},
+				{Name: aws.String("rule-3"), Priority: 10},
+			},
+			expected: []int32{1, 5, 10},
+		},
+		"reverse order": {
+			input: []awstypes.Rule{
+				{Name: aws.String("rule-3"), Priority: 10},
+				{Name: aws.String("rule-2"), Priority: 5},
+				{Name: aws.String("rule-1"), Priority: 1},
+			},
+			expected: []int32{1, 5, 10},
+		},
+		"random order": {
+			input: []awstypes.Rule{
+				{Name: aws.String("rule-2"), Priority: 19},
+				{Name: aws.String("rule-4"), Priority: 50},
+				{Name: aws.String("rule-1"), Priority: 5},
+				{Name: aws.String("rule-3"), Priority: 23},
+			},
+			expected: []int32{5, 19, 23, 50},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			result := flattenWebACLRules(tc.input)
+			rules, ok := result.([]map[string]any)
+			if !ok {
+				t.Fatalf("expected []map[string]any, got %T", result)
+			}
+
+			if len(rules) != len(tc.expected) {
+				t.Fatalf("expected %d rules, got %d", len(tc.expected), len(rules))
+			}
+
+			for i, rule := range rules {
+				priority, ok := rule["priority"].(int32)
+				if !ok {
+					t.Fatalf("expected priority to be int32, got %T", rule["priority"])
+				}
+				if priority != tc.expected[i] {
+					t.Errorf("rule[%d]: expected priority %d, got %d", i, tc.expected[i], priority)
+				}
+			}
+		})
+	}
+}
+
+func Test_flattenRules_sortsByPriority(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    []awstypes.Rule
+		expected []int32
+	}{
+		"empty slice": {
+			input:    []awstypes.Rule{},
+			expected: []int32{},
+		},
+		"single rule": {
+			input: []awstypes.Rule{
+				{Name: aws.String("rule-1"), Priority: 10},
+			},
+			expected: []int32{10},
+		},
+		"already sorted": {
+			input: []awstypes.Rule{
+				{Name: aws.String("rule-1"), Priority: 1},
+				{Name: aws.String("rule-2"), Priority: 5},
+				{Name: aws.String("rule-3"), Priority: 10},
+			},
+			expected: []int32{1, 5, 10},
+		},
+		"reverse order": {
+			input: []awstypes.Rule{
+				{Name: aws.String("rule-3"), Priority: 10},
+				{Name: aws.String("rule-2"), Priority: 5},
+				{Name: aws.String("rule-1"), Priority: 1},
+			},
+			expected: []int32{1, 5, 10},
+		},
+		"random order": {
+			input: []awstypes.Rule{
+				{Name: aws.String("rule-2"), Priority: 19},
+				{Name: aws.String("rule-4"), Priority: 50},
+				{Name: aws.String("rule-1"), Priority: 5},
+				{Name: aws.String("rule-3"), Priority: 23},
+			},
+			expected: []int32{5, 19, 23, 50},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			result := flattenRules(tc.input)
+			rules, ok := result.([]map[string]any)
+			if !ok {
+				t.Fatalf("expected []map[string]any, got %T", result)
+			}
+
+			if len(rules) != len(tc.expected) {
+				t.Fatalf("expected %d rules, got %d", len(tc.expected), len(rules))
+			}
+
+			for i, rule := range rules {
+				priority, ok := rule["priority"].(int32)
+				if !ok {
+					t.Fatalf("expected priority to be int32, got %T", rule["priority"])
+				}
+				if priority != tc.expected[i] {
+					t.Errorf("rule[%d]: expected priority %d, got %d", i, tc.expected[i], priority)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #45858

### Description

Sort rules by `priority` in `flattenWebACLRules()` and `flattenRules()` to ensure consistent ordering. This prevents unchanged rules from appearing as `-/+` changes when other rules are added or removed.

### Root Cause

The `rule` attribute uses `schema.TypeSet` (unordered, hash-based). The flatten functions return rules in API order without sorting. When rules change, hash ordering shifts, causing spurious diffs on unchanged rules.

### Changes

- Add `cmp` and `slices` imports to `flex.go`
- Sort rules by priority in `flattenWebACLRules()` (for `aws_wafv2_web_acl`)
- Sort rules by priority in `flattenRules()` (for `aws_wafv2_rule_group`)
- Add unit tests for sorting behavior

### Pattern Reference

Same pattern as `sortListenerActions()` in `internal/service/elbv2/listener.go`.

### Testing

- [x] Unit tests added for `flattenWebACLRules` and `flattenRules` sorting