### PR TITLE
Fix regex to exact match SDKDataSources and SDKResources

### DIFF
--- a/.github/workflows/plugin-sdk-monitor.yml
+++ b/.github/workflows/plugin-sdk-monitor.yml
@@ -51,14 +51,14 @@ jobs:
 
             # Count new Factory entries in SDKResources function
             RESOURCE_BLOCK=$(echo "$DIFF" | awk '
-              /func.*SDKResources/,/^func [^(]/ {
+              /func.*\) SDKResources\(/,/^func [^(]/ {
                 if (/^\+.*Factory:/) print
               }
             ')
 
             # Count new Factory entries in SDKDataSources function
             DATA_SOURCE_BLOCK=$(echo "$DIFF" | awk '
-              /func.*SDKDataSources/,/^func [^(]/ {
+              /func.*\) SDKDataSources\(/,/^func [^(]/ {
                 if (/^\+.*Factory:/) print
               }
             ')


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes regex to match the targeted SDKDataSources and SDKResources blocks exactly.