### PR TITLE
Fix: aws_vpclattice_resource_configuration to support custom domain name on GROUP resource

### DIFF
--- a/.changelog/46024.txt
+++ b/.changelog/46024.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpclattice_resource_configuration: Fix `custom_domain_name` support for GROUP type resource configurations
+```

--- a/internal/service/vpclattice/resource_configuration.go
+++ b/internal/service/vpclattice/resource_configuration.go
@@ -259,6 +259,11 @@ func (r *resourceConfigurationResource) Create(ctx context.Context, request reso
 
 	conn := r.Meta().VPCLatticeClient(ctx)
 
+	resourceType := awstypes.ResourceConfigurationTypeSingle
+	if !data.Type.IsNull() && !data.Type.IsUnknown() {
+		resourceType = data.Type.ValueEnum()
+	}
+
 	var input vpclattice.CreateResourceConfigurationInput
 	response.Diagnostics.Append(fwflex.Expand(ctx, data, &input)...)
 	if response.Diagnostics.HasError() {
@@ -271,6 +276,16 @@ func (r *resourceConfigurationResource) Create(ctx context.Context, request reso
 	input.ResourceConfigurationGroupIdentifier = fwflex.StringFromFramework(ctx, data.ResourceConfigurationGroupID)
 	input.ResourceGatewayIdentifier = fwflex.StringFromFramework(ctx, data.ResourceGatewayID)
 	input.Tags = getTagsIn(ctx)
+
+	// Handle domain name based on resource type:
+	// - GROUP type: custom_domain_name maps to GroupDomain in API
+	// - Other types: custom_domain_name maps to CustomDomainName in API
+	if resourceType == awstypes.ResourceConfigurationTypeGroup {
+		input.GroupDomain = fwflex.StringFromFramework(ctx, data.CustomDomainName)
+		input.CustomDomainName = nil
+	} else {
+		input.GroupDomain = nil
+	}
 
 	outputCRC, err := conn.CreateResourceConfiguration(ctx, &input)
 
@@ -295,6 +310,10 @@ func (r *resourceConfigurationResource) Create(ctx context.Context, request reso
 	response.Diagnostics.Append(fwflex.Flatten(ctx, outputGRC, &data)...)
 	if response.Diagnostics.HasError() {
 		return
+	}
+
+	if resourceType == awstypes.ResourceConfigurationTypeGroup && outputGRC.GroupDomain != nil {
+		data.CustomDomainName = fwflex.StringToFramework(ctx, outputGRC.GroupDomain)
 	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, data)...)
@@ -328,6 +347,15 @@ func (r *resourceConfigurationResource) Read(ctx context.Context, request resour
 	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &data)...)
 	if response.Diagnostics.HasError() {
 		return
+	}
+
+	resourceType := awstypes.ResourceConfigurationTypeSingle
+	if !data.Type.IsNull() && !data.Type.IsUnknown() {
+		resourceType = data.Type.ValueEnum()
+	}
+
+	if resourceType == awstypes.ResourceConfigurationTypeGroup && output.GroupDomain != nil {
+		data.CustomDomainName = fwflex.StringToFramework(ctx, output.GroupDomain)
 	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)

--- a/website/docs/r/vpclattice_resource_configuration.html.markdown
+++ b/website/docs/r/vpclattice_resource_configuration.html.markdown
@@ -88,6 +88,43 @@ resource "aws_vpclattice_resource_configuration" "example" {
 }
 ```
 
+### GROUP type with group domain
+
+```terraform
+resource "aws_vpclattice_domain_verification" "group" {
+  domain_name = "example.com"
+}
+
+resource "aws_vpclattice_resource_configuration" "group" {
+  name = "Group Example"
+
+  resource_gateway_identifier = aws_vpclattice_resource_gateway.example.id
+  type                        = "GROUP"
+  custom_domain_name          = "example.com"
+  domain_verification_id      = aws_vpclattice_domain_verification.group.id
+
+  protocol    = "TCP"
+  port_ranges = ["443"]
+}
+
+resource "aws_vpclattice_resource_configuration" "child" {
+  name = "Child Example"
+
+  resource_configuration_group_id = aws_vpclattice_resource_configuration.group.id
+  type                           = "CHILD"
+  custom_domain_name             = "child.example.com"
+
+  port_ranges = ["80"]
+
+  resource_configuration_definition {
+    dns_resource {
+      domain_name     = "backend.example.com"
+      ip_address_type = "IPV4"
+    }
+  }
+}
+```
+
 ### ARN Example
 
 ```terraform
@@ -118,8 +155,8 @@ The following arguments are optional:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `allow_association_to_shareable_service_network` (Optional) Allow or Deny the association of this resource to a shareable service network.
-* `custom_domain_name` - (Optional) Custom domain name for your resource configuration. Additionally, provide a `domain_verification_id` to prove your ownership of a domain.
-* `domain_verification_id` - (Optional) The domain verification ID of your verified custom domain name. If you don't provide an ID, you must configure the DNS settings yourself.
+* `custom_domain_name` - (Optional) Domain name for your resource configuration. For `GROUP` type resource configurations, this specifies the group domain. For other types (`CHILD`, `SINGLE`, `ARN`), this specifies a custom domain name. Additionally, provide a `domain_verification_id` to prove your ownership of a domain. For `CHILD` type resource configurations, the custom domain must be a subdomain of the parent group's domain.
+* `domain_verification_id` - (Optional) The domain verification ID of your verified domain name. If you don't provide an ID, you must configure the DNS settings yourself.
 * `protocol` - (Optional) Protocol for the Resource `TCP` is currently the only supported value.  MUST be specified if `resource_configuration_group_id` is not.
 * `resource_configuration_group_id` (Optional) ID of Resource Configuration where `type` is `CHILD`.
 * `resource_gateway_identifier` - (Optional) ID of the Resource Gateway used to access the resource. MUST be specified if `resource_configuration_group_id` is not.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls

### Description
Change fixes support for `custom_domain_name` on `aws_vpclattice_resource_configuration` resources with `type = "GROUP"`.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #46023

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
AWS docs:
https://docs.aws.amazon.com/vpc/latest/privatelink/create-resource-configuration.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc PKG=vpclattice
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 vpc-lattice-group-domain-fix 🌿...
TF_ACC=1 go1.25.5 test ./internal/service/vpclattice/... -v -count 1 -parallel 4   -timeout 360m -vet=off
2026/01/26 21:12:18 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/26 21:12:18 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCLatticeAccessLogSubscription_basic
=== PAUSE TestAccVPCLatticeAccessLogSubscription_basic
=== RUN   TestAccVPCLatticeAccessLogSubscription_disappears
=== PAUSE TestAccVPCLatticeAccessLogSubscription_disappears
=== RUN   TestAccVPCLatticeAccessLogSubscription_arn
=== PAUSE TestAccVPCLatticeAccessLogSubscription_arn
=== RUN   TestAccVPCLatticeAccessLogSubscription_tags
=== PAUSE TestAccVPCLatticeAccessLogSubscription_tags
=== RUN   TestAccVPCLatticeAccessLogSubscription_cloudwatchNoWildcard
=== PAUSE TestAccVPCLatticeAccessLogSubscription_cloudwatchNoWildcard
=== RUN   TestAccVPCLatticeAccessLogSubscription_cloudwatchWildcard
=== PAUSE TestAccVPCLatticeAccessLogSubscription_cloudwatchWildcard
=== RUN   TestAccVPCLatticeAccessLogSubscription_serviceNetworkLogType
=== PAUSE TestAccVPCLatticeAccessLogSubscription_serviceNetworkLogType
=== RUN   TestAccVPCLatticeAuthPolicyDataSource_basic
=== PAUSE TestAccVPCLatticeAuthPolicyDataSource_basic
=== RUN   TestAccVPCLatticeAuthPolicy_basic
=== PAUSE TestAccVPCLatticeAuthPolicy_basic
=== RUN   TestAccVPCLatticeAuthPolicy_disappears
=== PAUSE TestAccVPCLatticeAuthPolicy_disappears
=== RUN   TestAccVPCLatticeDomainVerification_tags
=== PAUSE TestAccVPCLatticeDomainVerification_tags
=== RUN   TestAccVPCLatticeDomainVerification_tags_null
=== PAUSE TestAccVPCLatticeDomainVerification_tags_null
=== RUN   TestAccVPCLatticeDomainVerification_tags_EmptyMap
=== PAUSE TestAccVPCLatticeDomainVerification_tags_EmptyMap
=== RUN   TestAccVPCLatticeDomainVerification_tags_AddOnUpdate
=== PAUSE TestAccVPCLatticeDomainVerification_tags_AddOnUpdate
=== RUN   TestAccVPCLatticeDomainVerification_tags_EmptyTag_OnCreate
=== PAUSE TestAccVPCLatticeDomainVerification_tags_EmptyTag_OnCreate
=== RUN   TestAccVPCLatticeDomainVerification_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccVPCLatticeDomainVerification_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccVPCLatticeDomainVerification_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccVPCLatticeDomainVerification_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccVPCLatticeDomainVerification_tags_DefaultTags_providerOnly
=== PAUSE TestAccVPCLatticeDomainVerification_tags_DefaultTags_providerOnly
=== RUN   TestAccVPCLatticeDomainVerification_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccVPCLatticeDomainVerification_tags_DefaultTags_nonOverlapping
=== RUN   TestAccVPCLatticeDomainVerification_tags_DefaultTags_overlapping
=== PAUSE TestAccVPCLatticeDomainVerification_tags_DefaultTags_overlapping
=== RUN   TestAccVPCLatticeDomainVerification_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccVPCLatticeDomainVerification_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccVPCLatticeDomainVerification_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccVPCLatticeDomainVerification_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccVPCLatticeDomainVerification_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccVPCLatticeDomainVerification_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccVPCLatticeDomainVerification_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccVPCLatticeDomainVerification_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccVPCLatticeDomainVerification_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccVPCLatticeDomainVerification_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccVPCLatticeDomainVerification_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccVPCLatticeDomainVerification_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccVPCLatticeDomainVerification_tags_ComputedTag_OnCreate
=== PAUSE TestAccVPCLatticeDomainVerification_tags_ComputedTag_OnCreate
=== RUN   TestAccVPCLatticeDomainVerification_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccVPCLatticeDomainVerification_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccVPCLatticeDomainVerification_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccVPCLatticeDomainVerification_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccVPCLatticeDomainVerification_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccVPCLatticeDomainVerification_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccVPCLatticeDomainVerification_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccVPCLatticeDomainVerification_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccVPCLatticeDomainVerification_basic
=== PAUSE TestAccVPCLatticeDomainVerification_basic
=== RUN   TestAccVPCLatticeDomainVerification_disappears
=== PAUSE TestAccVPCLatticeDomainVerification_disappears
=== RUN   TestAccVPCLatticeListenerDataSource_basic
=== PAUSE TestAccVPCLatticeListenerDataSource_basic
=== RUN   TestAccVPCLatticeListenerDataSource_tags
=== PAUSE TestAccVPCLatticeListenerDataSource_tags
=== RUN   TestAccVPCLatticeListenerDataSource_forwardMultiTargetGroupHTTP
=== PAUSE TestAccVPCLatticeListenerDataSource_forwardMultiTargetGroupHTTP
=== RUN   TestAccVPCLatticeListenerRule_basic
=== PAUSE TestAccVPCLatticeListenerRule_basic
=== RUN   TestAccVPCLatticeListenerRule_disappears
=== PAUSE TestAccVPCLatticeListenerRule_disappears
=== RUN   TestAccVPCLatticeListenerRule_ARNs
=== PAUSE TestAccVPCLatticeListenerRule_ARNs
=== RUN   TestAccVPCLatticeListenerRule_action_fixedResponse
=== PAUSE TestAccVPCLatticeListenerRule_action_fixedResponse
=== RUN   TestAccVPCLatticeListenerRule_action_forward_Multiple
=== PAUSE TestAccVPCLatticeListenerRule_action_forward_Multiple
=== RUN   TestAccVPCLatticeListenerRule_match_HeaderMatches_Single
=== PAUSE TestAccVPCLatticeListenerRule_match_HeaderMatches_Single
=== RUN   TestAccVPCLatticeListenerRule_match_HeaderMatches_Multiple
=== PAUSE TestAccVPCLatticeListenerRule_match_HeaderMatches_Multiple
=== RUN   TestAccVPCLatticeListenerRule_match_PathMatch
=== PAUSE TestAccVPCLatticeListenerRule_match_PathMatch
=== RUN   TestAccVPCLatticeListenerRule_tags
=== PAUSE TestAccVPCLatticeListenerRule_tags
=== RUN   TestAccVPCLatticeListener_defaultActionUpdate
=== PAUSE TestAccVPCLatticeListener_defaultActionUpdate
=== RUN   TestAccVPCLatticeListener_fixedResponseHTTP
=== PAUSE TestAccVPCLatticeListener_fixedResponseHTTP
=== RUN   TestAccVPCLatticeListener_fixedResponseHTTPS
=== PAUSE TestAccVPCLatticeListener_fixedResponseHTTPS
=== RUN   TestAccVPCLatticeListener_forwardTLSPassthrough
=== PAUSE TestAccVPCLatticeListener_forwardTLSPassthrough
=== RUN   TestAccVPCLatticeListener_forwardHTTPTargetGroup
=== PAUSE TestAccVPCLatticeListener_forwardHTTPTargetGroup
=== RUN   TestAccVPCLatticeListener_forwardHTTPTargetGroupCustomPort
=== PAUSE TestAccVPCLatticeListener_forwardHTTPTargetGroupCustomPort
=== RUN   TestAccVPCLatticeListener_forwardHTTPSTargetGroupARN
=== PAUSE TestAccVPCLatticeListener_forwardHTTPSTargetGroupARN
=== RUN   TestAccVPCLatticeListener_forwardHTTPSTargetGroupCustomPort
=== PAUSE TestAccVPCLatticeListener_forwardHTTPSTargetGroupCustomPort
=== RUN   TestAccVPCLatticeListener_forwardHTTPMultipleTargetGroups
=== PAUSE TestAccVPCLatticeListener_forwardHTTPMultipleTargetGroups
=== RUN   TestAccVPCLatticeListener_disappears
=== PAUSE TestAccVPCLatticeListener_disappears
=== RUN   TestAccVPCLatticeListener_tags
=== PAUSE TestAccVPCLatticeListener_tags
=== RUN   TestAccVPCLatticeResourceConfiguration_tags
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_null
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_null
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_EmptyMap
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_EmptyMap
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_AddOnUpdate
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_AddOnUpdate
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnCreate
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnCreate
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_providerOnly
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_providerOnly
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nonOverlapping
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_overlapping
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_overlapping
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnCreate
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnCreate
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccVPCLatticeResourceConfiguration_basic
=== PAUSE TestAccVPCLatticeResourceConfiguration_basic
=== RUN   TestAccVPCLatticeResourceConfiguration_update
=== PAUSE TestAccVPCLatticeResourceConfiguration_update
=== RUN   TestAccVPCLatticeResourceConfiguration_ipAddress
=== PAUSE TestAccVPCLatticeResourceConfiguration_ipAddress
=== RUN   TestAccVPCLatticeResourceConfiguration_parentChild
=== PAUSE TestAccVPCLatticeResourceConfiguration_parentChild
=== RUN   TestAccVPCLatticeResourceConfiguration_arnResource
=== PAUSE TestAccVPCLatticeResourceConfiguration_arnResource
=== RUN   TestAccVPCLatticeResourceConfiguration_domainVerification
=== PAUSE TestAccVPCLatticeResourceConfiguration_domainVerification
=== RUN   TestAccVPCLatticeResourceConfiguration_disappears
=== PAUSE TestAccVPCLatticeResourceConfiguration_disappears
=== RUN   TestAccVPCLatticeResourceGateway_tags
=== PAUSE TestAccVPCLatticeResourceGateway_tags
=== RUN   TestAccVPCLatticeResourceGateway_tags_null
=== PAUSE TestAccVPCLatticeResourceGateway_tags_null
=== RUN   TestAccVPCLatticeResourceGateway_tags_EmptyMap
=== PAUSE TestAccVPCLatticeResourceGateway_tags_EmptyMap
=== RUN   TestAccVPCLatticeResourceGateway_tags_AddOnUpdate
=== PAUSE TestAccVPCLatticeResourceGateway_tags_AddOnUpdate
=== RUN   TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnCreate
=== PAUSE TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnCreate
=== RUN   TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_providerOnly
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_providerOnly
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_nonOverlapping
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_overlapping
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_overlapping
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnCreate
=== PAUSE TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnCreate
=== RUN   TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccVPCLatticeResourceGateway_basic
=== PAUSE TestAccVPCLatticeResourceGateway_basic
=== RUN   TestAccVPCLatticeResourceGateway_addressTypeDualstack
=== PAUSE TestAccVPCLatticeResourceGateway_addressTypeDualstack
=== RUN   TestAccVPCLatticeResourceGateway_addressTypeIPv6
=== PAUSE TestAccVPCLatticeResourceGateway_addressTypeIPv6
=== RUN   TestAccVPCLatticeResourceGateway_multipleSubnets
=== PAUSE TestAccVPCLatticeResourceGateway_multipleSubnets
=== RUN   TestAccVPCLatticeResourceGateway_ipv4AddressesPerEni
=== PAUSE TestAccVPCLatticeResourceGateway_ipv4AddressesPerEni
=== RUN   TestAccVPCLatticeResourceGateway_update
=== PAUSE TestAccVPCLatticeResourceGateway_update
=== RUN   TestAccVPCLatticeResourceGateway_disappears
=== PAUSE TestAccVPCLatticeResourceGateway_disappears
=== RUN   TestAccVPCLatticeResourcePolicyDataSource_basic
=== PAUSE TestAccVPCLatticeResourcePolicyDataSource_basic
=== RUN   TestAccVPCLatticeResourcePolicy_basic
=== PAUSE TestAccVPCLatticeResourcePolicy_basic
=== RUN   TestAccVPCLatticeResourcePolicy_disappears
=== PAUSE TestAccVPCLatticeResourcePolicy_disappears
=== RUN   TestAccVPCLatticeServiceDataSource_basic
=== PAUSE TestAccVPCLatticeServiceDataSource_basic
=== RUN   TestAccVPCLatticeServiceDataSource_byName
=== PAUSE TestAccVPCLatticeServiceDataSource_byName
=== RUN   TestAccVPCLatticeServiceDataSource_shared
=== PAUSE TestAccVPCLatticeServiceDataSource_shared
=== RUN   TestEndpointConfiguration
=== RUN   TestEndpointConfiguration/service_config_file
=== RUN   TestEndpointConfiguration/use_fips_config
=== RUN   TestEndpointConfiguration/service_aws_envvar
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar
=== RUN   TestEndpointConfiguration/base_endpoint_envvar
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_config_file
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file
=== RUN   TestEndpointConfiguration/service_config_file_overrides_base_config_file
=== RUN   TestEndpointConfiguration/use_fips_config_with_package_name_endpoint_config
=== RUN   TestEndpointConfiguration/no_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file
--- PASS: TestEndpointConfiguration (0.72s)
    --- PASS: TestEndpointConfiguration/service_config_file (0.04s)
    --- PASS: TestEndpointConfiguration/use_fips_config (0.05s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar (0.03s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar (0.03s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar (0.05s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar (0.02s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/base_endpoint_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar (0.05s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file (0.06s)
    --- PASS: TestEndpointConfiguration/service_config_file_overrides_base_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/use_fips_config_with_package_name_endpoint_config (0.05s)
    --- PASS: TestEndpointConfiguration/no_config (0.03s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config (0.06s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file (0.05s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file (0.02s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file (0.03s)
=== RUN   TestAccVPCLatticeServiceNetworkDataSource_basic
=== PAUSE TestAccVPCLatticeServiceNetworkDataSource_basic
=== RUN   TestAccVPCLatticeServiceNetworkDataSource_shared
=== PAUSE TestAccVPCLatticeServiceNetworkDataSource_shared
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_null
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_null
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyMap
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyMap
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_AddOnUpdate
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_AddOnUpdate
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnCreate
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnCreate
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_providerOnly
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_providerOnly
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nonOverlapping
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_overlapping
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_overlapping
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnCreate
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnCreate
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_basic
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_basic
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_privateDNS
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_privateDNS
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_disappears
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_disappears
=== RUN   TestAccVPCLatticeServiceNetworkServiceAssociation_basic
=== PAUSE TestAccVPCLatticeServiceNetworkServiceAssociation_basic
=== RUN   TestAccVPCLatticeServiceNetworkServiceAssociation_arn
=== PAUSE TestAccVPCLatticeServiceNetworkServiceAssociation_arn
=== RUN   TestAccVPCLatticeServiceNetworkServiceAssociation_disappears
=== PAUSE TestAccVPCLatticeServiceNetworkServiceAssociation_disappears
=== RUN   TestAccVPCLatticeServiceNetworkServiceAssociation_tags
=== PAUSE TestAccVPCLatticeServiceNetworkServiceAssociation_tags
=== RUN   TestIDFromIDOrARN
=== PAUSE TestIDFromIDOrARN
=== RUN   TestSuppressEquivalentIDOrARN
=== PAUSE TestSuppressEquivalentIDOrARN
=== RUN   TestAccVPCLatticeServiceNetwork_basic
=== PAUSE TestAccVPCLatticeServiceNetwork_basic
=== RUN   TestAccVPCLatticeServiceNetwork_disappears
=== PAUSE TestAccVPCLatticeServiceNetwork_disappears
=== RUN   TestAccVPCLatticeServiceNetwork_full
=== PAUSE TestAccVPCLatticeServiceNetwork_full
=== RUN   TestAccVPCLatticeServiceNetwork_tags
=== PAUSE TestAccVPCLatticeServiceNetwork_tags
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_basic
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_basic
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_arn
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_arn
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_disappears
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_disappears
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_full
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_full
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_privateDNS
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_privateDNS
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_tags
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_tags
=== RUN   TestAccVPCLatticeService_basic
=== PAUSE TestAccVPCLatticeService_basic
=== RUN   TestAccVPCLatticeService_disappears
=== PAUSE TestAccVPCLatticeService_disappears
=== RUN   TestAccVPCLatticeService_full
=== PAUSE TestAccVPCLatticeService_full
=== RUN   TestAccVPCLatticeService_tags
=== PAUSE TestAccVPCLatticeService_tags
=== RUN   TestAccVPCLatticeTargetGroupAttachment_instance
=== PAUSE TestAccVPCLatticeTargetGroupAttachment_instance
=== RUN   TestAccVPCLatticeTargetGroupAttachment_ip
=== PAUSE TestAccVPCLatticeTargetGroupAttachment_ip
=== RUN   TestAccVPCLatticeTargetGroupAttachment_lambda
=== PAUSE TestAccVPCLatticeTargetGroupAttachment_lambda
=== RUN   TestAccVPCLatticeTargetGroupAttachment_alb
=== PAUSE TestAccVPCLatticeTargetGroupAttachment_alb
=== RUN   TestAccVPCLatticeTargetGroupAttachment_disappears
=== PAUSE TestAccVPCLatticeTargetGroupAttachment_disappears
=== RUN   TestAccVPCLatticeTargetGroup_basic
=== PAUSE TestAccVPCLatticeTargetGroup_basic
=== RUN   TestAccVPCLatticeTargetGroup_disappears
=== PAUSE TestAccVPCLatticeTargetGroup_disappears
=== RUN   TestAccVPCLatticeTargetGroup_tags
=== PAUSE TestAccVPCLatticeTargetGroup_tags
=== RUN   TestAccVPCLatticeTargetGroup_lambda
=== PAUSE TestAccVPCLatticeTargetGroup_lambda
=== RUN   TestAccVPCLatticeTargetGroup_lambdaEventStructureVersion
=== PAUSE TestAccVPCLatticeTargetGroup_lambdaEventStructureVersion
=== RUN   TestAccVPCLatticeTargetGroup_ip
=== PAUSE TestAccVPCLatticeTargetGroup_ip
=== RUN   TestAccVPCLatticeTargetGroup_alb
=== PAUSE TestAccVPCLatticeTargetGroup_alb
=== CONT  TestAccVPCLatticeAccessLogSubscription_basic
=== CONT  TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnCreate
=== CONT  TestAccVPCLatticeListenerRule_tags
=== CONT  TestAccVPCLatticeDomainVerification_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccVPCLatticeDomainVerification_tags_DefaultTags_emptyResourceTag (48.84s)
=== CONT  TestAccVPCLatticeListenerDataSource_basic
--- PASS: TestAccVPCLatticeAccessLogSubscription_basic (55.60s)
=== CONT  TestAccVPCLatticeListenerRule_match_PathMatch
--- PASS: TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnCreate (115.44s)
=== CONT  TestAccVPCLatticeListenerRule_match_HeaderMatches_Multiple
--- PASS: TestAccVPCLatticeListenerDataSource_basic (97.52s)
=== CONT  TestAccVPCLatticeListenerRule_match_HeaderMatches_Single
--- PASS: TestAccVPCLatticeListenerRule_tags (152.99s)
=== CONT  TestAccVPCLatticeListenerRule_action_forward_Multiple
--- PASS: TestAccVPCLatticeListenerRule_match_PathMatch (120.43s)
=== CONT  TestAccVPCLatticeListenerRule_action_fixedResponse
--- PASS: TestAccVPCLatticeListenerRule_match_HeaderMatches_Multiple (110.40s)
=== CONT  TestAccVPCLatticeListenerRule_ARNs
--- PASS: TestAccVPCLatticeListenerRule_match_HeaderMatches_Single (125.11s)
=== CONT  TestAccVPCLatticeListenerRule_disappears
--- PASS: TestAccVPCLatticeListenerRule_action_forward_Multiple (127.22s)
=== CONT  TestAccVPCLatticeListenerRule_basic
--- PASS: TestAccVPCLatticeListenerRule_action_fixedResponse (115.31s)
=== CONT  TestAccVPCLatticeListenerDataSource_forwardMultiTargetGroupHTTP
--- PASS: TestAccVPCLatticeListenerRule_disappears (96.39s)
=== CONT  TestAccVPCLatticeListenerDataSource_tags
--- PASS: TestAccVPCLatticeListenerRule_ARNs (149.79s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccVPCLatticeListenerDataSource_forwardMultiTargetGroupHTTP (108.50s)
=== CONT  TestAccVPCLatticeTargetGroup_alb
--- PASS: TestAccVPCLatticeListenerRule_basic (144.27s)
=== CONT  TestAccVPCLatticeTargetGroup_ip
--- PASS: TestAccVPCLatticeListenerDataSource_tags (94.01s)
=== CONT  TestAccVPCLatticeTargetGroup_lambdaEventStructureVersion
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_emptyResourceTag (107.44s)
=== CONT  TestAccVPCLatticeTargetGroup_lambda
--- PASS: TestAccVPCLatticeTargetGroup_alb (99.10s)
=== CONT  TestAccVPCLatticeTargetGroup_tags
--- PASS: TestAccVPCLatticeTargetGroup_lambdaEventStructureVersion (45.45s)
=== CONT  TestAccVPCLatticeTargetGroup_disappears
--- PASS: TestAccVPCLatticeTargetGroup_lambda (47.85s)
=== CONT  TestAccVPCLatticeTargetGroup_basic
--- PASS: TestAccVPCLatticeTargetGroup_ip (143.05s)
=== CONT  TestAccVPCLatticeTargetGroupAttachment_disappears
--- PASS: TestAccVPCLatticeTargetGroup_tags (94.22s)
=== CONT  TestAccVPCLatticeTargetGroupAttachment_alb
--- PASS: TestAccVPCLatticeTargetGroup_disappears (96.07s)
=== CONT  TestAccVPCLatticeTargetGroupAttachment_lambda
--- PASS: TestAccVPCLatticeTargetGroup_basic (93.56s)
=== CONT  TestAccVPCLatticeTargetGroupAttachment_ip
--- PASS: TestAccVPCLatticeTargetGroupAttachment_lambda (56.41s)
=== CONT  TestAccVPCLatticeTargetGroupAttachment_instance
--- PASS: TestAccVPCLatticeTargetGroupAttachment_disappears (146.55s)
=== CONT  TestAccVPCLatticeService_tags
--- PASS: TestAccVPCLatticeTargetGroupAttachment_ip (110.93s)
=== CONT  TestAccVPCLatticeService_full
--- PASS: TestAccVPCLatticeService_full (44.11s)
=== CONT  TestAccVPCLatticeService_disappears
--- PASS: TestAccVPCLatticeService_tags (91.15s)
=== CONT  TestAccVPCLatticeService_basic
--- PASS: TestAccVPCLatticeTargetGroupAttachment_instance (152.90s)
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_tags
--- PASS: TestAccVPCLatticeService_disappears (38.71s)
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_privateDNS
--- PASS: TestAccVPCLatticeTargetGroupAttachment_alb (234.82s)
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_full
--- PASS: TestAccVPCLatticeService_basic (43.42s)
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_disappears
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_full (175.10s)
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_arn
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_disappears (185.07s)
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_basic
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_tags (224.15s)
=== CONT  TestAccVPCLatticeServiceNetwork_tags
--- PASS: TestAccVPCLatticeServiceNetwork_tags (81.96s)
=== CONT  TestAccVPCLatticeServiceNetwork_full
--- PASS: TestAccVPCLatticeServiceNetwork_full (40.24s)
=== CONT  TestAccVPCLatticeServiceNetwork_disappears
--- PASS: TestAccVPCLatticeServiceNetwork_disappears (30.30s)
=== CONT  TestAccVPCLatticeServiceNetwork_basic
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_arn (190.82s)
=== CONT  TestSuppressEquivalentIDOrARN
--- PASS: TestSuppressEquivalentIDOrARN (0.00s)
=== CONT  TestIDFromIDOrARN
--- PASS: TestIDFromIDOrARN (0.00s)
=== CONT  TestAccVPCLatticeServiceNetworkServiceAssociation_tags
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_basic (169.98s)
=== CONT  TestAccVPCLatticeServiceNetworkServiceAssociation_disappears
--- PASS: TestAccVPCLatticeServiceNetwork_basic (39.21s)
=== CONT  TestAccVPCLatticeServiceNetworkServiceAssociation_arn
--- PASS: TestAccVPCLatticeServiceNetworkServiceAssociation_disappears (44.99s)
=== CONT  TestAccVPCLatticeServiceNetworkServiceAssociation_basic
--- PASS: TestAccVPCLatticeServiceNetworkServiceAssociation_arn (54.03s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_disappears
--- PASS: TestAccVPCLatticeServiceNetworkServiceAssociation_tags (107.29s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_privateDNS
--- PASS: TestAccVPCLatticeServiceNetworkServiceAssociation_basic (54.65s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_basic
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_disappears (106.55s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_basic (103.74s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_privateDNS (112.44s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_privateDNS (672.92s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnUpdate_Replace (152.39s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnCreate
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_IgnoreTags_Overlap_ResourceTag (183.00s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_IgnoreTags_Overlap_DefaultTag (172.15s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnUpdate_Add (146.96s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nullNonOverlappingResourceTag (103.84s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_DefaultTags_providerOnly
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnCreate (118.51s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nullOverlappingResourceTag (105.90s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_emptyProviderOnlyTag (118.99s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_DefaultTags_overlapping
--- PASS: TestAccVPCLatticeDomainVerification_tags_DefaultTags_updateToResourceOnly (82.21s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_DefaultTags_nonOverlapping
--- PASS: TestAccVPCLatticeDomainVerification_tags_DefaultTags_updateToProviderOnly (89.32s)
=== CONT  TestAccVPCLatticeAccessLogSubscription_serviceNetworkLogType
--- PASS: TestAccVPCLatticeDomainVerification_tags_DefaultTags_providerOnly (181.90s)
=== CONT  TestAccVPCLatticeDomainVerification_tags
--- PASS: TestAccVPCLatticeAccessLogSubscription_serviceNetworkLogType (111.93s)
=== CONT  TestAccVPCLatticeAuthPolicy_disappears
--- PASS: TestAccVPCLatticeDomainVerification_tags_DefaultTags_overlapping (148.62s)
=== CONT  TestAccVPCLatticeAuthPolicy_basic
--- PASS: TestAccVPCLatticeDomainVerification_tags_DefaultTags_nonOverlapping (147.59s)
=== CONT  TestAccVPCLatticeAuthPolicyDataSource_basic
--- PASS: TestAccVPCLatticeAuthPolicy_disappears (49.44s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccVPCLatticeAuthPolicyDataSource_basic (47.65s)
=== CONT  TestAccVPCLatticeDomainVerification_disappears
--- PASS: TestAccVPCLatticeAuthPolicy_basic (58.26s)
=== CONT  TestAccVPCLatticeDomainVerification_basic
--- PASS: TestAccVPCLatticeDomainVerification_disappears (44.09s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccVPCLatticeDomainVerification_basic (51.41s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccVPCLatticeDomainVerification_tags_ComputedTag_OnUpdate_Replace (96.50s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccVPCLatticeDomainVerification_tags (191.93s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_AddOnUpdate
--- PASS: TestAccVPCLatticeDomainVerification_tags_IgnoreTags_Overlap_DefaultTag (111.60s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_EmptyMap
--- PASS: TestAccVPCLatticeDomainVerification_tags_IgnoreTags_Overlap_ResourceTag (126.47s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_null
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_updateToProviderOnly (127.88s)
=== CONT  TestAccVPCLatticeResourceGateway_tags
--- PASS: TestAccVPCLatticeResourceGateway_tags_AddOnUpdate (116.40s)
=== CONT  TestAccVPCLatticeResourceConfiguration_disappears
--- PASS: TestAccVPCLatticeResourceGateway_tags_EmptyMap (77.73s)
=== CONT  TestAccVPCLatticeResourceConfiguration_domainVerification
--- PASS: TestAccVPCLatticeResourceGateway_tags_null (80.21s)
=== CONT  TestAccVPCLatticeResourceConfiguration_arnResource
--- PASS: TestAccVPCLatticeResourceConfiguration_disappears (68.72s)
=== CONT  TestAccVPCLatticeResourceConfiguration_parentChild
--- PASS: TestAccVPCLatticeResourceConfiguration_domainVerification (75.60s)
=== CONT  TestAccVPCLatticeResourceConfiguration_ipAddress
--- PASS: TestAccVPCLatticeResourceConfiguration_parentChild (76.70s)
=== CONT  TestAccVPCLatticeResourceConfiguration_update
--- PASS: TestAccVPCLatticeResourceGateway_tags (204.74s)
=== CONT  TestAccVPCLatticeResourceConfiguration_basic
--- PASS: TestAccVPCLatticeResourceConfiguration_ipAddress (117.24s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccVPCLatticeResourceConfiguration_update (117.99s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccVPCLatticeResourceConfiguration_basic (73.00s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_IgnoreTags_Overlap_ResourceTag (140.91s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnUpdate_Replace (119.50s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnCreate
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_IgnoreTags_Overlap_DefaultTag (137.41s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnCreate (76.13s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nullNonOverlappingResourceTag (73.94s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_null
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnUpdate_Add (112.24s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccVPCLatticeDomainVerification_tags_null (42.60s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nullOverlappingResourceTag (74.82s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_emptyProviderOnlyTag (78.03s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccVPCLatticeDomainVerification_tags_EmptyTag_OnUpdate_Replace (80.20s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_emptyResourceTag (80.51s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_EmptyTag_OnCreate
--- PASS: TestAccVPCLatticeDomainVerification_tags_EmptyTag_OnUpdate_Add (117.08s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_AddOnUpdate
--- PASS: TestAccVPCLatticeDomainVerification_tags_EmptyTag_OnCreate (86.85s)
=== CONT  TestAccVPCLatticeListener_tags
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_updateToResourceOnly (120.41s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_EmptyMap
--- PASS: TestAccVPCLatticeDomainVerification_tags_AddOnUpdate (76.58s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_overlapping
--- PASS: TestAccVPCLatticeDomainVerification_tags_EmptyMap (44.69s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nonOverlapping
--- PASS: TestAccVPCLatticeListener_tags (176.95s)
=== CONT  TestAccVPCLatticeListener_forwardHTTPTargetGroupCustomPort
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_overlapping (171.56s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_providerOnly
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nonOverlapping (170.98s)
=== CONT  TestAccVPCLatticeListener_disappears
--- PASS: TestAccVPCLatticeListener_forwardHTTPTargetGroupCustomPort (102.51s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccVPCLatticeListener_disappears (96.57s)
=== CONT  TestAccVPCLatticeListener_forwardHTTPMultipleTargetGroups
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnUpdate_Replace (103.75s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_providerOnly (210.73s)
=== CONT  TestAccVPCLatticeListener_forwardHTTPSTargetGroupCustomPort
--- PASS: TestAccVPCLatticeListener_forwardHTTPMultipleTargetGroups (121.48s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnCreate
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnUpdate_Add (150.09s)
=== CONT  TestAccVPCLatticeListener_forwardHTTPSTargetGroupARN
--- PASS: TestAccVPCLatticeListener_forwardHTTPSTargetGroupCustomPort (110.93s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_AddOnUpdate
--- PASS: TestAccVPCLatticeResourceConfiguration_arnResource (1214.26s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_EmptyMap
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnCreate (117.24s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccVPCLatticeDomainVerification_tags_DefaultTags_nullNonOverlappingResourceTag (44.46s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_EmptyMap (77.79s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_null
--- PASS: TestAccVPCLatticeListener_forwardHTTPSTargetGroupARN (110.90s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_AddOnUpdate (115.18s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_ComputedTag_OnCreate
--- PASS: TestAccVPCLatticeDomainVerification_tags_ComputedTag_OnUpdate_Add (86.25s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_null (80.40s)
=== CONT  TestAccVPCLatticeDomainVerification_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccVPCLatticeDomainVerification_tags_ComputedTag_OnCreate (55.04s)
=== CONT  TestAccVPCLatticeAccessLogSubscription_tags
--- PASS: TestAccVPCLatticeDomainVerification_tags_DefaultTags_nullOverlappingResourceTag (54.25s)
=== CONT  TestAccVPCLatticeAccessLogSubscription_cloudwatchWildcard
--- PASS: TestAccVPCLatticeDomainVerification_tags_DefaultTags_emptyProviderOnlyTag (56.04s)
=== CONT  TestAccVPCLatticeResourceGateway_update
--- PASS: TestAccVPCLatticeAccessLogSubscription_cloudwatchWildcard (46.81s)
=== CONT  TestAccVPCLatticeAccessLogSubscription_cloudwatchNoWildcard
--- PASS: TestAccVPCLatticeAccessLogSubscription_cloudwatchNoWildcard (44.04s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccVPCLatticeAccessLogSubscription_tags (135.97s)
=== CONT  TestAccVPCLatticeAccessLogSubscription_arn
--- PASS: TestAccVPCLatticeResourceConfiguration_tags (232.06s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccVPCLatticeAccessLogSubscription_arn (58.97s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_overlapping
--- PASS: TestAccVPCLatticeResourceGateway_update (157.47s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_updateToResourceOnly (148.17s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nonOverlapping
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullNonOverlappingResourceTag (76.84s)
=== CONT  TestAccVPCLatticeResourceGateway_ipv4AddressesPerEni
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_updateToProviderOnly (147.37s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_providerOnly
--- PASS: TestAccVPCLatticeResourceGateway_ipv4AddressesPerEni (72.37s)
=== CONT  TestAccVPCLatticeResourceGateway_multipleSubnets
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_overlapping (205.64s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccVPCLatticeResourceGateway_multipleSubnets (74.38s)
=== CONT  TestAccVPCLatticeResourceGateway_addressTypeIPv6
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nonOverlapping (220.88s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccVPCLatticeResourceGateway_addressTypeIPv6 (72.68s)
=== CONT  TestAccVPCLatticeResourceGateway_addressTypeDualstack
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnUpdate_Replace (154.33s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnCreate
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_providerOnly (267.39s)
=== CONT  TestAccVPCLatticeResourceGateway_basic
--- PASS: TestAccVPCLatticeResourceGateway_addressTypeDualstack (72.20s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_AddOnUpdate
--- PASS: TestAccVPCLatticeResourceGateway_basic (72.53s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnUpdate_Add (201.56s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnCreate (163.65s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyMap
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_AddOnUpdate (146.96s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_ResourceTag (148.47s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_null
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyMap (107.94s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_DefaultTag (141.61s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnCreate
--- PASS: TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Replace (116.65s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_null (103.22s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnCreate (76.91s)
=== CONT  TestAccVPCLatticeServiceNetworkDataSource_shared
    service_network_data_source_test.go:57: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccVPCLatticeServiceNetworkDataSource_shared (0.00s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Add (113.08s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullOverlappingResourceTag (78.37s)
=== CONT  TestAccVPCLatticeServiceNetworkDataSource_basic
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyProviderOnlyTag (79.97s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToProviderOnly (121.56s)
=== CONT  TestAccVPCLatticeServiceDataSource_shared
    service_data_source_test.go:90: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccVPCLatticeServiceDataSource_shared (0.00s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccVPCLatticeServiceNetworkDataSource_basic (42.61s)
=== CONT  TestAccVPCLatticeServiceDataSource_byName
--- PASS: TestAccVPCLatticeServiceDataSource_byName (45.08s)
=== CONT  TestAccVPCLatticeResourcePolicy_basic
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyResourceTag (77.10s)
=== CONT  TestAccVPCLatticeResourcePolicyDataSource_basic
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags (258.48s)
=== CONT  TestAccVPCLatticeServiceDataSource_basic
--- PASS: TestAccVPCLatticeResourcePolicy_basic (49.71s)
=== CONT  TestAccVPCLatticeResourceGateway_disappears
--- PASS: TestAccVPCLatticeResourcePolicyDataSource_basic (43.25s)
=== CONT  TestAccVPCLatticeResourcePolicy_disappears
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToResourceOnly (121.87s)
=== CONT  TestAccVPCLatticeListener_fixedResponseHTTP
--- PASS: TestAccVPCLatticeServiceDataSource_basic (46.93s)
=== CONT  TestAccVPCLatticeListener_forwardHTTPTargetGroup
--- PASS: TestAccVPCLatticeResourcePolicy_disappears (39.08s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_providerOnly
--- PASS: TestAccVPCLatticeResourceGateway_disappears (62.90s)
=== CONT  TestAccVPCLatticeListener_forwardTLSPassthrough
--- PASS: TestAccVPCLatticeListener_forwardHTTPTargetGroup (97.26s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_overlapping
--- PASS: TestAccVPCLatticeListener_fixedResponseHTTP (105.10s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_nonOverlapping
--- PASS: TestAccVPCLatticeListener_forwardTLSPassthrough (106.59s)
=== CONT  TestAccVPCLatticeAccessLogSubscription_disappears
--- PASS: TestAccVPCLatticeAccessLogSubscription_disappears (53.08s)
=== CONT  TestAccVPCLatticeListener_defaultActionUpdate
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_providerOnly (225.95s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_overlapping (181.37s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_nonOverlapping (183.09s)
=== CONT  TestAccVPCLatticeListener_fixedResponseHTTPS
--- PASS: TestAccVPCLatticeListener_defaultActionUpdate (143.86s)
--- PASS: TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Replace (112.01s)
--- PASS: TestAccVPCLatticeListener_fixedResponseHTTPS (109.15s)
--- PASS: TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Add (143.82s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice 5159.689s

...
```
