### PR TITLE
Docs: Add missing id attribute to Attribute Reference

### DIFF
--- a/website/docs/r/imagebuilder_component.html.markdown
+++ b/website/docs/r/imagebuilder_component.html.markdown
@@ -73,6 +73,7 @@ The following arguments are optional:
 
 This resource exports the following attributes in addition to the arguments above:
 
+* `id` - Amazon Resource Name (ARN) of the component.
 * `arn` - (Required) Amazon Resource Name (ARN) of the component.
 * `date_created` - Date the component was created.
 * `encrypted` - Encryption status of the component.

--- a/website/docs/r/imagebuilder_container_recipe.html.markdown
+++ b/website/docs/r/imagebuilder_container_recipe.html.markdown
@@ -127,6 +127,7 @@ The following arguments are optional:
 
 This resource exports the following attributes in addition to the arguments above:
 
+* `id` - Amazon Resource Name (ARN) of the container recipe.
 * `arn` - (Required) Amazon Resource Name (ARN) of the container recipe.
 * `date_created` - Date the container recipe was created.
 * `encrypted` - A flag that indicates if the target container is encrypted.

--- a/website/docs/r/imagebuilder_distribution_configuration.html.markdown
+++ b/website/docs/r/imagebuilder_distribution_configuration.html.markdown
@@ -142,6 +142,7 @@ The following arguments are optional:
 
 This resource exports the following attributes in addition to the arguments above:
 
+* `id` - Amazon Resource Name (ARN) of the distribution configuration.
 * `arn` - (Required) Amazon Resource Name (ARN) of the distribution configuration.
 * `date_created` - Date the distribution configuration was created.
 * `date_updated` - Date the distribution configuration was updated.

--- a/website/docs/r/imagebuilder_image.html.markdown
+++ b/website/docs/r/imagebuilder_image.html.markdown
@@ -94,6 +94,7 @@ The following arguments are required:
 
 This resource exports the following attributes in addition to the arguments above:
 
+* `id` - Amazon Resource Name (ARN) of the image.
 * `arn` - Amazon Resource Name (ARN) of the image.
 * `date_created` - Date the image was created.
 * `platform` - Platform of the image.

--- a/website/docs/r/imagebuilder_image_pipeline.html.markdown
+++ b/website/docs/r/imagebuilder_image_pipeline.html.markdown
@@ -154,6 +154,7 @@ The following arguments are required:
 
 This resource exports the following attributes in addition to the arguments above:
 
+* `id` - Amazon Resource Name (ARN) of the image pipeline.
 * `arn` - Amazon Resource Name (ARN) of the image pipeline.
 * `date_created` - Date the image pipeline was created.
 * `date_last_run` - Date the image pipeline was last run.

--- a/website/docs/r/imagebuilder_image_recipe.html.markdown
+++ b/website/docs/r/imagebuilder_image_recipe.html.markdown
@@ -100,6 +100,7 @@ The following arguments are optional:
 
 This resource exports the following attributes in addition to the arguments above:
 
+* `id` - Amazon Resource Name (ARN) of the image recipe.
 * `arn` - Amazon Resource Name (ARN) of the image recipe.
 * `date_created` - Date the image recipe was created.
 * `owner` - Owner of the image recipe.

--- a/website/docs/r/imagebuilder_workflow.html.markdown
+++ b/website/docs/r/imagebuilder_workflow.html.markdown
@@ -74,6 +74,7 @@ The following arguments are optional:
 
 This resource exports the following attributes in addition to the arguments above:
 
+* `id` - Amazon Resource Name (ARN) of the workflow.
 * `arn` - Amazon Resource Name (ARN) of the workflow.
 * `date_created` - Date the workflow was created.
 * `owner` - Owner of the workflow.


### PR DESCRIPTION
### Description
This PR Adds the missing "id" attribute in the documentation to the "Attribute Reference" section for the following ImageBuilder resources:

- aws_imagebuilder_component
- aws_imagebuilder_container_recipe
- aws_imagebuilder_distribution_configuration
- aws_imagebuilder_image
- aws_imagebuilder_image_pipeline
- aws_imagebuilder_image_recipe
- aws_imagebuilder_workflow

The id attribute is already implemented in the code (set via "d.SetId()" to the resource ARN) but was not documented.

This aligns with the existing documentation for aws_imagebuilder_infrastructure_configuration and aws_imagebuilder_lifecycle_policy which already document the `id` attribute as mentioned in #46044 

Fixes #46044

### Checklist

- [x] Documentation update
- [x] No changelog required for documentation updates

### Relations

Closes #46044

