### PR TITLE
tests(sfn): updated tests to use spn data resource

### DIFF
--- a/internal/service/sfn/state_machine_test.go
+++ b/internal/service/sfn/state_machine_test.go
@@ -661,6 +661,19 @@ func testAccCheckStateMachineDestroy(ctx context.Context) resource.TestCheckFunc
 
 func testAccStateMachineConfig_base(rName string) string {
 	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+data "aws_partition" "current" {}
+
+data "aws_service_principal" "lambda" {
+  service_name = "lambda"
+}
+
+data "aws_service_principal" "states" {
+  service_name = "states"
+  region       = data.aws_region.current.name
+}
+
 resource "aws_iam_role_policy" "for_lambda" {
   name = "%[1]s-lambda"
   role = aws_iam_role.for_lambda.id
@@ -690,7 +703,7 @@ resource "aws_iam_role" "for_lambda" {
   "Statement": [{
     "Action": "sts:AssumeRole",
     "Principal": {
-      "Service": "lambda.amazonaws.com"
+      "Service": "${data.aws_service_principal.lambda.name}"
     },
     "Effect": "Allow"
   }]
@@ -705,10 +718,6 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   runtime       = "nodejs20.x"
 }
-
-data "aws_region" "current" {}
-
-data "aws_partition" "current" {}
 
 resource "aws_iam_role_policy" "for_sfn" {
   name = "%[1]s-sfn"
@@ -749,7 +758,7 @@ resource "aws_iam_role" "for_sfn" {
   "Statement": [{
     "Effect": "Allow",
     "Principal": {
-      "Service": "states.${data.aws_region.current.region}.amazonaws.com"
+      "Service": "${data.aws_service_principal.states.name}"
     },
     "Action": "sts:AssumeRole"
   }]


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

N/A

### Description
I've updated all Step Functions (SFN) test files to use the `aws_service_principal` data source instead of hardcoded service principal names, following the same pattern used in S3 and OpenSearch tests. This ensures tests do not fail when running in Partitions where the SPN suffix is not the region's domain.

## Files Updated:
- `internal/service/sfn/state_machine_test.go`
- `internal/service/sfn/alias_test.go`
- `internal/service/sfn/start_execution_action_test.go`

## Changes Made:

### Added `aws_service_principal` Data Sources:
```hcl
data "aws_service_principal" "lambda" {
  service_name = "lambda"
}

data "aws_service_principal" "states" {
  service_name = "states"
  region       = data.aws_region.current.name
}
```

### Replaced Hardcoded Service Principals:

**Before:**
```hcl
"Service": "lambda.amazonaws.com"
"Service": "states.${data.aws_region.current.name}.amazonaws.com"
```

**After:**
```hcl
"Service": "${data.aws_service_principal.lambda.name}"
"Service": "${data.aws_service_principal.states.name}"
```

### Functions Updated:
- `testAccStateMachineConfig_base` - Added Lambda and States service principal data sources
- `testAccStateMachineAliasConfig_base` - Added Lambda and States service principal data sources
- `testAccStartExecutionActionConfig_base` - Added Lambda and States service principal data sources

## Relations

### References
- Previously done for S3 #38693
- Previously done for IAM #43144
- Previously done for EKS #43987
- Previously done for OpenSearch #45563

## Output from Acceptance Testing

```
make testacc TESTS=TestAccSFN PKG=sfn
TF_ACC=1 go1.25.5 test ./internal/service/sfn/... -v -count 1 -parallel 20 -run='TestAccSFN'  -timeout 360m -vet=off
=== RUN   TestAccSFNActivityDataSource_basic
=== PAUSE TestAccSFNActivityDataSource_basic
=== RUN   TestAccSFNActivity_Identity_Basic
=== PAUSE TestAccSFNActivity_Identity_Basic
=== RUN   TestAccSFNActivity_Identity_RegionOverride
=== PAUSE TestAccSFNActivity_Identity_RegionOverride
=== RUN   TestAccSFNActivity_Identity_ExistingResource
=== PAUSE TestAccSFNActivity_Identity_ExistingResource
=== RUN   TestAccSFNActivity_Identity_ExistingResource_NoRefresh_NoChange
=== PAUSE TestAccSFNActivity_Identity_ExistingResource_NoRefresh_NoChange
=== RUN   TestAccSFNActivity_basic
=== PAUSE TestAccSFNActivity_basic
=== RUN   TestAccSFNActivity_disappears
=== PAUSE TestAccSFNActivity_disappears
=== RUN   TestAccSFNActivity_tags
=== PAUSE TestAccSFNActivity_tags
=== RUN   TestAccSFNActivity_encryptionConfigurationCustomerManagedKMSKey
=== PAUSE TestAccSFNActivity_encryptionConfigurationCustomerManagedKMSKey
=== RUN   TestAccSFNActivity_encryptionConfigurationServiceOwnedKey
=== PAUSE TestAccSFNActivity_encryptionConfigurationServiceOwnedKey
=== RUN   TestAccSFNAliasDataSource_basic
=== PAUSE TestAccSFNAliasDataSource_basic
=== RUN   TestAccSFNAlias_Identity_Basic
=== PAUSE TestAccSFNAlias_Identity_Basic
=== RUN   TestAccSFNAlias_Identity_RegionOverride
=== PAUSE TestAccSFNAlias_Identity_RegionOverride
=== RUN   TestAccSFNAlias_Identity_ExistingResource
=== PAUSE TestAccSFNAlias_Identity_ExistingResource
=== RUN   TestAccSFNAlias_Identity_ExistingResource_NoRefresh_NoChange
=== PAUSE TestAccSFNAlias_Identity_ExistingResource_NoRefresh_NoChange
=== RUN   TestAccSFNAlias_basic
=== PAUSE TestAccSFNAlias_basic
=== RUN   TestAccSFNAlias_disappears
=== PAUSE TestAccSFNAlias_disappears
=== RUN   TestAccSFNStartExecutionAction_basic
=== PAUSE TestAccSFNStartExecutionAction_basic
=== RUN   TestAccSFNStartExecutionAction_withName
=== PAUSE TestAccSFNStartExecutionAction_withName
=== RUN   TestAccSFNStartExecutionAction_emptyInput
=== PAUSE TestAccSFNStartExecutionAction_emptyInput
=== RUN   TestAccSFNStateMachineDataSource_basic
=== PAUSE TestAccSFNStateMachineDataSource_basic
=== RUN   TestAccSFNStateMachine_Identity_Basic
=== PAUSE TestAccSFNStateMachine_Identity_Basic
=== RUN   TestAccSFNStateMachine_Identity_RegionOverride
=== PAUSE TestAccSFNStateMachine_Identity_RegionOverride
=== RUN   TestAccSFNStateMachine_Identity_ExistingResource
=== PAUSE TestAccSFNStateMachine_Identity_ExistingResource
=== RUN   TestAccSFNStateMachine_Identity_ExistingResource_NoRefresh_NoChange
=== PAUSE TestAccSFNStateMachine_Identity_ExistingResource_NoRefresh_NoChange
=== RUN   TestAccSFNStateMachine_createUpdate
=== PAUSE TestAccSFNStateMachine_createUpdate
=== RUN   TestAccSFNStateMachine_expressUpdate
=== PAUSE TestAccSFNStateMachine_expressUpdate
=== RUN   TestAccSFNStateMachine_standardUpdate
=== PAUSE TestAccSFNStateMachine_standardUpdate
=== RUN   TestAccSFNStateMachine_nameGenerated
=== PAUSE TestAccSFNStateMachine_nameGenerated
=== RUN   TestAccSFNStateMachine_namePrefix
=== PAUSE TestAccSFNStateMachine_namePrefix
=== RUN   TestAccSFNStateMachine_publish
=== PAUSE TestAccSFNStateMachine_publish
=== RUN   TestAccSFNStateMachine_tags
=== PAUSE TestAccSFNStateMachine_tags
=== RUN   TestAccSFNStateMachine_tracing
=== PAUSE TestAccSFNStateMachine_tracing
=== RUN   TestAccSFNStateMachine_disappears
=== PAUSE TestAccSFNStateMachine_disappears
=== RUN   TestAccSFNStateMachine_expressLogging
=== PAUSE TestAccSFNStateMachine_expressLogging
=== RUN   TestAccSFNStateMachine_encryptionConfigurationCustomerManagedKMSKey
=== PAUSE TestAccSFNStateMachine_encryptionConfigurationCustomerManagedKMSKey
=== RUN   TestAccSFNStateMachine_encryptionConfigurationServiceOwnedKey
=== PAUSE TestAccSFNStateMachine_encryptionConfigurationServiceOwnedKey
=== RUN   TestAccSFNStateMachine_definitionValidation
=== PAUSE TestAccSFNStateMachine_definitionValidation
=== RUN   TestAccSFNStateMachineVersionsDataSource_basic
=== PAUSE TestAccSFNStateMachineVersionsDataSource_basic
=== CONT  TestAccSFNActivityDataSource_basic
=== CONT  TestAccSFNStateMachineDataSource_basic
=== CONT  TestAccSFNStateMachineVersionsDataSource_basic
=== CONT  TestAccSFNStateMachine_definitionValidation
=== CONT  TestAccSFNStateMachine_encryptionConfigurationServiceOwnedKey
=== CONT  TestAccSFNStateMachine_encryptionConfigurationCustomerManagedKMSKey
=== CONT  TestAccSFNStateMachine_expressLogging
=== CONT  TestAccSFNStateMachine_disappears
=== CONT  TestAccSFNStateMachine_tracing
=== CONT  TestAccSFNStateMachine_tags
=== CONT  TestAccSFNStateMachine_publish
=== CONT  TestAccSFNStateMachine_namePrefix
=== CONT  TestAccSFNStateMachine_nameGenerated
=== CONT  TestAccSFNStateMachine_standardUpdate
=== CONT  TestAccSFNStateMachine_expressUpdate
=== CONT  TestAccSFNStateMachine_createUpdate
=== CONT  TestAccSFNStateMachine_Identity_ExistingResource_NoRefresh_NoChange
=== CONT  TestAccSFNStateMachine_Identity_ExistingResource
=== CONT  TestAccSFNStateMachine_Identity_RegionOverride
=== CONT  TestAccSFNStateMachine_Identity_Basic
--- PASS: TestAccSFNActivityDataSource_basic (29.99s)
=== CONT  TestAccSFNAliasDataSource_basic
--- PASS: TestAccSFNStateMachine_Identity_ExistingResource_NoRefresh_NoChange (90.63s)
=== CONT  TestAccSFNStartExecutionAction_emptyInput
--- PASS: TestAccSFNStateMachine_definitionValidation (99.71s)
=== CONT  TestAccSFNStartExecutionAction_withName
--- PASS: TestAccSFNStateMachine_namePrefix (109.54s)
=== CONT  TestAccSFNStartExecutionAction_basic
--- PASS: TestAccSFNStateMachineVersionsDataSource_basic (110.66s)
=== CONT  TestAccSFNAlias_disappears
--- PASS: TestAccSFNStateMachine_tracing (111.20s)
=== CONT  TestAccSFNAlias_basic
--- PASS: TestAccSFNStateMachine_expressUpdate (148.22s)
=== CONT  TestAccSFNAlias_Identity_ExistingResource_NoRefresh_NoChange
--- PASS: TestAccSFNStateMachineDataSource_basic (151.53s)
=== CONT  TestAccSFNAlias_Identity_ExistingResource
--- PASS: TestAccSFNAliasDataSource_basic (121.65s)
=== CONT  TestAccSFNAlias_Identity_RegionOverride
--- PASS: TestAccSFNStateMachine_expressLogging (153.88s)
=== CONT  TestAccSFNAlias_Identity_Basic
--- PASS: TestAccSFNStateMachine_Identity_Basic (154.06s)
=== CONT  TestAccSFNActivity_basic
--- PASS: TestAccSFNStateMachine_standardUpdate (154.57s)
=== CONT  TestAccSFNActivity_encryptionConfigurationServiceOwnedKey
--- PASS: TestAccSFNStateMachine_tags (157.41s)
=== CONT  TestAccSFNActivity_encryptionConfigurationCustomerManagedKMSKey
--- PASS: TestAccSFNStateMachine_Identity_ExistingResource (158.44s)
=== CONT  TestAccSFNActivity_tags
--- PASS: TestAccSFNStateMachine_encryptionConfigurationCustomerManagedKMSKey (160.28s)
=== CONT  TestAccSFNActivity_disappears
--- PASS: TestAccSFNStateMachine_encryptionConfigurationServiceOwnedKey (161.23s)
=== CONT  TestAccSFNActivity_Identity_ExistingResource
--- PASS: TestAccSFNStateMachine_disappears (161.83s)
=== CONT  TestAccSFNActivity_Identity_ExistingResource_NoRefresh_NoChange
=== CONT  TestAccSFNActivity_Identity_RegionOverride
--- PASS: TestAccSFNStateMachine_nameGenerated (161.85s)
--- PASS: TestAccSFNStateMachine_Identity_RegionOverride (167.93s)
=== CONT  TestAccSFNActivity_Identity_Basic
--- PASS: TestAccSFNStartExecutionAction_emptyInput (86.62s)
--- PASS: TestAccSFNStateMachine_createUpdate (191.71s)
--- PASS: TestAccSFNActivity_disappears (39.84s)
--- PASS: TestAccSFNActivity_encryptionConfigurationServiceOwnedKey (48.67s)
--- PASS: TestAccSFNActivity_encryptionConfigurationCustomerManagedKMSKey (46.34s)
--- PASS: TestAccSFNStartExecutionAction_withName (104.85s)
--- PASS: TestAccSFNActivity_basic (52.89s)
--- PASS: TestAccSFNStateMachine_publish (210.78s)
--- PASS: TestAccSFNAlias_disappears (102.99s)
--- PASS: TestAccSFNStartExecutionAction_basic (105.00s)
--- PASS: TestAccSFNAlias_basic (107.33s)
--- PASS: TestAccSFNActivity_Identity_Basic (64.64s)
--- PASS: TestAccSFNActivity_Identity_RegionOverride (78.34s)
--- PASS: TestAccSFNActivity_Identity_ExistingResource (81.99s)
--- PASS: TestAccSFNAlias_Identity_Basic (114.34s)
--- PASS: TestAccSFNActivity_Identity_ExistingResource_NoRefresh_NoChange (107.53s)
--- PASS: TestAccSFNActivity_tags (129.41s)
--- PASS: TestAccSFNAlias_Identity_RegionOverride (153.44s)
--- PASS: TestAccSFNAlias_Identity_ExistingResource_NoRefresh_NoChange (167.66s)
--- PASS: TestAccSFNAlias_Identity_ExistingResource (165.04s)
PASS
```
