### PR TITLE
Fix test naming convention in _list_test.go files

### DIFF
--- a/internal/service/appflow/connector_profile_list_test.go
+++ b/internal/service/appflow/connector_profile_list_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccAppFlowConnectorProfile_List_Basic(t *testing.T) {
+func TestAccAppFlowConnectorProfile_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_appflow_connector_profile.test[0]"

--- a/internal/service/appflow/flow_list_test.go
+++ b/internal/service/appflow/flow_list_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccAppFlowFlow_List_Basic(t *testing.T) {
+func TestAccAppFlowFlow_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_appflow_flow.test[0]"

--- a/internal/service/batch/job_queue_list_test.go
+++ b/internal/service/batch/job_queue_list_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccBatchJobQueue_List_Basic(t *testing.T) {
+func TestAccBatchJobQueue_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_batch_job_queue.test[0]"
@@ -72,7 +72,7 @@ func TestAccBatchJobQueue_List_Basic(t *testing.T) {
 	})
 }
 
-func TestAccBatchJobQueue_List_RegionOverride(t *testing.T) {
+func TestAccBatchJobQueue_List_regionOverride(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_batch_job_queue.test[0]"

--- a/internal/service/cleanrooms/collaboration_list_test.go
+++ b/internal/service/cleanrooms/collaboration_list_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccCleanRoomsCollaboration_List_Basic(t *testing.T) {
+func TestAccCleanRoomsCollaboration_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_cleanrooms_collaboration.test[0]"

--- a/internal/service/cleanrooms/configured_table_list_test.go
+++ b/internal/service/cleanrooms/configured_table_list_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccCleanRoomsConfiguredTable_List_Basic(t *testing.T) {
+func TestAccCleanRoomsConfiguredTable_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_cleanrooms_configured_table.test[0]"

--- a/internal/service/cloudfront/key_value_store_list_test.go
+++ b/internal/service/cloudfront/key_value_store_list_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccCloudFrontKeyValueStore_List_Basic(t *testing.T) {
+func TestAccCloudFrontKeyValueStore_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_cloudfront_key_value_store.test[0]"

--- a/internal/service/cloudwatch/metric_alarm_list_test.go
+++ b/internal/service/cloudwatch/metric_alarm_list_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccCloudWatchMetricAlarm_List_Basic(t *testing.T) {
+func TestAccCloudWatchMetricAlarm_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_cloudwatch_metric_alarm.test[0]"

--- a/internal/service/ec2/ec2_instance_list_test.go
+++ b/internal/service/ec2/ec2_instance_list_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccEC2Instance_List_Basic(t *testing.T) {
+func TestAccEC2Instance_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_instance.test[0]"
@@ -82,7 +82,7 @@ func TestAccEC2Instance_List_Basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2Instance_List_RegionOverride(t *testing.T) {
+func TestAccEC2Instance_List_regionOverride(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_instance.test[0]"
@@ -150,7 +150,7 @@ func TestAccEC2Instance_List_RegionOverride(t *testing.T) {
 	})
 }
 
-func TestAccEC2Instance_List_Filtered(t *testing.T) {
+func TestAccEC2Instance_List_filtered(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceNameExpected1 := "aws_instance.expected[0]"
@@ -207,7 +207,7 @@ func TestAccEC2Instance_List_Filtered(t *testing.T) {
 	})
 }
 
-func TestAccEC2Instance_List_ExcludeAutoScaled(t *testing.T) {
+func TestAccEC2Instance_List_excludeAutoScaled(t *testing.T) {
 	t.Skip("Skipping because zero-result queries cause a failure now")
 
 	ctx := acctest.Context(t)

--- a/internal/service/ec2/vpc_list_test.go
+++ b/internal/service/ec2/vpc_list_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccVPC_List_Basic(t *testing.T) {
+func TestAccVPC_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_vpc.test[0]"
@@ -85,7 +85,7 @@ func TestAccVPC_List_Basic(t *testing.T) {
 	})
 }
 
-func TestAccVPC_List_RegionOverride(t *testing.T) {
+func TestAccVPC_List_regionOverride(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_vpc.test[0]"
@@ -155,7 +155,7 @@ func TestAccVPC_List_RegionOverride(t *testing.T) {
 	})
 }
 
-func TestAccVPC_List_Filtered(t *testing.T) {
+func TestAccVPC_List_filtered(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceNameExpected1 := "aws_vpc.expected[0]"
@@ -238,7 +238,7 @@ func TestAccVPC_List_Filtered(t *testing.T) {
 	})
 }
 
-func TestAccVPC_List_DefaultVPC_Exclude(t *testing.T) {
+func TestAccVPC_List_defaultVPC_exclude(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	id := tfstatecheck.StateValue()
@@ -288,7 +288,7 @@ func TestAccVPC_List_DefaultVPC_Exclude(t *testing.T) {
 	})
 }
 
-func TestAccVPC_List_VPCIDs(t *testing.T) {
+func TestAccVPC_List_vpcIDs(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_vpc.test[0]"
@@ -354,7 +354,7 @@ func TestAccVPC_List_VPCIDs(t *testing.T) {
 	})
 }
 
-func TestAccVPC_List_FilteredVPCIDs(t *testing.T) {
+func TestAccVPC_List_filteredVPCIDs(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceNameExpected1 := "aws_vpc.expected[0]"
@@ -439,7 +439,7 @@ func TestAccVPC_List_FilteredVPCIDs(t *testing.T) {
 	})
 }
 
-func TestAccVPC_List_Filtered_IsDefault(t *testing.T) {
+func TestAccVPC_List_filtered_isDefault(t *testing.T) {
 	t.Skip("Skipping because ExpectError is not currently supported for Query mode")
 
 	ctx := acctest.Context(t)

--- a/internal/service/ec2/vpc_route_table_list_test.go
+++ b/internal/service/ec2/vpc_route_table_list_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccVPCRouteTable_List_Basic(t *testing.T) {
+func TestAccVPCRouteTable_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_route_table.test[0]"
@@ -77,7 +77,7 @@ func TestAccVPCRouteTable_List_Basic(t *testing.T) {
 	})
 }
 
-func TestAccVPCRouteTable_List_RegionOverride(t *testing.T) {
+func TestAccVPCRouteTable_List_regionOverride(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_route_table.test[0]"

--- a/internal/service/ec2/vpc_security_group_list_test.go
+++ b/internal/service/ec2/vpc_security_group_list_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccVPCSecurityGroup_List_Basic(t *testing.T) {
+func TestAccVPCSecurityGroup_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_security_group.test[0]"
@@ -75,7 +75,7 @@ func TestAccVPCSecurityGroup_List_Basic(t *testing.T) {
 	})
 }
 
-func TestAccVPCSecurityGroup_List_FilterByGroupIDs(t *testing.T) {
+func TestAccVPCSecurityGroup_List_filterByGroupIDs(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_security_group.expected[0]"
@@ -134,7 +134,7 @@ func TestAccVPCSecurityGroup_List_FilterByGroupIDs(t *testing.T) {
 	})
 }
 
-func TestAccVPCSecurityGroup_List_FilterByVPCID(t *testing.T) {
+func TestAccVPCSecurityGroup_List_filterByVPCID(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_security_group.expected[0]"

--- a/internal/service/ec2/vpc_subnet_list_test.go
+++ b/internal/service/ec2/vpc_subnet_list_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccVPCSubnet_List_Basic(t *testing.T) {
+func TestAccVPCSubnet_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_subnet.test[0]"
@@ -85,7 +85,7 @@ func TestAccVPCSubnet_List_Basic(t *testing.T) {
 	})
 }
 
-func TestAccVPCSubnet_List_RegionOverride(t *testing.T) {
+func TestAccVPCSubnet_List_regionOverride(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_subnet.test[0]"
@@ -155,7 +155,7 @@ func TestAccVPCSubnet_List_RegionOverride(t *testing.T) {
 	})
 }
 
-func TestAccVPCSubnet_List_Filtered(t *testing.T) {
+func TestAccVPCSubnet_List_filtered(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceNameExpected1 := "aws_subnet.expected[0]"
@@ -230,7 +230,7 @@ func TestAccVPCSubnet_List_Filtered(t *testing.T) {
 	})
 }
 
-func TestAccVPCSubnet_List_ExcludeDefaultSubnets(t *testing.T) {
+func TestAccVPCSubnet_List_excludeDefaultSubnets(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	id := tfstatecheck.StateValue()
@@ -288,7 +288,7 @@ func TestAccVPCSubnet_List_ExcludeDefaultSubnets(t *testing.T) {
 	})
 }
 
-func TestAccVPCSubnet_List_SubnetIDs(t *testing.T) {
+func TestAccVPCSubnet_List_subnetIDs(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_subnet.test[0]"
@@ -358,7 +358,7 @@ func TestAccVPCSubnet_List_SubnetIDs(t *testing.T) {
 	})
 }
 
-func TestAccVPCSubnet_List_FilteredSubnetIDs(t *testing.T) {
+func TestAccVPCSubnet_List_filteredSubnetIDs(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceNameExpected1 := "aws_subnet.expected[0]"
@@ -434,7 +434,7 @@ func TestAccVPCSubnet_List_FilteredSubnetIDs(t *testing.T) {
 	})
 }
 
-func TestAccVPCSubnet_List_Filtered_DefaultForAZ(t *testing.T) {
+func TestAccVPCSubnet_List_filtered_defaultForAZ(t *testing.T) {
 	t.Skip("Skipping because ExpectError is not currently supported for Query mode")
 
 	ctx := acctest.Context(t)

--- a/internal/service/ecr/repository_list_test.go
+++ b/internal/service/ecr/repository_list_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccECRRepository_List_Basic(t *testing.T) {
+func TestAccECRRepository_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_ecr_repository.test[0]"
@@ -74,7 +74,7 @@ func TestAccECRRepository_List_Basic(t *testing.T) {
 	})
 }
 
-func TestAccECRRepository_List_RegionOverride(t *testing.T) {
+func TestAccECRRepository_List_regionOverride(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/events/rule_list_test.go
+++ b/internal/service/events/rule_list_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccEventsRule_List_Basic(t *testing.T) {
+func TestAccEventsRule_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_cloudwatch_event_rule.test[0]"

--- a/internal/service/events/target_list_test.go
+++ b/internal/service/events/target_list_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccEventsTarget_List_Basic(t *testing.T) {
+func TestAccEventsTarget_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_cloudwatch_event_target.test[0]"

--- a/internal/service/iam/policy_list_test.go
+++ b/internal/service/iam/policy_list_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccIAMPolicy_List_Basic(t *testing.T) {
+func TestAccIAMPolicy_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_iam_policy.test[0]"
@@ -86,7 +86,7 @@ func TestAccIAMPolicy_List_Basic(t *testing.T) {
 	})
 }
 
-func TestAccIAMPolicy_List_PathPrefix(t *testing.T) {
+func TestAccIAMPolicy_List_pathPrefix(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceNameExpected1 := "aws_iam_policy.expected[0]"

--- a/internal/service/iam/role_list_test.go
+++ b/internal/service/iam/role_list_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccIAMRole_List_Basic(t *testing.T) {
+func TestAccIAMRole_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_iam_role.test[0]"

--- a/internal/service/iam/role_policy_attachment_list_test.go
+++ b/internal/service/iam/role_policy_attachment_list_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccIAMRolePolicyAttachment_List_Basic(t *testing.T) {
+func TestAccIAMRolePolicyAttachment_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	customerManagedName1 := "aws_iam_role_policy_attachment.customer_managed[0]"

--- a/internal/service/iam/role_policy_list_test.go
+++ b/internal/service/iam/role_policy_list_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccIAMRolePolicy_List_Basic(t *testing.T) {
+func TestAccIAMRolePolicy_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_iam_role_policy.test[0]"

--- a/internal/service/lambda/capacity_provider_list_test.go
+++ b/internal/service/lambda/capacity_provider_list_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccLambdaCapacityProvider_List_Basic(t *testing.T) {
+func TestAccLambdaCapacityProvider_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_lambda_capacity_provider.test[0]"
@@ -77,7 +77,7 @@ func TestAccLambdaCapacityProvider_List_Basic(t *testing.T) {
 	})
 }
 
-func TestAccLambdaCapacityProvider_List_RegionOverride(t *testing.T) {
+func TestAccLambdaCapacityProvider_List_regionOverride(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_lambda_capacity_provider.test[0]"

--- a/internal/service/lambda/function_list_test.go
+++ b/internal/service/lambda/function_list_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccLambdaFunction_List_Basic(t *testing.T) {
+func TestAccLambdaFunction_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_lambda_function.test[0]"

--- a/internal/service/lambda/permission_list_test.go
+++ b/internal/service/lambda/permission_list_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccLambdaPermission_List_Basic(t *testing.T) {
+func TestAccLambdaPermission_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_lambda_permission.test[0]"

--- a/internal/service/logs/group_list_test.go
+++ b/internal/service/logs/group_list_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccLogsLogGroup_List_Basic(t *testing.T) {
+func TestAccLogsLogGroup_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_cloudwatch_log_group.test[0]"
@@ -81,7 +81,7 @@ func TestAccLogsLogGroup_List_Basic(t *testing.T) {
 	})
 }
 
-func TestAccLogsLogGroup_List_RegionOverride(t *testing.T) {
+func TestAccLogsLogGroup_List_regionOverride(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_cloudwatch_log_group.test[0]"

--- a/internal/service/opensearchserverless/collection_list_test.go
+++ b/internal/service/opensearchserverless/collection_list_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccOpenSearchServerlessCollection_List_Basic(t *testing.T) {
+func TestAccOpenSearchServerlessCollection_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_opensearchserverless_collection.test[0]"

--- a/internal/service/route53/record_list_test.go
+++ b/internal/service/route53/record_list_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccRoute53Record_List_Basic(t *testing.T) {
+func TestAccRoute53Record_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 

--- a/internal/service/route53resolver/rule_association_list_test.go
+++ b/internal/service/route53resolver/rule_association_list_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccRoute53ResolverRuleAssociation_List_Basic(t *testing.T) {
+func TestAccRoute53ResolverRuleAssociation_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_route53_resolver_rule_association.test[0]"

--- a/internal/service/s3/bucket_acl_list_test.go
+++ b/internal/service/s3/bucket_acl_list_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccS3BucketACL_List_Basic(t *testing.T) {
+func TestAccS3BucketACL_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_s3_bucket_acl.test[0]"
@@ -96,7 +96,7 @@ func TestAccS3BucketACL_List_Basic(t *testing.T) {
 	})
 }
 
-func TestAccS3BucketACL_List_RegionOverride(t *testing.T) {
+func TestAccS3BucketACL_List_regionOverride(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_s3_bucket_acl.test[0]"

--- a/internal/service/s3/bucket_list_test.go
+++ b/internal/service/s3/bucket_list_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccS3Bucket_List_Basic(t *testing.T) {
+func TestAccS3Bucket_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_s3_bucket.test[0]"
@@ -80,7 +80,7 @@ func TestAccS3Bucket_List_Basic(t *testing.T) {
 	})
 }
 
-func TestAccS3Bucket_List_RegionOverride(t *testing.T) {
+func TestAccS3Bucket_List_regionOverride(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_s3_bucket.test[0]"

--- a/internal/service/s3/bucket_policy_list_test.go
+++ b/internal/service/s3/bucket_policy_list_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccS3BucketPolicy_List_Basic(t *testing.T) {
+func TestAccS3BucketPolicy_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_s3_bucket_policy.test[0]"
@@ -92,7 +92,7 @@ func TestAccS3BucketPolicy_List_Basic(t *testing.T) {
 	})
 }
 
-func TestAccS3BucketPolicy_List_RegionOverride(t *testing.T) {
+func TestAccS3BucketPolicy_List_regionOverride(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_s3_bucket_policy.test[0]"

--- a/internal/service/s3/bucket_public_access_block_list_test.go
+++ b/internal/service/s3/bucket_public_access_block_list_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccS3BucketPublicAccessBlock_List_Basic(t *testing.T) {
+func TestAccS3BucketPublicAccessBlock_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_s3_bucket_public_access_block.test[0]"
@@ -88,7 +88,7 @@ func TestAccS3BucketPublicAccessBlock_List_Basic(t *testing.T) {
 	})
 }
 
-func TestAccS3BucketPublicAccessBlock_List_RegionOverride(t *testing.T) {
+func TestAccS3BucketPublicAccessBlock_List_regionOverride(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_s3_bucket_public_access_block.test[0]"

--- a/internal/service/s3/object_list_test.go
+++ b/internal/service/s3/object_list_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccS3Object_List_Basic(t *testing.T) {
+func TestAccS3Object_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_s3_object.test[0]"
@@ -79,7 +79,7 @@ func TestAccS3Object_List_Basic(t *testing.T) {
 	})
 }
 
-func TestAccS3Object_List_DirectoryBucket(t *testing.T) {
+func TestAccS3Object_List_directoryBucket(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_s3_object.test[0]"
@@ -137,7 +137,7 @@ func TestAccS3Object_List_DirectoryBucket(t *testing.T) {
 	})
 }
 
-func TestAccS3Object_List_Prefix(t *testing.T) {
+func TestAccS3Object_List_prefix(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_s3_object.test[0]"

--- a/internal/service/secretsmanager/secret_list_test.go
+++ b/internal/service/secretsmanager/secret_list_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccSecretsManagerSecret_List_Basic(t *testing.T) {
+func TestAccSecretsManagerSecret_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_secretsmanager_secret.test[0]"

--- a/internal/service/secretsmanager/secret_version_list_test.go
+++ b/internal/service/secretsmanager/secret_version_list_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccSecretsManagerSecretVersion_List_Basic(t *testing.T) {
+func TestAccSecretsManagerSecretVersion_List_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_secretsmanager_secret_version.test[0]"


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Change test names from TestName_List_UpperCase to TestName_List_lowerCamelCase
to follow Go naming standards where the final segment after underscore should
start with lowercase.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
