### PR TITLE
codebuild: Improve error handling in project list resource

### DIFF
--- a/internal/service/codebuild/project_list.go
+++ b/internal/service/codebuild/project_list.go
@@ -65,9 +65,11 @@ func (l *projectListResource) List(ctx context.Context, request list.ListRequest
 			tflog.Info(ctx, "Listing CodeBuild project")
 			diags := resourceProjectRead(ctx, rd, awsClient)
 			if diags.HasError() {
-				result = fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("reading CodeBuild project %s", projectName))
-				yield(result)
-				return
+				tflog.Error(ctx, "Error reading CodeBuild project", map[string]any{
+					"project_name": projectName,
+					"error":        diags,
+				})
+				continue
 			}
 
 			if rd.Id() == "" {
@@ -78,8 +80,11 @@ func (l *projectListResource) List(ctx context.Context, request list.ListRequest
 
 			l.SetResult(ctx, awsClient, request.IncludeResource, &result, rd)
 			if result.Diagnostics.HasError() {
-				yield(result)
-				return
+				tflog.Error(ctx, "Error setting result for CodeBuild project", map[string]any{
+					"project_name": projectName,
+					"error":        result.Diagnostics,
+				})
+				continue
 			}
 
 			if !yield(result) {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Use modern standard for error handling

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
2026/02/05 16:59:33 Creating Terraform AWS Provider (SDKv2-style)...
2026/02/05 16:59:33 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCodeBuildProject_List_basic
=== PAUSE TestAccCodeBuildProject_List_basic
=== CONT  TestAccCodeBuildProject_List_basic
--- PASS: TestAccCodeBuildProject_List_basic (24.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codebuild	30.550s
```
