### PR TITLE
Implement remediation_types for aws_controltower_landing_zone resource

### DIFF
--- a/.changelog/46538.txt
+++ b/.changelog/46538.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_controltower_landing_zone: Add `remediation_types` argument
+```

--- a/internal/service/controltower/controltower_test.go
+++ b/internal/service/controltower/controltower_test.go
@@ -14,9 +14,10 @@ func TestAccControlTower_serial(t *testing.T) {
 
 	testCases := map[string]map[string]func(t *testing.T){
 		"LandingZone": {
-			acctest.CtBasic:      testAccLandingZone_basic,
-			acctest.CtDisappears: testAccLandingZone_disappears,
-			"tags":               testAccLandingZone_tags,
+			acctest.CtBasic:        testAccLandingZone_basic,
+			acctest.CtDisappears:   testAccLandingZone_disappears,
+			"tags":                 testAccLandingZone_tags,
+			"remediationTypes":     testAccLandingZone_remediationTypes,
 		},
 		"Control": {
 			acctest.CtBasic:      testAccControl_basic,

--- a/internal/service/controltower/landing_zone.go
+++ b/internal/service/controltower/landing_zone.go
@@ -84,6 +84,14 @@ func resourceLandingZone() *schema.Resource {
 					return json
 				},
 			},
+			"remediation_types": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: enum.Validate[types.RemediationType](),
+				},
+			},
 			names.AttrVersion: {
 				Type:     schema.TypeString,
 				Required: true,
@@ -107,6 +115,10 @@ func resourceLandingZoneCreate(ctx context.Context, d *schema.ResourceData, meta
 		Manifest: manifest,
 		Tags:     getTagsIn(ctx),
 		Version:  aws.String(d.Get(names.AttrVersion).(string)),
+	}
+
+	if v, ok := d.GetOk("remediation_types"); ok && v.(*schema.Set).Len() > 0 {
+		input.RemediationTypes = expandRemediationTypes(v.(*schema.Set).List())
 	}
 
 	output, err := conn.CreateLandingZone(ctx, input)
@@ -165,6 +177,7 @@ func resourceLandingZoneRead(ctx context.Context, d *schema.ResourceData, meta a
 	} else {
 		d.Set("manifest_json", nil)
 	}
+	d.Set("remediation_types", flattenRemediationTypes(landingZone.RemediationTypes))
 	d.Set(names.AttrVersion, landingZone.Version)
 
 	return diags
@@ -184,6 +197,10 @@ func resourceLandingZoneUpdate(ctx context.Context, d *schema.ResourceData, meta
 			LandingZoneIdentifier: aws.String(d.Id()),
 			Manifest:              manifest,
 			Version:               aws.String(d.Get(names.AttrVersion).(string)),
+		}
+
+		if v, ok := d.GetOk("remediation_types"); ok && v.(*schema.Set).Len() > 0 {
+			input.RemediationTypes = expandRemediationTypes(v.(*schema.Set).List())
 		}
 
 		output, err := conn.UpdateLandingZone(ctx, input)
@@ -314,6 +331,26 @@ func waitLandingZoneOperationSucceeded(ctx context.Context, conn *controltower.C
 	}
 
 	return nil, err
+}
+
+func expandRemediationTypes(tfList []any) []types.RemediationType {
+	apiObjects := make([]types.RemediationType, 0, len(tfList))
+
+	for _, v := range tfList {
+		apiObjects = append(apiObjects, types.RemediationType(v.(string)))
+	}
+
+	return apiObjects
+}
+
+func flattenRemediationTypes(apiObjects []types.RemediationType) []string {
+	tfList := make([]string, 0, len(apiObjects))
+
+	for _, v := range apiObjects {
+		tfList = append(tfList, string(v))
+	}
+
+	return tfList
 }
 
 func flattenLandingZoneDriftStatusSummary(apiObject *types.LandingZoneDriftStatusSummary) map[string]any {

--- a/internal/service/controltower/landing_zone_test.go
+++ b/internal/service/controltower/landing_zone_test.go
@@ -51,6 +51,38 @@ func testAccLandingZone_basic(t *testing.T) {
 	})
 }
 
+func testAccLandingZone_remediationTypes(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_controltower_landing_zone.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+			testAccPreCheck(ctx, t)
+			testAccPreCheckNoLandingZone(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ControlTowerServiceID),
+		CheckDestroy:             testAccCheckLandingZoneDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLandingZoneConfig_remediationTypes,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLandingZoneExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "remediation_types.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "remediation_types.*", "INHERITANCE_DRIFT"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccLandingZone_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_controltower_landing_zone.test"
@@ -227,3 +259,13 @@ resource "aws_controltower_landing_zone" "test" {
 }
 `, acctest.Region(), landingZoneVersion, tagKey1, tagValue1, tagKey2, tagValue2)
 }
+
+var testAccLandingZoneConfig_remediationTypes = fmt.Sprintf(`
+resource "aws_controltower_landing_zone" "test" {
+  manifest_json = file("${path.module}/test-fixtures/LandingZoneManifest.json")
+
+  version = %[2]q
+
+  remediation_types = ["INHERITANCE_DRIFT"]
+}
+`, acctest.Region(), landingZoneVersion)

--- a/website/docs/r/controltower_landing_zone.html.markdown
+++ b/website/docs/r/controltower_landing_zone.html.markdown
@@ -20,6 +20,16 @@ resource "aws_controltower_landing_zone" "example" {
 }
 ```
 
+### With Automatic Enrollment
+
+```terraform
+resource "aws_controltower_landing_zone" "example" {
+  manifest_json     = file("${path.module}/LandingZoneManifest.json")
+  version           = "3.3"
+  remediation_types = ["INHERITANCE_DRIFT"]
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
@@ -27,6 +37,7 @@ This resource supports the following arguments:
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `manifest_json` - (Required) The manifest JSON file is a text file that describes your AWS resources. For examples, review [Launch your landing zone](https://docs.aws.amazon.com/controltower/latest/userguide/lz-api-launch).
 * `version` - (Required) The landing zone version.
+* `remediation_types` - (Optional) The types of remediation actions to apply to the landing zone, such as automatic drift correction. Valid values: `INHERITANCE_DRIFT`. See [Configure automatic enrollment](https://docs.aws.amazon.com/controltower/latest/userguide/configure-auto-enroll.html) for more information.
 * `tags` - (Optional) Tags to apply to the landing zone. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference


### PR DESCRIPTION
### Description
This PR adds the remediation_types attribute to aws_controltower_landing_zone. 

AWS Control Tower released support for automatic enrollment of accounts in [November 2025](https://aws.amazon.com/about-aws/whats-new/2025/11/aws-control-tower-automatic-enrollment/). This feature allows accounts to be automatically enrolled when moved between Organizational Units, applying appropriate controls and configurations without manual intervention.

The [AWS Control Tower API](https://docs.aws.amazon.com/controltower/latest/APIReference/API_CreateLandingZone.html) supports this via the remediationTypes parameter in the [CreateLandingZone](https://docs.aws.amazon.com/controltower/latest/APIReference/API_CreateLandingZone.html#API_CreateLandingZone_RequestSyntax) and [UpdateLandingZone](https://docs.aws.amazon.com/controltower/latest/APIReference/API_UpdateLandingZone.html#API_UpdateLandingZone_RequestSyntax) APIs, but the Terraform [aws_controltower_landing_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/controltower_landing_zone) resource does not currently expose this parameter.

### Relations
Closes #45641

### References
AWS Documentation:

    AWS Feature Announcement: https://aws.amazon.com/about-aws/whats-new/2025/11/aws-control-tower-automatic-enrollment/
    AWS Control Tower User Guide - Configure Auto-enrollment: https://docs.aws.amazon.com/controltower/latest/userguide/configure-auto-enroll.html
    AWS Control Tower User Guide - Move and Enroll Accounts: https://docs.aws.amazon.com/controltower/latest/userguide/account-auto-enrollment.html
    CreateLandingZone API Reference: https://docs.aws.amazon.com/controltower/latest/APIReference/API_CreateLandingZone.html
    UpdateLandingZone API Reference: https://docs.aws.amazon.com/controltower/latest/APIReference/API_UpdateLandingZone.html
    GetLandingZone API Reference: https://docs.aws.amazon.com/controltower/latest/APIReference/API_GetLandingZone.html

AWS Go SDK v2:

    Control Tower Package: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/controltower
    CreateLandingZone Method: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/controltower#Client.CreateLandingZone
    UpdateLandingZone Method: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/controltower#Client.UpdateLandingZone
    GetLandingZone Method: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/controltower#Client.GetLandingZone
    RemediationType Type: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/controltower/types#RemediationType

### Output from Acceptance Testing
I don't have access to a test organisation to run these tests unfortunately. Can someone who has such access assist me here?

```console
# Run just remediationTypes subtest:
make testacc TESTS="TestAccControlTower_serial/LandingZone/remediationTypes" PKG=controltower

# Or run all Control Tower Landing Zone tests (basic, disappears, tags, remediationTypes):
make testacc TESTS="TestAccControlTower_serial/LandingZone" PKG=controltower
```
