### PR TITLE
internal/sweep: additional skippable errors for `ec2`

### DIFF
--- a/internal/sweep/awsv2/skip.go
+++ b/internal/sweep/awsv2/skip.go
@@ -150,6 +150,10 @@ func SkipSweepError(err error) bool {
 	if tfawserr.ErrMessageContains(err, "UnsupportedOperation", "The functionality you requested is not available in this region") {
 		return true
 	}
+	//  Example (ec2): UnsupportedOperation: The functionality you requested is not supported in this region
+	if tfawserr.ErrMessageContains(err, "UnsupportedOperation", "The functionality you requested is not supported in this region") {
+		return true
+	}
 	//  Example (fsx): UnsupportedOperation: This operation is unsupported.
 	if tfawserr.ErrMessageContains(err, "UnsupportedOperation", "This operation is unsupported") {
 		return true


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This addition is a slight variation on an existing skippable error (`not available` versus `not supported`), and will prevent failures when sweeping the newly added `aws_ec2_secondary_network` and `aws_ec2_secondary_subnet` resources.

Before:

```console
% make sweep SWEEPARGS="-sweep-run=aws_ec2_secondary"
WARNING: This will destroy infrastructure. Use only in development accounts.
go1.25.6 test ./internal/sweep -v -sweep=us-west-2,us-east-1,us-east-2,us-west-1 -sweep-run=aws_ec2_secondary -timeout 360m -vet=off
2026/02/12 15:01:48 [DEBUG] Running Sweepers for region (us-west-2):

<snip>

2026/02/12 15:01:49 [DEBUG] Completed Sweeper (aws_ec2_secondary_network) in region (us-west-2) in 769.73275ms
2026/02/12 15:01:49 [ERROR] Error running Sweeper (aws_ec2_secondary_network) in region (us-west-2): listing "aws_ec2_secondary_network" (us-west-2): error listing EC2 Secondary Networks: operation error EC2: DescribeSecondaryNetworks, https response error StatusCode: 400, RequestID: c0ef7ca1-4a89-45fc-a021-c29f061669cb, api error UnsupportedOperation: The functionality you requested is not supported in this region.
FAIL    github.com/hashicorp/terraform-provider-aws/internal/sweep      7.399s
FAIL
make: *** [sweep] Error 1
```

After:

```console
% make sweep SWEEPARGS="-sweep-run=aws_ec2_secondary"
WARNING: This will destroy infrastructure. Use only in development accounts.
go1.25.6 test ./internal/sweep -v -sweep=us-west-2,us-east-1,us-east-2,us-west-1 -sweep-run=aws_ec2_secondary -timeout 360m -vet=off
2026/02/12 15:05:51 [DEBUG] Running Sweepers for region (us-west-2):

<snip>

2026/02/12 15:05:54 Sweeper Tests for region (us-west-1) ran successfully:
2026/02/12 15:05:54     - aws_ec2_secondary_network
2026/02/12 15:05:54     - aws_ec2_secondary_subnet
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      9.922s
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #46408