### PR TITLE
bedrock: add input/output action and enabled fields to guardrail topic_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ ENHANCEMENTS:
 * resource/aws_fsx_openzfs_snapshot: Enforce tag policy compliance for the `fsx:snapshot` tag type ([#45671](https://github.com/hashicorp/terraform-provider-aws/issues/45671))
 * resource/aws_fsx_openzfs_volume: Enforce tag policy compliance for the `fsx:volume` tag type ([#45671](https://github.com/hashicorp/terraform-provider-aws/issues/45671))
 * resource/aws_fsx_windows_file_system: Enforce tag policy compliance for the `fsx:file-system` tag type ([#45671](https://github.com/hashicorp/terraform-provider-aws/issues/45671))
+* resource/aws_bedrock_guardrail: Add input_action, input_enabled, output_action, and output_enabled to topic_policy_config.topics_config ([#45915](https://github.com/hashicorp/terraform-provider-aws/issues/45915))
 * resource/aws_guardduty_filter: Add `finding_criteria.criterion.matches` and `finding_criteria.criterion.not_matches` arguments ([#45758](https://github.com/hashicorp/terraform-provider-aws/issues/45758))
 * resource/aws_iam_policy: Add `delay_after_policy_creation_in_ms` argument. This functionality requires the `iam:SetDefaultPolicyVersion` IAM permission ([#42054](https://github.com/hashicorp/terraform-provider-aws/issues/42054))
 * resource/aws_iam_saml_provider: Add `saml_provider_uuid` attribute ([#45707](https://github.com/hashicorp/terraform-provider-aws/issues/45707))

--- a/internal/service/bedrock/guardrail.go
+++ b/internal/service/bedrock/guardrail.go
@@ -398,12 +398,26 @@ func (r *guardrailResource) Schema(ctx context.Context, req resource.SchemaReque
 											listplanmodifier.UseStateForUnknown(),
 										},
 									},
+									"input_action": schema.StringAttribute{
+										Optional:   true,
+										CustomType: fwtypes.StringEnumType[awstypes.GuardrailTopicAction](),
+									},
+									"input_enabled": schema.BoolAttribute{
+										Optional: true,
+									},
 									names.AttrName: schema.StringAttribute{
 										Required: true,
 										Validators: []validator.String{
 											stringvalidator.LengthBetween(1, 100),
 											stringvalidator.RegexMatches(topicsConfigNameRegex, ""),
 										},
+									},
+									"output_action": schema.StringAttribute{
+										Optional:   true,
+										CustomType: fwtypes.StringEnumType[awstypes.GuardrailTopicAction](),
+									},
+									"output_enabled": schema.BoolAttribute{
+										Optional: true,
 									},
 									names.AttrType: schema.StringAttribute{
 										Required:   true,
@@ -889,10 +903,14 @@ type guardrailTopicPolicyConfigModel struct {
 }
 
 type guardrailTopicConfigModel struct {
-	Definition types.String                                    `tfsdk:"definition"`
-	Examples   fwtypes.ListOfString                            `tfsdk:"examples"`
-	Name       types.String                                    `tfsdk:"name"`
-	Type       fwtypes.StringEnum[awstypes.GuardrailTopicType] `tfsdk:"type"`
+	Definition    types.String                                      `tfsdk:"definition"`
+	Examples      fwtypes.ListOfString                              `tfsdk:"examples"`
+	InputAction   fwtypes.StringEnum[awstypes.GuardrailTopicAction] `tfsdk:"input_action"`
+	InputEnabled  types.Bool                                        `tfsdk:"input_enabled"`
+	Name          types.String                                      `tfsdk:"name"`
+	OutputAction  fwtypes.StringEnum[awstypes.GuardrailTopicAction] `tfsdk:"output_action"`
+	OutputEnabled types.Bool                                        `tfsdk:"output_enabled"`
+	Type          fwtypes.StringEnum[awstypes.GuardrailTopicType]   `tfsdk:"type"`
 }
 
 type guardrailTopicsTierConfigModel struct {

--- a/internal/service/bedrock/guardrail_test.go
+++ b/internal/service/bedrock/guardrail_test.go
@@ -187,6 +187,10 @@ func TestAccBedrockGuardrail_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "sensitive_information_policy_config.0.regexes_config.0.pattern", "^\\d{3}-\\d{2}-\\d{4}$"),
 					resource.TestCheckResourceAttr(resourceName, "sensitive_information_policy_config.0.pii_entities_config.0.type", "NAME"),
 					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.name", "investment_topic"),
+					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.input_action", "BLOCK"),
+					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.input_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.output_action", "BLOCK"),
+					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.output_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.words_config.0.text", "HATE"),
 				),
 			},
@@ -200,6 +204,10 @@ func TestAccBedrockGuardrail_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "sensitive_information_policy_config.0.regexes_config.0.pattern", "^\\d{4}-\\d{2}-\\d{4}$"),
 					resource.TestCheckResourceAttr(resourceName, "sensitive_information_policy_config.0.pii_entities_config.0.type", "USERNAME"),
 					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.name", "earnings_topic"),
+					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.input_action", "BLOCK"),
+					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.input_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.output_action", "BLOCK"),
+					resource.TestCheckResourceAttr(resourceName, "topic_policy_config.0.topics_config.0.output_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "word_policy_config.0.words_config.0.text", "HATRED"),
 				),
 			},
@@ -596,10 +604,14 @@ resource "aws_bedrock_guardrail" "test" {
 
   topic_policy_config {
     topics_config {
-      name       = %[7]q
-      examples   = ["Where should I invest my money ?"]
-      type       = "DENY"
-      definition = "Investment advice refers to inquiries, guidance, or recommendations regarding the management or allocation of funds or assets with the goal of generating returns ."
+      name          = %[7]q
+      examples      = ["Where should I invest my money ?"]
+      type          = "DENY"
+      definition    = "Investment advice refers to inquiries, guidance, or recommendations regarding the management or allocation of funds or assets with the goal of generating returns ."
+      input_action  = "BLOCK"
+      input_enabled = true
+      output_action = "BLOCK"
+      output_enabled = true
     }
   }
 
@@ -729,10 +741,14 @@ resource "aws_bedrock_guardrail" "test" {
 
   topic_policy_config {
     topics_config {
-      name       = "investment_topic"
-      examples   = ["Where should I invest my money ?"]
-      type       = "DENY"
-      definition = "Investment advice refers to inquiries, guidance, or recommendations regarding the management or allocation of funds or assets with the goal of generating returns ."
+      name          = "investment_topic"
+      examples      = ["Where should I invest my money ?"]
+      type          = "DENY"
+      definition    = "Investment advice refers to inquiries, guidance, or recommendations regarding the management or allocation of funds or assets with the goal of generating returns ."
+      input_action  = "BLOCK"
+      input_enabled = true
+      output_action = "BLOCK"
+      output_enabled = true
     }
     tier_config {
       tier_name = "STANDARD"


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Add input_action, input_enabled, output_action, and output_enabled fields to guardrail topic_policy_config.topics_config block. These optional fields allow users to control guardrail evaluation behavior for both input prompts and model responses, following AWS API specifications.

These parameters enable fine-grained control over topic-based guardrail filtering, allowing users to:
- Enable/disable guardrail evaluation independently for inputs and outputs
- Specify different actions (BLOCK or NONE) for input and output separately
- Control costs by disabling evaluation where not needed

References:
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_GuardrailTopicConfig.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_CreateGuardrail.html


### Relations

Closes #45915


### References

### Output from Acceptance Testing

**Note:** Unable to run full acceptance tests locally due to pre-existing test configuration issues with Bedrock foundation models (specifically amazon.titan-text-express-v1 no longer exists in us-east-1, which is unrelated to this change).

The implementation follows the same patterns used by other similar blocks in the codebase:
- words_config (in word_policy_config) - has identical input_action, input_enabled, output_action, output_enabled fields
- pii_entities_config and regexes_config (in sensitive_information_policy_config) - have the same optional input/output action and enabled fields

Code compiles successfully and test configurations have been updated to include the new fields with appropriate TestCheckResourceAttr verification checks in TestAccBedrockGuardrail_update.

```console
% make testacc TESTS=TestAccBedrockGuardrail PKG=bedrock

...
```
