### PR TITLE
r/aws_lakeformation_permissions: add catalog_resource_id for S3 Tables

### DIFF
--- a/.changelog/0000.txt
+++ b/.changelog/0000.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lakeformation_permissions: Add catalog_resource_id to support S3 Tables catalog grants.
+```

--- a/internal/service/lakeformation/permissions_internal_test.go
+++ b/internal/service/lakeformation/permissions_internal_test.go
@@ -1,0 +1,62 @@
+package lakeformation
+
+import (
+	"testing"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/lakeformation/types"
+)
+
+func TestNormalizeGrantOptionPermissions_FiltersSuperUser(t *testing.T) {
+	t.Parallel()
+
+	in := []awstypes.Permission{
+		awstypes.PermissionSuperUser,
+		awstypes.PermissionAll,
+		awstypes.PermissionDescribe,
+	}
+
+	out := normalizeGrantOptionPermissions(in)
+
+	if len(out) != 2 {
+		t.Fatalf("expected 2 permissions after filtering, got %d: %#v", len(out), out)
+	}
+	for _, p := range out {
+		if p == awstypes.PermissionSuperUser {
+			t.Fatalf("did not expect %q in output: %#v", awstypes.PermissionSuperUser, out)
+		}
+	}
+}
+
+func TestNormalizeGrantOptionPermissions_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	if got := normalizeGrantOptionPermissions(nil); got != nil {
+		t.Fatalf("expected nil output for nil input, got %#v", got)
+	}
+
+	if got := normalizeGrantOptionPermissions([]awstypes.Permission{}); got != nil {
+		t.Fatalf("expected nil output for empty input, got %#v", got)
+	}
+}
+
+func TestFlattenGrantPermissions_FiltersSuperUser(t *testing.T) {
+	t.Parallel()
+
+	apiObjects := []awstypes.PrincipalResourcePermissions{
+		{
+			PermissionsWithGrantOption: []awstypes.Permission{
+				awstypes.PermissionDescribe,
+				awstypes.PermissionSuperUser,
+				awstypes.PermissionAll,
+			},
+		},
+	}
+
+	got := flattenGrantPermissions(apiObjects)
+
+	for _, p := range got {
+		if p == string(awstypes.PermissionSuperUser) {
+			t.Fatalf("did not expect %q in output: %#v", awstypes.PermissionSuperUser, got)
+		}
+	}
+}

--- a/internal/service/lakeformation/permissions_test.go
+++ b/internal/service/lakeformation/permissions_test.go
@@ -46,6 +46,7 @@ func testAccPermissions_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckPermissionsExists(ctx, resourceName),
 					resource.TestCheckNoResourceAttr(resourceName, names.AttrCatalogID),
+					resource.TestCheckResourceAttr(resourceName, "catalog_resource_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "catalog_resource", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "data_cells_filter.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "data_location.#", "0"),
@@ -1108,7 +1109,9 @@ func permissionCountForResource(ctx context.Context, conn *lakeformation.Client,
 	}
 
 	if v, ok := rs.Primary.Attributes["catalog_resource"]; ok && v == acctest.CtTrue {
-		input.Resource.Catalog = tflakeformation.ExpandCatalogResource()
+		// When catalog_resource_id is set (e.g., S3 Tables catalog), it must be used as
+		// Resource.Catalog.Id for ListPermissions filtering.
+		input.Resource.Catalog = tflakeformation.ExpandCatalogResource(rs.Primary.Attributes["catalog_resource_id"])
 
 		noResource = false
 	}

--- a/website/docs/r/lakeformation_permissions.html.markdown
+++ b/website/docs/r/lakeformation_permissions.html.markdown
@@ -141,6 +141,19 @@ resource "aws_lakeformation_permissions" "example" {
 }
 ```
 
+### Grant Permissions For An S3 Tables Catalog
+
+```terraform
+resource "aws_lakeformation_permissions" "example" {
+  principal   = aws_iam_role.workflow_role.arn
+  permissions = ["ALL"]
+
+  # S3 Tables catalogs require the catalog identifier in Resource.Catalog.Id
+  catalog_resource    = true
+  catalog_resource_id = "110376042874:s3tablescatalog/my-s3tables-bucket"
+}
+```
+
 ### Grant Permissions Using Tag-Based Access Control
 
 ```terraform
@@ -188,6 +201,7 @@ The following arguments are optional:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `catalog_id` - (Optional) Identifier for the Data Catalog. By default, the account ID. The Data Catalog is the persistent metadata store. It contains database definitions, table definitions, and other control information to manage your Lake Formation environment.
+* `catalog_resource_id` - (Optional) Identifier for the catalog resource when `catalog_resource = true`. Use this to grant permissions on non-default catalogs such as S3 Tables (e.g., `<account-id>:s3tablescatalog/<bucket>`).
 * `permissions_with_grant_option` - (Optional) Subset of `permissions` which the principal can pass.
 
 ### data_cells_filter


### PR DESCRIPTION
### Description

Adds `catalog_resource_id` argument to `aws_lakeformation_permissions` to support granting permissions on S3 Tables catalogs.

S3 Tables uses a catalog identifier format (`<account-id>:s3tablescatalog/<bucket>`) that must be passed in `Resource.Catalog.Id`, not the top-level `CatalogId` field. The existing `catalog_id` argument only accepts 12-digit account IDs.

### Relations

Closes #40724
Closes #46246
Closes #49463

### Output from Acceptance Testing

```console
=== RUN   TestNormalizeGrantOptionPermissions_FiltersSuperUser
--- PASS: TestNormalizeGrantOptionPermissions_FiltersSuperUser (0.00s)
=== RUN   TestNormalizeGrantOptionPermissions_EmptyInput
--- PASS: TestNormalizeGrantOptionPermissions_EmptyInput (0.00s)
=== RUN   TestFlattenGrantPermissions_FiltersSuperUser
--- PASS: TestFlattenGrantPermissions_FiltersSuperUser (0.00s)
PASS
```

Manual testing verified grant/revoke cycle works with S3 Tables catalog.