### PR TITLE
[docs] aws_route53_record: Clarify that resource import requires hosted zone ID

### DIFF
--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -279,9 +279,9 @@ resource "aws_route53_record" "example" {
 * `account_id` (String) AWS Account where this resource is managed.
 * `set_identifier` (String) Set identifier for the record.
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Route53 Records using the ID of the record, record name, record type, and set identifier. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Route53 Records using the hosted zone ID, record name, record type, and set identifier. For example:
 
-Using the ID of the record, which is the zone identifier, record name, and record type, separated by underscores (`_`):
+Using the hosted zone ID, record name, and record type, separated by underscores (`_`):
 
 ```terraform
 import {
@@ -308,9 +308,9 @@ import {
 }
 ```
 
-**Using `terraform import` to import** Route53 Records using the ID of the record, record name, record type, and set identifier. For example:
+**Using `terraform import` to import** Route53 Records using the hosted zone ID, record name, record type, and set identifier. For example:
 
-Using the ID of the record, which is the zone identifier, record name, and record type, separated by underscores (`_`):
+Using the hosted zone ID, record name, and record type, separated by underscores (`_`):
 
 ```console
 % terraform import aws_route53_record.example Z4KAPRWWNC7JR_dev_NS


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

According to the current documentation, importing a resource requires the “ID of the record.” However, this is misleading, as the required identifier is the **hosted zone ID**, not the record ID. In this context, “record” is commonly understood to mean a DNS record, which can cause confusion (I was actually confused).

This PR replaces “ID of the record” with “hosted zone ID” in the documentation to clarify the correct requirement for importing resources.

