### PR TITLE
docs(lakeformation): Improve aws_lakeformation_data_cells_filter docu…

### DIFF
--- a/website/docs/r/lakeformation_data_cells_filter.html.markdown
+++ b/website/docs/r/lakeformation_data_cells_filter.html.markdown
@@ -16,10 +16,10 @@ Terraform resource for managing an AWS Lake Formation Data Cells Filter.
 ```terraform
 resource "aws_lakeformation_data_cells_filter" "example" {
   table_data {
-    database_name    = aws_glue_catalog_database.test.name
+    database_name    = aws_glue_catalog_database.example.name
     name             = "example"
     table_catalog_id = data.aws_caller_identity.current.account_id
-    table_name       = aws_glue_catalog_table.test.name
+    table_name       = aws_glue_catalog_table.example.name
 
     column_names = ["my_column"]
 
@@ -29,16 +29,18 @@ resource "aws_lakeformation_data_cells_filter" "example" {
   }
 }
 ```
+
 ### Filter with Excluded Columns Only (No Row Filter)
 
 When excluding columns without a row filter, you must include `all_rows_wildcard {}`:
+
 ```terraform
 resource "aws_lakeformation_data_cells_filter" "excluded_columns" {
   table_data {
-    database_name    = aws_glue_catalog_database.test.name
+    database_name    = aws_glue_catalog_database.example.name
     name             = "exclude-pii"
     table_catalog_id = data.aws_caller_identity.current.account_id
-    table_name       = aws_glue_catalog_table.test.name
+    table_name       = aws_glue_catalog_table.example.name
 
     column_wildcard {
       excluded_column_names = ["ssn", "credit_card"]
@@ -52,13 +54,14 @@ resource "aws_lakeformation_data_cells_filter" "excluded_columns" {
 ```
 
 ### Filter with Row Filter and Excluded Columns
+
 ```terraform
 resource "aws_lakeformation_data_cells_filter" "row_and_column" {
   table_data {
-    database_name    = aws_glue_catalog_database.test.name
+    database_name    = aws_glue_catalog_database.example.name
     name             = "marketing-filtered"
     table_catalog_id = data.aws_caller_identity.current.account_id
-    table_name       = aws_glue_catalog_table.test.name
+    table_name       = aws_glue_catalog_table.example.name
 
     column_wildcard {
       excluded_column_names = ["salary", "bonus"]
@@ -74,13 +77,14 @@ resource "aws_lakeformation_data_cells_filter" "row_and_column" {
 ### Filter with Row Filter Only (All Columns Included)
 
 To include all columns with a row filter, set `excluded_column_names` to an empty list:
+
 ```terraform
 resource "aws_lakeformation_data_cells_filter" "row_only" {
   table_data {
-    database_name    = aws_glue_catalog_database.test.name
+    database_name    = aws_glue_catalog_database.example.name
     name             = "regional-filter"
     table_catalog_id = data.aws_caller_identity.current.account_id
-    table_name       = aws_glue_catalog_table.test.name
+    table_name       = aws_glue_catalog_table.example.name
 
     column_wildcard {
       excluded_column_names = []


### PR DESCRIPTION
Fixes #41376

## Description
Improves the `aws_lakeformation_data_cells_filter` documentation by adding clarity and examples for common usage scenarios.

## Changes
- Added three additional usage examples covering:
  - Excluded columns only (requires `all_rows_wildcard {}`)
  - Row filter with excluded columns
  - Row filter only (all columns included with `excluded_column_names = []`)
- Clarified that exactly one of `filter_expression` or `all_rows_wildcard` must be specified
- Explained when `all_rows_wildcard` is required and its syntax
- Improved description of `filter_expression` parameter

## Context
Users were confused about when to use `all_rows_wildcard` and how to properly configure different filtering scenarios, leading to validation errors.