### PR TITLE
Additional Logging Arguments for Glue Job

### DIFF
--- a/website/docs/r/glue_job.html.markdown
+++ b/website/docs/r/glue_job.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a Glue Job resource.
 
--> Glue functionality, such as monitoring and logging of jobs, is typically managed with the `default_arguments` argument. See the [Special Parameters Used by AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-glue-arguments.html) topic in the Glue developer guide for additional information.
+-> Glue functionality, such as monitoring and logging of jobs, is typically managed with the `default_arguments` argument. See the [Special Parameters Used by AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-glue-arguments.html) topic in the Glue developer guide for additional information. More Additional parameters for Logging in this Guide [Custom Logging arguments for Glue 5.0 ]([url](https://docs.aws.amazon.com/glue/latest/dg/monitor-continuous-logging.html#monitor-logging-custom))
 
 ## Example Usage
 
@@ -208,6 +208,8 @@ resource "aws_glue_job" "example" {
     "--enable-continuous-cloudwatch-log" = "true"
     "--enable-continuous-log-filter"     = "true"
     "--enable-metrics"                   = ""
+    "--custom-logGroup-prefix"           = "/aws-glue/jobs/example"
+    "--custom-logStream-prefix"          =  "example-driver"
   }
 }
 ```


### PR DESCRIPTION
Added Glue 5.0 Custom Loggroup Arguments
--custom-logGroup-prefix
--custom-logStream-prefix
Updated the documentation with additional link as the first link for arguments doesn't include them https://docs.aws.amazon.com/glue/latest/dg/monitor-continuous-logging.html#monitor-logging-custom

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
