### PR TITLE
apigateway: enable `go-vcr` support

### DIFF
--- a/internal/service/apigateway/account_test.go
+++ b/internal/service/apigateway/account_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/compare"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -28,13 +26,13 @@ func testAccAccount_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_account.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAccountDestroy(ctx),
+		CheckDestroy:             testAccCheckAccountDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccountConfig_basic,
@@ -62,16 +60,16 @@ func testAccAccount_basic(t *testing.T) {
 
 func testAccAccount_cloudwatchRoleARN_value(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_account.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAccountDestroy(ctx),
+		CheckDestroy:             testAccCheckAccountDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccountConfig_role0(rName),
@@ -122,13 +120,13 @@ func testAccAccount_cloudwatchRoleARN_empty(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_account.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAccountDestroy(ctx),
+		CheckDestroy:             testAccCheckAccountDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccountConfig_empty,
@@ -149,12 +147,12 @@ func testAccAccount_frameworkMigration_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_account.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckAccountDestroy(ctx),
+		CheckDestroy: testAccCheckAccountDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
@@ -194,15 +192,15 @@ func testAccAccount_frameworkMigration_basic(t *testing.T) {
 
 func testAccAccount_frameworkMigration_cloudwatchRoleARN(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_account.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckAccountDestroy(ctx),
+		CheckDestroy: testAccCheckAccountDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
@@ -252,15 +250,15 @@ func testAccAccount_frameworkMigration_cloudwatchRoleARN(t *testing.T) {
 // removed does not result in unexpected behavior.
 func testAccAccount_upgradeV6(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_account.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckAccountDestroy(ctx),
+		CheckDestroy: testAccCheckAccountDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
@@ -294,9 +292,9 @@ func testAccAccount_upgradeV6(t *testing.T) {
 	})
 }
 
-func testAccCheckAccountDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckAccountDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		account, err := tfapigateway.FindAccount(ctx, conn)
 		if err != nil {

--- a/internal/service/apigateway/api_key.go
+++ b/internal/service/apigateway/api_key.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -28,6 +27,8 @@ import (
 // @SDKResource("aws_api_gateway_api_key", name="API Key")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigateway;apigateway.GetApiKeyOutput")
+// @Testing(existsTakesT=true)
+// @Testing(destroyTakesT=true)
 func resourceAPIKey() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAPIKeyCreate,
@@ -234,9 +235,8 @@ func findAPIKeyByID(ctx context.Context, conn *apigateway.Client, id string) (*a
 	output, err := conn.GetApiKey(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/api_key_data_source_test.go
+++ b/internal/service/apigateway/api_key_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -15,11 +14,11 @@ import (
 
 func TestAccAPIGatewayAPIKeyDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_api_key.test"
 	dataSourceName := "data.aws_api_gateway_api_key.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/apigateway/api_key_tags_gen_test.go
+++ b/internal/service/apigateway/api_key_tags_gen_test.go
@@ -33,7 +33,7 @@ func TestAccAPIGatewayAPIKey_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -45,7 +45,7 @@ func TestAccAPIGatewayAPIKey_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -89,7 +89,7 @@ func TestAccAPIGatewayAPIKey_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -137,7 +137,7 @@ func TestAccAPIGatewayAPIKey_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -178,7 +178,7 @@ func TestAccAPIGatewayAPIKey_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -219,7 +219,7 @@ func TestAccAPIGatewayAPIKey_tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -231,7 +231,7 @@ func TestAccAPIGatewayAPIKey_tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -290,7 +290,7 @@ func TestAccAPIGatewayAPIKey_tags_EmptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -300,7 +300,7 @@ func TestAccAPIGatewayAPIKey_tags_EmptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -357,7 +357,7 @@ func TestAccAPIGatewayAPIKey_tags_AddOnUpdate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -367,7 +367,7 @@ func TestAccAPIGatewayAPIKey_tags_AddOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -391,7 +391,7 @@ func TestAccAPIGatewayAPIKey_tags_AddOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -442,7 +442,7 @@ func TestAccAPIGatewayAPIKey_tags_EmptyTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -454,7 +454,7 @@ func TestAccAPIGatewayAPIKey_tags_EmptyTag_OnCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -494,7 +494,7 @@ func TestAccAPIGatewayAPIKey_tags_EmptyTag_OnCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -535,7 +535,7 @@ func TestAccAPIGatewayAPIKey_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -547,7 +547,7 @@ func TestAccAPIGatewayAPIKey_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -579,7 +579,7 @@ func TestAccAPIGatewayAPIKey_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -625,7 +625,7 @@ func TestAccAPIGatewayAPIKey_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -676,7 +676,7 @@ func TestAccAPIGatewayAPIKey_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -688,7 +688,7 @@ func TestAccAPIGatewayAPIKey_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -719,7 +719,7 @@ func TestAccAPIGatewayAPIKey_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -769,7 +769,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_providerOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy: testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -782,7 +782,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -826,7 +826,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -872,7 +872,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -912,7 +912,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -954,7 +954,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_nonOverlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy: testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -969,7 +969,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1023,7 +1023,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1076,7 +1076,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1118,7 +1118,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_overlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy: testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1133,7 +1133,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1186,7 +1186,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1243,7 +1243,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1298,7 +1298,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_updateToProviderOnly(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy: testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1310,7 +1310,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_updateToProviderOnly(t *testing.T)
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1343,7 +1343,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_updateToProviderOnly(t *testing.T)
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1392,7 +1392,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_updateToResourceOnly(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy: testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1405,7 +1405,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_updateToResourceOnly(t *testing.T)
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1433,7 +1433,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_updateToResourceOnly(t *testing.T)
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1485,7 +1485,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy: testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1500,7 +1500,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1554,7 +1554,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy: testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1567,7 +1567,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T)
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1615,7 +1615,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_nullOverlappingResourceTag(t *test
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy: testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1630,7 +1630,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_nullOverlappingResourceTag(t *test
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1681,7 +1681,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_nullNonOverlappingResourceTag(t *t
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy: testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1696,7 +1696,7 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_nullNonOverlappingResourceTag(t *t
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1747,7 +1747,7 @@ func TestAccAPIGatewayAPIKey_tags_ComputedTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy: testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1757,7 +1757,7 @@ func TestAccAPIGatewayAPIKey_tags_ComputedTag_OnCreate(t *testing.T) {
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1806,7 +1806,7 @@ func TestAccAPIGatewayAPIKey_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy: testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1818,7 +1818,7 @@ func TestAccAPIGatewayAPIKey_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1850,7 +1850,7 @@ func TestAccAPIGatewayAPIKey_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1907,7 +1907,7 @@ func TestAccAPIGatewayAPIKey_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy: testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1919,7 +1919,7 @@ func TestAccAPIGatewayAPIKey_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1949,7 +1949,7 @@ func TestAccAPIGatewayAPIKey_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1998,7 +1998,7 @@ func TestAccAPIGatewayAPIKey_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy: testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2017,7 +2017,7 @@ func TestAccAPIGatewayAPIKey_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2066,7 +2066,7 @@ func TestAccAPIGatewayAPIKey_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2115,7 +2115,7 @@ func TestAccAPIGatewayAPIKey_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2164,7 +2164,7 @@ func TestAccAPIGatewayAPIKey_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy: testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2181,7 +2181,7 @@ func TestAccAPIGatewayAPIKey_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2244,7 +2244,7 @@ func TestAccAPIGatewayAPIKey_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2307,7 +2307,7 @@ func TestAccAPIGatewayAPIKey_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &v),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/apigateway/api_key_test.go
+++ b/internal/service/apigateway/api_key_test.go
@@ -11,11 +11,9 @@ import (
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -25,19 +23,19 @@ func TestAccAPIGatewayAPIKey_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var apiKey1, apiKey2 apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rNameUpdated := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rNameUpdated := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAPIKeyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &apiKey1),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &apiKey1),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/apikeys/.+$`)),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreatedDate),
 					resource.TestCheckResourceAttr(resourceName, "customer_id", ""),
@@ -56,7 +54,7 @@ func TestAccAPIGatewayAPIKey_basic(t *testing.T) {
 			{
 				Config: testAccAPIKeyConfig_basic(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &apiKey2),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &apiKey2),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/apikeys/.+$`)),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreatedDate),
 					resource.TestCheckResourceAttr(resourceName, "customer_id", ""),
@@ -75,18 +73,18 @@ func TestAccAPIGatewayAPIKey_customerID(t *testing.T) {
 	ctx := acctest.Context(t)
 	var apiKey1, apiKey2 apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAPIKeyConfig_customerID(rName, "cid1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &apiKey1),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &apiKey1),
 					resource.TestCheckResourceAttr(resourceName, "customer_id", "cid1"),
 				),
 			},
@@ -98,7 +96,7 @@ func TestAccAPIGatewayAPIKey_customerID(t *testing.T) {
 			{
 				Config: testAccAPIKeyConfig_customerID(rName, "cid2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &apiKey2),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &apiKey2),
 					testAccCheckAPIKeyNotRecreated(&apiKey1, &apiKey2),
 					resource.TestCheckResourceAttr(resourceName, "customer_id", "cid2"),
 				),
@@ -111,18 +109,18 @@ func TestAccAPIGatewayAPIKey_description(t *testing.T) {
 	ctx := acctest.Context(t)
 	var apiKey1, apiKey2 apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAPIKeyConfig_description(rName, "description1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &apiKey1),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &apiKey1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description1"),
 				),
 			},
@@ -134,7 +132,7 @@ func TestAccAPIGatewayAPIKey_description(t *testing.T) {
 			{
 				Config: testAccAPIKeyConfig_description(rName, "description2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &apiKey2),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &apiKey2),
 					testAccCheckAPIKeyNotRecreated(&apiKey1, &apiKey2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description2"),
 				),
@@ -147,18 +145,18 @@ func TestAccAPIGatewayAPIKey_enabled(t *testing.T) {
 	ctx := acctest.Context(t)
 	var apiKey1, apiKey2 apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAPIKeyConfig_enabled(rName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &apiKey1),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &apiKey1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEnabled, acctest.CtFalse),
 				),
 			},
@@ -170,7 +168,7 @@ func TestAccAPIGatewayAPIKey_enabled(t *testing.T) {
 			{
 				Config: testAccAPIKeyConfig_enabled(rName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &apiKey2),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &apiKey2),
 					testAccCheckAPIKeyNotRecreated(&apiKey1, &apiKey2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEnabled, acctest.CtTrue),
 				),
@@ -183,18 +181,18 @@ func TestAccAPIGatewayAPIKey_value(t *testing.T) {
 	ctx := acctest.Context(t)
 	var apiKey1 apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAPIKeyConfig_value(rName, `8bjqPK0BkA5N32bwYj4no2aw3eqsSM1o67eXFTNU`),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &apiKey1),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &apiKey1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrValue, `8bjqPK0BkA5N32bwYj4no2aw3eqsSM1o67eXFTNU`),
 				),
 			},
@@ -211,18 +209,18 @@ func TestAccAPIGatewayAPIKey_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var apiKey1 apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAPIKeyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAPIKeyExists(ctx, resourceName, &apiKey1),
+					testAccCheckAPIKeyExists(ctx, t, resourceName, &apiKey1),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceAPIKey(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -231,14 +229,14 @@ func TestAccAPIGatewayAPIKey_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckAPIKeyExists(ctx context.Context, n string, v *apigateway.GetApiKeyOutput) resource.TestCheckFunc {
+func testAccCheckAPIKeyExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetApiKeyOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindAPIKeyByID(ctx, conn, rs.Primary.ID)
 
@@ -252,9 +250,9 @@ func testAccCheckAPIKeyExists(ctx context.Context, n string, v *apigateway.GetAp
 	}
 }
 
-func testAccCheckAPIKeyDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckAPIKeyDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_api_key" {

--- a/internal/service/apigateway/api_keys_data_source_test.go
+++ b/internal/service/apigateway/api_keys_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -15,15 +14,15 @@ import (
 
 func TestAccAPIGatewayAPIKeysDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_api_key.test"
 	dataSourceName := "data.aws_api_gateway_api_keys.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAPIKeysDataSourceConfig_basic(rName),
@@ -44,15 +43,15 @@ func TestAccAPIGatewayAPIKeysDataSource_basic(t *testing.T) {
 
 func TestAccAPIGatewayAPIKeysDataSource_includeValues(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_api_key.test"
 	dataSourceName := "data.aws_api_gateway_api_keys.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAPIKeysDataSourceConfig_includeValues(rName),
@@ -69,16 +68,16 @@ func TestAccAPIGatewayAPIKeysDataSource_includeValues(t *testing.T) {
 
 func TestAccAPIGatewayAPIKeysDataSource_manyKeys(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	dataSourceName := "data.aws_api_gateway_api_keys.test"
 	keyCount := 3
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAPIKeysDataSourceConfig_manyKeys(rName, keyCount),

--- a/internal/service/apigateway/authorizer.go
+++ b/internal/service/apigateway/authorizer.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -365,9 +364,8 @@ func findAuthorizerByTwoPartKey(ctx context.Context, conn *apigateway.Client, au
 	output, err := conn.GetAuthorizer(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/authorizer_data_source_test.go
+++ b/internal/service/apigateway/authorizer_data_source_test.go
@@ -6,7 +6,6 @@ package apigateway_test
 import (
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -14,11 +13,11 @@ import (
 
 func TestAccAPIGatewayAuthorizerDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_authorizer.test"
 	dataSourceName := "data.aws_api_gateway_authorizer.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/apigateway/authorizer_test.go
+++ b/internal/service/apigateway/authorizer_test.go
@@ -11,11 +11,9 @@ import (
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -24,21 +22,21 @@ import (
 func TestAccAPIGatewayAuthorizer_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetAuthorizerOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_authorizer.test"
 	lambdaResourceName := "aws_lambda_function.test"
 	roleResourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAuthorizerDestroy(ctx),
+		CheckDestroy:             testAccCheckAuthorizerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAuthorizerConfig_lambda(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAuthorizerExists(ctx, resourceName, &conf),
+					testAccCheckAuthorizerExists(ctx, t, resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/restapis/.+/authorizers/.+`)),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
 					resource.TestCheckResourceAttr(resourceName, "identity_source", "method.request.header.Authorization"),
@@ -58,7 +56,7 @@ func TestAccAPIGatewayAuthorizer_basic(t *testing.T) {
 			{
 				Config: testAccAuthorizerConfig_lambdaUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAuthorizerExists(ctx, resourceName, &conf),
+					testAccCheckAuthorizerExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
 					resource.TestCheckResourceAttr(resourceName, "identity_source", "method.request.header.Authorization"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName+"_modified"),
@@ -74,14 +72,14 @@ func TestAccAPIGatewayAuthorizer_basic(t *testing.T) {
 
 func TestAccAPIGatewayAuthorizer_cognito(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_authorizer.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAuthorizerDestroy(ctx),
+		CheckDestroy:             testAccCheckAuthorizerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAuthorizerConfig_cognito(rName),
@@ -112,15 +110,15 @@ func TestAccAPIGatewayAuthorizer_cognito(t *testing.T) {
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/16613
 func TestAccAPIGatewayAuthorizer_Cognito_authorizerCredentials(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_authorizer.test"
 	iamRoleResourceName := "aws_iam_role.lambda"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAuthorizerDestroy(ctx),
+		CheckDestroy:             testAccCheckAuthorizerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAuthorizerConfig_cognitoCredentials(rName),
@@ -143,16 +141,16 @@ func TestAccAPIGatewayAuthorizer_Cognito_authorizerCredentials(t *testing.T) {
 
 func TestAccAPIGatewayAuthorizer_switchAuthType(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_authorizer.test"
 	lambdaResourceName := "aws_lambda_function.test"
 	roleResourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAuthorizerDestroy(ctx),
+		CheckDestroy:             testAccCheckAuthorizerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAuthorizerConfig_lambda(rName),
@@ -193,19 +191,19 @@ func TestAccAPIGatewayAuthorizer_switchAuthType(t *testing.T) {
 func TestAccAPIGatewayAuthorizer_switchAuthorizerTTL(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetAuthorizerOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_authorizer.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAuthorizerDestroy(ctx),
+		CheckDestroy:             testAccCheckAuthorizerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAuthorizerConfig_lambda(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAuthorizerExists(ctx, resourceName, &conf),
+					testAccCheckAuthorizerExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", strconv.Itoa(tfapigateway.DefaultAuthorizerTTL)),
 				),
 			},
@@ -218,21 +216,21 @@ func TestAccAPIGatewayAuthorizer_switchAuthorizerTTL(t *testing.T) {
 			{
 				Config: testAccAuthorizerConfig_lambdaUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAuthorizerExists(ctx, resourceName, &conf),
+					testAccCheckAuthorizerExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", strconv.Itoa(360)),
 				),
 			},
 			{
 				Config: testAccAuthorizerConfig_lambdaNoCache(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAuthorizerExists(ctx, resourceName, &conf),
+					testAccCheckAuthorizerExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", strconv.Itoa(0)),
 				),
 			},
 			{
 				Config: testAccAuthorizerConfig_lambda(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAuthorizerExists(ctx, resourceName, &conf),
+					testAccCheckAuthorizerExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", strconv.Itoa(tfapigateway.DefaultAuthorizerTTL)),
 				),
 			},
@@ -242,13 +240,13 @@ func TestAccAPIGatewayAuthorizer_switchAuthorizerTTL(t *testing.T) {
 
 func TestAccAPIGatewayAuthorizer_authTypeValidation(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAuthorizerDestroy(ctx),
+		CheckDestroy:             testAccCheckAuthorizerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAuthorizerConfig_authTypeValidationDefaultToken(rName),
@@ -269,19 +267,19 @@ func TestAccAPIGatewayAuthorizer_authTypeValidation(t *testing.T) {
 func TestAccAPIGatewayAuthorizer_Zero_ttl(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetAuthorizerOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_authorizer.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAuthorizerDestroy(ctx),
+		CheckDestroy:             testAccCheckAuthorizerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAuthorizerConfig_lambdaNoCache(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAuthorizerExists(ctx, resourceName, &conf),
+					testAccCheckAuthorizerExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "0"),
 				),
 			},
@@ -298,19 +296,19 @@ func TestAccAPIGatewayAuthorizer_Zero_ttl(t *testing.T) {
 func TestAccAPIGatewayAuthorizer_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetAuthorizerOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_authorizer.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAuthorizerDestroy(ctx),
+		CheckDestroy:             testAccCheckAuthorizerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAuthorizerConfig_lambda(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAuthorizerExists(ctx, resourceName, &conf),
+					testAccCheckAuthorizerExists(ctx, t, resourceName, &conf),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceAuthorizer(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -319,14 +317,14 @@ func TestAccAPIGatewayAuthorizer_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckAuthorizerExists(ctx context.Context, n string, v *apigateway.GetAuthorizerOutput) resource.TestCheckFunc {
+func testAccCheckAuthorizerExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetAuthorizerOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindAuthorizerByTwoPartKey(ctx, conn, rs.Primary.ID, rs.Primary.Attributes["rest_api_id"])
 
@@ -340,9 +338,9 @@ func testAccCheckAuthorizerExists(ctx context.Context, n string, v *apigateway.G
 	}
 }
 
-func testAccCheckAuthorizerDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckAuthorizerDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_authorizer" {

--- a/internal/service/apigateway/authorizers_data_source_test.go
+++ b/internal/service/apigateway/authorizers_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -15,10 +14,10 @@ import (
 
 func TestAccAPIGatewayAuthorizersDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_api_gateway_authorizers.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/apigateway/base_path_mapping.go
+++ b/internal/service/apigateway/base_path_mapping.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -272,9 +271,8 @@ func findBasePathMappingByThreePartKey(ctx context.Context, conn *apigateway.Cli
 	output, err := conn.GetBasePathMapping(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/base_path_mapping_test.go
+++ b/internal/service/apigateway/base_path_mapping_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -28,16 +27,16 @@ func TestAccAPIGatewayBasePathMapping_basic(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, name)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBasePathDestroy(ctx),
+		CheckDestroy:             testAccCheckBasePathDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBasePathMappingConfig_basic(name, key, certificate, acctest.ResourcePrefix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBasePathExists(ctx, resourceName, &conf),
+					testAccCheckBasePathExists(ctx, t, resourceName, &conf),
 				),
 			},
 			{
@@ -57,16 +56,16 @@ func TestAccAPIGatewayBasePathMapping_private(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBasePathDestroy(ctx),
+		CheckDestroy:             testAccCheckBasePathDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBasePathMappingConfig_private(rName, key, certificate, acctest.ResourcePrefix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBasePathExists(ctx, resourceName, &conf),
+					testAccCheckBasePathExists(ctx, t, resourceName, &conf),
 				),
 			},
 			{
@@ -87,16 +86,16 @@ func TestAccAPIGatewayBasePathMapping_BasePath_empty(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, name)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBasePathDestroy(ctx),
+		CheckDestroy:             testAccCheckBasePathDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBasePathMappingConfig_basic(name, key, certificate, ""),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBasePathExists(ctx, resourceName, &conf),
+					testAccCheckBasePathExists(ctx, t, resourceName, &conf),
 				),
 			},
 			{
@@ -116,23 +115,23 @@ func TestAccAPIGatewayBasePathMapping_updates(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, name)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBasePathDestroy(ctx),
+		CheckDestroy:             testAccCheckBasePathDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBasePathMappingConfig_basic(name, key, certificate, ""),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBasePathExists(ctx, resourceName, &confFirst),
+					testAccCheckBasePathExists(ctx, t, resourceName, &confFirst),
 					testAccCheckBasePathStageAttribute(&confFirst, "test"),
 				),
 			},
 			{
 				Config: testAccBasePathMappingConfig_altStageAndAPI(name, key, certificate, ""),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBasePathExists(ctx, resourceName, &conf),
+					testAccCheckBasePathExists(ctx, t, resourceName, &conf),
 					testAccCheckBasePathBasePathAttribute(&conf, "(none)"),
 					testAccCheckBasePathStageAttribute(&conf, "test2"),
 					testAccCheckRestAPIIDAttributeHasChanged(&conf, &confFirst),
@@ -142,7 +141,7 @@ func TestAccAPIGatewayBasePathMapping_updates(t *testing.T) {
 			{
 				Config: testAccBasePathMappingConfig_altStageAndAPI(name, key, certificate, "thing"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBasePathExists(ctx, resourceName, &conf),
+					testAccCheckBasePathExists(ctx, t, resourceName, &conf),
 					testAccCheckBasePathBasePathAttribute(&conf, "thing"),
 					testAccCheckBasePathStageAttribute(&conf, "test2"),
 					resource.TestCheckResourceAttr(resourceName, "stage_name", "test2"),
@@ -166,16 +165,16 @@ func TestAccAPIGatewayBasePathMapping_disappears(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, name)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBasePathDestroy(ctx),
+		CheckDestroy:             testAccCheckBasePathDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBasePathMappingConfig_basic(name, key, certificate, acctest.ResourcePrefix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBasePathExists(ctx, resourceName, &conf),
+					testAccCheckBasePathExists(ctx, t, resourceName, &conf),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceBasePathMapping(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -192,10 +191,10 @@ func TestAccAPIGatewayBasePathMapping_updateIDFormat(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, name)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckBasePathDestroy(ctx),
+		CheckDestroy: testAccCheckBasePathDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
@@ -206,7 +205,7 @@ func TestAccAPIGatewayBasePathMapping_updateIDFormat(t *testing.T) {
 				},
 				Config: testAccBasePathMappingConfig_basic(name, key, certificate, acctest.ResourcePrefix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBasePathExists(ctx, resourceName, &conf),
+					testAccCheckBasePathExists(ctx, t, resourceName, &conf),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -230,14 +229,14 @@ func TestAccAPIGatewayBasePathMapping_updateIDFormat(t *testing.T) {
 	})
 }
 
-func testAccCheckBasePathExists(ctx context.Context, n string, v *apigateway.GetBasePathMappingOutput) resource.TestCheckFunc {
+func testAccCheckBasePathExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetBasePathMappingOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		basePath := rs.Primary.Attributes["base_path"]
 		if basePath == "" {
@@ -255,9 +254,9 @@ func testAccCheckBasePathExists(ctx context.Context, n string, v *apigateway.Get
 	}
 }
 
-func testAccCheckBasePathDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckBasePathDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_base_path_mapping" {

--- a/internal/service/apigateway/client_certificate.go
+++ b/internal/service/apigateway/client_certificate.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -26,6 +25,8 @@ import (
 // @SDKResource("aws_api_gateway_client_certificate", name="Client Certificate")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigateway;apigateway.GetClientCertificateOutput", generator=false)
+// @Testing(existsTakesT=true)
+// @Testing(destroyTakesT=true)
 func resourceClientCertificate() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClientCertificateCreate,
@@ -170,9 +171,8 @@ func findClientCertificateByID(ctx context.Context, conn *apigateway.Client, id 
 	output, err := conn.GetClientCertificate(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/client_certificate_tags_gen_test.go
+++ b/internal/service/apigateway/client_certificate_tags_gen_test.go
@@ -32,7 +32,7 @@ func TestAccAPIGatewayClientCertificate_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -43,7 +43,7 @@ func TestAccAPIGatewayClientCertificate_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -85,7 +85,7 @@ func TestAccAPIGatewayClientCertificate_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -131,7 +131,7 @@ func TestAccAPIGatewayClientCertificate_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -170,7 +170,7 @@ func TestAccAPIGatewayClientCertificate_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -209,7 +209,7 @@ func TestAccAPIGatewayClientCertificate_tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -220,7 +220,7 @@ func TestAccAPIGatewayClientCertificate_tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -276,7 +276,7 @@ func TestAccAPIGatewayClientCertificate_tags_EmptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -285,7 +285,7 @@ func TestAccAPIGatewayClientCertificate_tags_EmptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -339,7 +339,7 @@ func TestAccAPIGatewayClientCertificate_tags_AddOnUpdate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -348,7 +348,7 @@ func TestAccAPIGatewayClientCertificate_tags_AddOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -371,7 +371,7 @@ func TestAccAPIGatewayClientCertificate_tags_AddOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -420,7 +420,7 @@ func TestAccAPIGatewayClientCertificate_tags_EmptyTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -431,7 +431,7 @@ func TestAccAPIGatewayClientCertificate_tags_EmptyTag_OnCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -469,7 +469,7 @@ func TestAccAPIGatewayClientCertificate_tags_EmptyTag_OnCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -508,7 +508,7 @@ func TestAccAPIGatewayClientCertificate_tags_EmptyTag_OnUpdate_Add(t *testing.T)
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -519,7 +519,7 @@ func TestAccAPIGatewayClientCertificate_tags_EmptyTag_OnUpdate_Add(t *testing.T)
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -550,7 +550,7 @@ func TestAccAPIGatewayClientCertificate_tags_EmptyTag_OnUpdate_Add(t *testing.T)
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -594,7 +594,7 @@ func TestAccAPIGatewayClientCertificate_tags_EmptyTag_OnUpdate_Add(t *testing.T)
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -643,7 +643,7 @@ func TestAccAPIGatewayClientCertificate_tags_EmptyTag_OnUpdate_Replace(t *testin
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -654,7 +654,7 @@ func TestAccAPIGatewayClientCertificate_tags_EmptyTag_OnUpdate_Replace(t *testin
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -684,7 +684,7 @@ func TestAccAPIGatewayClientCertificate_tags_EmptyTag_OnUpdate_Replace(t *testin
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -732,7 +732,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_providerOnly(t *testing
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckClientCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -744,7 +744,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_providerOnly(t *testing
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -786,7 +786,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_providerOnly(t *testing
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -830,7 +830,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_providerOnly(t *testing
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -868,7 +868,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_providerOnly(t *testing
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -908,7 +908,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_nonOverlapping(t *testi
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckClientCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -922,7 +922,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_nonOverlapping(t *testi
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -974,7 +974,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_nonOverlapping(t *testi
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1025,7 +1025,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_nonOverlapping(t *testi
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1065,7 +1065,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_overlapping(t *testing.
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckClientCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1079,7 +1079,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_overlapping(t *testing.
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1130,7 +1130,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_overlapping(t *testing.
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1185,7 +1185,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_overlapping(t *testing.
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1238,7 +1238,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_updateToProviderOnly(t 
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckClientCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1249,7 +1249,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_updateToProviderOnly(t 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1281,7 +1281,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_updateToProviderOnly(t 
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1328,7 +1328,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_updateToResourceOnly(t 
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckClientCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1340,7 +1340,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_updateToResourceOnly(t 
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1367,7 +1367,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_updateToResourceOnly(t 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1417,7 +1417,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_emptyResourceTag(t *tes
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckClientCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1431,7 +1431,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_emptyResourceTag(t *tes
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1483,7 +1483,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_emptyProviderOnlyTag(t 
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckClientCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1495,7 +1495,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_emptyProviderOnlyTag(t 
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1541,7 +1541,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_nullOverlappingResource
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckClientCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1555,7 +1555,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_nullOverlappingResource
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1604,7 +1604,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_nullNonOverlappingResou
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckClientCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1618,7 +1618,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_nullNonOverlappingResou
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1667,7 +1667,7 @@ func TestAccAPIGatewayClientCertificate_tags_ComputedTag_OnCreate(t *testing.T) 
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckClientCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1676,7 +1676,7 @@ func TestAccAPIGatewayClientCertificate_tags_ComputedTag_OnCreate(t *testing.T) 
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1723,7 +1723,7 @@ func TestAccAPIGatewayClientCertificate_tags_ComputedTag_OnUpdate_Add(t *testing
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckClientCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1734,7 +1734,7 @@ func TestAccAPIGatewayClientCertificate_tags_ComputedTag_OnUpdate_Add(t *testing
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1765,7 +1765,7 @@ func TestAccAPIGatewayClientCertificate_tags_ComputedTag_OnUpdate_Add(t *testing
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1820,7 +1820,7 @@ func TestAccAPIGatewayClientCertificate_tags_ComputedTag_OnUpdate_Replace(t *tes
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckClientCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1831,7 +1831,7 @@ func TestAccAPIGatewayClientCertificate_tags_ComputedTag_OnUpdate_Replace(t *tes
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1860,7 +1860,7 @@ func TestAccAPIGatewayClientCertificate_tags_ComputedTag_OnUpdate_Replace(t *tes
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1907,7 +1907,7 @@ func TestAccAPIGatewayClientCertificate_tags_IgnoreTags_Overlap_DefaultTag(t *te
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckClientCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -1925,7 +1925,7 @@ func TestAccAPIGatewayClientCertificate_tags_IgnoreTags_Overlap_DefaultTag(t *te
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1973,7 +1973,7 @@ func TestAccAPIGatewayClientCertificate_tags_IgnoreTags_Overlap_DefaultTag(t *te
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2021,7 +2021,7 @@ func TestAccAPIGatewayClientCertificate_tags_IgnoreTags_Overlap_DefaultTag(t *te
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2069,7 +2069,7 @@ func TestAccAPIGatewayClientCertificate_tags_IgnoreTags_Overlap_ResourceTag(t *t
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckClientCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2085,7 +2085,7 @@ func TestAccAPIGatewayClientCertificate_tags_IgnoreTags_Overlap_ResourceTag(t *t
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2147,7 +2147,7 @@ func TestAccAPIGatewayClientCertificate_tags_IgnoreTags_Overlap_ResourceTag(t *t
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2209,7 +2209,7 @@ func TestAccAPIGatewayClientCertificate_tags_IgnoreTags_Overlap_ResourceTag(t *t
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClientCertificateExists(ctx, resourceName, &v),
+					testAccCheckClientCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/apigateway/deployment.go
+++ b/internal/service/apigateway/deployment.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -197,9 +196,8 @@ func findDeploymentByTwoPartKey(ctx context.Context, conn *apigateway.Client, re
 	output, err := conn.GetDeployment(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/deployment_test.go
+++ b/internal/service/apigateway/deployment_test.go
@@ -11,11 +11,9 @@ import (
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -24,20 +22,20 @@ import (
 func TestAccAPIGatewayDeployment_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var deployment apigateway.GetDeploymentOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_deployment.test"
 	restApiResourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeploymentDestroy(ctx),
+		CheckDestroy:             testAccCheckDeploymentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeploymentConfig_required(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeploymentExists(ctx, resourceName, &deployment),
+					testAccCheckDeploymentExists(ctx, t, resourceName, &deployment),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreatedDate),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 					resource.TestCheckResourceAttrPair(resourceName, "rest_api_id", restApiResourceName, names.AttrID),
@@ -57,19 +55,19 @@ func TestAccAPIGatewayDeployment_basic(t *testing.T) {
 func TestAccAPIGatewayDeployment_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var deployment apigateway.GetDeploymentOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_deployment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeploymentDestroy(ctx),
+		CheckDestroy:             testAccCheckDeploymentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeploymentConfig_required(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeploymentExists(ctx, resourceName, &deployment),
+					testAccCheckDeploymentExists(ctx, t, resourceName, &deployment),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceDeployment(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -82,22 +80,22 @@ func TestAccAPIGatewayDeployment_Disappears_restAPI(t *testing.T) {
 	ctx := acctest.Context(t)
 	var deployment apigateway.GetDeploymentOutput
 	var restApi apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_deployment.test"
 	restApiResourceName := "aws_api_gateway_rest_api.test"
-	stageName := sdkacctest.RandomWithPrefix("tf-acc-test-deployment")
+	stageName := acctest.RandomWithPrefix(t, "tf-acc-test-deployment")
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeploymentDestroy(ctx),
+		CheckDestroy:             testAccCheckDeploymentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeploymentConfig_stageName(rName, stageName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeploymentExists(ctx, resourceName, &deployment),
-					testAccCheckRESTAPIExists(ctx, restApiResourceName, &restApi),
+					testAccCheckDeploymentExists(ctx, t, resourceName, &deployment),
+					testAccCheckRESTAPIExists(ctx, t, restApiResourceName, &restApi),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceRestAPI(), restApiResourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -110,21 +108,21 @@ func TestAccAPIGatewayDeployment_triggers(t *testing.T) {
 	ctx := acctest.Context(t)
 	var deployment1, deployment2, deployment3, deployment4 apigateway.GetDeploymentOutput
 	var stage apigateway.GetStageOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_deployment.test"
 	stageResource := "aws_api_gateway_stage.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeploymentDestroy(ctx),
+		CheckDestroy:             testAccCheckDeploymentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeploymentConfig_triggers(rName, "description1", "https://example.com"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeploymentExists(ctx, resourceName, &deployment1),
-					testAccCheckStageExists(ctx, stageResource, &stage),
+					testAccCheckDeploymentExists(ctx, t, resourceName, &deployment1),
+					testAccCheckStageExists(ctx, t, stageResource, &stage),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description1"),
 					resource.TestCheckResourceAttr(stageResource, names.AttrDescription, "description1"),
 				),
@@ -135,9 +133,9 @@ func TestAccAPIGatewayDeployment_triggers(t *testing.T) {
 			{
 				Config: testAccDeploymentConfig_triggers(rName, "description1", "https://example.com"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeploymentExists(ctx, resourceName, &deployment2),
+					testAccCheckDeploymentExists(ctx, t, resourceName, &deployment2),
 					testAccCheckDeploymentRecreated(&deployment1, &deployment2),
-					testAccCheckStageExists(ctx, stageResource, &stage),
+					testAccCheckStageExists(ctx, t, stageResource, &stage),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description1"),
 					resource.TestCheckResourceAttr(stageResource, names.AttrDescription, "description1"),
 				),
@@ -145,9 +143,9 @@ func TestAccAPIGatewayDeployment_triggers(t *testing.T) {
 			{
 				Config: testAccDeploymentConfig_triggers(rName, "description1", "https://example.com"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeploymentExists(ctx, resourceName, &deployment3),
+					testAccCheckDeploymentExists(ctx, t, resourceName, &deployment3),
 					testAccCheckDeploymentNotRecreated(&deployment2, &deployment3),
-					testAccCheckStageExists(ctx, stageResource, &stage),
+					testAccCheckStageExists(ctx, t, stageResource, &stage),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description1"),
 					resource.TestCheckResourceAttr(stageResource, names.AttrDescription, "description1"),
 				),
@@ -155,9 +153,9 @@ func TestAccAPIGatewayDeployment_triggers(t *testing.T) {
 			{
 				Config: testAccDeploymentConfig_triggers(rName, "description2", "https://example.org"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeploymentExists(ctx, resourceName, &deployment4),
+					testAccCheckDeploymentExists(ctx, t, resourceName, &deployment4),
 					testAccCheckDeploymentRecreated(&deployment3, &deployment4),
-					testAccCheckStageExists(ctx, stageResource, &stage),
+					testAccCheckStageExists(ctx, t, stageResource, &stage),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description2"),
 					resource.TestCheckResourceAttr(stageResource, names.AttrDescription, "description2"),
 				),
@@ -169,26 +167,26 @@ func TestAccAPIGatewayDeployment_triggers(t *testing.T) {
 func TestAccAPIGatewayDeployment_description(t *testing.T) {
 	ctx := acctest.Context(t)
 	var deployment apigateway.GetDeploymentOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_deployment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeploymentDestroy(ctx),
+		CheckDestroy:             testAccCheckDeploymentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeploymentConfig_description(rName, "description1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeploymentExists(ctx, resourceName, &deployment),
+					testAccCheckDeploymentExists(ctx, t, resourceName, &deployment),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description1"),
 				),
 			},
 			{
 				Config: testAccDeploymentConfig_description(rName, "description2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeploymentExists(ctx, resourceName, &deployment),
+					testAccCheckDeploymentExists(ctx, t, resourceName, &deployment),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description2"),
 				),
 			},
@@ -200,21 +198,21 @@ func TestAccAPIGatewayDeployment_stageDescription(t *testing.T) {
 	ctx := acctest.Context(t)
 	var deployment apigateway.GetDeploymentOutput
 	var stage apigateway.GetStageOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_deployment.test"
 	stageResource := "aws_api_gateway_stage.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeploymentDestroy(ctx),
+		CheckDestroy:             testAccCheckDeploymentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeploymentConfig_stageDescription(rName, "description1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeploymentExists(ctx, resourceName, &deployment),
-					testAccCheckStageExists(ctx, stageResource, &stage),
+					testAccCheckDeploymentExists(ctx, t, resourceName, &deployment),
+					testAccCheckStageExists(ctx, t, stageResource, &stage),
 					resource.TestCheckResourceAttr(stageResource, names.AttrDescription, "description1"),
 				),
 			},
@@ -226,22 +224,22 @@ func TestAccAPIGatewayDeployment_stageName(t *testing.T) {
 	ctx := acctest.Context(t)
 	var deployment apigateway.GetDeploymentOutput
 	var stage apigateway.GetStageOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_deployment.test"
 	stageResource := "aws_api_gateway_stage.test"
-	stageName := sdkacctest.RandomWithPrefix("tf-acc-test-deployment")
+	stageName := acctest.RandomWithPrefix(t, "tf-acc-test-deployment")
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeploymentDestroy(ctx),
+		CheckDestroy:             testAccCheckDeploymentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeploymentConfig_stageName(rName, stageName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeploymentExists(ctx, resourceName, &deployment),
-					testAccCheckStageExists(ctx, stageResource, &stage),
+					testAccCheckDeploymentExists(ctx, t, resourceName, &deployment),
+					testAccCheckStageExists(ctx, t, stageResource, &stage),
 					resource.TestCheckResourceAttr(stageResource, "stage_name", stageName),
 					acctest.MatchResourceAttrRegionalARN(ctx, stageResource, "execution_arn", "execute-api", regexache.MustCompile(fmt.Sprintf(".+/%s", stageName))),
 					resource.TestMatchResourceAttr(stageResource, "invoke_url", regexache.MustCompile(fmt.Sprintf("https://.+\\.execute-api\\.%s.amazonaws\\.com/%s", acctest.Region(), stageName))),
@@ -254,19 +252,19 @@ func TestAccAPIGatewayDeployment_stageName(t *testing.T) {
 func TestAccAPIGatewayDeployment_variables(t *testing.T) {
 	ctx := acctest.Context(t)
 	var deployment apigateway.GetDeploymentOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_deployment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeploymentDestroy(ctx),
+		CheckDestroy:             testAccCheckDeploymentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeploymentConfig_variables(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeploymentExists(ctx, resourceName, &deployment),
+					testAccCheckDeploymentExists(ctx, t, resourceName, &deployment),
 					resource.TestCheckResourceAttr(resourceName, "variables.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "variables.key1", acctest.CtValue1),
 				),
@@ -280,18 +278,18 @@ func TestAccAPIGatewayDeployment_conflictingConnectionType(t *testing.T) {
 	ctx := acctest.Context(t)
 	var deployment apigateway.GetDeploymentOutput
 	resourceName := "aws_api_gateway_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeploymentDestroy(ctx),
+		CheckDestroy:             testAccCheckDeploymentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeploymentConfig_conflictingConnectionType(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeploymentExists(ctx, resourceName, &deployment),
+					testAccCheckDeploymentExists(ctx, t, resourceName, &deployment),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -299,14 +297,14 @@ func TestAccAPIGatewayDeployment_conflictingConnectionType(t *testing.T) {
 	})
 }
 
-func testAccCheckDeploymentExists(ctx context.Context, n string, v *apigateway.GetDeploymentOutput) resource.TestCheckFunc {
+func testAccCheckDeploymentExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetDeploymentOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindDeploymentByTwoPartKey(ctx, conn, rs.Primary.Attributes["rest_api_id"], rs.Primary.ID)
 
@@ -320,9 +318,9 @@ func testAccCheckDeploymentExists(ctx context.Context, n string, v *apigateway.G
 	}
 }
 
-func testAccCheckDeploymentDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckDeploymentDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_deployment" {

--- a/internal/service/apigateway/documentation_part.go
+++ b/internal/service/apigateway/documentation_part.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -210,9 +209,8 @@ func findDocumentationPartByTwoPartKey(ctx context.Context, conn *apigateway.Cli
 	output, err := conn.GetDocumentationPart(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/documentation_part_test.go
+++ b/internal/service/apigateway/documentation_part_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -29,16 +28,16 @@ func TestAccAPIGatewayDocumentationPart_basic(t *testing.T) {
 	uProperties := `{"description":"Terraform Acceptance Test Updated"}`
 	resourceName := "aws_api_gateway_documentation_part.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDocumentationPartDestroy(ctx),
+		CheckDestroy:             testAccCheckDocumentationPartDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDocumentationPartConfig_basic(apiName, strconv.Quote(properties)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDocumentationPartExists(ctx, resourceName, &conf),
+					testAccCheckDocumentationPartExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "documentation_part_id"),
 					resource.TestCheckResourceAttr(resourceName, "location.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "location.0.type", "API"),
@@ -54,7 +53,7 @@ func TestAccAPIGatewayDocumentationPart_basic(t *testing.T) {
 			{
 				Config: testAccDocumentationPartConfig_basic(apiName, strconv.Quote(uProperties)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDocumentationPartExists(ctx, resourceName, &conf),
+					testAccCheckDocumentationPartExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "location.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "location.0.type", "API"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrProperties, uProperties),
@@ -74,16 +73,16 @@ func TestAccAPIGatewayDocumentationPart_method(t *testing.T) {
 	uProperties := `{"description":"Terraform Acceptance Test Updated"}`
 	resourceName := "aws_api_gateway_documentation_part.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDocumentationPartDestroy(ctx),
+		CheckDestroy:             testAccCheckDocumentationPartDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDocumentationPartConfig_method(apiName, strconv.Quote(properties)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDocumentationPartExists(ctx, resourceName, &conf),
+					testAccCheckDocumentationPartExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "location.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "location.0.type", "METHOD"),
 					resource.TestCheckResourceAttr(resourceName, "location.0.method", "GET"),
@@ -100,7 +99,7 @@ func TestAccAPIGatewayDocumentationPart_method(t *testing.T) {
 			{
 				Config: testAccDocumentationPartConfig_method(apiName, strconv.Quote(uProperties)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDocumentationPartExists(ctx, resourceName, &conf),
+					testAccCheckDocumentationPartExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "location.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "location.0.type", "METHOD"),
 					resource.TestCheckResourceAttr(resourceName, "location.0.method", "GET"),
@@ -122,16 +121,16 @@ func TestAccAPIGatewayDocumentationPart_responseHeader(t *testing.T) {
 	uProperties := `{"description":"Terraform Acceptance Test Updated"}`
 	resourceName := "aws_api_gateway_documentation_part.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDocumentationPartDestroy(ctx),
+		CheckDestroy:             testAccCheckDocumentationPartDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDocumentationPartConfig_responseHeader(apiName, strconv.Quote(properties)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDocumentationPartExists(ctx, resourceName, &conf),
+					testAccCheckDocumentationPartExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "location.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "location.0.type", "RESPONSE_HEADER"),
 					resource.TestCheckResourceAttr(resourceName, "location.0.method", "GET"),
@@ -150,7 +149,7 @@ func TestAccAPIGatewayDocumentationPart_responseHeader(t *testing.T) {
 			{
 				Config: testAccDocumentationPartConfig_responseHeader(apiName, strconv.Quote(uProperties)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDocumentationPartExists(ctx, resourceName, &conf),
+					testAccCheckDocumentationPartExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "location.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "location.0.type", "RESPONSE_HEADER"),
 					resource.TestCheckResourceAttr(resourceName, "location.0.method", "GET"),
@@ -173,16 +172,16 @@ func TestAccAPIGatewayDocumentationPart_disappears(t *testing.T) {
 	properties := `{"description":"Terraform Acceptance Test"}`
 	resourceName := "aws_api_gateway_documentation_part.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDocumentationPartDestroy(ctx),
+		CheckDestroy:             testAccCheckDocumentationPartDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDocumentationPartConfig_basic(apiName, strconv.Quote(properties)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDocumentationPartExists(ctx, resourceName, &conf),
+					testAccCheckDocumentationPartExists(ctx, t, resourceName, &conf),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceDocumentationPart(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -191,14 +190,14 @@ func TestAccAPIGatewayDocumentationPart_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckDocumentationPartExists(ctx context.Context, n string, v *apigateway.GetDocumentationPartOutput) resource.TestCheckFunc {
+func testAccCheckDocumentationPartExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetDocumentationPartOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindDocumentationPartByTwoPartKey(ctx, conn, rs.Primary.Attributes["rest_api_id"], rs.Primary.Attributes["documentation_part_id"])
 
@@ -212,9 +211,9 @@ func testAccCheckDocumentationPartExists(ctx context.Context, n string, v *apiga
 	}
 }
 
-func testAccCheckDocumentationPartDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckDocumentationPartDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_documentation_part" {

--- a/internal/service/apigateway/documentation_version.go
+++ b/internal/service/apigateway/documentation_version.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -172,9 +171,8 @@ func findDocumentationVersionByTwoPartKey(ctx context.Context, conn *apigateway.
 	output, err := conn.GetDocumentationVersion(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/documentation_version_test.go
+++ b/internal/service/apigateway/documentation_version_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -27,16 +26,16 @@ func TestAccAPIGatewayDocumentationVersion_basic(t *testing.T) {
 	apiName := fmt.Sprintf("tf-acc-test_api_doc_version_basic_%s", rString)
 	resourceName := "aws_api_gateway_documentation_version.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDocumentationVersionDestroy(ctx),
+		CheckDestroy:             testAccCheckDocumentationVersionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDocumentationVersionConfig_basic(version, apiName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDocumentationVersionExists(ctx, resourceName, &conf),
+					testAccCheckDocumentationVersionExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, version),
 					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
 				),
@@ -61,16 +60,16 @@ func TestAccAPIGatewayDocumentationVersion_allFields(t *testing.T) {
 	uDescription := fmt.Sprintf("Tf Acc Test description updated %s", rString)
 	resourceName := "aws_api_gateway_documentation_version.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDocumentationVersionDestroy(ctx),
+		CheckDestroy:             testAccCheckDocumentationVersionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDocumentationVersionConfig_allFields(version, apiName, stageName, description),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDocumentationVersionExists(ctx, resourceName, &conf),
+					testAccCheckDocumentationVersionExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, version),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, description),
 					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
@@ -84,7 +83,7 @@ func TestAccAPIGatewayDocumentationVersion_allFields(t *testing.T) {
 			{
 				Config: testAccDocumentationVersionConfig_allFields(version, apiName, stageName, uDescription),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDocumentationVersionExists(ctx, resourceName, &conf),
+					testAccCheckDocumentationVersionExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, version),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, uDescription),
 					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
@@ -102,16 +101,16 @@ func TestAccAPIGatewayDocumentationVersion_disappears(t *testing.T) {
 	apiName := fmt.Sprintf("tf-acc-test_api_doc_version_basic_%s", rString)
 	resourceName := "aws_api_gateway_documentation_version.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDocumentationVersionDestroy(ctx),
+		CheckDestroy:             testAccCheckDocumentationVersionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDocumentationVersionConfig_basic(version, apiName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDocumentationVersionExists(ctx, resourceName, &conf),
+					testAccCheckDocumentationVersionExists(ctx, t, resourceName, &conf),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceDocumentationVersion(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -120,14 +119,14 @@ func TestAccAPIGatewayDocumentationVersion_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckDocumentationVersionExists(ctx context.Context, n string, v *apigateway.GetDocumentationVersionOutput) resource.TestCheckFunc {
+func testAccCheckDocumentationVersionExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetDocumentationVersionOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindDocumentationVersionByTwoPartKey(ctx, conn, rs.Primary.Attributes["rest_api_id"], rs.Primary.Attributes[names.AttrVersion])
 
@@ -141,9 +140,9 @@ func testAccCheckDocumentationVersionExists(ctx context.Context, n string, v *ap
 	}
 }
 
-func testAccCheckDocumentationVersionDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckDocumentationVersionDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_documentation_version" {

--- a/internal/service/apigateway/domain_name.go
+++ b/internal/service/apigateway/domain_name.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -35,6 +34,8 @@ import (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigateway;apigateway.GetDomainNameOutput")
 // @Testing(generator="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.RandomSubdomain()")
 // @Testing(tlsKey=true, tlsKeyDomain="rName")
+// @Testing(existsTakesT=true)
+// @Testing(destroyTakesT=true)
 func resourceDomainName() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDomainNameCreate,
@@ -566,9 +567,8 @@ func findDomainNameByTwoPartKey(ctx context.Context, conn *apigateway.Client, do
 	output, err := conn.GetDomainName(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 
@@ -583,8 +583,8 @@ func findDomainNameByTwoPartKey(ctx context.Context, conn *apigateway.Client, do
 	return output, nil
 }
 
-func statusDomainName(ctx context.Context, conn *apigateway.Client, domainName, domainNameID string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusDomainName(conn *apigateway.Client, domainName, domainNameID string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findDomainNameByTwoPartKey(ctx, conn, domainName, domainNameID)
 
 		if retry.NotFound(err) {
@@ -600,10 +600,10 @@ func statusDomainName(ctx context.Context, conn *apigateway.Client, domainName, 
 }
 
 func waitDomainNameUpdated(ctx context.Context, conn *apigateway.Client, domainName, domainNameID string, timeout time.Duration) error {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:    enum.Slice(types.DomainNameStatusUpdating),
 		Target:     enum.Slice(types.DomainNameStatusAvailable),
-		Refresh:    statusDomainName(ctx, conn, domainName, domainNameID),
+		Refresh:    statusDomainName(conn, domainName, domainNameID),
 		Timeout:    timeout,
 		Delay:      1 * time.Minute,
 		MinTimeout: 10 * time.Second,

--- a/internal/service/apigateway/domain_name_access_association.go
+++ b/internal/service/apigateway/domain_name_access_association.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
@@ -36,6 +35,8 @@ import (
 // @Testing(generator="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.RandomSubdomain()")
 // @Testing(tlsKey=true, tlsKeyDomain="rName")
 // @Testing(preIdentityVersion="v5.100.0")
+// @Testing(destroyTakesT=true)
+// @Testing(existsTakesT=true)
 func newDomainNameAccessAssociationResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &domainNameAccessAssociationResource{}
 
@@ -207,9 +208,8 @@ func findDomainNameAccessAssociations(ctx context.Context, conn *apigateway.Clie
 	})
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/domain_name_access_association_identity_gen_test.go
+++ b/internal/service/apigateway/domain_name_access_association_identity_gen_test.go
@@ -37,7 +37,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Identity_Basic(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			// Step 1: Setup
@@ -49,7 +49,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Identity_Basic(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
@@ -267,7 +267,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Identity_ExistingResource(t *t
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// Step 1: Create pre-Identity
 			{
@@ -278,7 +278,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Identity_ExistingResource(t *t
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),
@@ -294,7 +294,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Identity_ExistingResource(t *t
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -355,7 +355,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Identity_ExistingResource_NoRe
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
 			Plan: resource.PlanOptions{
 				NoRefresh: true,
@@ -371,7 +371,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Identity_ExistingResource_NoRe
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),

--- a/internal/service/apigateway/domain_name_access_association_tags_gen_test.go
+++ b/internal/service/apigateway/domain_name_access_association_tags_gen_test.go
@@ -35,7 +35,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -49,7 +49,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -97,7 +97,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -149,7 +149,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -194,7 +194,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -239,7 +239,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -253,7 +253,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_null(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -311,7 +311,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -323,7 +323,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyMap(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -371,7 +371,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_AddOnUpdate(t *testing.T)
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -383,7 +383,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_AddOnUpdate(t *testing.T)
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -408,7 +408,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_AddOnUpdate(t *testing.T)
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -463,7 +463,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnCreate(t *test
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -477,7 +477,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnCreate(t *test
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -522,7 +522,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnCreate(t *test
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -567,7 +567,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnUpdate_Add(t *
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -581,7 +581,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnUpdate_Add(t *
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -615,7 +615,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnUpdate_Add(t *
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -667,7 +667,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnUpdate_Add(t *
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -722,7 +722,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnUpdate_Replace
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -736,7 +736,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnUpdate_Replace
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -769,7 +769,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnUpdate_Replace
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -824,7 +824,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_providerOnly(
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -839,7 +839,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_providerOnly(
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -887,7 +887,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_providerOnly(
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -937,7 +937,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_providerOnly(
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -981,7 +981,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_providerOnly(
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1027,7 +1027,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nonOverlappin
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1044,7 +1044,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nonOverlappin
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1102,7 +1102,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nonOverlappin
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1159,7 +1159,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nonOverlappin
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1205,7 +1205,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_overlapping(t
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1222,7 +1222,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_overlapping(t
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1279,7 +1279,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_overlapping(t
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1340,7 +1340,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_overlapping(t
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1399,7 +1399,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_updateToProvi
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1413,7 +1413,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_updateToProvi
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1448,7 +1448,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_updateToProvi
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1501,7 +1501,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_updateToResou
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1516,7 +1516,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_updateToResou
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1546,7 +1546,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_updateToResou
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1602,7 +1602,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_emptyResource
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1619,7 +1619,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_emptyResource
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1678,7 +1678,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_emptyProvider
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1693,7 +1693,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_emptyProvider
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1746,7 +1746,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nullOverlappi
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1763,7 +1763,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nullOverlappi
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1825,7 +1825,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nullNonOverla
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1842,7 +1842,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nullNonOverla
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1906,7 +1906,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnCreate(t *t
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1918,7 +1918,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnCreate(t *t
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1971,7 +1971,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnUpdate_Add(
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1985,7 +1985,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnUpdate_Add(
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2019,7 +2019,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnUpdate_Add(
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2080,7 +2080,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnUpdate_Repl
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -2094,7 +2094,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnUpdate_Repl
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2126,7 +2126,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnUpdate_Repl
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2179,7 +2179,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_IgnoreTags_Overlap_Defaul
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2200,7 +2200,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_IgnoreTags_Overlap_Defaul
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2251,7 +2251,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_IgnoreTags_Overlap_Defaul
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2302,7 +2302,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_IgnoreTags_Overlap_Defaul
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2353,7 +2353,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_IgnoreTags_Overlap_Resour
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2372,7 +2372,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_IgnoreTags_Overlap_Resour
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2432,7 +2432,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_IgnoreTags_Overlap_Resour
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2491,7 +2491,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_IgnoreTags_Overlap_Resour
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/apigateway/domain_name_access_association_test.go
+++ b/internal/service/apigateway/domain_name_access_association_test.go
@@ -9,11 +9,9 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -23,21 +21,21 @@ func TestAccAPIGatewayDomainNameAccessAssociation_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	domain := acctest.RandomSubdomain()
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domain)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainNameAccessAssociationConfig_basic(rName, domain, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "access_association_source", "aws_vpc_endpoint.test", names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "access_association_source_type", "VPCE"),
 				),
@@ -55,21 +53,21 @@ func TestAccAPIGatewayDomainNameAccessAssociation_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	domain := acctest.RandomSubdomain()
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domain)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainNameAccessAssociationConfig_basic(rName, domain, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameAccessAssociationExists(ctx, resourceName, &v),
+					testAccCheckDomainNameAccessAssociationExists(ctx, t, resourceName, &v),
 					acctest.CheckFrameworkResourceDisappears(ctx, t, tfapigateway.ResourceDomainNameAccessAssociation, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -78,14 +76,14 @@ func TestAccAPIGatewayDomainNameAccessAssociation_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckDomainNameAccessAssociationExists(ctx context.Context, n string, v *types.DomainNameAccessAssociation) resource.TestCheckFunc {
+func testAccCheckDomainNameAccessAssociationExists(ctx context.Context, t *testing.T, n string, v *types.DomainNameAccessAssociation) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindDomainNameAccessAssociationByARN(ctx, conn, rs.Primary.ID)
 
@@ -99,9 +97,9 @@ func testAccCheckDomainNameAccessAssociationExists(ctx context.Context, n string
 	}
 }
 
-func testAccCheckDomainNameAccessAssociationDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckDomainNameAccessAssociationDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_domain_name_access_association" {

--- a/internal/service/apigateway/domain_name_data_source_test.go
+++ b/internal/service/apigateway/domain_name_data_source_test.go
@@ -20,11 +20,11 @@ func TestAccAPIGatewayDomainNameDataSource_basic(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainNameDataSourceConfig_regionalCertificateARN(rName, key, certificate),

--- a/internal/service/apigateway/domain_name_tags_gen_test.go
+++ b/internal/service/apigateway/domain_name_tags_gen_test.go
@@ -35,7 +35,7 @@ func TestAccAPIGatewayDomainName_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -49,7 +49,7 @@ func TestAccAPIGatewayDomainName_tags(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -97,7 +97,7 @@ func TestAccAPIGatewayDomainName_tags(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -149,7 +149,7 @@ func TestAccAPIGatewayDomainName_tags(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -194,7 +194,7 @@ func TestAccAPIGatewayDomainName_tags(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -239,7 +239,7 @@ func TestAccAPIGatewayDomainName_tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -253,7 +253,7 @@ func TestAccAPIGatewayDomainName_tags_null(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -318,7 +318,7 @@ func TestAccAPIGatewayDomainName_tags_EmptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -330,7 +330,7 @@ func TestAccAPIGatewayDomainName_tags_EmptyMap(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -393,7 +393,7 @@ func TestAccAPIGatewayDomainName_tags_AddOnUpdate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -405,7 +405,7 @@ func TestAccAPIGatewayDomainName_tags_AddOnUpdate(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -431,7 +431,7 @@ func TestAccAPIGatewayDomainName_tags_AddOnUpdate(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -486,7 +486,7 @@ func TestAccAPIGatewayDomainName_tags_EmptyTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -500,7 +500,7 @@ func TestAccAPIGatewayDomainName_tags_EmptyTag_OnCreate(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -544,7 +544,7 @@ func TestAccAPIGatewayDomainName_tags_EmptyTag_OnCreate(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -589,7 +589,7 @@ func TestAccAPIGatewayDomainName_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -603,7 +603,7 @@ func TestAccAPIGatewayDomainName_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -637,7 +637,7 @@ func TestAccAPIGatewayDomainName_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -687,7 +687,7 @@ func TestAccAPIGatewayDomainName_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -742,7 +742,7 @@ func TestAccAPIGatewayDomainName_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -756,7 +756,7 @@ func TestAccAPIGatewayDomainName_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -789,7 +789,7 @@ func TestAccAPIGatewayDomainName_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -843,7 +843,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_providerOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -858,7 +858,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -906,7 +906,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -956,7 +956,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1000,7 +1000,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1046,7 +1046,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_nonOverlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1063,7 +1063,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1121,7 +1121,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1178,7 +1178,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1224,7 +1224,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_overlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1241,7 +1241,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_overlapping(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1298,7 +1298,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_overlapping(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1359,7 +1359,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_overlapping(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1418,7 +1418,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_updateToProviderOnly(t *testin
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1432,7 +1432,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_updateToProviderOnly(t *testin
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1467,7 +1467,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_updateToProviderOnly(t *testin
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1520,7 +1520,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_updateToResourceOnly(t *testin
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1535,7 +1535,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_updateToResourceOnly(t *testin
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1565,7 +1565,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_updateToResourceOnly(t *testin
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1621,7 +1621,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_emptyResourceTag(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1638,7 +1638,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_emptyResourceTag(t *testing.T)
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1696,7 +1696,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1711,7 +1711,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1763,7 +1763,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_nullOverlappingResourceTag(t *
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1780,7 +1780,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_nullOverlappingResourceTag(t *
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1835,7 +1835,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_nullNonOverlappingResourceTag(
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1852,7 +1852,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_nullNonOverlappingResourceTag(
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1907,7 +1907,7 @@ func TestAccAPIGatewayDomainName_tags_ComputedTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1919,7 +1919,7 @@ func TestAccAPIGatewayDomainName_tags_ComputedTag_OnCreate(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1972,7 +1972,7 @@ func TestAccAPIGatewayDomainName_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1986,7 +1986,7 @@ func TestAccAPIGatewayDomainName_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2020,7 +2020,7 @@ func TestAccAPIGatewayDomainName_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2081,7 +2081,7 @@ func TestAccAPIGatewayDomainName_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -2095,7 +2095,7 @@ func TestAccAPIGatewayDomainName_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2127,7 +2127,7 @@ func TestAccAPIGatewayDomainName_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2180,7 +2180,7 @@ func TestAccAPIGatewayDomainName_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2201,7 +2201,7 @@ func TestAccAPIGatewayDomainName_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2252,7 +2252,7 @@ func TestAccAPIGatewayDomainName_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2303,7 +2303,7 @@ func TestAccAPIGatewayDomainName_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2354,7 +2354,7 @@ func TestAccAPIGatewayDomainName_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2373,7 +2373,7 @@ func TestAccAPIGatewayDomainName_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2438,7 +2438,7 @@ func TestAccAPIGatewayDomainName_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2503,7 +2503,7 @@ func TestAccAPIGatewayDomainName_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/apigateway/domain_name_test.go
+++ b/internal/service/apigateway/domain_name_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -37,20 +36,20 @@ func TestAccAPIGatewayDomainName_certificateARN(t *testing.T) {
 	acmCertificateResourceName := "aws_acm_certificate.test"
 	resourceName := "aws_api_gateway_domain_name.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckRegion(t, endpoints.UsEast1RegionID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainNameConfig_certificateARN(rootDomain, domain),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &domainName),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &domainName),
 					testAccCheckResourceAttrRegionalARNEdgeDomainName(resourceName, names.AttrARN, "apigateway", domain),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrCertificateARN, acmCertificateResourceName, names.AttrARN),
 					resource.TestMatchResourceAttr(resourceName, "cloudfront_domain_name", regexache.MustCompile(`[0-9a-z]+.cloudfront.net`)),
-					resource.TestCheckResourceAttr(resourceName, "cloudfront_zone_id", acctest.Provider.Meta().(*conns.AWSClient).CloudFrontDistributionHostedZoneID(ctx)),
+					resource.TestCheckResourceAttr(resourceName, "cloudfront_zone_id", acctest.ProviderMeta(ctx, t).CloudFrontDistributionHostedZoneID(ctx)),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrDomainName, acmCertificateResourceName, names.AttrDomainName),
 				),
 			},
@@ -99,20 +98,20 @@ func TestAccAPIGatewayDomainName_certificateName(t *testing.T) {
 	var conf apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainNameConfig_certificate(domainName, certificatePrivateKey, certificateBody, certificateChain),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &conf),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/domainnames/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "certificate_name", "tf-acc-apigateway-domain-name"),
 					resource.TestCheckResourceAttrSet(resourceName, "cloudfront_domain_name"),
-					resource.TestCheckResourceAttr(resourceName, "cloudfront_zone_id", acctest.Provider.Meta().(*conns.AWSClient).CloudFrontDistributionHostedZoneID(ctx)),
+					resource.TestCheckResourceAttr(resourceName, "cloudfront_zone_id", acctest.ProviderMeta(ctx, t).CloudFrontDistributionHostedZoneID(ctx)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, domainName),
 					resource.TestCheckResourceAttrSet(resourceName, "certificate_upload_date"),
 				),
@@ -135,16 +134,16 @@ func TestAccAPIGatewayDomainName_regionalCertificateARN(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainNameConfig_regionalCertificateARN(rName, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &domainName),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &domainName),
 					testAccCheckResourceAttrRegionalARNRegionalDomainName(resourceName, names.AttrARN, "apigateway", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, rName),
 					resource.TestCheckResourceAttr(resourceName, "domain_name_id", ""),
@@ -180,16 +179,16 @@ func TestAccAPIGatewayDomainName_regionalCertificateName(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509LocallySignedCertificatePEM(t, caKey, caCertificate, key, domainWildcard)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainNameConfig_regionalCertificate(rName, key, certificate, caCertificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &domainName),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &domainName),
 					testAccCheckResourceAttrRegionalARNRegionalDomainName(resourceName, names.AttrARN, "apigateway", rName),
 					resource.TestCheckResourceAttr(resourceName, "certificate_body", certificate),
 					resource.TestCheckResourceAttr(resourceName, names.AttrCertificateChain, caCertificate),
@@ -213,16 +212,16 @@ func TestAccAPIGatewayDomainName_securityPolicy(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainNameConfig_securityPolicy(rName, key, certificate, string(types.SecurityPolicyTls12)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &domainName),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &domainName),
 					resource.TestCheckResourceAttr(resourceName, "security_policy", string(types.SecurityPolicyTls12)),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_access_mode", ""),
 				),
@@ -244,16 +243,16 @@ func TestAccAPIGatewayDomainName_securityPolicyEnhanced(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainNameConfig_securityPolicyWithEndpointAccessMode(rName, key, certificate, string(types.SecurityPolicySecurityPolicyTls1312PfsPq202509), string(types.EndpointAccessModeBasic)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &domainName),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &domainName),
 					resource.TestCheckResourceAttr(resourceName, "security_policy", string(types.SecurityPolicySecurityPolicyTls1312PfsPq202509)),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_access_mode", string(types.EndpointAccessModeBasic)),
 				),
@@ -275,16 +274,16 @@ func TestAccAPIGatewayDomainName_securityPolicyEnhancedUpdate(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainNameConfig_securityPolicy(rName, key, certificate, string(types.SecurityPolicyTls12)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &domainName),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &domainName),
 					resource.TestCheckResourceAttr(resourceName, "security_policy", string(types.SecurityPolicyTls12)),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_access_mode", ""),
 				),
@@ -292,7 +291,7 @@ func TestAccAPIGatewayDomainName_securityPolicyEnhancedUpdate(t *testing.T) {
 			{
 				Config: testAccDomainNameConfig_securityPolicyWithEndpointAccessMode(rName, key, certificate, string(types.SecurityPolicySecurityPolicyTls1312PfsPq202509), string(types.EndpointAccessModeBasic)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &domainName),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &domainName),
 					resource.TestCheckResourceAttr(resourceName, "security_policy", string(types.SecurityPolicySecurityPolicyTls1312PfsPq202509)),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_access_mode", string(types.EndpointAccessModeBasic)),
 				),
@@ -305,7 +304,7 @@ func TestAccAPIGatewayDomainName_securityPolicyEnhancedUpdate(t *testing.T) {
 			{
 				Config: testAccDomainNameConfig_securityPolicyWithEndpointAccessMode(rName, key, certificate, string(types.SecurityPolicySecurityPolicyTls1313202509), string(types.EndpointAccessModeStrict)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &domainName),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &domainName),
 					resource.TestCheckResourceAttr(resourceName, "security_policy", string(types.SecurityPolicySecurityPolicyTls1313202509)),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_access_mode", string(types.EndpointAccessModeStrict)),
 				),
@@ -313,7 +312,7 @@ func TestAccAPIGatewayDomainName_securityPolicyEnhancedUpdate(t *testing.T) {
 			{
 				Config: testAccDomainNameConfig_securityPolicy(rName, key, certificate, string(types.SecurityPolicyTls12)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &domainName),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &domainName),
 					resource.TestCheckResourceAttr(resourceName, "security_policy", string(types.SecurityPolicyTls12)),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_access_mode", ""),
 				),
@@ -335,16 +334,16 @@ func TestAccAPIGatewayDomainName_private(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainNameConfig_private(rName, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &domainName),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &domainName),
 					resource.TestCheckResourceAttrSet(resourceName, "domain_name_id"),
 				),
 			},
@@ -365,16 +364,16 @@ func TestAccAPIGatewayDomainName_privatePolicy(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainNameConfig_privatePolicy(rName, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &domainName),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &domainName),
 					resource.TestCheckResourceAttrSet(resourceName, "domain_name_id"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrPolicy),
 				),
@@ -396,23 +395,23 @@ func TestAccAPIGatewayDomainName_privatePolicy_added(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainNameConfig_private(rName, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &domainName),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &domainName),
 					resource.TestCheckResourceAttrSet(resourceName, "domain_name_id"),
 				),
 			},
 			{
 				Config: testAccDomainNameConfig_privatePolicy(rName, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &domainName),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &domainName),
 					resource.TestCheckResourceAttrSet(resourceName, "domain_name_id"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrPolicy),
 				),
@@ -434,16 +433,16 @@ func TestAccAPIGatewayDomainName_disappears(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainNameConfig_regionalCertificateARN(rName, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &domainName),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &domainName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceDomainName(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -460,18 +459,18 @@ func TestAccAPIGatewayDomainName_MutualTLSAuthentication_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_domain_name.test"
 	acmCertificateResourceName := "aws_acm_certificate.test"
 	s3ObjectResourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainNameConfig_mutualTLSAuthentication(rName, rootDomain, domain),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/domainnames/.+$`)),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrDomainName, acmCertificateResourceName, names.AttrDomainName),
 					resource.TestCheckResourceAttr(resourceName, "mutual_tls_authentication.#", "1"),
@@ -488,7 +487,7 @@ func TestAccAPIGatewayDomainName_MutualTLSAuthentication_basic(t *testing.T) {
 			{
 				Config: testAccDomainNameConfig_mutualTLSAuthenticationMissing(rootDomain, domain),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrDomainName, acmCertificateResourceName, names.AttrDomainName),
 					resource.TestCheckResourceAttr(resourceName, "mutual_tls_authentication.#", "0"),
 				),
@@ -496,7 +495,7 @@ func TestAccAPIGatewayDomainName_MutualTLSAuthentication_basic(t *testing.T) {
 			{
 				Config: testAccDomainNameConfig_mutualTLSAuthentication(rName, rootDomain, domain),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/domainnames/.+$`)),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrDomainName, acmCertificateResourceName, names.AttrDomainName),
 					resource.TestCheckResourceAttr(resourceName, "mutual_tls_authentication.#", "1"),
@@ -518,18 +517,18 @@ func TestAccAPIGatewayDomainName_MutualTLSAuthentication_ownership(t *testing.T)
 	resourceName := "aws_api_gateway_domain_name.test"
 	publicAcmCertificateResourceName := "aws_acm_certificate.test"
 	s3ObjectResourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainNameConfig_mutualTLSOwnership(rName, rootDomain, domain, certificate, key),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &v),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/domainnames/.+$`)),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrDomainName, publicAcmCertificateResourceName, names.AttrDomainName),
 					resource.TestCheckResourceAttrPair(resourceName, "ownership_verification_certificate_arn", publicAcmCertificateResourceName, names.AttrARN),
@@ -555,10 +554,10 @@ func TestAccAPIGatewayDomainName_updateIDFormat(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy: testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
@@ -569,7 +568,7 @@ func TestAccAPIGatewayDomainName_updateIDFormat(t *testing.T) {
 				},
 				Config: testAccDomainNameConfig_regionalCertificateARN(rName, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &domainName),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &domainName),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -584,7 +583,7 @@ func TestAccAPIGatewayDomainName_updateIDFormat(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				Config:                   testAccDomainNameConfig_regionalCertificateARN(rName, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &domainName),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &domainName),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -610,16 +609,16 @@ func TestAccAPIGatewayDomainName_ipAddressType(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainNameConfig_ipAddressType(rName, key, certificate, "ipv4"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &domainName),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &domainName),
 					testAccCheckResourceAttrRegionalARNRegionalDomainName(resourceName, names.AttrARN, "apigateway", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, rName),
 					resource.TestCheckResourceAttr(resourceName, "domain_name_id", ""),
@@ -636,7 +635,7 @@ func TestAccAPIGatewayDomainName_ipAddressType(t *testing.T) {
 			{
 				Config: testAccDomainNameConfig_ipAddressType(rName, key, certificate, "dualstack"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(ctx, resourceName, &domainName),
+					testAccCheckDomainNameExists(ctx, t, resourceName, &domainName),
 					testAccCheckResourceAttrRegionalARNRegionalDomainName(resourceName, names.AttrARN, "apigateway", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, rName),
 					resource.TestCheckResourceAttr(resourceName, "domain_name_id", ""),
@@ -649,14 +648,14 @@ func TestAccAPIGatewayDomainName_ipAddressType(t *testing.T) {
 	})
 }
 
-func testAccCheckDomainNameExists(ctx context.Context, n string, v *apigateway.GetDomainNameOutput) resource.TestCheckFunc {
+func testAccCheckDomainNameExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetDomainNameOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindDomainNameByTwoPartKey(ctx, conn, rs.Primary.Attributes[names.AttrDomainName], rs.Primary.Attributes["domain_name_id"])
 
@@ -670,9 +669,9 @@ func testAccCheckDomainNameExists(ctx context.Context, n string, v *apigateway.G
 	}
 }
 
-func testAccCheckDomainNameDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckDomainNameDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_domain_name" {

--- a/internal/service/apigateway/export_data_source_test.go
+++ b/internal/service/apigateway/export_data_source_test.go
@@ -6,7 +6,6 @@ package apigateway_test
 import (
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -14,10 +13,10 @@ import (
 
 func TestAccAPIGatewayExportDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_api_gateway_export.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/apigateway/gateway_response.go
+++ b/internal/service/apigateway/gateway_response.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -165,9 +164,8 @@ func findGatewayResponseByTwoPartKey(ctx context.Context, conn *apigateway.Clien
 	output, err := conn.GetGatewayResponse(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/gateway_response_test.go
+++ b/internal/service/apigateway/gateway_response_test.go
@@ -9,11 +9,9 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -22,19 +20,19 @@ import (
 func TestAccAPIGatewayGatewayResponse_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetGatewayResponseOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_gateway_response.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGatewayResponseDestroy(ctx),
+		CheckDestroy:             testAccCheckGatewayResponseDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGatewayResponseConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGatewayResponseExists(ctx, resourceName, &conf),
+					testAccCheckGatewayResponseExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatusCode, "401"),
 					resource.TestCheckResourceAttr(resourceName, "response_parameters.gatewayresponse.header.Authorization", "'Basic'"),
 					resource.TestCheckResourceAttr(resourceName, "response_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
@@ -50,7 +48,7 @@ func TestAccAPIGatewayGatewayResponse_basic(t *testing.T) {
 			{
 				Config: testAccGatewayResponseConfig_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGatewayResponseExists(ctx, resourceName, &conf),
+					testAccCheckGatewayResponseExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatusCode, "477"),
 					resource.TestCheckResourceAttr(resourceName, "response_templates.application/json", "{'message':$context.error.messageString}"),
 					resource.TestCheckNoResourceAttr(resourceName, "response_templates.application/xml"),
@@ -64,19 +62,19 @@ func TestAccAPIGatewayGatewayResponse_basic(t *testing.T) {
 func TestAccAPIGatewayGatewayResponse_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetGatewayResponseOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_gateway_response.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGatewayResponseDestroy(ctx),
+		CheckDestroy:             testAccCheckGatewayResponseDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGatewayResponseConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGatewayResponseExists(ctx, resourceName, &conf),
+					testAccCheckGatewayResponseExists(ctx, t, resourceName, &conf),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceGatewayResponse(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -85,14 +83,14 @@ func TestAccAPIGatewayGatewayResponse_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckGatewayResponseExists(ctx context.Context, n string, v *apigateway.GetGatewayResponseOutput) resource.TestCheckFunc {
+func testAccCheckGatewayResponseExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetGatewayResponseOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindGatewayResponseByTwoPartKey(ctx, conn, rs.Primary.Attributes["response_type"], rs.Primary.Attributes["rest_api_id"])
 
@@ -106,9 +104,9 @@ func testAccCheckGatewayResponseExists(ctx context.Context, n string, v *apigate
 	}
 }
 
-func testAccCheckGatewayResponseDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckGatewayResponseDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_gateway_response" {

--- a/internal/service/apigateway/integration.go
+++ b/internal/service/apigateway/integration.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -713,9 +712,8 @@ func findIntegration(ctx context.Context, conn *apigateway.Client, input *apigat
 	output, err := conn.GetIntegration(ctx, input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/integration_response.go
+++ b/internal/service/apigateway/integration_response.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -198,9 +197,8 @@ func findIntegrationResponseByFourPartKey(ctx context.Context, conn *apigateway.
 	output, err := conn.GetIntegrationResponse(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/integration_response_test.go
+++ b/internal/service/apigateway/integration_response_test.go
@@ -9,11 +9,9 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -22,19 +20,19 @@ import (
 func TestAccAPIGatewayIntegrationResponse_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetIntegrationResponseOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_integration_response.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckIntegrationResponseDestroy(ctx),
+		CheckDestroy:             testAccCheckIntegrationResponseDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIntegrationResponseConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIntegrationResponseExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationResponseExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "content_handling", ""),
 					resource.TestCheckResourceAttr(resourceName, "response_parameters.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "response_parameters.method.response.header.Content-Type", "integration.response.body.type"),
@@ -54,7 +52,7 @@ func TestAccAPIGatewayIntegrationResponse_basic(t *testing.T) {
 			{
 				Config: testAccIntegrationResponseConfig_update(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIntegrationResponseExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationResponseExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "content_handling", "CONVERT_TO_BINARY"),
 					resource.TestCheckResourceAttr(resourceName, "response_parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "response_templates.%", "2"),
@@ -71,19 +69,19 @@ func TestAccAPIGatewayIntegrationResponse_basic(t *testing.T) {
 func TestAccAPIGatewayIntegrationResponse_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetIntegrationResponseOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_integration_response.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckIntegrationResponseDestroy(ctx),
+		CheckDestroy:             testAccCheckIntegrationResponseDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIntegrationResponseConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationResponseExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationResponseExists(ctx, t, resourceName, &conf),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceIntegrationResponse(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -92,14 +90,14 @@ func TestAccAPIGatewayIntegrationResponse_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckIntegrationResponseExists(ctx context.Context, n string, v *apigateway.GetIntegrationResponseOutput) resource.TestCheckFunc {
+func testAccCheckIntegrationResponseExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetIntegrationResponseOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindIntegrationResponseByFourPartKey(ctx, conn, rs.Primary.Attributes["http_method"], rs.Primary.Attributes[names.AttrResourceID], rs.Primary.Attributes["rest_api_id"], rs.Primary.Attributes[names.AttrStatusCode])
 
@@ -113,9 +111,9 @@ func testAccCheckIntegrationResponseExists(ctx context.Context, n string, v *api
 	}
 }
 
-func testAccCheckIntegrationResponseDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckIntegrationResponseDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_integration_response" {

--- a/internal/service/apigateway/integration_test.go
+++ b/internal/service/apigateway/integration_test.go
@@ -12,11 +12,9 @@ import (
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/apigateway/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -25,19 +23,19 @@ import (
 func TestAccAPIGatewayIntegration_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetIntegrationOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_integration.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckIntegrationDestroy(ctx),
+		CheckDestroy:             testAccCheckIntegrationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIntegrationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "GET"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
@@ -63,7 +61,7 @@ func TestAccAPIGatewayIntegration_basic(t *testing.T) {
 			{
 				Config: testAccIntegrationConfig_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "GET"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
@@ -82,7 +80,7 @@ func TestAccAPIGatewayIntegration_basic(t *testing.T) {
 			{
 				Config: testAccIntegrationConfig_updateURI(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "GET"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de/updated"),
@@ -101,7 +99,7 @@ func TestAccAPIGatewayIntegration_basic(t *testing.T) {
 			{
 				Config: testAccIntegrationConfig_updateNoTemplates(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "GET"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
@@ -116,7 +114,7 @@ func TestAccAPIGatewayIntegration_basic(t *testing.T) {
 			{
 				Config: testAccIntegrationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "GET"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
@@ -138,19 +136,19 @@ func TestAccAPIGatewayIntegration_basic(t *testing.T) {
 func TestAccAPIGatewayIntegration_contentHandling(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetIntegrationOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_integration.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckIntegrationDestroy(ctx),
+		CheckDestroy:             testAccCheckIntegrationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIntegrationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "GET"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
@@ -169,7 +167,7 @@ func TestAccAPIGatewayIntegration_contentHandling(t *testing.T) {
 			{
 				Config: testAccIntegrationConfig_updateContentHandling(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "GET"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
@@ -187,7 +185,7 @@ func TestAccAPIGatewayIntegration_contentHandling(t *testing.T) {
 			{
 				Config: testAccIntegrationConfig_removeContentHandling(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "GET"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
@@ -215,19 +213,19 @@ func TestAccAPIGatewayIntegration_contentHandling(t *testing.T) {
 func TestAccAPIGatewayIntegration_Parameters_cacheKey(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetIntegrationOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_integration.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckIntegrationDestroy(ctx),
+		CheckDestroy:             testAccCheckIntegrationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIntegrationConfig_Parameters_cacheKey(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "GET"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
@@ -259,19 +257,19 @@ func TestAccAPIGatewayIntegration_Parameters_cacheKey(t *testing.T) {
 func TestAccAPIGatewayIntegration_Parameters_cacheKeyUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetIntegrationOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_integration.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckIntegrationDestroy(ctx),
+		CheckDestroy:             testAccCheckIntegrationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIntegrationConfig_Parameters_cacheKey(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "GET"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
@@ -293,7 +291,7 @@ func TestAccAPIGatewayIntegration_Parameters_cacheKeyUpdate(t *testing.T) {
 			{
 				Config: testAccIntegrationConfig_Parameters_cacheKeyUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "GET"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
@@ -326,19 +324,19 @@ func TestAccAPIGatewayIntegration_Parameters_cacheKeyUpdate(t *testing.T) {
 func TestAccAPIGatewayIntegration_Parameters_requestUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetIntegrationOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_integration.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckIntegrationDestroy(ctx),
+		CheckDestroy:             testAccCheckIntegrationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIntegrationConfig_Parameters_requestUpdate(rName, []string{"X-Some-Header-1", "X-Some-Header-2", "X-Some-Header-3"}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP_PROXY"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "ANY"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
@@ -351,7 +349,7 @@ func TestAccAPIGatewayIntegration_Parameters_requestUpdate(t *testing.T) {
 			{
 				Config: testAccIntegrationConfig_Parameters_requestUpdate(rName, []string{"X-Some-Header-1", "X-Some-Header-3"}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP_PROXY"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "ANY"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
@@ -367,19 +365,19 @@ func TestAccAPIGatewayIntegration_Parameters_requestUpdate(t *testing.T) {
 func TestAccAPIGatewayIntegration_Parameters_requestCacheKeyUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetIntegrationOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_integration.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckIntegrationDestroy(ctx),
+		CheckDestroy:             testAccCheckIntegrationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIntegrationConfig_Parameters_requestCacheKeyUpdate(rName, []string{"X-Some-Header-1", "X-Some-Header-2", "X-Some-Header-3"}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP_PROXY"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "ANY"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
@@ -404,7 +402,7 @@ func TestAccAPIGatewayIntegration_Parameters_requestCacheKeyUpdate(t *testing.T)
 			{
 				Config: testAccIntegrationConfig_Parameters_requestCacheKeyUpdate(rName, []string{"X-Some-Header-1", "X-Some-Header-3"}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP_PROXY"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "ANY"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
@@ -426,7 +424,7 @@ func TestAccAPIGatewayIntegration_Parameters_requestCacheKeyUpdate(t *testing.T)
 			{
 				Config: testAccIntegrationConfig_Parameters_requestCacheKeyUpdate(rName, []string{"X-Some-Header-1", "X-Some-Header-4"}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP_PROXY"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "ANY"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
@@ -448,7 +446,7 @@ func TestAccAPIGatewayIntegration_Parameters_requestCacheKeyUpdate(t *testing.T)
 			{
 				Config: testAccIntegrationConfig_Parameters_requestCacheKeyUpdate(rName, []string{"X-Some-Header-1", "X-Some-Header-4", "X-Some-Header-5", "X-Some-Header-6", "X-Some-Header-7"}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP_PROXY"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "ANY"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
@@ -479,7 +477,7 @@ func TestAccAPIGatewayIntegration_Parameters_requestCacheKeyUpdate(t *testing.T)
 			{
 				Config: testAccIntegrationConfig_Parameters_requestCacheKeyUpdate(rName, []string{"X-Some-Header-2"}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP_PROXY"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "ANY"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
@@ -502,19 +500,19 @@ func TestAccAPIGatewayIntegration_Parameters_requestCacheKeyUpdate(t *testing.T)
 func TestAccAPIGatewayIntegration_integrationType(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetIntegrationOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_integration.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckIntegrationDestroy(ctx),
+		CheckDestroy:             testAccCheckIntegrationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIntegrationConfig_typeInternet(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "connection_type", "INTERNET"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrConnectionID, ""),
 				),
@@ -522,7 +520,7 @@ func TestAccAPIGatewayIntegration_integrationType(t *testing.T) {
 			{
 				Config: testAccIntegrationConfig_typeVPCLink(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "connection_type", "VPC_LINK"),
 					resource.TestMatchResourceAttr(resourceName, names.AttrConnectionID, regexache.MustCompile("^[0-9a-z]+$")),
 				),
@@ -530,7 +528,7 @@ func TestAccAPIGatewayIntegration_integrationType(t *testing.T) {
 			{
 				Config: testAccIntegrationConfig_typeInternet(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "connection_type", "INTERNET"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrConnectionID, ""),
 				),
@@ -548,19 +546,19 @@ func TestAccAPIGatewayIntegration_integrationType(t *testing.T) {
 func TestAccAPIGatewayIntegration_TLS_insecureSkipVerification(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetIntegrationOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_integration.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckIntegrationDestroy(ctx),
+		CheckDestroy:             testAccCheckIntegrationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIntegrationConfig_tlsInsecureSkipVerification(rName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.0.insecure_skip_verification", acctest.CtTrue),
 				),
@@ -574,7 +572,7 @@ func TestAccAPIGatewayIntegration_TLS_insecureSkipVerification(t *testing.T) {
 			{
 				Config: testAccIntegrationConfig_tlsInsecureSkipVerification(rName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.0.insecure_skip_verification", acctest.CtFalse),
 				),
@@ -586,19 +584,19 @@ func TestAccAPIGatewayIntegration_TLS_insecureSkipVerification(t *testing.T) {
 func TestAccAPIGatewayIntegration_responseTransferMode(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetIntegrationOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_integration.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckIntegrationDestroy(ctx),
+		CheckDestroy:             testAccCheckIntegrationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIntegrationConfig_responseTransferMode(rName, string(awstypes.ResponseTransferModeStream)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP_PROXY"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "ANY"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://example.com"),
@@ -615,7 +613,7 @@ func TestAccAPIGatewayIntegration_responseTransferMode(t *testing.T) {
 				// Switch to Buffered
 				Config: testAccIntegrationConfig_responseTransferMode(rName, string(awstypes.ResponseTransferModeBuffered)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP_PROXY"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "ANY"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://example.com"),
@@ -626,7 +624,7 @@ func TestAccAPIGatewayIntegration_responseTransferMode(t *testing.T) {
 				// Switch back to Stream, with timeout specified
 				Config: testAccIntegrationConfig_responseTransferModeWithTimeout(rName, string(awstypes.ResponseTransferModeStream), 900000),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP_PROXY"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "ANY"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://example.com"),
@@ -646,20 +644,20 @@ func TestAccAPIGatewayIntegration_responseTransferMode(t *testing.T) {
 func TestAccAPIGatewayIntegration_lambdaIntegrationResponseTransferModeBuffered(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetIntegrationOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_integration.test"
 	lambdaFunctionResourceName := "aws_lambda_function.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckIntegrationDestroy(ctx),
+		CheckDestroy:             testAccCheckIntegrationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIntegrationConfig_lambdaIntegration(rName, "invoke_arn", string(awstypes.ResponseTransferModeBuffered), 29000),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "AWS_PROXY"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "POST"),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrURI, lambdaFunctionResourceName, "invoke_arn"),
@@ -680,20 +678,20 @@ func TestAccAPIGatewayIntegration_lambdaIntegrationResponseTransferModeBuffered(
 func TestAccAPIGatewayIntegration_lambdaIntegrationResponseTransferModeStream(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetIntegrationOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_integration.test"
 	lambdaFunctionResourceName := "aws_lambda_function.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckIntegrationDestroy(ctx),
+		CheckDestroy:             testAccCheckIntegrationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIntegrationConfig_lambdaIntegration(rName, "response_streaming_invoke_arn", string(awstypes.ResponseTransferModeStream), 900000),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "AWS_PROXY"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "POST"),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrURI, lambdaFunctionResourceName, "response_streaming_invoke_arn"),
@@ -714,19 +712,19 @@ func TestAccAPIGatewayIntegration_lambdaIntegrationResponseTransferModeStream(t 
 func TestAccAPIGatewayIntegration_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetIntegrationOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_integration.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckIntegrationDestroy(ctx),
+		CheckDestroy:             testAccCheckIntegrationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIntegrationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceIntegration(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -735,14 +733,14 @@ func TestAccAPIGatewayIntegration_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckIntegrationExists(ctx context.Context, n string, v *apigateway.GetIntegrationOutput) resource.TestCheckFunc {
+func testAccCheckIntegrationExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetIntegrationOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindIntegrationByThreePartKey(ctx, conn, rs.Primary.Attributes["http_method"], rs.Primary.Attributes[names.AttrResourceID], rs.Primary.Attributes["rest_api_id"])
 
@@ -756,9 +754,9 @@ func testAccCheckIntegrationExists(ctx context.Context, n string, v *apigateway.
 	}
 }
 
-func testAccCheckIntegrationDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckIntegrationDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_integration" {
@@ -796,19 +794,19 @@ func testAccIntegrationImportStateIdFunc(resourceName string) resource.ImportSta
 func TestAccAPIGatewayIntegration_vpcLinkV2WithALB(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetIntegrationOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_integration.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckIntegrationDestroy(ctx),
+		CheckDestroy:             testAccCheckIntegrationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIntegrationConfig_vpcLinkV2ALB(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "connection_type", "VPC_LINK"),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrConnectionID, "aws_apigatewayv2_vpc_link.test", names.AttrID),
 					resource.TestCheckResourceAttrPair(resourceName, "integration_target", "aws_lb.test", names.AttrARN),
@@ -828,26 +826,26 @@ func TestAccAPIGatewayIntegration_vpcLinkV2WithALB(t *testing.T) {
 func TestAccAPIGatewayIntegration_vpcLinkV2Update(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetIntegrationOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_integration.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckIntegrationDestroy(ctx),
+		CheckDestroy:             testAccCheckIntegrationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIntegrationConfig_vpcLinkV2ALB(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttrPair(resourceName, "integration_target", "aws_lb.test", names.AttrARN),
 				),
 			},
 			{
 				Config: testAccIntegrationConfig_vpcLinkV2ALBUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					testAccCheckIntegrationExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttrPair(resourceName, "integration_target", "aws_lb.test2", names.AttrARN),
 				),
 			},

--- a/internal/service/apigateway/method.go
+++ b/internal/service/apigateway/method.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -394,9 +393,8 @@ func findMethodByThreePartKey(ctx context.Context, conn *apigateway.Client, http
 	output, err := conn.GetMethod(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/method_response.go
+++ b/internal/service/apigateway/method_response.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -218,9 +217,8 @@ func findMethodResponseByFourPartKey(ctx context.Context, conn *apigateway.Clien
 	output, err := conn.GetMethodResponse(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/method_response_test.go
+++ b/internal/service/apigateway/method_response_test.go
@@ -9,11 +9,9 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -22,19 +20,19 @@ import (
 func TestAccAPIGatewayMethodResponse_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetMethodResponseOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method_response.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodResponseDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodResponseDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodResponseConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodResponseExists(ctx, resourceName, &conf),
+					testAccCheckMethodResponseExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "http_method", "GET"),
 					resource.TestCheckResourceAttr(resourceName, "response_models.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "response_models.application/json", "Error"),
@@ -52,7 +50,7 @@ func TestAccAPIGatewayMethodResponse_basic(t *testing.T) {
 			{
 				Config: testAccMethodResponseConfig_update(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodResponseExists(ctx, resourceName, &conf),
+					testAccCheckMethodResponseExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "http_method", "GET"),
 					resource.TestCheckResourceAttr(resourceName, "response_models.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "response_models.application/json", "Empty"),
@@ -68,19 +66,19 @@ func TestAccAPIGatewayMethodResponse_basic(t *testing.T) {
 func TestAccAPIGatewayMethodResponse_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetMethodResponseOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method_response.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodResponseDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodResponseDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodResponseConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMethodResponseExists(ctx, resourceName, &conf),
+					testAccCheckMethodResponseExists(ctx, t, resourceName, &conf),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceMethodResponse(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -89,14 +87,14 @@ func TestAccAPIGatewayMethodResponse_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckMethodResponseExists(ctx context.Context, n string, v *apigateway.GetMethodResponseOutput) resource.TestCheckFunc {
+func testAccCheckMethodResponseExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetMethodResponseOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindMethodResponseByFourPartKey(ctx, conn, rs.Primary.Attributes["http_method"], rs.Primary.Attributes[names.AttrResourceID], rs.Primary.Attributes["rest_api_id"], rs.Primary.Attributes[names.AttrStatusCode])
 
@@ -110,9 +108,9 @@ func testAccCheckMethodResponseExists(ctx context.Context, n string, v *apigatew
 	}
 }
 
-func testAccCheckMethodResponseDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckMethodResponseDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_method_response" {

--- a/internal/service/apigateway/method_settings_test.go
+++ b/internal/service/apigateway/method_settings_test.go
@@ -8,11 +8,9 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -20,19 +18,19 @@ import (
 
 func testAccMethodSettings_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodSettingsConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.cache_data_encrypted", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.cache_ttl_in_seconds", "300"),
@@ -58,19 +56,19 @@ func testAccMethodSettings_basic(t *testing.T) {
 
 func testAccMethodSettings_Settings_cacheDataEncrypted(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodSettingsConfig_cacheDataEncrypted(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.cache_data_encrypted", acctest.CtTrue),
 				),
@@ -78,7 +76,7 @@ func testAccMethodSettings_Settings_cacheDataEncrypted(t *testing.T) {
 			{
 				Config: testAccMethodSettingsConfig_cacheDataEncrypted(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.cache_data_encrypted", acctest.CtFalse),
 				),
@@ -95,19 +93,19 @@ func testAccMethodSettings_Settings_cacheDataEncrypted(t *testing.T) {
 
 func testAccMethodSettings_Settings_cacheTTLInSeconds(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodSettingsConfig_cacheTTLInSeconds(rName, 0),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.cache_ttl_in_seconds", "0"),
 				),
@@ -115,7 +113,7 @@ func testAccMethodSettings_Settings_cacheTTLInSeconds(t *testing.T) {
 			{
 				Config: testAccMethodSettingsConfig_cacheTTLInSeconds(rName, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.cache_ttl_in_seconds", "1"),
 				),
@@ -123,7 +121,7 @@ func testAccMethodSettings_Settings_cacheTTLInSeconds(t *testing.T) {
 			{
 				Config: testAccMethodSettingsConfig_cacheTTLInSeconds(rName, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.cache_ttl_in_seconds", "2"),
 				),
@@ -140,19 +138,19 @@ func testAccMethodSettings_Settings_cacheTTLInSeconds(t *testing.T) {
 
 func testAccMethodSettings_Settings_cachingEnabled(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodSettingsConfig_cachingEnabled(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.caching_enabled", acctest.CtTrue),
 				),
@@ -160,7 +158,7 @@ func testAccMethodSettings_Settings_cachingEnabled(t *testing.T) {
 			{
 				Config: testAccMethodSettingsConfig_cachingEnabled(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.caching_enabled", acctest.CtFalse),
 				),
@@ -177,19 +175,19 @@ func testAccMethodSettings_Settings_cachingEnabled(t *testing.T) {
 
 func testAccMethodSettings_Settings_dataTraceEnabled(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodSettingsConfig_dataTraceEnabled(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.data_trace_enabled", acctest.CtTrue),
 				),
@@ -197,7 +195,7 @@ func testAccMethodSettings_Settings_dataTraceEnabled(t *testing.T) {
 			{
 				Config: testAccMethodSettingsConfig_dataTraceEnabled(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.data_trace_enabled", acctest.CtFalse),
 				),
@@ -214,19 +212,19 @@ func testAccMethodSettings_Settings_dataTraceEnabled(t *testing.T) {
 
 func testAccMethodSettings_Settings_loggingLevel(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method_settings.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodSettingsConfig_loggingLevel(rName, "INFO"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.logging_level", "INFO"),
 				),
@@ -234,7 +232,7 @@ func testAccMethodSettings_Settings_loggingLevel(t *testing.T) {
 			{
 				Config: testAccMethodSettingsConfig_loggingLevel(rName, "OFF"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.logging_level", "OFF"),
 				),
@@ -251,19 +249,19 @@ func testAccMethodSettings_Settings_loggingLevel(t *testing.T) {
 
 func testAccMethodSettings_Settings_metricsEnabled(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodSettingsConfig_metricsEnabled(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.metrics_enabled", acctest.CtTrue),
 				),
@@ -271,7 +269,7 @@ func testAccMethodSettings_Settings_metricsEnabled(t *testing.T) {
 			{
 				Config: testAccMethodSettingsConfig_metricsEnabled(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.metrics_enabled", acctest.CtFalse),
 				),
@@ -288,19 +286,19 @@ func testAccMethodSettings_Settings_metricsEnabled(t *testing.T) {
 
 func testAccMethodSettings_Settings_multiple(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method_settings.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodSettingsConfig_multiple(rName, "INFO", true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.metrics_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.logging_level", "INFO"),
@@ -326,19 +324,19 @@ func testAccMethodSettings_Settings_multiple(t *testing.T) {
 
 func testAccMethodSettings_Settings_requireAuthorizationForCacheControl(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodSettingsConfig_requireAuthorizationForCacheControl(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.require_authorization_for_cache_control", acctest.CtTrue),
 				),
@@ -346,7 +344,7 @@ func testAccMethodSettings_Settings_requireAuthorizationForCacheControl(t *testi
 			{
 				Config: testAccMethodSettingsConfig_requireAuthorizationForCacheControl(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.require_authorization_for_cache_control", acctest.CtFalse),
 				),
@@ -363,19 +361,19 @@ func testAccMethodSettings_Settings_requireAuthorizationForCacheControl(t *testi
 
 func testAccMethodSettings_Settings_throttlingBurstLimit(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodSettingsConfig_throttlingBurstLimit(rName, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.throttling_burst_limit", "1"),
 				),
@@ -383,7 +381,7 @@ func testAccMethodSettings_Settings_throttlingBurstLimit(t *testing.T) {
 			{
 				Config: testAccMethodSettingsConfig_throttlingBurstLimit(rName, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.throttling_burst_limit", "2"),
 				),
@@ -401,19 +399,19 @@ func testAccMethodSettings_Settings_throttlingBurstLimit(t *testing.T) {
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/5690
 func testAccMethodSettings_Settings_throttlingBurstLimitDisabledByDefault(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodSettingsConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.throttling_burst_limit", "-1"),
 				),
@@ -427,7 +425,7 @@ func testAccMethodSettings_Settings_throttlingBurstLimitDisabledByDefault(t *tes
 			{
 				Config: testAccMethodSettingsConfig_throttlingBurstLimit(rName, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.throttling_burst_limit", "1"),
 				),
@@ -438,19 +436,19 @@ func testAccMethodSettings_Settings_throttlingBurstLimitDisabledByDefault(t *tes
 
 func testAccMethodSettings_Settings_throttlingRateLimit(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodSettingsConfig_throttlingRateLimit(rName, 1.1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.throttling_rate_limit", "1.1"),
 				),
@@ -458,7 +456,7 @@ func testAccMethodSettings_Settings_throttlingRateLimit(t *testing.T) {
 			{
 				Config: testAccMethodSettingsConfig_throttlingRateLimit(rName, 2.2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.throttling_rate_limit", "2.2"),
 				),
@@ -476,19 +474,19 @@ func testAccMethodSettings_Settings_throttlingRateLimit(t *testing.T) {
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/5690
 func testAccMethodSettings_Settings_throttlingRateLimitDisabledByDefault(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodSettingsConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.throttling_rate_limit", "-1"),
 				),
@@ -502,7 +500,7 @@ func testAccMethodSettings_Settings_throttlingRateLimitDisabledByDefault(t *test
 			{
 				Config: testAccMethodSettingsConfig_throttlingRateLimit(rName, 1.1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.throttling_rate_limit", "1.1"),
 				),
@@ -513,19 +511,19 @@ func testAccMethodSettings_Settings_throttlingRateLimitDisabledByDefault(t *test
 
 func testAccMethodSettings_Settings_unauthorizedCacheControlHeaderStrategy(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodSettingsConfig_unauthorizedCacheControlHeaderStrategy(rName, "SUCCEED_WITH_RESPONSE_HEADER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.unauthorized_cache_control_header_strategy", "SUCCEED_WITH_RESPONSE_HEADER"),
 				),
@@ -533,7 +531,7 @@ func testAccMethodSettings_Settings_unauthorizedCacheControlHeaderStrategy(t *te
 			{
 				Config: testAccMethodSettingsConfig_unauthorizedCacheControlHeaderStrategy(rName, "SUCCEED_WITHOUT_RESPONSE_HEADER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.unauthorized_cache_control_header_strategy", "SUCCEED_WITHOUT_RESPONSE_HEADER"),
 				),
@@ -550,19 +548,19 @@ func testAccMethodSettings_Settings_unauthorizedCacheControlHeaderStrategy(t *te
 
 func testAccMethodSettings_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method_settings.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodSettingsDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodSettingsConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodSettingsExists(ctx, resourceName),
+					testAccCheckMethodSettingsExists(ctx, t, resourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceMethodSettings(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -571,14 +569,14 @@ func testAccMethodSettings_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckMethodSettingsExists(ctx context.Context, n string) resource.TestCheckFunc {
+func testAccCheckMethodSettingsExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		_, err := tfapigateway.FindMethodSettingsByThreePartKey(ctx, conn, rs.Primary.Attributes["rest_api_id"], rs.Primary.Attributes["stage_name"], rs.Primary.Attributes["method_path"])
 
@@ -586,9 +584,9 @@ func testAccCheckMethodSettingsExists(ctx context.Context, n string) resource.Te
 	}
 }
 
-func testAccCheckMethodSettingsDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckMethodSettingsDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_method_settings" {

--- a/internal/service/apigateway/method_test.go
+++ b/internal/service/apigateway/method_test.go
@@ -9,11 +9,9 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -22,19 +20,19 @@ import (
 func TestAccAPIGatewayMethod_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetMethodOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodExists(ctx, resourceName, &conf),
+					testAccCheckMethodExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "authorization", "NONE"),
 					resource.TestCheckResourceAttr(resourceName, "http_method", "GET"),
 					resource.TestCheckResourceAttr(resourceName, "request_models.%", "1"),
@@ -54,7 +52,7 @@ func TestAccAPIGatewayMethod_basic(t *testing.T) {
 			{
 				Config: testAccMethodConfig_update(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMethodExists(ctx, resourceName, &conf),
+					testAccCheckMethodExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "authorization", "NONE"),
 					resource.TestCheckResourceAttr(resourceName, "http_method", "GET"),
 					resource.TestCheckResourceAttr(resourceName, "request_models.%", "1"),
@@ -70,19 +68,19 @@ func TestAccAPIGatewayMethod_basic(t *testing.T) {
 func TestAccAPIGatewayMethod_customAuthorizer(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetMethodOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodConfig_customAuthorizer(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMethodExists(ctx, resourceName, &conf),
+					testAccCheckMethodExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "authorization", "CUSTOM"),
 					resource.TestCheckResourceAttrSet(resourceName, "authorizer_id"),
 				),
@@ -98,7 +96,7 @@ func TestAccAPIGatewayMethod_customAuthorizer(t *testing.T) {
 			{
 				Config: testAccMethodConfig_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMethodExists(ctx, resourceName, &conf),
+					testAccCheckMethodExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "authorization", "NONE"),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_id", ""),
 				),
@@ -110,19 +108,19 @@ func TestAccAPIGatewayMethod_customAuthorizer(t *testing.T) {
 func TestAccAPIGatewayMethod_cognitoAuthorizer(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetMethodOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodConfig_cognitoAuthorizer(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMethodExists(ctx, resourceName, &conf),
+					testAccCheckMethodExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "authorization", "COGNITO_USER_POOLS"),
 					resource.TestCheckResourceAttrSet(resourceName, "authorizer_id"),
 					resource.TestCheckResourceAttr(resourceName, "authorization_scopes.#", "2"),
@@ -132,7 +130,7 @@ func TestAccAPIGatewayMethod_cognitoAuthorizer(t *testing.T) {
 			{
 				Config: testAccMethodConfig_cognitoAuthorizerUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMethodExists(ctx, resourceName, &conf),
+					testAccCheckMethodExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "authorization", "COGNITO_USER_POOLS"),
 					resource.TestCheckResourceAttrSet(resourceName, "authorizer_id"),
 					resource.TestCheckResourceAttr(resourceName, "authorization_scopes.#", "3"),
@@ -151,19 +149,19 @@ func TestAccAPIGatewayMethod_cognitoAuthorizer(t *testing.T) {
 func TestAccAPIGatewayMethod_customRequestValidator(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetMethodOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodConfig_customRequestValidator(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMethodExists(ctx, resourceName, &conf),
+					testAccCheckMethodExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "request_validator_id"),
 				),
 			},
@@ -178,7 +176,7 @@ func TestAccAPIGatewayMethod_customRequestValidator(t *testing.T) {
 			{
 				Config: testAccMethodConfig_customRequestValidatorUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMethodExists(ctx, resourceName, &conf),
+					testAccCheckMethodExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "request_validator_id", ""),
 				),
 			},
@@ -189,19 +187,19 @@ func TestAccAPIGatewayMethod_customRequestValidator(t *testing.T) {
 func TestAccAPIGatewayMethod_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetMethodOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMethodExists(ctx, resourceName, &conf),
+					testAccCheckMethodExists(ctx, t, resourceName, &conf),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceMethod(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -213,19 +211,19 @@ func TestAccAPIGatewayMethod_disappears(t *testing.T) {
 func TestAccAPIGatewayMethod_operationName(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetMethodOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_method.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMethodDestroy(ctx),
+		CheckDestroy:             testAccCheckMethodDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMethodConfig_operationName(rName, "getTest"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMethodExists(ctx, resourceName, &conf),
+					testAccCheckMethodExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "operation_name", "getTest"),
 				),
 			},
@@ -239,7 +237,7 @@ func TestAccAPIGatewayMethod_operationName(t *testing.T) {
 			{
 				Config: testAccMethodConfig_operationName(rName, "describeTest"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMethodExists(ctx, resourceName, &conf),
+					testAccCheckMethodExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "operation_name", "describeTest"),
 				),
 			},
@@ -247,14 +245,14 @@ func TestAccAPIGatewayMethod_operationName(t *testing.T) {
 	})
 }
 
-func testAccCheckMethodExists(ctx context.Context, n string, v *apigateway.GetMethodOutput) resource.TestCheckFunc {
+func testAccCheckMethodExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetMethodOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindMethodByThreePartKey(ctx, conn, rs.Primary.Attributes["http_method"], rs.Primary.Attributes[names.AttrResourceID], rs.Primary.Attributes["rest_api_id"])
 
@@ -268,9 +266,9 @@ func testAccCheckMethodExists(ctx context.Context, n string, v *apigateway.GetMe
 	}
 }
 
-func testAccCheckMethodDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckMethodDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_method" {

--- a/internal/service/apigateway/model.go
+++ b/internal/service/apigateway/model.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -214,9 +213,8 @@ func findModelByTwoPartKey(ctx context.Context, conn *apigateway.Client, name, a
 	output, err := conn.GetModel(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/model_test.go
+++ b/internal/service/apigateway/model_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -22,20 +21,20 @@ import (
 func TestAccAPIGatewayModel_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetModelOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	modelName := sdkacctest.RandString(16)
 	resourceName := "aws_api_gateway_model.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckModelDestroy(ctx),
+		CheckDestroy:             testAccCheckModelDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccModelConfig_basic(rName, modelName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckModelExists(ctx, resourceName, &conf),
+					testAccCheckModelExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrContentType, "application/json"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "a test schema"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, modelName),
@@ -55,20 +54,20 @@ func TestAccAPIGatewayModel_basic(t *testing.T) {
 func TestAccAPIGatewayModel_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetModelOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	modelName := sdkacctest.RandString(16)
 	resourceName := "aws_api_gateway_model.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckModelDestroy(ctx),
+		CheckDestroy:             testAccCheckModelDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccModelConfig_basic(rName, modelName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckModelExists(ctx, resourceName, &conf),
+					testAccCheckModelExists(ctx, t, resourceName, &conf),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceModel(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -77,14 +76,14 @@ func TestAccAPIGatewayModel_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckModelExists(ctx context.Context, n string, v *apigateway.GetModelOutput) resource.TestCheckFunc {
+func testAccCheckModelExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetModelOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindModelByTwoPartKey(ctx, conn, rs.Primary.Attributes[names.AttrName], rs.Primary.Attributes["rest_api_id"])
 
@@ -98,9 +97,9 @@ func testAccCheckModelExists(ctx context.Context, n string, v *apigateway.GetMod
 	}
 }
 
-func testAccCheckModelDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckModelDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_model" {

--- a/internal/service/apigateway/request_validator.go
+++ b/internal/service/apigateway/request_validator.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -194,9 +193,8 @@ func findRequestValidatorByTwoPartKey(ctx context.Context, conn *apigateway.Clie
 	output, err := conn.GetRequestValidator(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/request_validator_test.go
+++ b/internal/service/apigateway/request_validator_test.go
@@ -9,11 +9,9 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -22,19 +20,19 @@ import (
 func TestAccAPIGatewayRequestValidator_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRequestValidatorOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_request_validator.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRequestValidatorDestroy(ctx),
+		CheckDestroy:             testAccCheckRequestValidatorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRequestValidatorConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRequestValidatorExists(ctx, resourceName, &conf),
+					testAccCheckRequestValidatorExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "validate_request_body", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "validate_request_parameters", acctest.CtFalse),
@@ -49,7 +47,7 @@ func TestAccAPIGatewayRequestValidator_basic(t *testing.T) {
 			{
 				Config: testAccRequestValidatorConfig_updated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRequestValidatorExists(ctx, resourceName, &conf),
+					testAccCheckRequestValidatorExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, fmt.Sprintf("%s-modified", rName)),
 					resource.TestCheckResourceAttr(resourceName, "validate_request_body", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "validate_request_parameters", acctest.CtTrue),
@@ -62,19 +60,19 @@ func TestAccAPIGatewayRequestValidator_basic(t *testing.T) {
 func TestAccAPIGatewayRequestValidator_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRequestValidatorOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_request_validator.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRequestValidatorDestroy(ctx),
+		CheckDestroy:             testAccCheckRequestValidatorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRequestValidatorConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRequestValidatorExists(ctx, resourceName, &conf),
+					testAccCheckRequestValidatorExists(ctx, t, resourceName, &conf),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceRequestValidator(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -83,14 +81,14 @@ func TestAccAPIGatewayRequestValidator_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckRequestValidatorExists(ctx context.Context, n string, v *apigateway.GetRequestValidatorOutput) resource.TestCheckFunc {
+func testAccCheckRequestValidatorExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetRequestValidatorOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindRequestValidatorByTwoPartKey(ctx, conn, rs.Primary.ID, rs.Primary.Attributes["rest_api_id"])
 
@@ -104,9 +102,9 @@ func testAccCheckRequestValidatorExists(ctx context.Context, n string, v *apigat
 	}
 }
 
-func testAccCheckRequestValidatorDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckRequestValidatorDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_request_validator" {

--- a/internal/service/apigateway/resource.go
+++ b/internal/service/apigateway/resource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -188,9 +187,8 @@ func findResourceByTwoPartKey(ctx context.Context, conn *apigateway.Client, reso
 	output, err := conn.GetResource(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/resource_data_source.go
+++ b/internal/service/apigateway/resource_data_source.go
@@ -10,11 +10,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -87,9 +87,8 @@ func findResources(ctx context.Context, conn *apigateway.Client, input *apigatew
 		page, err := pages.NextPage(ctx)
 
 		if errs.IsA[*types.NotFoundException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 

--- a/internal/service/apigateway/resource_data_source_test.go
+++ b/internal/service/apigateway/resource_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccAPIGatewayResourceDataSource_basic(t *testing.T) {
 	resourceName2 := "aws_api_gateway_resource.example_v1_endpoint"
 	dataSourceName2 := "data.aws_api_gateway_resource.example_v1_endpoint"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/apigateway/resource_test.go
+++ b/internal/service/apigateway/resource_test.go
@@ -10,11 +10,9 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -23,19 +21,19 @@ import (
 func TestAccAPIGatewayResource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetResourceOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_resource.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckResourceDestroy(ctx),
+		CheckDestroy:             testAccCheckResourceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceConfig_basic(rName, "test"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceExists(ctx, resourceName, &conf),
+					testAccCheckResourceExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/test"),
 					resource.TestCheckResourceAttr(resourceName, "path_part", "test"),
 				),
@@ -53,19 +51,19 @@ func TestAccAPIGatewayResource_basic(t *testing.T) {
 func TestAccAPIGatewayResource_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetResourceOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_resource.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckResourceDestroy(ctx),
+		CheckDestroy:             testAccCheckResourceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceConfig_basic(rName, "test"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceExists(ctx, resourceName, &conf),
+					testAccCheckResourceExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/test"),
 					resource.TestCheckResourceAttr(resourceName, "path_part", "test"),
 				),
@@ -79,7 +77,7 @@ func TestAccAPIGatewayResource_update(t *testing.T) {
 			{
 				Config: testAccResourceConfig_basic(rName, "test_changed"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceExists(ctx, resourceName, &conf),
+					testAccCheckResourceExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/test_changed"),
 					resource.TestCheckResourceAttr(resourceName, "path_part", "test_changed"),
 				),
@@ -92,21 +90,21 @@ func TestAccAPIGatewayResource_update(t *testing.T) {
 func TestAccAPIGatewayResource_recomputePath(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetResourceOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_resource.test"
 	copyName := "aws_api_gateway_resource.copy"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckResourceDestroy(ctx),
+		CheckDestroy:             testAccCheckResourceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceConfig_copy(rName, "test"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceExists(ctx, resourceName, &conf),
-					testAccCheckResourceExists(ctx, copyName, &conf),
+					testAccCheckResourceExists(ctx, t, resourceName, &conf),
+					testAccCheckResourceExists(ctx, t, copyName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/test"),
 					resource.TestCheckResourceAttr(resourceName, "path_part", "test"),
 					resource.TestCheckResourceAttr(copyName, names.AttrPath, "/test-copy"),
@@ -122,8 +120,8 @@ func TestAccAPIGatewayResource_recomputePath(t *testing.T) {
 			{
 				Config: testAccResourceConfig_copy(rName, "test_changed"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceExists(ctx, resourceName, &conf),
-					testAccCheckResourceExists(ctx, copyName, &conf),
+					testAccCheckResourceExists(ctx, t, resourceName, &conf),
+					testAccCheckResourceExists(ctx, t, copyName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/test_changed"),
 					resource.TestCheckResourceAttr(resourceName, "path_part", "test_changed"),
 					resource.TestCheckResourceAttr(copyName, names.AttrPath, "/test_changed-copy"),
@@ -137,19 +135,19 @@ func TestAccAPIGatewayResource_recomputePath(t *testing.T) {
 func TestAccAPIGatewayResource_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetResourceOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_resource.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckResourceDestroy(ctx),
+		CheckDestroy:             testAccCheckResourceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceConfig_basic(rName, "test"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceExists(ctx, resourceName, &conf),
+					testAccCheckResourceExists(ctx, t, resourceName, &conf),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceResource(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -162,14 +160,14 @@ func TestAccAPIGatewayResource_disappears(t *testing.T) {
 func TestAccAPIGatewayResource_withSleep(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetResourceOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_resource.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckResourceDestroy(ctx),
+		CheckDestroy:             testAccCheckResourceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceConfig_base(rName),
@@ -180,7 +178,7 @@ func TestAccAPIGatewayResource_withSleep(t *testing.T) {
 			{
 				Config: testAccResourceConfig_basic(rName, "test"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceExists(ctx, resourceName, &conf),
+					testAccCheckResourceExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/test"),
 					resource.TestCheckResourceAttr(resourceName, "path_part", "test"),
 				),
@@ -189,14 +187,14 @@ func TestAccAPIGatewayResource_withSleep(t *testing.T) {
 	})
 }
 
-func testAccCheckResourceExists(ctx context.Context, n string, v *apigateway.GetResourceOutput) resource.TestCheckFunc {
+func testAccCheckResourceExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetResourceOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindResourceByTwoPartKey(ctx, conn, rs.Primary.ID, rs.Primary.Attributes["rest_api_id"])
 
@@ -210,9 +208,9 @@ func testAccCheckResourceExists(ctx context.Context, n string, v *apigateway.Get
 	}
 }
 
-func testAccCheckResourceDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckResourceDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_resource" {

--- a/internal/service/apigateway/rest_api.go
+++ b/internal/service/apigateway/rest_api.go
@@ -17,7 +17,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -37,6 +36,8 @@ import (
 // @SDKResource("aws_api_gateway_rest_api", name="REST API")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigateway;apigateway.GetRestApiOutput", importIgnore="put_rest_api_mode")
+// @Testing(existsTakesT=true)
+// @Testing(destroyTakesT=true)
 func resourceRestAPI() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRestAPICreate,
@@ -595,9 +596,8 @@ func findRestAPIByID(ctx context.Context, conn *apigateway.Client, id string) (*
 	output, err := conn.GetRestApi(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/rest_api_data_source_test.go
+++ b/internal/service/apigateway/rest_api_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccAPIGatewayRestAPIDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandString(8)
 	dataSourceName := "data.aws_api_gateway_rest_api.test"
 	resourceName := "aws_api_gateway_rest_api.test"
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -47,7 +47,7 @@ func TestAccAPIGatewayRestAPIDataSource_Endpoint_vpcEndpointIDs(t *testing.T) {
 	rName := sdkacctest.RandString(8)
 	dataSourceName := "data.aws_api_gateway_rest_api.test"
 	resourceName := "aws_api_gateway_rest_api.test"
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -78,7 +78,7 @@ func TestAccAPIGatewayRestAPIDataSource_Endpoint_ipAddressType(t *testing.T) {
 	rName := sdkacctest.RandString(8)
 	dataSourceName := "data.aws_api_gateway_rest_api.test"
 	resourceName := "aws_api_gateway_rest_api.test"
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/apigateway/rest_api_policy_test.go
+++ b/internal/service/apigateway/rest_api_policy_test.go
@@ -13,11 +13,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -26,18 +24,18 @@ func TestAccAPIGatewayRestAPIPolicy_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRestAPIPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckRestAPIPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRestAPIPolicyExists(ctx, resourceName, &v),
+					testAccCheckRestAPIPolicyExists(ctx, t, resourceName, &v),
 					resource.TestMatchResourceAttr(resourceName, names.AttrPolicy, regexache.MustCompile(`"Action":"execute-api:Invoke".+`)),
 				),
 			},
@@ -50,7 +48,7 @@ func TestAccAPIGatewayRestAPIPolicy_basic(t *testing.T) {
 			{
 				Config: testAccRestAPIPolicyConfig_updated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRestAPIPolicyExists(ctx, resourceName, &v),
+					testAccCheckRestAPIPolicyExists(ctx, t, resourceName, &v),
 					resource.TestMatchResourceAttr(resourceName, names.AttrPolicy, regexache.MustCompile(`"aws:SourceIp":"123.123.123.123/32".+`))),
 			},
 		},
@@ -61,18 +59,18 @@ func TestAccAPIGatewayRestAPIPolicy_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRestAPIPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckRestAPIPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRestAPIPolicyExists(ctx, resourceName, &v),
+					testAccCheckRestAPIPolicyExists(ctx, t, resourceName, &v),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceRestAPIPolicy(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -85,18 +83,18 @@ func TestAccAPIGatewayRestAPIPolicy_Disappears_restAPI(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRestAPIPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckRestAPIPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRestAPIPolicyExists(ctx, resourceName, &v),
+					testAccCheckRestAPIPolicyExists(ctx, t, resourceName, &v),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceRestAPI(), "aws_api_gateway_rest_api.test"),
 				),
 				ExpectNonEmptyPlan: true,
@@ -105,7 +103,7 @@ func TestAccAPIGatewayRestAPIPolicy_Disappears_restAPI(t *testing.T) {
 	})
 }
 
-func testAccCheckRestAPIPolicyExists(ctx context.Context, n string, res *apigateway.GetRestApiOutput) resource.TestCheckFunc {
+func testAccCheckRestAPIPolicyExists(ctx context.Context, t *testing.T, n string, res *apigateway.GetRestApiOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -116,7 +114,7 @@ func testAccCheckRestAPIPolicyExists(ctx context.Context, n string, res *apigate
 			return fmt.Errorf("No API Gateway ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		req := apigateway.GetRestApiInput{
 			RestApiId: aws.String(rs.Primary.ID),
@@ -146,9 +144,9 @@ func testAccCheckRestAPIPolicyExists(ctx context.Context, n string, res *apigate
 	}
 }
 
-func testAccCheckRestAPIPolicyDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckRestAPIPolicyDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_rest_api_policy" {

--- a/internal/service/apigateway/rest_api_put.go
+++ b/internal/service/apigateway/rest_api_put.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
@@ -188,10 +187,10 @@ const (
 )
 
 func waitRestAPIPutCreated(ctx context.Context, conn *apigateway.Client, id string, timeout time.Duration) (*apigateway.GetRestApiOutput, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:                   []string{},
 		Target:                    []string{statusNormal},
-		Refresh:                   statusRestAPIPut(ctx, conn, id),
+		Refresh:                   statusRestAPIPut(conn, id),
 		Timeout:                   timeout,
 		NotFoundChecks:            20,
 		ContinuousTargetOccurence: 2,
@@ -205,8 +204,8 @@ func waitRestAPIPutCreated(ctx context.Context, conn *apigateway.Client, id stri
 	return nil, err
 }
 
-func statusRestAPIPut(ctx context.Context, conn *apigateway.Client, id string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusRestAPIPut(conn *apigateway.Client, id string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		out, err := findRestAPIByID(ctx, conn, id)
 		if retry.NotFound(err) {
 			return nil, "", nil

--- a/internal/service/apigateway/rest_api_put_test.go
+++ b/internal/service/apigateway/rest_api_put_test.go
@@ -9,11 +9,9 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -25,19 +23,19 @@ func TestAccAPIGatewayRestAPIPut_basic(t *testing.T) {
 	}
 
 	var restAPI apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api_put.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIPutConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIPutExists(ctx, resourceName, &restAPI),
+					testAccCheckRESTAPIPutExists(ctx, t, resourceName, &restAPI),
 					resource.TestCheckResourceAttr(resourceName, "fail_on_warnings", acctest.CtTrue),
 					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
 				),
@@ -64,35 +62,35 @@ func TestAccAPIGatewayRestAPIPut_multistage(t *testing.T) {
 	}
 
 	var restAPI apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api_put.testv1"
 	resourceName2 := "aws_api_gateway_rest_api_put.testv2"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIPutConfig_multistage(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIPutExists(ctx, resourceName, &restAPI),
-					testAccCheckRESTAPIPutExists(ctx, resourceName2, &restAPI),
+					testAccCheckRESTAPIPutExists(ctx, t, resourceName, &restAPI),
+					testAccCheckRESTAPIPutExists(ctx, t, resourceName2, &restAPI),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckRESTAPIPutExists(ctx context.Context, n string, v *apigateway.GetRestApiOutput) resource.TestCheckFunc {
+func testAccCheckRESTAPIPutExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetRestApiOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindRestAPIByID(ctx, conn, rs.Primary.Attributes["rest_api_id"])
 

--- a/internal/service/apigateway/rest_api_tags_gen_test.go
+++ b/internal/service/apigateway/rest_api_tags_gen_test.go
@@ -33,7 +33,7 @@ func TestAccAPIGatewayRESTAPI_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -45,7 +45,7 @@ func TestAccAPIGatewayRESTAPI_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -92,7 +92,7 @@ func TestAccAPIGatewayRESTAPI_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -143,7 +143,7 @@ func TestAccAPIGatewayRESTAPI_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -187,7 +187,7 @@ func TestAccAPIGatewayRESTAPI_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -231,7 +231,7 @@ func TestAccAPIGatewayRESTAPI_tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -243,7 +243,7 @@ func TestAccAPIGatewayRESTAPI_tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -305,7 +305,7 @@ func TestAccAPIGatewayRESTAPI_tags_EmptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -315,7 +315,7 @@ func TestAccAPIGatewayRESTAPI_tags_EmptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -375,7 +375,7 @@ func TestAccAPIGatewayRESTAPI_tags_AddOnUpdate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -385,7 +385,7 @@ func TestAccAPIGatewayRESTAPI_tags_AddOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -409,7 +409,7 @@ func TestAccAPIGatewayRESTAPI_tags_AddOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -463,7 +463,7 @@ func TestAccAPIGatewayRESTAPI_tags_EmptyTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -475,7 +475,7 @@ func TestAccAPIGatewayRESTAPI_tags_EmptyTag_OnCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -518,7 +518,7 @@ func TestAccAPIGatewayRESTAPI_tags_EmptyTag_OnCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -562,7 +562,7 @@ func TestAccAPIGatewayRESTAPI_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -574,7 +574,7 @@ func TestAccAPIGatewayRESTAPI_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -606,7 +606,7 @@ func TestAccAPIGatewayRESTAPI_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -655,7 +655,7 @@ func TestAccAPIGatewayRESTAPI_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -709,7 +709,7 @@ func TestAccAPIGatewayRESTAPI_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -721,7 +721,7 @@ func TestAccAPIGatewayRESTAPI_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -752,7 +752,7 @@ func TestAccAPIGatewayRESTAPI_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -805,7 +805,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_providerOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy: testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -818,7 +818,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -865,7 +865,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -914,7 +914,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -957,7 +957,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1002,7 +1002,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_nonOverlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy: testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1017,7 +1017,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1074,7 +1074,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1130,7 +1130,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1175,7 +1175,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_overlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy: testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1190,7 +1190,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1246,7 +1246,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1306,7 +1306,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1364,7 +1364,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_updateToProviderOnly(t *testing.T
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy: testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1376,7 +1376,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_updateToProviderOnly(t *testing.T
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1409,7 +1409,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_updateToProviderOnly(t *testing.T
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1461,7 +1461,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_updateToResourceOnly(t *testing.T
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy: testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1474,7 +1474,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_updateToResourceOnly(t *testing.T
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1502,7 +1502,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_updateToResourceOnly(t *testing.T
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1557,7 +1557,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy: testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1572,7 +1572,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1629,7 +1629,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy: testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1642,7 +1642,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1693,7 +1693,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_nullOverlappingResourceTag(t *tes
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy: testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1708,7 +1708,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_nullOverlappingResourceTag(t *tes
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1762,7 +1762,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_nullNonOverlappingResourceTag(t *
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy: testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1777,7 +1777,7 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_nullNonOverlappingResourceTag(t *
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1831,7 +1831,7 @@ func TestAccAPIGatewayRESTAPI_tags_ComputedTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy: testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1841,7 +1841,7 @@ func TestAccAPIGatewayRESTAPI_tags_ComputedTag_OnCreate(t *testing.T) {
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1893,7 +1893,7 @@ func TestAccAPIGatewayRESTAPI_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy: testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1905,7 +1905,7 @@ func TestAccAPIGatewayRESTAPI_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1937,7 +1937,7 @@ func TestAccAPIGatewayRESTAPI_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1997,7 +1997,7 @@ func TestAccAPIGatewayRESTAPI_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy: testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -2009,7 +2009,7 @@ func TestAccAPIGatewayRESTAPI_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2039,7 +2039,7 @@ func TestAccAPIGatewayRESTAPI_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2091,7 +2091,7 @@ func TestAccAPIGatewayRESTAPI_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy: testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2110,7 +2110,7 @@ func TestAccAPIGatewayRESTAPI_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2159,7 +2159,7 @@ func TestAccAPIGatewayRESTAPI_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2208,7 +2208,7 @@ func TestAccAPIGatewayRESTAPI_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2257,7 +2257,7 @@ func TestAccAPIGatewayRESTAPI_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) 
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy: testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2274,7 +2274,7 @@ func TestAccAPIGatewayRESTAPI_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) 
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2337,7 +2337,7 @@ func TestAccAPIGatewayRESTAPI_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) 
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2400,7 +2400,7 @@ func TestAccAPIGatewayRESTAPI_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) 
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &v),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/apigateway/rest_api_test.go
+++ b/internal/service/apigateway/rest_api_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -20,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
@@ -30,19 +28,19 @@ import (
 func TestAccAPIGatewayRestAPI_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_name(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "api_key_source", "HEADER"),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/restapis/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "binary_media_types.#", "0"),
@@ -75,18 +73,18 @@ func TestAccAPIGatewayRestAPI_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var restApi apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_name(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &restApi),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &restApi),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceRestAPI(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -98,19 +96,19 @@ func TestAccAPIGatewayRestAPI_disappears(t *testing.T) {
 func TestAccAPIGatewayRestAPI_endpoint(t *testing.T) {
 	ctx := acctest.Context(t)
 	var restApi apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_endpointConfiguration(rName, "REGIONAL"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &restApi),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &restApi),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.types.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.types.0", "REGIONAL"),
@@ -127,7 +125,7 @@ func TestAccAPIGatewayRestAPI_endpoint(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_name(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &restApi),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &restApi),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.types.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.types.0", "REGIONAL"),
@@ -141,9 +139,9 @@ func TestAccAPIGatewayRestAPI_endpoint(t *testing.T) {
 					// This can eventually be moved to a PreCheck function
 					// If the region does not support EDGE endpoint type, this test will either show
 					// SKIP (if REGIONAL passed) or FAIL (if REGIONAL failed)
-					conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+					conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 					createInput := apigateway.CreateRestApiInput{
-						Name: aws.String(sdkacctest.RandomWithPrefix("tf-acc-test-edge-endpoint-precheck")),
+						Name: aws.String(acctest.RandomWithPrefix(t, "tf-acc-test-edge-endpoint-precheck")),
 						EndpointConfiguration: &types.EndpointConfiguration{
 							Types: []types.EndpointType{types.EndpointTypeEdge},
 						},
@@ -167,7 +165,7 @@ func TestAccAPIGatewayRestAPI_endpoint(t *testing.T) {
 				},
 				Config: testAccRestAPIConfig_endpointConfiguration(rName, "EDGE"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &restApi),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &restApi),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.types.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.types.0", "EDGE"),
@@ -181,22 +179,22 @@ func TestAccAPIGatewayRestAPI_endpoint(t *testing.T) {
 func TestAccAPIGatewayRestAPI_Endpoint_private(t *testing.T) {
 	ctx := acctest.Context(t)
 	var restApi apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {
 					// Ensure region supports PRIVATE endpoint
 					// This can eventually be moved to a PreCheck function
-					conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+					conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 					createInput := apigateway.CreateRestApiInput{
-						Name: aws.String(sdkacctest.RandomWithPrefix("tf-acc-test-private-endpoint-precheck")),
+						Name: aws.String(acctest.RandomWithPrefix(t, "tf-acc-test-private-endpoint-precheck")),
 						EndpointConfiguration: &types.EndpointConfiguration{
 							Types: []types.EndpointType{types.EndpointTypePrivate},
 						},
@@ -220,7 +218,7 @@ func TestAccAPIGatewayRestAPI_Endpoint_private(t *testing.T) {
 				},
 				Config: testAccRestAPIConfig_endpointConfiguration(rName, "PRIVATE"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &restApi),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &restApi),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.types.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.types.0", "PRIVATE"),
@@ -238,14 +236,14 @@ func TestAccAPIGatewayRestAPI_Endpoint_private(t *testing.T) {
 
 func TestAccAPIGatewayRestAPI_apiKeySource(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_keySource(rName, "AUTHORIZER"),
@@ -278,19 +276,19 @@ func TestAccAPIGatewayRestAPI_apiKeySource(t *testing.T) {
 func TestAccAPIGatewayRestAPI_APIKeySource_overrideBody(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_keySourceOverrideBody(rName, "AUTHORIZER", "HEADER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "api_key_source", "AUTHORIZER"),
 				),
 			},
@@ -304,7 +302,7 @@ func TestAccAPIGatewayRestAPI_APIKeySource_overrideBody(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_keySourceOverrideBody(rName, "HEADER", "HEADER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "api_key_source", "HEADER"),
 				),
 			},
@@ -312,7 +310,7 @@ func TestAccAPIGatewayRestAPI_APIKeySource_overrideBody(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_keySourceOverrideBody(rName, "HEADER", "AUTHORIZER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "api_key_source", "HEADER"),
 				),
 			},
@@ -323,19 +321,19 @@ func TestAccAPIGatewayRestAPI_APIKeySource_overrideBody(t *testing.T) {
 func TestAccAPIGatewayRestAPI_APIKeySource_setByBody(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_keySourceSetByBody(rName, "AUTHORIZER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "api_key_source", "AUTHORIZER"),
 				),
 			},
@@ -352,19 +350,19 @@ func TestAccAPIGatewayRestAPI_APIKeySource_setByBody(t *testing.T) {
 func TestAccAPIGatewayRestAPI_binaryMediaTypes(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_binaryMediaTypes1(rName, "application/octet-stream"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "binary_media_types.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "binary_media_types.0", "application/octet-stream"),
 				),
@@ -378,7 +376,7 @@ func TestAccAPIGatewayRestAPI_binaryMediaTypes(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_binaryMediaTypes1(rName, "application/octet"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "binary_media_types.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "binary_media_types.0", "application/octet"),
 				),
@@ -390,19 +388,19 @@ func TestAccAPIGatewayRestAPI_binaryMediaTypes(t *testing.T) {
 func TestAccAPIGatewayRestAPI_BinaryMediaTypes_overrideBody(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_binaryMediaTypes1OverrideBody(rName, "application/octet-stream", "image/jpeg"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "binary_media_types.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "binary_media_types.0", "application/octet-stream"),
 				),
@@ -417,7 +415,7 @@ func TestAccAPIGatewayRestAPI_BinaryMediaTypes_overrideBody(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_binaryMediaTypes1OverrideBody(rName, "application/octet", "image/jpeg"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "binary_media_types.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "binary_media_types.0", "application/octet"),
 				),
@@ -426,7 +424,7 @@ func TestAccAPIGatewayRestAPI_BinaryMediaTypes_overrideBody(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_binaryMediaTypes1OverrideBody(rName, "application/octet", "image/png"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "binary_media_types.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "binary_media_types.0", "application/octet"),
 				),
@@ -438,19 +436,19 @@ func TestAccAPIGatewayRestAPI_BinaryMediaTypes_overrideBody(t *testing.T) {
 func TestAccAPIGatewayRestAPI_BinaryMediaTypes_setByBody(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_binaryMediaTypes1SetByBody(rName, "application/octet-stream"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "binary_media_types.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "binary_media_types.0", "application/octet-stream"),
 				),
@@ -468,21 +466,21 @@ func TestAccAPIGatewayRestAPI_BinaryMediaTypes_setByBody(t *testing.T) {
 func TestAccAPIGatewayRestAPI_body(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// The body is expected to only set a title (name) and one route
 			{
 				Config: testAccRestAPIConfig_body(rName, "/test"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
-					testAccCheckRestAPIRoutes(ctx, &conf, []string{"/", "/test"}),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					testAccCheckRestAPIRoutes(ctx, t, &conf, []string{"/", "/test"}),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreatedDate),
@@ -498,8 +496,8 @@ func TestAccAPIGatewayRestAPI_body(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_body(rName, "/update"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
-					testAccCheckRestAPIRoutes(ctx, &conf, []string{"/", "/update"}),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					testAccCheckRestAPIRoutes(ctx, t, &conf, []string{"/", "/update"}),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreatedDate),
 					resource.TestCheckResourceAttrSet(resourceName, "execution_arn"),
@@ -512,19 +510,19 @@ func TestAccAPIGatewayRestAPI_body(t *testing.T) {
 func TestAccAPIGatewayRestAPI_description(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_description(rName, "description1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description1"),
 				),
 			},
@@ -537,7 +535,7 @@ func TestAccAPIGatewayRestAPI_description(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_description(rName, "description2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description2"),
 				),
 			},
@@ -548,19 +546,19 @@ func TestAccAPIGatewayRestAPI_description(t *testing.T) {
 func TestAccAPIGatewayRestAPI_Description_overrideBody(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_descriptionOverrideBody(rName, "tfdescription1", "oasdescription1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "tfdescription1"),
 				),
 			},
@@ -574,7 +572,7 @@ func TestAccAPIGatewayRestAPI_Description_overrideBody(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_descriptionOverrideBody(rName, "tfdescription2", "oasdescription1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "tfdescription2"),
 				),
 			},
@@ -582,7 +580,7 @@ func TestAccAPIGatewayRestAPI_Description_overrideBody(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_descriptionOverrideBody(rName, "tfdescription2", "oasdescription2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "tfdescription2"),
 				),
 			},
@@ -593,19 +591,19 @@ func TestAccAPIGatewayRestAPI_Description_overrideBody(t *testing.T) {
 func TestAccAPIGatewayRestAPI_Description_setByBody(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_descriptionSetByBody(rName, "oasdescription1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "oasdescription1"),
 				),
 			},
@@ -621,14 +619,14 @@ func TestAccAPIGatewayRestAPI_Description_setByBody(t *testing.T) {
 
 func TestAccAPIGatewayRestAPI_disableExecuteAPIEndpoint(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_disableExecuteEndpoint(rName, false),
@@ -661,19 +659,19 @@ func TestAccAPIGatewayRestAPI_disableExecuteAPIEndpoint(t *testing.T) {
 func TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_overrideBody(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_disableExecuteEndpointOverrideBody(rName, true, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "disable_execute_api_endpoint", acctest.CtTrue),
 				),
 			},
@@ -687,7 +685,7 @@ func TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_overrideBody(t *testing.
 			{
 				Config: testAccRestAPIConfig_disableExecuteEndpointOverrideBody(rName, false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "disable_execute_api_endpoint", acctest.CtFalse),
 				),
 			},
@@ -695,7 +693,7 @@ func TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_overrideBody(t *testing.
 			{
 				Config: testAccRestAPIConfig_disableExecuteEndpointOverrideBody(rName, true, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "disable_execute_api_endpoint", acctest.CtTrue),
 				),
 			},
@@ -706,19 +704,19 @@ func TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_overrideBody(t *testing.
 func TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_setByBody(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_disableExecuteEndpointSetByBody(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "disable_execute_api_endpoint", acctest.CtTrue),
 				),
 			},
@@ -735,21 +733,21 @@ func TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_setByBody(t *testing.T) 
 func TestAccAPIGatewayRestAPI_Endpoint_vpcEndpointIDs(t *testing.T) {
 	ctx := acctest.Context(t)
 	var restApi apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 	vpcEndpointResourceName1 := "aws_vpc_endpoint.test"
 	vpcEndpointResourceName2 := "aws_vpc_endpoint.test2"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_vpcEndpointIDs1(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &restApi),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &restApi),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.types.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.types.0", "PRIVATE"),
@@ -766,7 +764,7 @@ func TestAccAPIGatewayRestAPI_Endpoint_vpcEndpointIDs(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_endpointConfigurationVPCEndpointIds2(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &restApi),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &restApi),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.types.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.types.0", "PRIVATE"),
@@ -778,7 +776,7 @@ func TestAccAPIGatewayRestAPI_Endpoint_vpcEndpointIDs(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_vpcEndpointIDs1(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &restApi),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &restApi),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.types.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.types.0", "PRIVATE"),
@@ -793,26 +791,26 @@ func TestAccAPIGatewayRestAPI_Endpoint_vpcEndpointIDs(t *testing.T) {
 func TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideBody(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 	vpcEndpointResourceName1 := "aws_vpc_endpoint.test.0"
 	vpcEndpointResourceName2 := "aws_vpc_endpoint.test.1"
 	vpcEndpointResourceName3 := "aws_vpc_endpoint.test.2"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_endpointConfigurationVPCEndpointIdsOverrideBody(rName, vpcEndpointResourceName1, vpcEndpointResourceName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.vpc_endpoint_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "endpoint_configuration.0.vpc_endpoint_ids.*", vpcEndpointResourceName1, names.AttrID),
-					testAccCheckRestAPIEndpointsCount(ctx, &conf, 1),
+					testAccCheckRestAPIEndpointsCount(ctx, t, &conf, 1),
 				),
 			},
 			{
@@ -825,22 +823,22 @@ func TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideBody(t *testing.T) 
 			{
 				Config: testAccRestAPIConfig_endpointConfigurationVPCEndpointIdsOverrideBody(rName, vpcEndpointResourceName3, vpcEndpointResourceName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.vpc_endpoint_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "endpoint_configuration.0.vpc_endpoint_ids.*", vpcEndpointResourceName3, names.AttrID),
-					testAccCheckRestAPIEndpointsCount(ctx, &conf, 1),
+					testAccCheckRestAPIEndpointsCount(ctx, t, &conf, 1),
 				),
 			},
 			// Verify updated body value is still overridden
 			{
 				Config: testAccRestAPIConfig_endpointConfigurationVPCEndpointIdsOverrideBody(rName, vpcEndpointResourceName3, vpcEndpointResourceName1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.vpc_endpoint_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "endpoint_configuration.0.vpc_endpoint_ids.*", vpcEndpointResourceName3, names.AttrID),
-					testAccCheckRestAPIEndpointsCount(ctx, &conf, 1),
+					testAccCheckRestAPIEndpointsCount(ctx, t, &conf, 1),
 				),
 			},
 		},
@@ -850,26 +848,26 @@ func TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideBody(t *testing.T) 
 func TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_mergeBody(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 	vpcEndpointResourceName1 := "aws_vpc_endpoint.test.0"
 	vpcEndpointResourceName2 := "aws_vpc_endpoint.test.1"
 	vpcEndpointResourceName3 := "aws_vpc_endpoint.test.2"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_endpointConfigurationVPCEndpointIdsMergeBody(rName, vpcEndpointResourceName1, vpcEndpointResourceName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.vpc_endpoint_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "endpoint_configuration.0.vpc_endpoint_ids.*", vpcEndpointResourceName1, names.AttrID),
-					testAccCheckRestAPIEndpointsCount(ctx, &conf, 1),
+					testAccCheckRestAPIEndpointsCount(ctx, t, &conf, 1),
 				),
 			},
 			{
@@ -883,22 +881,22 @@ func TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_mergeBody(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_endpointConfigurationVPCEndpointIdsMergeBody(rName, vpcEndpointResourceName3, vpcEndpointResourceName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.vpc_endpoint_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "endpoint_configuration.0.vpc_endpoint_ids.*", vpcEndpointResourceName3, names.AttrID),
-					testAccCheckRestAPIEndpointsCount(ctx, &conf, 1),
+					testAccCheckRestAPIEndpointsCount(ctx, t, &conf, 1),
 				),
 			},
 			// Verify updated endpoint configuration, and endpoint from OAS is discarded.
 			{
 				Config: testAccRestAPIConfig_endpointConfigurationVPCEndpointIdsMergeBody(rName, vpcEndpointResourceName3, vpcEndpointResourceName1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.vpc_endpoint_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "endpoint_configuration.0.vpc_endpoint_ids.*", vpcEndpointResourceName3, names.AttrID),
-					testAccCheckRestAPIEndpointsCount(ctx, &conf, 1),
+					testAccCheckRestAPIEndpointsCount(ctx, t, &conf, 1),
 				),
 			},
 		},
@@ -908,25 +906,25 @@ func TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_mergeBody(t *testing.T) {
 func TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideToMergeBody(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 	vpcEndpointResourceName1 := "aws_vpc_endpoint.test.0"
 	vpcEndpointResourceName2 := "aws_vpc_endpoint.test.1"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_endpointConfigurationVPCEndpointIdsOverrideBody(rName, vpcEndpointResourceName1, vpcEndpointResourceName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.vpc_endpoint_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "endpoint_configuration.0.vpc_endpoint_ids.*", vpcEndpointResourceName1, names.AttrID),
-					testAccCheckRestAPIEndpointsCount(ctx, &conf, 1),
+					testAccCheckRestAPIEndpointsCount(ctx, t, &conf, 1),
 				),
 			},
 			{
@@ -940,11 +938,11 @@ func TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideToMergeBody(t *test
 			{
 				Config: testAccRestAPIConfig_endpointConfigurationVPCEndpointIdsMergeBody(rName, vpcEndpointResourceName1, vpcEndpointResourceName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.vpc_endpoint_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "endpoint_configuration.0.vpc_endpoint_ids.*", vpcEndpointResourceName1, names.AttrID),
-					testAccCheckRestAPIEndpointsCount(ctx, &conf, 1),
+					testAccCheckRestAPIEndpointsCount(ctx, t, &conf, 1),
 				),
 			},
 			{
@@ -960,20 +958,20 @@ func TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideToMergeBody(t *test
 func TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_setByBody(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 	vpcEndpointResourceName := "aws_vpc_endpoint.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_endpointConfigurationVPCEndpointIdsSetByBody(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.vpc_endpoint_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "endpoint_configuration.0.vpc_endpoint_ids.*", vpcEndpointResourceName, names.AttrID),
@@ -992,19 +990,19 @@ func TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_setByBody(t *testing.T) {
 func TestAccAPIGatewayRestAPI_ipAddressType(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_ipAddressType(rName, "REGIONAL", "ipv4"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.types.0", "REGIONAL"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.ip_address_type", "ipv4"),
 				),
@@ -1018,7 +1016,7 @@ func TestAccAPIGatewayRestAPI_ipAddressType(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_ipAddressType(rName, "REGIONAL", "dualstack"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.types.0", "REGIONAL"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.ip_address_type", "dualstack"),
 				),
@@ -1030,19 +1028,19 @@ func TestAccAPIGatewayRestAPI_ipAddressType(t *testing.T) {
 func TestAccAPIGatewayRestAPI_ipAddressType_overrideBody(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_ipAddressTypeOverrideBody(rName, "REGIONAL", "ipv4"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.types.0", "REGIONAL"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.ip_address_type", "ipv4"),
 				),
@@ -1057,7 +1055,7 @@ func TestAccAPIGatewayRestAPI_ipAddressType_overrideBody(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_ipAddressTypeOverrideBody(rName, "REGIONAL", "dualstack"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.types.0", "REGIONAL"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.0.ip_address_type", "dualstack"),
 				),
@@ -1068,13 +1066,13 @@ func TestAccAPIGatewayRestAPI_ipAddressType_overrideBody(t *testing.T) {
 
 func TestAccAPIGatewayRestAPI_ipAddressType_privateError(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccRestAPIConfig_ipAddressType(rName, "PRIVATE", "ipv4"),
@@ -1087,19 +1085,19 @@ func TestAccAPIGatewayRestAPI_ipAddressType_privateError(t *testing.T) {
 func TestAccAPIGatewayRestAPI_minimumCompressionSize(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_minimumCompressionSize(rName, "1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "minimum_compression_size", "1"),
 				),
 			},
@@ -1112,14 +1110,14 @@ func TestAccAPIGatewayRestAPI_minimumCompressionSize(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_minimumCompressionSize(rName, "-1"), // -1 removes existing values
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "minimum_compression_size", ""),
 				),
 			},
 			{
 				Config: testAccRestAPIConfig_minimumCompressionSize(rName, "5242880"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "minimum_compression_size", "5242880"),
 				),
 			},
@@ -1130,19 +1128,19 @@ func TestAccAPIGatewayRestAPI_minimumCompressionSize(t *testing.T) {
 func TestAccAPIGatewayRestAPI_MinimumCompressionSize_overrideBody(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_minimumCompressionSizeOverrideBody(rName, "1", 5242880),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "minimum_compression_size", "1"),
 				),
 			},
@@ -1156,7 +1154,7 @@ func TestAccAPIGatewayRestAPI_MinimumCompressionSize_overrideBody(t *testing.T) 
 			{
 				Config: testAccRestAPIConfig_minimumCompressionSizeOverrideBody(rName, "2", 5242880),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "minimum_compression_size", "2"),
 				),
 			},
@@ -1164,7 +1162,7 @@ func TestAccAPIGatewayRestAPI_MinimumCompressionSize_overrideBody(t *testing.T) 
 			{
 				Config: testAccRestAPIConfig_minimumCompressionSizeOverrideBody(rName, "2", 1048576),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "minimum_compression_size", "2"),
 				),
 			},
@@ -1175,19 +1173,19 @@ func TestAccAPIGatewayRestAPI_MinimumCompressionSize_overrideBody(t *testing.T) 
 func TestAccAPIGatewayRestAPI_MinimumCompressionSize_setByBody(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_minimumCompressionSizeSetByBody(rName, 1048576),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "minimum_compression_size", "1048576"),
 				),
 			},
@@ -1204,20 +1202,20 @@ func TestAccAPIGatewayRestAPI_MinimumCompressionSize_setByBody(t *testing.T) {
 func TestAccAPIGatewayRestAPI_Name_overrideBody(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_nameOverrideBody(rName, "title1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 				),
 			},
@@ -1231,7 +1229,7 @@ func TestAccAPIGatewayRestAPI_Name_overrideBody(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_nameOverrideBody(rName2, "title1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName2),
 				),
 			},
@@ -1239,7 +1237,7 @@ func TestAccAPIGatewayRestAPI_Name_overrideBody(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_nameOverrideBody(rName2, "title2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName2),
 				),
 			},
@@ -1250,14 +1248,14 @@ func TestAccAPIGatewayRestAPI_Name_overrideBody(t *testing.T) {
 func TestAccAPIGatewayRestAPI_FailOnWarnings(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// Verify invalid body fails creation, when fail_on_warnings is true
 			{
@@ -1268,8 +1266,8 @@ func TestAccAPIGatewayRestAPI_FailOnWarnings(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_failOnWarnings(rName, "original", ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
-					testAccCheckRestAPIRoutes(ctx, &conf, []string{"/", "/users"}),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					testAccCheckRestAPIRoutes(ctx, t, &conf, []string{"/", "/users"}),
 					resource.TestMatchResourceAttr(resourceName, names.AttrDescription, regexache.MustCompile(`original`)),
 				),
 			},
@@ -1296,20 +1294,20 @@ func TestAccAPIGatewayRestAPI_FailOnWarnings(t *testing.T) {
 func TestAccAPIGatewayRestAPI_parameters(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_parameters1(rName, "basepath", "prepend"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
-					testAccCheckRestAPIRoutes(ctx, &conf, []string{"/", "/foo", "/foo/bar", "/foo/bar/baz", "/foo/bar/baz/test"}),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					testAccCheckRestAPIRoutes(ctx, t, &conf, []string{"/", "/foo", "/foo/bar", "/foo/bar/baz", "/foo/bar/baz/test"}),
 				),
 			},
 			{
@@ -1321,8 +1319,8 @@ func TestAccAPIGatewayRestAPI_parameters(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_parameters1(rName, "basepath", "ignore"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
-					testAccCheckRestAPIRoutes(ctx, &conf, []string{"/", "/test"}),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					testAccCheckRestAPIRoutes(ctx, t, &conf, []string{"/", "/test"}),
 				),
 			},
 		},
@@ -1334,13 +1332,13 @@ func TestAccAPIGatewayRestAPI_Policy_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 	expectedPolicyText := `{"Statement":[{"Action":"execute-api:Invoke","Condition":{"IpAddress":{"aws:SourceIp":"123.123.123.123/32"}},"Effect":"Allow","Principal":{"AWS":"*"},"Resource":"*"}],"Version":"2012-10-17"}`
 	expectedUpdatePolicyText := `{"Statement":[{"Action":"execute-api:Invoke","Effect":"Deny","Principal":{"AWS":"*"},"Resource":"*"}],"Version":"2012-10-17"}`
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_policy(rName),
@@ -1369,18 +1367,18 @@ func TestAccAPIGatewayRestAPI_Policy_order(t *testing.T) {
 	var conf apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
 	expectedPolicyText := `{"Statement":[{"Action":"execute-api:Invoke","Condition":{"IpAddress":{"aws:SourceIp":["123.123.123.123/32","122.122.122.122/32","169.254.169.253/32"]}},"Effect":"Allow","Principal":{"AWS":"*"},"Resource":"*"}],"Version":"2012-10-17"}`
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_policyOrder(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -1394,7 +1392,7 @@ func TestAccAPIGatewayRestAPI_Policy_order(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_policyNewOrder(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -1412,20 +1410,20 @@ func TestAccAPIGatewayRestAPI_Policy_order(t *testing.T) {
 func TestAccAPIGatewayRestAPI_Policy_overrideBody(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_policyOverrideBody(rName, "/test", "Allow"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
-					testAccCheckRestAPIRoutes(ctx, &conf, []string{"/", "/test"}),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					testAccCheckRestAPIRoutes(ctx, t, &conf, []string{"/", "/test"}),
 					resource.TestMatchResourceAttr(resourceName, names.AttrPolicy, regexache.MustCompile(`"Allow"`)),
 				),
 			},
@@ -1439,8 +1437,8 @@ func TestAccAPIGatewayRestAPI_Policy_overrideBody(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_policyOverrideBody(rName, "/test2", "Allow"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
-					testAccCheckRestAPIRoutes(ctx, &conf, []string{"/", "/test2"}),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					testAccCheckRestAPIRoutes(ctx, t, &conf, []string{"/", "/test2"}),
 					resource.TestMatchResourceAttr(resourceName, names.AttrPolicy, regexache.MustCompile(`"Allow"`)),
 				),
 			},
@@ -1448,8 +1446,8 @@ func TestAccAPIGatewayRestAPI_Policy_overrideBody(t *testing.T) {
 			{
 				Config: testAccRestAPIConfig_policyOverrideBody(rName, "/test2", "Deny"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
-					testAccCheckRestAPIRoutes(ctx, &conf, []string{"/", "/test2"}),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					testAccCheckRestAPIRoutes(ctx, t, &conf, []string{"/", "/test2"}),
 					resource.TestMatchResourceAttr(resourceName, names.AttrPolicy, regexache.MustCompile(`"Deny"`)),
 				),
 			},
@@ -1460,19 +1458,19 @@ func TestAccAPIGatewayRestAPI_Policy_overrideBody(t *testing.T) {
 func TestAccAPIGatewayRestAPI_Policy_setByBody(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetRestApiOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_rest_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRestAPIConfig_policySetByBody(rName, "Allow"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRESTAPIExists(ctx, resourceName, &conf),
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestMatchResourceAttr(resourceName, names.AttrPolicy, regexache.MustCompile(`"Allow"`)),
 				),
 			},
@@ -1486,9 +1484,9 @@ func TestAccAPIGatewayRestAPI_Policy_setByBody(t *testing.T) {
 	})
 }
 
-func testAccCheckRestAPIRoutes(ctx context.Context, conf *apigateway.GetRestApiOutput, routes []string) resource.TestCheckFunc {
+func testAccCheckRestAPIRoutes(ctx context.Context, t *testing.T, conf *apigateway.GetRestApiOutput, routes []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		input := apigateway.GetResourcesInput{
 			RestApiId: conf.Id,
@@ -1518,9 +1516,9 @@ func testAccCheckRestAPIRoutes(ctx context.Context, conf *apigateway.GetRestApiO
 	}
 }
 
-func testAccCheckRestAPIEndpointsCount(ctx context.Context, conf *apigateway.GetRestApiOutput, count int) resource.TestCheckFunc {
+func testAccCheckRestAPIEndpointsCount(ctx context.Context, t *testing.T, conf *apigateway.GetRestApiOutput, count int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		input := apigateway.GetRestApiInput{
 			RestApiId: conf.Id,
@@ -1543,14 +1541,14 @@ func testAccCheckRestAPIEndpointsCount(ctx context.Context, conf *apigateway.Get
 	}
 }
 
-func testAccCheckRESTAPIExists(ctx context.Context, n string, v *apigateway.GetRestApiOutput) resource.TestCheckFunc {
+func testAccCheckRESTAPIExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetRestApiOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindRestAPIByID(ctx, conn, rs.Primary.ID)
 
@@ -1564,9 +1562,9 @@ func testAccCheckRESTAPIExists(ctx context.Context, n string, v *apigateway.GetR
 	}
 }
 
-func testAccCheckRESTAPIDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckRESTAPIDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_rest_api" {

--- a/internal/service/apigateway/sdk_data_source_test.go
+++ b/internal/service/apigateway/sdk_data_source_test.go
@@ -6,7 +6,6 @@ package apigateway_test
 import (
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -14,10 +13,10 @@ import (
 
 func TestAccAPIGatewaySDKDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_api_gateway_sdk.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/apigateway/stage_tags_gen_test.go
+++ b/internal/service/apigateway/stage_tags_gen_test.go
@@ -63,7 +63,7 @@ func testAccAPIGatewayStage_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckStageDestroy(ctx),
+		CheckDestroy:             testAccCheckStageDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -75,7 +75,7 @@ func testAccAPIGatewayStage_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -120,7 +120,7 @@ func testAccAPIGatewayStage_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -169,7 +169,7 @@ func testAccAPIGatewayStage_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -211,7 +211,7 @@ func testAccAPIGatewayStage_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -253,7 +253,7 @@ func testAccAPIGatewayStage_tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckStageDestroy(ctx),
+		CheckDestroy:             testAccCheckStageDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -265,7 +265,7 @@ func testAccAPIGatewayStage_tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -325,7 +325,7 @@ func testAccAPIGatewayStage_tags_EmptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckStageDestroy(ctx),
+		CheckDestroy:             testAccCheckStageDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -335,7 +335,7 @@ func testAccAPIGatewayStage_tags_EmptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -393,7 +393,7 @@ func testAccAPIGatewayStage_tags_AddOnUpdate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckStageDestroy(ctx),
+		CheckDestroy:             testAccCheckStageDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -403,7 +403,7 @@ func testAccAPIGatewayStage_tags_AddOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -427,7 +427,7 @@ func testAccAPIGatewayStage_tags_AddOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -479,7 +479,7 @@ func testAccAPIGatewayStage_tags_EmptyTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckStageDestroy(ctx),
+		CheckDestroy:             testAccCheckStageDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -491,7 +491,7 @@ func testAccAPIGatewayStage_tags_EmptyTag_OnCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -532,7 +532,7 @@ func testAccAPIGatewayStage_tags_EmptyTag_OnCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -574,7 +574,7 @@ func testAccAPIGatewayStage_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckStageDestroy(ctx),
+		CheckDestroy:             testAccCheckStageDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -586,7 +586,7 @@ func testAccAPIGatewayStage_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -618,7 +618,7 @@ func testAccAPIGatewayStage_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -665,7 +665,7 @@ func testAccAPIGatewayStage_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -717,7 +717,7 @@ func testAccAPIGatewayStage_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckStageDestroy(ctx),
+		CheckDestroy:             testAccCheckStageDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -729,7 +729,7 @@ func testAccAPIGatewayStage_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -760,7 +760,7 @@ func testAccAPIGatewayStage_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -811,7 +811,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_providerOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckStageDestroy(ctx),
+		CheckDestroy: testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -824,7 +824,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -869,7 +869,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -916,7 +916,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -957,7 +957,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1000,7 +1000,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_nonOverlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckStageDestroy(ctx),
+		CheckDestroy: testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1015,7 +1015,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1070,7 +1070,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1124,7 +1124,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1167,7 +1167,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_overlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckStageDestroy(ctx),
+		CheckDestroy: testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1182,7 +1182,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1236,7 +1236,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1294,7 +1294,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1350,7 +1350,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_updateToProviderOnly(t *testing.T) 
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckStageDestroy(ctx),
+		CheckDestroy: testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1362,7 +1362,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_updateToProviderOnly(t *testing.T) 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1395,7 +1395,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_updateToProviderOnly(t *testing.T) 
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1445,7 +1445,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_updateToResourceOnly(t *testing.T) 
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckStageDestroy(ctx),
+		CheckDestroy: testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1458,7 +1458,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_updateToResourceOnly(t *testing.T) 
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1486,7 +1486,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_updateToResourceOnly(t *testing.T) 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1539,7 +1539,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckStageDestroy(ctx),
+		CheckDestroy: testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1554,7 +1554,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1609,7 +1609,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) 
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckStageDestroy(ctx),
+		CheckDestroy: testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1622,7 +1622,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) 
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1671,7 +1671,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_nullOverlappingResourceTag(t *testi
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckStageDestroy(ctx),
+		CheckDestroy: testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1686,7 +1686,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_nullOverlappingResourceTag(t *testi
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1738,7 +1738,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_nullNonOverlappingResourceTag(t *te
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckStageDestroy(ctx),
+		CheckDestroy: testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1753,7 +1753,7 @@ func testAccAPIGatewayStage_tags_DefaultTags_nullNonOverlappingResourceTag(t *te
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1805,7 +1805,7 @@ func testAccAPIGatewayStage_tags_ComputedTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckStageDestroy(ctx),
+		CheckDestroy: testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1815,7 +1815,7 @@ func testAccAPIGatewayStage_tags_ComputedTag_OnCreate(t *testing.T) {
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1865,7 +1865,7 @@ func testAccAPIGatewayStage_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckStageDestroy(ctx),
+		CheckDestroy: testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1877,7 +1877,7 @@ func testAccAPIGatewayStage_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1909,7 +1909,7 @@ func testAccAPIGatewayStage_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1967,7 +1967,7 @@ func testAccAPIGatewayStage_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckStageDestroy(ctx),
+		CheckDestroy: testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1979,7 +1979,7 @@ func testAccAPIGatewayStage_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2009,7 +2009,7 @@ func testAccAPIGatewayStage_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2059,7 +2059,7 @@ func testAccAPIGatewayStage_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckStageDestroy(ctx),
+		CheckDestroy: testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2078,7 +2078,7 @@ func testAccAPIGatewayStage_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2127,7 +2127,7 @@ func testAccAPIGatewayStage_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2176,7 +2176,7 @@ func testAccAPIGatewayStage_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2225,7 +2225,7 @@ func testAccAPIGatewayStage_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckStageDestroy(ctx),
+		CheckDestroy: testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2242,7 +2242,7 @@ func testAccAPIGatewayStage_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2305,7 +2305,7 @@ func testAccAPIGatewayStage_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2368,7 +2368,7 @@ func testAccAPIGatewayStage_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &v),
+					testAccCheckStageExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/apigateway/stage_test.go
+++ b/internal/service/apigateway/stage_test.go
@@ -10,11 +10,9 @@ import (
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -23,19 +21,19 @@ import (
 func testAccStage_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetStageOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_stage.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckStageDestroy(ctx),
+		CheckDestroy:             testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/restapis/.+/stages/prod`)),
 					resource.TestCheckResourceAttr(resourceName, "stage_name", "prod"),
 					resource.TestCheckResourceAttrSet(resourceName, "execution_arn"),
@@ -56,7 +54,7 @@ func testAccStage_basic(t *testing.T) {
 			{
 				Config: testAccStageConfig_updated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/restapis/.+/stages/prod`)),
 					resource.TestCheckResourceAttr(resourceName, "stage_name", "prod"),
 					resource.TestCheckResourceAttrSet(resourceName, "execution_arn"),
@@ -72,7 +70,7 @@ func testAccStage_basic(t *testing.T) {
 			{
 				Config: testAccStageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/restapis/.+/stages/prod`)),
 					resource.TestCheckResourceAttr(resourceName, "stage_name", "prod"),
 					resource.TestCheckResourceAttrSet(resourceName, "execution_arn"),
@@ -90,19 +88,19 @@ func testAccStage_basic(t *testing.T) {
 func testAccStage_cache(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetStageOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_stage.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckStageDestroy(ctx),
+		CheckDestroy:             testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "cache_cluster_enabled", acctest.CtFalse),
 				),
 			},
@@ -115,7 +113,7 @@ func testAccStage_cache(t *testing.T) {
 			{
 				Config: testAccStageConfig_cache(rName, "0.5"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "cache_cluster_size", "0.5"),
 					resource.TestCheckResourceAttr(resourceName, "cache_cluster_enabled", acctest.CtTrue),
 				),
@@ -124,7 +122,7 @@ func testAccStage_cache(t *testing.T) {
 			{
 				Config: testAccStageConfig_cache(rName, "1.6"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "cache_cluster_size", "1.6"),
 					resource.TestCheckResourceAttr(resourceName, "cache_cluster_enabled", acctest.CtTrue),
 				),
@@ -132,7 +130,7 @@ func testAccStage_cache(t *testing.T) {
 			{
 				Config: testAccStageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "cache_cluster_enabled", acctest.CtFalse),
 				),
 			},
@@ -144,19 +142,19 @@ func testAccStage_cache(t *testing.T) {
 func testAccStage_cacheSizeCacheDisabled(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetStageOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_stage.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckStageDestroy(ctx),
+		CheckDestroy:             testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStageConfig_cache(rName, "0.5"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "cache_cluster_size", "0.5"),
 					resource.TestCheckResourceAttr(resourceName, "cache_cluster_enabled", acctest.CtTrue),
 				),
@@ -170,7 +168,7 @@ func testAccStage_cacheSizeCacheDisabled(t *testing.T) {
 			{
 				Config: testAccStageConfig_cache(rName, "6.1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "cache_cluster_size", "6.1"),
 					resource.TestCheckResourceAttr(resourceName, "cache_cluster_enabled", acctest.CtTrue),
 				),
@@ -178,7 +176,7 @@ func testAccStage_cacheSizeCacheDisabled(t *testing.T) {
 			{
 				Config: testAccStageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "cache_cluster_size", ""),
 					resource.TestCheckResourceAttr(resourceName, "cache_cluster_enabled", acctest.CtFalse),
 				),
@@ -186,7 +184,7 @@ func testAccStage_cacheSizeCacheDisabled(t *testing.T) {
 			{
 				Config: testAccStageConfig_cacheSizeCacheDisabled(rName, "28.4"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "cache_cluster_size", "28.4"),
 					resource.TestCheckResourceAttr(resourceName, "cache_cluster_enabled", acctest.CtFalse),
 				),
@@ -198,19 +196,19 @@ func testAccStage_cacheSizeCacheDisabled(t *testing.T) {
 func testAccStage_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var stage apigateway.GetStageOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_stage.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckStageDestroy(ctx),
+		CheckDestroy:             testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &stage),
+					testAccCheckStageExists(ctx, t, resourceName, &stage),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceStage(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -222,19 +220,19 @@ func testAccStage_disappears(t *testing.T) {
 func testAccStage_Disappears_restAPI(t *testing.T) {
 	ctx := acctest.Context(t)
 	var stage apigateway.GetStageOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_stage.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckStageDestroy(ctx),
+		CheckDestroy:             testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &stage),
+					testAccCheckStageExists(ctx, t, resourceName, &stage),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceRestAPI(), "aws_api_gateway_rest_api.test"),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceStage(), resourceName),
 				),
@@ -247,7 +245,7 @@ func testAccStage_Disappears_restAPI(t *testing.T) {
 func testAccStage_accessLogSettings(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetStageOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.test"
 	resourceName := "aws_api_gateway_stage.test"
 	clf := `$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId`
@@ -256,16 +254,16 @@ func testAccStage_accessLogSettings(t *testing.T) {
 	csv := `$context.identity.sourceIp,$context.identity.caller,$context.identity.user,$context.requestTime,$context.httpMethod,$context.resourcePath,$context.protocol,$context.status,$context.responseLength,$context.requestId`
 
 	// Cannot be run in parallel, because this test uses the account-level CloudWatch Logs role ARN
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckStageDestroy(ctx),
+		CheckDestroy:             testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStageConfig_accessLogSettings(rName, clf),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/restapis/.+/stages/prod`)),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "access_log_settings.0.destination_arn", cloudwatchLogGroupResourceName, names.AttrARN),
@@ -276,7 +274,7 @@ func testAccStage_accessLogSettings(t *testing.T) {
 			{
 				Config: testAccStageConfig_accessLogSettings(rName, json),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/restapis/.+/stages/prod`)),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "access_log_settings.0.destination_arn", cloudwatchLogGroupResourceName, names.AttrARN),
@@ -286,7 +284,7 @@ func testAccStage_accessLogSettings(t *testing.T) {
 			{
 				Config: testAccStageConfig_accessLogSettings(rName, xml),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/restapis/.+/stages/prod`)),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "access_log_settings.0.destination_arn", cloudwatchLogGroupResourceName, names.AttrARN),
@@ -296,7 +294,7 @@ func testAccStage_accessLogSettings(t *testing.T) {
 			{
 				Config: testAccStageConfig_accessLogSettings(rName, csv),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/restapis/.+/stages/prod`)),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "access_log_settings.0.destination_arn", cloudwatchLogGroupResourceName, names.AttrARN),
@@ -306,7 +304,7 @@ func testAccStage_accessLogSettings(t *testing.T) {
 			{
 				Config: testAccStageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/restapis/.+/stages/prod`)),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
 				),
@@ -318,7 +316,7 @@ func testAccStage_accessLogSettings(t *testing.T) {
 func testAccStage_AccessLogSettings_kinesis(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetStageOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_stage.test"
 	kinesesResourceName := "aws_kinesis_firehose_delivery_stream.test"
 	clf := `$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId`
@@ -326,16 +324,16 @@ func testAccStage_AccessLogSettings_kinesis(t *testing.T) {
 	xml := `<request id="$context.requestId"> <ip>$context.identity.sourceIp</ip> <caller>$context.identity.caller</caller> <user>$context.identity.user</user> <requestTime>$context.requestTime</requestTime> <httpMethod>$context.httpMethod</httpMethod> <resourcePath>$context.resourcePath</resourcePath> <status>$context.status</status> <protocol>$context.protocol</protocol> <responseLength>$context.responseLength</responseLength> </request>`
 	csv := `$context.identity.sourceIp,$context.identity.caller,$context.identity.user,$context.requestTime,$context.httpMethod,$context.resourcePath,$context.protocol,$context.status,$context.responseLength,$context.requestId`
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckStageDestroy(ctx),
+		CheckDestroy:             testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStageConfig_accessLogSettingsKinesis(rName, clf),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "access_log_settings.0.destination_arn", kinesesResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.0.format", clf),
@@ -345,7 +343,7 @@ func testAccStage_AccessLogSettings_kinesis(t *testing.T) {
 			{
 				Config: testAccStageConfig_accessLogSettingsKinesis(rName, json),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/restapis/.+/stages/prod`)),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "access_log_settings.0.destination_arn", kinesesResourceName, names.AttrARN),
@@ -355,7 +353,7 @@ func testAccStage_AccessLogSettings_kinesis(t *testing.T) {
 			{
 				Config: testAccStageConfig_accessLogSettingsKinesis(rName, xml),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/restapis/.+/stages/prod`)),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "access_log_settings.0.destination_arn", kinesesResourceName, names.AttrARN),
@@ -365,7 +363,7 @@ func testAccStage_AccessLogSettings_kinesis(t *testing.T) {
 			{
 				Config: testAccStageConfig_accessLogSettingsKinesis(rName, csv),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/restapis/.+/stages/prod`)),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "access_log_settings.0.destination_arn", kinesesResourceName, names.AttrARN),
@@ -375,7 +373,7 @@ func testAccStage_AccessLogSettings_kinesis(t *testing.T) {
 			{
 				Config: testAccStageConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/restapis/.+/stages/prod`)),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
 				),
@@ -387,25 +385,25 @@ func testAccStage_AccessLogSettings_kinesis(t *testing.T) {
 func testAccStage_waf(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetStageOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_stage.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckStageDestroy(ctx),
+		CheckDestroy:             testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStageConfig_wafACL(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 				),
 			},
 			{
 				Config: testAccStageConfig_wafACL(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttrPair(resourceName, "web_acl_arn", "aws_wafregional_web_acl.test", names.AttrARN),
 				),
 			},
@@ -422,21 +420,21 @@ func testAccStage_waf(t *testing.T) {
 func testAccStage_canarySettings(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetStageOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_stage.test"
 	deployment2 := "aws_api_gateway_deployment.test2"
 	deployment3 := "aws_api_gateway_deployment.test3"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckStageDestroy(ctx),
+		CheckDestroy:             testAccCheckStageDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStageConfig_canarySettings(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "variables.one", "1"),
 					resource.TestCheckResourceAttr(resourceName, "canary_settings.0.percent_traffic", "33.33"),
 					resource.TestCheckResourceAttr(resourceName, "canary_settings.0.stage_variable_overrides.one", "3"),
@@ -453,14 +451,14 @@ func testAccStage_canarySettings(t *testing.T) {
 			{
 				Config: testAccStageConfig_canarySettingsRemoved(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "canary_settings.#", "0"),
 				),
 			},
 			{
 				Config: testAccStageConfig_canarySettingsUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "variables.one", "1"),
 					resource.TestCheckResourceAttr(resourceName, "canary_settings.0.percent_traffic", "66.66"),
 					resource.TestCheckResourceAttr(resourceName, "canary_settings.0.stage_variable_overrides.one", "5"),
@@ -471,7 +469,7 @@ func testAccStage_canarySettings(t *testing.T) {
 			{
 				Config: testAccStageConfig_canarySettingsNewDeployment(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "variables.one", "1"),
 					resource.TestCheckResourceAttr(resourceName, "canary_settings.0.percent_traffic", "66.66"),
 					resource.TestCheckResourceAttr(resourceName, "canary_settings.0.stage_variable_overrides.one", "5"),
@@ -482,7 +480,7 @@ func testAccStage_canarySettings(t *testing.T) {
 			{
 				Config: testAccStageConfig_canarySettingsPromote(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStageExists(ctx, resourceName, &conf),
+					testAccCheckStageExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttrPair(resourceName, "deployment_id", deployment3, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "canary_settings.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "variables.%", "2"),
@@ -493,14 +491,14 @@ func testAccStage_canarySettings(t *testing.T) {
 	})
 }
 
-func testAccCheckStageExists(ctx context.Context, n string, v *apigateway.GetStageOutput) resource.TestCheckFunc {
+func testAccCheckStageExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetStageOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindStageByTwoPartKey(ctx, conn, rs.Primary.Attributes["rest_api_id"], rs.Primary.Attributes["stage_name"])
 
@@ -514,9 +512,9 @@ func testAccCheckStageExists(ctx context.Context, n string, v *apigateway.GetSta
 	}
 }
 
-func testAccCheckStageDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckStageDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_stage" {

--- a/internal/service/apigateway/usage_plan.go
+++ b/internal/service/apigateway/usage_plan.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
@@ -28,6 +27,8 @@ import (
 // @SDKResource("aws_api_gateway_usage_plan", name="Usage Plan")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigateway;apigateway.GetUsagePlanOutput")
+// @Testing(existsTakesT=true)
+// @Testing(destroyTakesT=true)
 func resourceUsagePlan() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceUsagePlanCreate,
@@ -512,9 +513,8 @@ func findUsagePlanByID(ctx context.Context, conn *apigateway.Client, id string) 
 	output, err := conn.GetUsagePlan(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/usage_plan_key.go
+++ b/internal/service/apigateway/usage_plan_key.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -148,9 +147,8 @@ func findUsagePlanKeyByTwoPartKey(ctx context.Context, conn *apigateway.Client, 
 	output, err := conn.GetUsagePlanKey(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/apigateway/usage_plan_key_test.go
+++ b/internal/service/apigateway/usage_plan_key_test.go
@@ -9,11 +9,9 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -22,21 +20,21 @@ import (
 func TestAccAPIGatewayUsagePlanKey_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetUsagePlanKeyOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	apiGatewayApiKeyResourceName := "aws_api_gateway_api_key.test"
 	apiGatewayUsagePlanResourceName := "aws_api_gateway_usage_plan.test"
 	resourceName := "aws_api_gateway_usage_plan_key.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUsagePlanKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUsagePlanKeyConfig_typeAPI(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanKeyExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanKeyExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrKeyID, apiGatewayApiKeyResourceName, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "key_type", "API_KEY"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrName),
@@ -57,19 +55,19 @@ func TestAccAPIGatewayUsagePlanKey_basic(t *testing.T) {
 func TestAccAPIGatewayUsagePlanKey_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetUsagePlanKeyOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_usage_plan_key.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUsagePlanKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUsagePlanKeyConfig_typeAPI(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanKeyExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanKeyExists(ctx, t, resourceName, &conf),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceUsagePlanKey(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -81,41 +79,41 @@ func TestAccAPIGatewayUsagePlanKey_disappears(t *testing.T) {
 func TestAccAPIGatewayUsagePlanKey_KeyID_concurrency(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetUsagePlanKeyOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUsagePlanKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUsagePlanKeyConfig_idConcurrency(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanKeyExists(ctx, "aws_api_gateway_usage_plan_key.test.0", &conf),
-					testAccCheckUsagePlanKeyExists(ctx, "aws_api_gateway_usage_plan_key.test.1", &conf),
-					testAccCheckUsagePlanKeyExists(ctx, "aws_api_gateway_usage_plan_key.test.2", &conf),
-					testAccCheckUsagePlanKeyExists(ctx, "aws_api_gateway_usage_plan_key.test.3", &conf),
-					testAccCheckUsagePlanKeyExists(ctx, "aws_api_gateway_usage_plan_key.test.4", &conf),
-					testAccCheckUsagePlanKeyExists(ctx, "aws_api_gateway_usage_plan_key.test.5", &conf),
-					testAccCheckUsagePlanKeyExists(ctx, "aws_api_gateway_usage_plan_key.test.6", &conf),
-					testAccCheckUsagePlanKeyExists(ctx, "aws_api_gateway_usage_plan_key.test.7", &conf),
-					testAccCheckUsagePlanKeyExists(ctx, "aws_api_gateway_usage_plan_key.test.8", &conf),
-					testAccCheckUsagePlanKeyExists(ctx, "aws_api_gateway_usage_plan_key.test.9", &conf),
+					testAccCheckUsagePlanKeyExists(ctx, t, "aws_api_gateway_usage_plan_key.test.0", &conf),
+					testAccCheckUsagePlanKeyExists(ctx, t, "aws_api_gateway_usage_plan_key.test.1", &conf),
+					testAccCheckUsagePlanKeyExists(ctx, t, "aws_api_gateway_usage_plan_key.test.2", &conf),
+					testAccCheckUsagePlanKeyExists(ctx, t, "aws_api_gateway_usage_plan_key.test.3", &conf),
+					testAccCheckUsagePlanKeyExists(ctx, t, "aws_api_gateway_usage_plan_key.test.4", &conf),
+					testAccCheckUsagePlanKeyExists(ctx, t, "aws_api_gateway_usage_plan_key.test.5", &conf),
+					testAccCheckUsagePlanKeyExists(ctx, t, "aws_api_gateway_usage_plan_key.test.6", &conf),
+					testAccCheckUsagePlanKeyExists(ctx, t, "aws_api_gateway_usage_plan_key.test.7", &conf),
+					testAccCheckUsagePlanKeyExists(ctx, t, "aws_api_gateway_usage_plan_key.test.8", &conf),
+					testAccCheckUsagePlanKeyExists(ctx, t, "aws_api_gateway_usage_plan_key.test.9", &conf),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckUsagePlanKeyExists(ctx context.Context, n string, v *apigateway.GetUsagePlanKeyOutput) resource.TestCheckFunc {
+func testAccCheckUsagePlanKeyExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetUsagePlanKeyOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindUsagePlanKeyByTwoPartKey(ctx, conn, rs.Primary.Attributes["usage_plan_id"], rs.Primary.Attributes[names.AttrKeyID])
 
@@ -129,9 +127,9 @@ func testAccCheckUsagePlanKeyExists(ctx context.Context, n string, v *apigateway
 	}
 }
 
-func testAccCheckUsagePlanKeyDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckUsagePlanKeyDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_usage_plan_key" {

--- a/internal/service/apigateway/usage_plan_tags_gen_test.go
+++ b/internal/service/apigateway/usage_plan_tags_gen_test.go
@@ -33,7 +33,7 @@ func TestAccAPIGatewayUsagePlan_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -45,7 +45,7 @@ func TestAccAPIGatewayUsagePlan_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -89,7 +89,7 @@ func TestAccAPIGatewayUsagePlan_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -137,7 +137,7 @@ func TestAccAPIGatewayUsagePlan_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -178,7 +178,7 @@ func TestAccAPIGatewayUsagePlan_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -219,7 +219,7 @@ func TestAccAPIGatewayUsagePlan_tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -231,7 +231,7 @@ func TestAccAPIGatewayUsagePlan_tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -290,7 +290,7 @@ func TestAccAPIGatewayUsagePlan_tags_EmptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -300,7 +300,7 @@ func TestAccAPIGatewayUsagePlan_tags_EmptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -357,7 +357,7 @@ func TestAccAPIGatewayUsagePlan_tags_AddOnUpdate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -367,7 +367,7 @@ func TestAccAPIGatewayUsagePlan_tags_AddOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -391,7 +391,7 @@ func TestAccAPIGatewayUsagePlan_tags_AddOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -442,7 +442,7 @@ func TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -454,7 +454,7 @@ func TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -494,7 +494,7 @@ func TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -535,7 +535,7 @@ func TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -547,7 +547,7 @@ func TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -579,7 +579,7 @@ func TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -625,7 +625,7 @@ func TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -676,7 +676,7 @@ func TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -688,7 +688,7 @@ func TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -719,7 +719,7 @@ func TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -769,7 +769,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_providerOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy: testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -782,7 +782,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -826,7 +826,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -872,7 +872,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -912,7 +912,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -954,7 +954,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_nonOverlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy: testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -969,7 +969,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1023,7 +1023,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1076,7 +1076,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1118,7 +1118,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_overlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy: testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1133,7 +1133,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1186,7 +1186,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1243,7 +1243,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1298,7 +1298,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_updateToProviderOnly(t *testing
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy: testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1310,7 +1310,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_updateToProviderOnly(t *testing
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1343,7 +1343,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_updateToProviderOnly(t *testing
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1392,7 +1392,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_updateToResourceOnly(t *testing
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy: testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1405,7 +1405,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_updateToResourceOnly(t *testing
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1433,7 +1433,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_updateToResourceOnly(t *testing
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1485,7 +1485,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_emptyResourceTag(t *testing.T) 
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy: testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1500,7 +1500,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_emptyResourceTag(t *testing.T) 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1554,7 +1554,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_emptyProviderOnlyTag(t *testing
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy: testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1567,7 +1567,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_emptyProviderOnlyTag(t *testing
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1615,7 +1615,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_nullOverlappingResourceTag(t *t
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy: testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1630,7 +1630,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_nullOverlappingResourceTag(t *t
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1681,7 +1681,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_nullNonOverlappingResourceTag(t
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy: testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1696,7 +1696,7 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_nullNonOverlappingResourceTag(t
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1747,7 +1747,7 @@ func TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy: testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1757,7 +1757,7 @@ func TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnCreate(t *testing.T) {
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1806,7 +1806,7 @@ func TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy: testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1818,7 +1818,7 @@ func TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1850,7 +1850,7 @@ func TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1907,7 +1907,7 @@ func TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnUpdate_Replace(t *testing.T) 
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy: testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1919,7 +1919,7 @@ func TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnUpdate_Replace(t *testing.T) 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1949,7 +1949,7 @@ func TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnUpdate_Replace(t *testing.T) 
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1998,7 +1998,7 @@ func TestAccAPIGatewayUsagePlan_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy: testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2017,7 +2017,7 @@ func TestAccAPIGatewayUsagePlan_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2066,7 +2066,7 @@ func TestAccAPIGatewayUsagePlan_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2115,7 +2115,7 @@ func TestAccAPIGatewayUsagePlan_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2164,7 +2164,7 @@ func TestAccAPIGatewayUsagePlan_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy: testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2181,7 +2181,7 @@ func TestAccAPIGatewayUsagePlan_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2244,7 +2244,7 @@ func TestAccAPIGatewayUsagePlan_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2307,7 +2307,7 @@ func TestAccAPIGatewayUsagePlan_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &v),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/apigateway/usage_plan_test.go
+++ b/internal/service/apigateway/usage_plan_test.go
@@ -10,11 +10,9 @@ import (
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -23,20 +21,20 @@ import (
 func TestAccAPIGatewayUsagePlan_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetUsagePlanOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	updatedName := sdkacctest.RandomWithPrefix("tf-acc-test-2")
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	updatedName := acctest.RandomWithPrefix(t, "tf-acc-test-2")
 	resourceName := "aws_api_gateway_usage_plan.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUsagePlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/usageplans/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
@@ -65,19 +63,19 @@ func TestAccAPIGatewayUsagePlan_basic(t *testing.T) {
 func TestAccAPIGatewayUsagePlan_description(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetUsagePlanOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_usage_plan.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUsagePlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 				),
 			},
@@ -89,7 +87,7 @@ func TestAccAPIGatewayUsagePlan_description(t *testing.T) {
 			{
 				Config: testAccUsagePlanConfig_description(rName, "This is a description"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "This is a description"),
 				),
 			},
@@ -102,14 +100,14 @@ func TestAccAPIGatewayUsagePlan_description(t *testing.T) {
 			{
 				Config: testAccUsagePlanConfig_description(rName, "This is a description"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "This is a description"),
 				),
 			},
 			{
 				Config: testAccUsagePlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 				),
 			},
@@ -120,19 +118,19 @@ func TestAccAPIGatewayUsagePlan_description(t *testing.T) {
 func TestAccAPIGatewayUsagePlan_productCode(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetUsagePlanOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_usage_plan.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUsagePlanConfig_productCode(rName, "MYCODE"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "product_code", "MYCODE"),
 				),
 			},
@@ -144,21 +142,21 @@ func TestAccAPIGatewayUsagePlan_productCode(t *testing.T) {
 			{
 				Config: testAccUsagePlanConfig_productCode(rName, "MYCODE2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "product_code", "MYCODE2"),
 				),
 			},
 			{
 				Config: testAccUsagePlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "product_code", ""),
 				),
 			},
 			{
 				Config: testAccUsagePlanConfig_productCode(rName, "MYCODE"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "product_code", "MYCODE"),
 				),
 			},
@@ -169,19 +167,19 @@ func TestAccAPIGatewayUsagePlan_productCode(t *testing.T) {
 func TestAccAPIGatewayUsagePlan_throttling(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetUsagePlanOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_usage_plan.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUsagePlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "throttle_settings.#", "0"),
 				),
@@ -194,7 +192,7 @@ func TestAccAPIGatewayUsagePlan_throttling(t *testing.T) {
 			{
 				Config: testAccUsagePlanConfig_throttling(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "throttle_settings.0.burst_limit", "2"),
 					resource.TestCheckResourceAttr(resourceName, "throttle_settings.0.rate_limit", "5"),
@@ -203,7 +201,7 @@ func TestAccAPIGatewayUsagePlan_throttling(t *testing.T) {
 			{
 				Config: testAccUsagePlanConfig_throttlingModified(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "throttle_settings.0.burst_limit", "3"),
 					resource.TestCheckResourceAttr(resourceName, "throttle_settings.0.rate_limit", "6"),
@@ -212,7 +210,7 @@ func TestAccAPIGatewayUsagePlan_throttling(t *testing.T) {
 			{
 				Config: testAccUsagePlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "throttle_settings.#", "0"),
 				),
@@ -225,19 +223,19 @@ func TestAccAPIGatewayUsagePlan_throttling(t *testing.T) {
 func TestAccAPIGatewayUsagePlan_throttlingInitialRateLimit(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetUsagePlanOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_usage_plan.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUsagePlanConfig_throttling(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "throttle_settings.0.rate_limit", "5"),
 				),
 			},
@@ -253,19 +251,19 @@ func TestAccAPIGatewayUsagePlan_throttlingInitialRateLimit(t *testing.T) {
 func TestAccAPIGatewayUsagePlan_quota(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetUsagePlanOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_usage_plan.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUsagePlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "quota_settings.#", "0"),
 				),
@@ -278,7 +276,7 @@ func TestAccAPIGatewayUsagePlan_quota(t *testing.T) {
 			{
 				Config: testAccUsagePlanConfig_quota(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "quota_settings.0.limit", "100"),
 					resource.TestCheckResourceAttr(resourceName, "quota_settings.0.offset", "6"),
@@ -288,7 +286,7 @@ func TestAccAPIGatewayUsagePlan_quota(t *testing.T) {
 			{
 				Config: testAccUsagePlanConfig_quotaModified(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "quota_settings.0.limit", "200"),
 					resource.TestCheckResourceAttr(resourceName, "quota_settings.0.offset", "20"),
@@ -298,7 +296,7 @@ func TestAccAPIGatewayUsagePlan_quota(t *testing.T) {
 			{
 				Config: testAccUsagePlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "quota_settings.#", "0"),
 				),
@@ -310,21 +308,21 @@ func TestAccAPIGatewayUsagePlan_quota(t *testing.T) {
 func TestAccAPIGatewayUsagePlan_apiStages(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetUsagePlanOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_usage_plan.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// Create UsagePlan WITH Stages as the API calls are different
 			// when creating or updating.
 			{
 				Config: testAccUsagePlanConfig_apiStages(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "api_stages.*", map[string]string{
 						names.AttrStage: "test",
@@ -340,7 +338,7 @@ func TestAccAPIGatewayUsagePlan_apiStages(t *testing.T) {
 			{
 				Config: testAccUsagePlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "api_stages.#", "0"),
 				),
@@ -349,7 +347,7 @@ func TestAccAPIGatewayUsagePlan_apiStages(t *testing.T) {
 			{
 				Config: testAccUsagePlanConfig_apiStages(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "api_stages.*", map[string]string{
 						names.AttrStage: "test",
@@ -360,7 +358,7 @@ func TestAccAPIGatewayUsagePlan_apiStages(t *testing.T) {
 			{
 				Config: testAccUsagePlanConfig_apiStagesMultiple(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "api_stages.*", map[string]string{
 						names.AttrStage: "foo",
@@ -373,7 +371,7 @@ func TestAccAPIGatewayUsagePlan_apiStages(t *testing.T) {
 			{
 				Config: testAccUsagePlanConfig_apiStagesModified(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "api_stages.*", map[string]string{
 						names.AttrStage: "foo",
@@ -383,7 +381,7 @@ func TestAccAPIGatewayUsagePlan_apiStages(t *testing.T) {
 			{
 				Config: testAccUsagePlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "api_stages.#", "0"),
 				),
@@ -395,19 +393,19 @@ func TestAccAPIGatewayUsagePlan_apiStages(t *testing.T) {
 func TestAccAPIGatewayUsagePlan_APIStages_multiple(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetUsagePlanOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_usage_plan.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUsagePlanConfig_apiStagesMultiple(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "api_stages.*", map[string]string{
 						names.AttrStage: "foo",
@@ -429,19 +427,19 @@ func TestAccAPIGatewayUsagePlan_APIStages_multiple(t *testing.T) {
 func TestAccAPIGatewayUsagePlan_APIStages_throttle(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetUsagePlanOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_usage_plan.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUsagePlanConfig_apiStagesThrottle(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "api_stages.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "api_stages.*", map[string]string{
@@ -458,7 +456,7 @@ func TestAccAPIGatewayUsagePlan_APIStages_throttle(t *testing.T) {
 			{
 				Config: testAccUsagePlanConfig_apiStagesThrottleMulti(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "api_stages.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "api_stages.*", map[string]string{
@@ -488,19 +486,19 @@ func TestAccAPIGatewayUsagePlan_APIStages_throttle(t *testing.T) {
 func TestAccAPIGatewayUsagePlan_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetUsagePlanOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_usage_plan.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
+		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUsagePlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUsagePlanExists(ctx, resourceName, &conf),
+					testAccCheckUsagePlanExists(ctx, t, resourceName, &conf),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceUsagePlan(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -509,14 +507,14 @@ func TestAccAPIGatewayUsagePlan_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckUsagePlanExists(ctx context.Context, n string, v *apigateway.GetUsagePlanOutput) resource.TestCheckFunc {
+func testAccCheckUsagePlanExists(ctx context.Context, t *testing.T, n string, v *apigateway.GetUsagePlanOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		output, err := tfapigateway.FindUsagePlanByID(ctx, conn, rs.Primary.ID)
 
@@ -530,9 +528,9 @@ func testAccCheckUsagePlanExists(ctx context.Context, n string, v *apigateway.Ge
 	}
 }
 
-func testAccCheckUsagePlanDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckUsagePlanDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_usage_plan" {

--- a/internal/service/apigateway/vpc_link.go
+++ b/internal/service/apigateway/vpc_link.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
@@ -29,6 +28,8 @@ import (
 
 // @SDKResource("aws_api_gateway_vpc_link", name="VPC Link")
 // @Tags(identifierAttribute="arn")
+// @Testing(existsTakesT=true)
+// @Testing(destroyTakesT=true)
 func resourceVPCLink() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceVPCLinkCreate,
@@ -198,9 +199,8 @@ func findVPCLinkByID(ctx context.Context, conn *apigateway.Client, id string) (*
 	output, err := conn.GetVpcLink(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 
@@ -215,8 +215,8 @@ func findVPCLinkByID(ctx context.Context, conn *apigateway.Client, id string) (*
 	return output, nil
 }
 
-func vpcLinkStatus(ctx context.Context, conn *apigateway.Client, id string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func vpcLinkStatus(conn *apigateway.Client, id string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findVPCLinkByID(ctx, conn, id)
 
 		if retry.NotFound(err) {
@@ -235,10 +235,10 @@ func waitVPCLinkAvailable(ctx context.Context, conn *apigateway.Client, id strin
 	const (
 		timeout = 20 * time.Minute
 	)
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:    enum.Slice(types.VpcLinkStatusPending),
 		Target:     enum.Slice(types.VpcLinkStatusAvailable),
-		Refresh:    vpcLinkStatus(ctx, conn, id),
+		Refresh:    vpcLinkStatus(conn, id),
 		Timeout:    timeout,
 		MinTimeout: 3 * time.Second,
 	}
@@ -258,12 +258,12 @@ func waitVPCLinkDeleted(ctx context.Context, conn *apigateway.Client, id string)
 	const (
 		timeout = 20 * time.Minute
 	)
-	stateConf := sdkretry.StateChangeConf{
+	stateConf := retry.StateChangeConf{
 		Pending:    enum.Slice(types.VpcLinkStatusPending, types.VpcLinkStatusAvailable, types.VpcLinkStatusDeleting),
 		Target:     []string{},
 		Timeout:    timeout,
 		MinTimeout: 1 * time.Second,
-		Refresh:    vpcLinkStatus(ctx, conn, id),
+		Refresh:    vpcLinkStatus(conn, id),
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)

--- a/internal/service/apigateway/vpc_link_data_source_test.go
+++ b/internal/service/apigateway/vpc_link_data_source_test.go
@@ -6,7 +6,6 @@ package apigateway_test
 import (
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -14,11 +13,11 @@ import (
 
 func TestAccAPIGatewayVPCLinkDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_vpc_link.test"
 	dataSourceName := "data.aws_api_gateway_vpc_link.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/apigateway/vpc_link_tags_gen_test.go
+++ b/internal/service/apigateway/vpc_link_tags_gen_test.go
@@ -31,7 +31,7 @@ func TestAccAPIGatewayVPCLink_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -43,7 +43,7 @@ func TestAccAPIGatewayVPCLink_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -87,7 +87,7 @@ func TestAccAPIGatewayVPCLink_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -135,7 +135,7 @@ func TestAccAPIGatewayVPCLink_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -176,7 +176,7 @@ func TestAccAPIGatewayVPCLink_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -216,7 +216,7 @@ func TestAccAPIGatewayVPCLink_tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -228,7 +228,7 @@ func TestAccAPIGatewayVPCLink_tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -286,7 +286,7 @@ func TestAccAPIGatewayVPCLink_tags_EmptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -296,7 +296,7 @@ func TestAccAPIGatewayVPCLink_tags_EmptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -352,7 +352,7 @@ func TestAccAPIGatewayVPCLink_tags_AddOnUpdate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -362,7 +362,7 @@ func TestAccAPIGatewayVPCLink_tags_AddOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -386,7 +386,7 @@ func TestAccAPIGatewayVPCLink_tags_AddOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -436,7 +436,7 @@ func TestAccAPIGatewayVPCLink_tags_EmptyTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -448,7 +448,7 @@ func TestAccAPIGatewayVPCLink_tags_EmptyTag_OnCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -488,7 +488,7 @@ func TestAccAPIGatewayVPCLink_tags_EmptyTag_OnCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -528,7 +528,7 @@ func TestAccAPIGatewayVPCLink_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -540,7 +540,7 @@ func TestAccAPIGatewayVPCLink_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -572,7 +572,7 @@ func TestAccAPIGatewayVPCLink_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -618,7 +618,7 @@ func TestAccAPIGatewayVPCLink_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -668,7 +668,7 @@ func TestAccAPIGatewayVPCLink_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -680,7 +680,7 @@ func TestAccAPIGatewayVPCLink_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -711,7 +711,7 @@ func TestAccAPIGatewayVPCLink_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -760,7 +760,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_providerOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy: testAccCheckVPCLinkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -773,7 +773,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -817,7 +817,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -863,7 +863,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -903,7 +903,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -944,7 +944,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_nonOverlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy: testAccCheckVPCLinkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -959,7 +959,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1013,7 +1013,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1066,7 +1066,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1107,7 +1107,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_overlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy: testAccCheckVPCLinkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1122,7 +1122,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1175,7 +1175,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1232,7 +1232,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1286,7 +1286,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_updateToProviderOnly(t *testing.T
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy: testAccCheckVPCLinkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1298,7 +1298,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_updateToProviderOnly(t *testing.T
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1331,7 +1331,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_updateToProviderOnly(t *testing.T
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1379,7 +1379,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_updateToResourceOnly(t *testing.T
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy: testAccCheckVPCLinkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1392,7 +1392,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_updateToResourceOnly(t *testing.T
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1420,7 +1420,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_updateToResourceOnly(t *testing.T
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1471,7 +1471,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy: testAccCheckVPCLinkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1486,7 +1486,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1539,7 +1539,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy: testAccCheckVPCLinkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1552,7 +1552,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1599,7 +1599,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_nullOverlappingResourceTag(t *tes
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy: testAccCheckVPCLinkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1614,7 +1614,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_nullOverlappingResourceTag(t *tes
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1664,7 +1664,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_nullNonOverlappingResourceTag(t *
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy: testAccCheckVPCLinkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1679,7 +1679,7 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_nullNonOverlappingResourceTag(t *
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1729,7 +1729,7 @@ func TestAccAPIGatewayVPCLink_tags_ComputedTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy: testAccCheckVPCLinkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1739,7 +1739,7 @@ func TestAccAPIGatewayVPCLink_tags_ComputedTag_OnCreate(t *testing.T) {
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1787,7 +1787,7 @@ func TestAccAPIGatewayVPCLink_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy: testAccCheckVPCLinkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1799,7 +1799,7 @@ func TestAccAPIGatewayVPCLink_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1831,7 +1831,7 @@ func TestAccAPIGatewayVPCLink_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1887,7 +1887,7 @@ func TestAccAPIGatewayVPCLink_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy: testAccCheckVPCLinkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1899,7 +1899,7 @@ func TestAccAPIGatewayVPCLink_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1929,7 +1929,7 @@ func TestAccAPIGatewayVPCLink_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1977,7 +1977,7 @@ func TestAccAPIGatewayVPCLink_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy: testAccCheckVPCLinkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -1996,7 +1996,7 @@ func TestAccAPIGatewayVPCLink_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2045,7 +2045,7 @@ func TestAccAPIGatewayVPCLink_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2094,7 +2094,7 @@ func TestAccAPIGatewayVPCLink_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2142,7 +2142,7 @@ func TestAccAPIGatewayVPCLink_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) 
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy: testAccCheckVPCLinkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2159,7 +2159,7 @@ func TestAccAPIGatewayVPCLink_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) 
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2222,7 +2222,7 @@ func TestAccAPIGatewayVPCLink_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) 
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2285,7 +2285,7 @@ func TestAccAPIGatewayVPCLink_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) 
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/apigateway/vpc_link_test.go
+++ b/internal/service/apigateway/vpc_link_test.go
@@ -9,11 +9,9 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfapigateway "github.com/hashicorp/terraform-provider-aws/internal/service/apigateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -21,19 +19,19 @@ import (
 
 func TestAccAPIGatewayVPCLink_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_vpc_link.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVPCLinkConfig_basic(rName, "test"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/vpclinks/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "test"),
@@ -48,7 +46,7 @@ func TestAccAPIGatewayVPCLink_basic(t *testing.T) {
 			{
 				Config: testAccVPCLinkConfig_basic(rName, "test update"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", regexache.MustCompile(`/vpclinks/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "test update"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
@@ -61,19 +59,19 @@ func TestAccAPIGatewayVPCLink_basic(t *testing.T) {
 
 func TestAccAPIGatewayVPCLink_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_vpc_link.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
+		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVPCLinkConfig_basic(rName, "test"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVPCLinkExists(ctx, resourceName),
+					testAccCheckVPCLinkExists(ctx, t, resourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfapigateway.ResourceVPCLink(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -82,9 +80,9 @@ func TestAccAPIGatewayVPCLink_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckVPCLinkDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckVPCLinkDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_api_gateway_vpc_link" {
@@ -108,14 +106,14 @@ func testAccCheckVPCLinkDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckVPCLinkExists(ctx context.Context, n string) resource.TestCheckFunc {
+func testAccCheckVPCLinkExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
 
 		_, err := tfapigateway.FindVPCLinkByID(ctx, conn, rs.Primary.ID)
 


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Enables `go-vcr` for the `apigateway` service.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/25602
Relates https://github.com/hashicorp/terraform-provider-aws/issues/43717


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

See commit body for full test output.