### PR TITLE
.ci/semgrep: add `internal-retry-state-refresh-func-zero-value-result` rule

### DIFF
--- a/.ci/semgrep/retry/retry.yml
+++ b/.ci/semgrep/retry/retry.yml
@@ -28,3 +28,31 @@ rules:
       tfresource.SetLastError($ERR, $LASTERR)
     fix: |
       retry.SetLastError($ERR, $LASTERR)
+
+  - id: internal-retry-state-refresh-func-zero-value-result
+    languages: [go]
+    message: |
+      StateRefreshFunc returns a zero value with a non-empty status.
+      The internal/retry package uses reflect.Value.IsZero() to detect "not found" states.
+      Returning zero values with a non-empty status will be incorrectly interpreted as "resource not found".
+    paths:
+      include:
+        - "internal/service"
+    patterns:
+      - pattern-inside: |
+          func $FUNC(...) retry.StateRefreshFunc {
+            return func($CTX context.Context) (any, string, error) {
+              ...
+            }
+          }
+      - pattern-either:
+          - pattern: return struct{}{}, $STATUS, $ERR
+          - pattern: return false, $STATUS, $ERR
+          - pattern: return 0, $STATUS, $ERR
+          - pattern: return 0.0, $STATUS, $ERR
+          - pattern: return "", $STATUS, $ERR
+      - metavariable-pattern:
+          metavariable: $STATUS
+          patterns:
+            - pattern-not: '""'
+    severity: ERROR


### PR DESCRIPTION




<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This rule will capture scenarios where a zero value object is returned with a non-empty status. With the `internal/retry` state refresh logic, a zero value is interpreted to mean the resource was not found. The previous state refresh logic from Terraform Plugin SDK V2 checked only for `nil` values, so this rule aims to monitor for potential regressions when migrating between the two.

Had this been in place, a regression with the AutoScaling Group resource would have been caught:

```
    internal/service/autoscaling/group.go
   ❯❯❱ ci.semgrep.retry.internal-retry-state-refresh-func-zero-value-result
          StateRefreshFunc returns a zero value with a non-empty status. The internal/retry package uses
          reflect.Value.IsZero() to detect "not found" states. Returning zero values with a non-empty status
          will be incorrectly interpreted as "resource not found".

          2440┆ return struct{}{}, err.Error(), nil //nolint:nilerr // err is passed via the result
               State
            ⋮┆----------------------------------------
          2443┆ return struct{}{}, "ok", nil
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #46437
Relates #46452

