### PR TITLE
[ENHANCEMENT]:  Add enable_tls_session_holding support to aws_networkfirewall

### DIFF
--- a/.changelog/46206.txt
+++ b/.changelog/46206.txt
@@ -1,0 +1,3 @@
+```enhancement
+resource/aws_networkfirewall_firewall_policy: Add `enable_tls_session_holding` argument
+```

--- a/internal/service/networkfirewall/firewall_policy.go
+++ b/internal/service/networkfirewall/firewall_policy.go
@@ -214,6 +214,10 @@ func resourceFirewallPolicy() *schema.Resource {
 								Optional:     true,
 								ValidateFunc: verify.ValidARN,
 							},
+							"enable_tls_session_holding": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
 						},
 					},
 				},
@@ -592,6 +596,10 @@ func expandFirewallPolicy(tfList []any) *awstypes.FirewallPolicy {
 		apiObject.TLSInspectionConfigurationArn = aws.String(v)
 	}
 
+	if v, ok := tfMap["enable_tls_session_holding"].(bool); ok {
+		apiObject.EnableTLSSessionHolding = aws.Bool(v)
+	}
+
 	return apiObject
 }
 
@@ -628,6 +636,9 @@ func flattenFirewallPolicy(apiObject *awstypes.FirewallPolicy) []any {
 	}
 	if apiObject.TLSInspectionConfigurationArn != nil {
 		tfMap["tls_inspection_configuration_arn"] = aws.ToString(apiObject.TLSInspectionConfigurationArn)
+	}
+	if apiObject.EnableTLSSessionHolding != nil {
+		tfMap["enable_tls_session_holding"] = aws.ToBool(apiObject.EnableTLSSessionHolding)
 	}
 
 	return []any{tfMap}

--- a/website/docs/r/networkfirewall_firewall_policy.html.markdown
+++ b/website/docs/r/networkfirewall_firewall_policy.html.markdown
@@ -180,6 +180,8 @@ In addition, you can specify custom actions that are compatible with your standa
 
 * `tls_inspection_configuration_arn` - (Optional) The (ARN) of the TLS Inspection policy to attach to the FW Policy.  This must be added at creation of the resource per AWS documentation. "You can only add a TLS inspection configuration to a new policy, not to an existing policy."  This cannot be removed from a FW Policy.
 
+* `enable_tls_session_holding` - (Optional) Indicates whether stateful network traffic is subject to TLS session holding. When enabled, prevents TCP and TLS packets from reaching destination servers until TLS Inspection has evaluated Server Name Indication (SNI) rules. Requires an associated TLS Inspection configuration. Default: `false`.
+
 ### Rule Variables
 
 The `rule_variables` block supports the following arguments:


### PR DESCRIPTION
…kfirewall_firewall_policy

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR adds support for the `tls_session_holding` argument in the `aws_networkfirewall_firewall_policy` resource.

This feature allows users to configure the TLS session holding settings for their firewall policies, ensuring that the firewall maintains session state specifically during TLS inspection scenarios.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #46171

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

I can't test because I currently can't use AWS

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
