### PR TITLE
Fix Typo - `settong` -> `setting` 

### DIFF
--- a/website/docs/r/iam_policy.html.markdown
+++ b/website/docs/r/iam_policy.html.markdown
@@ -41,7 +41,7 @@ resource "aws_iam_policy" "policy" {
 
 This resource supports the following arguments:
 
-* `delay_after_policy_creation_in_ms` - (Optional) Number of ms to wait between creating the policy and settong its version as default. May be required in environments with very high S3 IO loads.
+* `delay_after_policy_creation_in_ms` - (Optional) Number of ms to wait between creating the policy and setting its version as default. May be required in environments with very high S3 IO loads.
 * `description` - (Optional, Forces new resource) Description of the IAM policy.
 * `name` - (Optional, Forces new resource) Name of the policy. If omitted, Terraform will assign a random, unique name.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes a typo on the [iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy#delay_after_policy_creation_in_ms-1) docs page 


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
