### PR TITLE
docs: clarify behavior of type argument for aws_service_discovery_service

### DIFF
--- a/website/docs/r/service_discovery_service.html.markdown
+++ b/website/docs/r/service_discovery_service.html.markdown
@@ -84,6 +84,10 @@ This resource supports the following arguments:
 * `health_check_custom_config` - (Optional, **Deprecated**, Forces new resource) Please use `health_check_config` instead. See [`health_check_custom_config` Block](#health_check_custom_config-block) for details.
 * `namespace_id` - (Optional) The ID of the namespace that you want to use to create the service.
 * `type` - (Optional) If present, specifies that the service instances are only discoverable using the `DiscoverInstances` API operation. No DNS records is registered for the service instances. The only valid value is `HTTP`.
+~> **Note:** The `type` argument is an instruction to the upstream `CreateService` API and is **not** a complete enumeration of all possible service types. Only `HTTP` is accepted as an input value.
+When `type` is omitted, AWS determines the service type based on the rest of the configuration (for example, `dns_config` and health checks). The resulting value is then populated in Terraform state as a computed attribute.
+In these cases, values such as `DNS_HTTP` may appear in state, even though they are not valid configuration values.
+For most DNS-based use cases, omitting `type` is the expected and recommended approach.
 * `tags` - (Optional) A map of tags to assign to the service. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### `dns_config` Block

--- a/website/docs/r/service_discovery_service.html.markdown
+++ b/website/docs/r/service_discovery_service.html.markdown
@@ -84,9 +84,15 @@ This resource supports the following arguments:
 * `health_check_custom_config` - (Optional, **Deprecated**, Forces new resource) Please use `health_check_config` instead. See [`health_check_custom_config` Block](#health_check_custom_config-block) for details.
 * `namespace_id` - (Optional) The ID of the namespace that you want to use to create the service.
 * `type` - (Optional) If present, specifies that the service instances are only discoverable using the `DiscoverInstances` API operation. No DNS records is registered for the service instances. The only valid value is `HTTP`.
-~> **Note:** The `type` argument is an instruction to the upstream `CreateService` API and is **not** a complete enumeration of all possible service types. Only `HTTP` is accepted as an input value.
-When `type` is omitted, AWS determines the service type based on the rest of the configuration (for example, `dns_config` and health checks). The resulting value is then populated in Terraform state as a computed attribute.
+
+**Note:** The `type` argument is an instruction to the upstream `CreateService` API and is **not** a complete enumeration of all possible service types.
+Only `HTTP` is accepted as an input value.
+
+When `type` is omitted, AWS determines the service type based on the rest of the configuration (for example, `dns_config` and health checks).
+The resulting value is then populated in Terraform state as a computed attribute.
+
 In these cases, values such as `DNS_HTTP` may appear in state, even though they are not valid configuration values.
+
 For most DNS-based use cases, omitting `type` is the expected and recommended approach.
 * `tags` - (Optional) A map of tags to assign to the service. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->





## Changes to Security Controls

No.

This change does not modify access controls, encryption, or logging behavior. It only affects how Service Discovery Service resources are managed via the Terraform AWS Provider and does not alter the underlying AWS security configuration.

### Description

This pull request improves support for AWS Service Discovery Service (Cloud Map) resources in the Terraform AWS Provider.

The change addresses inconsistencies between the Terraform state and the actual AWS API behavior when managing Service Discovery services. It ensures that the provider correctly reflects the service configuration returned by the AWS SDK, reducing unnecessary diffs and improving idempotency.

This enhancement makes Service Discovery Service management more reliable and aligns the provider behavior more closely with AWS Cloud Map expectations.



### Relations

Closes #46026 




### References

https://github.com/hashicorp/terraform-provider-aws/issues/46026#issuecomment-3804266946



