### PR TITLE
docs/db_instance: show correct blue_green_update block syntax

### DIFF
--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -47,7 +47,16 @@ They cannot be used with DB Instances with replicas.
 
 Backups must be enabled to use low-downtime updates.
 
-Enable low-downtime updates by setting `blue_green_update.enabled` to `true`.
+Enable low-downtime updates with the `blue_green_update` block:
+
+```terraform
+resource "aws_db_instance" "default" {
+  # ...
+  blue_green_update {
+    enabled = true
+  }
+}
+```
 
 ## Example Usage
 


### PR DESCRIPTION
## Summary
The `aws_db_instance` docs mention `blue_green_update.enabled`, but this can be misread as argument syntax and leads to `Unsupported argument` errors.

This update adds an explicit example showing the correct nested block form:

```hcl
blue_green_update {
  enabled = true
}
```

## Issue
Closes #44488
