### PR TITLE
Fix data_filter_expression.tags being ignored

### DIFF
--- a/internal/service/billing/view.go
+++ b/internal/service/billing/view.go
@@ -200,7 +200,9 @@ func (r *resourceView) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	var input billing.CreateBillingViewInput
-	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Expand(ctx, plan, &input))
+	// Using WithNoIgnoredFieldNames() because DataFilterExpression.Tags is a filter field,
+	// not resource tags. The SDK uses "ResourceTags" for resource tags, not "Tags".
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Expand(ctx, plan, &input, flex.WithNoIgnoredFieldNames()))
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -225,7 +227,7 @@ func (r *resourceView) Create(ctx context.Context, req resource.CreateRequest, r
 		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.Name.String())
 		return
 	}
-	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, view, &plan))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, view, &plan, flex.WithNoIgnoredFieldNames()))
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -254,7 +256,7 @@ func (r *resourceView) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &state))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &state, flex.WithNoIgnoredFieldNames()))
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -287,7 +289,7 @@ func (r *resourceView) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	if diff.HasChanges() {
 		var input billing.UpdateBillingViewInput
-		smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Expand(ctx, plan, &input))
+		smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Expand(ctx, plan, &input, flex.WithNoIgnoredFieldNames()))
 		if resp.Diagnostics.HasError() {
 			return
 		}
@@ -311,7 +313,8 @@ func (r *resourceView) Update(ctx context.Context, req resource.UpdateRequest, r
 		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.Name.String())
 		return
 	}
-	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, view, &plan))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, view, &plan, flex.WithNoIgnoredFieldNames()))
+
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
 }
 

--- a/internal/service/billing/view_test.go
+++ b/internal/service/billing/view_test.go
@@ -192,46 +192,6 @@ func TestAccBillingView_tags(t *testing.T) {
 func TestAccBillingView_dataFilterExpressionTags(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	var view awstypes.BillingViewElement
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_billing_view.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			testAccPreCheck(ctx, t)
-		},
-		ErrorCheck:               acctest.ErrorCheck(t, names.BillingServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckViewDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccViewConfig_dataFilterExpressionTags(rName, "Environment", []string{"production", "staging"}),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckViewExists(ctx, resourceName, &view),
-					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.tags.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.tags.0.key", "Environment"),
-					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.tags.0.values.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.tags.0.values.0", "production"),
-					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.tags.0.values.1", "staging"),
-				),
-			},
-			{
-				ResourceName:                         resourceName,
-				ImportState:                          true,
-				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrARN),
-				ImportStateVerify:                    true,
-				ImportStateVerifyIdentifierAttribute: names.AttrARN,
-			},
-		},
-	})
-}
-
-func TestAccBillingView_dataFilterExpressionTagsUpdate(t *testing.T) {
-	ctx := acctest.Context(t)
-
 	var view1, view2 awstypes.BillingViewElement
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_billing_view.test"
@@ -282,46 +242,6 @@ func TestAccBillingView_dataFilterExpressionTagsUpdate(t *testing.T) {
 func TestAccBillingView_dataFilterExpressionDimensions(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	var view awstypes.BillingViewElement
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_billing_view.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			testAccPreCheck(ctx, t)
-		},
-		ErrorCheck:               acctest.ErrorCheck(t, names.BillingServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckViewDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccViewConfig_dataFilterExpressionDimensions(rName, "LINKED_ACCOUNT", []string{"123456789012", "210987654321"}),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckViewExists(ctx, resourceName, &view),
-					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.0.key", "LINKED_ACCOUNT"),
-					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.0.values.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.0.values.0", "123456789012"),
-					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.0.values.1", "210987654321"),
-				),
-			},
-			{
-				ResourceName:                         resourceName,
-				ImportState:                          true,
-				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrARN),
-				ImportStateVerify:                    true,
-				ImportStateVerifyIdentifierAttribute: names.AttrARN,
-			},
-		},
-	})
-}
-
-func TestAccBillingView_dataFilterExpressionDimensionsUpdate(t *testing.T) {
-	ctx := acctest.Context(t)
-
 	var view1, view2 awstypes.BillingViewElement
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_billing_view.test"
@@ -346,13 +266,13 @@ func TestAccBillingView_dataFilterExpressionDimensionsUpdate(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccViewConfig_dataFilterExpressionDimensions(rName, "LINKED_ACCOUNT", []string{"123456789012", "210987654321", "111222333444"}),
+				Config: testAccViewConfig_dataFilterExpressionDimensions(rName, "LINKED_ACCOUNT", []string{"111222333444", "999999999912"}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckViewExists(ctx, resourceName, &view2),
 					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.0.key", "LINKED_ACCOUNT"),
-					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.0.values.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.0.values.#", "2"),
 				),
 			},
 			{

--- a/internal/service/billing/view_test.go
+++ b/internal/service/billing/view_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/billing"
@@ -491,12 +492,12 @@ resource "aws_billing_view" "test" {
 }
 
 func testAccViewConfig_dataFilterExpressionTags(rName, tagKey string, tagValues []string) string {
-	tagValuesStr := ""
+	var tagValuesStr strings.Builder
 	for i, v := range tagValues {
 		if i > 0 {
-			tagValuesStr += ", "
+			tagValuesStr.WriteString(", ")
 		}
-		tagValuesStr += fmt.Sprintf("%q", v)
+		tagValuesStr.WriteString(fmt.Sprintf("%q", v))
 	}
 	return acctest.ConfigCompose(testAccViewConfig_base(), fmt.Sprintf(`
 resource "aws_billing_view" "test" {
@@ -511,16 +512,16 @@ resource "aws_billing_view" "test" {
     }
   }
 }
-`, rName, tagKey, tagValuesStr))
+`, rName, tagKey, tagValuesStr.String()))
 }
 
 func testAccViewConfig_dataFilterExpressionDimensions(rName, dimensionKey string, dimensionValues []string) string {
-	dimensionValuesStr := ""
+	var dimensionValuesStr strings.Builder
 	for i, v := range dimensionValues {
 		if i > 0 {
-			dimensionValuesStr += ", "
+			dimensionValuesStr.WriteString(", ")
 		}
-		dimensionValuesStr += fmt.Sprintf("%q", v)
+		dimensionValuesStr.WriteString(fmt.Sprintf("%q", v))
 	}
 	return acctest.ConfigCompose(testAccViewConfig_base(), fmt.Sprintf(`
 resource "aws_billing_view" "test" {
@@ -535,5 +536,5 @@ resource "aws_billing_view" "test" {
     }
   }
 }
-`, rName, dimensionKey, dimensionValuesStr))
+`, rName, dimensionKey, dimensionValuesStr.String()))
 }

--- a/internal/service/billing/view_test.go
+++ b/internal/service/billing/view_test.go
@@ -228,6 +228,143 @@ func TestAccBillingView_dataFilterExpressionTags(t *testing.T) {
 	})
 }
 
+func TestAccBillingView_dataFilterExpressionTagsUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var view1, view2 awstypes.BillingViewElement
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_billing_view.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BillingServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckViewDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccViewConfig_dataFilterExpressionTags(rName, "Environment", []string{"production"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckViewExists(ctx, resourceName, &view1),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.tags.0.key", "Environment"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.tags.0.values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.tags.0.values.0", "production"),
+				),
+			},
+			{
+				Config: testAccViewConfig_dataFilterExpressionTags(rName, "CostCenter", []string{"engineering", "finance"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckViewExists(ctx, resourceName, &view2),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.tags.0.key", "CostCenter"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.tags.0.values.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.tags.0.values.0", "engineering"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.tags.0.values.1", "finance"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrARN),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrARN,
+			},
+		},
+	})
+}
+
+func TestAccBillingView_dataFilterExpressionDimensions(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var view awstypes.BillingViewElement
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_billing_view.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BillingServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckViewDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccViewConfig_dataFilterExpressionDimensions(rName, "LINKED_ACCOUNT", []string{"123456789012", "210987654321"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckViewExists(ctx, resourceName, &view),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.0.key", "LINKED_ACCOUNT"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.0.values.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.0.values.0", "123456789012"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.0.values.1", "210987654321"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrARN),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrARN,
+			},
+		},
+	})
+}
+
+func TestAccBillingView_dataFilterExpressionDimensionsUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var view1, view2 awstypes.BillingViewElement
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_billing_view.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BillingServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckViewDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccViewConfig_dataFilterExpressionDimensions(rName, "LINKED_ACCOUNT", []string{"123456789012"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckViewExists(ctx, resourceName, &view1),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.0.key", "LINKED_ACCOUNT"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.0.values.#", "1"),
+				),
+			},
+			{
+				Config: testAccViewConfig_dataFilterExpressionDimensions(rName, "LINKED_ACCOUNT", []string{"123456789012", "210987654321", "111222333444"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckViewExists(ctx, resourceName, &view2),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.0.key", "LINKED_ACCOUNT"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.dimensions.0.values.#", "3"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrARN),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrARN,
+			},
+		},
+	})
+}
+
 func testAccCheckViewDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).BillingClient(ctx)
@@ -375,4 +512,28 @@ resource "aws_billing_view" "test" {
   }
 }
 `, rName, tagKey, tagValuesStr))
+}
+
+func testAccViewConfig_dataFilterExpressionDimensions(rName, dimensionKey string, dimensionValues []string) string {
+	dimensionValuesStr := ""
+	for i, v := range dimensionValues {
+		if i > 0 {
+			dimensionValuesStr += ", "
+		}
+		dimensionValuesStr += fmt.Sprintf("%q", v)
+	}
+	return acctest.ConfigCompose(testAccViewConfig_base(), fmt.Sprintf(`
+resource "aws_billing_view" "test" {
+  name         = %[1]q
+  description  = "Test with data_filter_expression dimensions"
+  source_views = ["arn:${data.aws_partition.current.partition}:billing::${data.aws_caller_identity.current.account_id}:billingview/primary"]
+
+  data_filter_expression {
+    dimensions {
+      key    = %[2]q
+      values = [%[3]s]
+    }
+  }
+}
+`, rName, dimensionKey, dimensionValuesStr))
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
