### PR TITLE
feat: Add segment_actions.routing_policy_names arg to d/aws_networkmanager_core_network_policy_document

### DIFF
--- a/.changelog/45928.txt
+++ b/.changelog/45928.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_networkmanager_core_network_policy_document: Add `segment_actions.routing_policy_names` argument
+```

--- a/internal/service/networkmanager/core_network_policy_document_data_source.go
+++ b/internal/service/networkmanager/core_network_policy_document_data_source.go
@@ -210,8 +210,9 @@ func dataSourceCoreNetworkPolicyDocument() *schema.Resource {
 								"dual-hop",
 							}, false),
 						},
-						"share_with":        setOfStringOptional,
-						"share_with_except": setOfStringOptional,
+						"share_with":           setOfStringOptional,
+						"share_with_except":    setOfStringOptional,
+						"routing_policy_names": setOfStringOptional,
 						"destination_cidr_blocks": {
 							Type:     schema.TypeSet,
 							Optional: true,
@@ -700,6 +701,10 @@ func expandCoreNetworkPolicySegmentActions(tfList []any) ([]*coreNetworkPolicySe
 				apiObject.ShareWithExcept = shareWithExcept
 			}
 
+			if v := tfMap["routing_policy_names"].(*schema.Set).List(); len(v) > 0 {
+				apiObject.RoutingPolicyNames = coreNetworkPolicyExpandStringList(v)
+			}
+
 			if (shareWith != nil && shareWithExcept != nil) || (shareWith == nil && shareWithExcept == nil) {
 				return nil, fmt.Errorf(`you must specify only 1 of "share_with" or "share_with_except". See segment_actions[%d]`, i)
 			}
@@ -912,7 +917,7 @@ func expandDataCoreNetworkPolicyAttachmentPoliciesConditions(tfList []any) ([]*c
 
 		case names.AttrRegion, "resource-id", "account-id":
 			if k[names.AttrKey] || !k["operator"] || !k[names.AttrValue] {
-				return nil, fmt.Errorf("conditions %d: must set \"value\" and \"operator\" and cannot set \"key\" if type = \"region\", \"resource-id\", \"account\", or \"account-id\"\n%[2]t, %[3]t, %[4]t", i, k[names.AttrKey], k["operator"], k[names.AttrValue])
+				return nil, fmt.Errorf("conditions %d: must set \"value\" and \"operator\" and cannot set \"key\" if type = \"region\", \"resource-id\", or \"account-id\"\n%[2]t, %[3]t, %[4]t", i, k[names.AttrKey], k["operator"], k[names.AttrValue])
 			}
 
 		case "attachment-type":

--- a/internal/service/networkmanager/core_network_policy_model.go
+++ b/internal/service/networkmanager/core_network_policy_model.go
@@ -120,6 +120,7 @@ type coreNetworkPolicySegmentAction struct {
 	Mode                    string                                                 `json:"mode,omitempty"`
 	ShareWith               any                                                    `json:"share-with,omitempty"`
 	ShareWithExcept         any                                                    `json:",omitempty"`
+	RoutingPolicyNames      any                                                    `json:"routing-policy-names,omitempty"`
 	DestinationCidrBlocks   any                                                    `json:"destination-cidr-blocks,omitempty"`
 	Destinations            any                                                    `json:"destinations,omitempty"`
 	Description             string                                                 `json:"description,omitempty"`
@@ -223,6 +224,7 @@ func (c coreNetworkPolicySegmentAction) MarshalJSON() ([]byte, error) {
 		DestinationCidrBlocks:   c.DestinationCidrBlocks,
 		Segment:                 c.Segment,
 		ShareWith:               share,
+		RoutingPolicyNames:      c.RoutingPolicyNames,
 		Via:                     c.Via,
 		WhenSentTo:              whenSentTo,
 		Description:             c.Description,

--- a/website/docs/d/networkmanager_core_network_policy_document.html.markdown
+++ b/website/docs/d/networkmanager_core_network_policy_document.html.markdown
@@ -272,6 +272,7 @@ The following arguments are available:
 * `destinations` (Optional) - A list of strings. Valid values include `["blackhole"]` or a list of attachment ids.
 * `edge_location_association` (Optional) - Associates routing policies with specific edge location pairs. Available in policy version `2025.11` and later. Detailed below.
 * `mode` (Optional) - String. When `action` is `share`, a `mode` value of `attachment-route` places the attachment and return routes in each of the `share_with` segments. When `action` is `send-via`, indicates the mode used for packets. Valid values: `attachment-route`, `single-hop`, `dual-hop`.
+* `routing_policy_names` (Optional) - A list of routing policy names to apply to segment sharing. The routing policies control how routes are propagated between the shared segments. Only applicable when `action` is `share`. Available in policy version `2025.11` and later.
 * `segment` (Optional) - Name of the segment.
 * `share_with` (Optional) - A list of strings to share with. Must be a substring is all segments. Valid values include: `["*"]` or `["<segment-names>"]`.
 * `share_with_except` (Optional) - A set subtraction of segments to not share with.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR is to add the `segment_actions.routing_policy_names` argument to the `aws_networkmanager_core_network_policy_document` data source to complete the support of Cloud WAN routing policies.

**Note:** While running acceptance tests for the data source, the `_basic` test case failed because of a recent regression fix related to #45246. The test case is still using `account` when it has been rolled back to `account-id`. That said, it seems that AWS document is indeed referring to `account`, leading me to believe that `account-id` may be used mainly for the older 2021.12 policy version, while `account` is required for newer 2025.11 policy versions. As my focus is to add the argument, I didn't spend the time to fully test the behavior. I think it can only be tested via the core network resource when the policy is actually applied and evaluated. I would recommend that a maintain apply extra scrutiny on this potential issue and address it as appropriate.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #45918.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/45788.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [Core network policy version parameters in AWS Cloud WAN](https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-policies-json.html) for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_ PKG=networkmanager
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: ðŸŒ¿ f-aws_networkmanager_core_network_policy_document-add_routing_policy_names_arg ðŸŒ¿...
TF_ACC=1 go1.25.5 test ./internal/service/networkmanager/... -v -count 1 -parallel 20 -run='TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_'  -timeout 360m -vet=off
2026/01/12 15:31:32 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/12 15:31:32 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== RUN   TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_serviceInsertion
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_serviceInsertion
=== RUN   TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_whenSentTo
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_whenSentTo
=== RUN   TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_via
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_via
=== RUN   TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_viaCompat
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_viaCompat
=== RUN   TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_routingPolicyNames
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_routingPolicyNames
=== CONT  TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== CONT  TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_via
=== CONT  TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_serviceInsertion
=== CONT  TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_whenSentTo
=== CONT  TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_routingPolicyNames
=== CONT  TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_viaCompat
--- PASS: TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_routingPolicyNames (18.78s)
--- PASS: TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic (19.01s)
--- PASS: TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_serviceInsertion (19.05s)
--- PASS: TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_whenSentTo (19.07s)
--- PASS: TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_viaCompat (19.17s)
--- PASS: TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_via (19.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager 19.582s

$
```
