### PR TITLE
skaff: prefer `smerr.AddEnrich`

### DIFF
--- a/skaff/datasource/datasourcefw.gtpl
+++ b/skaff/datasource/datasourcefw.gtpl
@@ -174,7 +174,7 @@ func (d *{{ .DataSourceLowerCamel }}DataSource) Read(ctx context.Context, req da
 	// TIP: -- 2. Fetch the config
 	{{- end }}
 	var data {{ .DataSourceLowerCamel }}DataSourceModel
-	smerr.EnrichAppend(ctx, &resp.Diagnostics, req.Config.Get(ctx, &data))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Config.Get(ctx, &data))
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -191,7 +191,7 @@ func (d *{{ .DataSourceLowerCamel }}DataSource) Read(ctx context.Context, req da
 	// TIP: -- 4. Set the ID, arguments, and attributes
 	// Using a field name prefix allows mapping fields such as `{{ .DataSource }}Id` to `ID`
 	{{- end }}
-	smerr.EnrichAppend(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &data, flex.WithFieldNamePrefix("{{ .DataSource }}")), smerr.ID, data.Name.String())
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &data, flex.WithFieldNamePrefix("{{ .DataSource }}")), smerr.ID, data.Name.String())
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -208,7 +208,7 @@ func (d *{{ .DataSourceLowerCamel }}DataSource) Read(ctx context.Context, req da
 	{{ if .IncludeComments -}}
 	// TIP: -- 6. Set the state
 	{{- end }}
-	smerr.EnrichAppend(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data), smerr.ID, data.Name.String())
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data), smerr.ID, data.Name.String())
 }
 
 {{ if .IncludeComments }}


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
`smerr.EnrichAppend` is deprecated in favor of `smerr.AddEnrich`.


