### PR TITLE
chore: remove `existsTakesT=true` and `destroyTakesT=true` annotations

### DIFF
--- a/internal/service/acmpca/certificate.go
+++ b/internal/service/acmpca/certificate.go
@@ -45,8 +45,6 @@ import (
 // @CustomImport
 // @Testing(importIgnore="certificate_signing_request;signing_algorithm;template_arn;validity")
 // @Testing(plannableImportAction="Replace")
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func resourceCertificate() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceCertificateCreate,

--- a/internal/service/acmpca/certificate_authority.go
+++ b/internal/service/acmpca/certificate_authority.go
@@ -44,8 +44,6 @@ const (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/acmpca/types;types.CertificateAuthority")
 // @Testing(generator="acctest.RandomDomainName()")
 // @Testing(importIgnore="permanent_deletion_time_in_days")
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func resourceCertificateAuthority() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{

--- a/internal/service/acmpca/certificate_authority_certificate.go
+++ b/internal/service/acmpca/certificate_authority_certificate.go
@@ -30,7 +30,6 @@ import (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/acmpca;acmpca.GetCertificateAuthorityCertificateOutput")
 // @Testing(generator="acctest.RandomDomainName()")
 // @Testing(checkDestroyNoop=true)
-// @Testing(existsTakesT=true)
 func resourceCertificateAuthorityCertificate() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceCertificateAuthorityCertificateCreate,

--- a/internal/service/acmpca/policy.go
+++ b/internal/service/acmpca/policy.go
@@ -28,8 +28,6 @@ import (
 // @ArnIdentity("resource_arn")
 // @V60SDKv2Fix
 // @Testing(generator=false)
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func resourcePolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePolicyPut,

--- a/internal/service/amp/rule_group_namespace.go
+++ b/internal/service/amp/rule_group_namespace.go
@@ -33,8 +33,6 @@ import (
 // @ArnIdentity
 // @V60SDKv2Fix
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/amp/types;types.RuleGroupsNamespaceDescription")
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func resourceRuleGroupNamespace() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRuleGroupNamespaceCreate,

--- a/internal/service/amp/scraper.go
+++ b/internal/service/amp/scraper.go
@@ -44,8 +44,6 @@ import (
 // @FrameworkResource("aws_prometheus_scraper", name="Scraper")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/amp/types;types.ScraperDescription")
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func newScraperResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &scraperResource{}
 

--- a/internal/service/amp/workspace.go
+++ b/internal/service/amp/workspace.go
@@ -33,8 +33,6 @@ import (
 // @SDKResource("aws_prometheus_workspace", name="Workspace")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/amp/types;types.WorkspaceDescription")
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 // @Testing(generator=false)
 func resourceWorkspace() *schema.Resource {
 	return &schema.Resource{

--- a/internal/service/amplify/app.go
+++ b/internal/service/amplify/app.go
@@ -32,8 +32,6 @@ import (
 // @SDKResource("aws_amplify_app", name="App")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/amplify/types;types.App", serialize=true, serializeDelay=true)
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func resourceApp() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAppCreate,

--- a/internal/service/amplify/branch.go
+++ b/internal/service/amplify/branch.go
@@ -33,8 +33,6 @@ import (
 // @SDKResource("aws_amplify_branch", name="Branch")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/amplify/types;types.Branch", serialize=true, serializeDelay=true)
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func resourceBranch() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBranchCreate,

--- a/internal/service/apigateway/api_key.go
+++ b/internal/service/apigateway/api_key.go
@@ -29,8 +29,6 @@ import (
 // @SDKResource("aws_api_gateway_api_key", name="API Key")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigateway;apigateway.GetApiKeyOutput")
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func resourceAPIKey() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAPIKeyCreate,

--- a/internal/service/apigateway/client_certificate.go
+++ b/internal/service/apigateway/client_certificate.go
@@ -27,8 +27,6 @@ import (
 // @SDKResource("aws_api_gateway_client_certificate", name="Client Certificate")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigateway;apigateway.GetClientCertificateOutput", generator=false)
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func resourceClientCertificate() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClientCertificateCreate,

--- a/internal/service/apigateway/domain_name.go
+++ b/internal/service/apigateway/domain_name.go
@@ -35,8 +35,6 @@ import (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigateway;apigateway.GetDomainNameOutput")
 // @Testing(generator="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.RandomSubdomain()")
 // @Testing(tlsKey=true, tlsKeyDomain="rName")
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func resourceDomainName() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDomainNameCreate,

--- a/internal/service/apigateway/domain_name_access_association.go
+++ b/internal/service/apigateway/domain_name_access_association.go
@@ -37,8 +37,6 @@ import (
 // @Testing(generator="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.RandomSubdomain()")
 // @Testing(tlsKey=true, tlsKeyDomain="rName")
 // @Testing(preIdentityVersion="v5.100.0")
-// @Testing(destroyTakesT=true)
-// @Testing(existsTakesT=true)
 func newDomainNameAccessAssociationResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &domainNameAccessAssociationResource{}
 

--- a/internal/service/apigateway/rest_api.go
+++ b/internal/service/apigateway/rest_api.go
@@ -38,8 +38,6 @@ import (
 // @SDKResource("aws_api_gateway_rest_api", name="REST API")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigateway;apigateway.GetRestApiOutput", importIgnore="put_rest_api_mode")
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func resourceRestAPI() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRestAPICreate,

--- a/internal/service/apigateway/stage.go
+++ b/internal/service/apigateway/stage.go
@@ -35,8 +35,6 @@ import (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigateway;apigateway.GetStageOutput")
 // @Testing(serialize=true, serializeParallelTests=true)
 // @Testing(importStateIdFunc=testAccStageImportStateIdFunc)
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func resourceStage() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceStageCreate,

--- a/internal/service/apigateway/usage_plan.go
+++ b/internal/service/apigateway/usage_plan.go
@@ -29,8 +29,6 @@ import (
 // @SDKResource("aws_api_gateway_usage_plan", name="Usage Plan")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigateway;apigateway.GetUsagePlanOutput")
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func resourceUsagePlan() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceUsagePlanCreate,

--- a/internal/service/apigateway/vpc_link.go
+++ b/internal/service/apigateway/vpc_link.go
@@ -30,8 +30,6 @@ import (
 
 // @SDKResource("aws_api_gateway_vpc_link", name="VPC Link")
 // @Tags(identifierAttribute="arn")
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func resourceVPCLink() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceVPCLinkCreate,

--- a/internal/service/apigatewayv2/api.go
+++ b/internal/service/apigatewayv2/api.go
@@ -35,8 +35,6 @@ import (
 // @SDKResource("aws_apigatewayv2_api", name="API")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigatewayv2;apigatewayv2.GetApiOutput")
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func resourceAPI() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAPICreate,

--- a/internal/service/apigatewayv2/domain_name.go
+++ b/internal/service/apigatewayv2/domain_name.go
@@ -34,8 +34,6 @@ import (
 // @Testing(generator="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.RandomSubdomain()")
 // @Testing(tlsKey=true)
 // @Testing(tlsKeyDomain=rName)
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func resourceDomainName() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDomainNameCreate,

--- a/internal/service/apigatewayv2/stage.go
+++ b/internal/service/apigatewayv2/stage.go
@@ -34,8 +34,6 @@ import (
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigatewayv2;apigatewayv2.GetStageOutput")
 // @Testing(importStateIdFunc="testAccStageImportStateIdFunc")
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func resourceStage() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceStageCreate,

--- a/internal/service/apigatewayv2/vpc_link.go
+++ b/internal/service/apigatewayv2/vpc_link.go
@@ -31,8 +31,6 @@ import (
 // @SDKResource("aws_apigatewayv2_vpc_link", name="VPC Link")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigatewayv2;apigatewayv2.GetVpcLinkOutput")
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func resourceVPCLink() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceVPCLinkCreate,

--- a/internal/service/applicationinsights/application.go
+++ b/internal/service/applicationinsights/application.go
@@ -29,7 +29,6 @@ import (
 // @SDKResource("aws_applicationinsights_application", name="Application")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/applicationinsights/types;types.ApplicationInfo")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceApplication() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceApplicationCreate,

--- a/internal/service/chimesdkmediapipelines/media_insights_pipeline_configuration.go
+++ b/internal/service/chimesdkmediapipelines/media_insights_pipeline_configuration.go
@@ -47,7 +47,6 @@ var (
 // @ArnIdentity
 // @V60SDKv2Fix
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines/types;awstypes;awstypes.MediaInsightsPipelineConfiguration")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceMediaInsightsPipelineConfiguration() *schema.Resource {
 	return &schema.Resource{
 

--- a/internal/service/cloudfrontkeyvaluestore/key.go
+++ b/internal/service/cloudfrontkeyvaluestore/key.go
@@ -38,7 +38,6 @@ import (
 // @IdentityAttribute("key")
 // @ImportIDHandler("securityGroupVPCAssociationImportID", setIDAttribute=true)
 // @Testing(preIdentityVersion="6.0.0")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func newKeyResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &keyResource{}
 

--- a/internal/service/dynamodb/global_secondary_index.go
+++ b/internal/service/dynamodb/global_secondary_index.go
@@ -55,7 +55,6 @@ const (
 // @ImportIDHandler("globalSecondaryIndexImportID")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/dynamodb/types;awstypes;awstypes.GlobalSecondaryIndexDescription")
 // @Testing(hasNoPreExistingResource=true)
-// @Testing(existsTakesT=true, destroyTakesT=true)
 // @Testing(importStateIdFunc=testAccGlobalSecondaryIndexImportStateIdFunc)
 // @Testing(importStateIdAttribute="arn")
 // @Testing(requireEnvVar="TF_AWS_EXPERIMENT_dynamodb_global_secondary_index")

--- a/internal/service/dynamodb/resource_policy.go
+++ b/internal/service/dynamodb/resource_policy.go
@@ -34,7 +34,6 @@ import (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/dynamodb;dynamodb.GetResourcePolicyOutput")
 // @Testing(importIgnore="policy")
 // @Testing(preIdentityVersion="v5.100.0")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func newResourcePolicyResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resourcePolicyResource{}
 

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -52,7 +52,6 @@ const (
 // @SDKResource("aws_dynamodb_table", name="Table")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/dynamodb/types;types.TableDescription")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceTable() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{

--- a/internal/service/dynamodb/table_export.go
+++ b/internal/service/dynamodb/table_export.go
@@ -31,7 +31,6 @@ import (
 // @V60SDKv2Fix
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/dynamodb/types;awstypes;awstypes.ExportDescription")
 // @Testing(checkDestroyNoop=true)
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceTableExport() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTableExportCreate,

--- a/internal/service/dynamodb/table_replica.go
+++ b/internal/service/dynamodb/table_replica.go
@@ -40,7 +40,6 @@ const (
 // @SDKResource("aws_dynamodb_table_replica", name="Table Replica")
 // @Tags(identifierAttribute="arn")
 // @Testing(altRegionProvider=true)
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceTableReplica() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{

--- a/internal/service/ec2/vpc_.go
+++ b/internal/service/ec2/vpc_.go
@@ -57,7 +57,6 @@ var (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/ec2/types;awstypes;awstypes.Vpc")
 // @Testing(generator=false)
 // @Testing(preIdentityVersion="v6.15.0")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceVPC() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{

--- a/internal/service/ec2/vpc_encryption_control.go
+++ b/internal/service/ec2/vpc_encryption_control.go
@@ -43,7 +43,6 @@ import (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/ec2/types;awstypes;awstypes.VpcEncryptionControl")
 // @Testing(hasNoPreExistingResource=true)
 // @Testing(importIgnore="egress_only_internet_gateway_exclusion;elastic_file_system_exclusion;internet_gateway_exclusion;lambda_exclusion;nat_gateway_exclusion;virtual_private_gateway_exclusion;vpc_lattice_exclusion;vpc_peering_exclusion")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 // @Testing(generator=false)
 func newResourceVPCEncryptionControl(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resourceVPCEncryptionControl{}

--- a/internal/service/elbv2/listener.go
+++ b/internal/service/elbv2/listener.go
@@ -47,7 +47,6 @@ import (
 // @Testing(importIgnore="default_action.0.forward")
 // @ArnIdentity
 // @Testing(preIdentityVersion="v6.3.0")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceListener() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceListenerCreate,

--- a/internal/service/elbv2/listener_rule.go
+++ b/internal/service/elbv2/listener_rule.go
@@ -54,7 +54,6 @@ const (
 // @Testing(plannableImportAction="NoOp")
 // @ArnIdentity
 // @Testing(preIdentityVersion="v6.3.0")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceListenerRule() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceListenerRuleCreate,

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -45,7 +45,6 @@ import ( // nosemgrep:ci.semgrep.aws.multiple-service-imports
 // @ArnIdentity
 // @V60SDKv2Fix
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types;awstypes;awstypes.LoadBalancer")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceLoadBalancer() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceLoadBalancerCreate,

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -46,7 +46,6 @@ import (
 // @Testing(plannableImportAction="NoOp")
 // @ArnIdentity
 // @Testing(preIdentityVersion="v6.3.0")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceTargetGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTargetGroupCreate,

--- a/internal/service/elbv2/trust_store.go
+++ b/internal/service/elbv2/trust_store.go
@@ -34,7 +34,6 @@ import (
 // @Testing(importIgnore="ca_certificates_bundle_s3_bucket;ca_certificates_bundle_s3_key")
 // @ArnIdentity
 // @Testing(preIdentityVersion="v6.3.0")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceTrustStore() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTrustStoreCreate,

--- a/internal/service/iam/outbound_web_identity_federation.go
+++ b/internal/service/iam/outbound_web_identity_federation.go
@@ -30,7 +30,6 @@ import (
 // @Testing(serialize=true)
 // @Testing(importStateIdFunc=importStateIDAccountID", importStateIdAttribute="issuer_identifier")
 // @Testing(generator=false)
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func newOutboundWebIdentityFederationResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &outboundWebIdentityFederationResource{}
 

--- a/internal/service/logs/anomaly_detector.go
+++ b/internal/service/logs/anomaly_detector.go
@@ -38,8 +38,6 @@ import (
 // @Testing(importStateIdAttribute="arn")
 // @Testing(importIgnore="enabled")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs;cloudwatchlogs.GetLogAnomalyDetectorOutput")
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func newAnomalyDetectorResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &anomalyDetectorResource{}
 

--- a/internal/service/logs/destination.go
+++ b/internal/service/logs/destination.go
@@ -31,8 +31,6 @@ import (
 // @SDKResource("aws_cloudwatch_log_destination", name="Destination")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types;awstypes;awstypes.Destination")
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func resourceDestination() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDestinationCreate,

--- a/internal/service/logs/group.go
+++ b/internal/service/logs/group.go
@@ -31,8 +31,6 @@ import (
 // @SDKResource("aws_cloudwatch_log_group", name="Log Group")
 // @Tags(identifierAttribute="arn")
 // @IdentityAttribute("name")
-// @Testing(destroyTakesT=true)
-// @Testing(existsTakesT=true)
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types;awstypes;awstypes.LogGroup")
 // @Testing(idAttrDuplicates="name")
 // @Testing(preIdentityVersion="v6.7.0")

--- a/internal/service/logs/transformer.go
+++ b/internal/service/logs/transformer.go
@@ -35,8 +35,6 @@ import (
 // @FrameworkResource("aws_cloudwatch_log_transformer", name="Transformer")
 // @ArnIdentity("log_group_arn")
 // @Testing(hasNoPreExistingResource=true)
-// @Testing(destroyTakesT=true)
-// @Testing(existsTakesT=true)
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs;cloudwatchlogs.GetTransformerOutput")
 func newTransformerResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &transformerResource{}

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -45,7 +45,6 @@ const (
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/redshift/types;awstypes;awstypes.Cluster")
 // @Testing(importIgnore="final_snapshot_identifier;master_password;skip_final_snapshot;apply_immediately")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceCluster() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClusterCreate,

--- a/internal/service/redshift/cluster_snapshot.go
+++ b/internal/service/redshift/cluster_snapshot.go
@@ -25,7 +25,6 @@ import (
 // @SDKResource("aws_redshift_cluster_snapshot", name="Cluster Snapshot")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/redshift/types;awstypes;awstypes.Snapshot")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceClusterSnapshot() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClusterSnapshotCreate,

--- a/internal/service/redshift/event_subscription.go
+++ b/internal/service/redshift/event_subscription.go
@@ -30,7 +30,6 @@ import (
 // @SDKResource("aws_redshift_event_subscription", name="Event Subscription")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/redshift/types;awstypes;awstypes.EventSubscription")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceEventSubscription() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceEventSubscriptionCreate,

--- a/internal/service/redshift/hsm_client_certificate.go
+++ b/internal/service/redshift/hsm_client_certificate.go
@@ -24,7 +24,6 @@ import (
 
 // @SDKResource("aws_redshift_hsm_client_certificate", name="HSM Client Certificate")
 // @Tags(identifierAttribute="arn")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceHSMClientCertificate() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceHSMClientCertificateCreate,

--- a/internal/service/redshift/hsm_configuration.go
+++ b/internal/service/redshift/hsm_configuration.go
@@ -25,7 +25,6 @@ import (
 // @SDKResource("aws_redshift_hsm_configuration", name="HSM Configuration")
 // @Tags(identifierAttribute="arn")
 // @Testing(importIgnore="hsm_partition_password;hsm_server_public_certificate")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceHSMConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceHSMConfigurationCreate,

--- a/internal/service/redshift/integration.go
+++ b/internal/service/redshift/integration.go
@@ -35,7 +35,6 @@ import (
 // @ArnIdentity
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/redshift/types;awstypes;awstypes.Integration")
 // @Testing(preIdentityVersion="6.19.0")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func newIntegrationResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &integrationResource{}
 

--- a/internal/service/redshift/parameter_group.go
+++ b/internal/service/redshift/parameter_group.go
@@ -31,7 +31,6 @@ import (
 // @SDKResource("aws_redshift_parameter_group", name="Parameter Group")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/redshift/types;awstypes;awstypes.ClusterParameterGroup")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceParameterGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceParameterGroupCreate,

--- a/internal/service/redshift/snapshot_copy_grant.go
+++ b/internal/service/redshift/snapshot_copy_grant.go
@@ -26,7 +26,6 @@ import (
 
 // @SDKResource("aws_redshift_snapshot_copy_grant", name="Snapshot Copy Grant")
 // @Tags(identifierAttribute="arn")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceSnapshotCopyGrant() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSnapshotCopyGrantCreate,

--- a/internal/service/redshift/snapshot_schedule.go
+++ b/internal/service/redshift/snapshot_schedule.go
@@ -28,7 +28,6 @@ import (
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/redshift/types;awstypes;awstypes.SnapshotSchedule")
 // @Testing(importIgnore="force_destroy")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceSnapshotSchedule() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSnapshotScheduleCreate,

--- a/internal/service/redshift/subnet_group.go
+++ b/internal/service/redshift/subnet_group.go
@@ -29,7 +29,6 @@ import (
 // @SDKResource("aws_redshift_subnet_group", name="Subnet Group")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/redshift/types;awstypes;awstypes.ClusterSubnetGroup")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceSubnetGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSubnetGroupCreate,

--- a/internal/service/redshift/usage_limit.go
+++ b/internal/service/redshift/usage_limit.go
@@ -25,7 +25,6 @@ import (
 
 // @SDKResource("aws_redshift_usage_limit", name="Usage Limit")
 // @Tags(identifierAttribute="arn")
-// @Testing(existsTakesT=true, destroyTakesT=true)
 func resourceUsageLimit() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceUsageLimitCreate,

--- a/internal/service/timestreaminfluxdb/db_cluster.go
+++ b/internal/service/timestreaminfluxdb/db_cluster.go
@@ -50,8 +50,6 @@ import (
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb;timestreaminfluxdb.GetDbClusterOutput")
 // @Testing(importIgnore="bucket;username;organization;password")
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func newDBClusterResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &dbClusterResource{}
 

--- a/internal/service/timestreaminfluxdb/db_instance.go
+++ b/internal/service/timestreaminfluxdb/db_instance.go
@@ -48,8 +48,6 @@ import (
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb;timestreaminfluxdb.GetDbInstanceOutput")
 // @Testing(importIgnore="bucket;username;organization;password")
-// @Testing(existsTakesT=true)
-// @Testing(destroyTakesT=true)
 func newDBInstanceResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &dbInstanceResource{}
 


### PR DESCRIPTION

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The default value for these testing annotation arguments is `true`, making these explicit annotations redundant.

