### PR TITLE
fix(ecs): resolve perpetual diff in aws_ecs_task_definition

### DIFF
--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -108,7 +108,6 @@ func resourceTaskDefinition() *schema.Resource {
 					equal, _ := containerDefinitionsAreEquivalent(old, new, isAWSVPC)
 					return equal
 				},
-				DiffSuppressOnRefresh: true,
 				ValidateFunc:          validTaskDefinitionContainerDefinitions,
 			},
 			"cpu": {
@@ -295,6 +294,11 @@ func resourceTaskDefinition() *schema.Resource {
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								// Suppress diff when state has "false" and config is unset (empty).
+								// This prevents perpetual diffs when the API returns false as default.
+								return old == "false" && new == ""
+							},
 						},
 						"docker_volume_configuration": {
 							Type:     schema.TypeList,


### PR DESCRIPTION
- Add removeEmptyArraysFromJSON to strip empty arrays from SDK JSON output (mountPoints, volumesFrom, systemControls showing [] vs null)
- Remove DiffSuppressOnRefresh to allow state updates with cleaned JSON
- Add DiffSuppressFunc to configure_at_launch to suppress false vs null diff

Closes #11526
Closes #38153
Closes #11796

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
