### PR TITLE
[New resource] aws_arczonalshift_zonal _autoshift_configuration

### DIFF
--- a/.changelog/46007.txt
+++ b/.changelog/46007.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_arczonalshift_zonal_autoshift_configuration
+```

--- a/internal/service/arczonalshift/exports_test.go
+++ b/internal/service/arczonalshift/exports_test.go
@@ -1,0 +1,9 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package arczonalshift
+
+var (
+	ResourceZonalAutoshiftConfiguration = newResourceZonalAutoshiftConfiguration
+	FindManagedResourceByIdentifier     = findManagedResourceByIdentifier
+)

--- a/internal/service/arczonalshift/service_package_gen.go
+++ b/internal/service/arczonalshift/service_package_gen.go
@@ -7,6 +7,7 @@ package arczonalshift
 
 import (
 	"context"
+	"unique"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/arczonalshift"
@@ -24,7 +25,14 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.ServicePackageFrameworkResource {
-	return []*inttypes.ServicePackageFrameworkResource{}
+	return []*inttypes.ServicePackageFrameworkResource{
+		{
+			Factory:  newResourceZonalAutoshiftConfiguration,
+			TypeName: "aws_arczonalshift_zonal_autoshift_configuration",
+			Name:     "Zonal Autoshift Configuration",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*inttypes.ServicePackageSDKDataSource {

--- a/internal/service/arczonalshift/sweep.go
+++ b/internal/service/arczonalshift/sweep.go
@@ -1,0 +1,12 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package arczonalshift
+
+import (
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
+)
+
+func RegisterSweepers() {
+	awsv2.Register("aws_arczonalshift_zonal_autoshift_configuration", sweepZonalAutoshiftConfigurations)
+}

--- a/internal/service/arczonalshift/zonal_autoshift_configuration.go
+++ b/internal/service/arczonalshift/zonal_autoshift_configuration.go
@@ -1,0 +1,427 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package arczonalshift
+
+import (
+	"context"
+	"time"
+
+	"github.com/YakDriver/smarterr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/arczonalshift"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/arczonalshift/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	sweepfw "github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_arczonalshift_zonal_autoshift_configuration", name="Zonal Autoshift Configuration")
+func newResourceZonalAutoshiftConfiguration(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceZonalAutoshiftConfiguration{}
+
+	r.SetDefaultCreateTimeout(30 * time.Minute)
+	r.SetDefaultUpdateTimeout(30 * time.Minute)
+	r.SetDefaultDeleteTimeout(30 * time.Minute)
+
+	return r, nil
+}
+
+const (
+	ResNameZonalAutoshiftConfiguration = "Zonal Autoshift Configuration"
+)
+
+type resourceZonalAutoshiftConfiguration struct {
+	framework.ResourceWithModel[resourceZonalAutoshiftConfigurationModel]
+	framework.WithTimeouts
+}
+
+func (r *resourceZonalAutoshiftConfiguration) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrResourceARN: schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"outcome_alarm_arns": schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				Required:    true,
+				ElementType: types.StringType,
+			},
+			"blocking_alarm_arns": schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"blocked_dates": schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				Optional:    true,
+				ElementType: types.StringType,
+				Validators: []validator.List{
+					listvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("allowed_windows")),
+				},
+			},
+			"blocked_windows": schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				Optional:    true,
+				ElementType: types.StringType,
+				Validators: []validator.List{
+					listvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("allowed_windows")),
+				},
+			},
+			"allowed_windows": schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				Optional:    true,
+				ElementType: types.StringType,
+				Validators: []validator.List{
+					listvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("blocked_windows")),
+				},
+			},
+			"autoshift_enabled": schema.BoolAttribute{
+				Required: true,
+			},
+		},
+	}
+}
+
+func (r *resourceZonalAutoshiftConfiguration) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().ARCZonalShiftClient(ctx)
+
+	var plan resourceZonalAutoshiftConfigurationModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := arczonalshift.CreatePracticeRunConfigurationInput{
+		ResourceIdentifier: plan.ResourceARN.ValueStringPointer(),
+		OutcomeAlarms:      expandControlConditions(ctx, plan.OutcomeAlarmARNs),
+	}
+
+	if !plan.BlockingAlarmARNs.IsNull() {
+		input.BlockingAlarms = expandControlConditions(ctx, plan.BlockingAlarmARNs)
+	}
+
+	if !plan.BlockedDates.IsNull() {
+		input.BlockedDates = expandStringList(ctx, plan.BlockedDates)
+	}
+
+	if !plan.BlockedWindows.IsNull() {
+		input.BlockedWindows = expandStringList(ctx, plan.BlockedWindows)
+	}
+
+	if !plan.AllowedWindows.IsNull() {
+		input.AllowedWindows = expandStringList(ctx, plan.AllowedWindows)
+	}
+
+	out, err := conn.CreatePracticeRunConfiguration(ctx, &input)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ResourceARN.String())
+		return
+	}
+
+	if out == nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ResourceARN.String())
+		return
+	}
+
+	statusInput := arczonalshift.UpdateZonalAutoshiftConfigurationInput{
+		ResourceIdentifier:   plan.ResourceARN.ValueStringPointer(),
+		ZonalAutoshiftStatus: awstypes.ZonalAutoshiftStatusDisabled,
+	}
+
+	if plan.AutoshiftEnabled.ValueBool() {
+		statusInput.ZonalAutoshiftStatus = awstypes.ZonalAutoshiftStatusEnabled
+	}
+
+	out2, err := conn.UpdateZonalAutoshiftConfiguration(ctx, &statusInput)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ResourceARN.String())
+		return
+	}
+
+	if out2 == nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ResourceARN.String())
+		return
+	}
+
+	plan.ResourceARN = types.StringValue(aws.ToString(out2.ResourceIdentifier))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, plan))
+}
+
+func (r *resourceZonalAutoshiftConfiguration) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().ARCZonalShiftClient(ctx)
+
+	var state resourceZonalAutoshiftConfigurationModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findManagedResourceByIdentifier(ctx, conn, state.ResourceARN.ValueString())
+	if retry.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.ARCZonalShift, create.ErrActionReading, ResNameZonalAutoshiftConfiguration, state.ResourceARN.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	if out == nil || out.PracticeRunConfiguration == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	state.AutoshiftEnabled = types.BoolValue(out.ZonalAutoshiftStatus == awstypes.ZonalAutoshiftStatusEnabled)
+	state.OutcomeAlarmARNs = flattenControlConditions(ctx, out.PracticeRunConfiguration.OutcomeAlarms)
+	state.BlockingAlarmARNs = flattenControlConditions(ctx, out.PracticeRunConfiguration.BlockingAlarms)
+	state.BlockedDates = flattenStringList(ctx, out.PracticeRunConfiguration.BlockedDates)
+	state.BlockedWindows = flattenStringList(ctx, out.PracticeRunConfiguration.BlockedWindows)
+	state.AllowedWindows = flattenStringList(ctx, out.PracticeRunConfiguration.AllowedWindows)
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &state))
+}
+
+func (r *resourceZonalAutoshiftConfiguration) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().ARCZonalShiftClient(ctx)
+
+	var plan, state resourceZonalAutoshiftConfigurationModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceIdentifier := plan.ResourceARN.ValueString()
+
+	practiceRunChanged := !plan.OutcomeAlarmARNs.Equal(state.OutcomeAlarmARNs) ||
+		!plan.BlockingAlarmARNs.Equal(state.BlockingAlarmARNs) ||
+		!plan.BlockedDates.Equal(state.BlockedDates) ||
+		!plan.BlockedWindows.Equal(state.BlockedWindows) ||
+		!plan.AllowedWindows.Equal(state.AllowedWindows)
+
+	if practiceRunChanged {
+		input := arczonalshift.UpdatePracticeRunConfigurationInput{
+			ResourceIdentifier: aws.String(resourceIdentifier),
+			OutcomeAlarms:      expandControlConditions(ctx, plan.OutcomeAlarmARNs),
+		}
+
+		if !plan.BlockingAlarmARNs.IsNull() {
+			input.BlockingAlarms = expandControlConditions(ctx, plan.BlockingAlarmARNs)
+		}
+
+		if !plan.BlockedDates.IsNull() {
+			input.BlockedDates = expandStringList(ctx, plan.BlockedDates)
+		}
+
+		if !plan.BlockedWindows.IsNull() {
+			input.BlockedWindows = expandStringList(ctx, plan.BlockedWindows)
+			input.AllowedWindows = []string{}
+		} else if !plan.AllowedWindows.IsNull() {
+			input.AllowedWindows = expandStringList(ctx, plan.AllowedWindows)
+			input.BlockedWindows = []string{}
+		} else {
+			input.BlockedWindows = []string{}
+			input.AllowedWindows = []string{}
+		}
+
+		_, err := conn.UpdatePracticeRunConfiguration(ctx, &input)
+		if err != nil {
+			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, resourceIdentifier)
+			return
+		}
+	}
+
+	if !plan.AutoshiftEnabled.Equal(state.AutoshiftEnabled) {
+		status := awstypes.ZonalAutoshiftStatusDisabled
+		if plan.AutoshiftEnabled.ValueBool() {
+			status = awstypes.ZonalAutoshiftStatusEnabled
+		}
+
+		input := arczonalshift.UpdateZonalAutoshiftConfigurationInput{
+			ResourceIdentifier:   aws.String(resourceIdentifier),
+			ZonalAutoshiftStatus: status,
+		}
+		_, err := conn.UpdateZonalAutoshiftConfiguration(ctx, &input)
+		if err != nil {
+			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, resourceIdentifier)
+			return
+		}
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
+}
+
+func (r *resourceZonalAutoshiftConfiguration) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().ARCZonalShiftClient(ctx)
+
+	var state resourceZonalAutoshiftConfigurationModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceIdentifier := state.ResourceARN.ValueString()
+
+	statusInput := arczonalshift.UpdateZonalAutoshiftConfigurationInput{
+		ResourceIdentifier:   aws.String(resourceIdentifier),
+		ZonalAutoshiftStatus: awstypes.ZonalAutoshiftStatusDisabled,
+	}
+	_, err := conn.UpdateZonalAutoshiftConfiguration(ctx, &statusInput)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return
+		}
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, resourceIdentifier)
+		return
+	}
+
+	deleteInput := arczonalshift.DeletePracticeRunConfigurationInput{
+		ResourceIdentifier: aws.String(resourceIdentifier),
+	}
+	_, err = conn.DeletePracticeRunConfiguration(ctx, &deleteInput)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return
+		}
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, resourceIdentifier)
+		return
+	}
+}
+
+func (r *resourceZonalAutoshiftConfiguration) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root(names.AttrResourceARN), req, resp)
+}
+
+func expandControlConditions(ctx context.Context, list fwtypes.ListOfString) []awstypes.ControlCondition {
+	if list.IsNull() || list.IsUnknown() {
+		return nil
+	}
+
+	var arns []string
+	list.ElementsAs(ctx, &arns, false)
+
+	conditions := make([]awstypes.ControlCondition, len(arns))
+	for i, arn := range arns {
+		conditions[i] = awstypes.ControlCondition{
+			AlarmIdentifier: aws.String(arn),
+			Type:            awstypes.ControlConditionTypeCloudwatch,
+		}
+	}
+	return conditions
+}
+
+func flattenControlConditions(ctx context.Context, conditions []awstypes.ControlCondition) fwtypes.ListOfString {
+	if len(conditions) == 0 {
+		return fwtypes.NewListValueOfNull[basetypes.StringValue](ctx)
+	}
+
+	elements := make([]attr.Value, len(conditions))
+	for i, condition := range conditions {
+		elements[i] = basetypes.NewStringValue(aws.ToString(condition.AlarmIdentifier))
+	}
+
+	return fwtypes.NewListValueOfMust[basetypes.StringValue](ctx, elements)
+}
+
+func expandStringList(ctx context.Context, list fwtypes.ListOfString) []string {
+	if list.IsNull() || list.IsUnknown() {
+		return nil
+	}
+
+	var result []string
+	list.ElementsAs(ctx, &result, false)
+	return result
+}
+
+func flattenStringList(ctx context.Context, list []string) fwtypes.ListOfString {
+	if len(list) == 0 {
+		return fwtypes.NewListValueOfNull[basetypes.StringValue](ctx)
+	}
+
+	elements := make([]attr.Value, len(list))
+	for i, s := range list {
+		elements[i] = basetypes.NewStringValue(s)
+	}
+
+	return fwtypes.NewListValueOfMust[basetypes.StringValue](ctx, elements)
+}
+
+// Finder functions
+func findManagedResourceByIdentifier(ctx context.Context, conn *arczonalshift.Client, resourceIdentifier string) (*arczonalshift.GetManagedResourceOutput, error) {
+	input := arczonalshift.GetManagedResourceInput{
+		ResourceIdentifier: aws.String(resourceIdentifier),
+	}
+
+	out, err := conn.GetManagedResource(ctx, &input)
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError: err,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+type resourceZonalAutoshiftConfigurationModel struct {
+	framework.WithRegionModel
+	ResourceARN       types.String         `tfsdk:"resource_arn"`
+	OutcomeAlarmARNs  fwtypes.ListOfString `tfsdk:"outcome_alarm_arns"`
+	BlockingAlarmARNs fwtypes.ListOfString `tfsdk:"blocking_alarm_arns"`
+	BlockedDates      fwtypes.ListOfString `tfsdk:"blocked_dates"`
+	BlockedWindows    fwtypes.ListOfString `tfsdk:"blocked_windows"`
+	AllowedWindows    fwtypes.ListOfString `tfsdk:"allowed_windows"`
+	AutoshiftEnabled  types.Bool           `tfsdk:"autoshift_enabled"`
+}
+
+func sweepZonalAutoshiftConfigurations(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	input := arczonalshift.ListManagedResourcesInput{}
+	conn := client.ARCZonalShiftClient(ctx)
+	var sweepResources []sweep.Sweepable
+
+	pages := arczonalshift.NewListManagedResourcesPaginator(conn, &input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			return nil, smarterr.NewError(err)
+		}
+
+		for _, v := range page.Items {
+			if v.ZonalAutoshiftStatus == awstypes.ZonalAutoshiftStatusEnabled || v.PracticeRunStatus != "" {
+				sweepResources = append(sweepResources, sweepfw.NewSweepResource(newResourceZonalAutoshiftConfiguration, client,
+					sweepfw.NewAttribute(names.AttrResourceARN, aws.ToString(v.Arn))),
+				)
+			}
+		}
+	}
+
+	return sweepResources, nil
+}

--- a/internal/service/arczonalshift/zonal_autoshift_configuration_test.go
+++ b/internal/service/arczonalshift/zonal_autoshift_configuration_test.go
@@ -1,0 +1,456 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package arczonalshift_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/arczonalshift"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfarczonalshift "github.com/hashicorp/terraform-provider-aws/internal/service/arczonalshift"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccARCZonalShiftZonalAutoshiftConfiguration_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v arczonalshift.GetManagedResourceOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_arczonalshift_zonal_autoshift_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ARCZonalShiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckZonalAutoshiftConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZonalAutoshiftConfigurationConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckZonalAutoshiftConfigurationExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrResourceARN),
+					resource.TestCheckResourceAttr(resourceName, "autoshift_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "outcome_alarm_arns.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccARCZonalShiftZonalAutoshiftConfiguration_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v arczonalshift.GetManagedResourceOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_arczonalshift_zonal_autoshift_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ARCZonalShiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckZonalAutoshiftConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZonalAutoshiftConfigurationConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckZonalAutoshiftConfigurationExists(ctx, resourceName, &v),
+					acctest.CheckFrameworkResourceDisappears(ctx, t, tfarczonalshift.ResourceZonalAutoshiftConfiguration, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccARCZonalShiftZonalAutoshiftConfiguration_importBasic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_arczonalshift_zonal_autoshift_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ARCZonalShiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckZonalAutoshiftConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZonalAutoshiftConfigurationConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrResourceARN),
+					resource.TestCheckResourceAttr(resourceName, "autoshift_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "outcome_alarm_arns.#", "1"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrResourceARN),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrResourceARN,
+			},
+		},
+	})
+}
+
+func TestAccARCZonalShiftZonalAutoshiftConfiguration_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v arczonalshift.GetManagedResourceOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_arczonalshift_zonal_autoshift_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ARCZonalShiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckZonalAutoshiftConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZonalAutoshiftConfigurationConfig_autoshiftDisabled(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckZonalAutoshiftConfigurationExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "autoshift_enabled", acctest.CtFalse),
+				),
+			},
+			{
+				Config: testAccZonalAutoshiftConfigurationConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckZonalAutoshiftConfigurationExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "autoshift_enabled", acctest.CtTrue),
+				),
+			},
+		},
+	})
+}
+
+func TestAccARCZonalShiftZonalAutoshiftConfiguration_blockingAlarms(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v arczonalshift.GetManagedResourceOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_arczonalshift_zonal_autoshift_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ARCZonalShiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckZonalAutoshiftConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZonalAutoshiftConfigurationConfig_blockingAlarms(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckZonalAutoshiftConfigurationExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "outcome_alarm_arns.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "blocking_alarm_arns.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccARCZonalShiftZonalAutoshiftConfiguration_blockedWindows(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v arczonalshift.GetManagedResourceOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_arczonalshift_zonal_autoshift_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ARCZonalShiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckZonalAutoshiftConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZonalAutoshiftConfigurationConfig_blockedWindows(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckZonalAutoshiftConfigurationExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "blocked_windows.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccARCZonalShiftZonalAutoshiftConfiguration_allowedWindows(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v arczonalshift.GetManagedResourceOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_arczonalshift_zonal_autoshift_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ARCZonalShiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckZonalAutoshiftConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZonalAutoshiftConfigurationConfig_allowedWindows(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckZonalAutoshiftConfigurationExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "allowed_windows.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccARCZonalShiftZonalAutoshiftConfiguration_blockedDates(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v arczonalshift.GetManagedResourceOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_arczonalshift_zonal_autoshift_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ARCZonalShiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckZonalAutoshiftConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZonalAutoshiftConfigurationConfig_blockedDates(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckZonalAutoshiftConfigurationExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "blocked_dates.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckZonalAutoshiftConfigurationDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ARCZonalShiftClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_arczonalshift_zonal_autoshift_configuration" {
+				continue
+			}
+
+			out, err := tfarczonalshift.FindManagedResourceByIdentifier(ctx, conn, rs.Primary.Attributes[names.AttrResourceARN])
+			if err != nil {
+				return err
+			}
+
+			// Resource exists but practice run configuration should be nil after destroy
+			if out != nil && out.PracticeRunConfiguration == nil {
+				continue
+			}
+
+			if out != nil && out.PracticeRunConfiguration != nil {
+				return fmt.Errorf("ARC Zonal Shift Zonal Autoshift Configuration %s still exists", rs.Primary.Attributes[names.AttrResourceARN])
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckZonalAutoshiftConfigurationExists(ctx context.Context, name string, v *arczonalshift.GetManagedResourceOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ARCZonalShiftClient(ctx)
+
+		out, err := tfarczonalshift.FindManagedResourceByIdentifier(ctx, conn, rs.Primary.Attributes[names.AttrResourceARN])
+		if err != nil {
+			return err
+		}
+
+		if out == nil || out.PracticeRunConfiguration == nil {
+			return fmt.Errorf("ARC Zonal Shift Zonal Autoshift Configuration %s does not exist", rs.Primary.Attributes[names.AttrResourceARN])
+		}
+
+		*v = *out
+
+		return nil
+	}
+}
+
+func testAccZonalAutoshiftConfigurationConfig_base(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigVPCWithSubnets(rName, 2),
+		fmt.Sprintf(`
+resource "aws_lb" "test" {
+  name               = %[1]q
+  internal           = true
+  load_balancer_type = "application"
+  subnets            = aws_subnet.test[*].id
+
+  enable_deletion_protection = false
+  enable_zonal_shift         = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "outcome" {
+  alarm_name          = "%[1]s-outcome"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "TargetResponseTime"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 1
+  alarm_description   = "Outcome alarm for zonal autoshift practice run"
+
+  dimensions = {
+    LoadBalancer = aws_lb.test.arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "blocking" {
+  alarm_name          = "%[1]s-blocking"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "UnHealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 1
+  alarm_description   = "Blocking alarm for zonal autoshift practice run"
+
+  dimensions = {
+    LoadBalancer = aws_lb.test.arn_suffix
+  }
+}
+`, rName),
+	)
+}
+
+func testAccZonalAutoshiftConfigurationConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccZonalAutoshiftConfigurationConfig_base(rName),
+		`
+resource "aws_arczonalshift_zonal_autoshift_configuration" "test" {
+  resource_arn       = aws_lb.test.arn
+  outcome_alarm_arns = [aws_cloudwatch_metric_alarm.outcome.arn]
+  autoshift_enabled  = true
+}
+`)
+}
+
+func testAccZonalAutoshiftConfigurationConfig_autoshiftDisabled(rName string) string {
+	return acctest.ConfigCompose(
+		testAccZonalAutoshiftConfigurationConfig_base(rName),
+		`
+resource "aws_arczonalshift_zonal_autoshift_configuration" "test" {
+  resource_arn       = aws_lb.test.arn
+  outcome_alarm_arns = [aws_cloudwatch_metric_alarm.outcome.arn]
+  autoshift_enabled  = false
+}
+`)
+}
+
+func testAccZonalAutoshiftConfigurationConfig_blockingAlarms(rName string) string {
+	return acctest.ConfigCompose(
+		testAccZonalAutoshiftConfigurationConfig_base(rName),
+		`
+resource "aws_arczonalshift_zonal_autoshift_configuration" "test" {
+  resource_arn        = aws_lb.test.arn
+  outcome_alarm_arns  = [aws_cloudwatch_metric_alarm.outcome.arn]
+  blocking_alarm_arns = [aws_cloudwatch_metric_alarm.blocking.arn]
+  autoshift_enabled   = true
+}
+`)
+}
+
+func testAccZonalAutoshiftConfigurationConfig_blockedWindows(rName string) string {
+	return acctest.ConfigCompose(
+		testAccZonalAutoshiftConfigurationConfig_base(rName),
+		`
+resource "aws_arczonalshift_zonal_autoshift_configuration" "test" {
+  resource_arn       = aws_lb.test.arn
+  outcome_alarm_arns = [aws_cloudwatch_metric_alarm.outcome.arn]
+  blocked_windows    = ["Mon:00:00-Mon:08:00"]
+  autoshift_enabled  = true
+}
+`)
+}
+
+func testAccZonalAutoshiftConfigurationConfig_allowedWindows(rName string) string {
+	return acctest.ConfigCompose(
+		testAccZonalAutoshiftConfigurationConfig_base(rName),
+		`
+resource "aws_arczonalshift_zonal_autoshift_configuration" "test" {
+  resource_arn       = aws_lb.test.arn
+  outcome_alarm_arns = [aws_cloudwatch_metric_alarm.outcome.arn]
+  allowed_windows    = ["Mon:09:00-Mon:17:00"]
+  autoshift_enabled  = true
+}
+`)
+}
+
+func testAccZonalAutoshiftConfigurationConfig_blockedDates(rName string) string {
+	return acctest.ConfigCompose(
+		testAccZonalAutoshiftConfigurationConfig_base(rName),
+		`
+resource "aws_arczonalshift_zonal_autoshift_configuration" "test" {
+  resource_arn       = aws_lb.test.arn
+  outcome_alarm_arns = [aws_cloudwatch_metric_alarm.outcome.arn]
+  blocked_dates      = ["2026-12-25"]
+  autoshift_enabled  = true
+}
+`)
+}

--- a/internal/service/elbv2/sweep.go
+++ b/internal/service/elbv2/sweep.go
@@ -25,6 +25,7 @@ func RegisterSweepers() {
 			"aws_api_gateway_vpc_link",
 			"aws_vpc_endpoint_service",
 			"aws_lb_listener",
+			"aws_arczonalshift_zonal_autoshift_configuration",
 		},
 	})
 

--- a/internal/sweep/register_gen_test.go
+++ b/internal/sweep/register_gen_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/service/apprunner"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/appstream"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/appsync"
+	"github.com/hashicorp/terraform-provider-aws/internal/service/arczonalshift"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/athena"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/auditmanager"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling"
@@ -208,6 +209,7 @@ func registerSweepers() {
 	apprunner.RegisterSweepers()
 	appstream.RegisterSweepers()
 	appsync.RegisterSweepers()
+	arczonalshift.RegisterSweepers()
 	athena.RegisterSweepers()
 	auditmanager.RegisterSweepers()
 	autoscaling.RegisterSweepers()

--- a/website/docs/r/arczonalshift_zonal_autoshift_configuration.html.markdown
+++ b/website/docs/r/arczonalshift_zonal_autoshift_configuration.html.markdown
@@ -1,0 +1,109 @@
+---
+subcategory: "Application Recovery Controller Zonal Shift"
+layout: "aws"
+page_title: "AWS: aws_arczonalshift_zonal_autoshift_configuration"
+description: |-
+  Manages an AWS Application Recovery Controller Zonal Shift Zonal Autoshift Configuration.
+---
+
+# Resource: aws_arczonalshift_zonal_autoshift_configuration
+
+Manages an AWS Application Recovery Controller Zonal Shift Zonal Autoshift Configuration for a managed resource (such as a load balancer).
+
+Zonal autoshift is a capability in AWS Application Recovery Controller (ARC) that automatically shifts traffic away from an Availability Zone when AWS identifies a potential issue, helping maintain application availability.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_lb" "example" {
+  name               = "example"
+  internal           = true
+  load_balancer_type = "application"
+  subnets            = aws_subnet.example[*].id
+
+  enable_zonal_shift = true
+}
+
+resource "aws_cloudwatch_metric_alarm" "example" {
+  alarm_name          = "example-outcome-alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "TargetResponseTime"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 1
+  alarm_description   = "Outcome alarm for zonal autoshift practice run"
+
+  dimensions = {
+    LoadBalancer = aws_lb.example.arn_suffix
+  }
+}
+
+resource "aws_arczonalshift_zonal_autoshift_configuration" "example" {
+  resource_arn       = aws_lb.example.arn
+  outcome_alarm_arns = [aws_cloudwatch_metric_alarm.example.arn]
+  autoshift_enabled  = true
+}
+```
+
+### With Blocking Alarms
+
+```terraform
+resource "aws_arczonalshift_zonal_autoshift_configuration" "example" {
+  resource_arn        = aws_lb.example.arn
+  outcome_alarm_arns  = [aws_cloudwatch_metric_alarm.outcome.arn]
+  blocking_alarm_arns = [aws_cloudwatch_metric_alarm.blocking.arn]
+  autoshift_enabled   = true
+}
+```
+
+### With Blocked Windows
+
+```terraform
+resource "aws_arczonalshift_zonal_autoshift_configuration" "example" {
+  resource_arn       = aws_lb.example.arn
+  outcome_alarm_arns = [aws_cloudwatch_metric_alarm.example.arn]
+  blocked_windows    = ["Mon:00:00-Mon:08:00"]
+  autoshift_enabled  = true
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `resource_arn` - (Required) The ARN of the managed resource to configure zonal autoshift for (e.g., an Application Load Balancer). Changing this creates a new resource.
+* `outcome_alarm_arns` - (Required) List of CloudWatch alarm ARNs that are monitored during practice runs. These alarms help determine the health of your application during zonal shifts.
+* `autoshift_enabled` - (Required) Whether zonal autoshift is enabled. When set to `true`, traffic will be automatically shifted away from an Availability Zone when AWS identifies a potential issue.
+
+The following arguments are optional:
+
+* `region` - (Optional) AWS region where the resource is deployed.
+* `blocking_alarm_arns` - (Optional) List of CloudWatch alarm ARNs that can block practice runs when in alarm state.
+* `blocked_dates` - (Optional) List of dates when practice runs should not be started, in the format `YYYY-MM-DD`. Cannot be used together with `allowed_windows`.
+* `blocked_windows` - (Optional) List of time windows during which practice runs should not be started, in the format `Day:HH:MM-Day:HH:MM` (e.g., `Mon:00:00-Mon:08:00`). Cannot be used together with `allowed_windows`.
+* `allowed_windows` - (Optional) List of time windows during which practice runs are allowed, in the format `Day:HH:MM-Day:HH:MM` (e.g., `Mon:09:00-Mon:17:00`). Cannot be used together with `blocked_windows` or `blocked_dates`.
+
+## Attribute Reference
+
+This resource exports no additional attributes beyond the arguments above.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import ARC Zonal Shift Zonal Autoshift Configuration using the `resource_arn`. For example:
+
+```terraform
+import {
+  to = aws_arczonalshift_zonal_autoshift_configuration.example
+  id = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/example/50dc6c495c0c9188"
+}
+```
+
+Using `terraform import`, import ARC Zonal Shift Zonal Autoshift Configuration using the `resource_arn`. For example:
+
+```console
+% terraform import aws_arczonalshift_zonal_autoshift_configuration.example arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/example/50dc6c495c0c9188
+```


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Creates a zonal autoshift configuration resource to allow automatic zonal shift.

### Relations

Closes #37120

### References
https://docs.aws.amazon.com/r53recovery/latest/dg/arc-zonal-shift.html
https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/arczonalshift


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
✦ ❯ make testacc TESTS=TestAccARCZonalShiftZonalAutoshiftConfiguration PKG=arczonalshift
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_arczonalshift_zonal_autoshift_configuration 🌿...
TF_ACC=1 go1.25.5 test ./internal/service/arczonalshift/... -v -count 1 -parallel 20 -run='TestAccARCZonalShiftZonalAutoshiftConfiguration'  -timeout 360m -vet=off
2026/01/16 14:00:12 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/16 14:00:12 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccARCZonalShiftZonalAutoshiftConfiguration_basic
=== PAUSE TestAccARCZonalShiftZonalAutoshiftConfiguration_basic
=== RUN   TestAccARCZonalShiftZonalAutoshiftConfiguration_disappears
=== PAUSE TestAccARCZonalShiftZonalAutoshiftConfiguration_disappears
=== RUN   TestAccARCZonalShiftZonalAutoshiftConfiguration_update
=== PAUSE TestAccARCZonalShiftZonalAutoshiftConfiguration_update
=== RUN   TestAccARCZonalShiftZonalAutoshiftConfiguration_blockingAlarms
=== PAUSE TestAccARCZonalShiftZonalAutoshiftConfiguration_blockingAlarms
=== RUN   TestAccARCZonalShiftZonalAutoshiftConfiguration_blockedWindows
=== PAUSE TestAccARCZonalShiftZonalAutoshiftConfiguration_blockedWindows
=== RUN   TestAccARCZonalShiftZonalAutoshiftConfiguration_allowedWindows
=== PAUSE TestAccARCZonalShiftZonalAutoshiftConfiguration_allowedWindows
=== RUN   TestAccARCZonalShiftZonalAutoshiftConfiguration_blockedDates
=== PAUSE TestAccARCZonalShiftZonalAutoshiftConfiguration_blockedDates
=== CONT  TestAccARCZonalShiftZonalAutoshiftConfiguration_basic
=== CONT  TestAccARCZonalShiftZonalAutoshiftConfiguration_blockedWindows
=== CONT  TestAccARCZonalShiftZonalAutoshiftConfiguration_update
=== CONT  TestAccARCZonalShiftZonalAutoshiftConfiguration_blockingAlarms
=== CONT  TestAccARCZonalShiftZonalAutoshiftConfiguration_blockedDates
=== CONT  TestAccARCZonalShiftZonalAutoshiftConfiguration_allowedWindows
=== CONT  TestAccARCZonalShiftZonalAutoshiftConfiguration_disappears
--- PASS: TestAccARCZonalShiftZonalAutoshiftConfiguration_basic (229.25s)
--- PASS: TestAccARCZonalShiftZonalAutoshiftConfiguration_blockedWindows (232.49s)
--- PASS: TestAccARCZonalShiftZonalAutoshiftConfiguration_blockingAlarms (237.25s)
--- PASS: TestAccARCZonalShiftZonalAutoshiftConfiguration_allowedWindows (237.25s)
--- PASS: TestAccARCZonalShiftZonalAutoshiftConfiguration_disappears (241.42s)
--- PASS: TestAccARCZonalShiftZonalAutoshiftConfiguration_update (262.66s)
--- PASS: TestAccARCZonalShiftZonalAutoshiftConfiguration_blockedDates (266.01s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/arczonalshift	272.270s

...
```
