### PR TITLE
docs: fix aws_arcregionswitch_plan example using wrong block name

### DIFF
--- a/website/docs/r/arcregionswitch_plan.html.markdown
+++ b/website/docs/r/arcregionswitch_plan.html.markdown
@@ -190,7 +190,7 @@ The following arguments are optional:
 * `recovery_time_objective_minutes` - (Optional) Recovery time objective in minutes.
 * `region` - (Optional, **Deprecated**) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `triggers` - (Optional) Set of triggers that can initiate the plan execution. See [Trigger](#trigger) below.
+* `triggers` - (Optional) Set of triggers that can initiate the plan execution. See [Triggers](#triggers) below.
 
 ### Workflow
 


### PR DESCRIPTION
The Complex Usage example used `trigger` (singular) but the schema requires `triggers` (plural).

Fixes #46258