### PR TITLE
d/aws_resourcegroupstaggingapi_required_tags: new data source

### DIFF
--- a/.changelog/45994.txt
+++ b/.changelog/45994.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_resourcegroupstaggingapi_required_tags
+```

--- a/internal/service/resourcegroupstaggingapi/required_tags_data_source.go
+++ b/internal/service/resourcegroupstaggingapi/required_tags_data_source.go
@@ -1,0 +1,85 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package resourcegroupstaggingapi
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+)
+
+// @FrameworkDataSource("aws_resourcegroupstaggingapi_required_tags", name="Required Tags")
+func newRequiredTagsDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &requiredTagsDataSource{}, nil
+}
+
+type requiredTagsDataSource struct {
+	framework.DataSourceWithModel[requiredTagsDataSourceModel]
+}
+
+func (d *requiredTagsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"required_tags": framework.DataSourceComputedListOfObjectAttribute[requiredTagModel](ctx),
+		},
+	}
+}
+func (d *requiredTagsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().ResourceGroupsTaggingAPIClient(ctx)
+
+	var data requiredTagsDataSourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Config.Get(ctx, &data))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findRequiredTags(ctx, conn)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err)
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &data.RequiredTags))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
+}
+
+func findRequiredTags(ctx context.Context, conn *resourcegroupstaggingapi.Client) ([]awstypes.RequiredTag, error) {
+	input := resourcegroupstaggingapi.ListRequiredTagsInput{}
+	paginator := resourcegroupstaggingapi.NewListRequiredTagsPaginator(conn, &input)
+
+	var output []awstypes.RequiredTag
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, page.RequiredTags...)
+	}
+
+	return output, nil
+}
+
+type requiredTagsDataSourceModel struct {
+	framework.WithRegionModel
+	RequiredTags fwtypes.ListNestedObjectValueOf[requiredTagModel] `tfsdk:"required_tags"`
+}
+
+type requiredTagModel struct {
+	CloudFormationResourceTypes fwtypes.ListValueOf[types.String] `tfsdk:"cloud_formation_resource_types"`
+	ReportingTagKeys            fwtypes.ListValueOf[types.String] `tfsdk:"reporting_tag_keys"`
+	ResourceType                types.String                      `tfsdk:"resource_type"`
+}

--- a/internal/service/resourcegroupstaggingapi/required_tags_data_source_test.go
+++ b/internal/service/resourcegroupstaggingapi/required_tags_data_source_test.go
@@ -1,0 +1,41 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package resourcegroupstaggingapi_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccResourceGroupsTaggingAPIRequiredTagsDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_resourcegroupstaggingapi_required_tags.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ResourceGroupsTaggingAPIEndpointID)
+			acctest.PreCheckResourceGroupsTaggingAPIRequiredTags(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ResourceGroupsTaggingAPIServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRequiredTagsDataSourceConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "required_tags.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRequiredTagsDataSourceConfig_basic() string {
+	return `
+data "aws_resourcegroupstaggingapi_required_tags" "test" {}
+`
+}

--- a/internal/service/resourcegroupstaggingapi/service_package_gen.go
+++ b/internal/service/resourcegroupstaggingapi/service_package_gen.go
@@ -21,7 +21,14 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
-	return []*inttypes.ServicePackageFrameworkDataSource{}
+	return []*inttypes.ServicePackageFrameworkDataSource{
+		{
+			Factory:  newRequiredTagsDataSource,
+			TypeName: "aws_resourcegroupstaggingapi_required_tags",
+			Name:     "Required Tags",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.ServicePackageFrameworkResource {

--- a/names/names.go
+++ b/names/names.go
@@ -127,6 +127,7 @@ const (
 	RedshiftServerlessEndpointID           = "redshift-serverless"
 	RekognitionEndpointID                  = "rekognition"
 	ResourceExplorer2EndpointID            = "resource-explorer-2"
+	ResourceGroupsTaggingAPIEndpointID     = "tagging"
 	RolesAnywhereEndpointID                = "rolesanywhere"
 	Route53DomainsEndpointID               = "route53domains"
 	Route53RecoveryControlConfigEndpointID = "route53-recovery-control-config"

--- a/website/docs/d/resourcegroupstaggingapi_required_tags.html.markdown
+++ b/website/docs/d/resourcegroupstaggingapi_required_tags.html.markdown
@@ -1,0 +1,37 @@
+---
+subcategory: "Resource Groups Tagging"
+layout: "aws"
+page_title: "AWS: aws_resourcegroupstaggingapi_required_tags"
+description: |-
+  Lists required tags for supported resource types in an AWS account.
+---
+
+# Data Source: aws_resourcegroupstaggingapi_required_tags
+
+Lists the required tags for supported resource types in an AWS account. Required tags are defined through AWS Organizations [tag policies](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies.html).
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_resourcegroupstaggingapi_required_tags" "example" {}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `required_tags` - List of required tag configurations. See [`required_tags`](#required_tags) below.
+
+### `required_tags`
+
+* `cloud_formation_resource_types` - CloudFormation resource types assigned the required tag keys.
+* `reporting_tag_keys` - Tag keys marked as required in the `report_required_tag_for` block of the effective tag policy.
+* `resource_type` - Resource type for the required tag keys.


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This data source will allow practitioners to list all required tags defined in the tag policies applied by their owning organization.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #45214
Relates https://github.com/hashicorp/terraform-provider-aws/pull/45143

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make t K=resourcegroupstaggingapi T=TestAccResourceGroupsTaggingAPIRequiredTagsDataSource_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-rgta-required_tags 🌿...
TF_ACC=1 go1.25.5 test ./internal/service/resourcegroupstaggingapi/... -v -count 1 -parallel 20 -run='TestAccResourceGroupsTaggingAPIRequiredTagsDataSource_basic'  -timeout 360m -vet=off
2026/01/15 15:30:16 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/15 15:30:16 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccResourceGroupsTaggingAPIRequiredTagsDataSource_basic (10.38s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroupstaggingapi   16.977s
```
