### PR TITLE
Fix primary_key_arn reference in KMS replica key

### DIFF
--- a/website/docs/r/kms_replica_external_key.html.markdown
+++ b/website/docs/r/kms_replica_external_key.html.markdown
@@ -37,7 +37,7 @@ resource "aws_kms_external_key" "primary" {
 resource "aws_kms_replica_external_key" "replica" {
   description             = "Multi-Region replica key"
   deletion_window_in_days = 7
-  primary_key_arn         = aws_kms_external.primary.arn
+  primary_key_arn         = aws_kms_external_key.primary.arn
 
   key_material_base64 = "..." # Must be the same key material as the primary's.
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

<!---
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
--->

### Description
Fix a reference in the documentation. I'm pretty sure this should be `aws_kms_external_key`, not `aws_kms_external`.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

<!---
Closes #0000
-->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

<!---
```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
-->