### PR TITLE
Removes unneeded type parameters in List implementation

### DIFF
--- a/internal/framework/list_resource_with_sdkv2_resource.go
+++ b/internal/framework/list_resource_with_sdkv2_resource.go
@@ -24,11 +24,9 @@ type WithRegionSpec interface {
 	SetRegionSpec(regionSpec unique.Handle[inttypes.ServicePackageResourceRegion])
 }
 
-var _ Lister[listresource.InterceptorParamsSDK] = &listResourceWithSDKv2Resource{}
+var _ Lister[listresource.InterceptorParamsSDK] = &ListResourceWithSDKv2Resource{}
 
-type ListResourceWithSDKv2Resource = listResourceWithSDKv2Resource
-
-type listResourceWithSDKv2Resource struct {
+type ListResourceWithSDKv2Resource struct {
 	withListResourceConfigSchema
 	ResourceWithConfigure
 	resourceSchema *schema.Resource
@@ -38,11 +36,11 @@ type listResourceWithSDKv2Resource struct {
 	interceptors   []listresource.ListResultInterceptor[listresource.InterceptorParamsSDK]
 }
 
-func (l *listResourceWithSDKv2Resource) AppendResultInterceptor(interceptor listresource.ListResultInterceptor[listresource.InterceptorParamsSDK]) {
+func (l *ListResourceWithSDKv2Resource) AppendResultInterceptor(interceptor listresource.ListResultInterceptor[listresource.InterceptorParamsSDK]) {
 	l.interceptors = append(l.interceptors, interceptor)
 }
 
-func (l *listResourceWithSDKv2Resource) SetRegionSpec(regionSpec unique.Handle[inttypes.ServicePackageResourceRegion]) {
+func (l *ListResourceWithSDKv2Resource) SetRegionSpec(regionSpec unique.Handle[inttypes.ServicePackageResourceRegion]) {
 	l.regionSpec = regionSpec
 
 	var isRegionOverrideEnabled bool
@@ -62,7 +60,7 @@ func (l *listResourceWithSDKv2Resource) SetRegionSpec(regionSpec unique.Handle[i
 	}
 }
 
-func (l *listResourceWithSDKv2Resource) SetIdentitySpec(identitySpec inttypes.Identity) {
+func (l *ListResourceWithSDKv2Resource) SetIdentitySpec(identitySpec inttypes.Identity) {
 	out := make(map[string]*schema.Schema)
 	for _, v := range identitySpec.Attributes {
 		out[v.Name()] = &schema.Schema{
@@ -86,7 +84,7 @@ func (l *listResourceWithSDKv2Resource) SetIdentitySpec(identitySpec inttypes.Id
 	l.identitySpec = identitySpec
 }
 
-func (l *listResourceWithSDKv2Resource) runResultInterceptors(ctx context.Context, when listresource.When, awsClient *conns.AWSClient, d *schema.ResourceData) diag.Diagnostics {
+func (l *ListResourceWithSDKv2Resource) runResultInterceptors(ctx context.Context, when listresource.When, awsClient *conns.AWSClient, d *schema.ResourceData) diag.Diagnostics {
 	var diags diag.Diagnostics
 	params := listresource.InterceptorParamsSDK{
 		C:            awsClient,
@@ -114,20 +112,20 @@ func (l *listResourceWithSDKv2Resource) runResultInterceptors(ctx context.Contex
 	return diags
 }
 
-func (l *listResourceWithSDKv2Resource) RawV5Schemas(ctx context.Context, _ list.RawV5SchemaRequest, response *list.RawV5SchemaResponse) {
+func (l *ListResourceWithSDKv2Resource) RawV5Schemas(ctx context.Context, _ list.RawV5SchemaRequest, response *list.RawV5SchemaResponse) {
 	response.ProtoV5Schema = l.resourceSchema.ProtoSchema(ctx)()
 	response.ProtoV5IdentitySchema = l.resourceSchema.ProtoIdentitySchema(ctx)()
 }
 
-func (l *listResourceWithSDKv2Resource) SetResourceSchema(resource *schema.Resource) {
+func (l *ListResourceWithSDKv2Resource) SetResourceSchema(resource *schema.Resource) {
 	l.resourceSchema = resource
 }
 
-func (l *listResourceWithSDKv2Resource) ResourceData() *schema.ResourceData {
+func (l *ListResourceWithSDKv2Resource) ResourceData() *schema.ResourceData {
 	return l.resourceSchema.Data(&terraform.InstanceState{})
 }
 
-func (l *listResourceWithSDKv2Resource) setResourceIdentity(ctx context.Context, client *conns.AWSClient, d *schema.ResourceData) error {
+func (l *ListResourceWithSDKv2Resource) setResourceIdentity(ctx context.Context, client *conns.AWSClient, d *schema.ResourceData) error {
 	identity, err := d.Identity()
 	if err != nil {
 		return err
@@ -177,7 +175,7 @@ func getAttributeOk(d resourceData, name string) (string, bool) {
 
 // TODO modify to accept func() as parameter
 // will allow to use before interceptors as well
-func (l *listResourceWithSDKv2Resource) SetResult(ctx context.Context, awsClient *conns.AWSClient, includeResource bool, result *list.ListResult, rd *schema.ResourceData) {
+func (l *ListResourceWithSDKv2Resource) SetResult(ctx context.Context, awsClient *conns.AWSClient, includeResource bool, result *list.ListResult, rd *schema.ResourceData) {
 	if err := l.runResultInterceptors(ctx, listresource.After, awsClient, rd); err.HasError() {
 		result.Diagnostics.Append(err...)
 		return

--- a/internal/framework/with_list.go
+++ b/internal/framework/with_list.go
@@ -19,27 +19,25 @@ type Lister[T listresource.InterceptorParams | listresource.InterceptorParamsSDK
 	AppendResultInterceptor(listresource.ListResultInterceptor[T])
 }
 
-var _ Lister[listresource.InterceptorParams] = &withList{}
-
-type WithList = withList
+var _ Lister[listresource.InterceptorParams] = &WithList{}
 
 // WithList provides common functionality for ListResources
-type withList struct {
+type WithList struct {
 	withListResourceConfigSchema
 	interceptors []listresource.ListResultInterceptor[listresource.InterceptorParams]
 }
 
 type flattenFunc func()
 
-func (w *withList) AppendResultInterceptor(interceptor listresource.ListResultInterceptor[listresource.InterceptorParams]) {
+func (w *WithList) AppendResultInterceptor(interceptor listresource.ListResultInterceptor[listresource.InterceptorParams]) {
 	w.interceptors = append(w.interceptors, interceptor)
 }
 
-func (w withList) ResultInterceptors() []listresource.ListResultInterceptor[listresource.InterceptorParams] {
+func (w WithList) ResultInterceptors() []listresource.ListResultInterceptor[listresource.InterceptorParams] {
 	return w.interceptors
 }
 
-func (w *withList) runResultInterceptors(ctx context.Context, when listresource.When, awsClient *conns.AWSClient, data any, result *list.ListResult) diag.Diagnostics {
+func (w *WithList) runResultInterceptors(ctx context.Context, when listresource.When, awsClient *conns.AWSClient, data any, result *list.ListResult) diag.Diagnostics {
 	var diags diag.Diagnostics
 	params := listresource.InterceptorParams{
 		C:      awsClient,
@@ -62,7 +60,7 @@ func (w *withList) runResultInterceptors(ctx context.Context, when listresource.
 	return diags
 }
 
-func (w *withList) SetResult(ctx context.Context, awsClient *conns.AWSClient, data any, result *list.ListResult, f flattenFunc) {
+func (w *WithList) SetResult(ctx context.Context, awsClient *conns.AWSClient, data any, result *list.ListResult, f flattenFunc) {
 	var diags diag.Diagnostics
 
 	diags.Append(w.runResultInterceptors(ctx, listresource.Before, awsClient, data, result)...)


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

The types `framework.ListResourceWithSDKv2Resource` and `framework.WithList` had unneeded type parameters.

Shockingly, removing the type parameters reduced the local build (i.e. `go build .`) size by approximately 41 KB (from 1,134,289,746 to 1,134,248,610)