### PR TITLE
docs: fix broken example

### DIFF
--- a/website/docs/r/dynamodb_global_secondary_index.html.markdown
+++ b/website/docs/r/dynamodb_global_secondary_index.html.markdown
@@ -20,8 +20,8 @@ description: |-
 
 ```terraform
 resource "aws_dynamodb_global_secondary_index" "example" {
-  table = aws_dynamodb_table.example.name
-  name  = "GameTitleIndex"
+  table_name = aws_dynamodb_table.example.name
+  index_name = "GameTitleIndex"
 
   projection {
     projection_type    = "INCLUDE"


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes implemented.

### Description

The example for the resource [`aws_dynamodb_global_secondary_index`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_global_secondary_index) requires a fix: with `table` and  `name` it uses two non-existing arguments.
 

### Relations

Closes #45910 

### References

- [Source code reference](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/dynamodb/global_secondary_index.go#L83-L94)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.