### PR TITLE
fix(ecs): resolve perpetual diff in aws_ecs_task_definition

### DIFF
--- a/.changelog/46132.txt
+++ b/.changelog/46132.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_ecs_task_definition: Fix perpetual diff for `container_definitions` when `mountPoints`, `volumesFrom`, or `systemControls` are empty arrays
+```
+
+```release-note:bug
+resource/aws_ecs_task_definition: Fix perpetual diff for `volume.configure_at_launch` showing `false` vs `null`
+```

--- a/internal/service/ecs/container_definitions.go
+++ b/internal/service/ecs/container_definitions.go
@@ -210,7 +210,10 @@ func flattenContainerDefinitions(apiObjects []awstypes.ContainerDefinition) (str
 		return "", err
 	}
 
-	return jsonEncoder.String(), nil
+	// Remove empty fields (null, [], {}) from JSON to prevent spurious diffs.
+	// The AWS SDK serialization outputs [] for empty arrays, but Terraform
+	// configs typically omit these fields, causing diffs like "mountPoints: [] -> null".
+	return string(tfjson.RemoveEmptyFields([]byte(jsonEncoder.String()))), nil
 }
 
 func expandContainerDefinitions(tfString string) ([]awstypes.ContainerDefinition, error) {

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -108,7 +108,6 @@ func resourceTaskDefinition() *schema.Resource {
 					equal, _ := containerDefinitionsAreEquivalent(old, new, isAWSVPC)
 					return equal
 				},
-				DiffSuppressOnRefresh: true,
 				ValidateFunc:          validTaskDefinitionContainerDefinitions,
 			},
 			"cpu": {
@@ -293,8 +292,8 @@ func resourceTaskDefinition() *schema.Resource {
 						"configure_at_launch": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Computed: true,
 							ForceNew: true,
+							Default:  false,
 						},
 						"docker_volume_configuration": {
 							Type:     schema.TypeList,


### PR DESCRIPTION
  ## Rollback Plan

  If a change needs to be reverted, we will publish an updated version of the library.

  ## Changes to Security Controls

  No changes to security controls.

  ### Description

  This PR fixes perpetual diffs in `aws_ecs_task_definition` caused by:

  1. **Empty arrays in `container_definitions`**: The AWS SDK serialization outputs `[]` for empty arrays (`mountPoints`, `volumesFrom`, `systemControls`), but
  Terraform configs typically omit these fields. This causes diffs like `mountPoints: [] -> null` on every plan.

  2. **`volume.configure_at_launch` attribute**: Shows diff between `false` (API default) and `null` (unset in config).

  **Changes:**
  - Use `tfjson.RemoveEmptyFields` in `flattenContainerDefinitions` to strip empty arrays from SDK JSON output
  - Remove `DiffSuppressOnRefresh` from `container_definitions` to allow state updates with cleaned JSON
  - Add `Default: false` to `volume.configure_at_launch` to match the API default

  ### Relations

  Closes #11526
  Closes #38153
  Closes #11796

  ### References

  - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definitions

  ### Output from Acceptance Testing

  ```console
TF_ACC=1 go test ./internal/service/ecs/... -v -timeout 60m -run "TestAccECSTaskDefinition_basic|TestAccECSTaskDefinition_arrays|TestAccECSTaskDefinition_Volume_detectChangeInConfigureAtLaunch"
2026/01/23 16:59:03 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/23 16:59:03 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== RUN   TestAccECSTaskDefinition_arrays
=== PAUSE TestAccECSTaskDefinition_arrays
=== RUN   TestAccECSTaskDefinition_Volume_detectChangeInConfigureAtLaunch
=== PAUSE TestAccECSTaskDefinition_Volume_detectChangeInConfigureAtLaunch
=== CONT  TestAccECSTaskDefinition_basic
=== CONT  TestAccECSTaskDefinition_Volume_detectChangeInConfigureAtLaunch
=== CONT  TestAccECSTaskDefinition_arrays
--- PASS: TestAccECSTaskDefinition_Volume_detectChangeInConfigureAtLaunch (26.93s)
--- PASS: TestAccECSTaskDefinition_arrays (27.90s)
--- PASS: TestAccECSTaskDefinition_basic (42.84s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        43.008s
?       github.com/hashicorp/terraform-provider-aws/internal/service/ecs/test-fixtures  [no test files]