### PR TITLE
docs: Fix casing of target_storage_class for ecr_lifecycle_policy_document

### DIFF
--- a/website/docs/d/ecr_lifecycle_policy_document.html.markdown
+++ b/website/docs/d/ecr_lifecycle_policy_document.html.markdown
@@ -44,7 +44,7 @@ Each document configuration may have one or more `rule` blocks, which each accep
 
 * `action` (Optional) - Specifies the action to take.
     * `type` (Required) - Specify an action type. The supported values are `expire` (to delete images) and `transition` (to move images to archive storage).
-    * `targetStorageClass` (Required if `type` is `transition`) - The storage class you want the lifecycle policy to transition the image to. `archive` is the only supported value.
+    * `target_storage_class` (Required if `type` is `transition`) - The storage class you want the lifecycle policy to transition the image to. `archive` is the only supported value.
 * `description` (Optional) - Describes the purpose of a rule within a lifecycle policy.
 * `priority` (Required) - Sets the order in which rules are evaluated, lowest to highest. When you add rules to a lifecycle policy, you must give them each a unique value for `priority`. Values do not need to be sequential across rules in a policy. A rule with a `tag_status` value of `any` must have the highest value for `priority` and be evaluated last.
 * `selection` (Required) -  Collects parameters describing the selection criteria for the ECR lifecycle policy:


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

None

### Description

Correct casing of `target_storage_class` in docs for `ecr_lifecycle_policy_document` as specifying the current casing of  `targetStorageClass` does not work and results in an error: `An argument named "targetStorageClass" is not expected here.`


