### PR TITLE
r/codebuild_webhook: update filter type

### DIFF
--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -101,7 +101,7 @@ This resource supports the following arguments:
 
 ### filter
 
-* `type` - (Required) The webhook filter group's type. Valid values for this parameter are: `EVENT`, `BASE_REF`, `HEAD_REF`, `ACTOR_ACCOUNT_ID`, `FILE_PATH`, `COMMIT_MESSAGE`, `WORKFLOW_NAME`, `TAG_NAME`, `RELEASE_NAME`. At least one filter group must specify `EVENT` as its type.
+* `type` - (Required) The webhook filter group's type. Valid values for this parameter are: `EVENT`, `BASE_REF`, `HEAD_REF`, `ACTOR_ACCOUNT_ID`, `FILE_PATH`, `COMMIT_MESSAGE`, `WORKFLOW_NAME`, `TAG_NAME`, `RELEASE_NAME`, `REPOSITORY_NAME`. At least one filter group must specify `EVENT` as its type.
 * `pattern` - (Required) For a filter that uses `EVENT` type, a comma-separated string that specifies one event: `PUSH`, `PULL_REQUEST_CREATED`, `PULL_REQUEST_UPDATED`, `PULL_REQUEST_REOPENED`. `PULL_REQUEST_MERGED`, `WORKFLOW_JOB_QUEUED` works with GitHub & GitHub Enterprise only. For a filter that uses any of the other filter types, a regular expression.
 * `exclude_matched_pattern` - (Optional) If set to `true`, the specified filter does *not* trigger a build. Defaults to `false`.
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. This pull request only updates documentation and does not affect access controls, encryption, or logging behavior.

### Description

This pull request updates the documentation to clarify that `REPOSITORY_NAME` is a required filter type for `aws_codebuild_webhook`.

The current documentation omits `REPOSITORY_NAME` from the list of supported webhook filters, which may lead to confusion when configuring CodeBuild webhooks for GitHub or GitHub Enterprise.

This change is a documentation-only update and reflects the actual behavior supported by the AWS SDK after the fix included in v1.41.1.

### Relations

Relates #38868

### References

- https://github.com/hashicorp/terraform-provider-aws/issues/38868
- https://github.com/aws/aws-sdk-go-v2/issues/2746
- https://github.com/aws/aws-sdk-go-v2/releases/tag/v1.41.1

### Output from Acceptance Testing

Not applicable. This change only updates documentation and does not affect provider behavior or acceptance tests.
