### PR TITLE
appautoscaling: enable `go-vcr` support

### DIFF
--- a/internal/service/appautoscaling/target.go
+++ b/internal/service/appautoscaling/target.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/applicationautoscaling"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/applicationautoscaling/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -32,7 +31,6 @@ import (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/applicationautoscaling/types;awstypes;awstypes.ScalableTarget")
 // @Testing(importStateIdFunc="testAccTargetImportStateIdFunc")
 // @Testing(skipEmptyTags=true)
-// @Testing(existsTakesT=false, destroyTakesT=false)
 func resourceTarget() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTargetCreate,
@@ -265,9 +263,7 @@ func findTargetByThreePartKey(ctx context.Context, conn *applicationautoscaling.
 	}
 
 	if aws.ToString(target.ResourceId) != resourceID || string(target.ScalableDimension) != dimension || string(target.ServiceNamespace) != namespace {
-		return nil, &sdkretry.NotFoundError{
-			LastRequest: &input,
-		}
+		return nil, &retry.NotFoundError{}
 	}
 
 	return target, nil

--- a/internal/service/appautoscaling/target_tags_gen_test.go
+++ b/internal/service/appautoscaling/target_tags_gen_test.go
@@ -33,7 +33,7 @@ func TestAccAppAutoScalingTarget_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy:             testAccCheckTargetDestroy(ctx),
+		CheckDestroy:             testAccCheckTargetDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -45,7 +45,7 @@ func TestAccAppAutoScalingTarget_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -90,7 +90,7 @@ func TestAccAppAutoScalingTarget_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -139,7 +139,7 @@ func TestAccAppAutoScalingTarget_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -181,7 +181,7 @@ func TestAccAppAutoScalingTarget_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -223,7 +223,7 @@ func TestAccAppAutoScalingTarget_tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy:             testAccCheckTargetDestroy(ctx),
+		CheckDestroy:             testAccCheckTargetDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -235,7 +235,7 @@ func TestAccAppAutoScalingTarget_tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -295,7 +295,7 @@ func TestAccAppAutoScalingTarget_tags_EmptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy:             testAccCheckTargetDestroy(ctx),
+		CheckDestroy:             testAccCheckTargetDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -305,7 +305,7 @@ func TestAccAppAutoScalingTarget_tags_EmptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -363,7 +363,7 @@ func TestAccAppAutoScalingTarget_tags_AddOnUpdate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy:             testAccCheckTargetDestroy(ctx),
+		CheckDestroy:             testAccCheckTargetDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -373,7 +373,7 @@ func TestAccAppAutoScalingTarget_tags_AddOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -397,7 +397,7 @@ func TestAccAppAutoScalingTarget_tags_AddOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -451,7 +451,7 @@ func TestAccAppAutoScalingTarget_tags_EmptyTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy:             testAccCheckTargetDestroy(ctx),
+		CheckDestroy:             testAccCheckTargetDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -463,7 +463,7 @@ func TestAccAppAutoScalingTarget_tags_EmptyTag_OnCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -504,7 +504,7 @@ func TestAccAppAutoScalingTarget_tags_EmptyTag_OnCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -548,7 +548,7 @@ func TestAccAppAutoScalingTarget_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy:             testAccCheckTargetDestroy(ctx),
+		CheckDestroy:             testAccCheckTargetDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -560,7 +560,7 @@ func TestAccAppAutoScalingTarget_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -592,7 +592,7 @@ func TestAccAppAutoScalingTarget_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -639,7 +639,7 @@ func TestAccAppAutoScalingTarget_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -693,7 +693,7 @@ func TestAccAppAutoScalingTarget_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy:             testAccCheckTargetDestroy(ctx),
+		CheckDestroy:             testAccCheckTargetDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -705,7 +705,7 @@ func TestAccAppAutoScalingTarget_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -736,7 +736,7 @@ func TestAccAppAutoScalingTarget_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -787,7 +787,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_providerOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy: testAccCheckTargetDestroy(ctx),
+		CheckDestroy: testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -800,7 +800,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -845,7 +845,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -892,7 +892,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -933,7 +933,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -976,7 +976,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_nonOverlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy: testAccCheckTargetDestroy(ctx),
+		CheckDestroy: testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -991,7 +991,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1046,7 +1046,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1100,7 +1100,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1143,7 +1143,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_overlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy: testAccCheckTargetDestroy(ctx),
+		CheckDestroy: testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1158,7 +1158,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1212,7 +1212,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1270,7 +1270,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1326,7 +1326,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_updateToProviderOnly(t *testin
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy: testAccCheckTargetDestroy(ctx),
+		CheckDestroy: testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1338,7 +1338,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_updateToProviderOnly(t *testin
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1371,7 +1371,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_updateToProviderOnly(t *testin
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1421,7 +1421,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_updateToResourceOnly(t *testin
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy: testAccCheckTargetDestroy(ctx),
+		CheckDestroy: testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1434,7 +1434,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_updateToResourceOnly(t *testin
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1462,7 +1462,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_updateToResourceOnly(t *testin
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1517,7 +1517,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_emptyResourceTag(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy: testAccCheckTargetDestroy(ctx),
+		CheckDestroy: testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1532,7 +1532,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_emptyResourceTag(t *testing.T)
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1589,7 +1589,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy: testAccCheckTargetDestroy(ctx),
+		CheckDestroy: testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1602,7 +1602,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1651,7 +1651,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_nullOverlappingResourceTag(t *
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy: testAccCheckTargetDestroy(ctx),
+		CheckDestroy: testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1666,7 +1666,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_nullOverlappingResourceTag(t *
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1718,7 +1718,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_nullNonOverlappingResourceTag(
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy: testAccCheckTargetDestroy(ctx),
+		CheckDestroy: testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1733,7 +1733,7 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_nullNonOverlappingResourceTag(
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1785,7 +1785,7 @@ func TestAccAppAutoScalingTarget_tags_ComputedTag_OnCreate(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy: testAccCheckTargetDestroy(ctx),
+		CheckDestroy: testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1795,7 +1795,7 @@ func TestAccAppAutoScalingTarget_tags_ComputedTag_OnCreate(t *testing.T) {
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1845,7 +1845,7 @@ func TestAccAppAutoScalingTarget_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy: testAccCheckTargetDestroy(ctx),
+		CheckDestroy: testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1857,7 +1857,7 @@ func TestAccAppAutoScalingTarget_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1889,7 +1889,7 @@ func TestAccAppAutoScalingTarget_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1947,7 +1947,7 @@ func TestAccAppAutoScalingTarget_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy: testAccCheckTargetDestroy(ctx),
+		CheckDestroy: testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1959,7 +1959,7 @@ func TestAccAppAutoScalingTarget_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1989,7 +1989,7 @@ func TestAccAppAutoScalingTarget_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2039,7 +2039,7 @@ func TestAccAppAutoScalingTarget_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy: testAccCheckTargetDestroy(ctx),
+		CheckDestroy: testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2058,7 +2058,7 @@ func TestAccAppAutoScalingTarget_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2107,7 +2107,7 @@ func TestAccAppAutoScalingTarget_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2156,7 +2156,7 @@ func TestAccAppAutoScalingTarget_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2205,7 +2205,7 @@ func TestAccAppAutoScalingTarget_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
-		CheckDestroy: testAccCheckTargetDestroy(ctx),
+		CheckDestroy: testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2222,7 +2222,7 @@ func TestAccAppAutoScalingTarget_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2285,7 +2285,7 @@ func TestAccAppAutoScalingTarget_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2348,7 +2348,7 @@ func TestAccAppAutoScalingTarget_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &v),
+					testAccCheckTargetExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/appautoscaling/target_test.go
+++ b/internal/service/appautoscaling/target_test.go
@@ -11,11 +11,9 @@ import (
 
 	"github.com/YakDriver/regexache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/applicationautoscaling/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfappautoscaling "github.com/hashicorp/terraform-provider-aws/internal/service/appautoscaling"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -24,19 +22,19 @@ import (
 func TestAccAppAutoScalingTarget_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var target awstypes.ScalableTarget
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_appautoscaling_target.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckTargetDestroy(ctx),
+		CheckDestroy:             testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTargetConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &target),
+					testAccCheckTargetExists(ctx, t, resourceName, &target),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "application-autoscaling", regexache.MustCompile(`scalable-target/\w+$`)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrMaxCapacity, "3"),
 					resource.TestCheckResourceAttr(resourceName, "min_capacity", "1"),
@@ -49,7 +47,7 @@ func TestAccAppAutoScalingTarget_basic(t *testing.T) {
 			{
 				Config: testAccTargetConfig_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &target),
+					testAccCheckTargetExists(ctx, t, resourceName, &target),
 					resource.TestCheckResourceAttr(resourceName, names.AttrMaxCapacity, "8"),
 					resource.TestCheckResourceAttr(resourceName, "min_capacity", "2"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
@@ -68,19 +66,19 @@ func TestAccAppAutoScalingTarget_basic(t *testing.T) {
 func TestAccAppAutoScalingTarget_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var target awstypes.ScalableTarget
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_appautoscaling_target.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckTargetDestroy(ctx),
+		CheckDestroy:             testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTargetConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &target),
+					testAccCheckTargetExists(ctx, t, resourceName, &target),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfappautoscaling.ResourceTarget(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -93,19 +91,19 @@ func TestAccAppAutoScalingTarget_spotFleetRequest(t *testing.T) {
 	ctx := acctest.Context(t)
 	var target awstypes.ScalableTarget
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_appautoscaling_target.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckTargetDestroy(ctx),
+		CheckDestroy:             testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTargetConfig_spotFleetRequest(rName, validUntil),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &target),
+					testAccCheckTargetExists(ctx, t, resourceName, &target),
 					resource.TestCheckResourceAttr(resourceName, "service_namespace", "ec2"),
 					resource.TestCheckResourceAttr(resourceName, "scalable_dimension", "ec2:spot-fleet-request:TargetCapacity"),
 				),
@@ -123,19 +121,19 @@ func TestAccAppAutoScalingTarget_spotFleetRequest(t *testing.T) {
 func TestAccAppAutoScalingTarget_emrCluster(t *testing.T) {
 	ctx := acctest.Context(t)
 	var target awstypes.ScalableTarget
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_appautoscaling_target.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckTargetDestroy(ctx),
+		CheckDestroy:             testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTargetConfig_emrCluster(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &target),
+					testAccCheckTargetExists(ctx, t, resourceName, &target),
 					resource.TestCheckResourceAttr(resourceName, "service_namespace", "elasticmapreduce"),
 					resource.TestCheckResourceAttr(resourceName, "scalable_dimension", "elasticmapreduce:instancegroup:InstanceCount"),
 				),
@@ -154,27 +152,27 @@ func TestAccAppAutoScalingTarget_multipleTargets(t *testing.T) {
 	ctx := acctest.Context(t)
 	var writeTarget awstypes.ScalableTarget
 	var readTarget awstypes.ScalableTarget
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	readResourceName := "aws_appautoscaling_target.read"
 	writeResourceName := "aws_appautoscaling_target.write"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckTargetDestroy(ctx),
+		CheckDestroy:             testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTargetConfig_multiple(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTargetExists(ctx, writeResourceName, &writeTarget),
+					testAccCheckTargetExists(ctx, t, writeResourceName, &writeTarget),
 					resource.TestCheckResourceAttr(writeResourceName, "service_namespace", "dynamodb"),
 					resource.TestCheckResourceAttr(writeResourceName, names.AttrResourceID, "table/"+rName),
 					resource.TestCheckResourceAttr(writeResourceName, "scalable_dimension", "dynamodb:table:WriteCapacityUnits"),
 					resource.TestCheckResourceAttr(writeResourceName, "min_capacity", "1"),
 					resource.TestCheckResourceAttr(writeResourceName, names.AttrMaxCapacity, "10"),
 
-					testAccCheckTargetExists(ctx, readResourceName, &readTarget),
+					testAccCheckTargetExists(ctx, t, readResourceName, &readTarget),
 					resource.TestCheckResourceAttr(readResourceName, "service_namespace", "dynamodb"),
 					resource.TestCheckResourceAttr(readResourceName, names.AttrResourceID, "table/"+rName),
 					resource.TestCheckResourceAttr(readResourceName, "scalable_dimension", "dynamodb:table:ReadCapacityUnits"),
@@ -189,19 +187,19 @@ func TestAccAppAutoScalingTarget_multipleTargets(t *testing.T) {
 func TestAccAppAutoScalingTarget_optionalRoleARN(t *testing.T) {
 	ctx := acctest.Context(t)
 	var readTarget awstypes.ScalableTarget
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_appautoscaling_target.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckTargetDestroy(ctx),
+		CheckDestroy:             testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTargetConfig_optionalRoleARN(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &readTarget),
+					testAccCheckTargetExists(ctx, t, resourceName, &readTarget),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrRoleARN, "iam", "role/aws-service-role/dynamodb.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_DynamoDBTable"),
 				),
 			},
@@ -212,19 +210,19 @@ func TestAccAppAutoScalingTarget_optionalRoleARN(t *testing.T) {
 func TestAccAppAutoScalingTarget_suspendedState(t *testing.T) {
 	ctx := acctest.Context(t)
 	var readTarget awstypes.ScalableTarget
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_appautoscaling_target.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckTargetDestroy(ctx),
+		CheckDestroy:             testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTargetConfig_suspendedState(rName, true, true, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &readTarget),
+					testAccCheckTargetExists(ctx, t, resourceName, &readTarget),
 					resource.TestCheckResourceAttr(resourceName, "suspended_state.0.dynamic_scaling_in_suspended", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "suspended_state.0.dynamic_scaling_out_suspended", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "suspended_state.0.scheduled_scaling_suspended", acctest.CtTrue),
@@ -233,7 +231,7 @@ func TestAccAppAutoScalingTarget_suspendedState(t *testing.T) {
 			{
 				Config: testAccTargetConfig_suspendedStateDefault(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &readTarget),
+					testAccCheckTargetExists(ctx, t, resourceName, &readTarget),
 					resource.TestCheckResourceAttr(resourceName, "suspended_state.0.dynamic_scaling_in_suspended", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "suspended_state.0.dynamic_scaling_out_suspended", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "suspended_state.0.scheduled_scaling_suspended", acctest.CtFalse),
@@ -246,14 +244,14 @@ func TestAccAppAutoScalingTarget_suspendedState(t *testing.T) {
 func TestAccAppAutoScalingTarget_suspendedState_maintainsExisting(t *testing.T) {
 	ctx := acctest.Context(t)
 	var readTarget awstypes.ScalableTarget
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_appautoscaling_target.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckTargetDestroy(ctx),
+		CheckDestroy:             testAccCheckTargetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTargetConfig_suspendedState(rName, false, false, true),
@@ -267,7 +265,7 @@ func TestAccAppAutoScalingTarget_suspendedState_maintainsExisting(t *testing.T) 
 			{
 				Config: testAccTargetConfig_sansSuspendedState(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &readTarget),
+					testAccCheckTargetExists(ctx, t, resourceName, &readTarget),
 					resource.TestCheckResourceAttr(resourceName, "suspended_state.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "suspended_state.0.dynamic_scaling_in_suspended", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "suspended_state.0.dynamic_scaling_out_suspended", acctest.CtFalse),
@@ -277,7 +275,7 @@ func TestAccAppAutoScalingTarget_suspendedState_maintainsExisting(t *testing.T) 
 			{
 				Config: testAccTargetConfig_suspendedState(rName, false, true, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &readTarget),
+					testAccCheckTargetExists(ctx, t, resourceName, &readTarget),
 					resource.TestCheckResourceAttr(resourceName, "suspended_state.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "suspended_state.0.dynamic_scaling_in_suspended", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "suspended_state.0.dynamic_scaling_out_suspended", acctest.CtTrue),
@@ -287,7 +285,7 @@ func TestAccAppAutoScalingTarget_suspendedState_maintainsExisting(t *testing.T) 
 			{
 				Config: testAccTargetConfig_sansSuspendedState(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTargetExists(ctx, resourceName, &readTarget),
+					testAccCheckTargetExists(ctx, t, resourceName, &readTarget),
 					resource.TestCheckResourceAttr(resourceName, "suspended_state.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "suspended_state.0.dynamic_scaling_in_suspended", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "suspended_state.0.dynamic_scaling_out_suspended", acctest.CtTrue),
@@ -298,9 +296,9 @@ func TestAccAppAutoScalingTarget_suspendedState_maintainsExisting(t *testing.T) 
 	})
 }
 
-func testAccCheckTargetDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckTargetDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AppAutoScalingClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).AppAutoScalingClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_appautoscaling_target" {
@@ -324,7 +322,7 @@ func testAccCheckTargetDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckTargetExists(ctx context.Context, n string, v *awstypes.ScalableTarget) resource.TestCheckFunc {
+func testAccCheckTargetExists(ctx context.Context, t *testing.T, n string, v *awstypes.ScalableTarget) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -335,7 +333,7 @@ func testAccCheckTargetExists(ctx context.Context, n string, v *awstypes.Scalabl
 			return fmt.Errorf("No Application AutoScaling Target ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AppAutoScalingClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).AppAutoScalingClient(ctx)
 
 		output, err := tfappautoscaling.FindTargetByThreePartKey(ctx, conn, rs.Primary.ID, rs.Primary.Attributes["service_namespace"], rs.Primary.Attributes["scalable_dimension"])
 


### PR DESCRIPTION

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Enables `go-vcr` for the `appautoscaling` service.

**AI Disclosure:** AI agents were used to execute the migration workflow and run tests. All code changes and test results were subsequently hand reviewed for correctness.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/25602
Relates https://github.com/hashicorp/terraform-provider-aws/issues/43717



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=appautoscaling VCR_MODE=RECORD_ONLY VCR_PATH=/tmp/appautoscaling-vcr-testdata
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 tmp1 🌿...
TF_ACC=1 go1.25.6 test ./internal/service/appautoscaling/... -v -count 1 -parallel 20   -timeout 360m -vet=off
2026/01/22 14:39:15 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/22 14:39:15 Initializing Terraform AWS Provider (SDKv2-style)...

=== RUN   TestAccAppAutoScalingTarget_tags_EmptyTag_OnCreate
    target_tags_gen_test.go:440: Resource Target does not support empty tags
--- SKIP: TestAccAppAutoScalingTarget_tags_EmptyTag_OnCreate (0.00s)
=== RUN   TestAccAppAutoScalingTarget_tags_EmptyTag_OnUpdate_Add
    target_tags_gen_test.go:537: Resource Target does not support empty tags
--- SKIP: TestAccAppAutoScalingTarget_tags_EmptyTag_OnUpdate_Add (0.00s)
=== RUN   TestAccAppAutoScalingTarget_tags_EmptyTag_OnUpdate_Replace
    target_tags_gen_test.go:682: Resource Target does not support empty tags
--- SKIP: TestAccAppAutoScalingTarget_tags_EmptyTag_OnUpdate_Replace (0.00s)
=== RUN   TestAccAppAutoScalingTarget_tags_DefaultTags_providerOnly
    target_tags_gen_test.go:784: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccAppAutoScalingTarget_tags_DefaultTags_providerOnly (0.00s)
=== RUN   TestAccAppAutoScalingTarget_tags_DefaultTags_nonOverlapping
    target_tags_gen_test.go:973: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccAppAutoScalingTarget_tags_DefaultTags_nonOverlapping (0.00s)
=== RUN   TestAccAppAutoScalingTarget_tags_DefaultTags_overlapping
    target_tags_gen_test.go:1140: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccAppAutoScalingTarget_tags_DefaultTags_overlapping (0.00s)
=== RUN   TestAccAppAutoScalingTarget_tags_DefaultTags_updateToProviderOnly
    target_tags_gen_test.go:1323: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccAppAutoScalingTarget_tags_DefaultTags_updateToProviderOnly (0.00s)
=== RUN   TestAccAppAutoScalingTarget_tags_DefaultTags_updateToResourceOnly
    target_tags_gen_test.go:1418: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccAppAutoScalingTarget_tags_DefaultTags_updateToResourceOnly (0.00s)
=== RUN   TestAccAppAutoScalingTarget_tags_DefaultTags_emptyResourceTag
    target_tags_gen_test.go:1506: Resource Target does not support empty tags
--- SKIP: TestAccAppAutoScalingTarget_tags_DefaultTags_emptyResourceTag (0.00s)
=== RUN   TestAccAppAutoScalingTarget_tags_DefaultTags_emptyProviderOnlyTag
    target_tags_gen_test.go:1578: Resource Target does not support empty tags
--- SKIP: TestAccAppAutoScalingTarget_tags_DefaultTags_emptyProviderOnlyTag (0.00s)
=== RUN   TestAccAppAutoScalingTarget_tags_DefaultTags_nullOverlappingResourceTag
    target_tags_gen_test.go:1648: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccAppAutoScalingTarget_tags_DefaultTags_nullOverlappingResourceTag (0.00s)
=== RUN   TestAccAppAutoScalingTarget_tags_DefaultTags_nullNonOverlappingResourceTag
    target_tags_gen_test.go:1715: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccAppAutoScalingTarget_tags_DefaultTags_nullNonOverlappingResourceTag (0.00s)
=== RUN   TestAccAppAutoScalingTarget_tags_ComputedTag_OnCreate
    target_tags_gen_test.go:1782: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccAppAutoScalingTarget_tags_ComputedTag_OnCreate (0.00s)
=== RUN   TestAccAppAutoScalingTarget_tags_ComputedTag_OnUpdate_Add
    target_tags_gen_test.go:1842: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccAppAutoScalingTarget_tags_ComputedTag_OnUpdate_Add (0.00s)
=== RUN   TestAccAppAutoScalingTarget_tags_ComputedTag_OnUpdate_Replace
    target_tags_gen_test.go:1944: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccAppAutoScalingTarget_tags_ComputedTag_OnUpdate_Replace (0.00s)
=== RUN   TestAccAppAutoScalingTarget_tags_IgnoreTags_Overlap_DefaultTag
    target_tags_gen_test.go:2036: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccAppAutoScalingTarget_tags_IgnoreTags_Overlap_DefaultTag (0.00s)
=== RUN   TestAccAppAutoScalingTarget_tags_IgnoreTags_Overlap_ResourceTag
    target_tags_gen_test.go:2202: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccAppAutoScalingTarget_tags_IgnoreTags_Overlap_ResourceTag (0.00s)
=== RUN   TestAccAppAutoScalingTarget_basic
=== PAUSE TestAccAppAutoScalingTarget_basic
=== RUN   TestAccAppAutoScalingTarget_disappears
=== PAUSE TestAccAppAutoScalingTarget_disappears
=== RUN   TestAccAppAutoScalingTarget_spotFleetRequest
=== PAUSE TestAccAppAutoScalingTarget_spotFleetRequest
=== RUN   TestAccAppAutoScalingTarget_emrCluster
=== PAUSE TestAccAppAutoScalingTarget_emrCluster
=== RUN   TestAccAppAutoScalingTarget_multipleTargets
=== PAUSE TestAccAppAutoScalingTarget_multipleTargets
=== RUN   TestAccAppAutoScalingTarget_optionalRoleARN
=== PAUSE TestAccAppAutoScalingTarget_optionalRoleARN
=== RUN   TestAccAppAutoScalingTarget_suspendedState
=== PAUSE TestAccAppAutoScalingTarget_suspendedState
=== RUN   TestAccAppAutoScalingTarget_suspendedState_maintainsExisting
=== PAUSE TestAccAppAutoScalingTarget_suspendedState_maintainsExisting
=== CONT  TestPolicyParseImportID
=== CONT  TestAccAppAutoScalingTarget_basic
=== CONT  TestAccAppAutoScalingScheduledAction_ecsUpdateStartAndEndTime
=== CONT  TestAccAppAutoScalingPolicy_basic
=== CONT  TestAccAppAutoScalingTarget_tags
=== CONT  TestAccAppAutoScalingScheduledAction_ScheduleRateExpression_basic
--- PASS: TestPolicyParseImportID (0.00s)
=== CONT  TestAccAppAutoScalingScheduledAction_ecsUpdateScheduleRetainStartAndEndTime
=== CONT  TestAccAppAutoScalingScheduledAction_ecs
=== CONT  TestAccAppAutoScalingScheduledAction_disappears
=== CONT  TestAccAppAutoScalingScheduledAction_dynamoDB
=== CONT  TestAccAppAutoScalingPolicy_predictiveScalingCustom
=== CONT  TestAccAppAutoScalingPolicy_predictiveScalingSimple
=== CONT  TestAccAppAutoScalingPolicy_TargetTrack_metricMath
=== CONT  TestAccAppAutoScalingPolicy_ResourceID_forceNew
=== CONT  TestAccAppAutoScalingPolicy_multiplePoliciesSameResource
=== CONT  TestAccAppAutoScalingPolicy_multiplePoliciesSameName
=== CONT  TestAccAppAutoScalingPolicy_DynamoDB_index
=== CONT  TestAccAppAutoScalingPolicy_DynamoDB_table
=== CONT  TestAccAppAutoScalingPolicy_spotFleetRequest
=== CONT  TestAccAppAutoScalingPolicy_scaleOutAndIn
=== CONT  TestAccAppAutoScalingPolicy_disappears
=== NAME  TestAccAppAutoScalingScheduledAction_ScheduleRateExpression_basic
    scheduled_action_test.go:588: stopping VCR recorder
    scheduled_action_test.go:588: persisting randomness seed
--- PASS: TestAccAppAutoScalingScheduledAction_ScheduleRateExpression_basic (51.17s)
=== CONT  TestAccAppAutoScalingScheduledAction_spotFleet
=== NAME  TestAccAppAutoScalingScheduledAction_disappears
    scheduled_action_test.go:88: stopping VCR recorder
    scheduled_action_test.go:88: persisting randomness seed
--- PASS: TestAccAppAutoScalingScheduledAction_disappears (55.92s)
=== CONT  TestAccAppAutoScalingScheduledAction_ScheduleCronExpression_startEndTimeTimezone
=== NAME  TestAccAppAutoScalingPolicy_multiplePoliciesSameName
    policy_test.go:364: stopping VCR recorder
    policy_test.go:364: randomness source not found for test TestAccAppAutoScalingPolicy_multiplePoliciesSameName
--- PASS: TestAccAppAutoScalingPolicy_multiplePoliciesSameName (56.08s)
=== CONT  TestAccAppAutoScalingScheduledAction_ScheduleCronExpression_timezone
=== NAME  TestAccAppAutoScalingPolicy_DynamoDB_table
    policy_test.go:296: stopping VCR recorder
    policy_test.go:296: persisting randomness seed
--- PASS: TestAccAppAutoScalingPolicy_DynamoDB_table (60.49s)
=== CONT  TestAccAppAutoScalingScheduledAction_ScheduleCronExpression_basic
=== NAME  TestAccAppAutoScalingPolicy_spotFleetRequest
    policy_test.go:263: stopping VCR recorder
    policy_test.go:263: randomness source not found for test TestAccAppAutoScalingPolicy_spotFleetRequest
--- PASS: TestAccAppAutoScalingPolicy_spotFleetRequest (72.41s)
=== CONT  TestAccAppAutoScalingScheduledAction_ScheduleAtExpression_timezone
=== NAME  TestAccAppAutoScalingScheduledAction_dynamoDB
    scheduled_action_test.go:33: stopping VCR recorder
    scheduled_action_test.go:33: persisting randomness seed
--- PASS: TestAccAppAutoScalingScheduledAction_dynamoDB (73.33s)
=== CONT  TestAccAppAutoScalingScheduledAction_minCapacity
=== NAME  TestAccAppAutoScalingPolicy_multiplePoliciesSameResource
    policy_test.go:398: stopping VCR recorder
    policy_test.go:398: randomness source not found for test TestAccAppAutoScalingPolicy_multiplePoliciesSameResource
--- PASS: TestAccAppAutoScalingPolicy_multiplePoliciesSameResource (78.26s)
=== CONT  TestAccAppAutoScalingScheduledAction_maxCapacity
=== NAME  TestAccAppAutoScalingPolicy_DynamoDB_index
    policy_test.go:329: stopping VCR recorder
    policy_test.go:329: persisting randomness seed
--- PASS: TestAccAppAutoScalingPolicy_DynamoDB_index (78.28s)
=== CONT  TestAccAppAutoScalingScheduledAction_ScheduleRateExpression_timezone
=== NAME  TestAccAppAutoScalingPolicy_disappears
    policy_test.go:156: stopping VCR recorder
    policy_test.go:156: persisting randomness seed
--- PASS: TestAccAppAutoScalingPolicy_disappears (91.35s)
=== CONT  TestAccAppAutoScalingScheduledAction_emr
=== NAME  TestAccAppAutoScalingScheduledAction_ScheduleCronExpression_timezone
    scheduled_action_test.go:491: stopping VCR recorder
    scheduled_action_test.go:491: persisting randomness seed
--- PASS: TestAccAppAutoScalingScheduledAction_ScheduleCronExpression_timezone (37.49s)
=== CONT  TestAccAppAutoScalingScheduledAction_Name_duplicate
=== NAME  TestAccAppAutoScalingScheduledAction_ecs
    scheduled_action_test.go:114: stopping VCR recorder
    scheduled_action_test.go:114: persisting randomness seed
--- PASS: TestAccAppAutoScalingScheduledAction_ecs (94.58s)
=== CONT  TestAccAppAutoScalingTarget_tags_EmptyMap
=== NAME  TestAccAppAutoScalingPolicy_predictiveScalingSimple
    policy_test.go:512: stopping VCR recorder
    policy_test.go:512: persisting randomness seed
--- PASS: TestAccAppAutoScalingPolicy_predictiveScalingSimple (99.23s)
=== CONT  TestAccAppAutoScalingTarget_tags_AddOnUpdate
=== NAME  TestAccAppAutoScalingPolicy_ResourceID_forceNew
    policy_test.go:444: stopping VCR recorder
    policy_test.go:444: persisting randomness seed
--- PASS: TestAccAppAutoScalingPolicy_ResourceID_forceNew (99.93s)
=== CONT  TestAccAppAutoScalingTarget_multipleTargets
=== NAME  TestAccAppAutoScalingScheduledAction_ScheduleCronExpression_basic
    scheduled_action_test.go:452: stopping VCR recorder
    scheduled_action_test.go:452: persisting randomness seed
--- PASS: TestAccAppAutoScalingScheduledAction_ScheduleCronExpression_basic (40.36s)
=== CONT  TestAccAppAutoScalingTarget_suspendedState_maintainsExisting
=== NAME  TestAccAppAutoScalingScheduledAction_ScheduleCronExpression_startEndTimeTimezone
    scheduled_action_test.go:534: stopping VCR recorder
    scheduled_action_test.go:534: persisting randomness seed
--- PASS: TestAccAppAutoScalingScheduledAction_ScheduleCronExpression_startEndTimeTimezone (45.00s)
=== CONT  TestAccAppAutoScalingTarget_suspendedState
=== NAME  TestAccAppAutoScalingScheduledAction_ScheduleAtExpression_timezone
    scheduled_action_test.go:416: stopping VCR recorder
    scheduled_action_test.go:416: persisting randomness seed
--- PASS: TestAccAppAutoScalingScheduledAction_ScheduleAtExpression_timezone (31.65s)
=== CONT  TestAccAppAutoScalingTarget_optionalRoleARN
=== NAME  TestAccAppAutoScalingPolicy_scaleOutAndIn
    policy_test.go:181: stopping VCR recorder
    policy_test.go:181: randomness source not found for test TestAccAppAutoScalingPolicy_scaleOutAndIn
--- PASS: TestAccAppAutoScalingPolicy_scaleOutAndIn (104.32s)
=== CONT  TestAccAppAutoScalingTarget_tags_null
=== NAME  TestAccAppAutoScalingPolicy_basic
    policy_test.go:111: stopping VCR recorder
    policy_test.go:111: persisting randomness seed
--- PASS: TestAccAppAutoScalingPolicy_basic (104.68s)
=== CONT  TestAccAppAutoScalingTarget_spotFleetRequest
=== NAME  TestAccAppAutoScalingScheduledAction_ecsUpdateScheduleRetainStartAndEndTime
    scheduled_action_test.go:151: stopping VCR recorder
    scheduled_action_test.go:151: persisting randomness seed
--- PASS: TestAccAppAutoScalingScheduledAction_ecsUpdateScheduleRetainStartAndEndTime (107.32s)
=== CONT  TestAccAppAutoScalingTarget_emrCluster
=== NAME  TestAccAppAutoScalingTarget_basic
    target_test.go:28: stopping VCR recorder
    target_test.go:28: persisting randomness seed
--- PASS: TestAccAppAutoScalingTarget_basic (109.59s)
=== CONT  TestAccAppAutoScalingScheduledAction_ecsAddStartTimeAndEndTimeAfterResourceCreated
=== NAME  TestAccAppAutoScalingPolicy_predictiveScalingCustom
    policy_test.go:550: stopping VCR recorder
    policy_test.go:550: persisting randomness seed
--- PASS: TestAccAppAutoScalingPolicy_predictiveScalingCustom (109.80s)
=== CONT  TestAccAppAutoScalingTarget_disappears
=== NAME  TestAccAppAutoScalingPolicy_TargetTrack_metricMath
    policy_test.go:479: stopping VCR recorder
    policy_test.go:479: persisting randomness seed
--- PASS: TestAccAppAutoScalingPolicy_TargetTrack_metricMath (110.12s)
=== NAME  TestAccAppAutoScalingTarget_tags
    target_tags_gen_test.go:30: stopping VCR recorder
    target_tags_gen_test.go:30: persisting randomness seed
--- PASS: TestAccAppAutoScalingTarget_tags (110.41s)
=== NAME  TestAccAppAutoScalingScheduledAction_ecsUpdateStartAndEndTime
    scheduled_action_test.go:208: stopping VCR recorder
    scheduled_action_test.go:208: persisting randomness seed
--- PASS: TestAccAppAutoScalingScheduledAction_ecsUpdateStartAndEndTime (114.83s)
=== NAME  TestAccAppAutoScalingScheduledAction_spotFleet
    scheduled_action_test.go:378: stopping VCR recorder
    scheduled_action_test.go:378: persisting randomness seed
--- PASS: TestAccAppAutoScalingScheduledAction_spotFleet (72.08s)
=== NAME  TestAccAppAutoScalingScheduledAction_ScheduleRateExpression_timezone
    scheduled_action_test.go:627: stopping VCR recorder
    scheduled_action_test.go:627: persisting randomness seed
--- PASS: TestAccAppAutoScalingScheduledAction_ScheduleRateExpression_timezone (45.45s)
=== NAME  TestAccAppAutoScalingTarget_multipleTargets
    target_test.go:159: stopping VCR recorder
    target_test.go:159: persisting randomness seed
--- PASS: TestAccAppAutoScalingTarget_multipleTargets (33.72s)
=== NAME  TestAccAppAutoScalingScheduledAction_maxCapacity
    scheduled_action_test.go:719: stopping VCR recorder
    scheduled_action_test.go:719: persisting randomness seed
--- PASS: TestAccAppAutoScalingScheduledAction_maxCapacity (55.79s)
=== NAME  TestAccAppAutoScalingTarget_optionalRoleARN
    target_test.go:193: stopping VCR recorder
    target_test.go:193: persisting randomness seed
--- PASS: TestAccAppAutoScalingTarget_optionalRoleARN (35.05s)
=== NAME  TestAccAppAutoScalingScheduledAction_Name_duplicate
    scheduled_action_test.go:352: stopping VCR recorder
    scheduled_action_test.go:352: persisting randomness seed
--- PASS: TestAccAppAutoScalingScheduledAction_Name_duplicate (47.99s)
=== NAME  TestAccAppAutoScalingScheduledAction_minCapacity
    scheduled_action_test.go:663: stopping VCR recorder
    scheduled_action_test.go:663: persisting randomness seed
--- PASS: TestAccAppAutoScalingScheduledAction_minCapacity (69.78s)
=== NAME  TestAccAppAutoScalingTarget_tags_EmptyMap
    target_tags_gen_test.go:292: stopping VCR recorder
    target_tags_gen_test.go:292: persisting randomness seed
--- PASS: TestAccAppAutoScalingTarget_tags_EmptyMap (49.27s)
=== NAME  TestAccAppAutoScalingTarget_suspendedState
    target_test.go:216: stopping VCR recorder
    target_test.go:216: persisting randomness seed
--- PASS: TestAccAppAutoScalingTarget_suspendedState (46.95s)
=== NAME  TestAccAppAutoScalingTarget_tags_AddOnUpdate
    target_tags_gen_test.go:360: stopping VCR recorder
    target_tags_gen_test.go:360: persisting randomness seed
--- PASS: TestAccAppAutoScalingTarget_tags_AddOnUpdate (51.80s)
=== NAME  TestAccAppAutoScalingTarget_tags_null
    target_tags_gen_test.go:220: stopping VCR recorder
    target_tags_gen_test.go:220: persisting randomness seed
--- PASS: TestAccAppAutoScalingTarget_tags_null (49.54s)
=== NAME  TestAccAppAutoScalingTarget_suspendedState_maintainsExisting
    target_test.go:250: stopping VCR recorder
    target_test.go:250: persisting randomness seed
--- PASS: TestAccAppAutoScalingTarget_suspendedState_maintainsExisting (63.51s)
=== NAME  TestAccAppAutoScalingTarget_spotFleetRequest
    target_test.go:97: stopping VCR recorder
    target_test.go:97: persisting randomness seed
--- PASS: TestAccAppAutoScalingTarget_spotFleetRequest (67.31s)
=== NAME  TestAccAppAutoScalingTarget_disappears
    target_test.go:72: stopping VCR recorder
    target_test.go:72: persisting randomness seed
--- PASS: TestAccAppAutoScalingTarget_disappears (76.65s)
=== NAME  TestAccAppAutoScalingScheduledAction_ecsAddStartTimeAndEndTimeAfterResourceCreated
    scheduled_action_test.go:265: stopping VCR recorder
    scheduled_action_test.go:265: persisting randomness seed
--- PASS: TestAccAppAutoScalingScheduledAction_ecsAddStartTimeAndEndTimeAfterResourceCreated (85.60s)
=== NAME  TestAccAppAutoScalingScheduledAction_emr
    scheduled_action_test.go:319: stopping VCR recorder
    scheduled_action_test.go:319: persisting randomness seed
--- PASS: TestAccAppAutoScalingScheduledAction_emr (560.45s)
=== NAME  TestAccAppAutoScalingTarget_emrCluster
    target_test.go:127: stopping VCR recorder
    target_test.go:127: persisting randomness seed
--- PASS: TestAccAppAutoScalingTarget_emrCluster (624.01s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appautoscaling     738.468s
```
