### PR TITLE
feat: aws_servicequotas_service_quotas (plural) data source

### DIFF
--- a/.changelog/46463.txt
+++ b/.changelog/46463.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_servicequotas_service_quotas: lists all default service quotas for a given service code.
+```

--- a/internal/service/servicequotas/service_package_gen.go
+++ b/internal/service/servicequotas/service_package_gen.go
@@ -62,6 +62,12 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*inttypes.Service
 			Name:     "Service Quota",
 			Region:   unique.Make(inttypes.ResourceRegionDefault()),
 		},
+		{
+			Factory:  dataSourceServiceQuotas,
+			TypeName: "aws_servicequotas_service_quotas",
+			Name:     "Service Quotas",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
 	}
 }
 

--- a/internal/service/servicequotas/service_quotas_data_source.go
+++ b/internal/service/servicequotas/service_quotas_data_source.go
@@ -1,0 +1,166 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package servicequotas
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/servicequotas/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_servicequotas_service_quotas", name="Service Quotas")
+func dataSourceServiceQuotas() *schema.Resource { // nosemgrep:ci.servicequotas-in-func-name
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceServiceQuotasRead, // nosemgrep:ci.servicequotas-in-func-name
+
+		Schema: map[string]*schema.Schema{
+			"service_code": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"quotas": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"adjustable": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						names.AttrARN: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrDefaultValue: {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"global_quota": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"quota_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"quota_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"service_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrServiceName: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"usage_metric": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"metric_dimensions": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"class": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"resource": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"service": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												names.AttrType: {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									names.AttrMetricName: {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"metric_namespace": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"metric_statistic_recommendation": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						names.AttrValue: {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceServiceQuotasRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics { // nosemgrep:ci.servicequotas-in-func-name
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).ServiceQuotasClient(ctx)
+
+	serviceCode := d.Get("service_code").(string)
+
+	input := servicequotas.ListAWSDefaultServiceQuotasInput{
+		ServiceCode: aws.String(serviceCode),
+	}
+
+	quotas, err := findDefaultServiceQuotas(ctx, conn, &input, tfslices.PredicateTrue[*awstypes.ServiceQuota]())
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "listing Service Quotas Service Quotas (%s): %s", serviceCode, err)
+	}
+
+	d.SetId(serviceCode)
+
+	if err := d.Set("quotas", flattenServiceQuotas(quotas)); err != nil { // nosemgrep:ci.servicequotas-in-func-name
+		return sdkdiag.AppendErrorf(diags, "setting quotas: %s", err)
+	}
+
+	return diags
+}
+
+func flattenServiceQuotas(apiObjects []awstypes.ServiceQuota) []any { // nosemgrep:ci.servicequotas-in-func-name
+	var tfList []any
+
+	for _, apiObject := range apiObjects {
+		tfList = append(tfList, map[string]any{
+			"adjustable":           apiObject.Adjustable,
+			names.AttrARN:          aws.ToString(apiObject.QuotaArn),
+			names.AttrDefaultValue: aws.ToFloat64(apiObject.Value),
+			"global_quota":         apiObject.GlobalQuota,
+			"quota_code":           aws.ToString(apiObject.QuotaCode),
+			"quota_name":           aws.ToString(apiObject.QuotaName),
+			"service_code":         aws.ToString(apiObject.ServiceCode),
+			names.AttrServiceName:  aws.ToString(apiObject.ServiceName),
+			"usage_metric":         flattenMetricInfo(apiObject.UsageMetric),
+			names.AttrValue:        aws.ToFloat64(apiObject.Value),
+		})
+	}
+
+	return tfList
+}

--- a/internal/service/servicequotas/service_quotas_data_source_test.go
+++ b/internal/service/servicequotas/service_quotas_data_source_test.go
@@ -1,0 +1,76 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package servicequotas_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccServiceQuotasServiceQuotasDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	const dataSourceName = "data.aws_servicequotas_service_quotas.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ServiceQuotasEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceQuotasDataSourceConfig_basic("vpc"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "service_code", "vpc"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServiceQuotasServiceQuotasDataSource_quotaAttributes(t *testing.T) {
+	ctx := acctest.Context(t)
+	const dataSourceName = "data.aws_servicequotas_service_quotas.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ServiceQuotasEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceQuotasDataSourceConfig_basic("vpc"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.quota_code"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.quota_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.value"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.default_value"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.service_code"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.service_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccServiceQuotasDataSourceConfig_basic(serviceCode string) string { // nosemgrep:ci.servicequotas-in-func-name
+	return testAccServiceQuotasDataSourceConfig(serviceCode)
+}
+
+func testAccServiceQuotasDataSourceConfig(serviceCode string) string { // nosemgrep:ci.servicequotas-in-func-name
+	return fmt.Sprintf(`
+data "aws_servicequotas_service_quotas" "test" {
+  service_code = %[1]q
+}
+`, serviceCode)
+}

--- a/website/docs/d/servicequotas_service_quotas.html.markdown
+++ b/website/docs/d/servicequotas_service_quotas.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "Service Quotas"
+layout: "aws"
+page_title: "AWS: aws_servicequotas_service_quotas"
+description: |-
+  Retrieve information about all Service Quotas for a service
+---
+
+# Data Source: aws_servicequotas_service_quotas
+
+Retrieve information about all Service Quotas for a service.
+
+~> **NOTE:** Global quotas apply to all AWS regions, but can only be accessed in `us-east-1` in the Commercial partition or `us-gov-west-1` in the GovCloud partition. In other regions, the AWS API will return the error `The request failed because the specified service does not exist.`
+
+## Example Usage
+
+```terraform
+data "aws_servicequotas_service_quotas" "example" {
+  service_code = "vpc"
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `service_code` - (Required) Service code for the quota. Available values can be found with the [`aws_servicequotas_service` data source](/docs/providers/aws/d/servicequotas_service.html) or [AWS CLI service-quotas list-services command](https://docs.aws.amazon.com/cli/latest/reference/service-quotas/list-services.html).
+* `region` - (Optional) Region associated with the quota. Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `id` - Service code.
+* `quotas` - List of all quotas for the service. Each element contains the following attributes:
+    * `adjustable` - Whether the service quota is adjustable.
+    * `arn` - ARN of the service quota.
+    * `default_value` - Default value of the service quota.
+    * `global_quota` - Whether the service quota is global for the AWS account.
+    * `quota_code` - Quota code for the service quota.
+    * `quota_name` - Name of the service quota.
+    * `service_code` - Service code of the service quota.
+    * `service_name` - Name of the service.
+    * `usage_metric` - Information about the measurement.
+        * `metric_dimensions` - The metric dimensions.
+            * `class`
+            * `resource`
+            * `service`
+            * `type`
+        * `metric_name` - The name of the metric.
+        * `metric_namespace` - The namespace of the metric.
+        * `metric_statistic_recommendation` - The metric statistic that AWS recommend you use when determining quota usage.
+    * `value` - Default value of the service quota.


### PR DESCRIPTION
This closes #46457 and adds a new `aws_servicequotas_service_quotas` data source that lists all default service quotas for a given service code using ListAWSDefaultServiceQuotas. This enables users to enumerate all quotas for a service without first needing to know specific quota codes or names.

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description

This closes #46457 and adds a new `aws_servicequotas_service_quotas` data source that lists all default service quotas for a given service code using ListAWSDefaultServiceQuotas. This enables users to enumerate all quotas for a service without first needing to know specific quota codes or names.

### Relations

Closes #46457 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccServiceQuotasServiceQuotasDataSource_ PKG=servicequotas
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 mdb/service-quotas 🌿...
TF_ACC=1 go1.25.6 test ./internal/service/servicequotas/... -v -count 1 -parallel 20 -run='TestAccServiceQuotasServiceQuotasDataSource_'  -timeout 360m -vet=off
2026/02/13 08:38:57 Creating Terraform AWS Provider (SDKv2-style)...
2026/02/13 08:38:57 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccServiceQuotasServiceQuotasDataSource_basic
=== PAUSE TestAccServiceQuotasServiceQuotasDataSource_basic
=== RUN   TestAccServiceQuotasServiceQuotasDataSource_quotaAttributes
=== PAUSE TestAccServiceQuotasServiceQuotasDataSource_quotaAttributes
=== CONT  TestAccServiceQuotasServiceQuotasDataSource_basic
=== CONT  TestAccServiceQuotasServiceQuotasDataSource_quotaAttributes
--- PASS: TestAccServiceQuotasServiceQuotasDataSource_quotaAttributes (16.04s)
--- PASS: TestAccServiceQuotasServiceQuotasDataSource_basic (16.06s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas	23.913s
```
