### PR TITLE
fix: Add retry logic for claiming phone # for r/aws_connect_phone_number

### DIFF
--- a/.changelog/45937.txt
+++ b/.changelog/45937.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_connect_phone_number: Add retry logic to address a race condition when multiple resource instances attempt to claim the same phone number from a non-exclusive search
+```

--- a/internal/service/connect/connect_test.go
+++ b/internal/service/connect/connect_test.go
@@ -92,6 +92,7 @@ func TestAccConnect_serial(t *testing.T) {
 			"description":                       testAccPhoneNumber_description,
 			"prefix":                            testAccPhoneNumber_prefix,
 			"targetARN":                         testAccPhoneNumber_targetARN,
+			"multiple":                          testAccPhoneNumber_multiple,
 			"identityBasic":                     testAccConnectPhoneNumber_Identity_basic,
 			"identityExistingResource":          testAccConnectPhoneNumber_Identity_ExistingResource_basic,
 			"identityExistingResourceNoRefresh": testAccConnectPhoneNumber_Identity_ExistingResource_noRefreshNoChange,

--- a/internal/service/connect/phone_number.go
+++ b/internal/service/connect/phone_number.go
@@ -8,7 +8,9 @@ package connect
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -43,7 +45,7 @@ func resourcePhoneNumber() *schema.Resource {
 		DeleteWithoutTimeout: resourcePhoneNumberDelete,
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(2 * time.Minute),
+			Create: schema.DefaultTimeout(10 * time.Minute),
 			Update: schema.DefaultTimeout(2 * time.Minute),
 			Delete: schema.DefaultTimeout(2 * time.Minute),
 		},
@@ -112,60 +114,72 @@ func resourcePhoneNumberCreate(ctx context.Context, d *schema.ResourceData, meta
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ConnectClient(ctx)
 
-	var phoneNumber string
 	targetARN := d.Get(names.AttrTargetARN).(string)
+	phoneNumberType := d.Get(names.AttrType).(string)
 
-	{
-		phoneNumberType := d.Get(names.AttrType).(string)
-		input := &connect.SearchAvailablePhoneNumbersInput{
-			MaxResults:             aws.Int32(1),
-			PhoneNumberCountryCode: awstypes.PhoneNumberCountryCode(d.Get("country_code").(string)),
-			PhoneNumberType:        awstypes.PhoneNumberType(phoneNumberType),
-			TargetArn:              aws.String(targetARN),
-		}
+	// Use the standard Terraform retry mechanism for handling race conditions
+	// when multiple instances try to claim the same phone number in parallel
+	output, err := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutCreate),
+		func(ctx context.Context) (*connect.ClaimPhoneNumberOutput, error) {
+			// Search for available phone numbers
+			searchInput := &connect.SearchAvailablePhoneNumbersInput{
+				MaxResults:             aws.Int32(1),
+				PhoneNumberCountryCode: awstypes.PhoneNumberCountryCode(d.Get("country_code").(string)),
+				PhoneNumberType:        awstypes.PhoneNumberType(phoneNumberType),
+				TargetArn:              aws.String(targetARN),
+			}
 
-		if v, ok := d.GetOk(names.AttrPrefix); ok {
-			input.PhoneNumberPrefix = aws.String(v.(string))
-		}
+			if v, ok := d.GetOk(names.AttrPrefix); ok {
+				searchInput.PhoneNumberPrefix = aws.String(v.(string))
+			}
 
-		output, err := conn.SearchAvailablePhoneNumbers(ctx, input)
+			searchOutput, err := conn.SearchAvailablePhoneNumbers(ctx, searchInput)
 
-		if err == nil && (output == nil || len(output.AvailableNumbersList) == 0) {
-			err = tfresource.NewEmptyResultError()
-		}
+			if err == nil && (searchOutput == nil || len(searchOutput.AvailableNumbersList) == 0) {
+				err = tfresource.NewEmptyResultError()
+			}
 
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "searching Connect Phone Numbers (%s,%s): %s", targetARN, phoneNumberType, err)
-		}
+			if err != nil {
+				return nil, fmt.Errorf("searching Connect Phone Numbers (%s,%s): %w", targetARN, phoneNumberType, err)
+			}
 
-		phoneNumber = aws.ToString(output.AvailableNumbersList[0].PhoneNumber)
+			phoneNumber := aws.ToString(searchOutput.AvailableNumbersList[0].PhoneNumber)
+
+			// Attempt to claim the phone number
+			uuid, err := uuid.GenerateUUID()
+			if err != nil {
+				return nil, err
+			}
+
+			claimInput := &connect.ClaimPhoneNumberInput{
+				ClientToken: aws.String(uuid), // can't use aws.String(id.UniqueId()), because it's not a valid uuid
+				PhoneNumber: aws.String(phoneNumber),
+				Tags:        getTagsIn(ctx),
+				TargetArn:   aws.String(targetARN),
+			}
+
+			if v, ok := d.GetOk(names.AttrDescription); ok {
+				claimInput.PhoneNumberDescription = aws.String(v.(string))
+			}
+
+			log.Printf("[DEBUG] Attempting to claim Connect Phone Number: %s", phoneNumber)
+			return conn.ClaimPhoneNumber(ctx, claimInput)
+		},
+		func(err error) (bool, error) {
+			// Retry if this is a phone number already claimed error (race condition)
+			if isPhoneNumberAlreadyClaimedError(err) {
+				log.Printf("[DEBUG] Phone number already claimed, retrying: %s", err)
+				return true, err
+			}
+			return false, err
+		},
+	)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "claiming Connect Phone Number (%s,%s): %s", targetARN, phoneNumberType, err)
 	}
 
-	{
-		uuid, err := uuid.GenerateUUID()
-		if err != nil {
-			return sdkdiag.AppendFromErr(diags, err)
-		}
-
-		input := &connect.ClaimPhoneNumberInput{
-			ClientToken: aws.String(uuid), // can't use aws.String(id.UniqueId()), because it's not a valid uuid
-			PhoneNumber: aws.String(phoneNumber),
-			Tags:        getTagsIn(ctx),
-			TargetArn:   aws.String(targetARN),
-		}
-
-		if v, ok := d.GetOk(names.AttrDescription); ok {
-			input.PhoneNumberDescription = aws.String(v.(string))
-		}
-
-		output, err := conn.ClaimPhoneNumber(ctx, input)
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "claiming Connect Phone Number (%s,%s): %s", targetARN, phoneNumber, err)
-		}
-
-		d.SetId(aws.ToString(output.PhoneNumberId))
-	}
+	d.SetId(aws.ToString(output.PhoneNumberId))
 
 	if _, err := waitPhoneNumberCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for Connect Phone Number (%s) create: %s", d.Id(), err)
@@ -384,4 +398,21 @@ func waitPhoneNumberDeleted(ctx context.Context, conn *connect.Client, id string
 	}
 
 	return nil, err
+}
+
+// isPhoneNumberAlreadyClaimedError checks if the error indicates that a phone number
+// has already been claimed by another process (race condition scenario)
+func isPhoneNumberAlreadyClaimedError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := err.Error()
+
+	// Match the specific error message from AWS Connect ClaimPhoneNumber API
+	// when a phone number is not available (already claimed by another process)
+	// Example: "InvalidParameterException: Phone number not available: +15047846302. Try again with a different available number"
+	return strings.Contains(errStr, "InvalidParameterException") &&
+		strings.Contains(errStr, "Phone number not available") &&
+		strings.Contains(errStr, "Try again with a different available number")
 }

--- a/internal/service/connect/phone_number_test.go
+++ b/internal/service/connect/phone_number_test.go
@@ -219,6 +219,39 @@ func testAccPhoneNumber_disappears(t *testing.T) {
 	})
 }
 
+func testAccPhoneNumber_multiple(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v0, v1, v2 awstypes.ClaimedPhoneNumberSummary
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ConnectServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPhoneNumberDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPhoneNumberConfig_multiple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					// Check that all 3 phone numbers were created successfully
+					testAccCheckPhoneNumberExists(ctx, t, "aws_connect_phone_number.test.0", &v0),
+					testAccCheckPhoneNumberExists(ctx, t, "aws_connect_phone_number.test.1", &v1),
+					testAccCheckPhoneNumberExists(ctx, t, "aws_connect_phone_number.test.2", &v2),
+					// Verify each phone number has the expected attributes
+					resource.TestCheckResourceAttr("aws_connect_phone_number.test.0", "country_code", "US"),
+					resource.TestCheckResourceAttr("aws_connect_phone_number.test.1", "country_code", "US"),
+					resource.TestCheckResourceAttr("aws_connect_phone_number.test.2", "country_code", "US"),
+					resource.TestCheckResourceAttr("aws_connect_phone_number.test.0", names.AttrType, "DID"),
+					resource.TestCheckResourceAttr("aws_connect_phone_number.test.1", names.AttrType, "DID"),
+					resource.TestCheckResourceAttr("aws_connect_phone_number.test.2", names.AttrType, "DID"),
+					// Verify all phone numbers are different (no duplicates due to race conditions)
+					testAccCheckPhoneNumbersUnique(&v0, &v1, &v2),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckPhoneNumberExists(ctx context.Context, t *testing.T, n string, v *awstypes.ClaimedPhoneNumberSummary) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -260,6 +293,35 @@ func testAccCheckPhoneNumberDestroy(ctx context.Context, t *testing.T) resource.
 			}
 
 			return fmt.Errorf("Connect Phone Number %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckPhoneNumbersUnique(phoneNumbers ...*awstypes.ClaimedPhoneNumberSummary) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		phoneNumberSet := make(map[string]bool)
+
+		for i, phoneNumberSummary := range phoneNumbers {
+			if phoneNumberSummary == nil {
+				return fmt.Errorf("Phone number summary %d is nil", i)
+			}
+
+			if phoneNumberSummary.PhoneNumber == nil {
+				return fmt.Errorf("Phone number %d is nil", i)
+			}
+
+			phoneNumber := *phoneNumberSummary.PhoneNumber
+			if phoneNumber == "" {
+				return fmt.Errorf("Phone number %d is empty", i)
+			}
+
+			if phoneNumberSet[phoneNumber] {
+				return fmt.Errorf("Duplicate phone number found: %s", phoneNumber)
+			}
+
+			phoneNumberSet[phoneNumber] = true
 		}
 
 		return nil
@@ -369,4 +431,22 @@ resource "aws_connect_phone_number" "test" {
   }
 }
 `, tag1, value1, tag2, value2))
+}
+
+func testAccPhoneNumberConfig_multiple(rName string) string {
+	return acctest.ConfigCompose(
+		testAccPhoneNumberConfig_base(rName),
+		`
+resource "aws_connect_phone_number" "test" {
+  count = 3
+
+  target_arn   = aws_connect_instance.test.arn
+  country_code = "US"
+  type         = "DID"
+
+  tags = {
+    Name = "test-phone-number-${count.index}"
+  }
+}
+`)
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

n/a

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to introduce retry logic when claiming phone number to work around race conditions with multiple resource instances getting the same phone number from a search and then trying to claim it.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #45572

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [ClaimPhoneNumber](https://docs.aws.amazon.com/connect/latest/APIReference/API_ClaimPhoneNumber.html) to understand behavior.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

**Note:** Due to the following quota restriction with Connect phone number claims (200% x 5 = 10), I had to run limited test cases in us-east-1 after reaching the limit (and thus "locking myself out" for 180 days) in us-west-2. For whoever is running tests, please be careful with this.

> By default you can claim and release up to 200% of your maximum number of active phone numbers. If you claim and release phone numbers using the UI or API during a rolling 180 day cycle that exceeds 200% of your phone number service level quota, you will be blocked from claiming any more numbers until 180 days past the oldest number released has expired.

The error is of this pattern - note that it talks about it in the context of an instance but I believe the above limit is account-wide. I could be wrong but fact is I can't run test cases in us-west-2 anymore after running all the test cases twice.

```console
Error: waiting for Connect Phone Number (fc8a7a85-d3fa-4673-bcb5-88fdaaeca8cc) create: unexpected state 'FAILED', wanted target 'CLAIMED'. last error: The allowed limit for claimed phone numbers has been exceeded for your instance
```

**Updated 2026-03-15 after rebasing the branch and resolving conflict.**

```console
$ make testacc TESTS="TestAccConnect_serial/PhoneNumber$\/multiple" PKG=connect
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: ðŸŒ¿ b-aws_connect_phone_number-retry_phone_num_claims ðŸŒ¿...
TF_ACC=1 go1.25.8 test ./internal/service/connect/... -v -count 1 -parallel 20 -run='TestAccConnect_serial/PhoneNumber/multiple'  -timeout 360m -vet=off
2026/03/15 15:26:59 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/15 15:26:59 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccConnect_serial
=== PAUSE TestAccConnect_serial
=== CONT  TestAccConnect_serial
=== RUN   TestAccConnect_serial/PhoneNumber
=== RUN   TestAccConnect_serial/PhoneNumber/multiple
=== RUN   TestAccConnect_serial/PhoneNumberContactFlowAssociation
--- PASS: TestAccConnect_serial (99.20s)
    --- PASS: TestAccConnect_serial/PhoneNumber (99.20s)
        --- PASS: TestAccConnect_serial/PhoneNumber/multiple (99.20s)
    --- PASS: TestAccConnect_serial/PhoneNumberContactFlowAssociation (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/connect    99.515s

$
```

```console
$  make testacc TESTS="TestAccConnect_serial/PhoneNumber/basic" PKG=connect
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: ðŸŒ¿ b-aws_connect_phone_number-retry_phone_num_claims ðŸŒ¿...
TF_ACC=1 go1.25.8 test ./internal/service/connect/... -v -count 1 -parallel 20 -run='TestAccConnect_serial/PhoneNumber/basic'  -timeout 360m -vet=off
2026/03/15 15:38:28 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/15 15:38:28 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccConnect_serial
=== PAUSE TestAccConnect_serial
=== CONT  TestAccConnect_serial
=== RUN   TestAccConnect_serial/PhoneNumber
=== RUN   TestAccConnect_serial/PhoneNumber/basic
=== RUN   TestAccConnect_serial/PhoneNumberContactFlowAssociation
=== RUN   TestAccConnect_serial/PhoneNumberContactFlowAssociation/basic
--- PASS: TestAccConnect_serial (220.31s)
    --- PASS: TestAccConnect_serial/PhoneNumber (120.24s)
        --- PASS: TestAccConnect_serial/PhoneNumber/basic (120.24s)
    --- PASS: TestAccConnect_serial/PhoneNumberContactFlowAssociation (100.07s)       
        --- PASS: TestAccConnect_serial/PhoneNumberContactFlowAssociation/basic (100.07s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/connect    220.628s

$
```