### PR TITLE
Don't use `make` in "Modern Go Check" workflow

### DIFF
--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -47,5 +47,6 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
-      # long-running test
-      - run: make TEST=./... modern-check
+      # Don't use make target as it downloads a Go version.
+      # - run: make TEST=./... modern-check
+      - run: go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@v0.21.0 -test ./...


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Noticed recently:

```
Run make TEST=./... modern-check
make: go1.25.6 not found
make: installing go1.25.6...
make: if you get an error, see https://go.dev/doc/manage-install to locally install various Go versions
go: downloading golang.org/dl v0.0.0-20260115185237-0c2ae32c0e69
Downloaded   0.0% (   16384 / 59768880 bytes) ...
Downloaded 100.0% (59768880 / 59768880 bytes)
Unpacking /home/runner/sdk/go1.25.6/go1.25.6.linux-amd64.tar.gz ...
Success. You may now run 'go1.25.6'
make: go1.25.6 ready
make: Checking for modern Go code...
go: downloading golang.org/x/tools/gopls v0.21.0
go: downloading golang.org/x/tools v0.21.0
go: downloading golang.org/x/tools v0.39.1-0.20251205192105-907593008619
go: downloading golang.org/x/sync v0.18.0
go: downloading golang.org/x/mod v0.30.0
```

 A micro optimization 😃.