### PR TITLE
feat: Add d/aws_egress_only_internet_gateway

### DIFF
--- a/.changelog/46020.txt
+++ b/.changelog/46020.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_egress_only_internet_gateway
+```

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -61,6 +61,13 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 			Region:   inttypes.ResourceRegionDefault(),
 		},
 		{
+			Factory:  newEgressOnlyInternetGatewayDataSource,
+			TypeName: "aws_egress_only_internet_gateway",
+			Name:     "Egress-Only Internet Gateway",
+			Tags:     unique.Make(inttypes.ServicePackageResourceTags{}),
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newSpotDataFeedSubscriptionDataSource,
 			TypeName: "aws_spot_datafeed_subscription",
 			Name:     "Spot Data Feed Subscription Data Source",

--- a/internal/service/ec2/vpc_egress_only_internet_gateway_data_source.go
+++ b/internal/service/ec2/vpc_egress_only_internet_gateway_data_source.go
@@ -1,0 +1,103 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_egress_only_internet_gateway", name="Egress-Only Internet Gateway")
+// @Tags
+// @Testing(tagsTest=false)
+func newEgressOnlyInternetGatewayDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &egressOnlyInternetGatewayDataSource{}, nil
+}
+
+type egressOnlyInternetGatewayDataSource struct {
+	framework.DataSourceWithModel[egressOnlyInternetGatewayDataSourceModel]
+}
+
+func (d *egressOnlyInternetGatewayDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			names.AttrState: schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrTags: tftags.TagsAttributeComputedOnly(),
+			names.AttrVPCID: schema.StringAttribute{
+				Computed: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrFilter: customFiltersBlock(ctx),
+		},
+	}
+}
+
+func (d *egressOnlyInternetGatewayDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data egressOnlyInternetGatewayDataSourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Config.Get(ctx, &data))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := d.Meta().EC2Client(ctx)
+	//ignoreTagsConfig := d.Meta().IgnoreTagsConfig(ctx)
+
+	input := &ec2.DescribeEgressOnlyInternetGatewaysInput{
+		Filters: newCustomFilterListFramework(ctx, data.Filters),
+	}
+
+	if !data.ID.IsNull() {
+		input.EgressOnlyInternetGatewayIds = []string{fwflex.StringValueFromFramework(ctx, data.ID)}
+	}
+
+	if len(input.Filters) == 0 {
+		input.Filters = nil
+	}
+
+	output, err := findEgressOnlyInternetGateway(ctx, conn, input)
+
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err)
+		return
+	}
+
+	data.ID = fwflex.StringToFramework(ctx, output.EgressOnlyInternetGatewayId)
+
+	// Set state and VPC ID from attachments
+	if len(output.Attachments) > 0 {
+		attachment := output.Attachments[0]
+		data.State = fwflex.StringValueToFramework(ctx, attachment.State)
+		data.VpcID = fwflex.StringToFramework(ctx, attachment.VpcId)
+	}
+
+	//data.Tags = tftags.FlattenStringValueMap(ctx, keyValueTags(ctx, output.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
+	setTagsOut(ctx, output.Tags)
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data), smerr.ID, data.ID)
+}
+
+type egressOnlyInternetGatewayDataSourceModel struct {
+	framework.WithRegionModel
+	Filters customFilters `tfsdk:"filter"`
+	ID      types.String  `tfsdk:"id"`
+	State   types.String  `tfsdk:"state"`
+	Tags    tftags.Map    `tfsdk:"tags"`
+	VpcID   types.String  `tfsdk:"vpc_id"`
+}

--- a/internal/service/ec2/vpc_egress_only_internet_gateway_data_source_test.go
+++ b/internal/service/ec2/vpc_egress_only_internet_gateway_data_source_test.go
@@ -1,0 +1,76 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccVPCEgressOnlyInternetGatewayDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	eigwResourceName := "aws_egress_only_internet_gateway.test"
+	vpcResourceName := "aws_vpc.test"
+	ds1ResourceName := "data.aws_egress_only_internet_gateway.by_id"
+	ds2ResourceName := "data.aws_egress_only_internet_gateway.by_filter"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCEgressOnlyInternetGatewayDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(ds1ResourceName, names.AttrID, eigwResourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, names.AttrVPCID, vpcResourceName, names.AttrID),
+					resource.TestCheckResourceAttr(ds1ResourceName, names.AttrState, "attached"),
+
+					resource.TestCheckResourceAttrPair(ds2ResourceName, names.AttrID, eigwResourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, names.AttrVPCID, vpcResourceName, names.AttrID),
+					resource.TestCheckResourceAttr(ds2ResourceName, names.AttrState, "attached"),
+				),
+			},
+		},
+	})
+}
+
+func testAccVPCEgressOnlyInternetGatewayDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block                       = "10.1.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_egress_only_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_egress_only_internet_gateway" "by_id" {
+  id = aws_egress_only_internet_gateway.test.id
+}
+
+data "aws_egress_only_internet_gateway" "by_filter" {
+  filter {
+    name   = "tag:Name"
+    values = [%[1]q]
+  }
+
+  depends_on = [aws_egress_only_internet_gateway.test]
+}
+`, rName)
+}

--- a/website/docs/d/egress_only_internet_gateway.html.markdown
+++ b/website/docs/d/egress_only_internet_gateway.html.markdown
@@ -1,0 +1,56 @@
+---
+subcategory: "VPC (Virtual Private Cloud)"
+layout: "aws"
+page_title: "AWS: aws_egress_only_internet_gateway"
+description: |-
+  Provides details about an Amazon VPC (Virtual Private Cloud) Egress-Only Internet Gateway
+---
+
+# Data Source: aws_egress_only_internet_gateway
+
+Provides details about an Amazon VPC (Virtual Private Cloud) Egress-Only Internet Gateway.
+
+## Example Usage
+
+### By ID
+
+```terraform
+data "aws_egress_only_internet_gateway" "example" {
+  id = "eigw-12345678"
+}
+```
+
+### By Filter
+
+```terraform
+data "aws_egress_only_internet_gateway" "example" {
+  filter {
+    name   = "tag:Name"
+    values = ["example-eigw"]
+  }
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `filter` - (Optional) Custom filter block as described below.
+* `id` - (Optional) ID of the specific egress-only internet gateway to retrieve.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
+### `filter` Block
+
+The `filter` configuration block supports the following arguments:
+
+* `name` - (Required) Name of the field to filter by, as defined by [the underlying AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeEgressOnlyInternetGateways.html).
+* `values` - (Required) Set of values that are accepted for the given field. An egress-only Internet gateway will be selected if any one of the given values matches.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `id` - ID of the egress-only internet gateway.
+* `state` - State of the attachment between the gateway and the VPC.
+* `tags` - Map of tags assigned to the resource.
+* `vpc_id` - ID of the VPC to which the egress-only internet gateway is attached.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add a new `aws_egress_only_internet_gateway` data source.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #46019

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [DescribeEgressOnlyInternetGateways](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeEgressOnlyInternetGateways.html) for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS="TestAccVPCEgressOnlyInternetGatewayDataSource_" PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     1.312s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 1.328s
make: Running acceptance tests on branch: ðŸŒ¿ f-aws_egress_only_internet_gateway-new_data_source ðŸŒ¿...
TF_ACC=1 go1.26.4 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCEgressOnlyInternetGatewayDataSource_'  -timeout 360m -vet=off -buildvcs=false
2026/06/29 11:14:45 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/29 11:14:45 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCEgressOnlyInternetGatewayDataSource_basic
=== PAUSE TestAccVPCEgressOnlyInternetGatewayDataSource_basic
=== CONT  TestAccVPCEgressOnlyInternetGatewayDataSource_basic
--- PASS: TestAccVPCEgressOnlyInternetGatewayDataSource_basic (34.55s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        35.700s

$
```
