### PR TITLE
docs: clarify use of `user_agent` function in `provider_meta`

### DIFF
--- a/website/docs/functions/user_agent.html.markdown
+++ b/website/docs/functions/user_agent.html.markdown
@@ -7,7 +7,9 @@ description: |-
 ---
 # Function: user_agent
 
-Formats a User-Agent product for use with the `user_agent` argument in the `provider` or `provider_meta` block.
+Formats a User-Agent product for use with the `user_agent` argument in the `provider` block.
+
+-> Functions cannot be used in the [`terraform` block](https://developer.hashicorp.com/terraform/language/block/terraform#terraform-block), meaning this utility cannot be used with the [`provider_meta`](https://developer.hashicorp.com/terraform/language/block/terraform#provider_meta) `user_agent` argument.
 
 ## Example Usage
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -341,6 +341,8 @@ This block allows module authors to provide additional information in the `User-
 -> In a module, `provider_meta` is defined within the `terraform` block.
 The `provider` block is inherited from the root module.
 
+-> Functions, including the [`user_agent` provider-defined function](./functions/user_agent.html.markdown), cannot be used in the [`terraform` block](https://developer.hashicorp.com/terraform/language/block/terraform#terraform-block).
+
 ```terraform
 terraform {
   required_providers {
@@ -352,8 +354,7 @@ terraform {
 
   provider_meta "aws" {
     user_agent = [
-      provider::aws::user_agent("example-demo", "0.0.1", "a comment"),
-      "other-demo/0.0.2 (other comment)",
+      "module-demo/0.0.3 (another comment)",
     ]
   }
 }


### PR DESCRIPTION

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The `terraform` block prohibits use of named objects or functions (both built-in and provider defined). This change updates the relevant documentation with a notice about this limitation. 

Ref: https://developer.hashicorp.com/terraform/language/block/terraform#terraform-block


### Relations

Relates #45464