### PR TITLE
Add `aws_iam_outbound_web_identity_federation` data source

### DIFF
--- a/.changelog/46048.txt
+++ b/.changelog/46048.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_iam_outbound_web_identity_federation
+```

--- a/internal/service/iam/outbound_web_identity_federation_data_source.go
+++ b/internal/service/iam/outbound_web_identity_federation_data_source.go
@@ -1,0 +1,85 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package iam
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for datasource registration to the Provider. DO NOT EDIT.
+// @FrameworkDataSource("aws_iam_outbound_web_identity_federation", name="Outbound Web Identity Federation")
+func newOutboundWebIdentityFederationDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &outboundWebIdentityFederationDataSource{}, nil
+}
+
+const (
+	DSNameOutboundWebIdentityFederation = "Outbound Web Identity Federation Data Source"
+)
+
+type outboundWebIdentityFederationDataSource struct {
+	framework.DataSourceWithModel[outboundWebIdentityFederationDataSourceModel]
+}
+
+func (d *outboundWebIdentityFederationDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrEnabled: schema.BoolAttribute{
+				Computed: true,
+			},
+			names.AttrID: schema.StringAttribute{
+				Computed: true,
+			},
+			"issuer_identifier": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+	}
+}
+
+func (d *outboundWebIdentityFederationDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().IAMClient(ctx)
+
+	var data outboundWebIdentityFederationDataSourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Config.Get(ctx, &data))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findOutboundWebIdentityFederation(ctx, conn)
+	if retry.NotFound(err) {
+		// Feature is disabled
+		data.Enabled = types.BoolValue(false)
+		data.ID = types.StringValue(d.Meta().AccountID(ctx))
+		data.IssuerIdentifier = types.StringNull()
+
+		smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
+		return
+	}
+
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err)
+		return
+	}
+
+	data.Enabled = types.BoolValue(out.JwtVendingEnabled)
+	data.ID = types.StringValue(d.Meta().AccountID(ctx))
+	data.IssuerIdentifier = flex.StringToFramework(ctx, out.IssuerIdentifier)
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
+}
+
+type outboundWebIdentityFederationDataSourceModel struct {
+	Enabled          types.Bool   `tfsdk:"enabled"`
+	ID               types.String `tfsdk:"id"`
+	IssuerIdentifier types.String `tfsdk:"issuer_identifier"`
+}

--- a/internal/service/iam/outbound_web_identity_federation_data_source_test.go
+++ b/internal/service/iam/outbound_web_identity_federation_data_source_test.go
@@ -1,0 +1,57 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package iam_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccIAMOutboundWebIdentityFederationDataSource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_iam_outbound_web_identity_federation.test"
+	dataSourceName := "data.aws_iam_outbound_web_identity_federation.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOutboundWebIdentityFederationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOutboundWebIdentityFederationDataSourceConfig_basic,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrEnabled, "false"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "issuer_identifier"),
+				),
+			},
+			{
+				Config: testAccOutboundWebIdentityFederationDataSourceConfig_enabled,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOutboundWebIdentityFederationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrEnabled, "true"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "issuer_identifier"),
+				),
+			},
+		},
+	})
+}
+
+const testAccOutboundWebIdentityFederationDataSourceConfig_basic = `
+data "aws_iam_outbound_web_identity_federation" "test" {}
+`
+
+const testAccOutboundWebIdentityFederationDataSourceConfig_enabled = `
+resource "aws_iam_outbound_web_identity_federation" "test" {}
+
+data "aws_iam_outbound_web_identity_federation" "test" {
+  depends_on = [aws_iam_outbound_web_identity_federation.test]
+}
+`

--- a/internal/service/iam/service_package_gen.go
+++ b/internal/service/iam/service_package_gen.go
@@ -23,7 +23,14 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
-	return []*inttypes.ServicePackageFrameworkDataSource{}
+	return []*inttypes.ServicePackageFrameworkDataSource{
+		{
+			Factory:  newOutboundWebIdentityFederationDataSource,
+			TypeName: "aws_iam_outbound_web_identity_federation",
+			Name:     "Outbound Web Identity Federation",
+			Region:   unique.Make(inttypes.ResourceRegionDisabled()),
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.ServicePackageFrameworkResource {

--- a/website/docs/d/iam_outbound_web_identity_federation.html.markdown
+++ b/website/docs/d/iam_outbound_web_identity_federation.html.markdown
@@ -1,0 +1,40 @@
+---
+subcategory: "IAM (Identity & Access Management)"
+layout: "aws"
+page_title: "AWS: aws_iam_outbound_web_identity_federation"
+description: |-
+  Provides details about IAM Outbound Web Identity Federation configuration.
+---
+
+# Data Source: aws_iam_outbound_web_identity_federation
+
+Provides details about the IAM Outbound Web Identity Federation configuration for the AWS account.
+
+This data source can be used to check whether outbound web identity federation is enabled and retrieve the issuer identifier URL.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_iam_outbound_web_identity_federation" "example" {}
+
+output "federation_enabled" {
+  value = data.aws_iam_outbound_web_identity_federation.example.enabled
+}
+
+output "issuer_url" {
+  value = data.aws_iam_outbound_web_identity_federation.example.issuer_identifier
+}
+```
+
+## Argument Reference
+
+This data source does not support any arguments.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `enabled` - Whether outbound identity federation is currently enabled for the AWS account. When `true`, IAM principals in the account can call the `GetWebIdentityToken` API to obtain JSON Web Tokens (JWTs) for authentication with external services.
+* `issuer_identifier` - Unique issuer URL for the AWS account that hosts the OpenID Connect (OIDC) discovery endpoints at `/.well-known/openid-configuration` and `/.well-known/jwks.json`. The OpenID Connect (OIDC) discovery endpoints contain verification keys and metadata necessary for token verification. `null` if the feature is disabled.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

### References
https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetOutboundWebIdentityFederationInfo.html


### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccIAMOutboundWebIdentityFederationDataSource PKG=iam
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-iam-outbound-web-identity-federation 🌿...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMOutboundWebIdentityFederationDataSource'  -timeout 360m -vet=off
2026/01/20 14:31:27 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/20 14:31:27 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIAMOutboundWebIdentityFederationDataSource
--- PASS: TestAccIAMOutboundWebIdentityFederationDataSource (29.35s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	34.577s
```
