### PR TITLE
Add role_arn support for cross-account EFS replication

### DIFF
--- a/internal/service/efs/replication_configuration.go
+++ b/internal/service/efs/replication_configuration.go
@@ -81,6 +81,12 @@ func resourceReplicationConfiguration() *schema.Resource {
 							ValidateFunc: verify.ValidRegionName,
 							AtLeastOneOf: []string{"destination.0.availability_zone_name", "destination.0.region"},
 						},
+						names.AttrRoleARN: {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: verify.ValidARN,
+						},
 						names.AttrStatus: {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -346,6 +352,10 @@ func expandDestinationToCreate(tfMap map[string]any) *awstypes.DestinationToCrea
 		apiObject.Region = aws.String(v)
 	}
 
+	if v, ok := tfMap[names.AttrRoleARN].(string); ok && v != "" {
+		apiObject.RoleArn = aws.String(v)
+	}
+
 	return apiObject
 }
 
@@ -379,6 +389,10 @@ func flattenDestination(apiObject awstypes.Destination) map[string]any {
 
 	if v := apiObject.Region; v != nil {
 		tfMap[names.AttrRegion] = aws.ToString(v)
+	}
+
+	if v := apiObject.RoleArn; v != nil {
+		tfMap[names.AttrRoleARN] = aws.ToString(v)
 	}
 
 	tfMap[names.AttrStatus] = string(apiObject.Status)

--- a/website/docs/r/efs_replication_configuration.html.markdown
+++ b/website/docs/r/efs_replication_configuration.html.markdown
@@ -73,6 +73,7 @@ This resource supports the following arguments:
 * `file_system_id` - (Optional) The ID of the destination file system for the replication. If no ID is provided, then EFS creates a new file system with the default settings.
 * `kms_key_id` - (Optional) The Key ID, ARN, alias, or alias ARN of the KMS key that should be used to encrypt the replica file system. If omitted, the default KMS key for EFS `/aws/elasticfilesystem` will be used.
 * `region` - (Optional) The region in which the replica should be created.
+* `role_arn` - (Optional) Amazon Resource Name (ARN) of the IAM role in the source account that allows Amazon EFS to perform replication on its behalf. This is optional for same-account replication and required for cross-account replication.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Fixes #42814

### Description
Adds support for the `role_arn` argument in the `aws_efs_replication_configuration` resource's destination block. This enables cross-account EFS replication, which requires an IAM role ARN to grant replication permissions.

### Changes
- Added `role_arn` schema field to destination block (optional, ForceNew)
- Updated `expandDestinationToCreate` to pass role_arn to AWS API
- Updated `flattenDestination` to read role_arn from AWS API
- Updated documentation to describe the new argument

The `role_arn` parameter is:
- Optional for same-account replication
- Required for cross-account replication (as per AWS EFS API)

### Testing
Builds successfully with `go build` in internal/service/efs/

---

**Note:** This is my second contribution to the Terraform AWS Provider. I'm learning Go and contributing to open source to build DevOps skills. Would appreciate any feedback on code style or best practices!