### PR TITLE
docs: fix broken example for aws_cloudfront_multitenant_distribution

### DIFF
--- a/website/docs/r/cloudfront_multitenant_distribution.html.markdown
+++ b/website/docs/r/cloudfront_multitenant_distribution.html.markdown
@@ -52,7 +52,7 @@ resource "aws_cloudfront_multitenant_distribution" "example" {
 
   origin {
     domain_name = "example.com"
-    origin_id   = "example-origin"
+    id          = "example-origin"
 
     custom_origin_config {
       http_port              = 80
@@ -67,8 +67,10 @@ resource "aws_cloudfront_multitenant_distribution" "example" {
     viewer_protocol_policy = "redirect-to-https"
     cache_policy_id        = aws_cloudfront_cache_policy.example.id
 
-    allowed_methods = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
-    cached_methods  = ["GET", "HEAD"]
+    allowed_methods {
+      items          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+      cached_methods = ["GET", "HEAD"]
+    }
   }
 
   restrictions {
@@ -80,6 +82,18 @@ resource "aws_cloudfront_multitenant_distribution" "example" {
   viewer_certificate {
     acm_certificate_arn = aws_acm_certificate.example.arn
     ssl_support_method  = "sni-only"
+  }
+
+  tenant_config {
+    parameter_definition {
+      name = "origin_domain"
+      definition {
+        string_schema {
+          required = true
+          comment  = "Origin domain parameter for tenants"
+        }
+      }
+    }
   }
 
   tags = {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

The example code for [`aws_cloudfront_multitenant_distribution`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_multitenant_distribution) is not working. A `terraform plan` fails with multiple errors

```shell
 Error: Missing required argument
│ 
│   on main.tf line 19, in resource "aws_cloudfront_multitenant_distribution" "example":
│   19:   origin {
│ 
│ The argument "id" is required, but no definition was found.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 21, in resource "aws_cloudfront_multitenant_distribution" "example":
│   21:     origin_id   = "example-origin"
│ 
│ An argument named "origin_id" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 36, in resource "aws_cloudfront_multitenant_distribution" "example":
│   36:     allowed_methods = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
│ 
│ An argument named "allowed_methods" is not expected here. Did you mean to define a block of type "allowed_methods"?
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 37, in resource "aws_cloudfront_multitenant_distribution" "example":
│   37:     cached_methods  = ["GET", "HEAD"]
│ 
│ An argument named "cached_methods" is not expected here.
```

and also 

```shell
│ Error: Invalid Block
│ 
│   with aws_cloudfront_multitenant_distribution.example,
│   on main.tf line 15, in resource "aws_cloudfront_multitenant_distribution" "example":
│   15: resource "aws_cloudfront_multitenant_distribution" "example" {
│ 
│ Block tenant_config must have a configuration value as the provider has marked it as required
```

This PR updates the example by 

- renaming `origin_id` to `id`
- moving `allowed_methods` and `cached_methods` into the expected structure.
- adding a `tenant_config`

### Relations


Closes #45872 

### References

References to the source code sections 

- [`tenant_config` in source code](https://github.com/hashicorp/terraform-provider-aws/blob/417ded9ccf0938a673d12cfbf290e25a45ca14fe/internal/service/cloudfront/multitenant_distribution.go#L594)
- [`id` of `origin`](https://github.com/hashicorp/terraform-provider-aws/blob/417ded9ccf0938a673d12cfbf290e25a45ca14fe/internal/service/cloudfront/multitenant_distribution.go#L420) 
- [`allowed_methods`](https://github.com/hashicorp/terraform-provider-aws/blob/417ded9ccf0938a673d12cfbf290e25a45ca14fe/internal/service/cloudfront/multitenant_distribution.go#L217)


### Output from Acceptance Testing

Not applicable. Only documentation is updated.
