### PR TITLE
r/aws_configservice_configuration_recorder: omit optional/computed blocks when not configured

### DIFF
--- a/.changelog/46110.txt
+++ b/.changelog/46110.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_config_configuration_recorder: Fix `InvalidRecordingGroupException: The recording group provided is not valid` errors when the `recording_group.exclusion_by_resource_type` or `recording_group.recording_strategy` argument is removed during update
+```

--- a/internal/service/configservice/configservice_test.go
+++ b/internal/service/configservice/configservice_test.go
@@ -38,10 +38,11 @@ func TestAccConfigService_serial(t *testing.T) {
 			acctest.CtDisappears: testAccConfigurationRecorderStatus_disappears,
 		},
 		"ConfigurationRecorder": {
-			acctest.CtBasic:      testAccConfigurationRecorder_basic,
-			"allParams":          testAccConfigurationRecorder_allParams,
-			"recordStrategy":     testAccConfigurationRecorder_recordStrategy,
-			acctest.CtDisappears: testAccConfigurationRecorder_disappears,
+			acctest.CtBasic:            testAccConfigurationRecorder_basic,
+			"allParams":                testAccConfigurationRecorder_allParams,
+			"exclusionsToAllSupported": testAccConfigurationRecorder_exclusionsToAllSupported,
+			"recordStrategy":           testAccConfigurationRecorder_recordStrategy,
+			acctest.CtDisappears:       testAccConfigurationRecorder_disappears,
 		},
 		"ConformancePack": {
 			acctest.CtBasic:             testAccConformancePack_basic,


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This will prevent failed updates when the `recording_group.exclusion_by_resource_type` or `recording_group.recording_strategy` arguments are removed.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38820

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingGroup.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=configservice T='^TestAccConfigService_serial/ConfigurationRecorder$$'
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-configuration_recorder-update 🌿...
TF_ACC=1 go1.25.6 test ./internal/service/configservice/... -v -count 1 -parallel 20 -run='^TestAccConfigService_serial/ConfigurationRecorder$'  -timeout 360m -vet=off
2026/01/22 09:56:09 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/22 09:56:09 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccConfigService_serial (232.09s)
    --- PASS: TestAccConfigService_serial/ConfigurationRecorder (232.09s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/basic (43.78s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/allParams (38.36s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/exclusionsToAllSupported (65.43s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/recordStrategy (43.23s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/disappears (41.29s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/configservice      238.681s
```
