### PR TITLE
bedrock: add input/output action and enabled fields to guardrail topi…

### DIFF
--- a/internal/service/bedrock/guardrail.go
+++ b/internal/service/bedrock/guardrail.go
@@ -398,12 +398,26 @@ func (r *guardrailResource) Schema(ctx context.Context, req resource.SchemaReque
 											listplanmodifier.UseStateForUnknown(),
 										},
 									},
+									"input_action": schema.StringAttribute{
+										Optional:   true,
+										CustomType: fwtypes.StringEnumType[awstypes.GuardrailTopicAction](),
+									},
+									"input_enabled": schema.BoolAttribute{
+										Optional: true,
+									},
 									names.AttrName: schema.StringAttribute{
 										Required: true,
 										Validators: []validator.String{
 											stringvalidator.LengthBetween(1, 100),
 											stringvalidator.RegexMatches(topicsConfigNameRegex, ""),
 										},
+									},
+									"output_action": schema.StringAttribute{
+										Optional:   true,
+										CustomType: fwtypes.StringEnumType[awstypes.GuardrailTopicAction](),
+									},
+									"output_enabled": schema.BoolAttribute{
+										Optional: true,
 									},
 									names.AttrType: schema.StringAttribute{
 										Required:   true,
@@ -889,10 +903,14 @@ type guardrailTopicPolicyConfigModel struct {
 }
 
 type guardrailTopicConfigModel struct {
-	Definition types.String                                    `tfsdk:"definition"`
-	Examples   fwtypes.ListOfString                            `tfsdk:"examples"`
-	Name       types.String                                    `tfsdk:"name"`
-	Type       fwtypes.StringEnum[awstypes.GuardrailTopicType] `tfsdk:"type"`
+	Definition    types.String                                      `tfsdk:"definition"`
+	Examples      fwtypes.ListOfString                              `tfsdk:"examples"`
+	InputAction   fwtypes.StringEnum[awstypes.GuardrailTopicAction] `tfsdk:"input_action"`
+	InputEnabled  types.Bool                                        `tfsdk:"input_enabled"`
+	Name          types.String                                      `tfsdk:"name"`
+	OutputAction  fwtypes.StringEnum[awstypes.GuardrailTopicAction] `tfsdk:"output_action"`
+	OutputEnabled types.Bool                                        `tfsdk:"output_enabled"`
+	Type          fwtypes.StringEnum[awstypes.GuardrailTopicType]   `tfsdk:"type"`
 }
 
 type guardrailTopicsTierConfigModel struct {

--- a/internal/service/bedrock/guardrail_test.go
+++ b/internal/service/bedrock/guardrail_test.go
@@ -187,6 +187,10 @@ func TestAccBedrockGuardrail_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "sensitive_information_policy_config.0.regexes_config.0.pattern", "^\\d{3}-\\d{2}-\\d{4}$"),
 					resource.TestCheckResourceAttr(resourceName, "sensitive_information_policy_config.0.pii_entities_config.0.type", "NAME"),
 					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.name", "investment_topic"),
+					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.input_action", "BLOCK"),
+					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.input_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.output_action", "BLOCK"),
+					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.output_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.words_config.0.text", "HATE"),
 				),
 			},
@@ -200,6 +204,10 @@ func TestAccBedrockGuardrail_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "sensitive_information_policy_config.0.regexes_config.0.pattern", "^\\d{4}-\\d{2}-\\d{4}$"),
 					resource.TestCheckResourceAttr(resourceName, "sensitive_information_policy_config.0.pii_entities_config.0.type", "USERNAME"),
 					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.name", "earnings_topic"),
+					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.input_action", "BLOCK"),
+					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.input_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.output_action", "BLOCK"),
+					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.output_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.words_config.0.text", "HATRED"),
 				),
 			},
@@ -596,10 +604,14 @@ resource "aws_bedrock_guardrail" "test" {
 
   topic_policy_config {
     topics_config {
-      name       = %[7]q
-      examples   = ["Where should I invest my money ?"]
-      type       = "DENY"
-      definition = "Investment advice refers to inquiries, guidance, or recommendations regarding the management or allocation of funds or assets with the goal of generating returns ."
+      name          = %[7]q
+      examples      = ["Where should I invest my money ?"]
+      type          = "DENY"
+      definition    = "Investment advice refers to inquiries, guidance, or recommendations regarding the management or allocation of funds or assets with the goal of generating returns ."
+      input_action  = "BLOCK"
+      input_enabled = true
+      output_action = "BLOCK"
+      output_enabled = true
     }
   }
 
@@ -729,10 +741,14 @@ resource "aws_bedrock_guardrail" "test" {
 
   topic_policy_config {
     topics_config {
-      name       = "investment_topic"
-      examples   = ["Where should I invest my money ?"]
-      type       = "DENY"
-      definition = "Investment advice refers to inquiries, guidance, or recommendations regarding the management or allocation of funds or assets with the goal of generating returns ."
+      name          = "investment_topic"
+      examples      = ["Where should I invest my money ?"]
+      type          = "DENY"
+      definition    = "Investment advice refers to inquiries, guidance, or recommendations regarding the management or allocation of funds or assets with the goal of generating returns ."
+      input_action  = "BLOCK"
+      input_enabled = true
+      output_action = "BLOCK"
+      output_enabled = true
     }
     tier_config {
       tier_name = "STANDARD"


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No security related changes.

### Description

Add input_action, input_enabled, output_action, and output_enabled fields to guardrail topic_policy_config.topics_config block. These optional fields allow users to control guardrail evaluation behavior for both input prompts and model responses, following AWS API specifications.

### References
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_GuardrailTopicConfig.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_CreateGuardrail.html

### Output from Acceptance Testing
Unable to run full acceptance tests locally due to pre-existing test configuration issues with Bedrock foundation models (specifically amazon.titan-text-express-v1 no longer exists in us-east-1, which is unrelated to this change).

```console
% make testacc TESTS=TestAccBedrockGuardrail PKG=bedrock

...
```
