### PR TITLE
internal/acctest: tidy up vcr utilities

### DIFF
--- a/internal/acctest/vcr.go
+++ b/internal/acctest/vcr.go
@@ -1,6 +1,25 @@
 // Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
+// This file contains data structures and helper functions for recording
+// and replaying acceptance test interactions via go-vcr.
+//
+// The central data structures are two maps - one for storing VCR-enabled
+// provider meta, and another for storing "randomness" sources used to
+// generate resource names deterministically. The key for both maps is
+// a test name, representing a single acceptance test. Reads and writes
+// to both structures are always wrapped in a lock to a global mutex.
+// Where possible the lock is acquired and released immediately after
+// referencing the data (rather than deferring the Unlock) to reduce
+// the amount of time parallelized tests spend waiting to access a
+// shared data structure.
+//
+// Additionally this file contains wrapped variants of core testing
+// features from terraform-plugin-testing such as Test/ParallelTest
+// structures and randomized ID generation helpers. In all cases
+// these should be preferred over the bare plugin testing variants
+// to ensure VCR recording and replaying function as expected.
+
 package acctest
 
 import (
@@ -35,11 +54,6 @@ import (
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 )
 
-type randomnessSource struct {
-	seed   int64
-	source rand.Source
-}
-
 type metaMap map[string]*conns.AWSClient
 
 func (m metaMap) Lock() {
@@ -54,7 +68,14 @@ func (m metaMap) key() string {
 	return "vcr-metas"
 }
 
-type randomnessSourceMap map[string]*randomnessSource
+type (
+	randomnessSource struct {
+		seed   int64
+		source rand.Source
+	}
+
+	randomnessSourceMap map[string]*randomnessSource
+)
 
 func (m randomnessSourceMap) Lock() {
 	conns.GlobalMutexKV.Lock(m.key())
@@ -79,7 +100,7 @@ func ProviderMeta(_ context.Context, t *testing.T) *conns.AWSClient {
 
 	providerMetas.Lock()
 	meta, ok := providerMetas[t.Name()]
-	defer providerMetas.Unlock()
+	providerMetas.Unlock()
 
 	if !ok {
 		meta = Provider.Meta().(*conns.AWSClient)
@@ -140,85 +161,18 @@ func vcrProviderConfigureContextFunc(provider *schema.Provider, configureContext
 		httpClient := cleanhttp.DefaultPooledClient()
 		transport := httpClient.Transport.(*http.Transport)
 		transport.MaxIdleConnsPerHost = 10
-		if tlsConfig := transport.TLSClientConfig; tlsConfig == nil {
-			tlsConfig = &tls.Config{
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{
 				MinVersion: tls.VersionTLS13,
 			}
-			transport.TLSClientConfig = tlsConfig
-		}
-
-		// After capture hook to remove sensitive HTTP headers.
-		sensitiveHeaderHook := func(i *cassette.Interaction) error {
-			delete(i.Request.Headers, "Authorization")
-			delete(i.Request.Headers, "X-Amz-Security-Token")
-			return nil
-		}
-
-		// Define how VCR will match requests to stored interactions.
-		matchFunc := func(r *http.Request, i cassette.Request) bool {
-			if r.Method != i.Method {
-				return false
-			}
-
-			if r.URL.String() != i.URL {
-				return false
-			}
-
-			if r.Body == nil {
-				return true
-			}
-
-			var b bytes.Buffer
-			if _, err := b.ReadFrom(r.Body); err != nil {
-				tflog.Debug(ctx, "Failed to read request body from cassette", map[string]any{
-					"error": err,
-				})
-				return false
-			}
-
-			r.Body = io.NopCloser(&b)
-			body := b.String()
-			// If body matches identically, we are done.
-			if body == i.Body {
-				return true
-			}
-
-			// https://awslabs.github.io/smithy/1.0/spec/aws/index.html#aws-protocols.
-			switch contentType := r.Header.Get("Content-Type"); contentType {
-			case "application/json", "application/x-amz-json-1.0", "application/x-amz-json-1.1":
-				// JSON might be the same, but reordered. Try parsing and comparing.
-				return tfjson.EqualStrings(body, i.Body)
-
-			case "application/xml":
-				// XML might be the same, but reordered. Try parsing and comparing.
-				var requestXml, cassetteXml any
-
-				if err := xml.Unmarshal([]byte(body), &requestXml); err != nil {
-					tflog.Debug(ctx, "Failed to unmarshal request XML", map[string]any{
-						"error": err,
-					})
-					return false
-				}
-
-				if err := xml.Unmarshal([]byte(i.Body), &cassetteXml); err != nil {
-					tflog.Debug(ctx, "Failed to unmarshal cassette XML", map[string]any{
-						"error": err,
-					})
-					return false
-				}
-
-				return reflect.DeepEqual(requestXml, cassetteXml)
-			}
-
-			return false
 		}
 
 		cassetteName := filepath.Join(vcr.Path(), vcrFileName(testName))
 
 		// Create a VCR recorder around a default HTTP client.
 		r, err := recorder.New(cassetteName,
-			recorder.WithHook(sensitiveHeaderHook, recorder.AfterCaptureHook),
-			recorder.WithMatcher(matchFunc),
+			recorder.WithHook(vcrSensitiveHeaderHook, recorder.AfterCaptureHook),
+			recorder.WithMatcher(vcrMatcherFunc(ctx)),
 			recorder.WithMode(vcrMode),
 			recorder.WithRealTransport(httpClient.Transport),
 			recorder.WithSkipRequestLatency(true),
@@ -260,10 +214,78 @@ func vcrProviderConfigureContextFunc(provider *schema.Provider, configureContext
 	}
 }
 
+// vcrSensitiveHeaderHook is an after capture hook to remove sensitive HTTP headers.
+func vcrSensitiveHeaderHook(i *cassette.Interaction) error {
+	delete(i.Request.Headers, "Authorization")
+	delete(i.Request.Headers, "X-Amz-Security-Token")
+	return nil
+}
+
+// vcrMatcherFunc defines how VCR will match requests to stored interactions.
+func vcrMatcherFunc(ctx context.Context) recorder.MatcherFunc {
+	return func(r *http.Request, i cassette.Request) bool {
+		if r.Method != i.Method {
+			return false
+		}
+
+		if r.URL.String() != i.URL {
+			return false
+		}
+
+		if r.Body == nil {
+			return true
+		}
+
+		var b bytes.Buffer
+		if _, err := b.ReadFrom(r.Body); err != nil {
+			tflog.Debug(ctx, "Failed to read request body from cassette", map[string]any{
+				"error": err,
+			})
+			return false
+		}
+
+		r.Body = io.NopCloser(&b)
+		body := b.String()
+		// If body matches identically, we are done.
+		if body == i.Body {
+			return true
+		}
+
+		// https://awslabs.github.io/smithy/1.0/spec/aws/index.html#aws-protocols.
+		switch contentType := r.Header.Get("Content-Type"); contentType {
+		case "application/json", "application/x-amz-json-1.0", "application/x-amz-json-1.1":
+			// JSON might be the same, but reordered. Try parsing and comparing.
+			return tfjson.EqualStrings(body, i.Body)
+
+		case "application/xml":
+			// XML might be the same, but reordered. Try parsing and comparing.
+			var requestXML, cassetteXML any
+
+			if err := xml.Unmarshal([]byte(body), &requestXML); err != nil {
+				tflog.Debug(ctx, "Failed to unmarshal request XML", map[string]any{
+					"error": err,
+				})
+				return false
+			}
+
+			if err := xml.Unmarshal([]byte(i.Body), &cassetteXML); err != nil {
+				tflog.Debug(ctx, "Failed to unmarshal cassette XML", map[string]any{
+					"error": err,
+				})
+				return false
+			}
+
+			return reflect.DeepEqual(requestXML, cassetteXML)
+		}
+
+		return false
+	}
+}
+
 // vcrRandomnessSource returns a rand.Source for VCR testing
 //
-// In RECORD_ONLY mode, generates a new seed and saves it to a file, using the
-// seed for the source.
+// In RECORD_ONLY mode, generates a new seed to use as a source. This seed is
+// saved to a file when the recorder is closed.
 // In REPLAY_ONLY mode, reads a seed from a file and creates a source from it.
 func vcrRandomnessSource(t *testing.T) (*randomnessSource, error) {
 	t.Helper()
@@ -312,65 +334,22 @@ func vcrRandomnessSource(t *testing.T) (*randomnessSource, error) {
 	return s, nil
 }
 
-func vcrFileName(name string) string {
-	return strings.ReplaceAll(name, "/", "_")
-}
-
-func vcrSeedFile(path, name string) string {
-	return filepath.Join(path, fmt.Sprintf("%s.seed", vcrFileName(name)))
-}
-
-func readSeedFromFile(fileName string) (int64, error) {
-	// Max number of digits for int64 is 19.
-	data := make([]byte, 19)
-	f, err := os.Open(fileName)
-
-	if err != nil {
-		return 0, err
-	}
-
-	defer f.Close()
-
-	_, err = f.Read(data)
-
-	if err != nil {
-		return 0, err
-	}
-
-	// Remove NULL characters from seed.
-	return strconv.ParseInt(string(bytes.Trim(data, "\x00")), 10, 64)
-}
-
-func writeSeedToFile(seed int64, fileName string) error {
-	f, err := os.Create(fileName)
-
-	if err != nil {
-		return err
-	}
-
-	defer f.Close()
-
-	_, err = f.WriteString(strconv.FormatInt(seed, 10))
-
-	return err
-}
-
 // closeVCRRecorder closes the VCR recorder, saving the cassette and randomness seed
 func closeVCRRecorder(ctx context.Context, t *testing.T) {
 	t.Helper()
+	testName := t.Name()
 
 	// Don't close the recorder if we're running because of a panic.
 	if p := recover(); p != nil {
 		panic(p)
 	}
 
-	testName := t.Name()
 	providerMetas.Lock()
 	meta, ok := providerMetas[testName]
-	defer providerMetas.Unlock()
+	providerMetas.Unlock()
 
 	if ok {
-		if !t.Failed() && !t.Skipped() {
+		if !t.Failed() {
 			if v, ok := meta.HTTPClient(ctx).Transport.(*recorder.Recorder); ok {
 				t.Log("stopping VCR recorder")
 				if err := v.Stop(); err != nil {
@@ -379,7 +358,9 @@ func closeVCRRecorder(ctx context.Context, t *testing.T) {
 			}
 		}
 
+		providerMetas.Lock()
 		delete(providerMetas, testName)
+		providerMetas.Unlock()
 	} else {
 		t.Log("provider meta not found for test", testName)
 	}
@@ -387,17 +368,19 @@ func closeVCRRecorder(ctx context.Context, t *testing.T) {
 	// Save the randomness seed.
 	randomnessSources.Lock()
 	s, ok := randomnessSources[testName]
-	defer randomnessSources.Unlock()
+	randomnessSources.Unlock()
 
 	if ok {
-		if !t.Failed() && !t.Skipped() {
+		if !t.Failed() {
 			t.Log("persisting randomness seed")
 			if err := writeSeedToFile(s.seed, vcrSeedFile(vcr.Path(), t.Name())); err != nil {
 				t.Error(err)
 			}
 		}
 
+		randomnessSources.Lock()
 		delete(randomnessSources, testName)
+		randomnessSources.Unlock()
 	} else {
 		t.Log("randomness source not found for test", testName)
 	}
@@ -435,7 +418,7 @@ func Test(ctx context.Context, t *testing.T, c resource.TestCase) {
 	resource.Test(t, c)
 }
 
-// RandInt is a VCR-friendly replacement for acctest.RandInt
+// RandInt is a VCR-friendly replacement for sdkacctest.RandInt
 func RandInt(t *testing.T) int {
 	t.Helper()
 
@@ -444,7 +427,6 @@ func RandInt(t *testing.T) int {
 	}
 
 	s, err := vcrRandomnessSource(t)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -452,14 +434,14 @@ func RandInt(t *testing.T) int {
 	return rand.New(s.source).Int()
 }
 
-// RandomWithPrefix is a VCR-friendly replacement for acctest.RandomWithPrefix
+// RandomWithPrefix is a VCR-friendly replacement for sdkacctest.RandomWithPrefix
 func RandomWithPrefix(t *testing.T, prefix string) string {
 	t.Helper()
 
 	return fmt.Sprintf("%s-%d", prefix, RandInt(t))
 }
 
-// RandIntRange is a VCR-friendly replacement for acctest.RandIntRange
+// RandIntRange is a VCR-friendly replacement for sdkacctest.RandIntRange
 func RandIntRange(t *testing.T, minInt int, maxInt int) int {
 	t.Helper()
 
@@ -468,10 +450,39 @@ func RandIntRange(t *testing.T, minInt int, maxInt int) int {
 	}
 
 	s, err := vcrRandomnessSource(t)
-
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	return rand.New(s.source).Intn(maxInt-minInt) + minInt
+}
+
+func vcrFileName(name string) string {
+	return strings.ReplaceAll(name, "/", "_")
+}
+
+func vcrSeedFile(path, name string) string {
+	return filepath.Join(path, fmt.Sprintf("%s.seed", vcrFileName(name)))
+}
+
+func readSeedFromFile(fileName string) (int64, error) {
+	// Max number of digits for int64 is 19.
+	data := make([]byte, 19)
+	f, err := os.Open(fileName)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	_, err = f.Read(data)
+	if err != nil {
+		return 0, err
+	}
+
+	// Remove NULL characters from seed.
+	return strconv.ParseInt(string(bytes.Trim(data, "\x00")), 10, 64)
+}
+
+func writeSeedToFile(seed int64, fileName string) error {
+	return os.WriteFile(fileName, []byte(strconv.FormatInt(seed, 10)), 0644) //nolint:mnd
 }


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Minor cleanup of VCR-related acceptance testing functions, including some high level comments describing the functionality. Follow up from #46260.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #46260


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% VCR_MODE=REPLAY_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/ make t K=logs T=TestAccLogsLogGroup_ ACCTEST_PARALLELISM=100
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-vcr-cleanup 🌿...
TF_ACC=1 go1.25.6 test ./internal/service/logs/... -v -count 1 -parallel 100 -run='TestAccLogsLogGroup_'  -timeout 360m -vet=off
2026/02/05 15:39:56 Creating Terraform AWS Provider (SDKv2-style)...
2026/02/05 15:39:56 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLogsLogGroup_Identity_Basic
=== PAUSE TestAccLogsLogGroup_Identity_Basic
=== RUN   TestAccLogsLogGroup_Identity_RegionOverride
=== PAUSE TestAccLogsLogGroup_Identity_RegionOverride
=== RUN   TestAccLogsLogGroup_Identity_ExistingResource
    group_identity_gen_test.go:210: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccLogsLogGroup_Identity_ExistingResource (0.00s)
=== RUN   TestAccLogsLogGroup_Identity_ExistingResource_NoRefresh_NoChange
    group_identity_gen_test.go:268: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccLogsLogGroup_Identity_ExistingResource_NoRefresh_NoChange (0.00s)
=== RUN   TestAccLogsLogGroup_List_Basic
    group_list_test.go:30: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccLogsLogGroup_List_Basic (0.00s)
=== RUN   TestAccLogsLogGroup_List_RegionOverride
    group_list_test.go:92: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccLogsLogGroup_List_RegionOverride (0.00s)
=== RUN   TestAccLogsLogGroup_tags
=== PAUSE TestAccLogsLogGroup_tags
=== RUN   TestAccLogsLogGroup_tags_null
=== PAUSE TestAccLogsLogGroup_tags_null
=== RUN   TestAccLogsLogGroup_tags_EmptyMap
=== PAUSE TestAccLogsLogGroup_tags_EmptyMap
=== RUN   TestAccLogsLogGroup_tags_AddOnUpdate
=== PAUSE TestAccLogsLogGroup_tags_AddOnUpdate
=== RUN   TestAccLogsLogGroup_tags_EmptyTag_OnCreate
=== PAUSE TestAccLogsLogGroup_tags_EmptyTag_OnCreate
=== RUN   TestAccLogsLogGroup_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccLogsLogGroup_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccLogsLogGroup_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccLogsLogGroup_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccLogsLogGroup_tags_DefaultTags_providerOnly
    group_tags_gen_test.go:766: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccLogsLogGroup_tags_DefaultTags_providerOnly (0.00s)
=== RUN   TestAccLogsLogGroup_tags_DefaultTags_nonOverlapping
    group_tags_gen_test.go:951: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccLogsLogGroup_tags_DefaultTags_nonOverlapping (0.00s)
=== RUN   TestAccLogsLogGroup_tags_DefaultTags_overlapping
    group_tags_gen_test.go:1115: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccLogsLogGroup_tags_DefaultTags_overlapping (0.00s)
=== RUN   TestAccLogsLogGroup_tags_DefaultTags_updateToProviderOnly
    group_tags_gen_test.go:1295: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccLogsLogGroup_tags_DefaultTags_updateToProviderOnly (0.00s)
=== RUN   TestAccLogsLogGroup_tags_DefaultTags_updateToResourceOnly
    group_tags_gen_test.go:1389: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccLogsLogGroup_tags_DefaultTags_updateToResourceOnly (0.00s)
=== RUN   TestAccLogsLogGroup_tags_DefaultTags_emptyResourceTag
    group_tags_gen_test.go:1482: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccLogsLogGroup_tags_DefaultTags_emptyResourceTag (0.00s)
=== RUN   TestAccLogsLogGroup_tags_DefaultTags_emptyProviderOnlyTag
    group_tags_gen_test.go:1551: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccLogsLogGroup_tags_DefaultTags_emptyProviderOnlyTag (0.00s)
=== RUN   TestAccLogsLogGroup_tags_DefaultTags_nullOverlappingResourceTag
    group_tags_gen_test.go:1612: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccLogsLogGroup_tags_DefaultTags_nullOverlappingResourceTag (0.00s)
=== RUN   TestAccLogsLogGroup_tags_DefaultTags_nullNonOverlappingResourceTag
    group_tags_gen_test.go:1678: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccLogsLogGroup_tags_DefaultTags_nullNonOverlappingResourceTag (0.00s)
=== RUN   TestAccLogsLogGroup_tags_ComputedTag_OnCreate
    group_tags_gen_test.go:1744: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccLogsLogGroup_tags_ComputedTag_OnCreate (0.00s)
=== RUN   TestAccLogsLogGroup_tags_ComputedTag_OnUpdate_Add
    group_tags_gen_test.go:1803: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccLogsLogGroup_tags_ComputedTag_OnUpdate_Add (0.00s)
=== RUN   TestAccLogsLogGroup_tags_ComputedTag_OnUpdate_Replace
    group_tags_gen_test.go:1904: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccLogsLogGroup_tags_ComputedTag_OnUpdate_Replace (0.00s)
=== RUN   TestAccLogsLogGroup_tags_IgnoreTags_Overlap_DefaultTag
    group_tags_gen_test.go:1995: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccLogsLogGroup_tags_IgnoreTags_Overlap_DefaultTag (0.00s)
=== RUN   TestAccLogsLogGroup_tags_IgnoreTags_Overlap_ResourceTag
    group_tags_gen_test.go:2161: go-vcr is not currently supported for test step ProtoV5ProviderFactories
--- SKIP: TestAccLogsLogGroup_tags_IgnoreTags_Overlap_ResourceTag (0.00s)
=== RUN   TestAccLogsLogGroup_basic
=== PAUSE TestAccLogsLogGroup_basic
=== RUN   TestAccLogsLogGroup_nameGenerate
=== PAUSE TestAccLogsLogGroup_nameGenerate
=== RUN   TestAccLogsLogGroup_namePrefix
=== PAUSE TestAccLogsLogGroup_namePrefix
=== RUN   TestAccLogsLogGroup_disappears
=== PAUSE TestAccLogsLogGroup_disappears
=== RUN   TestAccLogsLogGroup_kmsKey
=== PAUSE TestAccLogsLogGroup_kmsKey
=== RUN   TestAccLogsLogGroup_logGroupClass
=== PAUSE TestAccLogsLogGroup_logGroupClass
=== RUN   TestAccLogsLogGroup_retentionPolicy
=== PAUSE TestAccLogsLogGroup_retentionPolicy
=== RUN   TestAccLogsLogGroup_multiple
=== PAUSE TestAccLogsLogGroup_multiple
=== RUN   TestAccLogsLogGroup_skipDestroy
=== PAUSE TestAccLogsLogGroup_skipDestroy
=== RUN   TestAccLogsLogGroup_skipDestroyInconsistentPlan
=== PAUSE TestAccLogsLogGroup_skipDestroyInconsistentPlan
=== RUN   TestAccLogsLogGroup_logGroupClassDELIVERY1
=== PAUSE TestAccLogsLogGroup_logGroupClassDELIVERY1
=== RUN   TestAccLogsLogGroup_logGroupClassDELIVERY2
=== PAUSE TestAccLogsLogGroup_logGroupClassDELIVERY2
=== RUN   TestAccLogsLogGroup_requiredTags
    group_test.go:403: skipping test; environment variable TF_ACC_REQUIRED_TAG_KEY must be set
--- SKIP: TestAccLogsLogGroup_requiredTags (0.00s)
=== RUN   TestAccLogsLogGroup_requiredTags_defaultTags
    group_test.go:494: skipping test; environment variable TF_ACC_REQUIRED_TAG_KEY must be set
--- SKIP: TestAccLogsLogGroup_requiredTags_defaultTags (0.00s)
=== RUN   TestAccLogsLogGroup_requiredTags_warning
    group_test.go:577: skipping test; environment variable TF_ACC_REQUIRED_TAG_KEY must be set
--- SKIP: TestAccLogsLogGroup_requiredTags_warning (0.00s)
=== RUN   TestAccLogsLogGroup_requiredTags_disabled
    group_test.go:675: skipping test; environment variable TF_ACC_REQUIRED_TAG_KEY must be set
--- SKIP: TestAccLogsLogGroup_requiredTags_disabled (0.00s)
=== RUN   TestAccLogsLogGroup_deletionProtectionEnabled
=== PAUSE TestAccLogsLogGroup_deletionProtectionEnabled
=== RUN   TestAccLogsLogGroup_providerMeta
=== PAUSE TestAccLogsLogGroup_providerMeta
=== CONT  TestAccLogsLogGroup_Identity_Basic
=== CONT  TestAccLogsLogGroup_providerMeta
=== CONT  TestAccLogsLogGroup_deletionProtectionEnabled
=== CONT  TestAccLogsLogGroup_logGroupClassDELIVERY2
=== CONT  TestAccLogsLogGroup_logGroupClassDELIVERY1
=== CONT  TestAccLogsLogGroup_skipDestroyInconsistentPlan
=== CONT  TestAccLogsLogGroup_skipDestroy
=== CONT  TestAccLogsLogGroup_multiple
=== CONT  TestAccLogsLogGroup_retentionPolicy
=== CONT  TestAccLogsLogGroup_logGroupClass
=== CONT  TestAccLogsLogGroup_kmsKey
=== CONT  TestAccLogsLogGroup_disappears
=== CONT  TestAccLogsLogGroup_namePrefix
=== CONT  TestAccLogsLogGroup_nameGenerate
=== CONT  TestAccLogsLogGroup_basic
=== CONT  TestAccLogsLogGroup_tags_EmptyTag_OnUpdate_Replace
=== CONT  TestAccLogsLogGroup_tags_EmptyTag_OnUpdate_Add
=== CONT  TestAccLogsLogGroup_tags_EmptyTag_OnCreate
=== CONT  TestAccLogsLogGroup_tags_AddOnUpdate
=== CONT  TestAccLogsLogGroup_tags_EmptyMap
=== CONT  TestAccLogsLogGroup_tags_null
=== CONT  TestAccLogsLogGroup_tags
=== CONT  TestAccLogsLogGroup_Identity_RegionOverride
=== NAME  TestAccLogsLogGroup_logGroupClassDELIVERY2
    group_test.go:383: stopping VCR recorder
    group_test.go:383: persisting randomness seed
--- PASS: TestAccLogsLogGroup_logGroupClassDELIVERY2 (46.54s)
=== NAME  TestAccLogsLogGroup_skipDestroy
    group_test.go:287: stopping VCR recorder
    group_test.go:287: persisting randomness seed
--- PASS: TestAccLogsLogGroup_skipDestroy (46.63s)
=== NAME  TestAccLogsLogGroup_multiple
    group_test.go:263: stopping VCR recorder
    group_test.go:263: persisting randomness seed
--- PASS: TestAccLogsLogGroup_multiple (46.87s)
=== NAME  TestAccLogsLogGroup_logGroupClass
    group_test.go:192: stopping VCR recorder
    group_test.go:192: persisting randomness seed
--- PASS: TestAccLogsLogGroup_logGroupClass (47.46s)
=== NAME  TestAccLogsLogGroup_disappears
    group_test.go:124: stopping VCR recorder
    group_test.go:124: persisting randomness seed
--- PASS: TestAccLogsLogGroup_disappears (50.23s)
=== NAME  TestAccLogsLogGroup_providerMeta
    group_test.go:810: stopping VCR recorder
    group_test.go:810: persisting randomness seed
--- PASS: TestAccLogsLogGroup_providerMeta (59.54s)
=== NAME  TestAccLogsLogGroup_namePrefix
    group_test.go:95: stopping VCR recorder
    group_test.go:95: persisting randomness seed
--- PASS: TestAccLogsLogGroup_namePrefix (60.79s)
=== NAME  TestAccLogsLogGroup_nameGenerate
    group_test.go:67: stopping VCR recorder
    group_test.go:67: persisting randomness seed
--- PASS: TestAccLogsLogGroup_nameGenerate (61.25s)
=== NAME  TestAccLogsLogGroup_basic
    group_test.go:33: stopping VCR recorder
    group_test.go:33: persisting randomness seed
--- PASS: TestAccLogsLogGroup_basic (61.31s)
=== NAME  TestAccLogsLogGroup_skipDestroyInconsistentPlan
    group_test.go:310: stopping VCR recorder
    group_test.go:310: persisting randomness seed
--- PASS: TestAccLogsLogGroup_skipDestroyInconsistentPlan (70.15s)
=== NAME  TestAccLogsLogGroup_deletionProtectionEnabled
    group_test.go:777: stopping VCR recorder
    group_test.go:777: persisting randomness seed
--- PASS: TestAccLogsLogGroup_deletionProtectionEnabled (73.18s)
=== NAME  TestAccLogsLogGroup_tags_EmptyMap
    group_tags_gen_test.go:287: stopping VCR recorder
    group_tags_gen_test.go:287: persisting randomness seed
--- PASS: TestAccLogsLogGroup_tags_EmptyMap (81.92s)
=== NAME  TestAccLogsLogGroup_Identity_Basic
    group_identity_gen_test.go:33: stopping VCR recorder
    group_identity_gen_test.go:33: persisting randomness seed
--- PASS: TestAccLogsLogGroup_Identity_Basic (82.26s)
=== NAME  TestAccLogsLogGroup_Identity_RegionOverride
    group_identity_gen_test.go:120: stopping VCR recorder
    group_identity_gen_test.go:120: persisting randomness seed
--- PASS: TestAccLogsLogGroup_Identity_RegionOverride (82.49s)
=== NAME  TestAccLogsLogGroup_tags_null
    group_tags_gen_test.go:216: stopping VCR recorder
    group_tags_gen_test.go:216: persisting randomness seed
--- PASS: TestAccLogsLogGroup_tags_null (84.27s)
=== NAME  TestAccLogsLogGroup_tags_AddOnUpdate
    group_tags_gen_test.go:354: stopping VCR recorder
    group_tags_gen_test.go:354: persisting randomness seed
--- PASS: TestAccLogsLogGroup_tags_AddOnUpdate (86.70s)
=== NAME  TestAccLogsLogGroup_logGroupClassDELIVERY1
    group_test.go:342: stopping VCR recorder
    group_test.go:342: persisting randomness seed
--- PASS: TestAccLogsLogGroup_logGroupClassDELIVERY1 (87.02s)
=== NAME  TestAccLogsLogGroup_tags_EmptyTag_OnUpdate_Replace
    group_tags_gen_test.go:673: stopping VCR recorder
    group_tags_gen_test.go:673: persisting randomness seed
--- PASS: TestAccLogsLogGroup_tags_EmptyTag_OnUpdate_Replace (87.68s)
=== NAME  TestAccLogsLogGroup_retentionPolicy
    group_test.go:219: stopping VCR recorder
    group_test.go:219: persisting randomness seed
--- PASS: TestAccLogsLogGroup_retentionPolicy (90.46s)
=== NAME  TestAccLogsLogGroup_kmsKey
    group_test.go:150: stopping VCR recorder
    group_test.go:150: persisting randomness seed
--- PASS: TestAccLogsLogGroup_kmsKey (91.11s)
=== NAME  TestAccLogsLogGroup_tags_EmptyTag_OnCreate
    group_tags_gen_test.go:439: stopping VCR recorder
    group_tags_gen_test.go:439: persisting randomness seed
--- PASS: TestAccLogsLogGroup_tags_EmptyTag_OnCreate (91.84s)
=== NAME  TestAccLogsLogGroup_tags_EmptyTag_OnUpdate_Add
    group_tags_gen_test.go:532: stopping VCR recorder
    group_tags_gen_test.go:532: persisting randomness seed
--- PASS: TestAccLogsLogGroup_tags_EmptyTag_OnUpdate_Add (99.40s)
=== NAME  TestAccLogsLogGroup_tags
    group_tags_gen_test.go:30: stopping VCR recorder
    group_tags_gen_test.go:30: persisting randomness seed
--- PASS: TestAccLogsLogGroup_tags (113.06s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       120.542s
```