### PR TITLE
d/aws_s3_bucket_object_lock_configuration: new data source

### DIFF
--- a/.changelog/45990.txt
+++ b/.changelog/45990.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_s3_bucket_object_lock_configuration
+```

--- a/internal/service/s3/bucket_object_lock_configuration_data_source.go
+++ b/internal/service/s3/bucket_object_lock_configuration_data_source.go
@@ -1,0 +1,97 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package s3
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_s3_bucket_object_lock_configuration", name="Bucket Object Lock Configuration")
+func newBucketObjectLockConfigurationDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &bucketObjectLockConfigurationDataSource{}, nil
+}
+
+const (
+	DSNameBucketObjectLockConfiguration = "Bucket Object Lock Configuration Data Source"
+)
+
+type bucketObjectLockConfigurationDataSource struct {
+	framework.DataSourceWithModel[bucketObjectLockConfigurationDataSourceModel]
+}
+
+func (d *bucketObjectLockConfigurationDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrBucket: schema.StringAttribute{
+				Required: true,
+			},
+			names.AttrExpectedBucketOwner: schema.StringAttribute{
+				Optional: true,
+			},
+			"object_lock_enabled": schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrRule: framework.DataSourceComputedListOfObjectAttribute[dataBucketObjectLockConfigRuleModel](ctx),
+		},
+	}
+}
+
+func (d *bucketObjectLockConfigurationDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().S3Client(ctx)
+
+	var data bucketObjectLockConfigurationDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	bucket := data.Bucket.ValueString()
+	if isDirectoryBucket(bucket) {
+		conn = d.Meta().S3ExpressClient(ctx)
+	}
+
+	expectedBucketOwner := data.ExpectedBucketOwner.ValueString()
+	out, err := findObjectLockConfiguration(ctx, conn, bucket, expectedBucketOwner)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.S3, create.ErrActionReading, DSNameBucketObjectLockConfiguration, bucket, err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+type bucketObjectLockConfigurationDataSourceModel struct {
+	framework.WithRegionModel
+	Bucket              types.String                                                         `tfsdk:"bucket"`
+	ExpectedBucketOwner types.String                                                         `tfsdk:"expected_bucket_owner"`
+	ObjectLockEnabled   types.String                                                         `tfsdk:"object_lock_enabled"`
+	Rule                fwtypes.ListNestedObjectValueOf[dataBucketObjectLockConfigRuleModel] `tfsdk:"rule"`
+}
+
+type dataBucketObjectLockConfigRuleModel struct {
+	DefaultRetention fwtypes.ListNestedObjectValueOf[dataBucketObjectLockConfigDefaultRetentionModel] `tfsdk:"default_retention"`
+}
+
+type dataBucketObjectLockConfigDefaultRetentionModel struct {
+	Days  types.Int64  `tfsdk:"days"`
+	Mode  types.String `tfsdk:"mode"`
+	Years types.Int64  `tfsdk:"years"`
+}

--- a/internal/service/s3/bucket_object_lock_configuration_data_source_test.go
+++ b/internal/service/s3/bucket_object_lock_configuration_data_source_test.go
@@ -1,0 +1,137 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package s3_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccS3BucketObjectLockConfigurationDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_s3_bucket_object_lock_configuration.test"
+	resourceName := "aws_s3_bucket_object_lock_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketObjectLockConfigurationDataSourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrBucket, resourceName, names.AttrBucket),
+					resource.TestCheckResourceAttr(dataSourceName, "object_lock_enabled", string(types.ObjectLockEnabledEnabled)),
+					resource.TestCheckResourceAttr(dataSourceName, acctest.CtRulePound, "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "rule.0.default_retention.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "rule.0.default_retention.0.days", "3"),
+					resource.TestCheckResourceAttr(dataSourceName, "rule.0.default_retention.0.mode", string(types.ObjectLockRetentionModeCompliance)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccS3BucketObjectLockConfigurationDataSource_noRule(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_s3_bucket_object_lock_configuration.test"
+	resourceName := "aws_s3_bucket_object_lock_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketObjectLockConfigurationDataSourceConfig_noRule(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrBucket, resourceName, names.AttrBucket),
+					resource.TestCheckResourceAttr(dataSourceName, "object_lock_enabled", string(types.ObjectLockEnabledEnabled)),
+					resource.TestCheckResourceAttr(dataSourceName, acctest.CtRulePound, "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccS3BucketObjectLockConfigurationDataSource_notConfigured(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccBucketObjectLockConfigurationDataSourceConfig_notConfigured(rName),
+				ExpectError: regexache.MustCompile(`couldn't find resource`),
+			},
+		},
+	})
+}
+
+func testAccBucketObjectLockConfigurationDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  object_lock_enabled = true
+}
+
+resource "aws_s3_bucket_object_lock_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  rule {
+    default_retention {
+      mode = %[2]q
+      days = 3
+    }
+  }
+}
+
+data "aws_s3_bucket_object_lock_configuration" "test" {
+  bucket = aws_s3_bucket_object_lock_configuration.test.bucket
+}
+`, rName, types.ObjectLockRetentionModeCompliance)
+}
+
+func testAccBucketObjectLockConfigurationDataSourceConfig_noRule(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  object_lock_enabled = true
+}
+
+resource "aws_s3_bucket_object_lock_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+}
+
+data "aws_s3_bucket_object_lock_configuration" "test" {
+  bucket = aws_s3_bucket_object_lock_configuration.test.bucket
+}
+`, rName)
+}
+
+func testAccBucketObjectLockConfigurationDataSourceConfig_notConfigured(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+data "aws_s3_bucket_object_lock_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+}
+`, rName)
+}

--- a/internal/service/s3/service_package_gen.go
+++ b/internal/service/s3/service_package_gen.go
@@ -23,6 +23,12 @@ type servicePackage struct{}
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
 	return []*inttypes.ServicePackageFrameworkDataSource{
 		{
+			Factory:  newBucketObjectLockConfigurationDataSource,
+			TypeName: "aws_s3_bucket_object_lock_configuration",
+			Name:     "Bucket Object Lock Configuration",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+		{
 			Factory:  newDataSourceBucketReplicationConfiguration,
 			TypeName: "aws_s3_bucket_replication_configuration",
 			Name:     "Bucket Replication Configuration",

--- a/website/docs/d/s3_bucket_object_lock_configuration.html.markdown
+++ b/website/docs/d/s3_bucket_object_lock_configuration.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "S3 (Simple Storage)"
+layout: "aws"
+page_title: "AWS: aws_s3_bucket_object_lock_configuration"
+description: |-
+  Provides details about an AWS S3 (Simple Storage) Bucket Object Lock Configuration.
+---
+
+# Data Source: aws_s3_bucket_object_lock_configuration
+
+Provides details about an AWS S3 (Simple Storage) Bucket Object Lock Configuration.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_s3_bucket_object_lock_configuration" "example" {
+  bucket = "example-bucket"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `bucket` - (Required) Name of the bucket.
+
+The following arguments are optional:
+
+* `expected_bucket_owner` - (Optional) Account ID of the expected bucket owner.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `object_lock_enabled` - Indicates whether this bucket has an Object Lock configuration enabled.
+* `rule` - Object lock rule for the specified object. See [Rule](#rule) below.
+
+### Rule
+
+The `rule` block supports the following:
+
+* `default_retention` - Default object lock retention settings for new objects placed in the bucket. See [Default Retention](#default-retention) below.
+
+### Default Retention
+
+The `default_retention` block supports the following:
+
+* `days` - Default retention period in days.
+* `mode` - Default object lock retention mode. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+* `years` - Default retention period in years.


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This data source will allow practitioners to retrieve details about the object lock configuration applied to an S3 bucket.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #45955

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectLockConfiguration.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=s3 T=TestAccS3BucketObjectLockConfigurationDataSource_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-s3-object_lock_config 🌿...
TF_ACC=1 go1.25.5 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketObjectLockConfigurationDataSource_'  -timeout 360m -vet=off
2026/01/15 10:35:03 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/15 10:35:03 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccS3BucketObjectLockConfigurationDataSource_notConfigured (9.03s)
--- PASS: TestAccS3BucketObjectLockConfigurationDataSource_noRule (16.04s)
--- PASS: TestAccS3BucketObjectLockConfigurationDataSource_basic (16.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 22.642s
```
