### PR TITLE
amplify: enable `go-vcr` support

### DIFF
--- a/internal/service/amplify/app.go
+++ b/internal/service/amplify/app.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/amplify/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -31,6 +30,8 @@ import (
 // @SDKResource("aws_amplify_app", name="App")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/amplify/types;types.App", serialize=true, serializeDelay=true)
+// @Testing(existsTakesT=true)
+// @Testing(destroyTakesT=true)
 func resourceApp() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAppCreate,
@@ -660,9 +661,8 @@ func findAppByID(ctx context.Context, conn *amplify.Client, id string) (*types.A
 	output, err := conn.GetApp(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: &input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/amplify/app_tags_gen_test.go
+++ b/internal/service/amplify/app_tags_gen_test.go
@@ -62,7 +62,7 @@ func testAccAmplifyApp_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -74,7 +74,7 @@ func testAccAmplifyApp_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -118,7 +118,7 @@ func testAccAmplifyApp_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -166,7 +166,7 @@ func testAccAmplifyApp_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -207,7 +207,7 @@ func testAccAmplifyApp_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -248,7 +248,7 @@ func testAccAmplifyApp_tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -260,7 +260,7 @@ func testAccAmplifyApp_tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -319,7 +319,7 @@ func testAccAmplifyApp_tags_EmptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -329,7 +329,7 @@ func testAccAmplifyApp_tags_EmptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -386,7 +386,7 @@ func testAccAmplifyApp_tags_AddOnUpdate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -396,7 +396,7 @@ func testAccAmplifyApp_tags_AddOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -420,7 +420,7 @@ func testAccAmplifyApp_tags_AddOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -471,7 +471,7 @@ func testAccAmplifyApp_tags_EmptyTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -483,7 +483,7 @@ func testAccAmplifyApp_tags_EmptyTag_OnCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -523,7 +523,7 @@ func testAccAmplifyApp_tags_EmptyTag_OnCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -564,7 +564,7 @@ func testAccAmplifyApp_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -576,7 +576,7 @@ func testAccAmplifyApp_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -608,7 +608,7 @@ func testAccAmplifyApp_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -654,7 +654,7 @@ func testAccAmplifyApp_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -705,7 +705,7 @@ func testAccAmplifyApp_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -717,7 +717,7 @@ func testAccAmplifyApp_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -748,7 +748,7 @@ func testAccAmplifyApp_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -798,7 +798,7 @@ func testAccAmplifyApp_tags_DefaultTags_providerOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckAppDestroy(ctx),
+		CheckDestroy: testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -811,7 +811,7 @@ func testAccAmplifyApp_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -855,7 +855,7 @@ func testAccAmplifyApp_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -901,7 +901,7 @@ func testAccAmplifyApp_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -941,7 +941,7 @@ func testAccAmplifyApp_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -983,7 +983,7 @@ func testAccAmplifyApp_tags_DefaultTags_nonOverlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckAppDestroy(ctx),
+		CheckDestroy: testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -998,7 +998,7 @@ func testAccAmplifyApp_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1052,7 +1052,7 @@ func testAccAmplifyApp_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1105,7 +1105,7 @@ func testAccAmplifyApp_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1147,7 +1147,7 @@ func testAccAmplifyApp_tags_DefaultTags_overlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckAppDestroy(ctx),
+		CheckDestroy: testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1162,7 +1162,7 @@ func testAccAmplifyApp_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1215,7 +1215,7 @@ func testAccAmplifyApp_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1272,7 +1272,7 @@ func testAccAmplifyApp_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1327,7 +1327,7 @@ func testAccAmplifyApp_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckAppDestroy(ctx),
+		CheckDestroy: testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1339,7 +1339,7 @@ func testAccAmplifyApp_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1372,7 +1372,7 @@ func testAccAmplifyApp_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1421,7 +1421,7 @@ func testAccAmplifyApp_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckAppDestroy(ctx),
+		CheckDestroy: testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1434,7 +1434,7 @@ func testAccAmplifyApp_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1462,7 +1462,7 @@ func testAccAmplifyApp_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1514,7 +1514,7 @@ func testAccAmplifyApp_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckAppDestroy(ctx),
+		CheckDestroy: testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1529,7 +1529,7 @@ func testAccAmplifyApp_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1583,7 +1583,7 @@ func testAccAmplifyApp_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckAppDestroy(ctx),
+		CheckDestroy: testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1596,7 +1596,7 @@ func testAccAmplifyApp_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1644,7 +1644,7 @@ func testAccAmplifyApp_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckAppDestroy(ctx),
+		CheckDestroy: testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1659,7 +1659,7 @@ func testAccAmplifyApp_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T)
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1710,7 +1710,7 @@ func testAccAmplifyApp_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckAppDestroy(ctx),
+		CheckDestroy: testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1725,7 +1725,7 @@ func testAccAmplifyApp_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1776,7 +1776,7 @@ func testAccAmplifyApp_tags_ComputedTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckAppDestroy(ctx),
+		CheckDestroy: testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1786,7 +1786,7 @@ func testAccAmplifyApp_tags_ComputedTag_OnCreate(t *testing.T) {
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1835,7 +1835,7 @@ func testAccAmplifyApp_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckAppDestroy(ctx),
+		CheckDestroy: testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1847,7 +1847,7 @@ func testAccAmplifyApp_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1879,7 +1879,7 @@ func testAccAmplifyApp_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1936,7 +1936,7 @@ func testAccAmplifyApp_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckAppDestroy(ctx),
+		CheckDestroy: testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1948,7 +1948,7 @@ func testAccAmplifyApp_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1978,7 +1978,7 @@ func testAccAmplifyApp_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2027,7 +2027,7 @@ func testAccAmplifyApp_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckAppDestroy(ctx),
+		CheckDestroy: testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2046,7 +2046,7 @@ func testAccAmplifyApp_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2095,7 +2095,7 @@ func testAccAmplifyApp_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2144,7 +2144,7 @@ func testAccAmplifyApp_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2193,7 +2193,7 @@ func testAccAmplifyApp_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckAppDestroy(ctx),
+		CheckDestroy: testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2210,7 +2210,7 @@ func testAccAmplifyApp_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2273,7 +2273,7 @@ func testAccAmplifyApp_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2336,7 +2336,7 @@ func testAccAmplifyApp_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &v),
+					testAccCheckAppExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/amplify/app_test.go
+++ b/internal/service/amplify/app_test.go
@@ -13,12 +13,10 @@ import (
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/amplify/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfamplify "github.com/hashicorp/terraform-provider-aws/internal/service/amplify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -27,19 +25,19 @@ import (
 func testAccApp_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var app types.App
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAppConfig_name(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckNoResourceAttr(resourceName, "access_token"),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(`apps/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "auto_branch_creation_config.#", "0"),
@@ -81,19 +79,19 @@ func testAccApp_basic(t *testing.T) {
 func testAccApp_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var app types.App
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAppConfig_name(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfamplify.ResourceApp(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -105,20 +103,20 @@ func testAccApp_disappears(t *testing.T) {
 func testAccApp_AutoBranchCreationConfig(t *testing.T) {
 	ctx := acctest.Context(t)
 	var app types.App
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 	credentials := base64.StdEncoding.EncodeToString([]byte("username1:password1"))
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAppConfig_autoBranchCreationNoAutoBranchCreation(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "auto_branch_creation_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "auto_branch_creation_config.0.basic_auth_credentials", ""),
 					resource.TestCheckResourceAttr(resourceName, "auto_branch_creation_config.0.build_spec", ""),
@@ -139,7 +137,7 @@ func testAccApp_AutoBranchCreationConfig(t *testing.T) {
 			{
 				Config: testAccAppConfig_autoBranchCreationAutoBranchCreation(rName, credentials),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "auto_branch_creation_config.#", "1"),
 					// resource.TestCheckResourceAttr(resourceName, "auto_branch_creation_config.0.basic_auth_credentials", credentials),
 					resource.TestCheckResourceAttr(resourceName, "auto_branch_creation_config.0.build_spec", "version: 0.1"),
@@ -166,7 +164,7 @@ func testAccApp_AutoBranchCreationConfig(t *testing.T) {
 			{
 				Config: testAccAppConfig_autoBranchCreationAutoBranchCreationUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "auto_branch_creation_config.#", "1"),
 					// Clearing basic_auth_credentials not reflected in API.
 					// resource.TestCheckResourceAttr(resourceName, "auto_branch_creation_config.0.basic_auth_credentials", ""),
@@ -187,7 +185,7 @@ func testAccApp_AutoBranchCreationConfig(t *testing.T) {
 			{
 				Config: testAccAppConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					// No change is reflected in API.
 					// resource.TestCheckResourceAttr(resourceName, "auto_branch_creation_config.#", "0"),
 					// resource.TestCheckResourceAttr(resourceName, "auto_branch_creation_patterns.#", "0"),
@@ -201,21 +199,21 @@ func testAccApp_AutoBranchCreationConfig(t *testing.T) {
 func testAccApp_BasicAuthCredentials(t *testing.T) {
 	ctx := acctest.Context(t)
 	var app types.App
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 	credentials1 := base64.StdEncoding.EncodeToString([]byte("username1:password1"))
 	credentials2 := base64.StdEncoding.EncodeToString([]byte("username2:password2"))
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAppConfig_basicAuthCredentials(rName, credentials1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "basic_auth_credentials", credentials1),
 					resource.TestCheckResourceAttr(resourceName, "enable_basic_auth", acctest.CtTrue),
 				),
@@ -228,7 +226,7 @@ func testAccApp_BasicAuthCredentials(t *testing.T) {
 			{
 				Config: testAccAppConfig_basicAuthCredentials(rName, credentials2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "basic_auth_credentials", credentials2),
 					resource.TestCheckResourceAttr(resourceName, "enable_basic_auth", acctest.CtTrue),
 				),
@@ -236,7 +234,7 @@ func testAccApp_BasicAuthCredentials(t *testing.T) {
 			{
 				Config: testAccAppConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					// Clearing basic_auth_credentials not reflected in API.
 					// resource.TestCheckResourceAttr(resourceName, "basic_auth_credentials", ""),
 					resource.TestCheckResourceAttr(resourceName, "enable_basic_auth", acctest.CtFalse),
@@ -249,19 +247,19 @@ func testAccApp_BasicAuthCredentials(t *testing.T) {
 func testAccApp_BuildSpec(t *testing.T) {
 	ctx := acctest.Context(t)
 	var app types.App
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAppConfig_buildSpec(rName, "version: 0.1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "build_spec", "version: 0.1"),
 				),
 			},
@@ -273,14 +271,14 @@ func testAccApp_BuildSpec(t *testing.T) {
 			{
 				Config: testAccAppConfig_buildSpec(rName, "version: 0.2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "build_spec", "version: 0.2"),
 				),
 			},
 			{
 				Config: testAccAppConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					// build_spec is Computed.
 					resource.TestCheckResourceAttr(resourceName, "build_spec", "version: 0.2"),
 				),
@@ -292,19 +290,19 @@ func testAccApp_BuildSpec(t *testing.T) {
 func testAccApp_CacheConfig(t *testing.T) {
 	ctx := acctest.Context(t)
 	var app types.App
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAppConfig_cacheConfig(rName, "AMPLIFY_MANAGED"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "cache_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "cache_config.0.type", "AMPLIFY_MANAGED"),
 				),
@@ -317,7 +315,7 @@ func testAccApp_CacheConfig(t *testing.T) {
 			{
 				Config: testAccAppConfig_cacheConfig(rName, "AMPLIFY_MANAGED_NO_COOKIES"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "cache_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "cache_config.0.type", "AMPLIFY_MANAGED_NO_COOKIES"),
 				),
@@ -329,16 +327,16 @@ func testAccApp_CacheConfig(t *testing.T) {
 func testAccApp_ComputeRole(t *testing.T) {
 	ctx := acctest.Context(t)
 	var app types.App
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 	computeRole1ResourceName := "aws_iam_role.compute_test1"
 	computeRole2ResourceName := "aws_iam_role.compute_test2"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAppConfig_computeRoleARN(rName),
@@ -348,7 +346,7 @@ func testAccApp_ComputeRole(t *testing.T) {
 					},
 				},
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttrPair(resourceName, "compute_role_arn", computeRole1ResourceName, names.AttrARN)),
 			},
 			{
@@ -364,7 +362,7 @@ func testAccApp_ComputeRole(t *testing.T) {
 					},
 				},
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttrPair(resourceName, "compute_role_arn", computeRole2ResourceName, names.AttrARN),
 				),
 			},
@@ -376,7 +374,7 @@ func testAccApp_ComputeRole(t *testing.T) {
 					},
 				},
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "compute_role_arn", ""),
 				),
 			},
@@ -387,19 +385,19 @@ func testAccApp_ComputeRole(t *testing.T) {
 func testAccApp_CustomRules(t *testing.T) {
 	ctx := acctest.Context(t)
 	var app types.App
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAppConfig_customRules(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "custom_rule.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "custom_rule.0.source", "/<*>"),
 					resource.TestCheckResourceAttr(resourceName, "custom_rule.0.status", "404"),
@@ -427,7 +425,7 @@ func testAccApp_CustomRules(t *testing.T) {
 			{
 				Config: testAccAppConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "custom_rule.#", "0"),
 				),
 			},
@@ -438,19 +436,19 @@ func testAccApp_CustomRules(t *testing.T) {
 func testAccApp_JobConfig(t *testing.T) {
 	ctx := acctest.Context(t)
 	var app types.App
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAppConfig_jobConfig(rName, "LARGE_16GB"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "job_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "job_config.0.build_compute_type", "LARGE_16GB"),
 				),
@@ -463,7 +461,7 @@ func testAccApp_JobConfig(t *testing.T) {
 			{
 				Config: testAccAppConfig_jobConfig(rName, "STANDARD_8GB"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "job_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "job_config.0.build_compute_type", "STANDARD_8GB"),
 				),
@@ -475,14 +473,14 @@ func testAccApp_JobConfig(t *testing.T) {
 func testAccApp_Description(t *testing.T) {
 	ctx := acctest.Context(t)
 	var app types.App
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAppConfig_description(rName, "description 1"),
@@ -492,7 +490,7 @@ func testAccApp_Description(t *testing.T) {
 					},
 				},
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description 1"),
 				),
 			},
@@ -509,7 +507,7 @@ func testAccApp_Description(t *testing.T) {
 					},
 				},
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description 2"),
 				),
 			},
@@ -521,7 +519,7 @@ func testAccApp_Description(t *testing.T) {
 					},
 				},
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 				),
 			},
@@ -532,19 +530,19 @@ func testAccApp_Description(t *testing.T) {
 func testAccApp_EnvironmentVariables(t *testing.T) {
 	ctx := acctest.Context(t)
 	var app types.App
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAppConfig_environmentVariables(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "environment_variables.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "environment_variables.ENVVAR1", "1"),
 				),
@@ -557,7 +555,7 @@ func testAccApp_EnvironmentVariables(t *testing.T) {
 			{
 				Config: testAccAppConfig_environmentVariablesUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "environment_variables.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "environment_variables.ENVVAR1", "2"),
 					resource.TestCheckResourceAttr(resourceName, "environment_variables.ENVVAR2", "2"),
@@ -566,7 +564,7 @@ func testAccApp_EnvironmentVariables(t *testing.T) {
 			{
 				Config: testAccAppConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "environment_variables.%", "0"),
 				),
 			},
@@ -577,16 +575,16 @@ func testAccApp_EnvironmentVariables(t *testing.T) {
 func testAccApp_IAMServiceRole(t *testing.T) {
 	ctx := acctest.Context(t)
 	var app types.App
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 	iamRole1ResourceName := "aws_iam_role.test1"
 	iamRole2ResourceName := "aws_iam_role.test2"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAppConfig_iamServiceRoleARN(rName),
@@ -596,7 +594,7 @@ func testAccApp_IAMServiceRole(t *testing.T) {
 					},
 				},
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttrPair(resourceName, "iam_service_role_arn", iamRole1ResourceName, names.AttrARN)),
 			},
 			{
@@ -612,7 +610,7 @@ func testAccApp_IAMServiceRole(t *testing.T) {
 					},
 				},
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttrPair(resourceName, "iam_service_role_arn", iamRole2ResourceName, names.AttrARN),
 				),
 			},
@@ -624,7 +622,7 @@ func testAccApp_IAMServiceRole(t *testing.T) {
 					},
 				},
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "iam_service_role_arn", ""),
 				),
 			},
@@ -635,20 +633,20 @@ func testAccApp_IAMServiceRole(t *testing.T) {
 func testAccApp_Name(t *testing.T) {
 	ctx := acctest.Context(t)
 	var app types.App
-	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAppConfig_name(rName1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName1),
 				),
 			},
@@ -660,7 +658,7 @@ func testAccApp_Name(t *testing.T) {
 			{
 				Config: testAccAppConfig_name(rName2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName2),
 				),
 			},
@@ -683,19 +681,19 @@ func testAccApp_Repository(t *testing.T) {
 	}
 
 	var app types.App
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_app.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		CheckDestroy:             testAccCheckAppDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAppConfig_repository(rName, repository, accessToken),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAppExists(ctx, resourceName, &app),
+					testAccCheckAppExists(ctx, t, resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "access_token", accessToken),
 					resource.TestCheckResourceAttr(resourceName, "repository", repository),
 				),
@@ -712,7 +710,7 @@ func testAccApp_Repository(t *testing.T) {
 	})
 }
 
-func testAccCheckAppExists(ctx context.Context, n string, v *types.App) resource.TestCheckFunc {
+func testAccCheckAppExists(ctx context.Context, t *testing.T, n string, v *types.App) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -723,7 +721,7 @@ func testAccCheckAppExists(ctx context.Context, n string, v *types.App) resource
 			return fmt.Errorf("No Amplify App ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AmplifyClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).AmplifyClient(ctx)
 
 		output, err := tfamplify.FindAppByID(ctx, conn, rs.Primary.ID)
 
@@ -737,9 +735,9 @@ func testAccCheckAppExists(ctx context.Context, n string, v *types.App) resource
 	}
 }
 
-func testAccCheckAppDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckAppDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AmplifyClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).AmplifyClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_amplify_app" {

--- a/internal/service/amplify/backend_environment.go
+++ b/internal/service/amplify/backend_environment.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/amplify"
 	"github.com/aws/aws-sdk-go-v2/service/amplify/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -168,9 +167,8 @@ func findBackendEnvironmentByTwoPartKey(ctx context.Context, conn *amplify.Clien
 	output, err := conn.GetBackendEnvironment(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: &input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/amplify/backend_environment_test.go
+++ b/internal/service/amplify/backend_environment_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfamplify "github.com/hashicorp/terraform-provider-aws/internal/service/amplify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -23,21 +22,21 @@ import (
 func testAccBackendEnvironment_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var env types.BackendEnvironment
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_backend_environment.test"
 
 	environmentName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlpha)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBackendEnvironmentDestroy(ctx),
+		CheckDestroy:             testAccCheckBackendEnvironmentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBackendEnvironmentConfig_basic(rName, environmentName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBackendEnvironmentExists(ctx, resourceName, &env),
+					testAccCheckBackendEnvironmentExists(ctx, t, resourceName, &env),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(`apps/[^/]+/backendenvironments/.+`)),
 					resource.TestCheckResourceAttrSet(resourceName, "deployment_artifacts"),
 					resource.TestCheckResourceAttr(resourceName, "environment_name", environmentName),
@@ -56,21 +55,21 @@ func testAccBackendEnvironment_basic(t *testing.T) {
 func testAccBackendEnvironment_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var env types.BackendEnvironment
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_backend_environment.test"
 
 	environmentName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlpha)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBackendEnvironmentDestroy(ctx),
+		CheckDestroy:             testAccCheckBackendEnvironmentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBackendEnvironmentConfig_basic(rName, environmentName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBackendEnvironmentExists(ctx, resourceName, &env),
+					testAccCheckBackendEnvironmentExists(ctx, t, resourceName, &env),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfamplify.ResourceBackendEnvironment(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -82,21 +81,21 @@ func testAccBackendEnvironment_disappears(t *testing.T) {
 func testAccBackendEnvironment_DeploymentArtifacts_StackName(t *testing.T) {
 	ctx := acctest.Context(t)
 	var env types.BackendEnvironment
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_backend_environment.test"
 
 	environmentName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlpha)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBackendEnvironmentDestroy(ctx),
+		CheckDestroy:             testAccCheckBackendEnvironmentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBackendEnvironmentConfig_deploymentArtifactsAndStackName(rName, environmentName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBackendEnvironmentExists(ctx, resourceName, &env),
+					testAccCheckBackendEnvironmentExists(ctx, t, resourceName, &env),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(`apps/[^/]+/backendenvironments/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "deployment_artifacts", rName),
 					resource.TestCheckResourceAttr(resourceName, "environment_name", environmentName),
@@ -112,14 +111,14 @@ func testAccBackendEnvironment_DeploymentArtifacts_StackName(t *testing.T) {
 	})
 }
 
-func testAccCheckBackendEnvironmentExists(ctx context.Context, resourceName string, v *types.BackendEnvironment) resource.TestCheckFunc {
+func testAccCheckBackendEnvironmentExists(ctx context.Context, t *testing.T, resourceName string, v *types.BackendEnvironment) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AmplifyClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).AmplifyClient(ctx)
 
 		output, err := tfamplify.FindBackendEnvironmentByTwoPartKey(ctx, conn, rs.Primary.Attributes["app_id"], rs.Primary.Attributes["environment_name"])
 
@@ -133,9 +132,9 @@ func testAccCheckBackendEnvironmentExists(ctx context.Context, resourceName stri
 	}
 }
 
-func testAccCheckBackendEnvironmentDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckBackendEnvironmentDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AmplifyClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).AmplifyClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_amplify_backend_environment" {

--- a/internal/service/amplify/branch.go
+++ b/internal/service/amplify/branch.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/amplify"
 	"github.com/aws/aws-sdk-go-v2/service/amplify/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -32,6 +31,8 @@ import (
 // @SDKResource("aws_amplify_branch", name="Branch")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/amplify/types;types.Branch", serialize=true, serializeDelay=true)
+// @Testing(existsTakesT=true)
+// @Testing(destroyTakesT=true)
 func resourceBranch() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBranchCreate,
@@ -433,9 +434,8 @@ func findBranchByTwoPartKey(ctx context.Context, conn *amplify.Client, appID, br
 	output, err := conn.GetBranch(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: &input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/amplify/branch_tags_gen_test.go
+++ b/internal/service/amplify/branch_tags_gen_test.go
@@ -62,7 +62,7 @@ func testAccAmplifyBranch_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy:             testAccCheckBranchDestroy(ctx),
+		CheckDestroy:             testAccCheckBranchDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -74,7 +74,7 @@ func testAccAmplifyBranch_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -118,7 +118,7 @@ func testAccAmplifyBranch_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -166,7 +166,7 @@ func testAccAmplifyBranch_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -207,7 +207,7 @@ func testAccAmplifyBranch_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -248,7 +248,7 @@ func testAccAmplifyBranch_tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy:             testAccCheckBranchDestroy(ctx),
+		CheckDestroy:             testAccCheckBranchDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -260,7 +260,7 @@ func testAccAmplifyBranch_tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -319,7 +319,7 @@ func testAccAmplifyBranch_tags_EmptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy:             testAccCheckBranchDestroy(ctx),
+		CheckDestroy:             testAccCheckBranchDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -329,7 +329,7 @@ func testAccAmplifyBranch_tags_EmptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -386,7 +386,7 @@ func testAccAmplifyBranch_tags_AddOnUpdate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy:             testAccCheckBranchDestroy(ctx),
+		CheckDestroy:             testAccCheckBranchDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -396,7 +396,7 @@ func testAccAmplifyBranch_tags_AddOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -420,7 +420,7 @@ func testAccAmplifyBranch_tags_AddOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -471,7 +471,7 @@ func testAccAmplifyBranch_tags_EmptyTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy:             testAccCheckBranchDestroy(ctx),
+		CheckDestroy:             testAccCheckBranchDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -483,7 +483,7 @@ func testAccAmplifyBranch_tags_EmptyTag_OnCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -523,7 +523,7 @@ func testAccAmplifyBranch_tags_EmptyTag_OnCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -564,7 +564,7 @@ func testAccAmplifyBranch_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy:             testAccCheckBranchDestroy(ctx),
+		CheckDestroy:             testAccCheckBranchDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -576,7 +576,7 @@ func testAccAmplifyBranch_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -608,7 +608,7 @@ func testAccAmplifyBranch_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -654,7 +654,7 @@ func testAccAmplifyBranch_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -705,7 +705,7 @@ func testAccAmplifyBranch_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy:             testAccCheckBranchDestroy(ctx),
+		CheckDestroy:             testAccCheckBranchDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -717,7 +717,7 @@ func testAccAmplifyBranch_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -748,7 +748,7 @@ func testAccAmplifyBranch_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -798,7 +798,7 @@ func testAccAmplifyBranch_tags_DefaultTags_providerOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckBranchDestroy(ctx),
+		CheckDestroy: testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -811,7 +811,7 @@ func testAccAmplifyBranch_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -855,7 +855,7 @@ func testAccAmplifyBranch_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -901,7 +901,7 @@ func testAccAmplifyBranch_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -941,7 +941,7 @@ func testAccAmplifyBranch_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -983,7 +983,7 @@ func testAccAmplifyBranch_tags_DefaultTags_nonOverlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckBranchDestroy(ctx),
+		CheckDestroy: testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -998,7 +998,7 @@ func testAccAmplifyBranch_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1052,7 +1052,7 @@ func testAccAmplifyBranch_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1105,7 +1105,7 @@ func testAccAmplifyBranch_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1147,7 +1147,7 @@ func testAccAmplifyBranch_tags_DefaultTags_overlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckBranchDestroy(ctx),
+		CheckDestroy: testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1162,7 +1162,7 @@ func testAccAmplifyBranch_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1215,7 +1215,7 @@ func testAccAmplifyBranch_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1272,7 +1272,7 @@ func testAccAmplifyBranch_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1327,7 +1327,7 @@ func testAccAmplifyBranch_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckBranchDestroy(ctx),
+		CheckDestroy: testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1339,7 +1339,7 @@ func testAccAmplifyBranch_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1372,7 +1372,7 @@ func testAccAmplifyBranch_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1421,7 +1421,7 @@ func testAccAmplifyBranch_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckBranchDestroy(ctx),
+		CheckDestroy: testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1434,7 +1434,7 @@ func testAccAmplifyBranch_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1462,7 +1462,7 @@ func testAccAmplifyBranch_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1514,7 +1514,7 @@ func testAccAmplifyBranch_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckBranchDestroy(ctx),
+		CheckDestroy: testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1529,7 +1529,7 @@ func testAccAmplifyBranch_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1583,7 +1583,7 @@ func testAccAmplifyBranch_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckBranchDestroy(ctx),
+		CheckDestroy: testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1596,7 +1596,7 @@ func testAccAmplifyBranch_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1644,7 +1644,7 @@ func testAccAmplifyBranch_tags_DefaultTags_nullOverlappingResourceTag(t *testing
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckBranchDestroy(ctx),
+		CheckDestroy: testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1659,7 +1659,7 @@ func testAccAmplifyBranch_tags_DefaultTags_nullOverlappingResourceTag(t *testing
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1710,7 +1710,7 @@ func testAccAmplifyBranch_tags_DefaultTags_nullNonOverlappingResourceTag(t *test
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckBranchDestroy(ctx),
+		CheckDestroy: testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1725,7 +1725,7 @@ func testAccAmplifyBranch_tags_DefaultTags_nullNonOverlappingResourceTag(t *test
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1776,7 +1776,7 @@ func testAccAmplifyBranch_tags_ComputedTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckBranchDestroy(ctx),
+		CheckDestroy: testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1786,7 +1786,7 @@ func testAccAmplifyBranch_tags_ComputedTag_OnCreate(t *testing.T) {
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1835,7 +1835,7 @@ func testAccAmplifyBranch_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckBranchDestroy(ctx),
+		CheckDestroy: testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1847,7 +1847,7 @@ func testAccAmplifyBranch_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1879,7 +1879,7 @@ func testAccAmplifyBranch_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1936,7 +1936,7 @@ func testAccAmplifyBranch_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckBranchDestroy(ctx),
+		CheckDestroy: testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1948,7 +1948,7 @@ func testAccAmplifyBranch_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1978,7 +1978,7 @@ func testAccAmplifyBranch_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2027,7 +2027,7 @@ func testAccAmplifyBranch_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckBranchDestroy(ctx),
+		CheckDestroy: testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2046,7 +2046,7 @@ func testAccAmplifyBranch_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2095,7 +2095,7 @@ func testAccAmplifyBranch_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2144,7 +2144,7 @@ func testAccAmplifyBranch_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2193,7 +2193,7 @@ func testAccAmplifyBranch_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
-		CheckDestroy: testAccCheckBranchDestroy(ctx),
+		CheckDestroy: testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2210,7 +2210,7 @@ func testAccAmplifyBranch_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2273,7 +2273,7 @@ func testAccAmplifyBranch_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2336,7 +2336,7 @@ func testAccAmplifyBranch_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &v),
+					testAccCheckBranchExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/amplify/branch_test.go
+++ b/internal/service/amplify/branch_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfamplify "github.com/hashicorp/terraform-provider-aws/internal/service/amplify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -24,19 +23,19 @@ import (
 func testAccBranch_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var branch types.Branch
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_branch.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBranchDestroy(ctx),
+		CheckDestroy:             testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBranchConfig_name(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &branch),
+					testAccCheckBranchExists(ctx, t, resourceName, &branch),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(`apps/.+/branches/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "associated_resources.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "backend_environment_arn", ""),
@@ -73,19 +72,19 @@ func testAccBranch_basic(t *testing.T) {
 func testAccBranch_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var branch types.Branch
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_branch.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBranchDestroy(ctx),
+		CheckDestroy:             testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBranchConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &branch),
+					testAccCheckBranchExists(ctx, t, resourceName, &branch),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfamplify.ResourceBranch(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -97,22 +96,22 @@ func testAccBranch_disappears(t *testing.T) {
 func testAccBranch_BasicAuthCredentials(t *testing.T) {
 	ctx := acctest.Context(t)
 	var branch types.Branch
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_branch.test"
 
 	credentials1 := base64.StdEncoding.EncodeToString([]byte("username1:password1"))
 	credentials2 := base64.StdEncoding.EncodeToString([]byte("username2:password2"))
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBranchDestroy(ctx),
+		CheckDestroy:             testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBranchConfig_basicAuthCredentials(rName, credentials1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &branch),
+					testAccCheckBranchExists(ctx, t, resourceName, &branch),
 					resource.TestCheckResourceAttr(resourceName, "basic_auth_credentials", credentials1),
 					resource.TestCheckResourceAttr(resourceName, "enable_basic_auth", acctest.CtTrue),
 				),
@@ -125,7 +124,7 @@ func testAccBranch_BasicAuthCredentials(t *testing.T) {
 			{
 				Config: testAccBranchConfig_basicAuthCredentials(rName, credentials2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &branch),
+					testAccCheckBranchExists(ctx, t, resourceName, &branch),
 					resource.TestCheckResourceAttr(resourceName, "basic_auth_credentials", credentials2),
 					resource.TestCheckResourceAttr(resourceName, "enable_basic_auth", acctest.CtTrue),
 				),
@@ -133,7 +132,7 @@ func testAccBranch_BasicAuthCredentials(t *testing.T) {
 			{
 				Config: testAccBranchConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &branch),
+					testAccCheckBranchExists(ctx, t, resourceName, &branch),
 					// Clearing basic_auth_credentials not reflected in API.
 					// resource.TestCheckResourceAttr(resourceName, "basic_auth_credentials", ""),
 					resource.TestCheckResourceAttr(resourceName, "enable_basic_auth", acctest.CtFalse),
@@ -146,19 +145,19 @@ func testAccBranch_BasicAuthCredentials(t *testing.T) {
 func testAccBranch_EnvironmentVariables(t *testing.T) {
 	ctx := acctest.Context(t)
 	var branch types.Branch
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_branch.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBranchDestroy(ctx),
+		CheckDestroy:             testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBranchConfig_environmentVariables(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &branch),
+					testAccCheckBranchExists(ctx, t, resourceName, &branch),
 					resource.TestCheckResourceAttr(resourceName, "environment_variables.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "environment_variables.ENVVAR1", "1"),
 				),
@@ -171,7 +170,7 @@ func testAccBranch_EnvironmentVariables(t *testing.T) {
 			{
 				Config: testAccBranchConfig_environmentVariablesUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &branch),
+					testAccCheckBranchExists(ctx, t, resourceName, &branch),
 					resource.TestCheckResourceAttr(resourceName, "environment_variables.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "environment_variables.ENVVAR1", "2"),
 					resource.TestCheckResourceAttr(resourceName, "environment_variables.ENVVAR2", "2"),
@@ -180,7 +179,7 @@ func testAccBranch_EnvironmentVariables(t *testing.T) {
 			{
 				Config: testAccBranchConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &branch),
+					testAccCheckBranchExists(ctx, t, resourceName, &branch),
 					resource.TestCheckResourceAttr(resourceName, "environment_variables.%", "0"),
 				),
 			},
@@ -191,22 +190,22 @@ func testAccBranch_EnvironmentVariables(t *testing.T) {
 func testAccBranch_OptionalArguments(t *testing.T) {
 	ctx := acctest.Context(t)
 	var branch types.Branch
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	environmentName := sdkacctest.RandStringFromCharSet(9, sdkacctest.CharSetAlpha)
 	resourceName := "aws_amplify_branch.test"
 	backendEnvironment1ResourceName := "aws_amplify_backend_environment.test1"
 	backendEnvironment2ResourceName := "aws_amplify_backend_environment.test2"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBranchDestroy(ctx),
+		CheckDestroy:             testAccCheckBranchDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBranchConfig_optionalArguments(rName, environmentName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &branch),
+					testAccCheckBranchExists(ctx, t, resourceName, &branch),
 					resource.TestCheckResourceAttrPair(resourceName, "backend_environment_arn", backendEnvironment1ResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "testdescription1"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDisplayName, "testdisplayname1"),
@@ -229,7 +228,7 @@ func testAccBranch_OptionalArguments(t *testing.T) {
 			{
 				Config: testAccBranchConfig_optionalArgumentsUpdated(rName, environmentName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBranchExists(ctx, resourceName, &branch),
+					testAccCheckBranchExists(ctx, t, resourceName, &branch),
 					resource.TestCheckResourceAttrPair(resourceName, "backend_environment_arn", backendEnvironment2ResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "testdescription2"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDisplayName, "testdisplayname2"),
@@ -247,14 +246,14 @@ func testAccBranch_OptionalArguments(t *testing.T) {
 	})
 }
 
-func testAccCheckBranchExists(ctx context.Context, resourceName string, v *types.Branch) resource.TestCheckFunc {
+func testAccCheckBranchExists(ctx context.Context, t *testing.T, resourceName string, v *types.Branch) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AmplifyClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).AmplifyClient(ctx)
 
 		output, err := tfamplify.FindBranchByTwoPartKey(ctx, conn, rs.Primary.Attributes["app_id"], rs.Primary.Attributes["branch_name"])
 
@@ -268,9 +267,9 @@ func testAccCheckBranchExists(ctx context.Context, resourceName string, v *types
 	}
 }
 
-func testAccCheckBranchDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckBranchDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AmplifyClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).AmplifyClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_amplify_branch" {

--- a/internal/service/amplify/domain_association.go
+++ b/internal/service/amplify/domain_association.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/amplify"
 	"github.com/aws/aws-sdk-go-v2/service/amplify/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -280,9 +279,8 @@ func findDomainAssociationByTwoPartKey(ctx context.Context, conn *amplify.Client
 	output, err := conn.GetDomainAssociation(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 
@@ -297,8 +295,8 @@ func findDomainAssociationByTwoPartKey(ctx context.Context, conn *amplify.Client
 	return output.DomainAssociation, nil
 }
 
-func statusDomainAssociation(ctx context.Context, conn *amplify.Client, appID, domainName string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusDomainAssociation(conn *amplify.Client, appID, domainName string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		domainAssociation, err := findDomainAssociationByTwoPartKey(ctx, conn, appID, domainName)
 
 		if retry.NotFound(err) {
@@ -317,7 +315,7 @@ func waitDomainAssociationCreated(ctx context.Context, conn *amplify.Client, app
 	const (
 		timeout = 5 * time.Minute
 	)
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(
 			types.DomainStatusCreating,
 			types.DomainStatusInProgress,
@@ -330,7 +328,7 @@ func waitDomainAssociationCreated(ctx context.Context, conn *amplify.Client, app
 			types.DomainStatusAvailable,
 			types.DomainStatusAwaitingAppCname,
 		),
-		Refresh: statusDomainAssociation(ctx, conn, appID, domainName),
+		Refresh: statusDomainAssociation(conn, appID, domainName),
 		Timeout: timeout,
 	}
 
@@ -351,7 +349,7 @@ func waitDomainAssociationVerified(ctx context.Context, conn *amplify.Client, ap
 	const (
 		timeout = 15 * time.Minute
 	)
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(
 			types.DomainStatusUpdating,
 			types.DomainStatusInProgress,
@@ -363,7 +361,7 @@ func waitDomainAssociationVerified(ctx context.Context, conn *amplify.Client, ap
 			types.DomainStatusPendingDeployment,
 			types.DomainStatusAvailable,
 		),
-		Refresh: statusDomainAssociation(ctx, conn, appID, domainName),
+		Refresh: statusDomainAssociation(conn, appID, domainName),
 		Timeout: timeout,
 	}
 
@@ -384,7 +382,7 @@ func waitDomainAssociationAvailable(ctx context.Context, conn *amplify.Client, a
 	const (
 		timeout = 15 * time.Minute
 	)
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(
 			types.DomainStatusUpdating,
 			types.DomainStatusInProgress,
@@ -394,7 +392,7 @@ func waitDomainAssociationAvailable(ctx context.Context, conn *amplify.Client, a
 		Target: enum.Slice(
 			types.DomainStatusAvailable,
 		),
-		Refresh: statusDomainAssociation(ctx, conn, appID, domainName),
+		Refresh: statusDomainAssociation(conn, appID, domainName),
 		Timeout: timeout,
 	}
 

--- a/internal/service/amplify/webhook.go
+++ b/internal/service/amplify/webhook.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/amplify"
 	"github.com/aws/aws-sdk-go-v2/service/amplify/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -165,9 +164,8 @@ func findWebhookByID(ctx context.Context, conn *amplify.Client, id string) (*typ
 	output, err := conn.GetWebhook(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/amplify/webhook_test.go
+++ b/internal/service/amplify/webhook_test.go
@@ -10,11 +10,9 @@ import (
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/amplify/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfamplify "github.com/hashicorp/terraform-provider-aws/internal/service/amplify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -23,19 +21,19 @@ import (
 func testAccWebhook_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var webhook types.Webhook
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_webhook.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckWebhookDestroy(ctx),
+		CheckDestroy:             testAccCheckWebhookDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWebhookConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckWebhookExists(ctx, resourceName, &webhook),
+					testAccCheckWebhookExists(ctx, t, resourceName, &webhook),
 					resource.TestCheckResourceAttrSet(resourceName, "app_id"),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(`apps/.+/webhooks/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "branch_name", rName),
@@ -55,19 +53,19 @@ func testAccWebhook_basic(t *testing.T) {
 func testAccWebhook_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var webhook types.Webhook
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_webhook.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckWebhookDestroy(ctx),
+		CheckDestroy:             testAccCheckWebhookDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWebhookConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckWebhookExists(ctx, resourceName, &webhook),
+					testAccCheckWebhookExists(ctx, t, resourceName, &webhook),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfamplify.ResourceWebhook(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -79,19 +77,19 @@ func testAccWebhook_disappears(t *testing.T) {
 func testAccWebhook_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	var webhook types.Webhook
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_amplify_webhook.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckWebhookDestroy(ctx),
+		CheckDestroy:             testAccCheckWebhookDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWebhookConfig_description(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckWebhookExists(ctx, resourceName, &webhook),
+					testAccCheckWebhookExists(ctx, t, resourceName, &webhook),
 					resource.TestCheckResourceAttr(resourceName, "branch_name", fmt.Sprintf("%s-1", rName)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "testdescription1"),
 				),
@@ -104,7 +102,7 @@ func testAccWebhook_update(t *testing.T) {
 			{
 				Config: testAccWebhookConfig_descriptionUpdated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckWebhookExists(ctx, resourceName, &webhook),
+					testAccCheckWebhookExists(ctx, t, resourceName, &webhook),
 					resource.TestCheckResourceAttr(resourceName, "branch_name", fmt.Sprintf("%s-2", rName)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "testdescription2"),
 				),
@@ -113,7 +111,7 @@ func testAccWebhook_update(t *testing.T) {
 	})
 }
 
-func testAccCheckWebhookExists(ctx context.Context, resourceName string, v *types.Webhook) resource.TestCheckFunc {
+func testAccCheckWebhookExists(ctx context.Context, t *testing.T, resourceName string, v *types.Webhook) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -124,7 +122,7 @@ func testAccCheckWebhookExists(ctx context.Context, resourceName string, v *type
 			return fmt.Errorf("No Amplify Webhook ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AmplifyClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).AmplifyClient(ctx)
 
 		webhook, err := tfamplify.FindWebhookByID(ctx, conn, rs.Primary.ID)
 
@@ -138,9 +136,9 @@ func testAccCheckWebhookExists(ctx context.Context, resourceName string, v *type
 	}
 }
 
-func testAccCheckWebhookDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckWebhookDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AmplifyClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).AmplifyClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_amplify_webhook" {


### PR DESCRIPTION

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Enables `go-vcr` support for the `amplify` service.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/25602
Relates https://github.com/hashicorp/terraform-provider-aws/issues/43717


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=amplify VCR_MODE=RECORD_ONLY VCR_PATH=~/development/_vcr-testdata/
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-go-vcr-amplify 🌿...
TF_ACC=1 go1.25.5 test ./internal/service/amplify/... -v -count 1 -parallel 20   -timeout 360m -vet=off
2026/01/09 09:48:25 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/09 09:48:25 Initializing Terraform AWS Provider (SDKv2-style)...

=== RUN   TestAccAmplify_serial/Branch/EnvironmentVariables
    branch_test.go:151: Step 4/4 error: Error running apply: exit status 1

        Error: updating Amplify Branch (d3z8hxayxbg9r/tf-acc-test-4646336276235413531): operation error Amplify: UpdateBranch, https response error StatusCode: 400, RequestID: ebb7b49c-7a0d-485e-bd8a-f2f061938a93, BadRequestException: Environment variables cannot have an empty key.

          with aws_amplify_branch.test,
          on terraform_plugin_test.tf line 16, in resource "aws_amplify_branch" "test":
          16: resource "aws_amplify_branch" "test" {

=== RUN   TestAccAmplify_serial/Branch/BasicAuthCredentials
    branch_test.go:105: Step 1/4 error: Check failed: Check 2/3 error: aws_amplify_branch.test: Attribute 'basic_auth_credentials' expected "dXNlcm5hbWUxOnBhc3N3b3JkMQ==", got "dXNlcm5hbWUxOjJGNXdYUGpFQ2xFTUQ1UG14M010WkE9PXx8L2FuOVhzMjlKQVo1MDhwalY3ZktZdXNSUHYxYTlRTWF3Mkhhbkp3dEZPVT0="

=== RUN   TestAccAmplify_serial/DomainAssociation
=== RUN   TestAccAmplify_serial/DomainAssociation/basic
    domain_association_test.go:32: Environment variable AMPLIFY_DOMAIN_NAME is not set
=== RUN   TestAccAmplify_serial/DomainAssociation/certificateSettings_Managed
    domain_association_test.go:185: Environment variable AMPLIFY_DOMAIN_NAME is not set
=== RUN   TestAccAmplify_serial/DomainAssociation/certificateSettings_Custom
    domain_association_test.go:248: Environment variable AMPLIFY_DOMAIN_NAME is not set
=== RUN   TestAccAmplify_serial/DomainAssociation/disappears
    domain_association_test.go:79: Environment variable AMPLIFY_DOMAIN_NAME is not set
=== RUN   TestAccAmplify_serial/DomainAssociation/update
    domain_association_test.go:109: Environment variable AMPLIFY_DOMAIN_NAME is not set
=== RUN   TestAccAmplify_serial/DomainAssociation/createWithSubdomain
    domain_association_test.go:315: Environment variable AMPLIFY_DOMAIN_NAME is not set
=== RUN   TestAccAmplify_serial/Webhook
=== RUN   TestAccAmplify_serial/Webhook/basic
    webhook_test.go:27: stopping VCR recorder
    webhook_test.go:27: persisting randomness seed
=== RUN   TestAccAmplify_serial/Webhook/disappears
    webhook_test.go:59: stopping VCR recorder
    webhook_test.go:59: persisting randomness seed
=== RUN   TestAccAmplify_serial/Webhook/update
    webhook_test.go:83: stopping VCR recorder
    webhook_test.go:83: persisting randomness seed
--- FAIL: TestAccAmplify_serial (10872.41s)
    --- FAIL: TestAccAmplify_serial/App (5909.65s)
        --- PASS: TestAccAmplify_serial/App/basic (282.59s)
        --- PASS: TestAccAmplify_serial/App/JobConfig (288.77s)
        --- PASS: TestAccAmplify_serial/App/disappears (280.58s)
        --- PASS: TestAccAmplify_serial/App/CacheConfig (289.29s)
        --- PASS: TestAccAmplify_serial/App/CustomRules (297.35s)
        --- FAIL: TestAccAmplify_serial/App/BasicAuthCredentials (6.69s)
        --- PASS: TestAccAmplify_serial/App/BuildSpec (294.62s)
        --- PASS: TestAccAmplify_serial/App/ComputeRole (307.30s)
        --- PASS: TestAccAmplify_serial/App/IamServiceRole (300.58s)
        --- PASS: TestAccAmplify_serial/App/Name (289.63s)
        --- SKIP: TestAccAmplify_serial/App/Repository (0.00s)
        --- PASS: TestAccAmplify_serial/App/tags (2365.73s)
            --- SKIP: TestAccAmplify_serial/App/tags/ComputedTag_OnCreate (0.00s)
            --- SKIP: TestAccAmplify_serial/App/tags/ComputedTag_OnUpdate_Replace (0.00s)
            --- PASS: TestAccAmplify_serial/App/tags/EmptyMap (288.45s)
            --- SKIP: TestAccAmplify_serial/App/tags/IgnoreTags_Overlap_ResourceTag (0.00s)
            --- PASS: TestAccAmplify_serial/App/tags/basic (334.70s)
            --- PASS: TestAccAmplify_serial/App/tags/null (289.12s)
            --- PASS: TestAccAmplify_serial/App/tags/AddOnUpdate (292.88s)
            --- SKIP: TestAccAmplify_serial/App/tags/DefaultTags_nonOverlapping (0.00s)
            --- SKIP: TestAccAmplify_serial/App/tags/DefaultTags_overlapping (0.00s)
            --- SKIP: TestAccAmplify_serial/App/tags/DefaultTags_updateToProviderOnly (0.00s)
            --- SKIP: TestAccAmplify_serial/App/tags/DefaultTags_updateToResourceOnly (0.00s)
            --- SKIP: TestAccAmplify_serial/App/tags/DefaultTags_nullNonOverlappingResourceTag (0.00s)
            --- PASS: TestAccAmplify_serial/App/tags/EmptyTag_OnCreate (293.77s)
            --- PASS: TestAccAmplify_serial/App/tags/EmptyTag_OnUpdate_Add (304.65s)
            --- SKIP: TestAccAmplify_serial/App/tags/ComputedTag_OnUpdate_Add (0.00s)
            --- SKIP: TestAccAmplify_serial/App/tags/IgnoreTags_Overlap_DefaultTag (0.00s)
            --- PASS: TestAccAmplify_serial/App/tags/EmptyTag_OnUpdate_Replace (292.15s)
            --- SKIP: TestAccAmplify_serial/App/tags/DefaultTags_providerOnly (0.00s)
            --- SKIP: TestAccAmplify_serial/App/tags/DefaultTags_emptyResourceTag (0.00s)
            --- SKIP: TestAccAmplify_serial/App/tags/DefaultTags_nullOverlappingResourceTag (0.00s)
        --- PASS: TestAccAmplify_serial/App/AutoBranchCreationConfig (309.00s)
        --- PASS: TestAccAmplify_serial/App/Description (301.62s)
        --- PASS: TestAccAmplify_serial/App/EnvironmentVariables (295.89s)
    --- PASS: TestAccAmplify_serial/BackendEnvironment (847.86s)
        --- PASS: TestAccAmplify_serial/BackendEnvironment/DeploymentArtifacts_StackName (282.91s)
        --- PASS: TestAccAmplify_serial/BackendEnvironment/basic (283.07s)
        --- PASS: TestAccAmplify_serial/BackendEnvironment/disappears (281.88s)
    --- FAIL: TestAccAmplify_serial/Branch (3254.13s)
        --- FAIL: TestAccAmplify_serial/Branch/EnvironmentVariables (24.31s)
        --- PASS: TestAccAmplify_serial/Branch/OptionalArguments (293.98s)
        --- PASS: TestAccAmplify_serial/Branch/basic (283.94s)
        --- PASS: TestAccAmplify_serial/Branch/disappears (282.62s)
        --- PASS: TestAccAmplify_serial/Branch/tags (2361.24s)
            --- SKIP: TestAccAmplify_serial/Branch/tags/ComputedTag_OnCreate (0.00s)
            --- SKIP: TestAccAmplify_serial/Branch/tags/ComputedTag_OnUpdate_Add (0.00s)
            --- PASS: TestAccAmplify_serial/Branch/tags/basic (319.51s)
            --- PASS: TestAccAmplify_serial/Branch/tags/AddOnUpdate (294.16s)
            --- SKIP: TestAccAmplify_serial/Branch/tags/DefaultTags_providerOnly (0.00s)
            --- SKIP: TestAccAmplify_serial/Branch/tags/IgnoreTags_Overlap_DefaultTag (0.00s)
            --- PASS: TestAccAmplify_serial/Branch/tags/EmptyTag_OnUpdate_Replace (294.41s)
            --- SKIP: TestAccAmplify_serial/Branch/tags/DefaultTags_nonOverlapping (0.00s)
            --- SKIP: TestAccAmplify_serial/Branch/tags/DefaultTags_updateToProviderOnly (0.00s)
            --- SKIP: TestAccAmplify_serial/Branch/tags/DefaultTags_updateToResourceOnly (0.00s)
            --- PASS: TestAccAmplify_serial/Branch/tags/EmptyMap (290.38s)
            --- SKIP: TestAccAmplify_serial/Branch/tags/DefaultTags_emptyResourceTag (0.00s)
            --- SKIP: TestAccAmplify_serial/Branch/tags/ComputedTag_OnUpdate_Replace (0.00s)
            --- SKIP: TestAccAmplify_serial/Branch/tags/IgnoreTags_Overlap_ResourceTag (0.00s)
            --- PASS: TestAccAmplify_serial/Branch/tags/null (290.65s)
            --- PASS: TestAccAmplify_serial/Branch/tags/EmptyTag_OnCreate (296.66s)
            --- PASS: TestAccAmplify_serial/Branch/tags/EmptyTag_OnUpdate_Add (305.46s)
            --- SKIP: TestAccAmplify_serial/Branch/tags/DefaultTags_overlapping (0.00s)
            --- SKIP: TestAccAmplify_serial/Branch/tags/DefaultTags_nullOverlappingResourceTag (0.00s)
            --- SKIP: TestAccAmplify_serial/Branch/tags/DefaultTags_nullNonOverlappingResourceTag (0.00s)
        --- FAIL: TestAccAmplify_serial/Branch/BasicAuthCredentials (8.04s)
    --- PASS: TestAccAmplify_serial/DomainAssociation (0.00s)
        --- SKIP: TestAccAmplify_serial/DomainAssociation/basic (0.00s)
        --- SKIP: TestAccAmplify_serial/DomainAssociation/certificateSettings_Managed (0.00s)
        --- SKIP: TestAccAmplify_serial/DomainAssociation/certificateSettings_Custom (0.00s)
        --- SKIP: TestAccAmplify_serial/DomainAssociation/disappears (0.00s)
        --- SKIP: TestAccAmplify_serial/DomainAssociation/update (0.00s)
        --- SKIP: TestAccAmplify_serial/DomainAssociation/createWithSubdomain (0.00s)
    --- PASS: TestAccAmplify_serial/Webhook (860.77s)
        --- PASS: TestAccAmplify_serial/Webhook/basic (284.19s)
        --- PASS: TestAccAmplify_serial/Webhook/disappears (282.83s)
        --- PASS: TestAccAmplify_serial/Webhook/update (293.74s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/amplify    10879.161s
```

