### PR TITLE
Test generation: Adds `acctest.PreCheckMultipleRegion` when using alternate region

### DIFF
--- a/internal/generate/tests/annotations.go
+++ b/internal/generate/tests/annotations.go
@@ -324,7 +324,7 @@ func ParseTestingAnnotations(args common.Args, stuff *CommonArgs) error {
 			})
 			stuff.GoImports = append(stuff.GoImports,
 				common.GoImport{
-					Path: "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema",
+					Path: "github.com/hashicorp/terraform-provider-aws/internal/acctest",
 				},
 			)
 		}
@@ -335,6 +335,14 @@ func ParseTestingAnnotations(args common.Args, stuff *CommonArgs) error {
 			return err
 		} else {
 			stuff.AlternateRegionProvider = b
+			stuff.PreChecks = append(stuff.PreChecks, CodeBlock{
+				Code: "acctest.PreCheckMultipleRegion(t, 2)",
+			})
+			stuff.GoImports = append(stuff.GoImports,
+				common.GoImport{
+					Path: "github.com/hashicorp/terraform-provider-aws/internal/acctest",
+				},
+			)
 		}
 	}
 

--- a/internal/service/dynamodb/table_replica_tags_gen_test.go
+++ b/internal/service/dynamodb/table_replica_tags_gen_test.go
@@ -29,7 +29,10 @@ func TestAccDynamoDBTableReplica_tags(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -229,7 +232,10 @@ func TestAccDynamoDBTableReplica_tags_null(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -304,7 +310,10 @@ func TestAccDynamoDBTableReplica_tags_EmptyMap(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -375,7 +384,10 @@ func TestAccDynamoDBTableReplica_tags_AddOnUpdate(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -464,7 +476,10 @@ func TestAccDynamoDBTableReplica_tags_EmptyTag_OnCreate(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -563,7 +578,10 @@ func TestAccDynamoDBTableReplica_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -712,7 +730,10 @@ func TestAccDynamoDBTableReplica_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -809,7 +830,10 @@ func TestAccDynamoDBTableReplica_tags_DefaultTags_providerOnly(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -1001,7 +1025,10 @@ func TestAccDynamoDBTableReplica_tags_DefaultTags_nonOverlapping(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -1170,7 +1197,10 @@ func TestAccDynamoDBTableReplica_tags_DefaultTags_overlapping(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -1355,7 +1385,10 @@ func TestAccDynamoDBTableReplica_tags_DefaultTags_updateToProviderOnly(t *testin
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -1451,7 +1484,10 @@ func TestAccDynamoDBTableReplica_tags_DefaultTags_updateToResourceOnly(t *testin
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -1546,7 +1582,10 @@ func TestAccDynamoDBTableReplica_tags_DefaultTags_emptyResourceTag(t *testing.T)
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -1616,7 +1655,10 @@ func TestAccDynamoDBTableReplica_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -1678,7 +1720,10 @@ func TestAccDynamoDBTableReplica_tags_DefaultTags_nullOverlappingResourceTag(t *
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -1745,7 +1790,10 @@ func TestAccDynamoDBTableReplica_tags_DefaultTags_nullNonOverlappingResourceTag(
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -1812,7 +1860,10 @@ func TestAccDynamoDBTableReplica_tags_ComputedTag_OnCreate(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -1872,7 +1923,10 @@ func TestAccDynamoDBTableReplica_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -1975,7 +2029,10 @@ func TestAccDynamoDBTableReplica_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -2068,7 +2125,10 @@ func TestAccDynamoDBTableReplica_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -2236,7 +2296,10 @@ func TestAccDynamoDBTableReplica_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{

--- a/internal/service/kms/replica_external_key_tags_gen_test.go
+++ b/internal/service/kms/replica_external_key_tags_gen_test.go
@@ -31,7 +31,10 @@ func TestAccKMSReplicaExternalKey_tags(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -244,7 +247,10 @@ func TestAccKMSReplicaExternalKey_tags_null(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -323,7 +329,10 @@ func TestAccKMSReplicaExternalKey_tags_EmptyMap(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -398,7 +407,10 @@ func TestAccKMSReplicaExternalKey_tags_AddOnUpdate(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -491,7 +503,10 @@ func TestAccKMSReplicaExternalKey_tags_EmptyTag_OnCreate(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -597,7 +612,10 @@ func TestAccKMSReplicaExternalKey_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -753,7 +771,10 @@ func TestAccKMSReplicaExternalKey_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -854,7 +875,10 @@ func TestAccKMSReplicaExternalKey_tags_DefaultTags_providerOnly(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1059,7 +1083,10 @@ func TestAccKMSReplicaExternalKey_tags_DefaultTags_nonOverlapping(t *testing.T) 
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1238,7 +1265,10 @@ func TestAccKMSReplicaExternalKey_tags_DefaultTags_overlapping(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1433,7 +1463,10 @@ func TestAccKMSReplicaExternalKey_tags_DefaultTags_updateToProviderOnly(t *testi
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1533,7 +1566,10 @@ func TestAccKMSReplicaExternalKey_tags_DefaultTags_updateToResourceOnly(t *testi
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1632,7 +1668,10 @@ func TestAccKMSReplicaExternalKey_tags_DefaultTags_emptyResourceTag(t *testing.T
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1706,7 +1745,10 @@ func TestAccKMSReplicaExternalKey_tags_DefaultTags_emptyProviderOnlyTag(t *testi
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1772,7 +1814,10 @@ func TestAccKMSReplicaExternalKey_tags_DefaultTags_nullOverlappingResourceTag(t 
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1843,7 +1888,10 @@ func TestAccKMSReplicaExternalKey_tags_DefaultTags_nullNonOverlappingResourceTag
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1914,7 +1962,10 @@ func TestAccKMSReplicaExternalKey_tags_ComputedTag_OnCreate(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1978,7 +2029,10 @@ func TestAccKMSReplicaExternalKey_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -2085,7 +2139,10 @@ func TestAccKMSReplicaExternalKey_tags_ComputedTag_OnUpdate_Replace(t *testing.T
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -2182,7 +2239,10 @@ func TestAccKMSReplicaExternalKey_tags_IgnoreTags_Overlap_DefaultTag(t *testing.
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -2351,7 +2411,10 @@ func TestAccKMSReplicaExternalKey_tags_IgnoreTags_Overlap_ResourceTag(t *testing
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
 		Steps: []resource.TestStep{

--- a/internal/service/kms/replica_key_tags_gen_test.go
+++ b/internal/service/kms/replica_key_tags_gen_test.go
@@ -31,7 +31,10 @@ func TestAccKMSReplicaKey_tags(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -244,7 +247,10 @@ func TestAccKMSReplicaKey_tags_null(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -323,7 +329,10 @@ func TestAccKMSReplicaKey_tags_EmptyMap(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -398,7 +407,10 @@ func TestAccKMSReplicaKey_tags_AddOnUpdate(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -491,7 +503,10 @@ func TestAccKMSReplicaKey_tags_EmptyTag_OnCreate(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -597,7 +612,10 @@ func TestAccKMSReplicaKey_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -753,7 +771,10 @@ func TestAccKMSReplicaKey_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -854,7 +875,10 @@ func TestAccKMSReplicaKey_tags_DefaultTags_providerOnly(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1059,7 +1083,10 @@ func TestAccKMSReplicaKey_tags_DefaultTags_nonOverlapping(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1238,7 +1265,10 @@ func TestAccKMSReplicaKey_tags_DefaultTags_overlapping(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1433,7 +1463,10 @@ func TestAccKMSReplicaKey_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1533,7 +1566,10 @@ func TestAccKMSReplicaKey_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1632,7 +1668,10 @@ func TestAccKMSReplicaKey_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1706,7 +1745,10 @@ func TestAccKMSReplicaKey_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1772,7 +1814,10 @@ func TestAccKMSReplicaKey_tags_DefaultTags_nullOverlappingResourceTag(t *testing
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1843,7 +1888,10 @@ func TestAccKMSReplicaKey_tags_DefaultTags_nullNonOverlappingResourceTag(t *test
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1914,7 +1962,10 @@ func TestAccKMSReplicaKey_tags_ComputedTag_OnCreate(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1978,7 +2029,10 @@ func TestAccKMSReplicaKey_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -2085,7 +2139,10 @@ func TestAccKMSReplicaKey_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -2182,7 +2239,10 @@ func TestAccKMSReplicaKey_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -2351,7 +2411,10 @@ func TestAccKMSReplicaKey_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
 		Steps: []resource.TestStep{


### PR DESCRIPTION
…egion is used

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Updates generated tests to include `acctest.PreCheckMultipleRegion` to `PreCheck`s when using alternate region
