### PR TITLE
feat(dynamodb): support cross-account global table replicas

### DIFF
--- a/.changelog/46393.txt
+++ b/.changelog/46393.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dynamodb_table_replica: Support cross-account replicas
+```

--- a/internal/service/dynamodb/arn.go
+++ b/internal/service/dynamodb/arn.go
@@ -20,6 +20,18 @@ func arnForNewRegion(rn string, newRegion string) (string, error) {
 	return parsedARN.String(), nil
 }
 
+func arnForNewRegionAndAccount(rn string, newRegion string, newAccountID string) (string, error) {
+	parsedARN, err := arn.Parse(rn)
+	if err != nil {
+		return "", err
+	}
+
+	parsedARN.Region = newRegion
+	parsedARN.AccountID = newAccountID
+
+	return parsedARN.String(), nil
+}
+
 func regionFromARN(rn string) (string, error) {
 	parsedARN, err := arn.Parse(rn)
 	if err != nil {

--- a/internal/service/dynamodb/table_replica.go
+++ b/internal/service/dynamodb/table_replica.go
@@ -138,7 +138,7 @@ func resourceTableReplicaCreate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	input := &dynamodb.UpdateTableInput{
-		TableName: aws.String(tableName),
+		TableName: aws.String(d.Get("global_table_arn").(string)),
 		ReplicaUpdates: []awstypes.ReplicationGroupUpdate{{
 			Create: replicaInput,
 		}},
@@ -178,7 +178,13 @@ func resourceTableReplicaCreate(ctx context.Context, d *schema.ResourceData, met
 
 	d.SetId(tableReplicaCreateResourceID(tableName, mainRegion))
 
-	repARN, err := arnForNewRegion(d.Get("global_table_arn").(string), replicaRegion)
+	// Cross-Account: The replica is created in the current account (replicaRegion),
+	// so we must use the current AccountID, not the one from the Global Table ARN (which is the main table's account).
+	repARN, err := arnForNewRegionAndAccount(
+		d.Get("global_table_arn").(string),
+		replicaRegion,
+		meta.(*conns.AWSClient).AccountID(ctx),
+	)
 	if err != nil {
 		return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionCreating, resNameTableReplica, d.Id(), err)
 	}
@@ -203,14 +209,19 @@ func resourceTableReplicaRead(ctx context.Context, d *schema.ResourceData, meta 
 		return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionReading, resNameTableReplica, d.Id(), err)
 	}
 
-	globalTableARN := arn.ARN{
-		AccountID: meta.(*conns.AWSClient).AccountID(ctx),
-		Partition: meta.(*conns.AWSClient).Partition(ctx),
-		Region:    mainRegion,
-		Resource:  fmt.Sprintf("table/%s", tableName),
-		Service:   "dynamodb",
-	}.String()
-	d.Set("global_table_arn", globalTableARN)
+	// If we have the ARN from state/config, use it. Otherwise construct a default (which might be wrong for cross-account import)
+	if v, ok := d.GetOk("global_table_arn"); ok {
+		d.Set("global_table_arn", v.(string))
+	} else {
+		globalTableARN := arn.ARN{
+			AccountID: meta.(*conns.AWSClient).AccountID(ctx),
+			Partition: meta.(*conns.AWSClient).Partition(ctx),
+			Region:    mainRegion,
+			Resource:  fmt.Sprintf("table/%s", tableName),
+			Service:   "dynamodb",
+		}.String()
+		d.Set("global_table_arn", globalTableARN)
+	}
 
 	if mainRegion == replicaRegion {
 		return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionReading, resNameTableReplica, d.Id(), errors.New("replica cannot be in same region as main table"))
@@ -274,7 +285,13 @@ func resourceTableReplicaReadReplica(ctx context.Context, d *schema.ResourceData
 		return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionReading, resNameTableReplica, d.Id(), err)
 	}
 
-	table, err := findTableByName(ctx, conn, tableName)
+	// Use ARN if available (critical for cross-account), else Name
+	tableIdentifier := tableName
+	if v, ok := d.GetOk("global_table_arn"); ok {
+		tableIdentifier = v.(string)
+	}
+
+	table, err := findTableByName(ctx, conn, tableIdentifier)
 
 	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] Dynamodb Table Replica (%s) not found, removing from state", d.Id())
@@ -353,7 +370,7 @@ func resourceTableReplicaUpdate(ctx context.Context, d *schema.ResourceData, met
 			ReplicaUpdates: []awstypes.ReplicationGroupUpdate{{
 				Update: viaMainInput,
 			}},
-			TableName: aws.String(tableName),
+			TableName: aws.String(d.Get("global_table_arn").(string)),
 		}
 
 		err := tfresource.Retry(ctx, max(replicaUpdateTimeout, d.Timeout(schema.TimeoutUpdate)), func(ctx context.Context) *tfresource.RetryError {
@@ -398,7 +415,7 @@ func resourceTableReplicaUpdate(ctx context.Context, d *schema.ResourceData, met
 			log.Printf("[DEBUG] Updating DynamoDB Table Replica deletion protection: %v", d.Get("deletion_protection_enabled").(bool))
 
 			input := dynamodb.UpdateTableInput{
-				TableName:                 aws.String(tableName),
+				TableName:                 aws.String(d.Get("global_table_arn").(string)),
 				DeletionProtectionEnabled: aws.Bool(d.Get("deletion_protection_enabled").(bool)),
 			}
 			if _, err := conn.UpdateTable(ctx, &input); err != nil {
@@ -434,7 +451,7 @@ func resourceTableReplicaDelete(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	input := &dynamodb.UpdateTableInput{
-		TableName: aws.String(tableName),
+		TableName: aws.String(d.Get("global_table_arn").(string)),
 		ReplicaUpdates: []awstypes.ReplicationGroupUpdate{
 			{
 				Delete: &awstypes.DeleteReplicationGroupMemberAction{

--- a/internal/service/dynamodb/table_replica_test.go
+++ b/internal/service/dynamodb/table_replica_test.go
@@ -685,9 +685,7 @@ func TestAccDynamoDBTableReplica_crossAccount(t *testing.T) {
 	// This test requires a second account configuration
 	// We'll skip if the environment variables aren't present
 	// expected: AWS_ALTERNATE_ACCESS_KEY_ID, AWS_ALTERNATE_SECRET_ACCESS_KEY, AWS_ALTERNATE_REGION
-	if !acctest.HasAlternateAccount() {
-		t.Skip("skipping cross-account test: missing alternate account credentials")
-	}
+	acctest.PreCheckAlternateAccount(t)
 
 	resourceName := "aws_dynamodb_table_replica.test"
 	tableResourceName := "aws_dynamodb_table.test"
@@ -700,7 +698,7 @@ func TestAccDynamoDBTableReplica_crossAccount(t *testing.T) {
 		CheckDestroy:             testAccCheckTableReplicaDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTableReplicaConfig_crossAccount(rName),
+				Config: testAccTableReplicaConfig_crossAccount(t, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTableReplicaExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "global_table_arn", tableResourceName, names.AttrARN),
@@ -716,9 +714,9 @@ func TestAccDynamoDBTableReplica_crossAccount(t *testing.T) {
 	})
 }
 
-func testAccTableReplicaConfig_crossAccount(rName string) string {
+func testAccTableReplicaConfig_crossAccount(t *testing.T, rName string) string {
 	return acctest.ConfigCompose(
-		acctest.ConfigMultipleAccountProvider(2),
+		acctest.ConfigMultipleAccountProvider(t, 2),
 		fmt.Sprintf(`
 resource "aws_dynamodb_table" "test" {
   provider         = "aws"

--- a/internal/service/dynamodb/table_replica_test.go
+++ b/internal/service/dynamodb/table_replica_test.go
@@ -675,3 +675,76 @@ resource "aws_dynamodb_table_replica" "test" {
 }
 `, rName, deletionProtection))
 }
+
+func TestAccDynamoDBTableReplica_crossAccount(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	// This test requires a second account configuration
+	// We'll skip if the environment variables aren't present
+	// expected: AWS_ALTERNATE_ACCESS_KEY_ID, AWS_ALTERNATE_SECRET_ACCESS_KEY, AWS_ALTERNATE_REGION
+	if !acctest.HasAlternateAccount() {
+		t.Skip("skipping cross-account test: missing alternate account credentials")
+	}
+
+	resourceName := "aws_dynamodb_table_replica.test"
+	tableResourceName := "aws_dynamodb_table.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckMultipleRegion(t, 2) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 3), // 3 includes the alternate account provider if configured correctly
+		CheckDestroy:             testAccCheckTableReplicaDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableReplicaConfig_crossAccount(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableReplicaExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "global_table_arn", tableResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccTableReplicaConfig_crossAccount(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleAccountProvider(2),
+		fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  provider         = "aws"
+  name             = %[1]q
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  lifecycle {
+    ignore_changes = [replica]
+  }
+}
+
+resource "aws_dynamodb_table_replica" "test" {
+  provider         = "awsalternate"
+  global_table_arn = aws_dynamodb_table.test.arn
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}

--- a/website/docs/r/dynamodb_table_replica.html.markdown
+++ b/website/docs/r/dynamodb_table_replica.html.markdown
@@ -58,36 +58,78 @@ resource "aws_dynamodb_table_replica" "example" {
 }
 ```
 
+### Cross-Account Replica Example
+
+```terraform
+provider "aws" {
+  alias  = "main"
+  region = "us-west-2"
+}
+
+provider "aws" {
+  alias  = "alt_account"
+  region = "us-east-2"
+  # credentials for account B
+}
+
+resource "aws_dynamodb_table" "example" {
+  provider         = aws.main
+  name             = "TestTable"
+  hash_key         = "BrodoBaggins"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "BrodoBaggins"
+    type = "S"
+  }
+
+  lifecycle {
+    ignore_changes = [replica]
+  }
+}
+
+resource "aws_dynamodb_table_replica" "example" {
+  provider         = aws.alt_account
+  global_table_arn = aws_dynamodb_table.example.arn
+
+  tags = {
+    Name = "CrossAccountReplica"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
 
-* `global_table_arn` - (Required) ARN of the _main_ or global table which this resource will replicate.
+- `global_table_arn` - (Required) ARN of the _main_ or global table which this resource will replicate.
 
 The following arguments are optional:
 
-* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `kms_key_arn` - (Optional, Forces new resource) ARN of the CMK that should be used for the AWS KMS encryption. This argument should only be used if the key is different from the default KMS-managed DynamoDB key, `alias/aws/dynamodb`. **Note:** This attribute will _not_ be populated with the ARN of _default_ keys.
-* `deletion_protection_enabled` - (Optional) Whether deletion protection is enabled (true) or disabled (false) on the table replica.
-* `point_in_time_recovery` - (Optional) Whether to enable Point In Time Recovery for the table replica. Default is `false`.
-* `table_class_override` - (Optional, Forces new resource) Storage class of the table replica. Valid values are `STANDARD` and `STANDARD_INFREQUENT_ACCESS`. If not used, the table replica will use the same class as the global table.
-* `tags` - (Optional) Map of tags to populate on the created table. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+- `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+- `kms_key_arn` - (Optional, Forces new resource) ARN of the CMK that should be used for the AWS KMS encryption. This argument should only be used if the key is different from the default KMS-managed DynamoDB key, `alias/aws/dynamodb`. **Note:** This attribute will _not_ be populated with the ARN of _default_ keys.
+- `deletion_protection_enabled` - (Optional) Whether deletion protection is enabled (true) or disabled (false) on the table replica.
+- `point_in_time_recovery` - (Optional) Whether to enable Point In Time Recovery for the table replica. Default is `false`.
+- `table_class_override` - (Optional, Forces new resource) Storage class of the table replica. Valid values are `STANDARD` and `STANDARD_INFREQUENT_ACCESS`. If not used, the table replica will use the same class as the global table.
+- `tags` - (Optional) Map of tags to populate on the created table. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `arn` - ARN of the table replica.
-* `id` - Name of the table and region of the main global table joined with a semicolon (_e.g._, `TableName:us-east-1`).
-* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+- `arn` - ARN of the table replica.
+- `id` - Name of the table and region of the main global table joined with a semicolon (_e.g._, `TableName:us-east-1`).
+- `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-* `create` - (Default `30m`)
-* `update` - (Default `30m`)
-* `delete` - (Default `20m`)
+- `create` - (Default `30m`)
+- `update` - (Default `30m`)
+- `delete` - (Default `20m`)
 
 ## Import
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Implements [Multi account DynamoDB global tables](https://aws.amazon.com/about-aws/whats-new/2026/02/dynamodb-gt-multi-account/)