### PR TITLE
aws_arcregionswitch_plan: Refactor to use AutoFlex Expander/Flattener interfaces

### DIFF
--- a/internal/service/arcregionswitch/plan.go
+++ b/internal/service/arcregionswitch/plan.go
@@ -4,6 +4,7 @@
 package arcregionswitch
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"slices"
@@ -974,15 +975,7 @@ func sortWorkflows(ctx context.Context, m *resourcePlanModel) fwdiag.Diagnostics
 	}
 
 	slices.SortFunc(workflows, func(a, b *workflowModel) int {
-		aAction := a.WorkflowTargetAction.ValueString()
-		bAction := b.WorkflowTargetAction.ValueString()
-		if aAction < bAction {
-			return -1
-		}
-		if aAction > bAction {
-			return 1
-		}
-		return 0
+		return cmp.Compare(a.WorkflowTargetAction.ValueString(), b.WorkflowTargetAction.ValueString())
 	})
 
 	m.Workflows = fwtypes.NewListNestedObjectValueOfSliceMust(ctx, workflows)


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

There are three kinds of lies: lies, damned lies, and comments claiming "AutoFlex cannot handle" something.

These comments incorrectly stated that AutoFlex fundamentally cannot handle union types and complex nested transformations. In reality, AutoFlex should be capable of handling these patterns - it just didn't work out of the box for plan.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccARCRegionSwitchPlan_ K=arcregionswitch
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 d-arcregionswitch-plan 🌿...
TF_ACC=1 go1.25.6 test ./internal/service/arcregionswitch/... -v -count 1 -parallel 20 -run='TestAccARCRegionSwitchPlan_'  -timeout 360m -vet=off
2026/01/29 19:16:20 Creating Terraform AWS Provider (SDKv2-style)...
2026/01/29 19:16:20 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccARCRegionSwitchPlan_basic
=== PAUSE TestAccARCRegionSwitchPlan_basic
=== RUN   TestAccARCRegionSwitchPlan_disappears
=== PAUSE TestAccARCRegionSwitchPlan_disappears
=== RUN   TestAccARCRegionSwitchPlan_update
=== PAUSE TestAccARCRegionSwitchPlan_update
=== RUN   TestAccARCRegionSwitchPlan_minimalRegions
=== PAUSE TestAccARCRegionSwitchPlan_minimalRegions
=== RUN   TestAccARCRegionSwitchPlan_multipleWorkflowsSameAction
=== PAUSE TestAccARCRegionSwitchPlan_multipleWorkflowsSameAction
=== RUN   TestAccARCRegionSwitchPlan_tags
=== PAUSE TestAccARCRegionSwitchPlan_tags
=== RUN   TestAccARCRegionSwitchPlan_route53HealthCheck
=== PAUSE TestAccARCRegionSwitchPlan_route53HealthCheck
=== RUN   TestAccARCRegionSwitchPlan_complex
=== PAUSE TestAccARCRegionSwitchPlan_complex
=== RUN   TestAccARCRegionSwitchPlan_validation
=== PAUSE TestAccARCRegionSwitchPlan_validation
=== CONT  TestAccARCRegionSwitchPlan_basic
=== CONT  TestAccARCRegionSwitchPlan_tags
=== CONT  TestAccARCRegionSwitchPlan_minimalRegions
=== CONT  TestAccARCRegionSwitchPlan_multipleWorkflowsSameAction
=== CONT  TestAccARCRegionSwitchPlan_update
=== CONT  TestAccARCRegionSwitchPlan_disappears
=== CONT  TestAccARCRegionSwitchPlan_complex
=== CONT  TestAccARCRegionSwitchPlan_validation
=== CONT  TestAccARCRegionSwitchPlan_route53HealthCheck
--- PASS: TestAccARCRegionSwitchPlan_validation (9.22s)
--- PASS: TestAccARCRegionSwitchPlan_multipleWorkflowsSameAction (14.73s)
--- PASS: TestAccARCRegionSwitchPlan_minimalRegions (14.73s)
--- PASS: TestAccARCRegionSwitchPlan_disappears (15.21s)
--- PASS: TestAccARCRegionSwitchPlan_basic (17.18s)
--- PASS: TestAccARCRegionSwitchPlan_update (22.86s)
--- PASS: TestAccARCRegionSwitchPlan_tags (31.74s)
--- PASS: TestAccARCRegionSwitchPlan_complex (50.12s)
--- PASS: TestAccARCRegionSwitchPlan_route53HealthCheck (449.15s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/arcregionswitch	455.476s
```