### PR TITLE
r/aws_vpc_security_group_rules_exclusive: new resource

### DIFF
--- a/.changelog/45876.txt
+++ b/.changelog/45876.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_vpc_security_group_rules_exclusive
+```

--- a/internal/service/ec2/exports_test.go
+++ b/internal/service/ec2/exports_test.go
@@ -213,6 +213,7 @@ var (
 	FindSecurityGroupByID                                       = findSecurityGroupByID
 	FindSecurityGroupEgressRuleByID                             = findSecurityGroupEgressRuleByID
 	FindSecurityGroupIngressRuleByID                            = findSecurityGroupIngressRuleByID
+	FindSecurityGroupRuleIDsBySecurityGroupID                   = findSecurityGroupRuleIDsBySecurityGroupID
 	FindSecurityGroupVPCAssociationByTwoPartKey                 = findSecurityGroupVPCAssociationByTwoPartKey
 	FindSerialConsoleAccessStatus                               = findSerialConsoleAccessStatus
 	FindSnapshot                                                = findSnapshot

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -268,6 +268,12 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			},
 		},
 		{
+			Factory:  newResourceSecurityGroupRulesExclusive,
+			TypeName: "aws_vpc_security_group_rules_exclusive",
+			Name:     "Security Group Rules Exclusive",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+		{
 			Factory:  newSecurityGroupVPCAssociationResource,
 			TypeName: "aws_vpc_security_group_vpc_association",
 			Name:     "Security Group VPC Association",

--- a/internal/service/ec2/vpc_security_group_rules_exclusive.go
+++ b/internal/service/ec2/vpc_security_group_rules_exclusive.go
@@ -1,0 +1,237 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_vpc_security_group_rules_exclusive", name="Security Group Rules Exclusive")
+func newResourceSecurityGroupRulesExclusive(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceSecurityGroupRulesExclusive{}, nil
+}
+
+const (
+	ResNameSecurityGroupRulesExclusive = "Security Group Rules Exclusive"
+)
+
+type resourceSecurityGroupRulesExclusive struct {
+	framework.ResourceWithModel[resourceSecurityGroupRulesExclusiveData]
+	framework.WithNoOpDelete
+}
+
+func (r *resourceSecurityGroupRulesExclusive) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"egress_rule_ids": schema.SetAttribute{
+				CustomType:  fwtypes.SetOfStringType,
+				Required:    true,
+				ElementType: types.StringType,
+			},
+			"ingress_rule_ids": schema.SetAttribute{
+				CustomType:  fwtypes.SetOfStringType,
+				Required:    true,
+				ElementType: types.StringType,
+			},
+			"security_group_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+	}
+}
+
+func (r *resourceSecurityGroupRulesExclusive) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan resourceSecurityGroupRulesExclusiveData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var ingressRuleIDs, egressRuleIDs []string
+	resp.Diagnostics.Append(plan.IngressRuleIDs.ElementsAs(ctx, &ingressRuleIDs, false)...)
+	resp.Diagnostics.Append(plan.EgressRuleIDs.ElementsAs(ctx, &egressRuleIDs, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.syncRules(ctx, &resp.Diagnostics, plan.SecurityGroupID.ValueString(), ingressRuleIDs, egressRuleIDs)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameSecurityGroupRulesExclusive, plan.SecurityGroupID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceSecurityGroupRulesExclusive) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().EC2Client(ctx)
+
+	var state resourceSecurityGroupRulesExclusiveData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// The ingress/egress rule finder below will simply return empty arrays for deleted
+	// security groups. To determine whether this resource should be removed from state,
+	// check for presence of the security group first.
+	if _, err := findSecurityGroupByID(ctx, conn, state.SecurityGroupID.ValueString()); retry.NotFound(err) { // nosemgrep:ci.semgrep.errors.notfound-without-err-checks
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	ingressRuleIDs, egressRuleIDs, err := findSecurityGroupRuleIDsBySecurityGroupID(ctx, conn, state.SecurityGroupID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionReading, ResNameSecurityGroupRulesExclusive, state.SecurityGroupID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.IngressRuleIDs = fwflex.FlattenFrameworkStringValueSetOfStringLegacy(ctx, ingressRuleIDs)
+	state.EgressRuleIDs = fwflex.FlattenFrameworkStringValueSetOfStringLegacy(ctx, egressRuleIDs)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceSecurityGroupRulesExclusive) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan, state resourceSecurityGroupRulesExclusiveData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.IngressRuleIDs.Equal(state.IngressRuleIDs) || !plan.EgressRuleIDs.Equal(state.EgressRuleIDs) {
+		var ingressRuleIDs, egressRuleIDs []string
+		resp.Diagnostics.Append(plan.IngressRuleIDs.ElementsAs(ctx, &ingressRuleIDs, false)...)
+		resp.Diagnostics.Append(plan.EgressRuleIDs.ElementsAs(ctx, &egressRuleIDs, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		err := r.syncRules(ctx, &resp.Diagnostics, plan.SecurityGroupID.ValueString(), ingressRuleIDs, egressRuleIDs)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.EC2, create.ErrActionUpdating, ResNameSecurityGroupRulesExclusive, plan.SecurityGroupID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// syncRules handles keeping the configured security group rules in sync with
+// the remote resource.
+//
+// Rules defined on this resource but not present in the security group will
+// generate warnings directing users to create them. Rules present in the security
+// group but not configured on this resource will be removed.
+func (r *resourceSecurityGroupRulesExclusive) syncRules(ctx context.Context, diags *diag.Diagnostics, securityGroupID string, wantIngress, wantEgress []string) error {
+	conn := r.Meta().EC2Client(ctx)
+
+	haveIngress, haveEgress, err := findSecurityGroupRuleIDsBySecurityGroupID(ctx, conn, securityGroupID)
+	if err != nil {
+		return err
+	}
+
+	createIngress, removeIngress, _ := intflex.DiffSlices(haveIngress, wantIngress, func(s1, s2 string) bool { return s1 == s2 })
+	createEgress, removeEgress, _ := intflex.DiffSlices(haveEgress, wantEgress, func(s1, s2 string) bool { return s1 == s2 })
+
+	// Emit warnings for rules that need to be created
+	for _, ruleID := range createIngress {
+		diags.AddWarning(
+			"Ingress Rule Not Found",
+			fmt.Sprintf("Security group rule %q is configured but not currently associated with security group %q. "+
+				"Use the aws_vpc_security_group_ingress_rule resource to create this rule.", ruleID, securityGroupID),
+		)
+	}
+
+	for _, ruleID := range createEgress {
+		diags.AddWarning(
+			"Egress Rule Not Found",
+			fmt.Sprintf("Security group rule %q is configured but not currently associated with security group %q. "+
+				"Use the aws_vpc_security_group_egress_rule resource to create this rule.", ruleID, securityGroupID),
+		)
+	}
+
+	for _, ruleID := range removeIngress {
+		input := ec2.RevokeSecurityGroupIngressInput{
+			GroupId:              aws.String(securityGroupID),
+			SecurityGroupRuleIds: []string{ruleID},
+		}
+		if _, err := conn.RevokeSecurityGroupIngress(ctx, &input); err != nil {
+			return err
+		}
+	}
+
+	for _, ruleID := range removeEgress {
+		input := ec2.RevokeSecurityGroupEgressInput{
+			GroupId:              aws.String(securityGroupID),
+			SecurityGroupRuleIds: []string{ruleID},
+		}
+		if _, err := conn.RevokeSecurityGroupEgress(ctx, &input); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *resourceSecurityGroupRulesExclusive) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("security_group_id"), req, resp)
+}
+
+func findSecurityGroupRuleIDsBySecurityGroupID(ctx context.Context, conn *ec2.Client, id string) ([]string, []string, error) {
+	rules, err := findSecurityGroupRulesBySecurityGroupID(ctx, conn, id)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ingressRuleIDs, egressRuleIDs []string
+	for _, rule := range rules {
+		if rule.SecurityGroupRuleId != nil {
+			if aws.ToBool(rule.IsEgress) {
+				egressRuleIDs = append(egressRuleIDs, aws.ToString(rule.SecurityGroupRuleId))
+			} else {
+				ingressRuleIDs = append(ingressRuleIDs, aws.ToString(rule.SecurityGroupRuleId))
+			}
+		}
+	}
+
+	return ingressRuleIDs, egressRuleIDs, nil
+}
+
+type resourceSecurityGroupRulesExclusiveData struct {
+	framework.WithRegionModel
+	EgressRuleIDs   fwtypes.SetOfString `tfsdk:"egress_rule_ids"`
+	IngressRuleIDs  fwtypes.SetOfString `tfsdk:"ingress_rule_ids"`
+	SecurityGroupID types.String        `tfsdk:"security_group_id"`
+}

--- a/internal/service/ec2/vpc_security_group_rules_exclusive_test.go
+++ b/internal/service/ec2/vpc_security_group_rules_exclusive_test.go
@@ -1,0 +1,439 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccVPCSecurityGroupRulesExclusive_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_vpc_security_group_rules_exclusive.test"
+	securityGroupResourceName := "aws_security_group.test"
+	ingressRuleResourceName := "aws_vpc_security_group_ingress_rule.test"
+	egressRuleResourceName := "aws_vpc_security_group_egress_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecurityGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecurityGroupRulesExclusiveConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecurityGroupRulesExclusiveExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_id", securityGroupResourceName, names.AttrID),
+					resource.TestCheckResourceAttr(resourceName, "ingress_rule_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "egress_rule_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "ingress_rule_ids.*", ingressRuleResourceName, names.AttrID),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "egress_rule_ids.*", egressRuleResourceName, names.AttrID),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "security_group_id"),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "security_group_id",
+			},
+		},
+	})
+}
+
+func TestAccVPCSecurityGroupRulesExclusive_disappears_SecurityGroup(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_vpc_security_group_rules_exclusive.test"
+	securityGroupResourceName := "aws_security_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecurityGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecurityGroupRulesExclusiveConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecurityGroupRulesExclusiveExists(ctx, resourceName),
+					acctest.CheckSDKResourceDisappears(ctx, t, tfec2.ResourceSecurityGroup(), securityGroupResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccVPCSecurityGroupRulesExclusive_multiple(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_vpc_security_group_rules_exclusive.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecurityGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecurityGroupRulesExclusiveConfig_multiple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecurityGroupRulesExclusiveExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ingress_rule_ids.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "egress_rule_ids.#", "2"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "security_group_id"),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "security_group_id",
+			},
+			{
+				Config: testAccSecurityGroupRulesExclusiveConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecurityGroupRulesExclusiveExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ingress_rule_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "egress_rule_ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVPCSecurityGroupRulesExclusive_empty(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_vpc_security_group_rules_exclusive.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecurityGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecurityGroupRulesExclusiveConfig_empty(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecurityGroupRulesExclusiveExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ingress_rule_ids.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "egress_rule_ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVPCSecurityGroupRulesExclusive_outOfBandAddition(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_vpc_security_group_rules_exclusive.test"
+	securityGroupResourceName := "aws_security_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecurityGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecurityGroupRulesExclusiveConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecurityGroupRulesExclusiveExists(ctx, resourceName),
+					testAccCheckSecurityGroupRulesExclusiveAddOutOfBandIngressRule(ctx, securityGroupResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccSecurityGroupRulesExclusiveConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecurityGroupRulesExclusiveExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ingress_rule_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "egress_rule_ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVPCSecurityGroupRulesExclusive_ingressOnly(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_vpc_security_group_rules_exclusive.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecurityGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecurityGroupRulesExclusiveConfig_ingressOnly(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecurityGroupRulesExclusiveExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ingress_rule_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "egress_rule_ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVPCSecurityGroupRulesExclusive_egressOnly(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_vpc_security_group_rules_exclusive.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecurityGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecurityGroupRulesExclusiveConfig_egressOnly(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecurityGroupRulesExclusiveExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ingress_rule_ids.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "egress_rule_ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSecurityGroupRulesExclusiveExists(ctx context.Context, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
+
+		ingressRuleIDs, egressRuleIDs, err := tfec2.FindSecurityGroupRuleIDsBySecurityGroupID(ctx, conn, rs.Primary.Attributes["security_group_id"])
+		if err != nil {
+			return err
+		}
+
+		if strconv.Itoa(len(ingressRuleIDs)) != rs.Primary.Attributes["ingress_rule_ids.#"] {
+			return fmt.Errorf("ingress rule count mismatch")
+		}
+		if strconv.Itoa(len(egressRuleIDs)) != rs.Primary.Attributes["egress_rule_ids.#"] {
+			return fmt.Errorf("egress rule count mismatch")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSecurityGroupRulesExclusiveAddOutOfBandIngressRule(ctx context.Context, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
+
+		// Add an out-of-band ingress rule
+		input := ec2.AuthorizeSecurityGroupIngressInput{
+			GroupId:    aws.String(rs.Primary.ID),
+			IpProtocol: aws.String("tcp"),
+			FromPort:   aws.Int32(8080),
+			ToPort:     aws.Int32(8080),
+			CidrIp:     aws.String("10.0.0.0/8"),
+		}
+		_, err := conn.AuthorizeSecurityGroupIngress(ctx, &input)
+
+		return err
+	}
+}
+
+func testAccSecurityGroupRulesExclusiveConfigBase(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigVPCWithSubnets(rName, 0),
+		fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name   = %[1]q
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccSecurityGroupRulesExclusiveConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSecurityGroupRulesExclusiveConfigBase(rName),
+		`
+resource "aws_vpc_security_group_ingress_rule" "test" {
+  security_group_id = aws_security_group.test.id
+
+  cidr_ipv4   = "10.0.0.0/8"
+  from_port   = 80
+  to_port     = 80
+  ip_protocol = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "test" {
+  security_group_id = aws_security_group.test.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "-1"
+}
+
+resource "aws_vpc_security_group_rules_exclusive" "test" {
+  security_group_id = aws_security_group.test.id
+  ingress_rule_ids  = [aws_vpc_security_group_ingress_rule.test.id]
+  egress_rule_ids   = [aws_vpc_security_group_egress_rule.test.id]
+}
+`)
+}
+
+func testAccSecurityGroupRulesExclusiveConfig_multiple(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSecurityGroupRulesExclusiveConfigBase(rName),
+		`
+resource "aws_vpc_security_group_ingress_rule" "test" {
+  security_group_id = aws_security_group.test.id
+
+  cidr_ipv4   = "10.0.0.0/8"
+  from_port   = 80
+  to_port     = 80
+  ip_protocol = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "test2" {
+  security_group_id = aws_security_group.test.id
+
+  cidr_ipv4   = "10.0.0.0/8"
+  from_port   = 443
+  to_port     = 443
+  ip_protocol = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "test3" {
+  security_group_id = aws_security_group.test.id
+
+  cidr_ipv4   = "10.0.0.0/8"
+  from_port   = 8080
+  to_port     = 8080
+  ip_protocol = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "test" {
+  security_group_id = aws_security_group.test.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "-1"
+}
+
+resource "aws_vpc_security_group_egress_rule" "test2" {
+  security_group_id = aws_security_group.test.id
+
+  cidr_ipv6   = "::/0"
+  ip_protocol = "-1"
+}
+
+resource "aws_vpc_security_group_rules_exclusive" "test" {
+  security_group_id = aws_security_group.test.id
+  ingress_rule_ids = [
+    aws_vpc_security_group_ingress_rule.test.id,
+    aws_vpc_security_group_ingress_rule.test2.id,
+    aws_vpc_security_group_ingress_rule.test3.id,
+  ]
+  egress_rule_ids = [
+    aws_vpc_security_group_egress_rule.test.id,
+    aws_vpc_security_group_egress_rule.test2.id,
+  ]
+}
+`)
+}
+
+func testAccSecurityGroupRulesExclusiveConfig_empty(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSecurityGroupRulesExclusiveConfigBase(rName),
+		`
+resource "aws_vpc_security_group_rules_exclusive" "test" {
+  security_group_id = aws_security_group.test.id
+  ingress_rule_ids  = []
+  egress_rule_ids   = []
+}
+`)
+}
+
+func testAccSecurityGroupRulesExclusiveConfig_ingressOnly(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSecurityGroupRulesExclusiveConfigBase(rName),
+		`
+resource "aws_vpc_security_group_ingress_rule" "test" {
+  security_group_id = aws_security_group.test.id
+
+  cidr_ipv4   = "10.0.0.0/8"
+  from_port   = 80
+  to_port     = 80
+  ip_protocol = "tcp"
+}
+
+resource "aws_vpc_security_group_rules_exclusive" "test" {
+  security_group_id = aws_security_group.test.id
+  ingress_rule_ids  = [aws_vpc_security_group_ingress_rule.test.id]
+  egress_rule_ids   = []
+}
+`)
+}
+
+func testAccSecurityGroupRulesExclusiveConfig_egressOnly(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSecurityGroupRulesExclusiveConfigBase(rName),
+		`
+resource "aws_vpc_security_group_egress_rule" "test" {
+  security_group_id = aws_security_group.test.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "-1"
+}
+
+resource "aws_vpc_security_group_rules_exclusive" "test" {
+  security_group_id = aws_security_group.test.id
+  ingress_rule_ids  = []
+  egress_rule_ids   = [aws_vpc_security_group_egress_rule.test.id]
+}
+`)
+}

--- a/website/docs/r/vpc_security_group_rules_exclusive.html.markdown
+++ b/website/docs/r/vpc_security_group_rules_exclusive.html.markdown
@@ -1,0 +1,100 @@
+---
+subcategory: "VPC (Virtual Private Cloud)"
+layout: "aws"
+page_title: "AWS: aws_vpc_security_group_rules_exclusive"
+description: |-
+  Terraform resource for managing an exclusive set of AWS VPC (Virtual Private Cloud) Security Group Rules.
+---
+
+# Resource: aws_vpc_security_group_rules_exclusive
+
+Terraform resource for managing an exclusive set of AWS VPC (Virtual Private Cloud) Security Group Rules.
+
+This resource manages the complete set of ingress and egress rules assigned to a security group. It provides exclusive control by removing any rules not explicitly defined in the configuration.
+
+!> This resource takes exclusive ownership over ingress and egress rules assigned to a security group. This includes removal of rules which are not explicitly configured. To prevent persistent drift, ensure any `aws_vpc_security_group_ingress_rule` and `aws_vpc_security_group_egress_rule` resources managed alongside this resource are included in the `ingress_rule_ids` and `egress_rule_ids` arguments.
+
+~> Destruction of this resource means Terraform will no longer manage reconciliation of the configured security group rules. It **will not** revoke the configured rules from the security group.
+
+~> When this resource detects a configured rule ID which must be created, a warning diagnostic is emitted. This is due to a limitation in the [`AuthorizeSecurityGroupEgress`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AuthorizeSecurityGroupEgress.html) and [`AuthorizeSecurityGroupIngress`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AuthorizeSecurityGroupIngress.html) APIs, which require the full rule definition to be provided rather than a reference to an existing rule ID.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_vpc" "example" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_security_group" "example" {
+  name   = "example"
+  vpc_id = aws_vpc.example.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "example" {
+  security_group_id = aws_security_group.example.id
+
+  cidr_ipv4   = "10.0.0.0/8"
+  from_port   = 80
+  to_port     = 80
+  ip_protocol = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "example" {
+  security_group_id = aws_security_group.example.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "-1"
+}
+
+resource "aws_vpc_security_group_rules_exclusive" "example" {
+  security_group_id = aws_security_group.example.id
+  ingress_rule_ids  = [aws_vpc_security_group_ingress_rule.example.id]
+  egress_rule_ids   = [aws_vpc_security_group_egress_rule.example.id]
+}
+```
+
+### Disallow All Rules
+
+To automatically remove any configured security group rules, set both `ingress_rule_ids` and `egress_rule_ids` to empty lists.
+
+~> This will not __prevent__ rules from being assigned to a security group via Terraform (or any other interface). This resource enables bringing security group rule assignments into a configured state, however, this reconciliation happens only when `apply` is proactively run.
+
+```terraform
+resource "aws_vpc_security_group_rules_exclusive" "example" {
+  security_group_id = aws_security_group.example.id
+  ingress_rule_ids  = []
+  egress_rule_ids   = []
+}
+```
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `egress_rule_ids` - (Required) Egress rule IDs.
+* `ingress_rule_ids` - (Required) Ingress rule IDs.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `security_group_id` - (Required, Forces new resource) ID of the security group.
+
+## Attribute Reference
+
+This resource exports no additional attributes.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import exclusive management of security group rules using the `security_group_id`. For example:
+
+```terraform
+import {
+  to = aws_vpc_security_group_rules_exclusive.example
+  id = "sg-1234567890abcdef0"
+}
+```
+
+Using `terraform import`, import exclusive management of security group rules using the `security_group_id`. For example:
+
+```console
+% terraform import aws_vpc_security_group_rules_exclusive.example sg-1234567890abcdef0
+```


### PR DESCRIPTION



<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This resource will enable Terraform to exclusively manage the rules assigned to a VPC security group.

One notable difference between other `_exclusive` resource types is that rule IDs set in configuration but missing on the remove resource cannot be attached to the security group by this resource. This is because the APIs for assigning egress and ingress rules require the full rule definition, rather than just a rule ID. In this scenario this resource will emit a warning diagnostic directing the user to create a rule with the appropriate ingress/egress resource instead.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39383
Relates #39376

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AuthorizeSecurityGroupEgress.html
- https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AuthorizeSecurityGroupIngress.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=vpc T=TestAccEC2SecurityGroupRulesExclusive_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-sg-rule-exclusive 🌿...
TF_ACC=1 go1.25.5 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2SecurityGroupRulesExclusive_'  -timeout 360m -vet=off
2026/01/08 15:53:18 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/08 15:53:18 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccEC2SecurityGroupRulesExclusive_empty (21.89s)
--- PASS: TestAccEC2SecurityGroupRulesExclusive_ingressOnly (22.52s)
--- PASS: TestAccEC2SecurityGroupRulesExclusive_egressOnly (23.42s)
--- PASS: TestAccEC2SecurityGroupRulesExclusive_disappears_SecurityGroup (25.07s)
--- PASS: TestAccEC2SecurityGroupRulesExclusive_basic (26.61s)
--- PASS: TestAccEC2SecurityGroupRulesExclusive_outOfBandAddition (36.81s)
--- PASS: TestAccEC2SecurityGroupRulesExclusive_multiple (39.25s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        45.919s
```
