### PR TITLE
resource/aws_cloudfront_multitenant_distribution: allows disabling `response_completion_timeout` for origins

### DIFF
--- a/.changelog/46329.txt
+++ b/.changelog/46329.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudfront_multitenant_distribution: Allows disabling the enforcement of a `response_completion_timeout` for Origins, by removing its default value. ([#46306](https://github.com/hashicorp/terraform-provider-aws/issues/46306))
+```

--- a/.changelog/46329.txt
+++ b/.changelog/46329.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_cloudfront_multitenant_distribution: Allows disabling the enforcement of a `response_completion_timeout` for Origins, by removing its default value. ([#46306](https://github.com/hashicorp/terraform-provider-aws/issues/46306))
+resource/aws_cloudfront_multitenant_distribution: Allows disabling the enforcement of a `response_completion_timeout` for Origins, by removing its default value
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ FEATURES:
 
 * **New List Resource:** `aws_secretsmanager_secret` ([#46318](https://github.com/hashicorp/terraform-provider-aws/issues/46318))
 
+BUG FIXES:
+
+* resource/aws_cloudfront_multitenant_distribution: Allows disabling the enforcement of a `response_completion_timeout` for Origins, by removing its default value. ([#46306](https://github.com/hashicorp/terraform-provider-aws/issues/46306))
+
 ## 6.31.0 (February 4, 2026)
 
 NOTES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ FEATURES:
 
 * **New List Resource:** `aws_secretsmanager_secret` ([#46318](https://github.com/hashicorp/terraform-provider-aws/issues/46318))
 
-BUG FIXES:
-
-* resource/aws_cloudfront_multitenant_distribution: Allows disabling the enforcement of a `response_completion_timeout` for Origins, by removing its default value. ([#46306](https://github.com/hashicorp/terraform-provider-aws/issues/46306))
-
 ## 6.31.0 (February 4, 2026)
 
 NOTES:

--- a/internal/service/cloudfront/multitenant_distribution.go
+++ b/internal/service/cloudfront/multitenant_distribution.go
@@ -39,11 +39,10 @@ import (
 )
 
 const (
-	defaultConnectionAttempts        = 3
-	defaultConnectionTimeout         = 10
-	defaultResponseCompletionTimeout = 30
-	defaultOriginKeepaliveTimeout    = 5
-	defaultOriginReadTimeout         = 30
+	defaultConnectionAttempts     = 3
+	defaultConnectionTimeout      = 10
+	defaultOriginKeepaliveTimeout = 5
+	defaultOriginReadTimeout      = 30
 )
 
 // @FrameworkResource("aws_cloudfront_multitenant_distribution", name="Multi-tenant Distribution")
@@ -432,8 +431,6 @@ func (r *multiTenantDistributionResource) Schema(ctx context.Context, request re
 						},
 						"response_completion_timeout": schema.Int32Attribute{
 							Optional: true,
-							Computed: true,
-							Default:  int32default.StaticInt32(defaultResponseCompletionTimeout),
 						},
 					},
 					Blocks: map[string]schema.Block{
@@ -1065,7 +1062,7 @@ type originModel struct {
 	OriginAccessControlID     types.String                                             `tfsdk:"origin_access_control_id" autoflex:",omitempty"`
 	OriginPath                types.String                                             `tfsdk:"origin_path"`
 	OriginShield              fwtypes.ListNestedObjectValueOf[originShieldModel]       `tfsdk:"origin_shield" autoflex:",omitempty"`
-	ResponseCompletionTimeout types.Int32                                              `tfsdk:"response_completion_timeout"`
+	ResponseCompletionTimeout types.Int32                                              `tfsdk:"response_completion_timeout" autoflex:",omitempty"`
 	VpcOriginConfig           fwtypes.ListNestedObjectValueOf[vpcOriginConfigModel]    `tfsdk:"vpc_origin_config" autoflex:",omitempty"`
 }
 

--- a/internal/service/cloudfront/multitenant_distribution.go
+++ b/internal/service/cloudfront/multitenant_distribution.go
@@ -431,6 +431,7 @@ func (r *multiTenantDistributionResource) Schema(ctx context.Context, request re
 						},
 						"response_completion_timeout": schema.Int32Attribute{
 							Optional: true,
+							Computed: true,
 						},
 					},
 					Blocks: map[string]schema.Block{

--- a/internal/service/cloudfront/multitenant_distribution_test.go
+++ b/internal/service/cloudfront/multitenant_distribution_test.go
@@ -39,6 +39,9 @@ func TestAccCloudFrontMultiTenantDistribution_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrEnabled, acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "tenant_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tenant_config.0.parameter_definition.0.definition.0.string_schema.0.required", acctest.CtTrue),
+
+					// Check ResponseCompletionTimeout is not enabled with no value set
+					resource.TestCheckNoResourceAttr(resourceName, "origin.0.response_completion_timeout"),
 				),
 			},
 			{
@@ -108,6 +111,9 @@ func TestAccCloudFrontMultiTenantDistribution_comprehensive(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin.0.custom_header.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "origin.0.custom_header.0.header_name", "X-Custom-Header"),
 					resource.TestCheckResourceAttr(resourceName, "origin.0.custom_header.0.header_value", "test-value"),
+
+					// Check ResponseCompletionTimeout is enabled with value set
+					resource.TestCheckResourceAttr(resourceName, "origin.0.response_completion_timeout", "30"),
 
 					// Check cache behaviors
 					resource.TestCheckResourceAttr(resourceName, "cache_behavior.#", "1"),
@@ -395,9 +401,10 @@ resource "aws_cloudfront_multitenant_distribution" "test" {
   default_root_object = %[3]q
 
   origin {
-    domain_name = "example.com"
-    id          = "custom-origin"
-    origin_path = "/api"
+    domain_name                 = "example.com"
+    id                          = "custom-origin"
+    origin_path                 = "/api"
+    response_completion_timeout = 30
 
     custom_header {
       header_name  = "X-Custom-Header"

--- a/website/docs/r/cloudfront_multitenant_distribution.html.markdown
+++ b/website/docs/r/cloudfront_multitenant_distribution.html.markdown
@@ -165,7 +165,7 @@ Cache behavior supports all the same arguments as [Default Cache Behavior](#defa
 * `origin_access_control_id` - (Optional) CloudFront origin access control identifier to associate with the origin.
 * `origin_path` - (Optional) Optional element that causes CloudFront to request your content from a directory in your Amazon S3 bucket or your custom origin.
 * `origin_shield` - (Optional) CloudFront Origin Shield configuration information. See [Origin Shield](#origin-shield) below.
-* `response_completion_timeout` - (Optional) Number of seconds that CloudFront waits for a response after forwarding a request to the origin. Default: 30.
+* `response_completion_timeout` - (Optional) Number of seconds that CloudFront waits for a response after forwarding a request to the origin. Must be integer greater than or equal to the value of `origin_read_timeout` in [Custom Origin Config](#custom-origin-config). If omitted, no maximum value is enforced.
 * `vpc_origin_config` - (Optional) CloudFront VPC origin configuration. See [VPC Origin Config](#vpc-origin-config) below.
 
 ### Custom Header


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change allows disabling the enforcement of a `response_completion_timeout` for origins, by removing its default value. Without this fix, it's not currently possible to disable the timeout. The timeout has been disabled by default, as per the API reference.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes [#46306](https://github.com/hashicorp/terraform-provider-aws/issues/46306)

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

API Reference: https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_Origin.html#cloudfront-Type-Origin-ResponseCompletionTimeout


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccCloudFrontMultiTenantDistribution_basic PKG=cloudfront
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws_cloudfront_multitenant_distribution-response_completion_timeout 🌿...
TF_ACC=1 go1.25.6 test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontMultiTenantDistribution_basic'  -timeout 360m -vet=off
2026/02/04 23:43:14 Creating Terraform AWS Provider (SDKv2-style)...
2026/02/04 23:43:14 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudFrontMultiTenantDistribution_basic
=== PAUSE TestAccCloudFrontMultiTenantDistribution_basic
=== CONT  TestAccCloudFrontMultiTenantDistribution_basic
--- PASS: TestAccCloudFrontMultiTenantDistribution_basic (255.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 266.760s

% make testacc TESTS=TestAccCloudFrontMultiTenantDistribution_comprehensive PKG=cloudfront
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws_cloudfront_multitenant_distribution-response_completion_timeout 🌿...
TF_ACC=1 go1.25.6 test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontMultiTenantDistribution_comprehensive'  -timeout 360m -vet=off
2026/02/04 23:54:03 Creating Terraform AWS Provider (SDKv2-style)...
2026/02/04 23:54:03 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudFrontMultiTenantDistribution_comprehensive
=== PAUSE TestAccCloudFrontMultiTenantDistribution_comprehensive
=== CONT  TestAccCloudFrontMultiTenantDistribution_comprehensive
--- PASS: TestAccCloudFrontMultiTenantDistribution_comprehensive (296.81s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 308.718s
```
