### PR TITLE
data-source/aws_eks_access_entry: Fix tags not being returned

### DIFF
--- a/.changelog/45867.txt
+++ b/.changelog/45867.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+data-source/aws_eks_access_entry: Fixed tags not being returned
+```
+
+```release-note:note
+data-source/aws_eks_access_entry: The `tags_all` attribute is deprecated and will be removed in a future major version
+```

--- a/internal/service/eks/access_entry_datasource.go
+++ b/internal/service/eks/access_entry_datasource.go
@@ -18,6 +18,7 @@ import (
 )
 
 // @SDKDataSource("aws_eks_access_entry", name="Access Entry")
+// @Tags(identifierAttribute="access_entry_arn")
 func dataSourceAccessEntry() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceAccessEntryRead,
@@ -60,7 +61,7 @@ func dataSourceAccessEntry() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTags:    tftags.TagsSchemaComputed(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}

--- a/internal/service/eks/service_package_gen.go
+++ b/internal/service/eks/service_package_gen.go
@@ -59,7 +59,10 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*inttypes.Service
 			Factory:  dataSourceAccessEntry,
 			TypeName: "aws_eks_access_entry",
 			Name:     "Access Entry",
-			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: "access_entry_arn",
+			}),
+			Region: unique.Make(inttypes.ResourceRegionDefault()),
 		},
 		{
 			Factory:  dataSourceAddon,


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The `aws_eks_access_entry` data source was not returning tags despite having the `tags` attribute in its schema. This was caused by two issues:

1. Missing `@Tags` annotation - The data source wasn't registered with the transparent tagging interceptor, so `setTagsOut()` stored tags in context but they were never written to state
2. Incorrect schema - Used `TagsSchema()` (for writable resources) instead of `TagsSchemaComputed()` (for read-only data sources)

- Added `@Tags(identifierAttribute="access_entry_arn")` annotation to register with tagging interceptor
- Changed `names.AttrTags: tftags.TagsSchema()` to `names.AttrTags: tftags.TagsSchemaComputed()`
- Removed `tags_all` attribute (not needed for data sources)
- Added `TestAccEKSAccessEntryDataSource_tags` acceptance test

### Output from Acceptance Testing

```console
--- PASS: TestAccEKSAccessEntryDataSource_tags (611.60s) PASS
ok    github.com/hashicorp/terraform-provider-aws/internal/service/eks        611.733s
```
