### PR TITLE
docs: update target_group_arns resource reference in autoscaling_group

### DIFF
--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -440,7 +440,7 @@ This resource supports the following arguments:
   group names. Only valid for classic load balancers. For ALBs, use `target_group_arns` instead. To remove all load balancer attachments an empty list should be specified.
 - `traffic_source` - (Optional) Attaches one or more traffic sources to the specified Auto Scaling group.
 - `vpc_zone_identifier` - (Optional) List of subnet IDs to launch resources in. Subnets automatically determine which availability zones the group will reside. Conflicts with `availability_zones`.
-- `target_group_arns` - (Optional) Set of `aws_alb_target_group` ARNs, for use with Application or Network Load Balancing. To remove all target group attachments an empty list should be specified.
+- `target_group_arns` - (Optional) Set of `aws_lb_target_group` ARNs, for use with Application or Network Load Balancing. To remove all target group attachments an empty list should be specified.
 - `termination_policies` - (Optional) List of policies to decide how the instances in the Auto Scaling Group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `OldestLaunchTemplate`, `AllocationStrategy`, `Default`. Additionally, the ARN of a Lambda function can be specified for custom termination policies.
 - `suspended_processes` - (Optional) List of processes to suspend for the Auto Scaling Group. The allowed values are `Launch`, `Terminate`, `HealthCheck`, `ReplaceUnhealthy`, `AZRebalance`, `AlarmNotification`, `ScheduledActions`, `AddToLoadBalancer`, `InstanceRefresh`.
   Note that if you suspend either the `Launch` or `Terminate` process types, it can prevent your Auto Scaling Group from functioning properly.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description

This pull request updates the `target_group_arns` argument reference in the `autoscaling_group` documentation. It changes the reference from `aws_alb_target_group` to `aws_lb_target_group`.

While the functionality is identical, `aws_alb_target_group` is an alias. Updating this to the preferred `aws_lb_target_group` resource name ensures consistency across the AWS provider documentation and follows current best practices.

### References

- [AWS Provider: `aws_lb_target_group` documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) - Verifies that `aws_alb_target_group` is known as `aws_lb_target_group`.

### Output from Acceptance Testing

N/A - Documentation change only.