### PR TITLE
r/aws_cloudfront_distribution & r/aws_cloudfront_multitenant_distribution: Add `origin.custom_origin_config.origin_mtls_config` argument

### DIFF
--- a/.changelog/46421.txt
+++ b/.changelog/46421.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_cloudfront_distribution: Add `origin_mtls_config` argument to `custom_origin_config` for mutual TLS authentication with origins
+```
+
+```release-note:enhancement
+resource/aws_cloudfront_multitenant_distribution: Add `origin_mtls_config` argument to `custom_origin_config` for mutual TLS authentication with origins
+```

--- a/.changelog/46421.txt
+++ b/.changelog/46421.txt
@@ -1,7 +1,7 @@
 ```release-note:enhancement
-resource/aws_cloudfront_distribution: Add `origin_mtls_config` argument to `custom_origin_config` for mutual TLS authentication with origins
+resource/aws_cloudfront_distribution: Add `origin.custom_origin_config.origin_mtls_config` argument
 ```
 
 ```release-note:enhancement
-resource/aws_cloudfront_multitenant_distribution: Add `origin_mtls_config` argument to `custom_origin_config` for mutual TLS authentication with origins
+resource/aws_cloudfront_multitenant_distribution: Add `origin.custom_origin_config.origin_mtls_config` argument
 ```

--- a/internal/acctest/crypto.go
+++ b/internal/acctest/crypto.go
@@ -402,6 +402,53 @@ func TLSRSAX509SelfSignedCertificatePEM(t *testing.T, keyPem, commonName string)
 	return string(pem.EncodeToMemory(certificateBlock))
 }
 
+// TLSRSAX509SelfSignedClientCertificatePEM generates a x509 certificate PEM string with client authentication extended key usage.
+// Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
+// configurations such as: certificate_pem = "%[1]s"
+func TLSRSAX509SelfSignedClientCertificatePEM(t *testing.T, keyPem, commonName string) string {
+	t.Helper()
+
+	keyBlock, _ := pem.Decode([]byte(keyPem))
+
+	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, tlsX509CertificateSerialNumberLimit)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	certificate := &x509.Certificate{
+		BasicConstraintsValid: true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		NotAfter:              time.Now().Add(hoursForCertificateValidity * time.Hour),
+		NotBefore:             time.Now(),
+		SerialNumber:          serialNumber,
+		Subject: pkix.Name{
+			CommonName:   commonName,
+			Organization: []string{"ACME Examples, Inc"},
+		},
+	}
+
+	certificateBytes, err := x509.CreateCertificate(rand.Reader, certificate, certificate, &key.PublicKey, key)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	certificateBlock := &pem.Block{
+		Bytes: certificateBytes,
+		Type:  PEMBlockTypeCertificate,
+	}
+
+	return string(pem.EncodeToMemory(certificateBlock))
+}
+
 // TLSRSAX509CertificateRequestPEM generates a x509 certificate request PEM string
 // and a RSA private key PEM string.
 // Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()

--- a/internal/acctest/crypto.go
+++ b/internal/acctest/crypto.go
@@ -403,6 +403,7 @@ func TLSRSAX509SelfSignedCertificatePEM(t *testing.T, keyPem, commonName string)
 }
 
 // TLSRSAX509SelfSignedClientCertificatePEM generates a x509 certificate PEM string with client authentication extended key usage.
+// This is suitable for use with CloudFront Origin mTLS configuration.
 // Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
 // configurations such as: certificate_pem = "%[1]s"
 func TLSRSAX509SelfSignedClientCertificatePEM(t *testing.T, keyPem, commonName string) string {

--- a/internal/acctest/crypto.go
+++ b/internal/acctest/crypto.go
@@ -403,7 +403,6 @@ func TLSRSAX509SelfSignedCertificatePEM(t *testing.T, keyPem, commonName string)
 }
 
 // TLSRSAX509SelfSignedClientCertificatePEM generates a x509 certificate PEM string with client authentication extended key usage.
-// This is suitable for use with CloudFront Origin mTLS configuration.
 // Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
 // configurations such as: certificate_pem = "%[1]s"
 func TLSRSAX509SelfSignedClientCertificatePEM(t *testing.T, keyPem, commonName string) string {

--- a/internal/acctest/crypto.go
+++ b/internal/acctest/crypto.go
@@ -355,51 +355,13 @@ func TLSRSAX509SelfSignedCACertificateForRolesAnywhereTrustAnchorPEM(t *testing.
 	return string(pem.EncodeToMemory(certificateBlock))
 }
 
-// TLSRSAX509SelfSignedCertificatePEM generates a x509 certificate PEM string.
+// TLSRSAX509SelfSignedCertificatePEM generates a x509 certificate PEM string with server authentication extended key usage.
 // Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
 // configurations such as: private_key_pem = "%[1]s"
 func TLSRSAX509SelfSignedCertificatePEM(t *testing.T, keyPem, commonName string) string {
 	t.Helper()
 
-	keyBlock, _ := pem.Decode([]byte(keyPem))
-
-	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	serialNumber, err := rand.Int(rand.Reader, tlsX509CertificateSerialNumberLimit)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	certificate := &x509.Certificate{
-		BasicConstraintsValid: true,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		NotAfter:              time.Now().Add(hoursForCertificateValidity * time.Hour),
-		NotBefore:             time.Now(),
-		SerialNumber:          serialNumber,
-		Subject: pkix.Name{
-			CommonName:   commonName,
-			Organization: []string{"ACME Examples, Inc"},
-		},
-	}
-
-	certificateBytes, err := x509.CreateCertificate(rand.Reader, certificate, certificate, &key.PublicKey, key)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	certificateBlock := &pem.Block{
-		Bytes: certificateBytes,
-		Type:  PEMBlockTypeCertificate,
-	}
-
-	return string(pem.EncodeToMemory(certificateBlock))
+	return tlsRSAX509SelfSignedCertificatePEM(t, keyPem, commonName, x509.ExtKeyUsageServerAuth)
 }
 
 // TLSRSAX509SelfSignedClientCertificatePEM generates a x509 certificate PEM string with client authentication extended key usage.
@@ -408,6 +370,12 @@ func TLSRSAX509SelfSignedCertificatePEM(t *testing.T, keyPem, commonName string)
 func TLSRSAX509SelfSignedClientCertificatePEM(t *testing.T, keyPem, commonName string) string {
 	t.Helper()
 
+	return tlsRSAX509SelfSignedCertificatePEM(t, keyPem, commonName, x509.ExtKeyUsageClientAuth)
+}
+
+func tlsRSAX509SelfSignedCertificatePEM(t *testing.T, keyPem, commonName string, extKeyUsage x509.ExtKeyUsage) string {
+	t.Helper()
+
 	keyBlock, _ := pem.Decode([]byte(keyPem))
 
 	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
@@ -424,7 +392,7 @@ func TLSRSAX509SelfSignedClientCertificatePEM(t *testing.T, keyPem, commonName s
 
 	certificate := &x509.Certificate{
 		BasicConstraintsValid: true,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		ExtKeyUsage:           []x509.ExtKeyUsage{extKeyUsage},
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		NotAfter:              time.Now().Add(hoursForCertificateValidity * time.Hour),
 		NotBefore:             time.Now(),

--- a/internal/acctest/crypto_test.go
+++ b/internal/acctest/crypto_test.go
@@ -66,6 +66,17 @@ func TestTLSRSAX509SelfSignedCertificatePEM(t *testing.T) {
 	}
 }
 
+func TestTLSRSAX509SelfSignedClientCertificatePEM(t *testing.T) {
+	t.Parallel()
+
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	certificate := acctest.TLSRSAX509SelfSignedClientCertificatePEM(t, key, "example.com")
+
+	if !strings.Contains(certificate, acctest.PEMBlockTypeCertificate) {
+		t.Errorf("certificate does not contain CERTIFICATE: %s", certificate)
+	}
+}
+
 func TestTLSRSAX509CertificateRequestPEM(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -696,6 +696,20 @@ func resourceDistribution() *schema.Resource {
 											Default:      5,
 											ValidateFunc: validation.IntAtLeast(1),
 										},
+										"origin_mtls_config": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"client_certificate_arn": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: verify.ValidARN,
+													},
+												},
+											},
+										},
 										"origin_read_timeout": {
 											Type:         schema.TypeInt,
 											Optional:     true,
@@ -2594,6 +2608,12 @@ func expandCustomOriginConfig(tfMap map[string]any) *awstypes.CustomOriginConfig
 		apiObject.IpAddressType = awstypes.IpAddressType(v.(string))
 	}
 
+	if v, ok := tfMap["origin_mtls_config"]; ok {
+		if v := v.([]any); len(v) > 0 {
+			apiObject.OriginMtlsConfig = expandOriginMtlsConfig(v[0].(map[string]any))
+		}
+	}
+
 	return apiObject
 }
 
@@ -2615,6 +2635,10 @@ func flattenCustomOriginConfig(apiObject *awstypes.CustomOriginConfig) map[strin
 		tfMap[names.AttrIPAddressType] = apiObject.IpAddressType
 	}
 
+	if apiObject.OriginMtlsConfig != nil {
+		tfMap["origin_mtls_config"] = []any{flattenOriginMtlsConfig(apiObject.OriginMtlsConfig)}
+	}
+
 	return tfMap
 }
 
@@ -2631,6 +2655,26 @@ func flattenCustomOriginConfigSSL(apiObject *awstypes.OriginSslProtocols) []any 
 	}
 
 	return flex.FlattenStringyValueList(apiObject.Items)
+}
+
+func expandOriginMtlsConfig(tfMap map[string]any) *awstypes.OriginMtlsConfig {
+	if tfMap == nil {
+		return nil
+	}
+
+	return &awstypes.OriginMtlsConfig{
+		ClientCertificateArn: aws.String(tfMap["client_certificate_arn"].(string)),
+	}
+}
+
+func flattenOriginMtlsConfig(apiObject *awstypes.OriginMtlsConfig) map[string]any {
+	if apiObject == nil {
+		return nil
+	}
+
+	return map[string]any{
+		"client_certificate_arn": aws.ToString(apiObject.ClientCertificateArn),
+	}
 }
 
 func expandOriginShield(tfMap map[string]any) *awstypes.OriginShield {

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -790,6 +790,11 @@ func TestAccCloudFrontDistribution_Origin_originMtlsConfig(t *testing.T) {
 			},
 			{
 				Config: testAccDistributionConfig_originMtlsConfig(t, rName, 1),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDistributionExists(ctx, t, resourceName, &distribution),
 					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -751,6 +751,56 @@ func TestAccCloudFrontDistribution_Origin_originAccessControl(t *testing.T) {
 		},
 	})
 }
+func TestAccCloudFrontDistribution_Origin_originMtlsConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var distribution awstypes.Distribution
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cloudfront_distribution.test"
+	certificateResourceName := "aws_acm_certificate.test"
+	certificateResourceName2 := "aws_acm_certificate.test2"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDistributionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistributionConfig_originMtlsConfig(t, rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionExists(ctx, t, resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.0.origin_mtls_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "origin.0.custom_origin_config.0.origin_mtls_config.0.client_certificate_arn", certificateResourceName, names.AttrARN),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
+			},
+			{
+				Config: testAccDistributionConfig_originMtlsConfig(t, rName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionExists(ctx, t, resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.0.origin_mtls_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "origin.0.custom_origin_config.0.origin_mtls_config.0.client_certificate_arn", certificateResourceName2, names.AttrARN),
+				),
+			},
+		},
+	})
+}
 
 // TestAccCloudFrontDistribution_noOptionalItems runs an
 // aws_cloudfront_distribution acceptance test with no optional items set.
@@ -5152,7 +5202,79 @@ resource "aws_cloudfront_distribution" "test" {
 }
 `, rName, testAccDistributionRetainConfig(), which))
 }
+func testAccDistributionConfig_originMtlsConfig(t *testing.T, rName string, certIndex int) string {
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	certificate := acctest.TLSRSAX509SelfSignedClientCertificatePEM(t, key, rName+".example.com")
+	key2 := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	certificate2 := acctest.TLSRSAX509SelfSignedClientCertificatePEM(t, key2, rName+"-updated.example.com")
 
+	return acctest.ConfigCompose(testAccRegionProviderConfig(), fmt.Sprintf(`
+resource "aws_acm_certificate" "test" {
+  certificate_body = "%[1]s"
+  private_key      = "%[2]s"
+}
+
+resource "aws_acm_certificate" "test2" {
+  certificate_body = "%[3]s"
+  private_key      = "%[4]s"
+}
+
+resource "aws_cloudfront_distribution" "test" {
+  enabled          = true
+  retain_on_delete = false
+
+  origin {
+    domain_name = "www.example.com"
+    origin_id   = "test"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+
+      origin_mtls_config {
+        client_certificate_arn = %[6]s
+      }
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "test"
+    viewer_protocol_policy = "allow-all"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 3600
+    max_ttl     = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  %[5]s
+}
+`, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key),
+		acctest.TLSPEMEscapeNewlines(certificate2), acctest.TLSPEMEscapeNewlines(key2),
+		testAccDistributionRetainConfig(),
+		[]string{"aws_acm_certificate.test.arn", "aws_acm_certificate.test2.arn"}[certIndex]))
+}
 func testAccDistributionConfig_vpcOriginConfig(rName string) string {
 	return acctest.ConfigCompose(testAccVPCOriginConfig_basic(rName), `
 resource "aws_cloudfront_distribution" "test" {

--- a/internal/service/cloudfront/multitenant_distribution.go
+++ b/internal/service/cloudfront/multitenant_distribution.go
@@ -484,6 +484,22 @@ func (r *multiTenantDistributionResource) Schema(ctx context.Context, request re
 										CustomType: fwtypes.SetOfStringEnumType[awstypes.SslProtocol](),
 									},
 								},
+								Blocks: map[string]schema.Block{
+									"origin_mtls_config": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[originMtlsConfigModel](ctx),
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"client_certificate_arn": schema.StringAttribute{
+													Required:   true,
+													CustomType: fwtypes.ARNType,
+												},
+											},
+										},
+									},
+								},
 							},
 						},
 						"origin_shield": schema.ListNestedBlock{
@@ -1086,9 +1102,14 @@ type customOriginConfigModel struct {
 	HTTPSPort              types.Int32                                                  `tfsdk:"https_port"`
 	IPAddressType          fwtypes.StringEnum[awstypes.IpAddressType]                   `tfsdk:"ip_address_type"`
 	OriginKeepaliveTimeout types.Int32                                                  `tfsdk:"origin_keepalive_timeout"`
+	OriginMtlsConfig       fwtypes.ListNestedObjectValueOf[originMtlsConfigModel]       `tfsdk:"origin_mtls_config" autoflex:",omitempty"`
 	OriginReadTimeout      types.Int32                                                  `tfsdk:"origin_read_timeout"`
 	OriginProtocolPolicy   fwtypes.StringEnum[awstypes.OriginProtocolPolicy]            `tfsdk:"origin_protocol_policy"`
 	OriginSSLProtocols     fwtypes.SetValueOf[fwtypes.StringEnum[awstypes.SslProtocol]] `tfsdk:"origin_ssl_protocols" autoflex:",xmlwrapper=Items"`
+}
+
+type originMtlsConfigModel struct {
+	ClientCertificateArn fwtypes.ARN `tfsdk:"client_certificate_arn"`
 }
 
 type originShieldModel struct {

--- a/internal/service/cloudfront/multitenant_distribution_test.go
+++ b/internal/service/cloudfront/multitenant_distribution_test.go
@@ -274,74 +274,78 @@ func TestAccCloudFrontMultiTenantDistribution_tags(t *testing.T) {
 	})
 }
 
+func TestAccCloudFrontMultiTenantDistribution_originMtlsConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	var distribution awstypes.Distribution
+	resourceName := "aws_cloudfront_multitenant_distribution.test"
+	certificateResourceName := "aws_acm_certificate.test"
+	certificateResourceName2 := "aws_acm_certificate.test2"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMultiTenantDistributionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMultiTenantDistributionConfig_originMtlsConfig(t, rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.0.origin_mtls_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "origin.0.custom_origin_config.0.origin_mtls_config.0.client_certificate_arn", certificateResourceName, names.AttrARN),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag"},
+			},
+			{
+				Config: testAccMultiTenantDistributionConfig_originMtlsConfig(t, rName, 1),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.0.origin_mtls_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "origin.0.custom_origin_config.0.origin_mtls_config.0.client_certificate_arn", certificateResourceName2, names.AttrARN),
+				),
+			},
+		},
+	})
+}
+
 // Ref: https://github.com/hashicorp/terraform-provider-aws/issues/46045
 func TestAccCloudFrontMultiTenantDistribution_originSwapOrder(t *testing.T) {
 	ctx := acctest.Context(t)
 	var distribution awstypes.Distribution
 	resourceName := "aws_cloudfront_multitenant_distribution.test"
-<<<<<<< HEAD
-=======
-func TestAccCloudFrontMultiTenantDistribution_originMtlsConfig(t *testing.T) {
-  ctx := acctest.Context(t)
-  var distribution awstypes.Distribution
-  resourceName := "aws_cloudfront_multitenant_distribution.test"
-  certificateResourceName := "aws_acm_certificate.test"
-  certificateResourceName2 := "aws_acm_certificate.test2"
-  rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-  acctest.ParallelTest(ctx, t, resource.TestCase{
-    PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
-    ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
-    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-    CheckDestroy:             testAccCheckMultiTenantDistributionDestroy(ctx, t),
-    Steps: []resource.TestStep{
-      {
-        Config: testAccMultiTenantDistributionConfig_originMtlsConfig(t, rName, 0),
-        Check: resource.ComposeTestCheckFunc(
-          testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
-          resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
-          resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.#", "1"),
-          resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.0.origin_mtls_config.#", "1"),
-          resource.TestCheckResourceAttrPair(resourceName, "origin.0.custom_origin_config.0.origin_mtls_config.0.client_certificate_arn", certificateResourceName, names.AttrARN),
-        ),
-      },
-      {
-        ResourceName:            resourceName,
-        ImportState:             true,
-        ImportStateVerify:       true,
-        ImportStateVerifyIgnore: []string{"etag"},
-      },
-      {
-        Config: testAccMultiTenantDistributionConfig_originMtlsConfig(t, rName, 1),
-        Check: resource.ComposeTestCheckFunc(
-          testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
-          resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
-          resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.#", "1"),
-          resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.0.origin_mtls_config.#", "1"),
-          resource.TestCheckResourceAttrPair(resourceName, "origin.0.custom_origin_config.0.origin_mtls_config.0.client_certificate_arn", certificateResourceName2, names.AttrARN),
-        ),
-      },
-    },
-  })
-}
-
-	certificateResourceName := "aws_acm_certificate.test"
-	certificateResourceName2 := "aws_acm_certificate.test2"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
->>>>>>> a71be536dc5 (Added update steps to the test cases)
-
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMultiTenantDistributionDestroy(ctx, t),
+		Steps: []resource.TestStep{
 			{
-<<<<<<< HEAD
 				Config: testAccMultiTenantDistributionConfig_originOrder(false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
 					resource.TestCheckResourceAttr(resourceName, "origin.#", "2"),
-=======
-				Config: testAccMultiTenantDistributionConfig_originMtlsConfig(t, rName, 0),
-        Config: testAccMultiTenantDistributionConfig_originOrder(false),
->>>>>>> a71be536dc5 (Added update steps to the test cases)
 				),
-          resource.TestCheckResourceAttr(resourceName, "origin.#", "2"),
+			},
+			{
+				Config: testAccMultiTenantDistributionConfig_originOrder(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
 					resource.TestCheckResourceAttr(resourceName, "origin.#", "2"),
 				),
 			},

--- a/internal/service/cloudfront/multitenant_distribution_test.go
+++ b/internal/service/cloudfront/multitenant_distribution_test.go
@@ -279,24 +279,69 @@ func TestAccCloudFrontMultiTenantDistribution_originSwapOrder(t *testing.T) {
 	ctx := acctest.Context(t)
 	var distribution awstypes.Distribution
 	resourceName := "aws_cloudfront_multitenant_distribution.test"
+<<<<<<< HEAD
+=======
+func TestAccCloudFrontMultiTenantDistribution_originMtlsConfig(t *testing.T) {
+  ctx := acctest.Context(t)
+  var distribution awstypes.Distribution
+  resourceName := "aws_cloudfront_multitenant_distribution.test"
+  certificateResourceName := "aws_acm_certificate.test"
+  certificateResourceName2 := "aws_acm_certificate.test2"
+  rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMultiTenantDistributionDestroy(ctx, t),
-		Steps: []resource.TestStep{
+  acctest.ParallelTest(ctx, t, resource.TestCase{
+    PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+    ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+    CheckDestroy:             testAccCheckMultiTenantDistributionDestroy(ctx, t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccMultiTenantDistributionConfig_originMtlsConfig(t, rName, 0),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
+          resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
+          resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.#", "1"),
+          resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.0.origin_mtls_config.#", "1"),
+          resource.TestCheckResourceAttrPair(resourceName, "origin.0.custom_origin_config.0.origin_mtls_config.0.client_certificate_arn", certificateResourceName, names.AttrARN),
+        ),
+      },
+      {
+        ResourceName:            resourceName,
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"etag"},
+      },
+      {
+        Config: testAccMultiTenantDistributionConfig_originMtlsConfig(t, rName, 1),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
+          resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
+          resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.#", "1"),
+          resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.0.origin_mtls_config.#", "1"),
+          resource.TestCheckResourceAttrPair(resourceName, "origin.0.custom_origin_config.0.origin_mtls_config.0.client_certificate_arn", certificateResourceName2, names.AttrARN),
+        ),
+      },
+    },
+  })
+}
+
+	certificateResourceName := "aws_acm_certificate.test"
+	certificateResourceName2 := "aws_acm_certificate.test2"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+>>>>>>> a71be536dc5 (Added update steps to the test cases)
+
 			{
+<<<<<<< HEAD
 				Config: testAccMultiTenantDistributionConfig_originOrder(false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
 					resource.TestCheckResourceAttr(resourceName, "origin.#", "2"),
+=======
+				Config: testAccMultiTenantDistributionConfig_originMtlsConfig(t, rName, 0),
+        Config: testAccMultiTenantDistributionConfig_originOrder(false),
+>>>>>>> a71be536dc5 (Added update steps to the test cases)
 				),
-			},
-			{
-				Config: testAccMultiTenantDistributionConfig_originOrder(true),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
+          resource.TestCheckResourceAttr(resourceName, "origin.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "origin.#", "2"),
 				),
 			},
@@ -819,7 +864,80 @@ resource "aws_cloudfront_multitenant_distribution" "test" {
 }
 `, comment, httpVersion, defaultRootObjectConfig)
 }
+func testAccMultiTenantDistributionConfig_originMtlsConfig(t *testing.T, rName string, certIndex int) string {
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	certificate := acctest.TLSRSAX509SelfSignedClientCertificatePEM(t, key, rName+".example.com")
+	key2 := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	certificate2 := acctest.TLSRSAX509SelfSignedClientCertificatePEM(t, key2, rName+"-updated.example.com")
 
+	return acctest.ConfigCompose(testAccRegionProviderConfig(), fmt.Sprintf(`
+resource "aws_acm_certificate" "test" {
+  certificate_body = "%[1]s"
+  private_key      = "%[2]s"
+}
+
+resource "aws_acm_certificate" "test2" {
+  certificate_body = "%[3]s"
+  private_key      = "%[4]s"
+}
+
+resource "aws_cloudfront_multitenant_distribution" "test" {
+  enabled = false
+  comment = "Test distribution with origin mTLS config"
+
+  origin {
+    domain_name = "www.example.com"
+    id          = "test"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+
+      origin_mtls_config {
+        client_certificate_arn = %[5]s
+      }
+    }
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "test"
+    viewer_protocol_policy = "allow-all"
+    cache_policy_id        = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled policy
+
+    allowed_methods {
+      items          = ["GET", "HEAD"]
+      cached_methods = ["GET", "HEAD"]
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tenant_config {
+    parameter_definition {
+      name = "origin_domain"
+      definition {
+        string_schema {
+          required = true
+          comment  = "Origin domain parameter for tenants"
+        }
+      }
+    }
+  }
+}
+`, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key),
+		acctest.TLSPEMEscapeNewlines(certificate2), acctest.TLSPEMEscapeNewlines(key2),
+		[]string{"aws_acm_certificate.test.arn", "aws_acm_certificate.test2.arn"}[certIndex]))
+}
 func testAccMultiTenantDistributionConfig_s3OriginWithOAC(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -592,7 +592,12 @@ argument should not be specified.
 * `origin_protocol_policy` (Required) - Origin protocol policy to apply to your origin. One of `http-only`, `https-only`, or `match-viewer`.
 * `origin_ssl_protocols` (Required) - List of SSL/TLS protocols that CloudFront can use when connecting to your origin over HTTPS. Valid values: `SSLv3`, `TLSv1`, `TLSv1.1`, `TLSv1.2`. For more information, see [Minimum Origin SSL Protocol](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesOriginSSLProtocols) in the Amazon CloudFront Developer Guide.
 * `origin_keepalive_timeout` - (Optional) The Custom KeepAlive timeout, in seconds. By default, AWS enforces an upper limit of `60`. But you can request an [increase](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-request-timeout). Defaults to `5`.
+* `origin_mtls_config` - (Optional) The [origin mTLS configuration](#origin-mtls-config-arguments) for mutual TLS authentication between CloudFront and your origin.
 * `origin_read_timeout` - (Optional) The Custom Read timeout, in seconds. By default, AWS enforces an upper limit of `60`. But you can request an [increase](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-request-timeout). Defaults to `30`.
+
+##### Origin mTLS Config Arguments
+
+* `client_certificate_arn` (Required) - ARN of the ACM certificate to use for mutual TLS authentication with the origin. The certificate must have Extended Key Usage set to TLS Web Client Authentication (OID 1.3.6.1.5.5.7.3.2).
 
 ##### Origin Shield Arguments
 

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -597,7 +597,7 @@ argument should not be specified.
 
 ##### Origin mTLS Config Arguments
 
-* `client_certificate_arn` (Required) - ARN of the ACM certificate to use for mutual TLS authentication with the origin. The certificate must have Extended Key Usage set to TLS Web Client Authentication (OID 1.3.6.1.5.5.7.3.2).
+* `client_certificate_arn` (Required) - ARN of the ACM certificate to use for mutual TLS authentication with the origin. The certificate must have Extended Key Usage set to TLS Client Authentication.
 
 ##### Origin Shield Arguments
 

--- a/website/docs/r/cloudfront_multitenant_distribution.html.markdown
+++ b/website/docs/r/cloudfront_multitenant_distribution.html.markdown
@@ -179,9 +179,14 @@ Cache behavior supports all the same arguments as [Default Cache Behavior](#defa
 * `https_port` - (Required) HTTPS port the custom origin listens on.
 * `ip_address_type` - (Optional) Type of IP addresses used by your origins. Valid values are `ipv4` and `dualstack`.
 * `origin_keepalive_timeout` - (Optional) Custom keep-alive timeout, in seconds. Default: 5.
+* `origin_mtls_config` - (Optional) Origin mTLS configuration for mutual TLS authentication between CloudFront and your origin. See [Origin mTLS Config](#origin-mtls-config) below.
 * `origin_read_timeout` - (Optional) Custom read timeout, in seconds. Default: 30.
 * `origin_protocol_policy` - (Required) Origin protocol policy to apply to your origin. Valid values are `http-only`, `https-only`, and `match-viewer`.
 * `origin_ssl_protocols` - (Required) List of SSL/TLS protocols that you want CloudFront to use when communicating with your origin over HTTPS.
+
+### Origin mTLS Config
+
+* `client_certificate_arn` - (Required) ARN of the ACM certificate to use for mutual TLS authentication with the origin. The certificate must have Extended Key Usage set to TLS Web Client Authentication (OID 1.3.6.1.5.5.7.3.2).
 
 ### Origin Shield
 

--- a/website/docs/r/cloudfront_multitenant_distribution.html.markdown
+++ b/website/docs/r/cloudfront_multitenant_distribution.html.markdown
@@ -186,7 +186,7 @@ Cache behavior supports all the same arguments as [Default Cache Behavior](#defa
 
 ### Origin mTLS Config
 
-* `client_certificate_arn` - (Required) ARN of the ACM certificate to use for mutual TLS authentication with the origin. The certificate must have Extended Key Usage set to TLS Web Client Authentication (OID 1.3.6.1.5.5.7.3.2).
+* `client_certificate_arn` - (Required) ARN of the ACM certificate to use for mutual TLS authentication with the origin. The certificate must have Extended Key Usage set to TLS Client Authentication.
 
 ### Origin Shield
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #46360 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test ./internal/acctest -run TestTLSRSAX509SelfSignedClientCertificatePEM -v
2026/02/11 09:32:39 Creating Terraform AWS Provider (SDKv2-style)...
2026/02/11 09:32:39 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestTLSRSAX509SelfSignedClientCertificatePEM
=== PAUSE TestTLSRSAX509SelfSignedClientCertificatePEM
=== CONT  TestTLSRSAX509SelfSignedClientCertificatePEM
--- PASS: TestTLSRSAX509SelfSignedClientCertificatePEM (0.08s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/acctest    5.249s

% make testacc PKG=cloudfront TESTS=TestAccCloudFrontMultiTenantDistribution_originMtlsConfig
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-mtls_customer_origins 🌿...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontMultiTenantDistribution_originMtlsConfig'  -timeout 360m -vet=off
2026/02/11 11:45:53 Creating Terraform AWS Provider (SDKv2-style)...
2026/02/11 11:45:53 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudFrontMultiTenantDistribution_originMtlsConfig
=== PAUSE TestAccCloudFrontMultiTenantDistribution_originMtlsConfig
=== CONT  TestAccCloudFrontMultiTenantDistribution_originMtlsConfig
--- PASS: TestAccCloudFrontMultiTenantDistribution_originMtlsConfig (308.68s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 314.914s

% make testacc PKG=cloudfront TESTS=TestAccCloudFrontDistribution_Origin_originMtlsConfig    
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-mtls_customer_origins 🌿...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontDistribution_Origin_originMtlsConfig'  -timeout 360m -vet=off
2026/02/11 12:00:38 Creating Terraform AWS Provider (SDKv2-style)...
2026/02/11 12:00:38 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudFrontDistribution_Origin_originMtlsConfig
=== PAUSE TestAccCloudFrontDistribution_Origin_originMtlsConfig
=== CONT  TestAccCloudFrontDistribution_Origin_originMtlsConfig
--- PASS: TestAccCloudFrontDistribution_Origin_originMtlsConfig (515.23s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 521.638s
...
```
