### PR TITLE
fix(savingsplans): Fix upfront_payment_amount causing inconsistent result after apply

### DIFF
--- a/.changelog/46265.txt
+++ b/.changelog/46265.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_savingsplans_savings_plan: Fix `upfront_payment_amount` causing "inconsistent result after apply" error when not specified
+```

--- a/internal/service/savingsplans/savings_plan.go
+++ b/internal/service/savingsplans/savings_plan.go
@@ -182,9 +182,11 @@ func (r *savingsPlanResource) Schema(ctx context.Context, req resource.SchemaReq
 			},
 			"upfront_payment_amount": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "The up-front payment amount.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 		},

--- a/website/docs/r/savingsplans_savings_plan.html.markdown
+++ b/website/docs/r/savingsplans_savings_plan.html.markdown
@@ -53,6 +53,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `purchase_time` - (Optional) The time at which to purchase the Savings Plan, in UTC format (YYYY-MM-DDTHH:MM:SSZ). If not specified, the plan is purchased immediately. Plans with a future purchase time are placed in `queued` state and can be deleted before they become active.
+* `upfront_payment_amount` - (Optional) The up-front payment amount. This is only supported if the payment option is `Partial Upfront`. The value must be between 50 and 99 percent of the total value of the Savings Plan. If not specified, the amount is computed by AWS.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference
@@ -67,7 +68,6 @@ This resource exports the following attributes in addition to the arguments abov
 * `savings_plan_type` - The type of Savings Plan (e.g., `Compute`, `EC2Instance`).
 * `payment_option` - The payment option for the Savings Plan (e.g., `All Upfront`, `Partial Upfront`, `No Upfront`).
 * `currency` - The currency of the Savings Plan (e.g., `USD`).
-* `upfront_payment_amount` - The up-front payment amount.
 * `recurring_payment_amount` - The recurring payment amount.
 * `term_duration_in_seconds` - The duration of the term, in seconds.
 * `ec2_instance_family` - The EC2 instance family for the Savings Plan (only applicable to EC2 Instance Savings Plans).


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

The `upfront_payment_amount` attribute was defined as `Optional` only, causing an "inconsistent result after apply" error when users don't specify the value. AWS returns `"0.00000000"` for No Upfront plans, but Terraform expected null.

This change:
- Adds `Computed: true` to accept AWS-computed values
- Adds `UseStateForUnknown()` plan modifier for proper state handling
- Updates documentation to reflect that this attribute is optional (for Partial Upfront plans) and computed by AWS otherwise

### Relations

Closes #46265

### References

- [AWS CreateSavingsPlan API](https://docs.aws.amazon.com/savingsplans/latest/APIReference/API_CreateSavingsPlan.html) - `upfrontPaymentAmount` is only supported for Partial Upfront payment option
- [AWS SavingsPlan API](https://docs.aws.amazon.com/savingsplans/latest/APIReference/API_SavingsPlan.html) - `upfrontPaymentAmount` is included in the response

### Output from Acceptance Testing

Note: Savings Plans tests are commented out in the codebase because running them would create actual Savings Plans with real financial commitments that cannot be cancelled.

```console
% go build ./internal/service/savingsplans/...
(no errors)

% go vet ./internal/service/savingsplans/...
(no errors)
```