### PR TITLE
Surface block device tagging failures as warnings and document ABAC limitations

### DIFF
--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1210,7 +1210,11 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta an
 
 	for vol, blockDeviceTags := range blockDeviceTagsToCreate {
 		if err := createTags(ctx, conn, vol, svcTags(tftags.New(ctx, blockDeviceTags))); err != nil {
-			log.Printf("[ERR] Error creating tags for EBS volume %s: %s", vol, err)
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  fmt.Sprintf("Failed to create tags for EBS volume %s", vol),
+				Detail:   err.Error(),
+			})
 		}
 	}
 

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -319,7 +319,7 @@ The `root_block_device` block supports the following:
 * `encrypted` - (Optional) Whether to enable volume encryption. Defaults to `false`. Must be configured to perform drift detection.
 * `iops` - (Optional) Amount of provisioned [IOPS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html). Only valid for volume_type of `io1`, `io2` or `gp3`.
 * `kms_key_id` - (Optional) Amazon Resource Name (ARN) of the KMS Key to use when encrypting the volume. Must be configured to perform drift detection.
-* `tags` - (Optional) Map of tags to assign to the device.
+* `tags` - (Optional) Map of tags to assign to the device. **Note:** Tags specified here are applied after instance creation via a separate API call. This means they cannot be used with IAM policies that require tags during resource creation (e.g., ABAC policies with `ec2:CreateAction` conditions or SCPs requiring volume tags). For ABAC compliance, use `volume_tags` instead, which applies uniform tags to all volumes during instance creation.
 * `throughput` - (Optional) Throughput to provision for a volume in mebibytes per second (MiB/s). This is only valid for `volume_type` of `gp3`.
 * `volume_size` - (Optional) Size of the volume in gibibytes (GiB).
 * `volume_type` - (Optional) Type of volume. Valid values include `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1`, or `st1`. Defaults to the volume type that the AMI uses.
@@ -334,7 +334,7 @@ Each `ebs_block_device` block supports the following:
 * `iops` - (Optional) Amount of provisioned [IOPS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html). Only valid for volume_type of `io1`, `io2` or `gp3`.
 * `kms_key_id` - (Optional) Amazon Resource Name (ARN) of the KMS Key to use when encrypting the volume. Must be configured to perform drift detection.
 * `snapshot_id` - (Optional) Snapshot ID to mount.
-* `tags` - (Optional) Map of tags to assign to the device.
+* `tags` - (Optional) Map of tags to assign to the device. **Note:** Tags specified here are applied after instance creation via a separate API call. This means they cannot be used with IAM policies that require tags during resource creation (e.g., ABAC policies with `ec2:CreateAction` conditions or SCPs requiring volume tags). For ABAC compliance, use `volume_tags` instead, which applies uniform tags to all volumes during instance creation.
 * `throughput` - (Optional) Throughput to provision for a volume in mebibytes per second (MiB/s). This is only valid for `volume_type` of `gp3`.
 * `volume_size` - (Optional) Size of the volume in gibibytes (GiB).
 * `volume_type` - (Optional) Type of volume. Valid values include `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1`, or `st1`. Defaults to `gp2`.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Changes:
- Replace silent error logging with warning diagnostics for block device tagging failures
- Add documentation explaining that `root_block_device.tags` and `ebs_block_device.tags` don't work with ABAC/SCP policies
- Guide users to `volume_tags` for ABAC compliance scenarios

Fixes silent failures when IAM policies require tags during resource creation (`ec2:CreateAction` conditions).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41653
Relates #36726
Relates #35639

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T='TestAccEC2Instance_BlockDeviceTags_volumeTags|TestAccEC2Instance_BlockDeviceTags_attachedVolume|TestAccEC2Instance_BlockDeviceTags_ebsAndRoot' K=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-ec2-instance-tags-abac 🌿...
TF_ACC=1 go1.25.6 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Instance_BlockDeviceTags_volumeTags|TestAccEC2Instance_BlockDeviceTags_attachedVolume|TestAccEC2Instance_BlockDeviceTags_ebsAndRoot'  -timeout 360m -vet=off
2026/02/02 16:22:55 Creating Terraform AWS Provider (SDKv2-style)...
2026/02/02 16:22:55 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEC2Instance_BlockDeviceTags_volumeTags
=== PAUSE TestAccEC2Instance_BlockDeviceTags_volumeTags
=== RUN   TestAccEC2Instance_BlockDeviceTags_attachedVolume
=== PAUSE TestAccEC2Instance_BlockDeviceTags_attachedVolume
=== RUN   TestAccEC2Instance_BlockDeviceTags_ebsAndRoot
=== PAUSE TestAccEC2Instance_BlockDeviceTags_ebsAndRoot
=== CONT  TestAccEC2Instance_BlockDeviceTags_volumeTags
=== CONT  TestAccEC2Instance_BlockDeviceTags_ebsAndRoot
=== CONT  TestAccEC2Instance_BlockDeviceTags_attachedVolume
--- PASS: TestAccEC2Instance_BlockDeviceTags_ebsAndRoot (128.26s)
--- PASS: TestAccEC2Instance_BlockDeviceTags_attachedVolume (152.34s)
--- PASS: TestAccEC2Instance_BlockDeviceTags_volumeTags (161.72s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	168.278s
```
