### PR TITLE
docs/quicksight_data_source: clarify rds instance_id expects instance identifier

### DIFF
--- a/website/docs/r/quicksight_data_source.html.markdown
+++ b/website/docs/r/quicksight_data_source.html.markdown
@@ -265,7 +265,7 @@ To specify data source connection parameters, exactly one of the following sub-o
 ### rds Argument Reference
 
 * `database` - (Required) The database to which to connect.
-* `instance_id` - (Optional) The instance ID to which to connect.
+* `instance_id` - (Optional) The RDS instance identifier to which to connect.
 
 ### redshift Argument Reference
 


### PR DESCRIPTION
## Summary
Updates `aws_quicksight_data_source` documentation for the `rds` block to clarify that `instance_id` expects the RDS **instance identifier** value.

This resolves confusion caused by the previous wording, which could be interpreted as the internal DB instance ID.

## Issue
Closes #41672
