### PR TITLE
d/aws_s3control_multi_region_access_points: new data source

### DIFF
--- a/.changelog/45974.txt
+++ b/.changelog/45974.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_s3control_multi_region_access_points
+```

--- a/internal/service/s3control/access_points_data_source.go
+++ b/internal/service/s3control/access_points_data_source.go
@@ -26,10 +26,6 @@ func newDataSourceAccessPoints(context.Context) (datasource.DataSourceWithConfig
 	return &dataSourceAccessPoints{}, nil
 }
 
-const (
-	DSNameAccessPoints = "Access Points Data Source"
-)
-
 type dataSourceAccessPoints struct {
 	framework.DataSourceWithModel[dataSourceAccessPointsModel]
 }

--- a/internal/service/s3control/multi_region_access_points_data_source.go
+++ b/internal/service/s3control/multi_region_access_points_data_source.go
@@ -1,0 +1,116 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package s3control
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3control"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/s3control/types"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_s3control_multi_region_access_points", name="Multi Region Access Points")
+func newMultiRegionAccessPointsDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &multiRegionAccessPointsDataSource{}, nil
+}
+
+type multiRegionAccessPointsDataSource struct {
+	framework.DataSourceWithModel[multiRegionAccessPointsDataSourceModel]
+}
+
+func (d *multiRegionAccessPointsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"access_points": framework.DataSourceComputedListOfObjectAttribute[multiRegionAccessPointListDataSourceModel](ctx),
+			names.AttrAccountID: schema.StringAttribute{
+				Optional: true,
+				Validators: []validator.String{
+					fwvalidators.AWSAccountID(),
+				},
+			},
+		},
+	}
+}
+
+func (d *multiRegionAccessPointsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().S3ControlClient(ctx)
+
+	var data multiRegionAccessPointsDataSourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Config.Get(ctx, &data))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var input s3control.ListMultiRegionAccessPointsInput
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Expand(ctx, data, &input))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if input.AccountId == nil {
+		input.AccountId = aws.String(d.Meta().AccountID(ctx))
+	}
+
+	out, err := findMultiRegionAccessPoints(ctx, conn, &input)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err)
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &data.AccessPoints))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
+}
+
+func findMultiRegionAccessPoints(ctx context.Context, conn *s3control.Client, input *s3control.ListMultiRegionAccessPointsInput) ([]awstypes.MultiRegionAccessPointReport, error) {
+	paginator := s3control.NewListMultiRegionAccessPointsPaginator(conn, input)
+
+	var output []awstypes.MultiRegionAccessPointReport
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, page.AccessPoints...)
+	}
+
+	return output, nil
+}
+
+type multiRegionAccessPointsDataSourceModel struct {
+	framework.WithRegionModel
+	AccessPoints fwtypes.ListNestedObjectValueOf[multiRegionAccessPointListDataSourceModel] `tfsdk:"access_points"`
+	AccountID    types.String                                                               `tfsdk:"account_id"`
+}
+
+type multiRegionAccessPointListDataSourceModel struct {
+	Alias             types.String                                                         `tfsdk:"alias"`
+	CreatedAt         timetypes.RFC3339                                                    `tfsdk:"created_at"`
+	Name              types.String                                                         `tfsdk:"name"`
+	PublicAccessBlock fwtypes.ListNestedObjectValueOf[publicAccessBlockConfigurationModel] `tfsdk:"public_access_block"`
+	Regions           fwtypes.ListNestedObjectValueOf[regionReportModel]                   `tfsdk:"regions"`
+	Status            types.String                                                         `tfsdk:"status"`
+}
+
+type regionReportModel struct {
+	Bucket          types.String `tfsdk:"bucket"`
+	BucketAccountID types.String `tfsdk:"bucket_account_id"`
+	Region          types.String `tfsdk:"region"`
+}

--- a/internal/service/s3control/multi_region_access_points_data_source_test.go
+++ b/internal/service/s3control/multi_region_access_points_data_source_test.go
@@ -1,0 +1,54 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package s3control_test
+
+import (
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccS3ControlMultiRegionAccessPointsDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_s3control_multi_region_access_points.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ControlServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMultiRegionAccessPointsDataSourceConfig_basic(bucketName, rName),
+				// Use traditional Check block here as the knownvalue.ListPartial check requires
+				// the index at which the partially known object is stored. When run in parallel
+				// this test configuration may return many multi-region access points in an unpredictable order.
+				Check: resource.ComposeTestCheckFunc(
+					// Check that we have at least one multi-region access point with the expected name
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "access_points.*", map[string]string{
+						names.AttrName: rName,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccMultiRegionAccessPointsDataSourceConfig_basic(bucketName, rName string) string {
+	return acctest.ConfigCompose(
+		testAccMultiRegionAccessPointConfig_basic(bucketName, rName),
+		`
+data "aws_s3control_multi_region_access_points" "test" {
+  depends_on = [aws_s3control_multi_region_access_point.test]
+}
+`)
+}

--- a/internal/service/s3control/service_package_gen.go
+++ b/internal/service/s3control/service_package_gen.go
@@ -37,6 +37,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 			Name:     "Access Points",
 			Region:   unique.Make(inttypes.ResourceRegionDefault()),
 		},
+		{
+			Factory:  newMultiRegionAccessPointsDataSource,
+			TypeName: "aws_s3control_multi_region_access_points",
+			Name:     "Multi Region Access Points",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
 	}
 }
 

--- a/website/docs/d/s3control_multi_region_access_points.html.markdown
+++ b/website/docs/d/s3control_multi_region_access_points.html.markdown
@@ -1,0 +1,54 @@
+---
+subcategory: "S3 Control"
+layout: "aws"
+page_title: "AWS: aws_s3control_multi_region_access_points"
+description: |-
+  Provides details about AWS S3 Control Multi-Region Access Points.
+---
+
+# Data Source: aws_s3control_multi_region_access_points
+
+Provides details about AWS S3 Control Multi-Region Access Points.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_s3control_multi_region_access_points" "example" {}
+```
+
+## Argument Reference
+
+The following arguments are optional:
+
+* `account_id` - (Optional) AWS account ID for the account that owns the multi-region access points. If omitted, defaults to the caller's account ID.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `access_points` - List of multi-region access points. See [`access_points`](#access_points-attribute-reference) below.
+
+### `access_points` Attribute Reference
+
+* `alias` - Alias for the multi-region access point.
+* `created_at` - Time the multi-region access point was created.
+* `name` - Name of the multi-region access point.
+* `public_access_block` - Public access block configuration for this multi-region access point. See [`public_access_block`](#public_access_block-attribute-reference) below.
+* `regions` - List of AWS Regions where the multi-region access point has data support. See [`regions`](#regions-attribute-reference) below.
+* `status` - Current status of the multi-region access point.
+
+#### `public_access_block` Attribute Reference
+
+* `block_public_acls` - Whether Amazon S3 should block public ACLs for buckets in this account.
+* `block_public_policy` - Whether Amazon S3 should block public bucket policies for buckets in this account.
+* `ignore_public_acls` - Whether Amazon S3 should ignore public ACLs for buckets in this account.
+* `restrict_public_buckets` - Whether Amazon S3 should restrict public bucket policies for buckets in this account.
+
+#### `regions` Attribute Reference
+
+* `bucket` - Name of the associated bucket for the Region.
+* `bucket_account_id` - AWS account ID that owns the Amazon S3 bucket associated with this multi-region access point.
+* `region` - Name of the Region.


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This data source will allow practitioners to list S3 multi-region access points within a given account.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42027

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_ListMultiRegionAccessPoints.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=s3control T=TestAccS3ControlMultiRegionAccessPointsDataSource_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-s3control_multiregion_access_points 🌿...
TF_ACC=1 go1.25.5 test ./internal/service/s3control/... -v -count 1 -parallel 20 -run='TestAccS3ControlMultiRegionAccessPointsDataSource_'  -timeout 360m -vet=off
2026/01/14 10:37:29 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/14 10:37:29 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccS3ControlMultiRegionAccessPointsDataSource_basic (243.23s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3control  249.780s
```
