### PR TITLE
r/aws_msk_cluster: Prevent trying to remove empty `tls {}` block

### DIFF
--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -1974,11 +1974,15 @@ func flattenClientAuthentication(apiObject *types.ClientAuthentication) map[stri
 	tfMap := map[string]any{}
 
 	if v := apiObject.Sasl; v != nil {
-		tfMap["sasl"] = []any{flattenSASL(v)}
+		if v := flattenSASL(v); v != nil {
+			tfMap["sasl"] = []any{v}
+		}
 	}
 
 	if v := apiObject.Tls; v != nil {
-		tfMap["tls"] = []any{flattenTLS(v)}
+		if v := flattenTLS(v); v != nil {
+			tfMap["tls"] = []any{v}
+		}
 	}
 
 	if v := apiObject.Unauthenticated; v != nil {
@@ -1987,7 +1991,11 @@ func flattenClientAuthentication(apiObject *types.ClientAuthentication) map[stri
 		}
 	}
 
-	return tfMap
+	if len(tfMap) > 0 {
+		return tfMap
+	}
+
+	return nil
 }
 
 func flattenSASL(apiObject *types.Sasl) map[string]any {
@@ -2009,7 +2017,11 @@ func flattenSASL(apiObject *types.Sasl) map[string]any {
 		}
 	}
 
-	return tfMap
+	if len(tfMap) > 0 {
+		return tfMap
+	}
+
+	return nil
 }
 
 func flattenTLS(apiObject *types.Tls) map[string]any {
@@ -2023,7 +2035,11 @@ func flattenTLS(apiObject *types.Tls) map[string]any {
 		tfMap["certificate_authority_arns"] = v
 	}
 
-	return tfMap
+	if len(tfMap) > 0 {
+		return tfMap
+	}
+
+	return nil
 }
 
 func flattenBrokerSoftwareInfo(apiObject *types.BrokerSoftwareInfo) map[string]any {


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR fixes the issue where Terraform keeps wanting to remove an empty `tls {}` block from the client authentication settings for the MSK cluster.

See https://github.com/hashicorp/terraform-provider-aws/issues/24914#issuecomment-3734383954 for my detailed debugging.

Essentially the AWS API doesn't return all of the output all of the time, some fields are optional and can be absent, implicitly disabling a feature, or the field can be present and explicitly disabling a feature.

You can see from my examples, the AWS API can return either no TLS settings, or TLS settings that show the feature is disabled, (i.e. no Certificate Authority ARNs).

The problem is the `flatten*()` functions return different values, when a field is absent, `nil` is returned. When a field is present and explicitly disables a feature, or rather just doesn't contain any values considered useful, a `flatten*()` function can return something like `[]any{map[string]any{}}` which is enough to trigger a planned change, but which is considered a no-op by the upstream API.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #24914
or 
Closes #0000
--->

Relates #24914

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
This might be tricky as it's entirely reliant on the AWS API behaving in a certain way, it's maybe easier to mock the API. I think for acceptance testing I need to create an MSK cluster with TLS enabled, then disable TLS and check that with no TLS settings in the resource there are no planned changes.

Edit: In order to enable TLS, I need to have an ACM PCA which costs significant money.
```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
