### PR TITLE
r/aws_neptunegraph_graph: Adding import from S3, Neptune database cluster, and snapshot.

### DIFF
--- a/.changelog/45906.txt
+++ b/.changelog/45906.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_neptunegraph_graph: Adding import from S3, Neptune database cluster, and snapshot.  Supported by CreateGraphUsingImportTask API.
+```

--- a/internal/service/neptunegraph/graph.go
+++ b/internal/service/neptunegraph/graph.go
@@ -42,7 +42,10 @@ import (
 )
 
 // @FrameworkResource("aws_neptunegraph_graph", name="Graph")
+// @IdentityAttribute("id")
 // @Tags(identifierAttribute="arn")
+// @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/neptunegraph;neptunegraph.GetGraphOutput")
+// @Testing(preIdentityVersion="v6.44.0")
 func newGraphResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &graphResource{}
 
@@ -55,7 +58,7 @@ func newGraphResource(_ context.Context) (resource.ResourceWithConfigure, error)
 
 type graphResource struct {
 	framework.ResourceWithModel[graphResourceModel]
-	framework.WithImportByID
+	framework.WithImportByIdentity
 	framework.WithTimeouts
 }
 
@@ -332,7 +335,7 @@ func (r *graphResource) Create(ctx context.Context, request resource.CreateReque
 		create.WithConfiguredName(data.Name.ValueString()),
 		create.WithConfiguredPrefix(data.NamePrefix.ValueString()),
 		create.WithDefaultPrefix("tf-"),
-	).Generate()
+	).Generate(ctx)
 
 	// Determine whether to use CreateGraphUsingImportTask or CreateGraph API
 	if !data.ImportTask.IsNull() && !data.ImportTask.IsUnknown() {

--- a/internal/service/neptunegraph/graph.go
+++ b/internal/service/neptunegraph/graph.go
@@ -28,7 +28,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -168,14 +167,14 @@ func (r *graphResource) Schema(ctx context.Context, request resource.SchemaReque
 				Description: "Configuration for importing data into the graph during creation. Forces replacement if changed.",
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
-						"source": schema.StringAttribute{
+						names.AttrSource: schema.StringAttribute{
 							Description: "URL identifying the location of data to import (S3 path, Neptune endpoint, or snapshot).",
 							Required:    true,
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplace(),
 							},
 						},
-						"role_arn": schema.StringAttribute{
+						names.AttrRoleARN: schema.StringAttribute{
 							Description: "ARN of the IAM role that allows access to the data to be imported.",
 							Required:    true,
 							PlanModifiers: []planmodifier.String{
@@ -188,7 +187,7 @@ func (r *graphResource) Schema(ctx context.Context, request resource.SchemaReque
 								),
 							},
 						},
-						"format": schema.StringAttribute{
+						names.AttrFormat: schema.StringAttribute{
 							Description: `Specifies the format of S3 data to be imported. Valid values are CSV, PARQUET, OPEN_CYPHER, or NTRIPLES.`,
 							Optional:    true,
 							PlanModifiers: []planmodifier.String{
@@ -247,33 +246,45 @@ func (r *graphResource) Schema(ctx context.Context, request resource.SchemaReque
 						},
 					},
 					Blocks: map[string]schema.Block{
-						"import_options": schema.SingleNestedBlock{
+						"import_options": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[importOptionsModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
 							Description: "Options for controlling the import process.",
-							Blocks: map[string]schema.Block{
-								"neptune": schema.SingleNestedBlock{
-									Description: "Options for importing data from a Neptune database.",
-									Attributes: map[string]schema.Attribute{
-										"s3_export_path": schema.StringAttribute{
-											Description: "The path to an S3 bucket from which to import data.",
-											Optional:    true,
-											Validators: []validator.String{
-												stringvalidator.LengthBetween(1, 1024),
+							NestedObject: schema.NestedBlockObject{
+								Blocks: map[string]schema.Block{
+									"neptune": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[neptuneImportOptionsModel](ctx),
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										Description: "Options for importing data from a Neptune database.",
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"s3_export_path": schema.StringAttribute{
+													Description: "The path to an S3 bucket from which to import data.",
+													Optional:    true,
+													Validators: []validator.String{
+														stringvalidator.LengthBetween(1, 1024),
+													},
+												},
+												"s3_export_kms_key_id": schema.StringAttribute{
+													Description: "The KMS key to use to encrypt data in the S3 bucket where the graph data is exported.",
+													Optional:    true,
+													Validators: []validator.String{
+														stringvalidator.LengthBetween(1, 1024),
+													},
+												},
+												"preserve_default_vertex_labels": schema.BoolAttribute{
+													Description: "Whether to preserve default vertex labels.",
+													Optional:    true,
+												},
+												"preserve_edge_ids": schema.BoolAttribute{
+													Description: "Whether to preserve edge IDs as properties.",
+													Optional:    true,
+												},
 											},
-										},
-										"s3_export_kms_key_id": schema.StringAttribute{
-											Description: "The KMS key to use to encrypt data in the S3 bucket where the graph data is exported.",
-											Optional:    true,
-											Validators: []validator.String{
-												stringvalidator.LengthBetween(1, 1024),
-											},
-										},
-										"preserve_default_vertex_labels": schema.BoolAttribute{
-											Description: "Whether to preserve default vertex labels.",
-											Optional:    true,
-										},
-										"preserve_edge_ids": schema.BoolAttribute{
-											Description: "Whether to preserve edge IDs as properties.",
-											Optional:    true,
 										},
 									},
 								},
@@ -325,7 +336,6 @@ func (r *graphResource) Create(ctx context.Context, request resource.CreateReque
 
 	// Determine whether to use CreateGraphUsingImportTask or CreateGraph API
 	if !data.ImportTask.IsNull() && !data.ImportTask.IsUnknown() {
-
 		var importInput neptunegraph.CreateGraphUsingImportTaskInput
 
 		response.Diagnostics.Append(fwflex.Expand(ctx, data, &importInput)...)
@@ -343,7 +353,7 @@ func (r *graphResource) Create(ctx context.Context, request resource.CreateReque
 			task := importTaskData[0]
 
 			taskImportOptions := task.ImportOptions
-			task.ImportOptions = fwtypes.NewObjectValueOfNull[importOptionsModel](ctx)
+			task.ImportOptions = fwtypes.NewListNestedObjectValueOfNull[importOptionsModel](ctx)
 
 			response.Diagnostics.Append(fwflex.Expand(ctx, task, &importInput)...)
 			if response.Diagnostics.HasError() {
@@ -351,26 +361,33 @@ func (r *graphResource) Create(ctx context.Context, request resource.CreateReque
 			}
 
 			if !taskImportOptions.IsNull() && !taskImportOptions.IsUnknown() {
-				var importOptionsData importOptionsModel
-				response.Diagnostics.Append(taskImportOptions.As(ctx, &importOptionsData, basetypes.ObjectAsOptions{})...)
+				var importOptionsDataSlice []importOptionsModel
+				response.Diagnostics.Append(taskImportOptions.ElementsAs(ctx, &importOptionsDataSlice, false)...)
 				if response.Diagnostics.HasError() {
 					return
 				}
 
-				if !importOptionsData.Neptune.IsNull() {
-					var neptuneOptionsData neptuneImportOptionsModel
-					response.Diagnostics.Append(importOptionsData.Neptune.As(ctx, &neptuneOptionsData, basetypes.ObjectAsOptions{})...)
-					if response.Diagnostics.HasError() {
-						return
-					}
+				if len(importOptionsDataSlice) > 0 {
+					importOptionsData := importOptionsDataSlice[0]
 
-					neptuneOpts := &awstypes.NeptuneImportOptions{}
-					response.Diagnostics.Append(fwflex.Expand(ctx, neptuneOptionsData, neptuneOpts)...)
-					if response.Diagnostics.HasError() {
-						return
-					}
-					importInput.ImportOptions = &awstypes.ImportOptionsMemberNeptune{
-						Value: *neptuneOpts,
+					if !importOptionsData.Neptune.IsNull() {
+						var neptuneOptionsDataSlice []neptuneImportOptionsModel
+						response.Diagnostics.Append(importOptionsData.Neptune.ElementsAs(ctx, &neptuneOptionsDataSlice, false)...)
+						if response.Diagnostics.HasError() {
+							return
+						}
+						if len(neptuneOptionsDataSlice) > 0 {
+							neptuneOptionsData := neptuneOptionsDataSlice[0]
+
+							neptuneOpts := &awstypes.NeptuneImportOptions{}
+							response.Diagnostics.Append(fwflex.Expand(ctx, neptuneOptionsData, neptuneOpts)...)
+							if response.Diagnostics.HasError() {
+								return
+							}
+							importInput.ImportOptions = &awstypes.ImportOptionsMemberNeptune{
+								Value: *neptuneOpts,
+							}
+						}
 					}
 				}
 			}
@@ -401,7 +418,7 @@ func (r *graphResource) Create(ctx context.Context, request resource.CreateReque
 			return
 		}
 
-		response.Diagnostics.Append(fwflex.Flatten(ctx, graph, &data)...)
+		response.Diagnostics.Append(fwflex.Flatten(ctx, graph, &data, fwflex.WithIgnoredFieldNames([]string{"ImportTask"}))...)
 	} else {
 		// Use existing CreateGraph API
 		var input neptunegraph.CreateGraphInput
@@ -611,11 +628,11 @@ func waitGraphCreated(ctx context.Context, conn *neptunegraph.Client, id string,
 }
 
 func findImportTaskByID(ctx context.Context, conn *neptunegraph.Client, taskID string) (*neptunegraph.GetImportTaskOutput, error) {
-	input := &neptunegraph.GetImportTaskInput{
+	input := neptunegraph.GetImportTaskInput{
 		TaskIdentifier: aws.String(taskID),
 	}
 
-	output, err := conn.GetImportTask(ctx, input)
+	output, err := conn.GetImportTask(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
@@ -732,19 +749,19 @@ type graphResourceModel struct {
 }
 
 type importTaskModel struct {
-	Source               types.String                              `tfsdk:"source"`
-	RoleArn              types.String                              `tfsdk:"role_arn"`
-	Format               types.String                              `tfsdk:"format"`
-	FailOnError          types.Bool                                `tfsdk:"fail_on_error"`
-	MaxProvisionedMemory types.Int32                               `tfsdk:"max_provisioned_memory"`
-	MinProvisionedMemory types.Int32                               `tfsdk:"min_provisioned_memory"`
-	BlankNodeHandling    types.String                              `tfsdk:"blank_node_handling"`
-	ParquetType          types.String                              `tfsdk:"parquet_type"`
-	ImportOptions        fwtypes.ObjectValueOf[importOptionsModel] `tfsdk:"import_options"`
+	Source               types.String                                        `tfsdk:"source"`
+	RoleArn              types.String                                        `tfsdk:"role_arn"`
+	Format               types.String                                        `tfsdk:"format"`
+	FailOnError          types.Bool                                          `tfsdk:"fail_on_error"`
+	MaxProvisionedMemory types.Int32                                         `tfsdk:"max_provisioned_memory"`
+	MinProvisionedMemory types.Int32                                         `tfsdk:"min_provisioned_memory"`
+	BlankNodeHandling    types.String                                        `tfsdk:"blank_node_handling"`
+	ParquetType          types.String                                        `tfsdk:"parquet_type"`
+	ImportOptions        fwtypes.ListNestedObjectValueOf[importOptionsModel] `tfsdk:"import_options"`
 }
 
 type importOptionsModel struct {
-	Neptune fwtypes.ObjectValueOf[neptuneImportOptionsModel] `tfsdk:"neptune"`
+	Neptune fwtypes.ListNestedObjectValueOf[neptuneImportOptionsModel] `tfsdk:"neptune"`
 }
 
 type neptuneImportOptionsModel struct {

--- a/internal/service/neptunegraph/graph.go
+++ b/internal/service/neptunegraph/graph.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -107,17 +108,22 @@ func (r *graphResource) Schema(ctx context.Context, request resource.SchemaReque
 			"kms_key_identifier": schema.StringAttribute{
 				Description: "Specifies a KMS key to use to encrypt data in the new graph.  Value must be ARN of KMS Key.",
 				Optional:    true,
-				Computed:    true, //value will default to AWS_OWNED_KEY if no KMS key ARN is specified
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 				},
 			},
 			"provisioned_memory": schema.Int32Attribute{
-				Description: "The provisioned memory-optimized Neptune Capacity Units (m-NCUs) to use for the graph.",
-				Required:    true,
+				Description: "The provisioned memory-optimized Neptune Capacity Units (m-NCUs) to use for the graph. Required when max_provisioned_memory and min_provisioned_memory are not specified.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Int32{
+					int32planmodifier.UseStateForUnknown(),
+				},
 				Validators: []validator.Int32{
 					int32validator.OneOf(8, 16, 32, 64, 128, 256, 384, 512, 768, 1024, 2048, 3072, 4096),
+					int32validator.ConflictsWith(path.MatchRoot("import_task")),
 				},
 			},
 			"public_connectivity": schema.BoolAttribute{
@@ -154,6 +160,128 @@ func (r *graphResource) Schema(ctx context.Context, request resource.SchemaReque
 				Update: true,
 				Delete: true,
 			}),
+			"import_task": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[importTaskModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				Description: "Configuration for importing data into the graph during creation. Forces replacement if changed.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"source": schema.StringAttribute{
+							Description: "URL identifying the location of data to import (S3 path, Neptune endpoint, or snapshot).",
+							Required:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
+						},
+						"role_arn": schema.StringAttribute{
+							Description: "ARN of the IAM role that allows access to the data to be imported.",
+							Required:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(
+									regexache.MustCompile(`^arn:aws[^:]*:iam::\d{12}:(role|role/service-role)(/[\w+=,.@-]+)+$`),
+									"must be a valid IAM role ARN",
+								),
+							},
+						},
+						"format": schema.StringAttribute{
+							Description: `Specifies the format of S3 data to be imported. Valid values are CSV, PARQUET, OPEN_CYPHER, or NTRIPLES.`,
+							Optional:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
+							Validators: []validator.String{
+								stringvalidator.OneOf("CSV", "PARQUET", "OPEN_CYPHER", "NTRIPLES"),
+							},
+						},
+						"fail_on_error": schema.BoolAttribute{
+							Description: "If true, task halts on import error. If false, skips problem data and continues.",
+							Optional:    true,
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.RequiresReplace(),
+							},
+						},
+						"max_provisioned_memory": schema.Int32Attribute{
+							Description: "Maximum m-NCUs for the import task. Default: 1024.",
+							Optional:    true,
+							PlanModifiers: []planmodifier.Int32{
+								int32planmodifier.RequiresReplace(),
+							},
+							Validators: []validator.Int32{
+								int32validator.OneOf(8, 16, 32, 64, 128, 256, 384, 512, 768, 1024, 2048, 3072, 4096),
+							},
+						},
+						"min_provisioned_memory": schema.Int32Attribute{
+							Description: "Minimum m-NCUs for the import task. Default: 16",
+							Optional:    true,
+							PlanModifiers: []planmodifier.Int32{
+								int32planmodifier.RequiresReplace(),
+							},
+							Validators: []validator.Int32{
+								int32validator.OneOf(8, 16, 32, 64, 128, 256, 384, 512, 768, 1024, 2048, 3072, 4096),
+							},
+						},
+						"blank_node_handling": schema.StringAttribute{
+							Description: `The method to handle blank nodes in the dataset. Currently, only convertToIri is supported.`,
+							Optional:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
+							Validators: []validator.String{
+								stringvalidator.OneOf("convertToIri"),
+							},
+						},
+						"parquet_type": schema.StringAttribute{
+							Description: "Parquet type for import processing.",
+							Optional:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
+							Validators: []validator.String{
+								stringvalidator.OneOf("COLUMNAR"),
+							},
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"import_options": schema.SingleNestedBlock{
+							Description: "Options for controlling the import process.",
+							Blocks: map[string]schema.Block{
+								"neptune": schema.SingleNestedBlock{
+									Description: "Options for importing data from a Neptune database.",
+									Attributes: map[string]schema.Attribute{
+										"s3_export_path": schema.StringAttribute{
+											Description: "The path to an S3 bucket from which to import data.",
+											Optional:    true,
+											Validators: []validator.String{
+												stringvalidator.LengthBetween(1, 1024),
+											},
+										},
+										"s3_export_kms_key_id": schema.StringAttribute{
+											Description: "The KMS key to use to encrypt data in the S3 bucket where the graph data is exported.",
+											Optional:    true,
+											Validators: []validator.String{
+												stringvalidator.LengthBetween(1, 1024),
+											},
+										},
+										"preserve_default_vertex_labels": schema.BoolAttribute{
+											Description: "Whether to preserve default vertex labels.",
+											Optional:    true,
+										},
+										"preserve_edge_ids": schema.BoolAttribute{
+											Description: "Whether to preserve edge IDs as properties.",
+											Optional:    true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"vector_search_configuration": schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[vectorSearchConfigurationModel](ctx),
 				Validators: []validator.List{
@@ -188,45 +316,121 @@ func (r *graphResource) Create(ctx context.Context, request resource.CreateReque
 
 	conn := r.Meta().NeptuneGraphClient(ctx)
 
-	var input neptunegraph.CreateGraphInput
-	response.Diagnostics.Append(fwflex.Expand(ctx, data, &input)...)
-	if response.Diagnostics.HasError() {
-		return
+	// Generate graph name
+	graphName := create.NewNameGenerator(
+		create.WithConfiguredName(data.Name.ValueString()),
+		create.WithConfiguredPrefix(data.NamePrefix.ValueString()),
+		create.WithDefaultPrefix("tf-"),
+	).Generate()
+
+	// Determine whether to use CreateGraphUsingImportTask or CreateGraph API
+	if !data.ImportTask.IsNull() && !data.ImportTask.IsUnknown() {
+
+		var importInput neptunegraph.CreateGraphUsingImportTaskInput
+
+		response.Diagnostics.Append(fwflex.Expand(ctx, data, &importInput)...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		var importTaskData []importTaskModel
+		response.Diagnostics.Append(data.ImportTask.ElementsAs(ctx, &importTaskData, false)...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		if len(importTaskData) > 0 {
+			task := importTaskData[0]
+
+			taskImportOptions := task.ImportOptions
+			task.ImportOptions = fwtypes.NewObjectValueOfNull[importOptionsModel](ctx)
+
+			response.Diagnostics.Append(fwflex.Expand(ctx, task, &importInput)...)
+			if response.Diagnostics.HasError() {
+				return
+			}
+
+			if !taskImportOptions.IsNull() && !taskImportOptions.IsUnknown() {
+				var importOptionsData importOptionsModel
+				response.Diagnostics.Append(taskImportOptions.As(ctx, &importOptionsData, basetypes.ObjectAsOptions{})...)
+				if response.Diagnostics.HasError() {
+					return
+				}
+
+				if !importOptionsData.Neptune.IsNull() {
+					var neptuneOptionsData neptuneImportOptionsModel
+					response.Diagnostics.Append(importOptionsData.Neptune.As(ctx, &neptuneOptionsData, basetypes.ObjectAsOptions{})...)
+					if response.Diagnostics.HasError() {
+						return
+					}
+
+					neptuneOpts := &awstypes.NeptuneImportOptions{}
+					response.Diagnostics.Append(fwflex.Expand(ctx, neptuneOptionsData, neptuneOpts)...)
+					if response.Diagnostics.HasError() {
+						return
+					}
+					importInput.ImportOptions = &awstypes.ImportOptionsMemberNeptune{
+						Value: *neptuneOpts,
+					}
+				}
+			}
+		}
+
+		importInput.GraphName = aws.String(graphName)
+		importInput.Tags = getTagsIn(ctx)
+
+		output, err := conn.CreateGraphUsingImportTask(ctx, &importInput)
+		if err != nil {
+			response.Diagnostics.AddError(fmt.Sprintf("creating Neptune Graph with import task (%s)", graphName), err.Error())
+			return
+		}
+
+		data.ID = fwflex.StringToFramework(ctx, output.GraphId)
+
+		_, err = waitGraphImportTaskCompleted(ctx, conn, aws.ToString(output.TaskId), r.CreateTimeout(ctx, data.Timeouts))
+		if err != nil {
+			response.State.SetAttribute(ctx, path.Root(names.AttrID), data.ID)
+			response.Diagnostics.AddError(fmt.Sprintf("waiting for Neptune Graph import task (%s) completion", data.ID.ValueString()), err.Error())
+			return
+		}
+
+		graph, err := findGraphByID(ctx, conn, data.ID.ValueString())
+		if err != nil {
+			response.State.SetAttribute(ctx, path.Root(names.AttrID), data.ID)
+			response.Diagnostics.AddError(fmt.Sprintf("reading Neptune Graph (%s) after import", data.ID.ValueString()), err.Error())
+			return
+		}
+
+		response.Diagnostics.Append(fwflex.Flatten(ctx, graph, &data)...)
+	} else {
+		// Use existing CreateGraph API
+		var input neptunegraph.CreateGraphInput
+		response.Diagnostics.Append(fwflex.Expand(ctx, data, &input)...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		input.GraphName = aws.String(graphName)
+		input.Tags = getTagsIn(ctx)
+
+		output, err := conn.CreateGraph(ctx, &input)
+		if err != nil {
+			response.Diagnostics.AddError(fmt.Sprintf("creating Neptune Graph (%s)", graphName), err.Error())
+			return
+		}
+
+		data.ID = fwflex.StringToFramework(ctx, output.Id)
+
+		graph, err := waitGraphCreated(ctx, conn, data.ID.ValueString(), r.CreateTimeout(ctx, data.Timeouts))
+		if err != nil {
+			response.State.SetAttribute(ctx, path.Root(names.AttrID), data.ID)
+			response.Diagnostics.AddError(fmt.Sprintf("waiting for Neptune Graph (%s) create", data.ID.ValueString()), err.Error())
+			return
+		}
+
+		response.Diagnostics.Append(fwflex.Flatten(ctx, graph, &data)...)
 	}
 
-	// Additional fields.
-	// NeptuneGraph Sdk GetGraphOutput param for Name differs from CreateGraphInput param as GraphName
-	input.GraphName = aws.String(
-		create.NewNameGenerator(
-			create.WithConfiguredName(data.Name.ValueString()),
-			create.WithConfiguredPrefix(data.NamePrefix.ValueString()),
-			create.WithDefaultPrefix("tf-"),
-		).Generate(ctx),
-	)
-	input.Tags = getTagsIn(ctx)
-
-	output, err := conn.CreateGraph(ctx, &input)
-
-	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("creating Neptune Graph Graph (%s)", aws.ToString(input.GraphName)), err.Error())
-
-		return
-	}
-
-	// Set values for unknowns.
-	data.ID = fwflex.StringToFramework(ctx, output.Id)
-
-	graph, err := waitGraphCreated(ctx, conn, data.ID.ValueString(), r.CreateTimeout(ctx, data.Timeouts))
-
-	if err != nil {
-		response.State.SetAttribute(ctx, path.Root(names.AttrID), data.ID) // Set 'id' so as to taint the resource.
-		response.Diagnostics.AddError(fmt.Sprintf("waiting for Neptune Graph Graph (%s) create", data.ID.ValueString()), err.Error())
-
-		return
-	}
-
-	// Set values for unknowns.
-	response.Diagnostics.Append(fwflex.Flatten(ctx, graph, &data)...)
 	if response.Diagnostics.HasError() {
 		return
 	}
@@ -258,7 +462,6 @@ func (r *graphResource) Read(ctx context.Context, request resource.ReadRequest, 
 		return
 	}
 
-	// Set attributes for import.
 	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &data)...)
 	if response.Diagnostics.HasError() {
 		return
@@ -322,8 +525,6 @@ func (r *graphResource) Delete(ctx context.Context, request resource.DeleteReque
 
 	conn := r.Meta().NeptuneGraphClient(ctx)
 
-	//SkipSnapshot is hardcoded here as this is the same behavior currently supported
-	//in AWS CloudFormation.
 	input := neptunegraph.DeleteGraphInput{
 		GraphIdentifier: data.ID.ValueStringPointer(),
 		SkipSnapshot:    aws.Bool(true),
@@ -337,13 +538,11 @@ func (r *graphResource) Delete(ctx context.Context, request resource.DeleteReque
 
 	if err != nil {
 		response.Diagnostics.AddError(fmt.Sprintf("deleting Neptune Graph Graph (%s)", data.ID.ValueString()), err.Error())
-
 		return
 	}
 
 	if _, err := waitGraphDeleted(ctx, conn, data.ID.ValueString(), r.DeleteTimeout(ctx, data.Timeouts)); err != nil {
 		response.Diagnostics.AddError(fmt.Sprintf("waiting for Neptune Graph Graph (%s) delete", data.ID.ValueString()), err.Error())
-
 		return
 	}
 }
@@ -405,7 +604,65 @@ func waitGraphCreated(ctx context.Context, conn *neptunegraph.Client, id string,
 
 	if output, ok := outputRaw.(*neptunegraph.GetGraphOutput); ok {
 		retry.SetLastError(err, errors.New(aws.ToString(output.StatusReason)))
+		return output, err
+	}
 
+	return nil, err
+}
+
+func findImportTaskByID(ctx context.Context, conn *neptunegraph.Client, taskID string) (*neptunegraph.GetImportTaskOutput, error) {
+	input := &neptunegraph.GetImportTaskInput{
+		TaskIdentifier: aws.String(taskID),
+	}
+
+	output, err := conn.GetImportTask(ctx, input)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError: err,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
+}
+
+func statusImportTask(conn *neptunegraph.Client, taskID string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
+		output, err := findImportTaskByID(ctx, conn, taskID)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, string(output.Status), nil
+	}
+}
+
+func waitGraphImportTaskCompleted(ctx context.Context, conn *neptunegraph.Client, taskID string, timeout time.Duration) (*neptunegraph.GetImportTaskOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(awstypes.ImportTaskStatusInitializing, awstypes.ImportTaskStatusImporting, awstypes.ImportTaskStatusExporting,
+			awstypes.ImportTaskStatusAnalyzingData, awstypes.ImportTaskStatusReprovisioning),
+		Target:  enum.Slice(awstypes.ImportTaskStatusSucceeded),
+		Refresh: statusImportTask(conn, taskID),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*neptunegraph.GetImportTaskOutput); ok {
+		retry.SetLastError(err, errors.New(aws.ToString(output.StatusReason)))
 		return output, err
 	}
 
@@ -471,6 +728,30 @@ type graphResourceModel struct {
 	TagsAll                   tftags.Map                                                      `tfsdk:"tags_all"`
 	Timeouts                  timeouts.Value                                                  `tfsdk:"timeouts"`
 	VectorSearchConfiguration fwtypes.ListNestedObjectValueOf[vectorSearchConfigurationModel] `tfsdk:"vector_search_configuration"`
+	ImportTask                fwtypes.ListNestedObjectValueOf[importTaskModel]                `tfsdk:"import_task"`
+}
+
+type importTaskModel struct {
+	Source               types.String                              `tfsdk:"source"`
+	RoleArn              types.String                              `tfsdk:"role_arn"`
+	Format               types.String                              `tfsdk:"format"`
+	FailOnError          types.Bool                                `tfsdk:"fail_on_error"`
+	MaxProvisionedMemory types.Int32                               `tfsdk:"max_provisioned_memory"`
+	MinProvisionedMemory types.Int32                               `tfsdk:"min_provisioned_memory"`
+	BlankNodeHandling    types.String                              `tfsdk:"blank_node_handling"`
+	ParquetType          types.String                              `tfsdk:"parquet_type"`
+	ImportOptions        fwtypes.ObjectValueOf[importOptionsModel] `tfsdk:"import_options"`
+}
+
+type importOptionsModel struct {
+	Neptune fwtypes.ObjectValueOf[neptuneImportOptionsModel] `tfsdk:"neptune"`
+}
+
+type neptuneImportOptionsModel struct {
+	S3ExportPath                types.String `tfsdk:"s3_export_path"`
+	S3ExportKmsKeyId            types.String `tfsdk:"s3_export_kms_key_id"`
+	PreserveDefaultVertexLabels types.Bool   `tfsdk:"preserve_default_vertex_labels"`
+	PreserveEdgeIds             types.Bool   `tfsdk:"preserve_edge_ids"`
 }
 
 type vectorSearchConfigurationModel struct {

--- a/internal/service/neptunegraph/graph.go
+++ b/internal/service/neptunegraph/graph.go
@@ -645,7 +645,7 @@ func findImportTaskByID(ctx context.Context, conn *neptunegraph.Client, taskID s
 	}
 
 	if output == nil {
-		return nil, tfresource.NewEmptyResultError(input)
+		return nil, tfresource.NewEmptyResultError()
 	}
 
 	return output, nil
@@ -655,7 +655,7 @@ func statusImportTask(conn *neptunegraph.Client, taskID string) retry.StateRefre
 	return func(ctx context.Context) (any, string, error) {
 		output, err := findImportTaskByID(ctx, conn, taskID)
 
-		if tfresource.NotFound(err) {
+		if retry.NotFound(err) {
 			return nil, "", nil
 		}
 

--- a/internal/service/neptunegraph/graph_list.go
+++ b/internal/service/neptunegraph/graph_list.go
@@ -1,0 +1,113 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package neptunegraph
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/neptunegraph"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/neptunegraph/types"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for list resource registration to the Provider. DO NOT EDIT.
+// @FrameworkListResource("aws_neptunegraph_graph")
+func newGraphResourceAsListResource() list.ListResourceWithConfigure {
+	return &listResourceGraph{}
+}
+
+var _ list.ListResource = &listResourceGraph{}
+
+type listResourceGraph struct {
+	graphResource
+	framework.WithList
+}
+
+type listGraphModel struct {
+	framework.WithRegionModel
+}
+
+func (l *listResourceGraph) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	var query listGraphModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	conn := l.Meta().NeptuneGraphClient(ctx)
+
+	tflog.Info(ctx, "Listing Neptune Analytics Graphs")
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		var input neptunegraph.ListGraphsInput
+		for item, err := range listGraphs(ctx, conn, &input) {
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+
+			id := aws.ToString(item.Id)
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrID), id)
+
+			result := request.NewListResult(ctx)
+
+			var data graphResourceModel
+			l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
+				if request.IncludeResource {
+					graph, err := findGraphByID(ctx, conn, id)
+					if err != nil {
+						tflog.Error(ctx, "Reading Neptune Analytics Graph", map[string]any{
+							"error": err.Error(),
+						})
+						return
+					}
+					result.Diagnostics.Append(fwflex.Flatten(ctx, graph, &data)...)
+				} else {
+					data.ID = fwflex.StringToFramework(ctx, item.Id)
+				}
+				result.DisplayName = aws.ToString(item.Name)
+			})
+
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+func listGraphs(ctx context.Context, conn *neptunegraph.Client, input *neptunegraph.ListGraphsInput) iter.Seq2[awstypes.GraphSummary, error] {
+	return func(yield func(awstypes.GraphSummary, error) bool) {
+		pages := neptunegraph.NewListGraphsPaginator(conn, input)
+		for pages.HasMorePages() {
+			page, err := pages.NextPage(ctx)
+			if err != nil {
+				yield(awstypes.GraphSummary{}, fmt.Errorf("listing Neptune Analytics Graph resources: %w", err))
+				return
+			}
+
+			for _, item := range page.Graphs {
+				if !yield(item, nil) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/service/neptunegraph/graph_list_test.go
+++ b/internal/service/neptunegraph/graph_list_test.go
@@ -1,0 +1,148 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package neptunegraph_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccNeptuneGraphGraph_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_neptunegraph_graph.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.NeptuneGraphServiceID),
+		CheckDestroy:             testAccCheckGraphDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Graph/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity.GetIdentity(resourceName),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Graph/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_neptunegraph_graph.test", identity.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_neptunegraph_graph.test", tfqueryfilter.ByResourceIdentityFunc(identity.Checks()), knownvalue.StringExact(rName)),
+					tfquerycheck.ExpectNoResourceObject("aws_neptunegraph_graph.test", tfqueryfilter.ByResourceIdentityFunc(identity.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccNeptuneGraphGraph_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_neptunegraph_graph.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.NeptuneGraphServiceID),
+		CheckDestroy:             testAccCheckGraphDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Graph/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity.GetIdentity(resourceName),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Graph/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_neptunegraph_graph.test", identity.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_neptunegraph_graph.test", tfqueryfilter.ByResourceIdentityFunc(identity.Checks()), knownvalue.StringExact(rName)),
+				},
+			},
+		},
+	})
+}
+
+func TestAccNeptuneGraphGraph_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_neptunegraph_graph.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.NeptuneGraphServiceID),
+		CheckDestroy:             testAccCheckGraphDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Graph/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"region":        config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity.GetIdentity(resourceName),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Graph/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"region":        config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_neptunegraph_graph.test", identity.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/neptunegraph/graph_test.go
+++ b/internal/service/neptunegraph/graph_test.go
@@ -577,7 +577,7 @@ resource "aws_neptunegraph_graph" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func TestAccNeptuneGraphGraph_importFromS3(t *testing.T) {
+func TestAccNeptuneGraphGraph_fromS3(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -603,7 +603,7 @@ func TestAccNeptuneGraphGraph_importFromS3(t *testing.T) {
 		CheckDestroy: testAccCheckGraphDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGraphConfig_importFromS3(rName),
+				Config: testAccGraphConfig_fromS3(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGraphExists(ctx, t, resourceName, &graph),
 					resource.TestCheckResourceAttr(resourceName, "import_task.#", "1"),
@@ -613,26 +613,26 @@ func TestAccNeptuneGraphGraph_importFromS3(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccGraphConfig_importFromS3_removed(rName),
+				Config: testAccGraphConfig_fromS3_removed(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGraphExists(ctx, t, resourceName, &graph),
 					resource.TestCheckResourceAttr(resourceName, "import_task.#", "0"),
 				),
 			},
 			{
-				Config: testAccGraphConfig_importFromS3_modified(rName),
+				Config: testAccGraphConfig_fromS3_modified(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGraphExists(ctx, t, resourceName, &graph),
 					resource.TestCheckResourceAttr(resourceName, "import_task.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "import_task.0.format", "CSV"),
-					resource.TestCheckResourceAttr(resourceName, "import_task.0.fail_on_error", "true"),
+					resource.TestCheckResourceAttr(resourceName, "import_task.0.fail_on_error", acctest.CtTrue),
 				),
 			},
 		},
 	})
 }
 
-func testAccGraphConfig_importFromS3(rName string) string {
+func testAccGraphConfig_fromS3(rName string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
@@ -664,7 +664,7 @@ resource "aws_iam_role" "test" {
       Action = "sts:AssumeRole"
       Effect = "Allow"
       Principal = {
-		Service = "neptune-graph.amazonaws.com"
+        Service = "neptune-graph.amazonaws.com"
       }
     }]
   })
@@ -691,7 +691,7 @@ resource "aws_iam_role_policy" "test" {
 
 # Allow time for IAM role to propagate
 resource "time_sleep" "wait" {
-  depends_on = [aws_iam_role_policy.test]
+  depends_on      = [aws_iam_role_policy.test]
   create_duration = "10s"
 }
 
@@ -716,7 +716,7 @@ resource "aws_neptunegraph_graph" "test" {
 `, rName)
 }
 
-func testAccGraphConfig_importFromS3_removed(rName string) string {
+func testAccGraphConfig_fromS3_removed(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
@@ -732,7 +732,7 @@ resource "aws_iam_role" "test" {
       Action = "sts:AssumeRole"
       Effect = "Allow"
       Principal = {
-		Service = "neptune-graph.amazonaws.com"
+        Service = "neptune-graph.amazonaws.com"
       }
     }]
   })
@@ -748,7 +748,7 @@ resource "aws_neptunegraph_graph" "test" {
 `, rName)
 }
 
-func testAccGraphConfig_importFromS3_modified(rName string) string {
+func testAccGraphConfig_fromS3_modified(rName string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
@@ -779,7 +779,7 @@ resource "aws_iam_role" "test" {
       Action = "sts:AssumeRole"
       Effect = "Allow"
       Principal = {
-		Service = "neptune-graph.amazonaws.com"
+        Service = "neptune-graph.amazonaws.com"
       }
     }]
   })
@@ -805,7 +805,7 @@ resource "aws_iam_role_policy" "test" {
 }
 
 resource "time_sleep" "wait" {
-  depends_on = [aws_iam_role_policy.test]
+  depends_on      = [aws_iam_role_policy.test]
   create_duration = "10s"
 }
 
@@ -831,7 +831,7 @@ resource "aws_neptunegraph_graph" "test" {
 `, rName)
 }
 
-func TestAccNeptuneGraphGraph_importFromNeptuneDB(t *testing.T) {
+func TestAccNeptuneGraphGraph_fromNeptuneDB(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -861,12 +861,12 @@ func TestAccNeptuneGraphGraph_importFromNeptuneDB(t *testing.T) {
 		CheckDestroy: testAccCheckGraphDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGraphConfig_importFromNeptuneDB(rName),
+				Config: testAccGraphConfig_fromNeptuneDB(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGraphExists(ctx, t, resourceName, &graph),
 					resource.TestCheckResourceAttr(resourceName, "import_task.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "import_task.0.import_options.neptune.s3_export_path"),
-					resource.TestCheckResourceAttrSet(resourceName, "import_task.0.import_options.neptune.s3_export_kms_key_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "import_task.0.import_options.0.neptune.0.s3_export_path"),
+					resource.TestCheckResourceAttrSet(resourceName, "import_task.0.import_options.0.neptune.0.s3_export_kms_key_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "import_task.0.source"),
 					resource.TestCheckResourceAttrSet(resourceName, "import_task.0.role_arn"),
 				),
@@ -875,13 +875,13 @@ func TestAccNeptuneGraphGraph_importFromNeptuneDB(t *testing.T) {
 	})
 }
 
-func testAccGraphConfig_importFromNeptuneDB(rName string) string {
+func testAccGraphConfig_fromNeptuneDB(rName string) string {
 	return fmt.Sprintf(`
 data "aws_region" "current" {}
 data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_neptune_engine_version" "latest" {
-    latest = true
+  latest = true
 }
 
 resource "aws_s3_bucket" "test" {
@@ -969,14 +969,14 @@ resource "aws_neptune_subnet_group" "test" {
 }
 
 resource "aws_neptune_cluster" "test" {
-  cluster_identifier          = %[1]q
-  engine                      = "neptune"
-  engine_version              = data.aws_neptune_engine_version.latest.version_actual
-  skip_final_snapshot         = true
-  neptune_subnet_group_name   = aws_neptune_subnet_group.test.name
-  apply_immediately           = true
-  iam_roles                   = [aws_iam_role.neptune_load.arn]
-  vpc_security_group_ids      = [aws_security_group.test.id]
+  cluster_identifier                  = %[1]q
+  engine                              = "neptune"
+  engine_version                      = data.aws_neptune_engine_version.latest.version_actual
+  skip_final_snapshot                 = true
+  neptune_subnet_group_name           = aws_neptune_subnet_group.test.name
+  apply_immediately                   = true
+  iam_roles                           = [aws_iam_role.neptune_load.arn]
+  vpc_security_group_ids              = [aws_security_group.test.id]
   iam_database_authentication_enabled = true
 }
 
@@ -1038,39 +1038,37 @@ resource "null_resource" "bulk_load" {
 }
 
 resource "aws_iam_role" "graph_import" {
-  name = "%[1]s-graph"
-
+  name               = "%[1]s-graph"
   assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Action = "sts:AssumeRole"
-      Effect = "Allow"
-      Principal = {
-        Service = [
-			"neptune-graph.amazonaws.com",
-			"export.rds.amazonaws.com"
-		]
+    Version   = "2012-10-17"
+    Statement = [
+      {
+        Action    = "sts:AssumeRole"
+        Effect    = "Allow"
+        Principal = {
+          Service = [
+            "neptune-graph.amazonaws.com",
+            "export.rds.amazonaws.com"
+          ]
+        }
       }
-    }]
+    ]
   })
 }
 
 resource "aws_iam_role_policy" "graph_import" {
-  role = aws_iam_role.graph_import.id
-
+  role   = aws_iam_role.graph_import.id
   policy = jsonencode({
-    Version = "2012-10-17"
+    Version   = "2012-10-17"
     Statement = [
-        {
-            Effect = "Allow",
-            Action = [
-                "iam:PassRole"
-            ],
-            Resource = aws_iam_role.graph_import.arn
-        },
       {
-        Effect = "Allow"
-        Action = [
+          Effect   = "Allow",
+          Action   = "iam:PassRole"
+          Resource = aws_iam_role.graph_import.arn
+      },
+      {
+        Effect  = "Allow"
+        Action  = [
           "s3:GetObject*",
           "s3:ListBucket",
           "s3:PutObject*",
@@ -1083,8 +1081,8 @@ resource "aws_iam_role_policy" "graph_import" {
         ]
       },
       {
-        Effect = "Allow"
-        Action = [
+        Effect  = "Allow"
+        Action  = [
           "kms:ListGrants",
           "kms:CreateGrant",
           "kms:RevokeGrant",
@@ -1097,16 +1095,16 @@ resource "aws_iam_role_policy" "graph_import" {
         Resource = aws_kms_key.test.arn
       },
       {
-        Effect = "Allow"
-        Action = [
+        Effect  = "Allow"
+        Action  = [
           "rds:DescribeDBClusters",
           "rds:StartExportTask"
         ]
         Resource = aws_neptune_cluster.test.arn
       },
       {
-        Effect = "Allow"
-        Action = [
+        Effect  = "Allow"
+        Action  = [
           "rds:DescribeExportTasks",
           "rds:CancelExportTask"
         ]
@@ -1126,41 +1124,38 @@ resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
 
   policy = jsonencode({
-    Version = "2012-10-17"
+    Version   = "2012-10-17"
     Statement = [
       {
-        Sid    = "Enable IAM User Permissions"
-        Effect = "Allow"
+        Effect    = "Allow"
         Principal = {
           AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
         }
-        Action   = "kms:*"
-        Resource = "*"
+        Action    = "kms:*"
+        Resource  = "*"
       },
       {
-        Sid    = "Allow Neptune Graph to use the key"
-        Effect = "Allow"
+        Effect    = "Allow"
         Principal = {
           Service = "neptune-graph.amazonaws.com"
         }
-        Action = [
+        Action    = [
           "kms:Decrypt",
           "kms:DescribeKey",
           "kms:CreateGrant"
         ]
-        Resource = "*"
+        Resource  = "*"
       },
       {
-        Sid    = "Allow S3 to use the key"
-        Effect = "Allow"
+        Effect    = "Allow"
         Principal = {
           Service = "s3.amazonaws.com"
         }
-        Action = [
+        Action    = [
           "kms:Decrypt",
           "kms:GenerateDataKey"
         ]
-        Resource = "*"
+        Resource  = "*"
       }
     ]
   })
@@ -1178,8 +1173,8 @@ resource "aws_neptunegraph_graph" "test" {
 
     import_options {
       neptune {
-        s3_export_path       = "s3://${aws_s3_bucket.test.bucket}/export/"
-        s3_export_kms_key_id = aws_kms_key.test.arn
+        s3_export_path                 = "s3://${aws_s3_bucket.test.bucket}/export/"
+        s3_export_kms_key_id           = aws_kms_key.test.arn
         preserve_default_vertex_labels = true
         preserve_edge_ids              = true
       }

--- a/internal/service/neptunegraph/graph_test.go
+++ b/internal/service/neptunegraph/graph_test.go
@@ -576,3 +576,619 @@ resource "aws_neptunegraph_graph" "test" {
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
+
+func TestAccNeptuneGraphGraph_importFromS3(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var graph neptunegraph.GetGraphOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_neptunegraph_graph.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.NeptuneGraphServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "0.12.1",
+			},
+		},
+		CheckDestroy: testAccCheckGraphDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGraphConfig_importFromS3(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGraphExists(ctx, t, resourceName, &graph),
+					resource.TestCheckResourceAttr(resourceName, "import_task.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "import_task.0.format", "CSV"),
+					resource.TestCheckResourceAttrSet(resourceName, "import_task.0.source"),
+					resource.TestCheckResourceAttrSet(resourceName, "import_task.0.role_arn"),
+				),
+			},
+			{
+				Config: testAccGraphConfig_importFromS3_removed(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGraphExists(ctx, t, resourceName, &graph),
+					resource.TestCheckResourceAttr(resourceName, "import_task.#", "0"),
+				),
+			},
+			{
+				Config: testAccGraphConfig_importFromS3_modified(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGraphExists(ctx, t, resourceName, &graph),
+					resource.TestCheckResourceAttr(resourceName, "import_task.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "import_task.0.format", "CSV"),
+					resource.TestCheckResourceAttr(resourceName, "import_task.0.fail_on_error", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGraphConfig_importFromS3(rName string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+
+# Create minimal Neptune CSV data
+resource "aws_s3_object" "vertices" {
+  bucket  = aws_s3_bucket.test.bucket
+  key     = "vertices/vertices.csv"
+  content = "~id,~label\nv1,airport\nv2,airport\n"
+}
+
+resource "aws_s3_object" "edges" {
+  bucket  = aws_s3_bucket.test.bucket
+  key     = "edges/edges.csv"
+  content = "~id,~from,~to,~label\ne1,v1,v2,route\n"
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+		Service = "neptune-graph.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "test" {
+  role = aws_iam_role.test.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:Get*",
+        "s3:List*"
+      ]
+      Resource = [
+        "${aws_s3_bucket.test.arn}/*",
+        aws_s3_bucket.test.arn
+      ]
+    }]
+  })
+}
+
+# Allow time for IAM role to propagate
+resource "time_sleep" "wait" {
+  depends_on = [aws_iam_role_policy.test]
+  create_duration = "10s"
+}
+
+resource "aws_neptunegraph_graph" "test" {
+  graph_name          = %[1]q
+  deletion_protection = false
+  public_connectivity = false
+  replica_count       = 0
+
+  import_task {
+    source   = "s3://${aws_s3_bucket.test.bucket}/"
+    role_arn = aws_iam_role.test.arn
+    format   = "CSV"
+  }
+
+  depends_on = [
+    time_sleep.wait,
+    aws_s3_object.vertices,
+    aws_s3_object.edges
+  ]
+}
+`, rName)
+}
+
+func testAccGraphConfig_importFromS3_removed(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+		Service = "neptune-graph.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_neptunegraph_graph" "test" {
+  graph_name          = %[1]q
+  provisioned_memory  = 128
+  deletion_protection = false
+  public_connectivity = false
+  replica_count       = 0
+}
+`, rName)
+}
+
+func testAccGraphConfig_importFromS3_modified(rName string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+
+resource "aws_s3_object" "vertices" {
+  bucket  = aws_s3_bucket.test.bucket
+  key     = "vertices/vertices.csv"
+  content = "~id,~label\nv1,airport\nv2,airport\n"
+}
+
+resource "aws_s3_object" "edges" {
+  bucket  = aws_s3_bucket.test.bucket
+  key     = "edges/edges.csv"
+  content = "~id,~from,~to,~label\ne1,v1,v2,route\n"
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+		Service = "neptune-graph.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "test" {
+  role = aws_iam_role.test.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:Get*",
+        "s3:List*"
+      ]
+      Resource = [
+        "${aws_s3_bucket.test.arn}/*",
+        aws_s3_bucket.test.arn
+      ]
+    }]
+  })
+}
+
+resource "time_sleep" "wait" {
+  depends_on = [aws_iam_role_policy.test]
+  create_duration = "10s"
+}
+
+resource "aws_neptunegraph_graph" "test" {
+  graph_name          = %[1]q
+  deletion_protection = false
+  public_connectivity = false
+  replica_count       = 0
+
+  import_task {
+    source        = "s3://${aws_s3_bucket.test.bucket}/"
+    role_arn      = aws_iam_role.test.arn
+    format        = "CSV"
+    fail_on_error = true
+  }
+
+  depends_on = [
+    time_sleep.wait,
+    aws_s3_object.vertices,
+    aws_s3_object.edges
+  ]
+}
+`, rName)
+}
+
+func TestAccNeptuneGraphGraph_importFromNeptuneDB(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var graph neptunegraph.GetGraphOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_neptunegraph_graph.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.NeptuneGraphServiceID, names.NeptuneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"null": {
+				Source:            "hashicorp/null",
+				VersionConstraint: "3.2.2",
+			},
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "0.12.1",
+			},
+		},
+		CheckDestroy: testAccCheckGraphDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGraphConfig_importFromNeptuneDB(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGraphExists(ctx, t, resourceName, &graph),
+					resource.TestCheckResourceAttr(resourceName, "import_task.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "import_task.0.import_options.neptune.s3_export_path"),
+					resource.TestCheckResourceAttrSet(resourceName, "import_task.0.import_options.neptune.s3_export_kms_key_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "import_task.0.source"),
+					resource.TestCheckResourceAttrSet(resourceName, "import_task.0.role_arn"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGraphConfig_importFromNeptuneDB(rName string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+data "aws_partition" "current" {}
+data "aws_caller_identity" "current" {}
+data "aws_neptune_engine_version" "latest" {
+    latest = true
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+
+resource "aws_s3_object" "vertices" {
+  bucket  = aws_s3_bucket.test.bucket
+  key     = "vertices.csv"
+  content = "~id,~label\nv1,airport\nv2,airport\n"
+}
+
+resource "aws_s3_object" "edges" {
+  bucket  = aws_s3_bucket.test.bucket
+  key     = "edges.csv"
+  content = "~id,~from,~to,~label\ne1,v1,v2,route\n"
+}
+
+resource "aws_iam_role" "neptune_load" {
+  name = "%[1]s-load"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "rds.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "neptune_load" {
+  role = aws_iam_role.neptune_load.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:Get*",
+        "s3:List*"
+      ]
+      Resource = [
+        "${aws_s3_bucket.test.arn}/*",
+        aws_s3_bucket.test.arn
+      ]
+    }]
+  })
+}
+
+resource "aws_default_vpc" "test" {}
+
+data "aws_subnets" "test" {
+  filter {
+    name   = "vpc-id"
+    values = [aws_default_vpc.test.id]
+  }
+}
+
+resource "aws_security_group" "test" {
+  name   = %[1]q
+  vpc_id = aws_default_vpc.test.id
+
+  ingress {
+    from_port   = 8182
+    to_port     = 8182
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_neptune_subnet_group" "test" {
+  name       = %[1]q
+  subnet_ids = data.aws_subnets.test.ids
+}
+
+resource "aws_neptune_cluster" "test" {
+  cluster_identifier          = %[1]q
+  engine                      = "neptune"
+  engine_version              = data.aws_neptune_engine_version.latest.version_actual
+  skip_final_snapshot         = true
+  neptune_subnet_group_name   = aws_neptune_subnet_group.test.name
+  apply_immediately           = true
+  iam_roles                   = [aws_iam_role.neptune_load.arn]
+  vpc_security_group_ids      = [aws_security_group.test.id]
+  iam_database_authentication_enabled = true
+}
+
+resource "aws_neptune_cluster_instance" "test" {
+  identifier                 = %[1]q
+  cluster_identifier         = aws_neptune_cluster.test.id
+  instance_class             = "db.t4g.medium"
+  apply_immediately          = true
+  publicly_accessible        = true
+}
+
+resource "time_sleep" "neptune_ready" {
+  depends_on      = [aws_neptune_cluster_instance.test]
+  create_duration = "60s"
+}
+
+resource "null_resource" "bulk_load" {
+  depends_on = [time_sleep.neptune_ready]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      LOAD_ID=$(aws neptunedata start-loader-job \
+        --source s3://${aws_s3_bucket.test.bucket}/ \
+        --format csv \
+        --s3-bucket-region ${data.aws_region.current.region} \
+        --iam-role-arn ${aws_iam_role.neptune_load.arn} \
+        --region ${data.aws_region.current.region} \
+        --endpoint-url https://${aws_neptune_cluster.test.endpoint}:${aws_neptune_cluster.test.port} \
+        --query 'payload.loadId' \
+        --output text)
+      
+      echo "Waiting for load job $LOAD_ID to complete..."
+      while true; do
+        STATUS=$(aws neptunedata get-loader-job-status \
+          --load-id "$LOAD_ID" \
+          --endpoint-url https://${aws_neptune_cluster.test.endpoint}:${aws_neptune_cluster.test.port} \
+          --region ${data.aws_region.current.region} \
+          --query 'payload.overallStatus.status' \
+          --output text)
+        
+        if [ "$STATUS" = "LOAD_COMPLETED" ]; then
+          echo "Load completed successfully"
+          break
+        elif [ "$STATUS" = "LOAD_FAILED" ] || [ "$STATUS" = "LOAD_CANCELLED" ]; then
+          echo "Load failed with status: $STATUS"
+          exit 1
+        fi
+        
+        echo "Current status: $STATUS, waiting..."
+        sleep 10
+      done
+    EOT
+  }
+
+  triggers = {
+    cluster_id = aws_neptune_cluster.test.id
+    bucket     = aws_s3_bucket.test.id
+  }
+}
+
+resource "aws_iam_role" "graph_import" {
+  name = "%[1]s-graph"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = [
+			"neptune-graph.amazonaws.com",
+			"export.rds.amazonaws.com"
+		]
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "graph_import" {
+  role = aws_iam_role.graph_import.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+        {
+            Effect = "Allow",
+            Action = [
+                "iam:PassRole"
+            ],
+            Resource = aws_iam_role.graph_import.arn
+        },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject*",
+          "s3:ListBucket",
+          "s3:PutObject*",
+          "s3:GetBucketLocation",
+          "s3:DeleteObject*"
+        ]
+        Resource = [
+          "${aws_s3_bucket.test.arn}/*",
+          aws_s3_bucket.test.arn
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:ListGrants",
+          "kms:CreateGrant",
+          "kms:RevokeGrant",
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:DescribeKey",
+          "kms:GenerateDataKey"
+        ]
+        Resource = aws_kms_key.test.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "rds:DescribeDBClusters",
+          "rds:StartExportTask"
+        ]
+        Resource = aws_neptune_cluster.test.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "rds:DescribeExportTasks",
+          "rds:CancelExportTask"
+        ]
+        Resource = "*"
+      }    
+    ]
+  })
+}
+
+resource "time_sleep" "iam_propagate" {
+  depends_on      = [aws_iam_role_policy.graph_import]
+  create_duration = "10s"
+}
+
+resource "aws_kms_key" "test" {
+  description             = "KMS key for Neptune DB export encryption"
+  deletion_window_in_days = 7
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow Neptune Graph to use the key"
+        Effect = "Allow"
+        Principal = {
+          Service = "neptune-graph.amazonaws.com"
+        }
+        Action = [
+          "kms:Decrypt",
+          "kms:DescribeKey",
+          "kms:CreateGrant"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow S3 to use the key"
+        Effect = "Allow"
+        Principal = {
+          Service = "s3.amazonaws.com"
+        }
+        Action = [
+          "kms:Decrypt",
+          "kms:GenerateDataKey"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_neptunegraph_graph" "test" {
+  graph_name          = %[1]q
+  deletion_protection = false
+  public_connectivity = false
+  replica_count       = 0
+
+  import_task {
+    source   = aws_neptune_cluster.test.arn
+    role_arn = aws_iam_role.graph_import.arn
+
+    import_options {
+      neptune {
+        s3_export_path       = "s3://${aws_s3_bucket.test.bucket}/export/"
+        s3_export_kms_key_id = aws_kms_key.test.arn
+        preserve_default_vertex_labels = true
+        preserve_edge_ids              = true
+      }
+    }
+  }
+
+  depends_on = [
+    null_resource.bulk_load,
+    time_sleep.iam_propagate
+  ]
+}`, rName)
+}

--- a/internal/service/neptunegraph/graph_test.go
+++ b/internal/service/neptunegraph/graph_test.go
@@ -841,7 +841,7 @@ func TestAccNeptuneGraphGraph_fromNeptuneDB(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_neptunegraph_graph.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)

--- a/internal/service/neptunegraph/service_package_gen.go
+++ b/internal/service/neptunegraph/service_package_gen.go
@@ -7,6 +7,8 @@ package neptunegraph
 
 import (
 	"context"
+	"iter"
+	"slices"
 	"unique"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -33,9 +35,28 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			Tags: unique.Make(inttypes.ServicePackageResourceTags{
 				IdentifierAttribute: names.AttrARN,
 			}),
-			Region: inttypes.ResourceRegionDefault(),
+			Region:   inttypes.ResourceRegionDefault(),
+			Identity: inttypes.RegionalSingleParameterIdentity(inttypes.StringIdentityAttribute(names.AttrID, true)),
+			Import: inttypes.FrameworkImport{
+				WrappedImport: true,
+			},
 		},
 	}
+}
+
+func (p *servicePackage) FrameworkListResources(ctx context.Context) iter.Seq[*inttypes.ServicePackageFrameworkListResource] {
+	return slices.Values([]*inttypes.ServicePackageFrameworkListResource{
+		{
+			Factory:  newGraphResourceAsListResource,
+			TypeName: "aws_neptunegraph_graph",
+			Name:     "Graph",
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrARN,
+			}),
+			Region:   inttypes.ResourceRegionDefault(),
+			Identity: inttypes.RegionalSingleParameterIdentity(inttypes.StringIdentityAttribute(names.AttrID, true)),
+		},
+	})
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*inttypes.ServicePackageSDKDataSource {

--- a/internal/service/neptunegraph/testdata/Graph/list_basic/main.tf
+++ b/internal/service/neptunegraph/testdata/Graph/list_basic/main.tf
@@ -1,0 +1,14 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_neptunegraph_graph" "test" {
+  graph_name          = var.rName
+  provisioned_memory  = 16
+  deletion_protection = false
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/neptunegraph/testdata/Graph/list_basic/query.tfquery.hcl
+++ b/internal/service/neptunegraph/testdata/Graph/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_neptunegraph_graph" "test" {
+  provider = aws
+}

--- a/internal/service/neptunegraph/testdata/Graph/list_include_resource/main.tf
+++ b/internal/service/neptunegraph/testdata/Graph/list_include_resource/main.tf
@@ -1,0 +1,14 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_neptunegraph_graph" "test" {
+  graph_name          = var.rName
+  provisioned_memory  = 16
+  deletion_protection = false
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/neptunegraph/testdata/Graph/list_include_resource/query.tfquery.hcl
+++ b/internal/service/neptunegraph/testdata/Graph/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_neptunegraph_graph" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/neptunegraph/testdata/Graph/list_region_override/main.tf
+++ b/internal/service/neptunegraph/testdata/Graph/list_region_override/main.tf
@@ -1,0 +1,21 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_neptunegraph_graph" "test" {
+  region              = var.region
+  graph_name          = var.rName
+  provisioned_memory  = 16
+  deletion_protection = false
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/neptunegraph/testdata/Graph/list_region_override/query.tfquery.hcl
+++ b/internal/service/neptunegraph/testdata/Graph/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_neptunegraph_graph" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}

--- a/website/docs/list-resources/neptunegraph_graph.html.markdown
+++ b/website/docs/list-resources/neptunegraph_graph.html.markdown
@@ -1,0 +1,25 @@
+---
+subcategory: "Neptune Analytics"
+layout: "aws"
+page_title: "AWS: aws_neptunegraph_graph"
+description: |-
+  Lists Neptune Analytics Graph resources.
+---
+
+# List Resource: aws_neptunegraph_graph
+
+Lists Neptune Analytics Graph resources.
+
+## Example Usage
+
+```terraform
+list "aws_neptunegraph_graph" "example" {
+  provider = aws
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.

--- a/website/docs/r/neptunegraph_graph.html.markdown
+++ b/website/docs/r/neptunegraph_graph.html.markdown
@@ -49,10 +49,10 @@ resource "aws_neptunegraph_graph" "example" {
   replica_count       = 1
 
   import_task {
-    source = "s3://example-bucket/prefix"
-    role_arn = "arn:aws:iam::123456789012:role/NeptuneGraphImportRole"
-    format = "CSV"
-    fail_on_error = false
+    source                 = "s3://example-bucket/prefix"
+    role_arn               = "arn:aws:iam::123456789012:role/NeptuneGraphImportRole"
+    format                 = "CSV"
+    fail_on_error          = false
     max_provisioned_memory = 32
     min_provisioned_memory = 16
   }
@@ -81,8 +81,8 @@ resource "aws_neptunegraph_graph" "example" {
 
     import_options {
       neptune {
-        s3_export_path       = "s3://example-export-bucket/export/"
-        s3_export_kms_key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+        s3_export_path                 = "s3://example-export-bucket/export/"
+        s3_export_kms_key_id           = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
         preserve_default_vertex_labels = true
         preserve_edge_ids              = true
       }

--- a/website/docs/r/neptunegraph_graph.html.markdown
+++ b/website/docs/r/neptunegraph_graph.html.markdown
@@ -37,6 +37,65 @@ resource "aws_neptunegraph_graph" "example" {
 }
 ```
 
+### Create Graph from Data in S3
+
+Creates a Neptune Graph using source data hosted in an S3 bucket.  For more details: https://docs.aws.amazon.com/neptune-analytics/latest/userguide/bulk-import-create-from-s3.html
+
+```terraform
+resource "aws_neptunegraph_graph" "example" {
+  graph_name          = "example-graph-test-20250203"
+  deletion_protection = false
+  public_connectivity = false
+  replica_count       = 1
+
+  import_task {
+    source = "s3://example-bucket/prefix"
+    role_arn = "arn:aws:iam::123456789012:role/NeptuneGraphImportRole"
+    format = "CSV"
+    fail_on_error = false
+    max_provisioned_memory = 32
+    min_provisioned_memory = 16
+  }
+
+  tags = {
+    "Environment" = "Development"
+    "ModifiedBy"  = "AWS"
+  }
+}
+```
+
+### Create Graph from a Neptune Database cluster
+
+Creates a Neptune Graph using data from a Neptune Database cluster as the source.  For more details:  https://docs.aws.amazon.com/neptune-analytics/latest/userguide/bulk-import-create-from-neptune.html
+
+```terraform
+resource "aws_neptunegraph_graph" "example" {
+  graph_name          = "example-graph-test-20250203"
+  deletion_protection = false
+  public_connectivity = false
+  replica_count       = 0
+
+  import_task {
+    source   = "arn:aws:rds:us-east-1:123456789012:cluster:neptune-db-cluster-name"
+    role_arn = "arn:aws:iam::123456789012:role/NeptuneGraphImportRole"
+
+    import_options {
+      neptune {
+        s3_export_path       = "s3://example-export-bucket/export/"
+        s3_export_kms_key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+        preserve_default_vertex_labels = true
+        preserve_edge_ids              = true
+      }
+    }
+  }
+
+  tags = {
+    "Environment" = "Development"
+    "ModifiedBy"  = "AWS"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -52,6 +111,7 @@ The following arguments are optional:
 - `replica_count` (Number, Default: `1`, Forces new resource) Specifies the number of replicas you want when finished. All replicas will be provisioned in different availability zones.  Replica Count should always be less than or equal to 2.
 - `kms_key_identifier` (String) The ARN for the KMS encryption key. By Default, Neptune Analytics will use an AWS provided key ("AWS_OWNED_KEY"). This parameter is used if you want to encrypt the graph using a KMS Customer Managed Key (CMK).
 - `vector_search_configuration` (Block, Forces new resource) Vector Search Configuration (see below for nested schema of vector_search_configuration)
+- `import_task` (Block, Forces new source) Creates a new Neptune Analytics graph and imports data into it, either from Amazon Simple Storage Service (S3) or from a Neptune database or a Neptune database snapshot.
 - `tags` - (Optional) Key-value tags for the graph. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference
@@ -83,6 +143,27 @@ Optional:
 Optional:
 
 - `vector_search_dimension` (Number, Forces new resource) Specifies the number of dimensions for vector embeddings.  Value must be between 1 and 65,535.
+
+### Nested Schema for `import_task`
+
+Optional:
+
+- `blankNodeHandling` (String) The method to handle blank nodes in the dataset. Currently, only `convertToIri` is supported, meaning blank nodes are converted to unique IRIs at load time. Must be provided when format is ntriples. For more information, see [Handling RDF values](https://docs.aws.amazon.com/neptune-analytics/latest/userguide/using-rdf-data.html#rdf-handling).
+- `parquetType` (String) The parquet type of the import task.  Currently, only `COLUMNAR` is supported.
+- `source` (String) A URL identifying to the location of the data to be imported. This can be an Amazon S3 URL, Neptune Database cluster resource ARN or Neptune Database cluster snapshot ARN.
+- `role_arn` (String) The ARN of the IAM role that will allow access to the data that is to be imported.
+- `format` (String) Specifies the format of S3 data to be imported. Valid values are CSV, which identifies the [Gremlin CSV format](https://docs.aws.amazon.com/neptune/latest/userguide/bulk-load-tutorial-format-gremlin.html), OPEN_CYPHER, which identifies the [openCypher load format](https://docs.aws.amazon.com/neptune/latest/userguide/bulk-load-tutorial-format-opencypher.html), NTRIPLES, which identifies the [RDF n-triples](https://docs.aws.amazon.com/neptune-analytics/latest/userguide/using-rdf-data.html) format, or PARQUET.
+- `fail_on_error` (Boolean) If set to true, the task halts when an import error is encountered. If set to false, the task skips the data that caused the error and continues if possible.
+- `min_provisioned_memory` (Integer, Default: 16) The minimum provisioned memory-optimized Neptune Capacity Units (m-NCUs) to use for the graph.  (Minimum value of 16. Maximum value of 24576.)
+- `max_provisioned_memory` (Integer, Default: 1024, or the approved upper limit for your account.) The maximum provisioned memory-optimized Neptune Capacity Units (m-NCUs) to use for the graph.   If both the minimum and maximum values are specified, the final provisioned-memory will be chosen per the actual size of your imported data. If neither value is specified, 128 m-NCUs are used.  (Minimum value of 16. Maximum value of 24576.)
+- `import_options` (Block) Contains options for controlling the import process. For example, if the failOnError key is set to false, the import skips problem data and attempts to continue (whereas if set to true, the default, or if omitted, the import operation halts immediately when an error is encountered.
+
+#### Nested Schema for `import_options`.`neptune`
+
+- `s3ExportKmsKeyId` (String) The ARN of the KMS key to use to encrypt data in the S3 bucket where the graph data is exported.
+- `s3ExportPath` (String) The path (URL) to an S3 bucket from which to import data.
+- `preserveDefaultVertexLabels` (Boolean) Neptune Analytics supports label-less vertices and no labels are assigned unless one is explicitly provided. Neptune assigns default labels when none is explicitly provided. When importing the data into Neptune Analytics, the default vertex labels can be omitted by setting preserveDefaultVertexLabels to false. Note that if the vertex only has default labels, and has no other properties or edges, then the vertex will effectively not get imported into Neptune Analytics when preserveDefaultVertexLabels is set to false.
+- `preserveEdgeIds` (Boolean) Neptune Analytics currently does not support user defined edge ids. The edge ids are not imported by default. They are imported if preserveEdgeIds is set to true, and ids are stored as properties on the relationships with the property name neptuneEdgeId.
 
 ## Import
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
No.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Neptune Analytics offers the ability to create a new Analytics graph from various data sources: data hosted in an S3 bucket, data hosted in a Neptune Database cluster, or data from a Neptune Database cluster snapshot.  The following PR includes changes necessary to implement this feature.  Also noted in the issue here: https://github.com/hashicorp/terraform-provider-aws/issues/44202

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #44202 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/neptune-analytics/latest/userguide/bulk-import-into-a-graph.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccNeptuneGraphGraph PKG=neptunegraph
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/neptunegraph/... -v -count 1 -parallel 20 -run='TestAccNeptuneGraphGraph'  -timeout 360m -vet=off
2026/01/10 05:30:09 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/10 05:30:09 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccNeptuneGraphGraph_basic
=== PAUSE TestAccNeptuneGraphGraph_basic
=== RUN   TestAccNeptuneGraphGraph_disappears
=== PAUSE TestAccNeptuneGraphGraph_disappears
=== RUN   TestAccNeptuneGraphGraph_vectorSearch
=== PAUSE TestAccNeptuneGraphGraph_vectorSearch
=== RUN   TestAccNeptuneGraphGraph_kmsKey
=== PAUSE TestAccNeptuneGraphGraph_kmsKey
=== RUN   TestAccNeptuneGraphGraph_deletionProtection
=== PAUSE TestAccNeptuneGraphGraph_deletionProtection
=== RUN   TestAccNeptuneGraphGraph_nameGenerated
=== PAUSE TestAccNeptuneGraphGraph_nameGenerated
=== RUN   TestAccNeptuneGraphGraph_namePrefix
=== PAUSE TestAccNeptuneGraphGraph_namePrefix
=== RUN   TestAccNeptuneGraphGraph_tags
=== PAUSE TestAccNeptuneGraphGraph_tags
=== RUN   TestAccNeptuneGraphGraph_importFromS3
=== PAUSE TestAccNeptuneGraphGraph_importFromS3
=== RUN   TestAccNeptuneGraphGraph_importFromNeptuneDB
--- PASS: TestAccNeptuneGraphGraph_importFromNeptuneDB (2493.90s)
=== CONT  TestAccNeptuneGraphGraph_basic
=== CONT  TestAccNeptuneGraphGraph_nameGenerated
=== CONT  TestAccNeptuneGraphGraph_kmsKey
=== CONT  TestAccNeptuneGraphGraph_vectorSearch
=== CONT  TestAccNeptuneGraphGraph_tags
=== CONT  TestAccNeptuneGraphGraph_deletionProtection
=== CONT  TestAccNeptuneGraphGraph_namePrefix
=== CONT  TestAccNeptuneGraphGraph_importFromS3
=== CONT  TestAccNeptuneGraphGraph_disappears
--- PASS: TestAccNeptuneGraphGraph_basic (321.17s)
--- PASS: TestAccNeptuneGraphGraph_disappears (328.71s)
--- PASS: TestAccNeptuneGraphGraph_tags (335.34s)
--- PASS: TestAccNeptuneGraphGraph_vectorSearch (338.77s)
--- PASS: TestAccNeptuneGraphGraph_nameGenerated (348.53s)
--- PASS: TestAccNeptuneGraphGraph_kmsKey (405.25s)
--- PASS: TestAccNeptuneGraphGraph_deletionProtection (416.99s)
--- PASS: TestAccNeptuneGraphGraph_namePrefix (430.63s)
--- PASS: TestAccNeptuneGraphGraph_importFromS3 (986.55s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/neptunegraph       3480.576s
```
