### PR TITLE
skaff: Rearrange word order in object + function names

### DIFF
--- a/skaff/datasource/datasource.go
+++ b/skaff/datasource/datasource.go
@@ -34,6 +34,7 @@ var websiteTmpl string
 type TemplateData struct {
 	DataSource           string
 	DataSourceLower      string
+	DataSourceLowerCamel string
 	DataSourceSnake      string
 	IncludeComments      bool
 	IncludeTags          bool
@@ -80,6 +81,7 @@ func Create(dsName, snakeName string, comments, force, pluginFramework, tags boo
 	templateData := TemplateData{
 		DataSource:           dsName,
 		DataSourceLower:      strings.ToLower(dsName),
+		DataSourceLowerCamel: convert.ToLowercasePrefix(dsName),
 		DataSourceSnake:      snakeName,
 		HumanFriendlyService: service.HumanFriendly(),
 		IncludeComments:      comments,

--- a/skaff/datasource/datasourcefw.gtpl
+++ b/skaff/datasource/datasourcefw.gtpl
@@ -67,16 +67,16 @@ import (
 
 // Function annotations are used for datasource registration to the Provider. DO NOT EDIT.
 // @FrameworkDataSource("{{ .ProviderResourceName }}", name="{{ .HumanDataSourceName }}")
-func newDataSource{{ .DataSource }}(context.Context) (datasource.DataSourceWithConfigure, error) {
-	return &dataSource{{ .DataSource }}{}, nil
+func new{{ .DataSource }}DataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &{{ .DataSourceLowerCamel }}DataSource{}, nil
 }
 
 const (
 	DSName{{ .DataSource }} = "{{ .HumanDataSourceName }} Data Source"
 )
 
-type dataSource{{ .DataSource }} struct {
-	framework.DataSourceWithModel[dataSource{{ .DataSource }}Model]
+type {{ .DataSourceLowerCamel }}DataSource struct {
+	framework.DataSourceWithModel[{{ .DataSourceLowerCamel }}DataSourceModel]
 }
 
 {{ if .IncludeComments }}
@@ -104,7 +104,7 @@ type dataSource{{ .DataSource }} struct {
 // For more about schema options, visit
 // https://developer.hashicorp.com/terraform/plugin/framework/handling-data/schemas?page=schemas
 {{- end }}
-func (d *dataSource{{ .DataSource }}) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *{{ .DataSourceLowerCamel }}DataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			names.AttrARN: framework.ARNAttributeComputedOnly(),
@@ -152,7 +152,7 @@ func (d *dataSource{{ .DataSource }}) Schema(ctx context.Context, req datasource
 // TIP: ==== ASSIGN CRUD METHODS ====
 // Data sources only have a read method.
 {{- end }}
-func (d *dataSource{{ .DataSource }}) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *{{ .DataSourceLowerCamel }}DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	{{- if .IncludeComments }}
 	// TIP: ==== DATA SOURCE READ ====
 	// Generally, the Read function should do the following things. Make
@@ -173,7 +173,7 @@ func (d *dataSource{{ .DataSource }}) Read(ctx context.Context, req datasource.R
 	{{ if .IncludeComments }}
 	// TIP: -- 2. Fetch the config
 	{{- end }}
-	var data dataSource{{ .DataSource }}Model
+	var data {{ .DataSourceLowerCamel }}DataSourceModel
 	smerr.EnrichAppend(ctx, &resp.Diagnostics, req.Config.Get(ctx, &data))
 	if resp.Diagnostics.HasError() {
 		return
@@ -225,7 +225,7 @@ func (d *dataSource{{ .DataSource }}) Read(ctx context.Context, req datasource.R
 // See more:
 // https://developer.hashicorp.com/terraform/plugin/framework/handling-data/accessing-values
 {{- end }}
-type dataSource{{ .DataSource }}Model struct {
+type {{ .DataSourceLowerCamel }}DataSourceModel struct {
 	framework.WithRegionModel
 	ARN             types.String                                          `tfsdk:"arn"`
 	ComplexArgument fwtypes.ListNestedObjectValueOf[complexArgumentModel] `tfsdk:"complex_argument"`

--- a/skaff/ephemeral/ephemeral.go
+++ b/skaff/ephemeral/ephemeral.go
@@ -29,18 +29,19 @@ var ephemeralTestTmpl string
 var websiteTmpl string
 
 type TemplateData struct {
-	EphemeralResource          string
-	EphemeralResourceLower     string
-	EphemeralResourceSnake     string
-	IncludeComments            bool
-	HumanFriendlyService       string
-	SDKPackage                 string
-	ServicePackage             string
-	Service                    string
-	ServiceLower               string
-	AWSServiceName             string
-	HumanEphemeralResourceName string
-	ProviderResourceName       string
+	EphemeralResource           string
+	EphemeralResourceLower      string
+	EphemeralResourceLowerCamel string
+	EphemeralResourceSnake      string
+	IncludeComments             bool
+	HumanFriendlyService        string
+	SDKPackage                  string
+	ServicePackage              string
+	Service                     string
+	ServiceLower                string
+	AWSServiceName              string
+	HumanEphemeralResourceName  string
+	ProviderResourceName        string
 }
 
 func Create(ephemeralName, snakeName string, comments, force bool) error {
@@ -73,18 +74,19 @@ func Create(ephemeralName, snakeName string, comments, force bool) error {
 	}
 
 	templateData := TemplateData{
-		EphemeralResource:          ephemeralName,
-		EphemeralResourceLower:     strings.ToLower(ephemeralName),
-		EphemeralResourceSnake:     snakeName,
-		HumanFriendlyService:       service.HumanFriendly(),
-		IncludeComments:            comments,
-		SDKPackage:                 service.GoV2Package(),
-		ServicePackage:             servicePackage,
-		Service:                    service.ProviderNameUpper(),
-		ServiceLower:               strings.ToLower(service.ProviderNameUpper()),
-		AWSServiceName:             service.FullHumanFriendly(),
-		HumanEphemeralResourceName: convert.ToHumanResName(ephemeralName),
-		ProviderResourceName:       convert.ToProviderResourceName(servicePackage, snakeName),
+		EphemeralResource:           ephemeralName,
+		EphemeralResourceLower:      strings.ToLower(ephemeralName),
+		EphemeralResourceLowerCamel: convert.ToLowercasePrefix(ephemeralName),
+		EphemeralResourceSnake:      snakeName,
+		HumanFriendlyService:        service.HumanFriendly(),
+		IncludeComments:             comments,
+		SDKPackage:                  service.GoV2Package(),
+		ServicePackage:              servicePackage,
+		Service:                     service.ProviderNameUpper(),
+		ServiceLower:                strings.ToLower(service.ProviderNameUpper()),
+		AWSServiceName:              service.FullHumanFriendly(),
+		HumanEphemeralResourceName:  convert.ToHumanResName(ephemeralName),
+		ProviderResourceName:        convert.ToProviderResourceName(servicePackage, snakeName),
 	}
 
 	tmpl := ephemeralTmpl

--- a/skaff/ephemeral/ephemeral.gtpl
+++ b/skaff/ephemeral/ephemeral.gtpl
@@ -64,16 +64,16 @@ import (
 
 // Function annotations are used for ephemeral registration to the Provider. DO NOT EDIT.
 // @EphemeralResource("{{ .ProviderResourceName }}", name="{{ .HumanEphemeralResourceName }}")
-func newEphemeral{{ .EphemeralResource }}(context.Context) (ephemeral.EphemeralResourceWithConfigure, error) {
-	return &ephemeral{{ .EphemeralResource }}{}, nil
+func new{{ .EphemeralResource }}EphemeralResource(context.Context) (ephemeral.EphemeralResourceWithConfigure, error) {
+	return &{{ .EphemeralResourceLowerCamel }}EphemeralResource{}, nil
 }
 
 const (
-	EPName{{ .EphemeralResource }} = "{{ .HumanEphemeralResourceName }} Ephemeral Resource"
+	ERName{{ .EphemeralResource }} = "{{ .HumanEphemeralResourceName }} Ephemeral Resource"
 )
 
-type ephemeral{{ .EphemeralResource }} struct {
-	framework.EphemeralResourceWithModel[ephemeral{{ .EphemeralResource }}Model]
+type {{ .EphemeralResourceLowerCamel }}EphemeralResource struct {
+	framework.EphemeralResourceWithModel[{{ .EphemeralResourceLowerCamel }}EphemeralResourceModel]
 }
 
 {{ if .IncludeComments }}
@@ -101,7 +101,7 @@ type ephemeral{{ .EphemeralResource }} struct {
 // For more about schema options, visit
 // https://developer.hashicorp.com/terraform/plugin/framework/handling-data/schemas?page=schemas
 {{- end }}
-func (e *ephemeral{{ .EphemeralResource }}) Schema(ctx context.Context, req ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+func (e *{{ .EphemeralResourceLowerCamel }}EphemeralResource) Schema(ctx context.Context, req ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			names.AttrARN: framework.ARNAttributeComputedOnly(),
@@ -146,7 +146,7 @@ func (e *ephemeral{{ .EphemeralResource }}) Schema(ctx context.Context, req ephe
 {{- if .IncludeComments }}
 // TIP: ==== ASSIGN CRUD METHODS ====
 {{- end }}
-func (e *ephemeral{{ .EphemeralResource }}) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+func (e *{{ .EphemeralResourceLowerCamel }}EphemeralResource) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
 	{{- if .IncludeComments }}
 	// TIP: ==== EPHEMERAL RESOURCE OPEN ====
 	// Generally, the Open function should do the following things. Make
@@ -167,7 +167,7 @@ func (e *ephemeral{{ .EphemeralResource }}) Open(ctx context.Context, req epheme
 	{{ if .IncludeComments }}
 	// TIP: -- 2. Fetch the config
 	{{- end }}
-	var data ephemeral{{ .EphemeralResource }}Model
+	var data {{ .EphemeralResourceLowerCamel }}EphemeralResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -217,7 +217,7 @@ func (e *ephemeral{{ .EphemeralResource }}) Open(ctx context.Context, req epheme
 // See more:
 // https://developer.hashicorp.com/terraform/plugin/framework/handling-data/accessing-values
 {{- end }}
-type ephemeral{{ .EphemeralResource }}Model struct {
+type {{ .EphemeralResourceLowerCamel }}EphemeralResourceModel struct {
 	framework.WithRegionModel
 	ARN             types.String                                          `tfsdk:"arn"`
 	ComplexArgument fwtypes.ListNestedObjectValueOf[complexArgumentModel] `tfsdk:"complex_argument"`

--- a/skaff/list/list.go
+++ b/skaff/list/list.go
@@ -38,18 +38,19 @@ var queryTmpl string
 var websiteTmpl string
 
 type TemplateData struct {
-	ListResource          string
-	ListResourceLower     string
-	ListResourceSnake     string
-	IncludeComments       bool
-	HumanFriendlyService  string
-	SDKPackage            string
-	ServicePackage        string
-	Service               string
-	ServiceLower          string
-	AWSServiceName        string
-	HumanListResourceName string
-	ProviderResourceName  string
+	ListResource           string
+	ListResourceLower      string
+	ListResourceLowerCamel string
+	ListResourceSnake      string
+	IncludeComments        bool
+	HumanFriendlyService   string
+	SDKPackage             string
+	ServicePackage         string
+	Service                string
+	ServiceLower           string
+	AWSServiceName         string
+	HumanListResourceName  string
+	ProviderResourceName   string
 }
 
 func Create(listName, snakeName string, comments, framework, force bool) error {
@@ -82,18 +83,19 @@ func Create(listName, snakeName string, comments, framework, force bool) error {
 	}
 
 	templateData := TemplateData{
-		ListResource:          listName,
-		ListResourceLower:     strings.ToLower(listName),
-		ListResourceSnake:     snakeName,
-		HumanFriendlyService:  service.HumanFriendly(),
-		IncludeComments:       comments,
-		SDKPackage:            service.GoV2Package(),
-		ServicePackage:        servicePackage,
-		Service:               service.ProviderNameUpper(),
-		ServiceLower:          strings.ToLower(service.ProviderNameUpper()),
-		AWSServiceName:        service.FullHumanFriendly(),
-		HumanListResourceName: convert.ToHumanResName(listName),
-		ProviderResourceName:  convert.ToProviderResourceName(servicePackage, snakeName),
+		ListResource:           listName,
+		ListResourceLower:      strings.ToLower(listName),
+		ListResourceLowerCamel: convert.ToLowercasePrefix(listName),
+		ListResourceSnake:      snakeName,
+		HumanFriendlyService:   service.HumanFriendly(),
+		IncludeComments:        comments,
+		SDKPackage:             service.GoV2Package(),
+		ServicePackage:         servicePackage,
+		Service:                service.ProviderNameUpper(),
+		ServiceLower:           strings.ToLower(service.ProviderNameUpper()),
+		AWSServiceName:         service.FullHumanFriendly(),
+		HumanListResourceName:  convert.ToHumanResName(listName),
+		ProviderResourceName:   convert.ToProviderResourceName(servicePackage, snakeName),
 	}
 
 	tmpl := listTmplFramework

--- a/skaff/list/list_framework.gtpl
+++ b/skaff/list/list_framework.gtpl
@@ -63,17 +63,17 @@ import (
 // Function annotations are used for list resource registration to the Provider. DO NOT EDIT.
 // @FrameworkListResource("{{ .ProviderResourceName }}")
 func new{{ .ListResource }}ResourceAsListResource() list.ListResourceWithConfigure {
-	return &listResource{{ .ListResource }}{}
+	return &{{ .ListResourceLowerCamel }}ListResource{}
 }
 
-var _ list.ListResource = &listResource{{ .ListResource }}{}
+var _ list.ListResource = &{{ .ListResourceLowerCamel }}ListResource{}
 
-type listResource{{ .ListResource }} struct {
-	resource{{ .ListResource }}
+type {{ .ListResourceLowerCamel }}ListResource struct {
+	{{ .ListResourceLowerCamel }}Resource
 	framework.WithList
 }
 
-func (r *listResource{{ .ListResource }}) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+func (r *{{ .ListResourceLowerCamel }}ListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	{{- if .IncludeComments }}
 	// TIP: ==== LIST RESOURCE LIST ====
 	// Generally, the List function should do the following things. Make

--- a/skaff/resource/resource.go
+++ b/skaff/resource/resource.go
@@ -32,6 +32,7 @@ type TemplateData struct {
 	Resource             string
 	ResourceAWS          string
 	ResourceLower        string
+	ResourceLowerCamel   string
 	ResourceSnake        string
 	HumanFriendlyService string
 	IncludeComments      bool
@@ -78,6 +79,7 @@ func Create(resName, snakeName string, comments, force, tags bool) error {
 		Resource:             resName,
 		ResourceAWS:          capitalizeForAWS(resName),
 		ResourceLower:        strings.ToLower(resName),
+		ResourceLowerCamel:   convert.ToLowercasePrefix(resName),
 		ResourceSnake:        snakeName,
 		HumanFriendlyService: service.HumanFriendly(),
 		IncludeComments:      comments,

--- a/skaff/resource/resource.gtpl
+++ b/skaff/resource/resource.gtpl
@@ -87,8 +87,8 @@ import (
 {{- if .IncludeTags }}
 // @Tags(identifierAttribute="arn")
 {{- end }}
-func newResource{{ .Resource }}(_ context.Context) (resource.ResourceWithConfigure, error) {
-	r := &resource{{ .Resource }}{}
+func new{{ .Resource }}Resource(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &{{ .ResourceLowerCamel }}Resource{}
 
 	{{ if .IncludeComments -}}
 	// TIP: ==== CONFIGURABLE TIMEOUTS ====
@@ -108,8 +108,8 @@ const (
 	ResName{{ .Resource }} = "{{ .HumanResourceName }}"
 )
 
-type resource{{ .Resource }} struct {
-	framework.ResourceWithModel[resource{{ .Resource }}Model]
+type {{ .ResourceLowerCamel }}Resource struct {
+	framework.ResourceWithModel[{{ .ResourceLowerCamel }}ResourceModel]
 	framework.WithTimeouts
 }
 
@@ -156,7 +156,7 @@ type resource{{ .Resource }} struct {
 // For more about schema options, visit
 // https://developer.hashicorp.com/terraform/plugin/framework/handling-data/schemas?page=schemas
 {{- end }}
-func (r *resource{{ .Resource }}) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *{{ .ResourceLowerCamel }}Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			names.AttrARN: framework.ARNAttributeComputedOnly(),
@@ -240,7 +240,7 @@ func (r *resource{{ .Resource }}) Schema(ctx context.Context, req resource.Schem
 	}
 }
 
-func (r *resource{{ .Resource }}) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *{{ .ResourceLowerCamel }}Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	{{- if .IncludeComments }}
 	// TIP: ==== RESOURCE CREATE ====
 	// Generally, the Create function should do the following things. Make
@@ -264,7 +264,7 @@ func (r *resource{{ .Resource }}) Create(ctx context.Context, req resource.Creat
 	{{ if .IncludeComments }}
 	// TIP: -- 2. Fetch the plan
 	{{- end }}
-	var plan resource{{ .Resource }}Model
+	var plan {{ .ResourceLowerCamel }}ResourceModel
 	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
 	if resp.Diagnostics.HasError() {
 		return
@@ -325,7 +325,7 @@ func (r *resource{{ .Resource }}) Create(ctx context.Context, req resource.Creat
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, plan))
 }
 
-func (r *resource{{ .Resource }}) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *{{ .ResourceLowerCamel }}Resource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	{{- if .IncludeComments }}
 	// TIP: ==== RESOURCE READ ====
 	// Generally, the Read function should do the following things. Make
@@ -346,7 +346,7 @@ func (r *resource{{ .Resource }}) Read(ctx context.Context, req resource.ReadReq
 	{{ if .IncludeComments }}
 	// TIP: -- 2. Fetch the state
 	{{- end }}
-	var state resource{{ .Resource }}Model
+	var state {{ .ResourceLowerCamel }}ResourceModel
 	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
 	if resp.Diagnostics.HasError() {
 		return
@@ -381,7 +381,7 @@ func (r *resource{{ .Resource }}) Read(ctx context.Context, req resource.ReadReq
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &state))
 }
 
-func (r *resource{{ .Resource }}) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *{{ .ResourceLowerCamel }}Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	{{- if .IncludeComments }}
 	// TIP: ==== RESOURCE UPDATE ====
 	// Not all resources have Update functions. There are a few reasons:
@@ -412,7 +412,7 @@ func (r *resource{{ .Resource }}) Update(ctx context.Context, req resource.Updat
 	{{ if .IncludeComments }}
 	// TIP: -- 2. Fetch the plan
 	{{- end }}
-	var plan, state resource{{ .Resource }}Model
+	var plan, state {{ .ResourceLowerCamel }}ResourceModel
 	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
 	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
 	if resp.Diagnostics.HasError() {
@@ -470,7 +470,7 @@ func (r *resource{{ .Resource }}) Update(ctx context.Context, req resource.Updat
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
 }
 
-func (r *resource{{ .Resource }}) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *{{ .ResourceLowerCamel }}Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	{{- if .IncludeComments }}
 	// TIP: ==== RESOURCE DELETE ====
 	// Most resources have Delete functions. There are rare situations
@@ -496,7 +496,7 @@ func (r *resource{{ .Resource }}) Delete(ctx context.Context, req resource.Delet
 	{{ if .IncludeComments }}
 	// TIP: -- 2. Fetch the state
 	{{- end }}
-	var state resource{{ .Resource }}Model
+	var state {{ .ResourceLowerCamel }}ResourceModel
 	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
 	if resp.Diagnostics.HasError() {
 		return
@@ -542,7 +542,7 @@ func (r *resource{{ .Resource }}) Delete(ctx context.Context, req resource.Delet
 // See more:
 // https://developer.hashicorp.com/terraform/plugin/framework/resources/import
 {{- end }}
-func (r *resource{{ .Resource }}) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *{{ .ResourceLowerCamel }}Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root(names.AttrID), req, resp)
 }
 
@@ -698,7 +698,7 @@ func find{{ .Resource }}ByID(ctx context.Context, conn *{{ .ServiceLower }}.Clie
 // See more:
 // https://developer.hashicorp.com/terraform/plugin/framework/handling-data/accessing-values
 {{- end }}
-type resource{{ .Resource }}Model struct {
+type {{ .ResourceLowerCamel }}ResourceModel struct {
 	framework.WithRegionModel
 	ARN             types.String                                          `tfsdk:"arn"`
 	ComplexArgument fwtypes.ListNestedObjectValueOf[complexArgumentModel] `tfsdk:"complex_argument"`
@@ -750,7 +750,7 @@ func sweep{{ .Resource }}s(ctx context.Context, client *conns.AWSClient) ([]swee
 		}
 
 		for _, v := range page.{{ .ResourceAWS }}s {
-			sweepResources = append(sweepResources, sweepfw.NewSweepResource(newResource{{ .Resource }}, client,
+			sweepResources = append(sweepResources, sweepfw.NewSweepResource(new{{ .Resource }}Resource, client,
 				sweepfw.NewAttribute(names.AttrID, aws.ToString(v.{{ .ResourceAWS }}Id))),
 			)
 		}

--- a/skaff/resource/resourcetest.gtpl
+++ b/skaff/resource/resourcetest.gtpl
@@ -235,7 +235,7 @@ func TestAcc{{ .Service }}{{ .Resource }}_disappears(t *testing.T) {
 					// private function to the testing package, you may need to add a line like the following
 					// to exports_test.go:
 					//
-					//   var Resource{{ .Resource}} = newResource{{ .Resource }}
+					//   var Resource{{ .Resource}} = new{{ .Resource }}Resource
 					{{- end }}
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tf{{ .ServicePackage }}.Resource{{ .Resource }}, resourceName),
 				),


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to update skaff and templates to generate function and object names based on the proper naming convention with correct word ordering.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #45938

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Reviewed various existing resource, data source, list resource, and ephemeral resource code for the standard naming conventions.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

n/a - tests were done locally by running `skaff` for various objects and reviewing the generate code for proper function/variable names and whether there are related bad syntax errors in the IDE.