### PR TITLE
Fix perpetual diff for `warm_throughput` in `global_secondary_index` when not set in configuration

### DIFF
--- a/.changelog/46094.txt
+++ b/.changelog/46094.txt
@@ -1,0 +1,2 @@
+```release-note:bug
+resource/aws_dynamodb_table: Fix perpetual diff for `warm_throughput` in global_secondary_index when not set in configuration.

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -2158,8 +2158,16 @@ func updateDiffGSI(oldGsi, newGsi []any, billingMode awstypes.BillingMode) ([]aw
 					}
 					ops = append(ops, update)
 				}
-				// Separating the WarmThroughput updates from the others
-				if warmThroughputChanged {
+				// Only update WarmThroughput if the user has set it in the new config (not omitted or empty)
+				newWarmThroughputOmitted := true
+				if v, ok := newMap["warm_throughput"]; ok {
+					if arr, ok := v.([]any); ok {
+						if len(arr) > 0 && arr[0] != nil {
+							newWarmThroughputOmitted = false
+						}
+					}
+				}
+				if warmThroughputChanged && !newWarmThroughputOmitted {
 					update := awstypes.GlobalSecondaryIndexUpdate{
 						Update: &awstypes.UpdateGlobalSecondaryIndexAction{
 							IndexName:      aws.String(idxName),
@@ -3590,6 +3598,17 @@ func customDiffGlobalSecondaryIndex(_ context.Context, diff *schema.ResourceDiff
 				if p.LengthInt() == 0 && s.LengthInt() > 0 {
 					// "hash_key" is set
 					continue // change to "hash_key" will be caught by equality test
+				}
+				if !ctyValueLegacyEquals(s, p) {
+					return nil
+				}
+
+			case "warm_throughput":
+				// AWS automatically sets warm_throughput
+				// values for on-demand tables, but these should not cause diffs when
+				// the user hasn't explicitly configured warm_throughput.
+				if p.IsNull() || (p.IsKnown() && p.LengthInt() == 0) {
+					continue
 				}
 				if !ctyValueLegacyEquals(s, p) {
 					return nil

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -890,6 +890,70 @@ func TestUpdateDiffGSI_OnDemand(t *testing.T) {
 		New             []any
 		ExpectedUpdates []awstypes.GlobalSecondaryIndexUpdate
 	}{
+		"plan omits warm_throughput - should not update": {
+			Old: []any{
+				map[string]any{
+					names.AttrName: "att1-index",
+					"hash_key":     "att1",
+					"on_demand_throughput": []any{map[string]any{
+						"max_read_request_units":  5,
+						"max_write_request_units": 10,
+					}},
+					"projection_type": "ALL",
+					"warm_throughput": []any{
+						map[string]any{
+							"read_units_per_second":  12000,
+							"write_units_per_second": 17194,
+						},
+					},
+				},
+			},
+			New: []any{
+				map[string]any{
+					names.AttrName: "att1-index",
+					"hash_key":     "att1",
+					"on_demand_throughput": []any{map[string]any{
+						"max_read_request_units":  5,
+						"max_write_request_units": 10,
+					}},
+					"projection_type": "ALL",
+					// "warm_throughput" omitted
+				},
+			},
+			ExpectedUpdates: nil,
+		},
+		"plan has empty warm_throughput - should not update": {
+			Old: []any{
+				map[string]any{
+					names.AttrName: "att1-index",
+					"hash_key":     "att1",
+					"on_demand_throughput": []any{map[string]any{
+						"max_read_request_units":  5,
+						"max_write_request_units": 10,
+					}},
+					"projection_type": "ALL",
+					"warm_throughput": []any{
+						map[string]any{
+							"read_units_per_second":  12000,
+							"write_units_per_second": 17194,
+						},
+					},
+				},
+			},
+			New: []any{
+				map[string]any{
+					names.AttrName: "att1-index",
+					"hash_key":     "att1",
+					"on_demand_throughput": []any{map[string]any{
+						"max_read_request_units":  5,
+						"max_write_request_units": 10,
+					}},
+					"projection_type": "ALL",
+					"warm_throughput": []any{}, // explicitly empty
+				},
+			},
+			ExpectedUpdates: nil,
+		},
 		"no changes": { // No-op => no changes
 			Old: []any{
 				map[string]any{


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.


### Description

Th issue was Terraform was generating perpetual diffs and unnecessary update operations for the DynamoDB GSI warm_throughput attribute, even when the user did not set it. This happened because AWS manages warm_throughput automatically, but the provider logic was still checking and updating it.

Fix :  if warm_throughput is not set by the user (i.e omitted or empty), Terraform will ignore any changes to it and not trigger updates. This prevents unwanted diffs and unnecessary API calls, aligning the provider behavior with user intent.

### Relations


Closes #44692 
Closes #46053

### Output from Acceptance Testing

The DynamoDB table was created, and then the warm_throughput value was manually increased outside of Terraform (via the AWS Console). This reproduced the perpetual diff issue, as AWS manages warm_throughput automatically for on-demand tables based on traffic/load, making it difficult to test this scenario with an acceptance test(?). For now, I have relied on unit tests. If there is a way to replicate the same in the acceptance test environment, I will explore it.


### Output from Unit Testing
```console
make t T=TestUpdateDiffGSI_OnDemand K=dynamodb
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-dynamodb_table-warm_throughput-perpetual-diff 🌿...
TF_ACC=1 go1.25.5 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestUpdateDiffGSI_OnDemand'  -timeout 360m -vet=off
2026/01/22 12:16:51 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/22 12:16:51 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestUpdateDiffGSI_OnDemand
=== PAUSE TestUpdateDiffGSI_OnDemand
=== CONT  TestUpdateDiffGSI_OnDemand
=== RUN   TestUpdateDiffGSI_OnDemand/remove_GSI
=== PAUSE TestUpdateDiffGSI_OnDemand/remove_GSI
=== RUN   TestUpdateDiffGSI_OnDemand/update_capacity_and_warm_throughput
=== PAUSE TestUpdateDiffGSI_OnDemand/update_capacity_and_warm_throughput
=== RUN   TestUpdateDiffGSI_OnDemand/update_on_demand_throughput_only
=== PAUSE TestUpdateDiffGSI_OnDemand/update_on_demand_throughput_only
=== RUN   TestUpdateDiffGSI_OnDemand/no_changes
=== PAUSE TestUpdateDiffGSI_OnDemand/no_changes
=== RUN   TestUpdateDiffGSI_OnDemand/non-key_attribute_order
=== PAUSE TestUpdateDiffGSI_OnDemand/non-key_attribute_order
=== RUN   TestUpdateDiffGSI_OnDemand/add_GSI_with_warm_throughput
=== PAUSE TestUpdateDiffGSI_OnDemand/add_GSI_with_warm_throughput
=== RUN   TestUpdateDiffGSI_OnDemand/update_warm_throughput_in_place
=== PAUSE TestUpdateDiffGSI_OnDemand/update_warm_throughput_in_place
=== RUN   TestUpdateDiffGSI_OnDemand/change_key_schema_and_non-key_attributes
=== PAUSE TestUpdateDiffGSI_OnDemand/change_key_schema_and_non-key_attributes
=== RUN   TestUpdateDiffGSI_OnDemand/decrease_warm_throughput
=== PAUSE TestUpdateDiffGSI_OnDemand/decrease_warm_throughput
=== RUN   TestUpdateDiffGSI_OnDemand/change_hash_key_to_multiple_hash_keys
=== PAUSE TestUpdateDiffGSI_OnDemand/change_hash_key_to_multiple_hash_keys
=== RUN   TestUpdateDiffGSI_OnDemand/remove_key_from_hash_keys
=== PAUSE TestUpdateDiffGSI_OnDemand/remove_key_from_hash_keys
=== RUN   TestUpdateDiffGSI_OnDemand/add_GSI
=== PAUSE TestUpdateDiffGSI_OnDemand/add_GSI
=== RUN   TestUpdateDiffGSI_OnDemand/update_hash_key_only
=== PAUSE TestUpdateDiffGSI_OnDemand/update_hash_key_only
=== RUN   TestUpdateDiffGSI_OnDemand/add_with_multiple_hash_keys
=== PAUSE TestUpdateDiffGSI_OnDemand/add_with_multiple_hash_keys
=== RUN   TestUpdateDiffGSI_OnDemand/change_multiple_hash_keys_to_hash_key
=== PAUSE TestUpdateDiffGSI_OnDemand/change_multiple_hash_keys_to_hash_key
=== RUN   TestUpdateDiffGSI_OnDemand/plan_omits_warm_throughput_-_should_not_update
=== PAUSE TestUpdateDiffGSI_OnDemand/plan_omits_warm_throughput_-_should_not_update
=== RUN   TestUpdateDiffGSI_OnDemand/plan_has_empty_warm_throughput_-_should_not_update
=== PAUSE TestUpdateDiffGSI_OnDemand/plan_has_empty_warm_throughput_-_should_not_update
=== CONT  TestUpdateDiffGSI_OnDemand/remove_GSI
=== CONT  TestUpdateDiffGSI_OnDemand/change_hash_key_to_multiple_hash_keys
=== CONT  TestUpdateDiffGSI_OnDemand/add_GSI_with_warm_throughput
=== CONT  TestUpdateDiffGSI_OnDemand/update_on_demand_throughput_only
=== CONT  TestUpdateDiffGSI_OnDemand/add_with_multiple_hash_keys
=== CONT  TestUpdateDiffGSI_OnDemand/plan_has_empty_warm_throughput_-_should_not_update
=== CONT  TestUpdateDiffGSI_OnDemand/plan_omits_warm_throughput_-_should_not_update
=== CONT  TestUpdateDiffGSI_OnDemand/change_multiple_hash_keys_to_hash_key
=== CONT  TestUpdateDiffGSI_OnDemand/add_GSI
=== CONT  TestUpdateDiffGSI_OnDemand/update_hash_key_only
=== CONT  TestUpdateDiffGSI_OnDemand/remove_key_from_hash_keys
=== CONT  TestUpdateDiffGSI_OnDemand/change_key_schema_and_non-key_attributes
=== CONT  TestUpdateDiffGSI_OnDemand/decrease_warm_throughput
=== CONT  TestUpdateDiffGSI_OnDemand/update_warm_throughput_in_place
=== CONT  TestUpdateDiffGSI_OnDemand/no_changes
=== CONT  TestUpdateDiffGSI_OnDemand/non-key_attribute_order
=== CONT  TestUpdateDiffGSI_OnDemand/update_capacity_and_warm_throughput
--- PASS: TestUpdateDiffGSI_OnDemand (0.00s)
    --- PASS: TestUpdateDiffGSI_OnDemand/plan_has_empty_warm_throughput_-_should_not_update (0.00s)
    --- PASS: TestUpdateDiffGSI_OnDemand/plan_omits_warm_throughput_-_should_not_update (0.00s)
    --- PASS: TestUpdateDiffGSI_OnDemand/remove_GSI (0.00s)
    --- PASS: TestUpdateDiffGSI_OnDemand/update_warm_throughput_in_place (0.00s)
    --- PASS: TestUpdateDiffGSI_OnDemand/update_hash_key_only (0.00s)
    --- PASS: TestUpdateDiffGSI_OnDemand/change_multiple_hash_keys_to_hash_key (0.00s)
    --- PASS: TestUpdateDiffGSI_OnDemand/add_with_multiple_hash_keys (0.00s)
    --- PASS: TestUpdateDiffGSI_OnDemand/remove_key_from_hash_keys (0.00s)
    --- PASS: TestUpdateDiffGSI_OnDemand/no_changes (0.00s)
    --- PASS: TestUpdateDiffGSI_OnDemand/change_key_schema_and_non-key_attributes (0.00s)
    --- PASS: TestUpdateDiffGSI_OnDemand/add_GSI (0.00s)
    --- PASS: TestUpdateDiffGSI_OnDemand/add_GSI_with_warm_throughput (0.00s)
    --- PASS: TestUpdateDiffGSI_OnDemand/decrease_warm_throughput (0.00s)
    --- PASS: TestUpdateDiffGSI_OnDemand/update_on_demand_throughput_only (0.00s)
    --- PASS: TestUpdateDiffGSI_OnDemand/non-key_attribute_order (0.00s)
    --- PASS: TestUpdateDiffGSI_OnDemand/change_hash_key_to_multiple_hash_keys (0.00s)
    --- PASS: TestUpdateDiffGSI_OnDemand/update_capacity_and_warm_throughput (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   5.140s
```
