### PR TITLE
docs: add ARN as valid input for `aws_dynamodb_table_item.table_name`

### DIFF
--- a/website/docs/d/dynamodb_table_item.html.markdown
+++ b/website/docs/d/dynamodb_table_item.html.markdown
@@ -34,7 +34,7 @@ KEY
 
 The following arguments are required:
 
-* `table_name` - (Required) The name of the table containing the requested item.
+* `table_name` - (Required) The name or ARN of the table containing the requested item.
 * `key` - (Required) A map of attribute names to AttributeValue objects, representing the primary key of the item to retrieve.
   For the primary key, you must provide all of the attributes. For example, with a simple primary key, you only need to provide a value for the partition key. For a composite primary key, you must provide values for both the partition key and the sort key.
 

--- a/website/docs/r/dynamodb_table_item.html.markdown
+++ b/website/docs/r/dynamodb_table_item.html.markdown
@@ -52,7 +52,7 @@ This resource supports the following arguments:
 * `hash_key` - (Required) Hash key to use for lookups and identification of the item
 * `item` - (Required) JSON representation of a map of attribute name/value pairs, one for each attribute. Only the primary key attributes are required; you can optionally provide other attribute name-value pairs for the item.
 * `range_key` - (Optional) Range key to use for lookups and identification of the item. Required if there is range key defined in the table.
-* `table_name` - (Required) Name of the table to contain the item.
+* `table_name` - (Required) Name or ARN of the table to contain the item.
 
 ~> **Note:** Names included in `item` are represented internally with everything but letters removed. There is the possibility of collisions if two names, once filtered, are the same. For example, the names `your-name-here` and `yournamehere` will overlap and cause an error.
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes implemented.

### Description

Update the  `table_name` description for  `aws_dynamodb_table_item` resource and data source.
In addition to the table name also the ARN can be used as input for `table_name`. 

So below example works out of the box:

```hcl
resource "aws_dynamodb_table" "example" {
  name           = "example-name"
  read_capacity  = 10
  write_capacity = 10
  hash_key       = "exampleHashKey"
  attribute {
    name = "exampleHashKey"
    type = "S"
  }
}

resource "aws_dynamodb_table_item" "example" {
  table_name = aws_dynamodb_table.example.arn # Use ARN instead of name
  hash_key   = aws_dynamodb_table.example.hash_key
  item = <<ITEM
{
  "exampleHashKey": {"S": "something"}
}
ITEM
}

data "aws_dynamodb_table_item" "test" {
  table_name = aws_dynamodb_table.example.arn # Use ARN instead of name
  key                   = <<KEY
{
  "exampleHashKey": {"S": "something"}
}
KEY
  depends_on            = [aws_dynamodb_table_item.example]
}

output "example" {
  value = data.aws_dynamodb_table_item.test.item
}
```

### Relations

Closes #46133 

### References

- [AWS API Docs - PutItem](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html) stating that ARN and table name are accepted as input.

### Output from Acceptance Testing

Not applicable. Only documentation is updated.