### PR TITLE
docs/launch_template[connectionTrackingSpecification]: Fix documents on connection tracking specs

### DIFF
--- a/website/docs/cdktf/python/r/launch_template.html.markdown
+++ b/website/docs/cdktf/python/r/launch_template.html.markdown
@@ -443,8 +443,8 @@ NOTE: ENA Express requires [specific instance types](https://docs.aws.amazon.com
 The `connection_tracking_specification` block supports the following:
 
 * `tcp_established_timeout` - (Optional) Timeout (in seconds) for idle TCP connections in an established state. Min: 60 seconds. Max: 432000 seconds (5 days). Default: 432000 seconds. Recommended: Less than 432000 seconds.
-* `udp_stream_timeout` - Optional) Timeout (in seconds) for idle UDP flows classified as streams which have seen more than one request-response transaction. Min: 60 seconds. Max: 180 seconds (3 minutes). Default: 180 seconds.
-* `udp_timeout` - (Optional) Timeout (in seconds) for idle UDP flows that have seen traffic only in a single direction or a single request-response transaction. Min: 30 seconds. Max: 60 seconds. Default: 30 seconds.
+* `udp_stream_timeout` - (Optional) Timeout (in seconds) for idle UDP flows that have seen traffic only in a single direction or a single request-response transaction. Min: 30 seconds. Max: 60 seconds. Default: 30 seconds.
+* `udp_timeout` - (Optional) Timeout (in seconds) for idle UDP flows classified as streams which have seen more than one request-response transaction. Min: 60 seconds. Max: 180 seconds (3 minutes). Default: 180 seconds.
 
 ### Placement
 

--- a/website/docs/cdktf/typescript/r/launch_template.html.markdown
+++ b/website/docs/cdktf/typescript/r/launch_template.html.markdown
@@ -451,8 +451,8 @@ NOTE: ENA Express requires [specific instance types](https://docs.aws.amazon.com
 The `connectionTrackingSpecification` block supports the following:
 
 * `tcpEstablishedTimeout` - (Optional) Timeout (in seconds) for idle TCP connections in an established state. Min: 60 seconds. Max: 432000 seconds (5 days). Default: 432000 seconds. Recommended: Less than 432000 seconds.
-* `udpStreamTimeout` - (Optional) Timeout (in seconds) for idle UDP flows classified as streams which have seen more than one request-response transaction. Min: 60 seconds. Max: 180 seconds (3 minutes). Default: 180 seconds.
-* `udpTimeout` - (Optional) Timeout (in seconds) for idle UDP flows that have seen traffic only in a single direction or a single request-response transaction. Min: 30 seconds. Max: 60 seconds. Default: 30 seconds.
+* `udpStreamTimeout` - (Optional) Timeout (in seconds) for idle UDP flows that have seen traffic only in a single direction or a single request-response transaction. Min: 30 seconds. Max: 60 seconds. Default: 30 seconds.
+* `udpTimeout` - (Optional) Timeout (in seconds) for idle UDP flows classified as streams which have seen more than one request-response transaction. Min: 60 seconds. Max: 180 seconds (3 minutes). Default: 180 seconds.
 
 ### Placement
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description
This PR fixes docs on parameter descriptions for `connectionTrackingSpecification` block in `launch_template`. 

The values and checks are valid in the source code:
* https://github.com/hashicorp/terraform-provider-aws/blob/8ed280ee276e8b925074eef7ce20ff0d2a6f971d/internal/service/ec2/ec2_launch_template.go#L754-L758
* https://github.com/hashicorp/terraform-provider-aws/blob/8ed280ee276e8b925074eef7ce20ff0d2a6f971d/internal/service/ec2/ec2_launch_template.go#L759-L763

The default/min/max values for `udpStreamTimeout` and `udpTimeout` are incorrectly specified (they are swapped as a matter of fact)

In [EC2 user guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-connection-tracking.html#connection-tracking-timeouts), the order of parameters listed are: 
* `TCP established timeout`
* `UDP timeout`
* `UDP stream timeout`

However, in [EC2 API reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ConnectionTrackingSpecificationRequest.html) and [CloudFormation reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-ec2-launchtemplate-connectiontrackingspecification.html#cfn-ec2-launchtemplate-connectiontrackingspecification-tcpestablishedtimeout), the order of the parameters listed are: 
* `TcpEstablishedTimeout`
* `UdpStreamTimeout`
* `UdpTimeout`

This PR fixes descriptions for those values

### References
* https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-ec2-launchtemplate-connectiontrackingspecification.html#aws-properties-ec2-launchtemplate-connectiontrackingspecification-properties
* https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ConnectionTrackingSpecificationRequest.html#API_ConnectionTrackingSpecificationRequest_Contents
