### PR TITLE
docs/index: fix multiple broken docs links

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -314,7 +314,7 @@ There are three ways to provide additional User-Agent information.
 ### `user_agent` Provider Argument
 
 When using the `user_agent` provider argument, the items will be appended to the `User-Agent` header in order.
-The [`user_agent` provider-defined function](./functions/user_agent.html.markdown) can be used to format the name, version, and comment components.
+The [`user_agent` provider-defined function](./docs/functions/user_agent.html.markdown) can be used to format the name, version, and comment components.
 
 ```terraform
 provider "aws" {
@@ -341,7 +341,7 @@ This block allows module authors to provide additional information in the `User-
 -> In a module, `provider_meta` is defined within the `terraform` block.
 The `provider` block is inherited from the root module.
 
--> Functions, including the [`user_agent` provider-defined function](./functions/user_agent.html.markdown), cannot be used in the [`terraform` block](https://developer.hashicorp.com/terraform/language/block/terraform#terraform-block).
+-> Functions, including the [`user_agent` provider-defined function](./docs/functions/user_agent.html.markdown), cannot be used in the [`terraform` block](https://developer.hashicorp.com/terraform/language/block/terraform#terraform-block).
 
 ```terraform
 terraform {
@@ -551,7 +551,7 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
   Valid values are `error`, `warning`, and `disabled`.
   When unset or `disabled`, tag policy compliance will not be enforced by the provider.
   Can also be configured with the `TF_AWS_TAG_POLICY_COMPLIANCE` environment variable.
-  See the [Tag Policy Compliance user guide](./guides/tag-policy-compliance.html.markdown) for additional details.
+  See the [Tag Policy Compliance user guide](./docs/guides/tag-policy-compliance.html.markdown) for additional details.
 * `token` - (Optional) Session token for validating temporary credentials. Typically provided after successful identity federation or Multi-Factor Authentication (MFA) login. With MFA login, this is the session token provided afterward, not the 6 digit MFA code used to get temporary credentials.  Can also be set with the `AWS_SESSION_TOKEN` environment variable.
 * `token_bucket_rate_limiter_capacity` - (Optional) The capacity of the AWS SDK's token bucket retry rate limiter. If no value is specified then client-side rate limiting is disabled. If a value is specified there is a greater likelihood of `retry quota exceeded` errors being raised.
 * `use_dualstack_endpoint` - (Optional) Force the provider to resolve endpoints with DualStack capability. Can also be set with the `AWS_USE_DUALSTACK_ENDPOINT` environment variable or in a shared config file (`use_dualstack_endpoint`).


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
Fixes broken links on the main Docs page to the `user_agent` provider defined function, along with a broken link to the **Tag Policy Compliance user guide**.
