### PR TITLE
Add label for EUSC partition

### DIFF
--- a/infrastructure/repository/labels-partition.tf
+++ b/infrastructure/repository/labels-partition.tf
@@ -4,6 +4,7 @@
 variable "partition_labels" {
   default = [
     "aws-cn",
+    "aws-eusc",
     "aws-iso",
     "aws-iso-b",
     "aws-us-gov",


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None

## Description

Adds a label for the EU Sovereign Cloud partition

## Output from Acceptance Testing

N/a, labels
