### PR TITLE
internal/sweep: additional skippable errors for `athena`

### DIFF
--- a/internal/sweep/awsv2/skip.go
+++ b/internal/sweep/awsv2/skip.go
@@ -106,6 +106,10 @@ func SkipSweepError(err error) bool {
 	if tfawserr.ErrMessageContains(err, "InvalidParameterValueException", "This API operation is currently unavailable") {
 		return true
 	}
+	// Example (athena): InvalidRequestException: Not authorized to make this request.
+	if tfawserr.ErrMessageContains(err, "InvalidRequestException", "Not authorized to make this request") {
+		return true
+	}
 	// Example (GovCloud): InvalidSignatureException: Credential should be scoped to a valid region
 	if tfawserr.ErrMessageContains(err, "InvalidSignatureException", "Credential should be scoped to a valid region") {
 		return true


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds an additional skippable error to match the following from the Athena service.

```
2026/01/28 10:18:39 [ERROR] Error running Sweeper (aws_athena_capacity_reservation) in region (us-west-1): listing "aws_athena_capacity_reservation" (us-west-1): operation error Athena: ListCapacityReservations, https response error StatusCode: 400, RequestID: a906e3fc-b169-48de-af01-f50f57165f10, InvalidRequestException: Not authorized to make this request.
```

After: 

```
2026/01/28 10:24:25 [WARN]  sweeper: Skipping sweeper: sweeper_region=us-west-1 tf_resource_type=aws_athena_capacity_reservation error="operation error Athena: ListCapacityReservations, https response error StatusCode: 400, RequestID: 258591f1-9442-4c98-8b71-e31d39cb3c2c, InvalidRequestException: Not authorized to make this request."
2026/01/28 10:24:25 [DEBUG] Completed Sweeper (aws_athena_capacity_reservation) in region (us-west-1) in 612.453833ms
2026/01/28 10:24:25 Completed Sweepers for region (us-west-1) in 612.465875ms
2026/01/28 10:24:25 Sweeper Tests for region (us-west-1) ran successfully:
2026/01/28 10:24:25     - aws_athena_capacity_reservation
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      8.556s
```