### PR TITLE
r/aws_s3tables_table: Add `metadata.iceberg.partition_spec` argument

### DIFF
--- a/.changelog/46532.txt
+++ b/.changelog/46532.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3tables_table: Add `metadata.iceberg.partition_spec` argument
+```

--- a/internal/service/s3tables/table.go
+++ b/internal/service/s3tables/table.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -219,6 +220,63 @@ func (r *tableResource) Schema(ctx context.Context, request resource.SchemaReque
 											listplanmodifier.RequiresReplace(),
 										},
 									},
+									"partition_spec": schema.ListNestedBlock{
+										Description: "Partition specification for the Iceberg table.",
+										NestedObject: schema.NestedBlockObject{
+											Blocks: map[string]schema.Block{
+												names.AttrField: schema.ListNestedBlock{
+													Description: "List of partition fields.",
+													NestedObject: schema.NestedBlockObject{
+														Attributes: map[string]schema.Attribute{
+															"field_id": schema.Int32Attribute{
+																Optional:    true,
+																Computed:    true,
+																Description: "Unique identifier for this partition field. Auto-assigned if not specified.",
+																PlanModifiers: []planmodifier.Int32{
+																	int32planmodifier.RequiresReplace(),
+																	int32planmodifier.UseStateForUnknown(),
+																},
+															},
+															names.AttrName: schema.StringAttribute{
+																Required:    true,
+																Description: "The name for this partition field.",
+																PlanModifiers: []planmodifier.String{
+																	stringplanmodifier.RequiresReplace(),
+																},
+															},
+															"source_id": schema.Int32Attribute{
+																Required:    true,
+																Description: "The ID of the source schema field to partition by.",
+																PlanModifiers: []planmodifier.Int32{
+																	int32planmodifier.RequiresReplace(),
+																},
+															},
+															"transform": schema.StringAttribute{
+																Required:    true,
+																Description: "The partition transform. Valid values: identity, year, month, day, hour, bucket, truncate.",
+																PlanModifiers: []planmodifier.String{
+																	stringplanmodifier.RequiresReplace(),
+																},
+															},
+														},
+													},
+													Validators: []validator.List{
+														listvalidator.IsRequired(),
+														listvalidator.SizeAtLeast(1),
+													},
+													PlanModifiers: []planmodifier.List{
+														listplanmodifier.RequiresReplace(),
+													},
+												},
+											},
+										},
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										PlanModifiers: []planmodifier.List{
+											listplanmodifier.RequiresReplace(),
+										},
+									},
 								},
 							},
 							Validators: []validator.List{
@@ -275,8 +333,16 @@ func (r *tableResource) Create(ctx context.Context, request resource.CreateReque
 		}
 	}
 
-	_, err := conn.CreateTable(ctx, &input)
+	if input.Metadata != nil {
+		if icebergMeta, ok := input.Metadata.(*awstypes.TableMetadataMemberIceberg); ok && icebergMeta.Value.PartitionSpec != nil {
+			response.Diagnostics.Append(resolvePartitionFieldIDs(ctx, icebergMeta, &data)...)
+			if response.Diagnostics.HasError() {
+				return
+			}
+		}
+	}
 
+	_, err := conn.CreateTable(ctx, &input)
 	if err != nil {
 		response.Diagnostics.AddError(fmt.Sprintf("creating S3 Tables Table (%s)", name), err.Error())
 
@@ -1014,7 +1080,19 @@ type tableMetadataModel struct {
 }
 
 type icebergMetadataModel struct {
-	Schema fwtypes.ListNestedObjectValueOf[icebergSchemaModel] `tfsdk:"schema"`
+	PartitionSpec fwtypes.ListNestedObjectValueOf[icebergPartitionSpecModel] `tfsdk:"partition_spec"`
+	Schema        fwtypes.ListNestedObjectValueOf[icebergSchemaModel]        `tfsdk:"schema"`
+}
+
+type icebergPartitionSpecModel struct {
+	Fields fwtypes.ListNestedObjectValueOf[icebergPartitionFieldModel] `tfsdk:"field"`
+}
+
+type icebergPartitionFieldModel struct {
+	FieldId   types.Int32  `tfsdk:"field_id"`
+	Name      types.String `tfsdk:"name"`
+	SourceId  types.Int32  `tfsdk:"source_id"`
+	Transform types.String `tfsdk:"transform"`
 }
 
 type icebergSchemaModel struct {
@@ -1025,6 +1103,62 @@ type icebergSchemaFieldModel struct {
 	Name     types.String `tfsdk:"name"`
 	Required types.Bool   `tfsdk:"required"`
 	Type     types.String `tfsdk:"type"`
+}
+
+// resolvePartitionFieldIDs auto-assigns field IDs starting from 1000 for any
+// partition fields without one, and syncs the values back into the model.
+func resolvePartitionFieldIDs(ctx context.Context, icebergMeta *awstypes.TableMetadataMemberIceberg, data *tableResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// Auto-assign field IDs on the API input (Iceberg convention: starting from 1000).
+	for i := range icebergMeta.Value.PartitionSpec.Fields {
+		if icebergMeta.Value.PartitionSpec.Fields[i].FieldId == nil {
+			fieldId := int32(1000 + i)
+			icebergMeta.Value.PartitionSpec.Fields[i].FieldId = &fieldId
+		}
+	}
+
+	// Sync assigned values back into the Terraform model.
+	metadataModel, d := data.Metadata.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+
+	icebergModel, d := metadataModel.Iceberg.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+
+	if icebergModel.PartitionSpec.IsNull() || icebergModel.PartitionSpec.IsUnknown() {
+		return diags
+	}
+
+	partSpecModel, d := icebergModel.PartitionSpec.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+
+	fields, d := partSpecModel.Fields.ToSlice(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+
+	for i, f := range fields {
+		if f.FieldId.IsUnknown() && i < len(icebergMeta.Value.PartitionSpec.Fields) {
+			fields[i].FieldId = types.Int32Value(*icebergMeta.Value.PartitionSpec.Fields[i].FieldId)
+		}
+	}
+
+	partSpecModel.Fields = fwtypes.NewListNestedObjectValueOfSliceMust(ctx, fields)
+	icebergModel.PartitionSpec = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, partSpecModel)
+	metadataModel.Iceberg = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, icebergModel)
+	data.Metadata = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, metadataModel)
+
+	return diags
 }
 
 var (

--- a/internal/service/s3tables/table_test.go
+++ b/internal/service/s3tables/table_test.go
@@ -588,6 +588,98 @@ func TestAccS3TablesTable_metadata(t *testing.T) {
 	})
 }
 
+func TestAccS3TablesTable_metadataWithPartitionSpec(t *testing.T) {
+	ctx := acctest.Context(t)
+	var table s3tables.GetTableOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	bucketName := rName
+	nsName := strings.ReplaceAll(rName, "-", "_")
+	tableName := strings.ReplaceAll(rName, "-", "_")
+	resourceName := "aws_s3tables_table.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3TablesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_metadataWithPartitionSpec(tableName, nsName, bucketName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableExists(ctx, t, resourceName, &table),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.schema.0.field.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.partition_spec.0.field.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.partition_spec.0.field.0.name", "date_partition"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.partition_spec.0.field.0.source_id", "2"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.partition_spec.0.field.0.transform", "month"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.partition_spec.0.field.0.field_id", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.partition_spec.0.field.1.name", "category_partition"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.partition_spec.0.field.1.source_id", "3"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.partition_spec.0.field.1.transform", "identity"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.partition_spec.0.field.1.field_id", "1001"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    testAccTableImportStateIdFunc(resourceName),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrARN,
+				ImportStateVerifyIgnore:              []string{"metadata"},
+			},
+		},
+	})
+}
+
+func TestAccS3TablesTable_metadataWithPartitionSpecCustomFieldIDs(t *testing.T) {
+	ctx := acctest.Context(t)
+	var table s3tables.GetTableOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	bucketName := rName
+	nsName := strings.ReplaceAll(rName, "-", "_")
+	tableName := strings.ReplaceAll(rName, "-", "_")
+	resourceName := "aws_s3tables_table.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3TablesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_metadataWithPartitionSpecFieldIDs(tableName, nsName, bucketName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableExists(ctx, t, resourceName, &table),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.schema.0.field.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.partition_spec.0.field.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.partition_spec.0.field.0.name", "date_partition"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.partition_spec.0.field.0.source_id", "2"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.partition_spec.0.field.0.transform", "month"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.partition_spec.0.field.0.field_id", "5000"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.partition_spec.0.field.1.name", "category_partition"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.partition_spec.0.field.1.source_id", "3"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.partition_spec.0.field.1.transform", "identity"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.partition_spec.0.field.1.field_id", "5001"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    testAccTableImportStateIdFunc(resourceName),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrARN,
+				ImportStateVerifyIgnore:              []string{"metadata"},
+			},
+		},
+	})
+}
+
 func testAccCheckTableDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).S3TablesClient(ctx)
@@ -814,6 +906,98 @@ resource "aws_s3tables_table" "test" {
           name     = "created_at"
           type     = "timestamp"
           required = true
+        }
+      }
+    }
+  }
+}
+`, tableName))
+}
+
+func testAccTableConfig_metadataWithPartitionSpec(tableName, nsName, bucketName string) string {
+	return acctest.ConfigCompose(testAccTableConfig_base(nsName, bucketName), fmt.Sprintf(`
+resource "aws_s3tables_table" "test" {
+  name             = %[1]q
+  namespace        = aws_s3tables_namespace.test.namespace
+  table_bucket_arn = aws_s3tables_namespace.test.table_bucket_arn
+  format           = "ICEBERG"
+
+  metadata {
+    iceberg {
+      schema {
+        field {
+          name     = "id"
+          type     = "int"
+          required = true
+        }
+        field {
+          name     = "event_date"
+          type     = "date"
+          required = true
+        }
+        field {
+          name = "category"
+          type = "string"
+        }
+      }
+
+      partition_spec {
+        field {
+          name      = "date_partition"
+          source_id = 2
+          transform = "month"
+        }
+        field {
+          name      = "category_partition"
+          source_id = 3
+          transform = "identity"
+        }
+      }
+    }
+  }
+}
+`, tableName))
+}
+
+func testAccTableConfig_metadataWithPartitionSpecFieldIDs(tableName, nsName, bucketName string) string {
+	return acctest.ConfigCompose(testAccTableConfig_base(nsName, bucketName), fmt.Sprintf(`
+resource "aws_s3tables_table" "test" {
+  name             = %[1]q
+  namespace        = aws_s3tables_namespace.test.namespace
+  table_bucket_arn = aws_s3tables_namespace.test.table_bucket_arn
+  format           = "ICEBERG"
+
+  metadata {
+    iceberg {
+      schema {
+        field {
+          name     = "id"
+          type     = "int"
+          required = true
+        }
+        field {
+          name     = "event_date"
+          type     = "date"
+          required = true
+        }
+        field {
+          name = "category"
+          type = "string"
+        }
+      }
+
+      partition_spec {
+        field {
+          name      = "date_partition"
+          source_id = 2
+          transform = "month"
+          field_id  = 5000
+        }
+        field {
+          name      = "category_partition"
+          source_id = 3
+          transform = "identity"
+          field_id  = 5001
         }
       }
     }

--- a/website/docs/r/s3tables_table.html.markdown
+++ b/website/docs/r/s3tables_table.html.markdown
@@ -79,6 +79,60 @@ resource "aws_s3tables_table_bucket" "example" {
 }
 ```
 
+### With Metadata Schema and Partition Spec
+
+```terraform
+resource "aws_s3tables_table" "example" {
+  name             = "example_table"
+  namespace        = aws_s3tables_namespace.example.namespace
+  table_bucket_arn = aws_s3tables_namespace.example.table_bucket_arn
+  format           = "ICEBERG"
+
+  metadata {
+    iceberg {
+      schema {
+        field {
+          name     = "id"
+          type     = "long"
+          required = true
+        }
+        field {
+          name     = "event_date"
+          type     = "date"
+          required = true
+        }
+        field {
+          name = "category"
+          type = "string"
+        }
+      }
+
+      partition_spec {
+        field {
+          name      = "date_partition"
+          source_id = 2
+          transform = "month"
+        }
+        field {
+          name      = "category_partition"
+          source_id = 3
+          transform = "identity"
+        }
+      }
+    }
+  }
+}
+
+resource "aws_s3tables_namespace" "example" {
+  namespace        = "example_namespace"
+  table_bucket_arn = aws_s3tables_table_bucket.example.arn
+}
+
+resource "aws_s3tables_table_bucket" "example" {
+  name = "example-bucket"
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -164,25 +218,43 @@ The `metadata` configuration block supports the following argument:
 
 ### `iceberg`
 
-The `iceberg` configuration block supports the following argument:
+The `iceberg` configuration block supports the following arguments:
 
 * `schema` - (Required) Schema configuration for the Iceberg table.
   [See `schema` below](#schema).
+* `partition_spec` - (Optional, Forces new resource) Partition specification for the Iceberg table.
+  [See `partition_spec` below](#partition_spec).
 
 ### `schema`
 
 The `schema` configuration block supports the following argument:
 
 * `field` - (Required) List of schema fields for the Iceberg table. Each field defines a column in the table schema.
-  [See `field` below](#field).
+  [See `schema.field` below](#schemafield).
 
-### `field`
+### `schema.field`
 
-The `field` configuration block supports the following arguments:
+The `schema` `field` configuration block supports the following arguments:
 
 * `name` - (Required) The name of the field.
 * `type` - (Required) The field type. S3 Tables supports all Apache Iceberg primitive types including: `boolean`, `int`, `long`, `float`, `double`, `decimal(precision,scale)`, `date`, `time`, `timestamp`, `timestamptz`, `string`, `uuid`, `fixed(length)`, `binary`.
 * `required` - (Optional) A Boolean value that specifies whether values are required for each row in this field. Defaults to `false`.
+
+### `partition_spec`
+
+The `partition_spec` configuration block supports the following argument:
+
+* `field` - (Required) List of partition fields that define how the table data is partitioned. At least one field must be specified.
+  [See `partition_spec.field` below](#partition_specfield).
+
+### `partition_spec.field`
+
+The `partition_spec` `field` configuration block supports the following arguments:
+
+* `name` - (Required, Forces new resource) The name for this partition field. This name is used in the partitioned file paths.
+* `source_id` - (Required, Forces new resource) The ID of the source schema field to partition by. This must reference a valid field ID from the table schema.
+* `transform` - (Required, Forces new resource) The partition transform to apply to the source field. Valid values: `identity`, `year`, `month`, `day`, `hour`, `bucket`, `truncate`.
+* `field_id` - (Optional, Forces new resource) Unique identifier for this partition field. Auto-assigned if not specified.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add support for the `partition_spec` when creating a new S3Tables table.

I implemented the changes mostly based on the [AWS SDK go V2 CreateTable API](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3tables#CreateTableInput)

The partition_spec's `field_id` is set to auto-increment from 1000 based on the [Iceberg implementation](https://github.com/apache/iceberg/blob/d06e6c22fecf00be81f2eb399f090fae320560a4/api/src/main/java/org/apache/iceberg/PartitionSpec.java#L55) and I verified the aws cli also uses the same starting ID when a table is created without specifying the field_ids.

The acceptance tests are currently failing due to an unrelated issue that has been discussed in https://github.com/hashicorp/terraform-provider-aws/issues/46033

With the suggested patch in https://github.com/hashicorp/terraform-provider-aws/pull/46150, the tests are passing

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #46494

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/AmazonS3/latest/API/API_s3Buckets_CreateTable.html
- https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3tables@v1.14.0/types#IcebergMetadata

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

#### Output with Encryption configuration patch
```console
% make testacc TESTS='TestAccS3TablesTable_metadata' PKG=s3tables
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-s3tables_table-partition_spec 🌿...
TF_ACC=1 go1.25.7 test ./internal/service/s3tables/... -v -count 1 -parallel 20 -run='TestAccS3TablesTable_metadata'  -timeout 360m -vet=off
2026/02/18 18:58:56 Creating Terraform AWS Provider (SDKv2-style)...
2026/02/18 18:58:56 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3TablesTable_metadata
=== PAUSE TestAccS3TablesTable_metadata
=== RUN   TestAccS3TablesTable_metadataWithPartitionSpec
=== PAUSE TestAccS3TablesTable_metadataWithPartitionSpec
=== RUN   TestAccS3TablesTable_metadataWithPartitionSpecCustomFieldIDs
=== PAUSE TestAccS3TablesTable_metadataWithPartitionSpecCustomFieldIDs
=== CONT  TestAccS3TablesTable_metadata
=== CONT  TestAccS3TablesTable_metadataWithPartitionSpecCustomFieldIDs
=== CONT  TestAccS3TablesTable_metadataWithPartitionSpec
--- PASS: TestAccS3TablesTable_metadataWithPartitionSpecCustomFieldIDs (14.28s)
--- PASS: TestAccS3TablesTable_metadata (14.43s)
--- PASS: TestAccS3TablesTable_metadataWithPartitionSpec (14.87s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3tables   21.277s
```

#### Output without patch

```console
% make testacc TESTS='TestAccS3TablesTable_metadata' PKG=s3tables
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-s3tables_table-partition_spec 🌿...
TF_ACC=1 go1.25.7 test ./internal/service/s3tables/... -v -count 1 -parallel 20 -run='TestAccS3TablesTable_metadata'  -timeout 360m -vet=off
2026/02/18 18:46:31 Creating Terraform AWS Provider (SDKv2-style)...
2026/02/18 18:46:31 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3TablesTable_metadata
=== PAUSE TestAccS3TablesTable_metadata
=== RUN   TestAccS3TablesTable_metadataWithPartitionSpec
=== PAUSE TestAccS3TablesTable_metadataWithPartitionSpec
=== RUN   TestAccS3TablesTable_metadataWithPartitionSpecCustomFieldIDs
=== PAUSE TestAccS3TablesTable_metadataWithPartitionSpecCustomFieldIDs
=== CONT  TestAccS3TablesTable_metadata
=== CONT  TestAccS3TablesTable_metadataWithPartitionSpecCustomFieldIDs
=== CONT  TestAccS3TablesTable_metadataWithPartitionSpec
    table_test.go:600: Step 1/2 error: Error running apply: exit status 1

        Error: Provider produced inconsistent result after apply

        When applying changes to aws_s3tables_table_bucket.test, provider
        "provider[\"registry.terraform.io/hashicorp/aws\"]" produced an unexpected
        new value: .encryption_configuration: was null, but now
        cty.ObjectVal(map[string]cty.Value{"kms_key_arn":cty.NullVal(cty.String),
        "sse_algorithm":cty.StringVal("AES256")}).

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
=== NAME  TestAccS3TablesTable_metadata
    table_test.go:554: Step 1/2 error: Error running apply: exit status 1

        Error: Provider produced inconsistent result after apply

        When applying changes to aws_s3tables_table_bucket.test, provider
        "provider[\"registry.terraform.io/hashicorp/aws\"]" produced an unexpected
        new value: .encryption_configuration: was null, but now
        cty.ObjectVal(map[string]cty.Value{"kms_key_arn":cty.NullVal(cty.String),
        "sse_algorithm":cty.StringVal("AES256")}).

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
=== NAME  TestAccS3TablesTable_metadataWithPartitionSpecCustomFieldIDs
    table_test.go:646: Step 1/2 error: Error running apply: exit status 1

        Error: Provider produced inconsistent result after apply

        When applying changes to aws_s3tables_table_bucket.test, provider
        "provider[\"registry.terraform.io/hashicorp/aws\"]" produced an unexpected
        new value: .encryption_configuration: was null, but now
        cty.ObjectVal(map[string]cty.Value{"kms_key_arn":cty.NullVal(cty.String),
        "sse_algorithm":cty.StringVal("AES256")}).

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
--- FAIL: TestAccS3TablesTable_metadata (7.41s)
--- FAIL: TestAccS3TablesTable_metadataWithPartitionSpecCustomFieldIDs (7.42s)
--- FAIL: TestAccS3TablesTable_metadataWithPartitionSpec (7.73s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/s3tables   13.693s
FAIL
make: *** [testacc] Error 1
```