### PR TITLE
ci: Update tflint-ruleset-aws version to 0.45.0 and adjust rule enablement

### DIFF
--- a/.ci/.tflint.hcl
+++ b/.ci/.tflint.hcl
@@ -30,6 +30,11 @@ rule "aws_acm_certificate_lifecycle" {
 }
 
 # Rule needs to be disabled due to enum value case inconsistencies
+rule "aws_dms_s3_endpoint_invalid_canned_acl_for_objects" {
+  enabled = false
+}
+
+# Rule needs to be disabled due to enum value case inconsistencies
 rule "aws_dms_s3_endpoint_invalid_compression_type" {
   enabled = false
 }
@@ -46,10 +51,5 @@ rule "aws_dms_s3_endpoint_invalid_encryption_mode" {
 
 # Avoids errant findings related to directory paths in generated configuration files
 rule "aws_iam_saml_provider_invalid_saml_metadata_document" {
-  enabled = false
-}
-
-# Rule needs to be disabled due to bad email regex in the linter rule
-rule "aws_guardduty_member_invalid_email" {
   enabled = false
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to update `tflint-ruleset-aws` version to 0.45.0 and re-enable the `aws_api_gateway_domain_name_invalid_security_policy` linter rule that was disabled earlier due to missing SecurityPolicy enum values.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #45167
Relates #43083

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

n/a