### PR TITLE
r/aws_emr_instance_fleet: Add throughput support to ebs_config

### DIFF
--- a/internal/service/emr/cluster.go
+++ b/internal/service/emr/cluster.go
@@ -118,6 +118,11 @@ func resourceCluster() *schema.Resource {
 													Required: true,
 													ForceNew: true,
 												},
+												names.AttrThroughput: {
+													Type:     schema.TypeInt,
+													Optional: true,
+													ForceNew: true,
+												},
 												names.AttrType: {
 													Type:         schema.TypeString,
 													Required:     true,

--- a/internal/service/emr/instance_fleet.go
+++ b/internal/service/emr/instance_fleet.go
@@ -110,6 +110,11 @@ func resourceInstanceFleet() *schema.Resource {
 										Required: true,
 										ForceNew: true,
 									},
+									names.AttrThroughput: {
+										Type:     schema.TypeInt,
+										Optional: true,
+										ForceNew: true,
+									},
 									names.AttrType: {
 										Type:         schema.TypeString,
 										Required:     true,


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No.

### Description

The `throughput` attribute is missing from the `ebs_config` schema in `aws_emr_instance_fleet` and the fleet config schema in `aws_emr_cluster`. The expand/flatten/hash logic already supports it — only schema declarations are needed. This enables setting gp3 throughput (125–1000 MiB/s) on EMR instance fleet EBS volumes.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.
--->

Closes #41021
Relates to #29679

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
