### PR TITLE
feat: Add storage_class_configuration block for r/aws_s3tables_table_bucket and r/aws_s3tables_table

### DIFF
--- a/.changelog/46015.txt
+++ b/.changelog/46015.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3tables_table_bucket: Add `storage_class_configuration` argument
+```

--- a/.changelog/46015.txt
+++ b/.changelog/46015.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_s3tables_table_bucket: Add `storage_class_configuration` argument
 ```
+
+```release-note:enhancement
+resource/aws_s3tables_table: Add `storage_class_configuration` argument
+```

--- a/website/docs/r/s3tables_table.html.markdown
+++ b/website/docs/r/s3tables_table.html.markdown
@@ -79,6 +79,30 @@ resource "aws_s3tables_table_bucket" "example" {
 }
 ```
 
+### With Storage Class Configuration
+
+```terraform
+resource "aws_s3tables_table" "example" {
+  name             = "example_table"
+  namespace        = aws_s3tables_namespace.example.namespace
+  table_bucket_arn = aws_s3tables_namespace.example.table_bucket_arn
+  format           = "ICEBERG"
+
+  storage_class_configuration = {
+    storage_class = "INTELLIGENT_TIERING"
+  }
+}
+
+resource "aws_s3tables_namespace" "example" {
+  namespace        = "example_namespace"
+  table_bucket_arn = aws_s3tables_table_bucket.example.arn
+}
+
+resource "aws_s3tables_table_bucket" "example" {
+  name = "example-bucket"
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -103,6 +127,8 @@ The following arguments are optional:
 * `metadata` - (Optional) Contains details about the table metadata. This configuration specifies the metadata format and schema for the table. Currently only supports Iceberg format.
   [See `metadata` below](#metadata).
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `storage_class_configuration` - (Optional, Forces new resource) A single table storage class configuration object.
+  [See `storage_class_configuration` below](#storage_class_configuration).
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### `encryption_configuration`
@@ -183,6 +209,14 @@ The `field` configuration block supports the following arguments:
 * `name` - (Required) The name of the field.
 * `type` - (Required) The field type. S3 Tables supports all Apache Iceberg primitive types including: `boolean`, `int`, `long`, `float`, `double`, `decimal(precision,scale)`, `date`, `time`, `timestamp`, `timestamptz`, `string`, `uuid`, `fixed(length)`, `binary`.
 * `required` - (Optional) A Boolean value that specifies whether values are required for each row in this field. Defaults to `false`.
+
+### `storage_class_configuration`
+
+The `storage_class_configuration` object supports the following argument:
+
+* `storage_class` - (Required, Forces new resource) The storage class for the table.
+  Valid values are `STANDARD` and `INTELLIGENT_TIERING`.
+  Note: Once set, the storage class cannot be changed and requires resource replacement.
 
 ## Attribute Reference
 

--- a/website/docs/r/s3tables_table_bucket.html.markdown
+++ b/website/docs/r/s3tables_table_bucket.html.markdown
@@ -20,6 +20,18 @@ resource "aws_s3tables_table_bucket" "example" {
 }
 ```
 
+### With Storage Class Configuration
+
+```terraform
+resource "aws_s3tables_table_bucket" "example" {
+  name = "example-bucket"
+
+  storage_class_configuration = {
+    storage_class = "INTELLIGENT_TIERING"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -37,6 +49,9 @@ The following arguments are optional:
 * `maintenance_configuration` - (Optional) A single table bucket maintenance configuration object.
   [See `maintenance_configuration` below](#maintenance_configuration).
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `storage_class_configuration` - (Optional) A single table bucket storage class configuration object.
+  If not specified, AWS will use the default storage class (`STANDARD`).
+  [See `storage_class_configuration` below](#storage_class_configuration).
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### `encryption_configuration`
@@ -70,6 +85,12 @@ The `iceberg_unreferenced_file_removal.settings` object supports the following a
   Must be at least `1`.
 * `unreferenced_days` - (Required) Unreferenced data objects are marked for deletion after this many days.
   Must be at least `1`.
+
+### `storage_class_configuration`
+
+The `storage_class_configuration` object supports the following argument:
+
+* `storage_class` - (Required) The storage class for the table bucket. Valid values are `STANDARD` and `INTELLIGENT_TIERING`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the `storage_class_configuration` block to the `aws_s3tables_table_bucket` and `aws_s3tables_table` resources to support Intelligent-Tiering storage class.

Note that for `aws_s3tables_table_bucket` I opted for a design that always set the block with Standard tiering by default to avoid unintended diffs. It seems that the API to get the configuration would always return Standard by default when not specified during creation.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #45361

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to the following API reference pages for specs and workings:

- [CreateTableBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_s3Buckets_CreateTableBucket.html)
- [GetTableBucketStorageClass](https://docs.aws.amazon.com/AmazonS3/latest/API/API_s3Buckets_GetTableBucketStorageClass.html)
- [PutTableBucketStorageClass](https://docs.aws.amazon.com/AmazonS3/latest/API/API_s3Buckets_PutTableBucketStorageClass.html)
- [CreateTable](https://docs.aws.amazon.com/AmazonS3/latest/API/API_s3Buckets_CreateTable.html)
- [GetTableStorageClass](https://docs.aws.amazon.com/AmazonS3/latest/API/API_s3Buckets_GetTableStorageClass.html)



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

**Note:** The identity tests always fail in my dev env possibly due to provider overriding - please ignore the fail statuses of those test cases.

For `aws_s3tables_table_bucket`:

```console
$ make testacc TESTS="TestAccS3TablesTableBucket_" PKG=s3tables ACCTEST_PARALLELISM=5
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: ðŸŒ¿ f-aws_s3tables_table_bucket-add_storage_class_configuration_arg ðŸŒ¿...
TF_ACC=1 go1.25.5 test ./internal/service/s3tables/... -v -count 1 -parallel 5 -run='TestAccS3TablesTableBucket_'  -timeout 360m -vet=off
2026/01/17 15:48:41 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/17 15:48:41 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3TablesTableBucket_Identity_Basic
=== PAUSE TestAccS3TablesTableBucket_Identity_Basic
=== RUN   TestAccS3TablesTableBucket_Identity_RegionOverride
=== PAUSE TestAccS3TablesTableBucket_Identity_RegionOverride
=== RUN   TestAccS3TablesTableBucket_Identity_ExistingResource
=== PAUSE TestAccS3TablesTableBucket_Identity_ExistingResource
=== RUN   TestAccS3TablesTableBucket_Identity_ExistingResource_NoRefresh_NoChange
=== PAUSE TestAccS3TablesTableBucket_Identity_ExistingResource_NoRefresh_NoChange
=== RUN   TestAccS3TablesTableBucket_tags
=== PAUSE TestAccS3TablesTableBucket_tags
=== RUN   TestAccS3TablesTableBucket_tags_null
=== PAUSE TestAccS3TablesTableBucket_tags_null
=== RUN   TestAccS3TablesTableBucket_tags_EmptyMap
=== PAUSE TestAccS3TablesTableBucket_tags_EmptyMap
=== RUN   TestAccS3TablesTableBucket_tags_AddOnUpdate
=== PAUSE TestAccS3TablesTableBucket_tags_AddOnUpdate
=== RUN   TestAccS3TablesTableBucket_tags_EmptyTag_OnCreate
=== PAUSE TestAccS3TablesTableBucket_tags_EmptyTag_OnCreate
=== RUN   TestAccS3TablesTableBucket_tags_EmptyTag_OnUpdate_Add      
=== PAUSE TestAccS3TablesTableBucket_tags_EmptyTag_OnUpdate_Add      
=== RUN   TestAccS3TablesTableBucket_tags_EmptyTag_OnUpdate_Replace  
=== PAUSE TestAccS3TablesTableBucket_tags_EmptyTag_OnUpdate_Replace  
=== RUN   TestAccS3TablesTableBucket_tags_DefaultTags_providerOnly   
=== PAUSE TestAccS3TablesTableBucket_tags_DefaultTags_providerOnly   
=== RUN   TestAccS3TablesTableBucket_tags_DefaultTags_nonOverlapping 
=== PAUSE TestAccS3TablesTableBucket_tags_DefaultTags_nonOverlapping 
=== RUN   TestAccS3TablesTableBucket_tags_DefaultTags_overlapping    
=== PAUSE TestAccS3TablesTableBucket_tags_DefaultTags_overlapping    
=== RUN   TestAccS3TablesTableBucket_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccS3TablesTableBucket_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccS3TablesTableBucket_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccS3TablesTableBucket_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccS3TablesTableBucket_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccS3TablesTableBucket_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccS3TablesTableBucket_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccS3TablesTableBucket_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccS3TablesTableBucket_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccS3TablesTableBucket_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccS3TablesTableBucket_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccS3TablesTableBucket_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccS3TablesTableBucket_tags_ComputedTag_OnCreate       
=== PAUSE TestAccS3TablesTableBucket_tags_ComputedTag_OnCreate       
=== RUN   TestAccS3TablesTableBucket_tags_ComputedTag_OnUpdate_Add   
=== PAUSE TestAccS3TablesTableBucket_tags_ComputedTag_OnUpdate_Add   
=== RUN   TestAccS3TablesTableBucket_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccS3TablesTableBucket_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccS3TablesTableBucket_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccS3TablesTableBucket_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccS3TablesTableBucket_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccS3TablesTableBucket_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccS3TablesTableBucket_basic
=== PAUSE TestAccS3TablesTableBucket_basic
=== RUN   TestAccS3TablesTableBucket_encryptionConfiguration
=== PAUSE TestAccS3TablesTableBucket_encryptionConfiguration
=== RUN   TestAccS3TablesTableBucket_disappears
=== PAUSE TestAccS3TablesTableBucket_disappears
=== RUN   TestAccS3TablesTableBucket_maintenanceConfiguration        
=== PAUSE TestAccS3TablesTableBucket_maintenanceConfiguration        
=== RUN   TestAccS3TablesTableBucket_forceDestroy
=== PAUSE TestAccS3TablesTableBucket_forceDestroy
=== RUN   TestAccS3TablesTableBucket_forceDestroyMultipleNamespacesAndTables
=== PAUSE TestAccS3TablesTableBucket_forceDestroyMultipleNamespacesAndTables
=== RUN   TestAccS3TablesTableBucket_storageClassConfiguration       
=== PAUSE TestAccS3TablesTableBucket_storageClassConfiguration       
=== CONT  TestAccS3TablesTableBucket_Identity_Basic
=== CONT  TestAccS3TablesTableBucket_tags_DefaultTags_emptyResourceTag
=== CONT  TestAccS3TablesTableBucket_tags_EmptyTag_OnCreate
=== CONT  TestAccS3TablesTableBucket_tags_DefaultTags_nonOverlapping 
=== CONT  TestAccS3TablesTableBucket_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccS3TablesTableBucket_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccS3TablesTableBucket_tags_DefaultTags_emptyResourceTag (36.03s)
--- PASS: TestAccS3TablesTableBucket_Identity_Basic (49.02s)
=== CONT  TestAccS3TablesTableBucket_tags_DefaultTags_overlapping
--- PASS: TestAccS3TablesTableBucket_tags_DefaultTags_updateToResourceOnly (54.23s)
=== CONT  TestAccS3TablesTableBucket_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccS3TablesTableBucket_tags_EmptyTag_OnCreate (60.27s)
=== CONT  TestAccS3TablesTableBucket_tags_DefaultTags_providerOnly
--- PASS: TestAccS3TablesTableBucket_tags_DefaultTags_updateToProviderOnly (51.95s)
=== CONT  TestAccS3TablesTableBucket_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccS3TablesTableBucket_tags_DefaultTags_nonOverlapping (88.00s)
=== CONT  TestAccS3TablesTableBucket_storageClassConfiguration       
--- PASS: TestAccS3TablesTableBucket_tags_EmptyTag_OnUpdate_Replace (51.72s)
=== CONT  TestAccS3TablesTableBucket_forceDestroyMultipleNamespacesAndTables
--- PASS: TestAccS3TablesTableBucket_tags_DefaultTags_overlapping (85.07s)
=== CONT  TestAccS3TablesTableBucket_forceDestroy
--- PASS: TestAccS3TablesTableBucket_forceDestroyMultipleNamespacesAndTables (31.47s)
=== CONT  TestAccS3TablesTableBucket_maintenanceConfiguration
--- PASS: TestAccS3TablesTableBucket_storageClassConfiguration (51.82s)
=== CONT  TestAccS3TablesTableBucket_disappears
--- PASS: TestAccS3TablesTableBucket_tags_IgnoreTags_Overlap_ResourceTag (70.57s)
=== CONT  TestAccS3TablesTableBucket_encryptionConfiguration
--- PASS: TestAccS3TablesTableBucket_forceDestroy (25.49s)
=== CONT  TestAccS3TablesTableBucket_tags_ComputedTag_OnCreate
--- PASS: TestAccS3TablesTableBucket_disappears (23.69s)
=== CONT  TestAccS3TablesTableBucket_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccS3TablesTableBucket_tags_DefaultTags_providerOnly (106.80s)
=== CONT  TestAccS3TablesTableBucket_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccS3TablesTableBucket_tags_ComputedTag_OnCreate (34.98s)
=== CONT  TestAccS3TablesTableBucket_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccS3TablesTableBucket_encryptionConfiguration (50.45s)
=== CONT  TestAccS3TablesTableBucket_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccS3TablesTableBucket_maintenanceConfiguration (78.08s)
=== CONT  TestAccS3TablesTableBucket_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccS3TablesTableBucket_tags_ComputedTag_OnUpdate_Replace (53.33s)
=== CONT  TestAccS3TablesTableBucket_tags
--- PASS: TestAccS3TablesTableBucket_tags_IgnoreTags_Overlap_DefaultTag (61.90s)
=== CONT  TestAccS3TablesTableBucket_tags_AddOnUpdate
--- PASS: TestAccS3TablesTableBucket_tags_DefaultTags_nullOverlappingResourceTag (31.64s)
=== CONT  TestAccS3TablesTableBucket_tags_EmptyMap
--- PASS: TestAccS3TablesTableBucket_tags_DefaultTags_nullNonOverlappingResourceTag (33.16s)
=== CONT  TestAccS3TablesTableBucket_tags_null
--- PASS: TestAccS3TablesTableBucket_tags_ComputedTag_OnUpdate_Add (56.87s)
=== CONT  TestAccS3TablesTableBucket_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccS3TablesTableBucket_tags_EmptyMap (32.78s)
=== CONT  TestAccS3TablesTableBucket_Identity_ExistingResource
--- PASS: TestAccS3TablesTableBucket_tags_AddOnUpdate (53.32s)
=== CONT  TestAccS3TablesTableBucket_Identity_ExistingResource_NoRefresh_NoChange
--- PASS: TestAccS3TablesTableBucket_tags_null (32.80s)
=== CONT  TestAccS3TablesTableBucket_tags_DefaultTags_emptyProviderOnlyTag
=== NAME  TestAccS3TablesTableBucket_Identity_ExistingResource
    table_bucket_identity_gen_test.go:246: Step 1/2 error: Post-apply refresh state check(s) failed:
        aws_s3tables_table_bucket.test - Identity found in state, and was not expected.
=== NAME  TestAccS3TablesTableBucket_Identity_ExistingResource_NoRefresh_NoChange
    table_bucket_identity_gen_test.go:305: Step 1/2 error: Post-apply refresh state check(s) failed:
        aws_s3tables_table_bucket.test - Identity found in state, and was not expected.
--- FAIL: TestAccS3TablesTableBucket_Identity_ExistingResource (37.38s)
=== CONT  TestAccS3TablesTableBucket_Identity_RegionOverride
--- FAIL: TestAccS3TablesTableBucket_Identity_ExistingResource_NoRefresh_NoChange (33.32s)
=== CONT  TestAccS3TablesTableBucket_basic
--- PASS: TestAccS3TablesTableBucket_tags_DefaultTags_emptyProviderOnlyTag (31.79s)
--- PASS: TestAccS3TablesTableBucket_tags_EmptyTag_OnUpdate_Add (75.39s)
--- PASS: TestAccS3TablesTableBucket_tags (106.81s)
--- PASS: TestAccS3TablesTableBucket_basic (29.02s)
--- PASS: TestAccS3TablesTableBucket_Identity_RegionOverride (48.16s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/s3tables        359.298s
FAIL
make: *** [GNUmakefile:839: testacc] Error 1

$
```

For `aws_s3tables_table_`:

```console
$ make testacc TESTS="TestAccS3TablesTable_" PKG=s3tables ACCTEST_PAR
ALLELISM=5
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: ðŸŒ¿ f-aws_s3tables_table_bucket-add_storage_class_configuration_arg ðŸŒ¿...
TF_ACC=1 go1.25.5 test ./internal/service/s3tables/... -v -count 1 -parallel 5 -run='TestAccS3TablesTable_'  -timeout 360m -vet=off       
2026/01/17 23:05:07 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/17 23:05:07 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3TablesTable_tags
=== PAUSE TestAccS3TablesTable_tags
=== RUN   TestAccS3TablesTable_tags_null
=== PAUSE TestAccS3TablesTable_tags_null
=== RUN   TestAccS3TablesTable_tags_EmptyMap
=== PAUSE TestAccS3TablesTable_tags_EmptyMap
=== RUN   TestAccS3TablesTable_tags_AddOnUpdate
=== PAUSE TestAccS3TablesTable_tags_AddOnUpdate
=== RUN   TestAccS3TablesTable_tags_EmptyTag_OnCreate
=== PAUSE TestAccS3TablesTable_tags_EmptyTag_OnCreate
=== RUN   TestAccS3TablesTable_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccS3TablesTable_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccS3TablesTable_tags_EmptyTag_OnUpdate_Replace        
=== PAUSE TestAccS3TablesTable_tags_EmptyTag_OnUpdate_Replace        
=== RUN   TestAccS3TablesTable_tags_DefaultTags_providerOnly
=== PAUSE TestAccS3TablesTable_tags_DefaultTags_providerOnly
=== RUN   TestAccS3TablesTable_tags_DefaultTags_nonOverlapping       
=== PAUSE TestAccS3TablesTable_tags_DefaultTags_nonOverlapping       
=== RUN   TestAccS3TablesTable_tags_DefaultTags_overlapping
=== PAUSE TestAccS3TablesTable_tags_DefaultTags_overlapping
=== RUN   TestAccS3TablesTable_tags_DefaultTags_updateToProviderOnly 
=== PAUSE TestAccS3TablesTable_tags_DefaultTags_updateToProviderOnly 
=== RUN   TestAccS3TablesTable_tags_DefaultTags_updateToResourceOnly 
=== PAUSE TestAccS3TablesTable_tags_DefaultTags_updateToResourceOnly 
=== RUN   TestAccS3TablesTable_tags_DefaultTags_emptyResourceTag     
=== PAUSE TestAccS3TablesTable_tags_DefaultTags_emptyResourceTag     
=== RUN   TestAccS3TablesTable_tags_DefaultTags_emptyProviderOnlyTag 
=== PAUSE TestAccS3TablesTable_tags_DefaultTags_emptyProviderOnlyTag 
=== RUN   TestAccS3TablesTable_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccS3TablesTable_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccS3TablesTable_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccS3TablesTable_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccS3TablesTable_tags_ComputedTag_OnCreate
=== PAUSE TestAccS3TablesTable_tags_ComputedTag_OnCreate
=== RUN   TestAccS3TablesTable_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccS3TablesTable_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccS3TablesTable_tags_ComputedTag_OnUpdate_Replace     
=== PAUSE TestAccS3TablesTable_tags_ComputedTag_OnUpdate_Replace     
=== RUN   TestAccS3TablesTable_tags_IgnoreTags_Overlap_DefaultTag    
=== PAUSE TestAccS3TablesTable_tags_IgnoreTags_Overlap_DefaultTag    
=== RUN   TestAccS3TablesTable_tags_IgnoreTags_Overlap_ResourceTag   
=== PAUSE TestAccS3TablesTable_tags_IgnoreTags_Overlap_ResourceTag   
=== RUN   TestAccS3TablesTable_basic
=== PAUSE TestAccS3TablesTable_basic
=== RUN   TestAccS3TablesTable_disappears
=== PAUSE TestAccS3TablesTable_disappears
=== RUN   TestAccS3TablesTable_rename
=== PAUSE TestAccS3TablesTable_rename
=== RUN   TestAccS3TablesTable_updateNamespace
=== PAUSE TestAccS3TablesTable_updateNamespace
=== RUN   TestAccS3TablesTable_updateNameAndNamespace
=== PAUSE TestAccS3TablesTable_updateNameAndNamespace
=== RUN   TestAccS3TablesTable_maintenanceConfiguration
=== PAUSE TestAccS3TablesTable_maintenanceConfiguration
=== RUN   TestAccS3TablesTable_encryptionConfiguration
=== PAUSE TestAccS3TablesTable_encryptionConfiguration
=== RUN   TestAccS3TablesTable_metadata
=== PAUSE TestAccS3TablesTable_metadata
=== RUN   TestAccS3TablesTable_storageClassConfiguration
=== PAUSE TestAccS3TablesTable_storageClassConfiguration
=== RUN   TestAccS3TablesTable_storageClassConfiguration_inheritFromBucket
=== PAUSE TestAccS3TablesTable_storageClassConfiguration_inheritFromBucket
=== CONT  TestAccS3TablesTable_tags
=== CONT  TestAccS3TablesTable_tags_ComputedTag_OnCreate
=== CONT  TestAccS3TablesTable_tags_DefaultTags_nonOverlapping       
=== CONT  TestAccS3TablesTable_tags_DefaultTags_emptyResourceTag     
=== CONT  TestAccS3TablesTable_tags_EmptyTag_OnCreate
=== CONT  TestAccS3TablesTable_tags_EmptyMap
--- PASS: TestAccS3TablesTable_tags_DefaultTags_emptyResourceTag (39.92s)
--- PASS: TestAccS3TablesTable_tags_ComputedTag_OnCreate (41.75s)
=== CONT  TestAccS3TablesTable_tags_AddOnUpdate
--- PASS: TestAccS3TablesTable_tags_EmptyTag_OnCreate (66.06s)
=== CONT  TestAccS3TablesTable_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccS3TablesTable_tags_EmptyMap (34.18s)
=== CONT  TestAccS3TablesTable_tags_DefaultTags_providerOnly
--- PASS: TestAccS3TablesTable_tags_DefaultTags_nonOverlapping (92.93s)
=== CONT  TestAccS3TablesTable_updateNamespace
--- PASS: TestAccS3TablesTable_tags_AddOnUpdate (54.85s)
=== CONT  TestAccS3TablesTable_storageClassConfiguration_inheritFromBucket
--- PASS: TestAccS3TablesTable_tags (119.34s)
=== CONT  TestAccS3TablesTable_storageClassConfiguration
--- PASS: TestAccS3TablesTable_tags_EmptyTag_OnUpdate_Replace (53.69s)
=== CONT  TestAccS3TablesTable_metadata
--- PASS: TestAccS3TablesTable_storageClassConfiguration_inheritFromBucket (31.72s)
=== CONT  TestAccS3TablesTable_encryptionConfiguration
--- PASS: TestAccS3TablesTable_updateNamespace (53.34s)
=== CONT  TestAccS3TablesTable_maintenanceConfiguration
--- PASS: TestAccS3TablesTable_storageClassConfiguration (31.40s)
=== CONT  TestAccS3TablesTable_updateNameAndNamespace
--- PASS: TestAccS3TablesTable_metadata (31.92s)
=== CONT  TestAccS3TablesTable_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccS3TablesTable_encryptionConfiguration (41.77s)
=== CONT  TestAccS3TablesTable_rename
--- PASS: TestAccS3TablesTable_tags_DefaultTags_providerOnly (116.21s)
=== CONT  TestAccS3TablesTable_disappears
--- PASS: TestAccS3TablesTable_updateNameAndNamespace (53.77s)
=== CONT  TestAccS3TablesTable_basic
--- PASS: TestAccS3TablesTable_maintenanceConfiguration (58.54s)
=== CONT  TestAccS3TablesTable_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccS3TablesTable_disappears (27.15s)
=== CONT  TestAccS3TablesTable_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccS3TablesTable_rename (54.35s)
=== CONT  TestAccS3TablesTable_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccS3TablesTable_tags_IgnoreTags_Overlap_ResourceTag (77.27s)
=== CONT  TestAccS3TablesTable_tags_null
--- PASS: TestAccS3TablesTable_basic (34.70s)
=== CONT  TestAccS3TablesTable_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccS3TablesTable_tags_DefaultTags_nullOverlappingResourceTag (36.03s)
=== CONT  TestAccS3TablesTable_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccS3TablesTable_tags_DefaultTags_nullNonOverlappingResourceTag (34.91s)
(57.55s)
=== CONT  TestAccS3TablesTable_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccS3TablesTable_tags_IgnoreTags_Overlap_DefaultTag (72.68s)
=== CONT  TestAccS3TablesTable_tags_DefaultTags_overlapping
--- PASS: TestAccS3TablesTable_tags_DefaultTags_updateToResourceOnly (57.59s)
--- PASS: TestAccS3TablesTable_tags_ComputedTag_OnUpdate_Add (60.83s)
--- PASS: TestAccS3TablesTable_tags_DefaultTags_emptyProviderOnlyTag (34.14s)
--- PASS: TestAccS3TablesTable_tags_ComputedTag_OnUpdate_Replace (59.50s)
--- PASS: TestAccS3TablesTable_tags_DefaultTags_overlapping (84.08s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3tables        396.372s

$
```