### PR TITLE
iam: enable `go-vcr` support

### DIFF
--- a/internal/service/iam/access_key.go
+++ b/internal/service/iam/access_key.go
@@ -17,7 +17,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
@@ -315,9 +314,8 @@ func findAccessKeys(ctx context.Context, conn *iam.Client, input *iam.ListAccess
 		page, err := pages.NextPage(ctx)
 
 		if errs.IsA[*awstypes.NoSuchEntityException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 

--- a/internal/service/iam/access_keys_data_source_test.go
+++ b/internal/service/iam/access_keys_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -15,18 +14,18 @@ import (
 
 func TestAccIAMAccessKeysDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_iam_access_keys.test"
 	resourceName := "aws_iam_access_key.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.IAM)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAccessKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckAccessKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccessKeysDataSourceConfig_basic(rName),
@@ -43,19 +42,19 @@ func TestAccIAMAccessKeysDataSource_basic(t *testing.T) {
 
 func TestAccIAMAccessKeysDataSource_twoKeys(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_iam_access_keys.test"
 	resourceName1 := "aws_iam_access_key.test.0"
 	resourceName2 := "aws_iam_access_key.test.1"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.IAM)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAccessKeyDestroy(ctx),
+		CheckDestroy:             testAccCheckAccessKeyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccessKeysDataSourceConfig_twoKeys(rName),

--- a/internal/service/iam/account_alias_data_source_test.go
+++ b/internal/service/iam/account_alias_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -18,16 +17,16 @@ func testAccAccountAliasDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_iam_account_alias.test"
 	resourceName := "aws_iam_account_alias.test"
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckAccountAlias(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAccountAliasDestroy(ctx),
+		CheckDestroy:             testAccCheckAccountAliasDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccountAliasDataSourceConfig_basic(rName),

--- a/internal/service/iam/account_alias_test.go
+++ b/internal/service/iam/account_alias_test.go
@@ -11,11 +11,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -40,21 +38,21 @@ func TestAccIAMAccountAlias_serial(t *testing.T) {
 func testAccAccountAlias_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_account_alias.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckAccountAlias(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAccountAliasDestroy(ctx),
+		CheckDestroy:             testAccCheckAccountAliasDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccountAliasConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAccountAliasExists(ctx, resourceName),
+					testAccCheckAccountAliasExists(ctx, t, resourceName),
 				),
 			},
 			{
@@ -69,21 +67,21 @@ func testAccAccountAlias_basic(t *testing.T) {
 func testAccAccountAlias_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_account_alias.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckAccountAlias(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAccountAliasDestroy(ctx),
+		CheckDestroy:             testAccCheckAccountAliasDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccountAliasConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAccountAliasExists(ctx, resourceName),
+					testAccCheckAccountAliasExists(ctx, t, resourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceAccountAlias(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -92,9 +90,9 @@ func testAccAccountAlias_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckAccountAliasDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckAccountAliasDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_account_alias" {
@@ -119,14 +117,14 @@ func testAccCheckAccountAliasDestroy(ctx context.Context) resource.TestCheckFunc
 	}
 }
 
-func testAccCheckAccountAliasExists(ctx context.Context, n string) resource.TestCheckFunc {
+func testAccCheckAccountAliasExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		var input iam.ListAccountAliasesInput
 		_, err := tfiam.FindAccountAlias(ctx, conn, &input)
@@ -136,10 +134,10 @@ func testAccCheckAccountAliasExists(ctx context.Context, n string) resource.Test
 }
 
 func testAccPreCheckAccountAlias(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+	conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 	input := &iam.CreateAccountAliasInput{
-		AccountAlias: aws.String(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)),
+		AccountAlias: aws.String(acctest.RandomWithPrefix(t, acctest.ResourcePrefix)),
 	}
 	_, err := conn.CreateAccountAlias(ctx, input)
 

--- a/internal/service/iam/account_password_policy.go
+++ b/internal/service/iam/account_password_policy.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -189,9 +188,8 @@ func findAccountPasswordPolicy(ctx context.Context, conn *iam.Client) (*awstypes
 	output, err := conn.GetAccountPasswordPolicy(ctx, input)
 
 	if errs.IsA[*awstypes.NoSuchEntityException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/iam/account_password_policy_test.go
+++ b/internal/service/iam/account_password_policy_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -34,16 +33,16 @@ func testAccAccountPasswordPolicy_basic(t *testing.T) {
 	var policy awstypes.PasswordPolicy
 	resourceName := "aws_iam_account_password_policy.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAccountPasswordPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckAccountPasswordPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccountPasswordPolicyConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAccountPasswordPolicyExists(ctx, resourceName, &policy),
+					testAccCheckAccountPasswordPolicyExists(ctx, t, resourceName, &policy),
 					resource.TestCheckResourceAttr(resourceName, "minimum_password_length", "8"),
 				),
 			},
@@ -55,7 +54,7 @@ func testAccAccountPasswordPolicy_basic(t *testing.T) {
 			{
 				Config: testAccAccountPasswordPolicyConfig_modified,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAccountPasswordPolicyExists(ctx, resourceName, &policy),
+					testAccCheckAccountPasswordPolicyExists(ctx, t, resourceName, &policy),
 					resource.TestCheckResourceAttr(resourceName, "minimum_password_length", "7"),
 				),
 			},
@@ -68,16 +67,16 @@ func testAccAccountPasswordPolicy_disappears(t *testing.T) {
 	var policy awstypes.PasswordPolicy
 	resourceName := "aws_iam_account_password_policy.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAccountPasswordPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckAccountPasswordPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccountPasswordPolicyConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAccountPasswordPolicyExists(ctx, resourceName, &policy),
+					testAccCheckAccountPasswordPolicyExists(ctx, t, resourceName, &policy),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceAccountPasswordPolicy(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -86,9 +85,9 @@ func testAccAccountPasswordPolicy_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckAccountPasswordPolicyDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckAccountPasswordPolicyDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_account_password_policy" {
@@ -112,7 +111,7 @@ func testAccCheckAccountPasswordPolicyDestroy(ctx context.Context) resource.Test
 	}
 }
 
-func testAccCheckAccountPasswordPolicyExists(ctx context.Context, n string, v *awstypes.PasswordPolicy) resource.TestCheckFunc {
+func testAccCheckAccountPasswordPolicyExists(ctx context.Context, t *testing.T, n string, v *awstypes.PasswordPolicy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -123,7 +122,7 @@ func testAccCheckAccountPasswordPolicyExists(ctx context.Context, n string, v *a
 			return fmt.Errorf("No IAM Account Password Policy ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		output, err := tfiam.FindAccountPasswordPolicy(ctx, conn)
 

--- a/internal/service/iam/group.go
+++ b/internal/service/iam/group.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -175,9 +174,8 @@ func findGroupByName(ctx context.Context, conn *iam.Client, name string) (*awsty
 	output, err := conn.GetGroup(ctx, input)
 
 	if errs.IsA[*awstypes.NoSuchEntityException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/iam/group_data_source_test.go
+++ b/internal/service/iam/group_data_source_test.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -16,9 +15,9 @@ import (
 
 func TestAccIAMGroupDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	groupName := fmt.Sprintf("test-datasource-user-%d", sdkacctest.RandInt())
+	groupName := fmt.Sprintf("test-datasource-user-%d", acctest.RandInt(t))
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -38,12 +37,12 @@ func TestAccIAMGroupDataSource_basic(t *testing.T) {
 
 func TestAccIAMGroupDataSource_users(t *testing.T) {
 	ctx := acctest.Context(t)
-	groupName := fmt.Sprintf("test-datasource-group-%d", sdkacctest.RandInt())
-	userName := fmt.Sprintf("test-datasource-user-%d", sdkacctest.RandInt())
-	groupMemberShipName := fmt.Sprintf("test-datasource-group-membership-%d", sdkacctest.RandInt())
+	groupName := fmt.Sprintf("test-datasource-group-%d", acctest.RandInt(t))
+	userName := fmt.Sprintf("test-datasource-user-%d", acctest.RandInt(t))
+	groupMemberShipName := fmt.Sprintf("test-datasource-group-membership-%d", acctest.RandInt(t))
 	userCount := 101
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/iam/group_policies_exclusive.go
+++ b/internal/service/iam/group_policies_exclusive.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
@@ -202,9 +201,8 @@ func findGroupPoliciesByName(ctx context.Context, conn *iam.Client, groupName st
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			if errs.IsA[*awstypes.NoSuchEntityException](err) {
-				return nil, &sdkretry.NotFoundError{
-					LastError:   err,
-					LastRequest: in,
+				return nil, &retry.NotFoundError{
+					LastError: err,
 				}
 			}
 			return policyNames, err

--- a/internal/service/iam/group_policies_exclusive_test.go
+++ b/internal/service/iam/group_policies_exclusive_test.go
@@ -13,11 +13,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
@@ -29,25 +27,25 @@ func TestAccIAMGroupPoliciesExclusive_basic(t *testing.T) {
 
 	var group types.Group
 	var groupPolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policies_exclusive.test"
 	groupResourceName := "aws_iam_group.test"
 	groupPolicyResourceName := "aws_iam_group_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupPoliciesExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupPoliciesExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupExists(ctx, groupResourceName, &group),
-					testAccCheckGroupPolicyExists(ctx, groupPolicyResourceName, &groupPolicy),
-					testAccCheckGroupPoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckGroupExists(ctx, t, groupResourceName, &group),
+					testAccCheckGroupPolicyExists(ctx, t, groupPolicyResourceName, &groupPolicy),
+					testAccCheckGroupPoliciesExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrGroupName, groupResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_names.*", groupPolicyResourceName, names.AttrName),
 				),
@@ -68,25 +66,25 @@ func TestAccIAMGroupPoliciesExclusive_disappears_Group(t *testing.T) {
 
 	var group types.Group
 	var groupPolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policies_exclusive.test"
 	groupResourceName := "aws_iam_group.test"
 	groupPolicyResourceName := "aws_iam_group_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupPoliciesExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupPoliciesExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupExists(ctx, groupResourceName, &group),
-					testAccCheckGroupPolicyExists(ctx, groupPolicyResourceName, &groupPolicy),
-					testAccCheckGroupPoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckGroupExists(ctx, t, groupResourceName, &group),
+					testAccCheckGroupPolicyExists(ctx, t, groupPolicyResourceName, &groupPolicy),
+					testAccCheckGroupPoliciesExclusiveExists(ctx, t, resourceName),
 					// Inline policy must be deleted before the group can be
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceGroupPolicy(), groupPolicyResourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceGroup(), groupResourceName),
@@ -102,27 +100,27 @@ func TestAccIAMGroupPoliciesExclusive_multiple(t *testing.T) {
 
 	var group types.Group
 	var groupPolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policies_exclusive.test"
 	groupResourceName := "aws_iam_group.test"
 	groupPolicyResourceName := "aws_iam_group_policy.test"
 	groupPolicyResourceName2 := "aws_iam_group_policy.test2"
 	groupPolicyResourceName3 := "aws_iam_group_policy.test3"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupPoliciesExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupPoliciesExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPoliciesExclusiveConfig_multiple(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupExists(ctx, groupResourceName, &group),
-					testAccCheckGroupPolicyExists(ctx, groupPolicyResourceName, &groupPolicy),
-					testAccCheckGroupPoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckGroupExists(ctx, t, groupResourceName, &group),
+					testAccCheckGroupPolicyExists(ctx, t, groupPolicyResourceName, &groupPolicy),
+					testAccCheckGroupPoliciesExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrGroupName, groupResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_names.*", groupPolicyResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_names.*", groupPolicyResourceName2, names.AttrName),
@@ -139,9 +137,9 @@ func TestAccIAMGroupPoliciesExclusive_multiple(t *testing.T) {
 			{
 				Config: testAccGroupPoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupExists(ctx, groupResourceName, &group),
-					testAccCheckGroupPolicyExists(ctx, groupPolicyResourceName, &groupPolicy),
-					testAccCheckGroupPoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckGroupExists(ctx, t, groupResourceName, &group),
+					testAccCheckGroupPolicyExists(ctx, t, groupPolicyResourceName, &groupPolicy),
+					testAccCheckGroupPoliciesExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrGroupName, groupResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_names.*", groupPolicyResourceName, names.AttrName),
 				),
@@ -154,23 +152,23 @@ func TestAccIAMGroupPoliciesExclusive_empty(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var group types.Group
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policies_exclusive.test"
 	groupResourceName := "aws_iam_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupPoliciesExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupPoliciesExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPoliciesExclusiveConfig_empty(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupExists(ctx, groupResourceName, &group),
-					testAccCheckGroupPoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckGroupExists(ctx, t, groupResourceName, &group),
+					testAccCheckGroupPoliciesExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrGroupName, groupResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "policy_names.#", "0"),
 				),
@@ -187,30 +185,30 @@ func TestAccIAMGroupPoliciesExclusive_outOfBandRemoval(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var group types.Group
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policies_exclusive.test"
 	groupResourceName := "aws_iam_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupExists(ctx, groupResourceName, &group),
-					testAccCheckGroupPoliciesExclusiveExists(ctx, resourceName),
-					testAccCheckGroupPolicyRemoveInlinePolicy(ctx, &group, rName),
+					testAccCheckGroupExists(ctx, t, groupResourceName, &group),
+					testAccCheckGroupPoliciesExclusiveExists(ctx, t, resourceName),
+					testAccCheckGroupPolicyRemoveInlinePolicy(ctx, t, &group, rName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccGroupPoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupExists(ctx, groupResourceName, &group),
-					testAccCheckGroupPoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckGroupExists(ctx, t, groupResourceName, &group),
+					testAccCheckGroupPoliciesExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrGroupName, groupResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "policy_names.#", "1"),
 				),
@@ -224,31 +222,31 @@ func TestAccIAMGroupPoliciesExclusive_outOfBandAddition(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var group types.Group
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	policyName := rName + "-out-of-band"
 	resourceName := "aws_iam_group_policies_exclusive.test"
 	groupResourceName := "aws_iam_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupExists(ctx, groupResourceName, &group),
-					testAccCheckGroupPoliciesExclusiveExists(ctx, resourceName),
-					testAccCheckGroupPolicyAddInlinePolicy(ctx, &group, policyName),
+					testAccCheckGroupExists(ctx, t, groupResourceName, &group),
+					testAccCheckGroupPoliciesExclusiveExists(ctx, t, resourceName),
+					testAccCheckGroupPolicyAddInlinePolicy(ctx, t, &group, policyName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccGroupPoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupExists(ctx, groupResourceName, &group),
-					testAccCheckGroupPoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckGroupExists(ctx, t, groupResourceName, &group),
+					testAccCheckGroupPoliciesExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrGroupName, groupResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "policy_names.#", "1"),
 				),
@@ -257,9 +255,9 @@ func TestAccIAMGroupPoliciesExclusive_outOfBandAddition(t *testing.T) {
 	})
 }
 
-func testAccCheckGroupPoliciesExclusiveDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckGroupPoliciesExclusiveDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_group_policies_exclusive" {
@@ -282,7 +280,7 @@ func testAccCheckGroupPoliciesExclusiveDestroy(ctx context.Context) resource.Tes
 	}
 }
 
-func testAccCheckGroupPoliciesExclusiveExists(ctx context.Context, name string) resource.TestCheckFunc {
+func testAccCheckGroupPoliciesExclusiveExists(ctx context.Context, t *testing.T, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -294,7 +292,7 @@ func testAccCheckGroupPoliciesExclusiveExists(ctx context.Context, name string) 
 			return create.Error(names.IAM, create.ErrActionCheckingExistence, tfiam.ResNameGroupPoliciesExclusive, name, errors.New("not set"))
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 		out, err := tfiam.FindGroupPoliciesByName(ctx, conn, groupName)
 		if err != nil {
 			return create.Error(names.IAM, create.ErrActionCheckingExistence, tfiam.ResNameGroupPoliciesExclusive, groupName, err)
@@ -309,9 +307,9 @@ func testAccCheckGroupPoliciesExclusiveExists(ctx context.Context, name string) 
 	}
 }
 
-func testAccCheckGroupPolicyAddInlinePolicy(ctx context.Context, group *types.Group, inlinePolicy string) resource.TestCheckFunc {
+func testAccCheckGroupPolicyAddInlinePolicy(ctx context.Context, t *testing.T, group *types.Group, inlinePolicy string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		_, err := conn.PutGroupPolicy(ctx, &iam.PutGroupPolicyInput{
 			PolicyDocument: aws.String(testAccGroupPolicyExtraInlineConfig()),
@@ -323,9 +321,9 @@ func testAccCheckGroupPolicyAddInlinePolicy(ctx context.Context, group *types.Gr
 	}
 }
 
-func testAccCheckGroupPolicyRemoveInlinePolicy(ctx context.Context, group *types.Group, inlinePolicy string) resource.TestCheckFunc {
+func testAccCheckGroupPolicyRemoveInlinePolicy(ctx context.Context, t *testing.T, group *types.Group, inlinePolicy string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		_, err := conn.DeleteGroupPolicy(ctx, &iam.DeleteGroupPolicyInput{
 			PolicyName: aws.String(inlinePolicy),

--- a/internal/service/iam/group_policy.go
+++ b/internal/service/iam/group_policy.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
@@ -191,9 +190,8 @@ func findGroupPolicy(ctx context.Context, conn *iam.Client, input *iam.GetGroupP
 	output, err := conn.GetGroupPolicy(ctx, input)
 
 	if errs.IsA[*awstypes.NoSuchEntityException](err) {
-		return "", &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return "", &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/iam/group_policy_attachment.go
+++ b/internal/service/iam/group_policy_attachment.go
@@ -16,7 +16,6 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -189,9 +188,8 @@ func findAttachedGroupPolicies(ctx context.Context, conn *iam.Client, input *iam
 		page, err := pages.NextPage(ctx)
 
 		if errs.IsA[*awstypes.NoSuchEntityException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 

--- a/internal/service/iam/group_policy_attachment_test.go
+++ b/internal/service/iam/group_policy_attachment_test.go
@@ -12,11 +12,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
@@ -25,23 +23,23 @@ import (
 
 func TestAccIAMGroupPolicyAttachment_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	groupName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	groupName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName3 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policy_attachment.test1"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupPolicyAttachmentDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupPolicyAttachmentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPolicyAttachmentConfig_attach(groupName, policyName1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupPolicyAttachmentExists(ctx, resourceName),
-					testAccCheckGroupPolicyAttachmentCount(ctx, groupName, 1),
+					testAccCheckGroupPolicyAttachmentExists(ctx, t, resourceName),
+					testAccCheckGroupPolicyAttachmentCount(ctx, t, groupName, 1),
 				),
 			},
 			{
@@ -65,8 +63,8 @@ func TestAccIAMGroupPolicyAttachment_basic(t *testing.T) {
 			{
 				Config: testAccGroupPolicyAttachmentConfig_attachUpdate(groupName, policyName1, policyName2, policyName3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupPolicyAttachmentExists(ctx, resourceName),
-					testAccCheckGroupPolicyAttachmentCount(ctx, groupName, 2),
+					testAccCheckGroupPolicyAttachmentExists(ctx, t, resourceName),
+					testAccCheckGroupPolicyAttachmentCount(ctx, t, groupName, 2),
 				),
 			},
 		},
@@ -75,20 +73,20 @@ func TestAccIAMGroupPolicyAttachment_basic(t *testing.T) {
 
 func TestAccIAMGroupPolicyAttachment_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	groupName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	groupName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policy_attachment.test1"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupPolicyAttachmentDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupPolicyAttachmentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPolicyAttachmentConfig_attach(groupName, policyName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupPolicyAttachmentExists(ctx, resourceName),
+					testAccCheckGroupPolicyAttachmentExists(ctx, t, resourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceGroupPolicyAttachment(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -97,9 +95,9 @@ func TestAccIAMGroupPolicyAttachment_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckGroupPolicyAttachmentDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckGroupPolicyAttachmentDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_group_policy_attachment" {
@@ -123,14 +121,14 @@ func testAccCheckGroupPolicyAttachmentDestroy(ctx context.Context) resource.Test
 	}
 }
 
-func testAccCheckGroupPolicyAttachmentExists(ctx context.Context, n string) resource.TestCheckFunc {
+func testAccCheckGroupPolicyAttachmentExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		_, err := tfiam.FindAttachedGroupPolicyByTwoPartKey(ctx, conn, rs.Primary.Attributes["group"], rs.Primary.Attributes["policy_arn"])
 
@@ -138,9 +136,9 @@ func testAccCheckGroupPolicyAttachmentExists(ctx context.Context, n string) reso
 	}
 }
 
-func testAccCheckGroupPolicyAttachmentCount(ctx context.Context, groupName string, want int) resource.TestCheckFunc {
+func testAccCheckGroupPolicyAttachmentCount(ctx context.Context, t *testing.T, groupName string, want int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		input := &iam.ListAttachedGroupPoliciesInput{
 			GroupName: aws.String(groupName),

--- a/internal/service/iam/group_policy_attachments_exclusive.go
+++ b/internal/service/iam/group_policy_attachments_exclusive.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
@@ -192,9 +191,8 @@ func findGroupPolicyAttachmentsByName(ctx context.Context, conn *iam.Client, gro
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			if errs.IsA[*awstypes.NoSuchEntityException](err) {
-				return nil, &sdkretry.NotFoundError{
-					LastError:   err,
-					LastRequest: in,
+				return nil, &retry.NotFoundError{
+					LastError: err,
 				}
 			}
 			return policyARNs, err

--- a/internal/service/iam/group_policy_attachments_exclusive_test.go
+++ b/internal/service/iam/group_policy_attachments_exclusive_test.go
@@ -13,11 +13,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
@@ -27,25 +25,25 @@ import (
 func TestAccIAMGroupPolicyAttachmentsExclusive_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policy_attachments_exclusive.test"
 	groupResourceName := "aws_iam_group.test"
 	attachmentResourceName := "aws_iam_group_policy_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupPolicyAttachmentsExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupPolicyAttachmentsExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPolicyAttachmentsExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupPolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckGroupPolicyAttachmentCount(ctx, rName, 1),
-					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckGroupPolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckGroupPolicyAttachmentCount(ctx, t, rName, 1),
+					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrGroupName, groupResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_arns.*", attachmentResourceName, "policy_arn"),
 				),
@@ -64,25 +62,25 @@ func TestAccIAMGroupPolicyAttachmentsExclusive_basic(t *testing.T) {
 func TestAccIAMGroupPolicyAttachmentsExclusive_disappears_Group(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policy_attachments_exclusive.test"
 	groupResourceName := "aws_iam_group.test"
 	attachmentResourceName := "aws_iam_group_policy_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupPolicyAttachmentsExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupPolicyAttachmentsExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPolicyAttachmentsExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupPolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckGroupPolicyAttachmentCount(ctx, rName, 1),
-					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckGroupPolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckGroupPolicyAttachmentCount(ctx, t, rName, 1),
+					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					// Managed policies must be detached before group can be deleted
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceGroupPolicyAttachment(), attachmentResourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceGroup(), groupResourceName),
@@ -96,25 +94,25 @@ func TestAccIAMGroupPolicyAttachmentsExclusive_disappears_Group(t *testing.T) {
 func TestAccIAMGroupPolicyAttachmentsExclusive_disappears_Policy(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policy_attachments_exclusive.test"
 	policyResourceName := "aws_iam_policy.test"
 	attachmentResourceName := "aws_iam_group_policy_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupPolicyAttachmentsExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupPolicyAttachmentsExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPolicyAttachmentsExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupPolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckGroupPolicyAttachmentCount(ctx, rName, 1),
-					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckGroupPolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckGroupPolicyAttachmentCount(ctx, t, rName, 1),
+					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					// Managed policy must be detached before it can be deleted
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceGroupPolicyAttachment(), attachmentResourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourcePolicy(), policyResourceName),
@@ -128,29 +126,29 @@ func TestAccIAMGroupPolicyAttachmentsExclusive_disappears_Policy(t *testing.T) {
 func TestAccIAMGroupPolicyAttachmentsExclusive_multiple(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policy_attachments_exclusive.test"
 	groupResourceName := "aws_iam_group.test"
 	attachmentResourceName := "aws_iam_group_policy_attachment.test"
 	attachmentResourceName2 := "aws_iam_group_policy_attachment.test2"
 	attachmentResourceName3 := "aws_iam_group_policy_attachment.test3"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupPolicyAttachmentsExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupPolicyAttachmentsExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPolicyAttachmentsExclusiveConfig_multiple(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupPolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckGroupPolicyAttachmentExists(ctx, attachmentResourceName2),
-					testAccCheckGroupPolicyAttachmentExists(ctx, attachmentResourceName3),
-					testAccCheckGroupPolicyAttachmentCount(ctx, rName, 3),
-					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckGroupPolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckGroupPolicyAttachmentExists(ctx, t, attachmentResourceName2),
+					testAccCheckGroupPolicyAttachmentExists(ctx, t, attachmentResourceName3),
+					testAccCheckGroupPolicyAttachmentCount(ctx, t, rName, 3),
+					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrGroupName, groupResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_arns.*", attachmentResourceName, "policy_arn"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_arns.*", attachmentResourceName2, "policy_arn"),
@@ -167,9 +165,9 @@ func TestAccIAMGroupPolicyAttachmentsExclusive_multiple(t *testing.T) {
 			{
 				Config: testAccGroupPolicyAttachmentsExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupPolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckGroupPolicyAttachmentCount(ctx, rName, 1),
-					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckGroupPolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckGroupPolicyAttachmentCount(ctx, t, rName, 1),
+					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrGroupName, groupResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_arns.*", attachmentResourceName, "policy_arn"),
 				),
@@ -181,22 +179,22 @@ func TestAccIAMGroupPolicyAttachmentsExclusive_multiple(t *testing.T) {
 func TestAccIAMGroupPolicyAttachmentsExclusive_empty(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policy_attachments_exclusive.test"
 	groupResourceName := "aws_iam_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupPolicyAttachmentsExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupPolicyAttachmentsExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPolicyAttachmentsExclusiveConfig_empty(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrGroupName, groupResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "policy_arns.#", "0"),
 				),
@@ -213,35 +211,35 @@ func TestAccIAMGroupPolicyAttachmentsExclusive_outOfBandRemoval(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var group types.Group
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policy_attachments_exclusive.test"
 	groupResourceName := "aws_iam_group.test"
 	attachmentResourceName := "aws_iam_group_policy_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPolicyAttachmentsExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupExists(ctx, groupResourceName, &group),
-					testAccCheckGroupPolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckGroupPolicyAttachmentCount(ctx, rName, 1),
-					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, resourceName),
-					testAccCheckGroupPolicyDetachManagedPolicy(ctx, &group, rName),
+					testAccCheckGroupExists(ctx, t, groupResourceName, &group),
+					testAccCheckGroupPolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckGroupPolicyAttachmentCount(ctx, t, rName, 1),
+					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
+					testAccCheckGroupPolicyDetachManagedPolicy(ctx, t, &group, rName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccGroupPolicyAttachmentsExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupExists(ctx, groupResourceName, &group),
-					testAccCheckGroupPolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckGroupPolicyAttachmentCount(ctx, rName, 1),
-					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckGroupExists(ctx, t, groupResourceName, &group),
+					testAccCheckGroupPolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckGroupPolicyAttachmentCount(ctx, t, rName, 1),
+					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrGroupName, groupResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "policy_arns.#", "1"),
 				),
@@ -255,31 +253,31 @@ func TestAccIAMGroupPolicyAttachmentsExclusive_outOfBandAddition(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var group types.Group
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	oobPolicyName := rName + "-out-of-band"
 	resourceName := "aws_iam_group_policy_attachments_exclusive.test"
 	groupResourceName := "aws_iam_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPolicyAttachmentsExclusiveConfig_outOfBandAddition(rName, oobPolicyName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupExists(ctx, groupResourceName, &group),
-					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, resourceName),
-					testAccCheckGroupPolicyAttachManagedPolicy(ctx, &group, oobPolicyName),
+					testAccCheckGroupExists(ctx, t, groupResourceName, &group),
+					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
+					testAccCheckGroupPolicyAttachManagedPolicy(ctx, t, &group, oobPolicyName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccGroupPolicyAttachmentsExclusiveConfig_outOfBandAddition(rName, oobPolicyName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupExists(ctx, groupResourceName, &group),
-					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckGroupExists(ctx, t, groupResourceName, &group),
+					testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrGroupName, groupResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "policy_arns.#", "1"),
 				),
@@ -288,9 +286,9 @@ func TestAccIAMGroupPolicyAttachmentsExclusive_outOfBandAddition(t *testing.T) {
 	})
 }
 
-func testAccCheckGroupPolicyAttachmentsExclusiveDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckGroupPolicyAttachmentsExclusiveDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_group_policy_attachments_exclusive" {
@@ -313,7 +311,7 @@ func testAccCheckGroupPolicyAttachmentsExclusiveDestroy(ctx context.Context) res
 	}
 }
 
-func testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx context.Context, name string) resource.TestCheckFunc {
+func testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx context.Context, t *testing.T, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -325,7 +323,7 @@ func testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx context.Context, name
 			return create.Error(names.IAM, create.ErrActionCheckingExistence, tfiam.ResNameGroupPolicyAttachmentsExclusive, name, errors.New("not set"))
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 		out, err := tfiam.FindGroupPolicyAttachmentsByName(ctx, conn, groupName)
 		if err != nil {
 			return create.Error(names.IAM, create.ErrActionCheckingExistence, tfiam.ResNameGroupPolicyAttachmentsExclusive, groupName, err)
@@ -340,9 +338,9 @@ func testAccCheckGroupPolicyAttachmentsExclusiveExists(ctx context.Context, name
 	}
 }
 
-func testAccCheckGroupPolicyDetachManagedPolicy(ctx context.Context, group *types.Group, policyName string) resource.TestCheckFunc {
+func testAccCheckGroupPolicyDetachManagedPolicy(ctx context.Context, t *testing.T, group *types.Group, policyName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		var managedARN string
 		input := &iam.ListAttachedGroupPoliciesInput{
@@ -382,9 +380,9 @@ func testAccCheckGroupPolicyDetachManagedPolicy(ctx context.Context, group *type
 	}
 }
 
-func testAccCheckGroupPolicyAttachManagedPolicy(ctx context.Context, group *types.Group, policyName string) resource.TestCheckFunc {
+func testAccCheckGroupPolicyAttachManagedPolicy(ctx context.Context, t *testing.T, group *types.Group, policyName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		var managedARN string
 		input := &iam.ListPoliciesInput{

--- a/internal/service/iam/group_policy_test.go
+++ b/internal/service/iam/group_policy_test.go
@@ -9,11 +9,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -22,19 +20,19 @@ import (
 func TestAccIAMGroupPolicy_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var groupPolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPolicyConfig_basic(rName, "*"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupPolicyExists(ctx, resourceName, &groupPolicy),
+					testAccCheckGroupPolicyExists(ctx, t, resourceName, &groupPolicy),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, ""),
 				),
@@ -51,19 +49,19 @@ func TestAccIAMGroupPolicy_basic(t *testing.T) {
 func TestAccIAMGroupPolicy_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var groupPolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPolicyConfig_basic(rName, "*"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupPolicyExists(ctx, resourceName, &groupPolicy),
+					testAccCheckGroupPolicyExists(ctx, t, resourceName, &groupPolicy),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceGroupPolicy(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -75,19 +73,19 @@ func TestAccIAMGroupPolicy_disappears(t *testing.T) {
 func TestAccIAMGroupPolicy_nameGenerated(t *testing.T) {
 	ctx := acctest.Context(t)
 	var groupPolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPolicyConfig_nameGenerated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupPolicyExists(ctx, resourceName, &groupPolicy),
+					testAccCheckGroupPolicyExists(ctx, t, resourceName, &groupPolicy),
 					acctest.CheckResourceAttrNameGenerated(resourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, id.UniqueIdPrefix),
 				),
@@ -104,19 +102,19 @@ func TestAccIAMGroupPolicy_nameGenerated(t *testing.T) {
 func TestAccIAMGroupPolicy_namePrefix(t *testing.T) {
 	ctx := acctest.Context(t)
 	var groupPolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPolicyConfig_namePrefix(rName, "tf-acc-test-prefix-"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupPolicyExists(ctx, resourceName, &groupPolicy),
+					testAccCheckGroupPolicyExists(ctx, t, resourceName, &groupPolicy),
 					acctest.CheckResourceAttrNameFromPrefix(resourceName, names.AttrName, "tf-acc-test-prefix-"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, "tf-acc-test-prefix-"),
 				),
@@ -138,19 +136,19 @@ func TestAccIAMGroupPolicy_namePrefix(t *testing.T) {
 func TestAccIAMGroupPolicy_unknownsInPolicy(t *testing.T) {
 	ctx := acctest.Context(t)
 	var groupPolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPolicyConfig_unknowns(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupPolicyExists(ctx, resourceName, &groupPolicy),
+					testAccCheckGroupPolicyExists(ctx, t, resourceName, &groupPolicy),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 				),
 			},
@@ -161,19 +159,19 @@ func TestAccIAMGroupPolicy_unknownsInPolicy(t *testing.T) {
 func TestAccIAMGroupPolicy_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	var groupPolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupPolicyConfig_basic(rName, "*"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupPolicyExists(ctx, resourceName, &groupPolicy),
+					testAccCheckGroupPolicyExists(ctx, t, resourceName, &groupPolicy),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, ""),
 				),
@@ -181,7 +179,7 @@ func TestAccIAMGroupPolicy_update(t *testing.T) {
 			{
 				Config: testAccGroupPolicyConfig_basic(rName, "ec2:*"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupPolicyExists(ctx, resourceName, &groupPolicy),
+					testAccCheckGroupPolicyExists(ctx, t, resourceName, &groupPolicy),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, ""),
 				),
@@ -190,9 +188,9 @@ func TestAccIAMGroupPolicy_update(t *testing.T) {
 	})
 }
 
-func testAccCheckGroupPolicyDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckGroupPolicyDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_group_policy" {
@@ -216,14 +214,14 @@ func testAccCheckGroupPolicyDestroy(ctx context.Context) resource.TestCheckFunc 
 	}
 }
 
-func testAccCheckGroupPolicyExists(ctx context.Context, n string, v *string) resource.TestCheckFunc {
+func testAccCheckGroupPolicyExists(ctx context.Context, t *testing.T, n string, v *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not Found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		output, err := tfiam.FindGroupPolicyByTwoPartKey(ctx, conn, rs.Primary.Attributes["group"], rs.Primary.Attributes[names.AttrName])
 

--- a/internal/service/iam/group_test.go
+++ b/internal/service/iam/group_test.go
@@ -9,11 +9,9 @@ import (
 	"testing"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -22,19 +20,19 @@ import (
 func TestAccIAMGroup_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Group
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGroupExists(ctx, resourceName, &conf),
+					testAccCheckGroupExists(ctx, t, resourceName, &conf),
 					// arn:${Partition}:iam::${Account}:group/${GroupNameWithPath}
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("group/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
@@ -54,19 +52,19 @@ func TestAccIAMGroup_basic(t *testing.T) {
 func TestAccIAMGroup_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Group
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupExists(ctx, resourceName, &conf),
+					testAccCheckGroupExists(ctx, t, resourceName, &conf),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceGroup(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -78,20 +76,20 @@ func TestAccIAMGroup_disappears(t *testing.T) {
 func TestAccIAMGroup_nameChange(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Group
-	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupConfig_basic(rName1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupExists(ctx, resourceName, &conf),
+					testAccCheckGroupExists(ctx, t, resourceName, &conf),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("group/%s", rName1)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName1),
 				),
@@ -99,7 +97,7 @@ func TestAccIAMGroup_nameChange(t *testing.T) {
 			{
 				Config: testAccGroupConfig_basic(rName2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupExists(ctx, resourceName, &conf),
+					testAccCheckGroupExists(ctx, t, resourceName, &conf),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("group/%s", rName2)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName2),
 				),
@@ -111,19 +109,19 @@ func TestAccIAMGroup_nameChange(t *testing.T) {
 func TestAccIAMGroup_path(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Group
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupConfig_path(rName, "/path1/"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGroupExists(ctx, resourceName, &conf),
+					testAccCheckGroupExists(ctx, t, resourceName, &conf),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("group/path1/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/path1/"),
@@ -137,7 +135,7 @@ func TestAccIAMGroup_path(t *testing.T) {
 			{
 				Config: testAccGroupConfig_path(rName, "/path2/"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGroupExists(ctx, resourceName, &conf),
+					testAccCheckGroupExists(ctx, t, resourceName, &conf),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("group/path2/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/path2/"),
@@ -147,9 +145,9 @@ func TestAccIAMGroup_path(t *testing.T) {
 	})
 }
 
-func testAccCheckGroupDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckGroupDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_group" {
@@ -173,14 +171,14 @@ func testAccCheckGroupDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckGroupExists(ctx context.Context, n string, v *awstypes.Group) resource.TestCheckFunc {
+func testAccCheckGroupExists(ctx context.Context, t *testing.T, n string, v *awstypes.Group) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		output, err := tfiam.FindGroupByName(ctx, conn, rs.Primary.Attributes[names.AttrName])
 

--- a/internal/service/iam/instance_profile.go
+++ b/internal/service/iam/instance_profile.go
@@ -17,7 +17,6 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
@@ -38,7 +37,6 @@ const (
 // @SDKResource("aws_iam_instance_profile", name="Instance Profile")
 // @Tags(identifierAttribute="id", resourceType="InstanceProfile")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/iam/types;types.InstanceProfile")
-// @Testing(existsTakesT=false, destroyTakesT=false)
 func resourceInstanceProfile() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceInstanceProfileCreate,
@@ -328,9 +326,8 @@ func findInstanceProfileByName(ctx context.Context, conn *iam.Client, name strin
 	output, err := conn.GetInstanceProfile(ctx, input)
 
 	if errs.IsA[*awstypes.NoSuchEntityException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 
@@ -350,8 +347,8 @@ const (
 	instanceProfileInvalidARNState = "InvalidARN"
 )
 
-func statusInstanceProfile(ctx context.Context, conn *iam.Client, name string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusInstanceProfile(conn *iam.Client, name string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findInstanceProfileByName(ctx, conn, name)
 		if retry.NotFound(err) {
 			return nil, "", nil
@@ -371,10 +368,10 @@ func statusInstanceProfile(ctx context.Context, conn *iam.Client, name string) s
 }
 
 func waitInstanceProfileReady(ctx context.Context, conn *iam.Client, id string, timeout time.Duration) error {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:                   []string{"", instanceProfileInvalidARNState},
 		Target:                    enum.Slice(instanceProfileFoundState),
-		Refresh:                   statusInstanceProfile(ctx, conn, id),
+		Refresh:                   statusInstanceProfile(conn, id),
 		Timeout:                   timeout,
 		Delay:                     5 * time.Second,
 		NotFoundChecks:            5,

--- a/internal/service/iam/instance_profile_data_source_test.go
+++ b/internal/service/iam/instance_profile_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -18,10 +17,10 @@ func TestAccIAMInstanceProfileDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_iam_instance_profile.test"
 	resourceName := "aws_iam_instance_profile.test"
 	roleResourceName := "aws_iam_role.test"
-	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/iam/instance_profile_tags_gen_test.go
+++ b/internal/service/iam/instance_profile_tags_gen_test.go
@@ -33,7 +33,7 @@ func TestAccIAMInstanceProfile_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -45,7 +45,7 @@ func TestAccIAMInstanceProfile_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -89,7 +89,7 @@ func TestAccIAMInstanceProfile_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -137,7 +137,7 @@ func TestAccIAMInstanceProfile_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -178,7 +178,7 @@ func TestAccIAMInstanceProfile_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -219,7 +219,7 @@ func TestAccIAMInstanceProfile_Tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -231,7 +231,7 @@ func TestAccIAMInstanceProfile_Tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -290,7 +290,7 @@ func TestAccIAMInstanceProfile_Tags_emptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -300,7 +300,7 @@ func TestAccIAMInstanceProfile_Tags_emptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -357,7 +357,7 @@ func TestAccIAMInstanceProfile_Tags_addOnUpdate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -367,7 +367,7 @@ func TestAccIAMInstanceProfile_Tags_addOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -391,7 +391,7 @@ func TestAccIAMInstanceProfile_Tags_addOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -442,7 +442,7 @@ func TestAccIAMInstanceProfile_Tags_EmptyTag_onCreate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -454,7 +454,7 @@ func TestAccIAMInstanceProfile_Tags_EmptyTag_onCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -494,7 +494,7 @@ func TestAccIAMInstanceProfile_Tags_EmptyTag_onCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -535,7 +535,7 @@ func TestAccIAMInstanceProfile_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -547,7 +547,7 @@ func TestAccIAMInstanceProfile_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -579,7 +579,7 @@ func TestAccIAMInstanceProfile_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -625,7 +625,7 @@ func TestAccIAMInstanceProfile_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -676,7 +676,7 @@ func TestAccIAMInstanceProfile_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -688,7 +688,7 @@ func TestAccIAMInstanceProfile_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -719,7 +719,7 @@ func TestAccIAMInstanceProfile_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -769,7 +769,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_providerOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -782,7 +782,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -826,7 +826,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -872,7 +872,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -912,7 +912,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -954,7 +954,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -969,7 +969,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1023,7 +1023,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1076,7 +1076,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1118,7 +1118,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_overlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1133,7 +1133,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1186,7 +1186,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1243,7 +1243,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1298,7 +1298,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_updateToProviderOnly(t *testing.
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1310,7 +1310,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_updateToProviderOnly(t *testing.
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1343,7 +1343,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_updateToProviderOnly(t *testing.
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1392,7 +1392,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_updateToResourceOnly(t *testing.
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1405,7 +1405,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_updateToResourceOnly(t *testing.
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1433,7 +1433,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_updateToResourceOnly(t *testing.
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1485,7 +1485,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_emptyResourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1500,7 +1500,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_emptyResourceTag(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1554,7 +1554,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_emptyProviderOnlyTag(t *testing.
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1567,7 +1567,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_emptyProviderOnlyTag(t *testing.
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1615,7 +1615,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_nullOverlappingResourceTag(t *te
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1630,7 +1630,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_nullOverlappingResourceTag(t *te
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1681,7 +1681,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_nullNonOverlappingResourceTag(t 
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1696,7 +1696,7 @@ func TestAccIAMInstanceProfile_Tags_DefaultTags_nullNonOverlappingResourceTag(t 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1747,7 +1747,7 @@ func TestAccIAMInstanceProfile_Tags_ComputedTag_onCreate(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1757,7 +1757,7 @@ func TestAccIAMInstanceProfile_Tags_ComputedTag_onCreate(t *testing.T) {
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1806,7 +1806,7 @@ func TestAccIAMInstanceProfile_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1818,7 +1818,7 @@ func TestAccIAMInstanceProfile_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1850,7 +1850,7 @@ func TestAccIAMInstanceProfile_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1907,7 +1907,7 @@ func TestAccIAMInstanceProfile_Tags_ComputedTag_OnUpdate_replace(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1919,7 +1919,7 @@ func TestAccIAMInstanceProfile_Tags_ComputedTag_OnUpdate_replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1949,7 +1949,7 @@ func TestAccIAMInstanceProfile_Tags_ComputedTag_OnUpdate_replace(t *testing.T) {
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1998,7 +1998,7 @@ func TestAccIAMInstanceProfile_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) 
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2017,7 +2017,7 @@ func TestAccIAMInstanceProfile_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) 
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2066,7 +2066,7 @@ func TestAccIAMInstanceProfile_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) 
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2115,7 +2115,7 @@ func TestAccIAMInstanceProfile_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) 
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2164,7 +2164,7 @@ func TestAccIAMInstanceProfile_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2181,7 +2181,7 @@ func TestAccIAMInstanceProfile_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T)
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2244,7 +2244,7 @@ func TestAccIAMInstanceProfile_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T)
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2307,7 +2307,7 @@ func TestAccIAMInstanceProfile_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T)
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/iam/instance_profile_test.go
+++ b/internal/service/iam/instance_profile_test.go
@@ -10,11 +10,9 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -24,18 +22,18 @@ func TestAccIAMInstanceProfile_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceProfileConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &conf),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &conf),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("instance-profile/%s", rName)),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrRole, "aws_iam_role.test", names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
@@ -55,18 +53,18 @@ func TestAccIAMInstanceProfile_withoutRole(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceProfileConfig_noRole(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &conf),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &conf),
 					resource.TestCheckNoResourceAttr(resourceName, names.AttrRole),
 				),
 			},
@@ -83,18 +81,18 @@ func TestAccIAMInstanceProfile_nameGenerated(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceProfileConfig_nameGenerated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &conf),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &conf),
 					acctest.CheckResourceAttrNameGenerated(resourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, id.UniqueIdPrefix),
 				),
@@ -112,18 +110,18 @@ func TestAccIAMInstanceProfile_namePrefix(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceProfileConfig_namePrefix(rName, "tf-acc-test-prefix-"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &conf),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &conf),
 					acctest.CheckResourceAttrNameFromPrefix(resourceName, names.AttrName, "tf-acc-test-prefix-"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, "tf-acc-test-prefix-"),
 				),
@@ -141,18 +139,18 @@ func TestAccIAMInstanceProfile_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceProfileConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &conf),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &conf),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceInstanceProfile(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -165,18 +163,18 @@ func TestAccIAMInstanceProfile_Disappears_role(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceProfileConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &conf),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &conf),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceRole(), "aws_iam_role.test"),
 				),
 				ExpectNonEmptyPlan: true,
@@ -189,18 +187,18 @@ func TestAccIAMInstanceProfile_launchConfiguration(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceProfileConfig_launchConfiguration(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &conf),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &conf),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("instance-profile/%s", rName)),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrRole, "aws_iam_role.test", names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
@@ -214,7 +212,7 @@ func TestAccIAMInstanceProfile_launchConfiguration(t *testing.T) {
 			{
 				Config: testAccInstanceProfileConfig_launchConfiguration(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &conf),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &conf),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("instance-profile/%s", rName)),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrRole, "aws_iam_role.test", names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
@@ -223,7 +221,7 @@ func TestAccIAMInstanceProfile_launchConfiguration(t *testing.T) {
 			{
 				Config: testAccInstanceProfileConfig_launchConfiguration(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &conf),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &conf),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("instance-profile/%s", rName)),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrRole, "aws_iam_role.test", names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
@@ -232,7 +230,7 @@ func TestAccIAMInstanceProfile_launchConfiguration(t *testing.T) {
 			{
 				Config: testAccInstanceProfileConfig_launchConfiguration(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &conf),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &conf),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("instance-profile/%s", rName)),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrRole, "aws_iam_role.test", names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
@@ -246,7 +244,7 @@ func TestAccIAMInstanceProfile_launchConfiguration(t *testing.T) {
 			{
 				Config: testAccInstanceProfileConfig_launchConfiguration(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceProfileExists(ctx, resourceName, &conf),
+					testAccCheckInstanceProfileExists(ctx, t, resourceName, &conf),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("instance-profile/%s", rName)),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrRole, "aws_iam_role.test", names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
@@ -256,9 +254,9 @@ func TestAccIAMInstanceProfile_launchConfiguration(t *testing.T) {
 	})
 }
 
-func testAccCheckInstanceProfileDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckInstanceProfileDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_instance_profile" {
@@ -282,7 +280,7 @@ func testAccCheckInstanceProfileDestroy(ctx context.Context) resource.TestCheckF
 	}
 }
 
-func testAccCheckInstanceProfileExists(ctx context.Context, n string, v *awstypes.InstanceProfile) resource.TestCheckFunc {
+func testAccCheckInstanceProfileExists(ctx context.Context, t *testing.T, n string, v *awstypes.InstanceProfile) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -293,7 +291,7 @@ func testAccCheckInstanceProfileExists(ctx context.Context, n string, v *awstype
 			return fmt.Errorf("No IAM Instance Profile ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		output, err := tfiam.FindInstanceProfileByName(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/iam/instance_profiles_data_source.go
+++ b/internal/service/iam/instance_profiles_data_source.go
@@ -12,11 +12,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -89,9 +89,8 @@ func findInstanceProfilesForRole(ctx context.Context, conn *iam.Client, roleName
 		page, err := pages.NextPage(ctx)
 
 		if errs.IsA[*awstypes.NoSuchEntityException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 

--- a/internal/service/iam/instance_profiles_data_source_test.go
+++ b/internal/service/iam/instance_profiles_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -17,9 +16,9 @@ func TestAccIAMInstanceProfilesDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	datasourceName := "data.aws_iam_instance_profiles.test"
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/iam/openid_connect_provider.go
+++ b/internal/service/iam/openid_connect_provider.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -31,7 +30,6 @@ import (
 // @Testing(name="OpenIDConnectProvider")
 // @ArnIdentity
 // @Testing(preIdentityVersion="v6.4.0")
-// @Testing(existsTakesT=false, destroyTakesT=false)
 func resourceOpenIDConnectProvider() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceOpenIDConnectProviderCreate,
@@ -239,9 +237,8 @@ func findOpenIDConnectProvider(ctx context.Context, conn *iam.Client, input *iam
 	output, err := conn.GetOpenIDConnectProvider(ctx, input)
 
 	if errs.IsA[*awstypes.NoSuchEntityException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/iam/openid_connect_provider_data_source.go
+++ b/internal/service/iam/openid_connect_provider_data_source.go
@@ -14,10 +14,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -124,7 +124,7 @@ func findOpenIDConnectProviderByURL(ctx context.Context, conn *iam.Client, url s
 		}
 	}
 
-	return nil, &sdkretry.NotFoundError{}
+	return nil, &retry.NotFoundError{}
 }
 
 func urlFromOpenIDConnectProviderARN(arn string) (string, error) {

--- a/internal/service/iam/openid_connect_provider_data_source_test.go
+++ b/internal/service/iam/openid_connect_provider_data_source_test.go
@@ -22,16 +22,16 @@ func TestAccIAMOpenidConnectProviderDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_iam_openid_connect_provider.test"
 	resourceName := "aws_iam_openid_connect_provider.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOpenIDConnectProviderDataSourceConfig_basic(rString),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrURL, resourceName, names.AttrURL),
 					resource.TestCheckResourceAttrPair(dataSourceName, "client_id_list", resourceName, "client_id_list"),
@@ -51,16 +51,16 @@ func TestAccIAMOpenidConnectProviderDataSource_url(t *testing.T) {
 	dataSourceName := "data.aws_iam_openid_connect_provider.test"
 	resourceName := "aws_iam_openid_connect_provider.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOpenIDConnectProviderDataSourceConfig_url(rString),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrURL, resourceName, names.AttrURL),
 					resource.TestCheckResourceAttrPair(dataSourceName, "client_id_list", resourceName, "client_id_list"),

--- a/internal/service/iam/openid_connect_provider_identity_gen_test.go
+++ b/internal/service/iam/openid_connect_provider_identity_gen_test.go
@@ -33,7 +33,7 @@ func TestAccIAMOpenIDConnectProvider_Identity_basic(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			// Step 1: Setup
@@ -43,7 +43,7 @@ func TestAccIAMOpenIDConnectProvider_Identity_basic(t *testing.T) {
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
@@ -116,7 +116,7 @@ func TestAccIAMOpenIDConnectProvider_Identity_ExistingResource_basic(t *testing.
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// Step 1: Create pre-Identity
 			{
@@ -125,7 +125,7 @@ func TestAccIAMOpenIDConnectProvider_Identity_ExistingResource_basic(t *testing.
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),
@@ -171,7 +171,7 @@ func TestAccIAMOpenIDConnectProvider_Identity_ExistingResource_noRefreshNoChange
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
 			Plan: resource.PlanOptions{
 				NoRefresh: true,
@@ -185,7 +185,7 @@ func TestAccIAMOpenIDConnectProvider_Identity_ExistingResource_noRefreshNoChange
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),

--- a/internal/service/iam/openid_connect_provider_tags_gen_test.go
+++ b/internal/service/iam/openid_connect_provider_tags_gen_test.go
@@ -31,7 +31,7 @@ func TestAccIAMOpenIDConnectProvider_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -43,7 +43,7 @@ func TestAccIAMOpenIDConnectProvider_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -87,7 +87,7 @@ func TestAccIAMOpenIDConnectProvider_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -135,7 +135,7 @@ func TestAccIAMOpenIDConnectProvider_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -176,7 +176,7 @@ func TestAccIAMOpenIDConnectProvider_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -216,7 +216,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -228,7 +228,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -286,7 +286,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_emptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -296,7 +296,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_emptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -352,7 +352,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_addOnUpdate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -362,7 +362,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_addOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -386,7 +386,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_addOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -436,7 +436,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_EmptyTag_onCreate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -448,7 +448,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_EmptyTag_onCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -488,7 +488,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_EmptyTag_onCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -528,7 +528,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -540,7 +540,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -572,7 +572,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -618,7 +618,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -668,7 +668,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_EmptyTag_OnUpdate_replace(t *testing.T
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -680,7 +680,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_EmptyTag_OnUpdate_replace(t *testing.T
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -711,7 +711,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_EmptyTag_OnUpdate_replace(t *testing.T
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -760,7 +760,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_providerOnly(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -773,7 +773,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_providerOnly(t *testing.T)
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -817,7 +817,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_providerOnly(t *testing.T)
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -863,7 +863,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_providerOnly(t *testing.T)
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -903,7 +903,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_providerOnly(t *testing.T)
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -944,7 +944,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_nonOverlapping(t *testing.
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -959,7 +959,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_nonOverlapping(t *testing.
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1013,7 +1013,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_nonOverlapping(t *testing.
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1066,7 +1066,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_nonOverlapping(t *testing.
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1107,7 +1107,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_overlapping(t *testing.T) 
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1122,7 +1122,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_overlapping(t *testing.T) 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1175,7 +1175,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_overlapping(t *testing.T) 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1232,7 +1232,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_overlapping(t *testing.T) 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1286,7 +1286,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_updateToProviderOnly(t *te
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1298,7 +1298,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_updateToProviderOnly(t *te
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1331,7 +1331,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_updateToProviderOnly(t *te
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1379,7 +1379,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_updateToResourceOnly(t *te
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1392,7 +1392,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_updateToResourceOnly(t *te
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1420,7 +1420,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_updateToResourceOnly(t *te
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1471,7 +1471,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_emptyResourceTag(t *testin
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1486,7 +1486,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_emptyResourceTag(t *testin
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1539,7 +1539,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_emptyProviderOnlyTag(t *te
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1552,7 +1552,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_emptyProviderOnlyTag(t *te
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1599,7 +1599,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_nullOverlappingResourceTag
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1614,7 +1614,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_nullOverlappingResourceTag
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1664,7 +1664,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_nullNonOverlappingResource
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1679,7 +1679,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_DefaultTags_nullNonOverlappingResource
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1729,7 +1729,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_ComputedTag_onCreate(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1739,7 +1739,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_ComputedTag_onCreate(t *testing.T) {
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1787,7 +1787,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_ComputedTag_OnUpdate_add(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1799,7 +1799,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_ComputedTag_OnUpdate_add(t *testing.T)
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1831,7 +1831,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_ComputedTag_OnUpdate_add(t *testing.T)
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1887,7 +1887,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_ComputedTag_OnUpdate_replace(t *testin
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1899,7 +1899,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_ComputedTag_OnUpdate_replace(t *testin
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1929,7 +1929,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_ComputedTag_OnUpdate_replace(t *testin
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1977,7 +1977,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_IgnoreTags_Overlap_defaultTag(t *testi
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -1996,7 +1996,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_IgnoreTags_Overlap_defaultTag(t *testi
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2045,7 +2045,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_IgnoreTags_Overlap_defaultTag(t *testi
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2094,7 +2094,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_IgnoreTags_Overlap_defaultTag(t *testi
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2142,7 +2142,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_IgnoreTags_Overlap_resourceTag(t *test
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2159,7 +2159,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_IgnoreTags_Overlap_resourceTag(t *test
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2222,7 +2222,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_IgnoreTags_Overlap_resourceTag(t *test
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2285,7 +2285,7 @@ func TestAccIAMOpenIDConnectProvider_Tags_IgnoreTags_Overlap_resourceTag(t *test
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/iam/openid_connect_provider_test.go
+++ b/internal/service/iam/openid_connect_provider_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -25,16 +24,16 @@ func TestAccIAMOpenIDConnectProvider_basic(t *testing.T) {
 	url := "accounts.testle.com/" + rString
 	resourceName := "aws_iam_openid_connect_provider.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOpenIDConnectProviderConfig_basic(rString),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("oidc-provider/%s", url)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURL, url),
 					resource.TestCheckResourceAttr(resourceName, "client_id_list.#", "1"),
@@ -52,7 +51,7 @@ func TestAccIAMOpenIDConnectProvider_basic(t *testing.T) {
 			{
 				Config: testAccOpenIDConnectProviderConfig_modified(rString),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURL, url),
 					resource.TestCheckResourceAttr(resourceName, "client_id_list.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "client_id_list.0",
@@ -72,16 +71,16 @@ func TestAccIAMOpenIDConnectProvider_Thumbprints_none(t *testing.T) {
 	url := "accounts.google.com"
 	resourceName := "aws_iam_openid_connect_provider.test"
 
-	resource.Test(t, resource.TestCase{ // can't run in parallel b/c of google URL, needed for no thumbprints
+	acctest.Test(ctx, t, resource.TestCase{ // can't run in parallel b/c of google URL, needed for no thumbprints
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOpenIDConnectProviderConfig_withoutThumbprints(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("oidc-provider/%s", url)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURL, url),
 					resource.TestCheckResourceAttr(resourceName, "client_id_list.#", "1"),
@@ -100,16 +99,16 @@ func TestAccIAMOpenIDConnectProvider_Thumbprints_withToWithout(t *testing.T) {
 	url := "accounts.google.com"
 	resourceName := "aws_iam_openid_connect_provider.test"
 
-	resource.Test(t, resource.TestCase{ // can't run in parallel b/c of google URL, needed for no thumbprints
+	acctest.Test(ctx, t, resource.TestCase{ // can't run in parallel b/c of google URL, needed for no thumbprints
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOpenIDConnectProviderConfig_thumbprint(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("oidc-provider/%s", url)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURL, url),
 					resource.TestCheckResourceAttr(resourceName, "client_id_list.#", "1"),
@@ -123,7 +122,7 @@ func TestAccIAMOpenIDConnectProvider_Thumbprints_withToWithout(t *testing.T) {
 			{
 				Config: testAccOpenIDConnectProviderConfig_withoutThumbprints(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("oidc-provider/%s", url)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURL, url),
 					resource.TestCheckResourceAttr(resourceName, "client_id_list.#", "1"),
@@ -145,16 +144,16 @@ func TestAccIAMOpenIDConnectProvider_Thumbprints_withoutToWith(t *testing.T) {
 	url := "accounts.google.com"
 	resourceName := "aws_iam_openid_connect_provider.test"
 
-	resource.Test(t, resource.TestCase{ // can't run in parallel b/c of google URL, needed for no thumbprints
+	acctest.Test(ctx, t, resource.TestCase{ // can't run in parallel b/c of google URL, needed for no thumbprints
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOpenIDConnectProviderConfig_withoutThumbprints(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("oidc-provider/%s", url)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURL, url),
 					resource.TestCheckResourceAttr(resourceName, "client_id_list.#", "1"),
@@ -168,7 +167,7 @@ func TestAccIAMOpenIDConnectProvider_Thumbprints_withoutToWith(t *testing.T) {
 			{
 				Config: testAccOpenIDConnectProviderConfig_thumbprint(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("oidc-provider/%s", url)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURL, url),
 					resource.TestCheckResourceAttr(resourceName, "client_id_list.#", "1"),
@@ -188,16 +187,16 @@ func TestAccIAMOpenIDConnectProvider_disappears(t *testing.T) {
 	rString := sdkacctest.RandString(5)
 	resourceName := "aws_iam_openid_connect_provider.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOpenIDConnectProviderConfig_basic(rString),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceOpenIDConnectProvider(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -211,16 +210,16 @@ func TestAccIAMOpenIDConnectProvider_clientIDListOrder(t *testing.T) {
 	rString := sdkacctest.RandString(5)
 	resourceName := "aws_iam_openid_connect_provider.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOpenIDConnectProviderConfig_clientIDList_first(rString),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -231,7 +230,7 @@ func TestAccIAMOpenIDConnectProvider_clientIDListOrder(t *testing.T) {
 			{
 				Config: testAccOpenIDConnectProviderConfig_clientIDList_second(rString),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 				// Expect an empty plan as only the order has been changed
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -252,16 +251,16 @@ func TestAccIAMOpenIDConnectProvider_clientIDModification(t *testing.T) {
 	rString := sdkacctest.RandString(5)
 	resourceName := "aws_iam_openid_connect_provider.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOpenIDConnectProviderConfig_clientIDList_first(rString),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 				),
 			},
 			{
@@ -272,7 +271,7 @@ func TestAccIAMOpenIDConnectProvider_clientIDModification(t *testing.T) {
 			{
 				Config: testAccOpenIDConnectProviderConfig_clientIDList_add(rString),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "client_id_list.#", "4"),
 					resource.TestCheckResourceAttr(resourceName, "client_id_list.0", "abc.testle.com"),
 					resource.TestCheckResourceAttr(resourceName, "client_id_list.3", "xyz.testle.com"),
@@ -286,7 +285,7 @@ func TestAccIAMOpenIDConnectProvider_clientIDModification(t *testing.T) {
 			{
 				Config: testAccOpenIDConnectProviderConfig_clientIDList_remove(rString),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					testAccCheckOpenIDConnectProviderExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "client_id_list.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "client_id_list.0", "def.testle.com"),
 					resource.TestCheckResourceAttr(resourceName, "client_id_list.2", "xyz.testle.com"),
@@ -296,9 +295,9 @@ func TestAccIAMOpenIDConnectProvider_clientIDModification(t *testing.T) {
 	})
 }
 
-func testAccCheckOpenIDConnectProviderDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckOpenIDConnectProviderDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_openid_connect_provider" {
@@ -322,7 +321,7 @@ func testAccCheckOpenIDConnectProviderDestroy(ctx context.Context) resource.Test
 	}
 }
 
-func testAccCheckOpenIDConnectProviderExists(ctx context.Context, n string /*, v *iam.GetOpenIDConnectProviderOutput*/) resource.TestCheckFunc {
+func testAccCheckOpenIDConnectProviderExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -333,7 +332,7 @@ func testAccCheckOpenIDConnectProviderExists(ctx context.Context, n string /*, v
 			return fmt.Errorf("No IAM OIDC Provider ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		_, err := tfiam.FindOpenIDConnectProviderByARN(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/iam/organizations_features.go
+++ b/internal/service/iam/organizations_features.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
@@ -184,9 +183,8 @@ func findOrganizationsFeatures(ctx context.Context, conn *iam.Client) (*iam.List
 	output, err := conn.ListOrganizationsFeatures(ctx, input)
 
 	if errs.IsA[*awstypes.OrganizationNotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/iam/organizations_features_test.go
+++ b/internal/service/iam/organizations_features_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -36,7 +35,7 @@ func testAccOrganizationsFeatures_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_organizations_features.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckOrganizationManagementAccount(ctx, t)
@@ -44,12 +43,12 @@ func testAccOrganizationsFeatures_basic(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckOrganizationsFeaturesDestroy(ctx),
+		CheckDestroy:             testAccCheckOrganizationsFeaturesDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationsFeaturesConfig_basic([]string{"RootCredentialsManagement", "RootSessions"}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOrganizationsFeaturesExists(ctx, resourceName),
+					testAccCheckOrganizationsFeaturesExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled_features"), knownvalue.SetSizeExact(2)),
@@ -72,7 +71,7 @@ func testAccOrganizationsFeatures_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_organizations_features.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckOrganizationManagementAccount(ctx, t)
@@ -80,12 +79,12 @@ func testAccOrganizationsFeatures_update(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckOrganizationsFeaturesDestroy(ctx),
+		CheckDestroy:             testAccCheckOrganizationsFeaturesDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationsFeaturesConfig_basic([]string{"RootCredentialsManagement"}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOrganizationsFeaturesExists(ctx, resourceName),
+					testAccCheckOrganizationsFeaturesExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled_features"), knownvalue.SetSizeExact(1)),
@@ -102,7 +101,7 @@ func testAccOrganizationsFeatures_update(t *testing.T) {
 			{
 				Config: testAccOrganizationsFeaturesConfig_basic([]string{"RootSessions"}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOrganizationsFeaturesExists(ctx, resourceName),
+					testAccCheckOrganizationsFeaturesExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("enabled_features"), knownvalue.SetSizeExact(1)),
@@ -115,9 +114,9 @@ func testAccOrganizationsFeatures_update(t *testing.T) {
 	})
 }
 
-func testAccCheckOrganizationsFeaturesDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckOrganizationsFeaturesDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_organizations_features" {
@@ -141,14 +140,14 @@ func testAccCheckOrganizationsFeaturesDestroy(ctx context.Context) resource.Test
 	}
 }
 
-func testAccCheckOrganizationsFeaturesExists(ctx context.Context, n string) resource.TestCheckFunc {
+func testAccCheckOrganizationsFeaturesExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		_, err := tfiam.FindOrganizationsFeatures(ctx, conn)
 

--- a/internal/service/iam/policy.go
+++ b/internal/service/iam/policy.go
@@ -42,7 +42,6 @@ const (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/iam/types;types.Policy")
 // @ArnIdentity
 // @Testing(preIdentityVersion="v6.4.0")
-// @Testing(existsTakesT=false, destroyTakesT=false)
 func resourcePolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePolicyCreate,

--- a/internal/service/iam/policy_attachment.go
+++ b/internal/service/iam/policy_attachment.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -308,9 +307,8 @@ func findEntitiesForPolicy(ctx context.Context, conn *iam.Client, input *iam.Lis
 		page, err := pages.NextPage(ctx)
 
 		if errs.IsA[*awstypes.NoSuchEntityException](err) {
-			return nil, nil, nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+			return nil, nil, nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 

--- a/internal/service/iam/policy_data_source_test.go
+++ b/internal/service/iam/policy_data_source_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -18,9 +17,9 @@ func TestAccIAMPolicyDataSource_arn(t *testing.T) {
 	ctx := acctest.Context(t)
 	datasourceName := "data.aws_iam_policy.test"
 	resourceName := "aws_iam_policy.test"
-	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccIAMPolicyDataSource_name(t *testing.T) {
 	ctx := acctest.Context(t)
 	datasourceName := "data.aws_iam_policy.test"
 	resourceName := "aws_iam_policy.test"
-	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,10 +74,10 @@ func TestAccIAMPolicyDataSource_nameAndPathPrefix(t *testing.T) {
 	datasourceName := "data.aws_iam_policy.test"
 	resourceName := "aws_iam_policy.test"
 
-	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	policyPath := "/test-path/"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -102,10 +101,10 @@ func TestAccIAMPolicyDataSource_nameAndPathPrefix(t *testing.T) {
 
 func TestAccIAMPolicyDataSource_nonExistent(t *testing.T) {
 	ctx := acctest.Context(t)
-	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	policyPath := "/test-path/"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/iam/policy_document_data_source_test.go
+++ b/internal/service/iam/policy_document_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccIAMPolicyDocumentDataSource_basic(t *testing.T) {
 	// acceptance test, but just instantiating the AWS provider requires
 	// some AWS API calls, and so this needs valid AWS credentials to work.
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -43,7 +43,7 @@ func TestAccIAMPolicyDocumentDataSource_singleConditionValue(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_policy_document.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -62,7 +62,7 @@ func TestAccIAMPolicyDocumentDataSource_multipleConditionKeys(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_policy_document.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -81,7 +81,7 @@ func TestAccIAMPolicyDocumentDataSource_duplicateConditionKeys(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_policy_document.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -98,7 +98,7 @@ func TestAccIAMPolicyDocumentDataSource_duplicateConditionKeys(t *testing.T) {
 
 func TestAccIAMPolicyDocumentDataSource_conditionWithBoolValue(t *testing.T) {
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -120,7 +120,7 @@ func TestAccIAMPolicyDocumentDataSource_source(t *testing.T) {
 	// acceptance test, but just instantiating the AWS provider requires
 	// some AWS API calls, and so this needs valid AWS credentials to work.
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -147,7 +147,7 @@ func TestAccIAMPolicyDocumentDataSource_source(t *testing.T) {
 
 func TestAccIAMPolicyDocumentDataSource_sourceList(t *testing.T) {
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -166,7 +166,7 @@ func TestAccIAMPolicyDocumentDataSource_sourceList(t *testing.T) {
 
 func TestAccIAMPolicyDocumentDataSource_sourceConflicting(t *testing.T) {
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -185,7 +185,7 @@ func TestAccIAMPolicyDocumentDataSource_sourceConflicting(t *testing.T) {
 
 func TestAccIAMPolicyDocumentDataSource_sourceListConflicting(t *testing.T) {
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -200,7 +200,7 @@ func TestAccIAMPolicyDocumentDataSource_sourceListConflicting(t *testing.T) {
 
 func TestAccIAMPolicyDocumentDataSource_override(t *testing.T) {
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -219,7 +219,7 @@ func TestAccIAMPolicyDocumentDataSource_override(t *testing.T) {
 
 func TestAccIAMPolicyDocumentDataSource_overrideList(t *testing.T) {
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -238,7 +238,7 @@ func TestAccIAMPolicyDocumentDataSource_overrideList(t *testing.T) {
 
 func TestAccIAMPolicyDocumentDataSource_invalidSidValid(t *testing.T) {
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -252,7 +252,7 @@ func TestAccIAMPolicyDocumentDataSource_invalidSidValid(t *testing.T) {
 
 func TestAccIAMPolicyDocumentDataSource_noStatementMerge(t *testing.T) {
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -271,7 +271,7 @@ func TestAccIAMPolicyDocumentDataSource_noStatementMerge(t *testing.T) {
 
 func TestAccIAMPolicyDocumentDataSource_noStatementOverride(t *testing.T) {
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -290,7 +290,7 @@ func TestAccIAMPolicyDocumentDataSource_noStatementOverride(t *testing.T) {
 
 func TestAccIAMPolicyDocumentDataSource_duplicateSid(t *testing.T) {
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -313,7 +313,7 @@ func TestAccIAMPolicyDocumentDataSource_duplicateSid(t *testing.T) {
 
 func TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJSON(t *testing.T) {
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -336,7 +336,7 @@ func TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJSON(t *testing.T) {
 
 func TestAccIAMPolicyDocumentDataSource_overridePolicyDocumentValidJSON(t *testing.T) {
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -365,7 +365,7 @@ func TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndS
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_policy_document.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -385,7 +385,7 @@ func TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePr
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_policy_document.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartition(t, endpoints.AwsPartitionID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -404,7 +404,7 @@ func TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePr
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_policy_document.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartition(t, endpoints.AwsUsGovPartitionID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -421,7 +421,7 @@ func TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePr
 
 func TestAccIAMPolicyDocumentDataSource_version20081017(t *testing.T) {
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/iam/policy_identity_gen_test.go
+++ b/internal/service/iam/policy_identity_gen_test.go
@@ -35,7 +35,7 @@ func TestAccIAMPolicy_Identity_basic(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckPolicyDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			// Step 1: Setup
@@ -45,7 +45,7 @@ func TestAccIAMPolicy_Identity_basic(t *testing.T) {
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
@@ -119,7 +119,7 @@ func TestAccIAMPolicy_Identity_ExistingResource_basic(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// Step 1: Create pre-Identity
 			{
@@ -128,7 +128,7 @@ func TestAccIAMPolicy_Identity_ExistingResource_basic(t *testing.T) {
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),
@@ -175,7 +175,7 @@ func TestAccIAMPolicy_Identity_ExistingResource_noRefreshNoChange(t *testing.T) 
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx, t),
 		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
 			Plan: resource.PlanOptions{
 				NoRefresh: true,
@@ -189,7 +189,7 @@ func TestAccIAMPolicy_Identity_ExistingResource_noRefreshNoChange(t *testing.T) 
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),

--- a/internal/service/iam/policy_list_test.go
+++ b/internal/service/iam/policy_list_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/querycheck"
@@ -27,7 +26,7 @@ func TestAccIAMPolicy_List_basic(t *testing.T) {
 	resourceName2 := "aws_iam_policy.test[1]"
 	resourceName3 := "aws_iam_policy.test[2]"
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	arn1 := tfstatecheck.StateValue()
 	arn2 := tfstatecheck.StateValue()
@@ -39,7 +38,7 @@ func TestAccIAMPolicy_List_basic(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// Step 1: Setup
 			{
@@ -94,9 +93,9 @@ func TestAccIAMPolicy_List_pathPrefix(t *testing.T) {
 	resourceNameNotExpected1 := "aws_iam_policy.not_expected[0]"
 	resourceNameNotExpected2 := "aws_iam_policy.not_expected[1]"
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rPathName := "/" + sdkacctest.RandomWithPrefix(acctest.ResourcePrefix) + "/"
-	rOtherPathName := "/" + sdkacctest.RandomWithPrefix(acctest.ResourcePrefix) + "/"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rPathName := "/" + acctest.RandomWithPrefix(t, acctest.ResourcePrefix) + "/"
+	rOtherPathName := "/" + acctest.RandomWithPrefix(t, acctest.ResourcePrefix) + "/"
 
 	expected1 := tfstatecheck.StateValue()
 	expected2 := tfstatecheck.StateValue()
@@ -109,7 +108,7 @@ func TestAccIAMPolicy_List_pathPrefix(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// Step 1: Setup
 			{

--- a/internal/service/iam/policy_tags_gen_test.go
+++ b/internal/service/iam/policy_tags_gen_test.go
@@ -33,7 +33,7 @@ func TestAccIAMPolicy_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckPolicyDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -45,7 +45,7 @@ func TestAccIAMPolicy_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -89,7 +89,7 @@ func TestAccIAMPolicy_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -137,7 +137,7 @@ func TestAccIAMPolicy_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -178,7 +178,7 @@ func TestAccIAMPolicy_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -219,7 +219,7 @@ func TestAccIAMPolicy_Tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckPolicyDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -231,7 +231,7 @@ func TestAccIAMPolicy_Tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -290,7 +290,7 @@ func TestAccIAMPolicy_Tags_emptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckPolicyDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -300,7 +300,7 @@ func TestAccIAMPolicy_Tags_emptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -357,7 +357,7 @@ func TestAccIAMPolicy_Tags_addOnUpdate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckPolicyDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -367,7 +367,7 @@ func TestAccIAMPolicy_Tags_addOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -391,7 +391,7 @@ func TestAccIAMPolicy_Tags_addOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -442,7 +442,7 @@ func TestAccIAMPolicy_Tags_EmptyTag_onCreate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckPolicyDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -454,7 +454,7 @@ func TestAccIAMPolicy_Tags_EmptyTag_onCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -494,7 +494,7 @@ func TestAccIAMPolicy_Tags_EmptyTag_onCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -535,7 +535,7 @@ func TestAccIAMPolicy_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckPolicyDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -547,7 +547,7 @@ func TestAccIAMPolicy_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -579,7 +579,7 @@ func TestAccIAMPolicy_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -625,7 +625,7 @@ func TestAccIAMPolicy_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -676,7 +676,7 @@ func TestAccIAMPolicy_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckPolicyDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -688,7 +688,7 @@ func TestAccIAMPolicy_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -719,7 +719,7 @@ func TestAccIAMPolicy_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -769,7 +769,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_providerOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -782,7 +782,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -826,7 +826,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -872,7 +872,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -912,7 +912,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -954,7 +954,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -969,7 +969,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1023,7 +1023,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1076,7 +1076,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1118,7 +1118,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_overlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1133,7 +1133,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1186,7 +1186,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1243,7 +1243,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1298,7 +1298,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1310,7 +1310,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1343,7 +1343,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1392,7 +1392,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1405,7 +1405,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1433,7 +1433,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1485,7 +1485,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_emptyResourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1500,7 +1500,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_emptyResourceTag(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1554,7 +1554,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1567,7 +1567,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1615,7 +1615,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) 
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1630,7 +1630,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1681,7 +1681,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1696,7 +1696,7 @@ func TestAccIAMPolicy_Tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1747,7 +1747,7 @@ func TestAccIAMPolicy_Tags_ComputedTag_onCreate(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1757,7 +1757,7 @@ func TestAccIAMPolicy_Tags_ComputedTag_onCreate(t *testing.T) {
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1806,7 +1806,7 @@ func TestAccIAMPolicy_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1818,7 +1818,7 @@ func TestAccIAMPolicy_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1850,7 +1850,7 @@ func TestAccIAMPolicy_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1907,7 +1907,7 @@ func TestAccIAMPolicy_Tags_ComputedTag_OnUpdate_replace(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1919,7 +1919,7 @@ func TestAccIAMPolicy_Tags_ComputedTag_OnUpdate_replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1949,7 +1949,7 @@ func TestAccIAMPolicy_Tags_ComputedTag_OnUpdate_replace(t *testing.T) {
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1998,7 +1998,7 @@ func TestAccIAMPolicy_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2017,7 +2017,7 @@ func TestAccIAMPolicy_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2066,7 +2066,7 @@ func TestAccIAMPolicy_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2115,7 +2115,7 @@ func TestAccIAMPolicy_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2164,7 +2164,7 @@ func TestAccIAMPolicy_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2181,7 +2181,7 @@ func TestAccIAMPolicy_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2244,7 +2244,7 @@ func TestAccIAMPolicy_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2307,7 +2307,7 @@ func TestAccIAMPolicy_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPolicyExists(ctx, resourceName, &v),
+					testAccCheckPolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/iam/principal_policy_simulation_data_source_test.go
+++ b/internal/service/iam/principal_policy_simulation_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -16,9 +15,9 @@ import (
 
 func TestAccIAMPrincipalPolicySimulationDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -54,7 +54,6 @@ const (
 // @V60SDKv2Fix
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/iam/types;types.Role")
 // @Testing(idAttrDuplicates="name")
-// @Testing(existsTakesT=false, destroyTakesT=false)
 func resourceRole() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRoleCreate,

--- a/internal/service/iam/role_data_source_test.go
+++ b/internal/service/iam/role_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -15,11 +14,11 @@ import (
 
 func TestAccIAMRoleDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	roleName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_iam_role.test"
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/iam/role_identity_gen_test.go
+++ b/internal/service/iam/role_identity_gen_test.go
@@ -36,7 +36,7 @@ func TestAccIAMRole_Identity_basic(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			// Step 1: Setup
@@ -46,7 +46,7 @@ func TestAccIAMRole_Identity_basic(t *testing.T) {
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrName), compare.ValuesSame()),
@@ -120,7 +120,7 @@ func TestAccIAMRole_Identity_ExistingResource_basic(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// Step 1: Create pre-Identity
 			{
@@ -129,7 +129,7 @@ func TestAccIAMRole_Identity_ExistingResource_basic(t *testing.T) {
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),
@@ -143,7 +143,7 @@ func TestAccIAMRole_Identity_ExistingResource_basic(t *testing.T) {
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -201,7 +201,7 @@ func TestAccIAMRole_Identity_ExistingResource_noRefreshNoChange(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
 			Plan: resource.PlanOptions{
 				NoRefresh: true,
@@ -215,7 +215,7 @@ func TestAccIAMRole_Identity_ExistingResource_noRefreshNoChange(t *testing.T) {
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),
@@ -230,7 +230,7 @@ func TestAccIAMRole_Identity_ExistingResource_noRefreshNoChange(t *testing.T) {
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 			},
 		},

--- a/internal/service/iam/role_list_test.go
+++ b/internal/service/iam/role_list_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/querycheck"
@@ -25,7 +24,7 @@ func TestAccIAMRole_List_basic(t *testing.T) {
 	resourceName1 := "aws_iam_role.test[0]"
 	resourceName2 := "aws_iam_role.test[1]"
 	resourceName3 := "aws_iam_role.test[2]"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -33,7 +32,7 @@ func TestAccIAMRole_List_basic(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// Step 1: Setup
 			{

--- a/internal/service/iam/role_policies_exclusive.go
+++ b/internal/service/iam/role_policies_exclusive.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
@@ -202,9 +201,8 @@ func findRolePoliciesByName(ctx context.Context, conn *iam.Client, roleName stri
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			if errs.IsA[*awstypes.NoSuchEntityException](err) {
-				return nil, &sdkretry.NotFoundError{
-					LastError:   err,
-					LastRequest: in,
+				return nil, &retry.NotFoundError{
+					LastError: err,
 				}
 			}
 			return policyNames, err

--- a/internal/service/iam/role_policies_exclusive_test.go
+++ b/internal/service/iam/role_policies_exclusive_test.go
@@ -11,11 +11,9 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
@@ -27,25 +25,25 @@ func TestAccIAMRolePoliciesExclusive_basic(t *testing.T) {
 
 	var role types.Role
 	var rolePolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policies_exclusive.test"
 	roleResourceName := "aws_iam_role.test"
 	rolePolicyResourceName := "aws_iam_role_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePoliciesExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePoliciesExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoleExists(ctx, roleResourceName, &role),
-					testAccCheckRolePolicyExists(ctx, rolePolicyResourceName, &rolePolicy),
-					testAccCheckRolePoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckRoleExists(ctx, t, roleResourceName, &role),
+					testAccCheckRolePolicyExists(ctx, t, rolePolicyResourceName, &rolePolicy),
+					testAccCheckRolePoliciesExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "role_name", roleResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_names.*", rolePolicyResourceName, names.AttrName),
 				),
@@ -66,25 +64,25 @@ func TestAccIAMRolePoliciesExclusive_disappears_Role(t *testing.T) {
 
 	var role types.Role
 	var rolePolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policies_exclusive.test"
 	roleResourceName := "aws_iam_role.test"
 	rolePolicyResourceName := "aws_iam_role_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePoliciesExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePoliciesExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoleExists(ctx, roleResourceName, &role),
-					testAccCheckRolePolicyExists(ctx, rolePolicyResourceName, &rolePolicy),
-					testAccCheckRolePoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckRoleExists(ctx, t, roleResourceName, &role),
+					testAccCheckRolePolicyExists(ctx, t, rolePolicyResourceName, &rolePolicy),
+					testAccCheckRolePoliciesExclusiveExists(ctx, t, resourceName),
 					// Inline policy must be deleted before the role can be
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceRolePolicy(), rolePolicyResourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceRole(), roleResourceName),
@@ -100,27 +98,27 @@ func TestAccIAMRolePoliciesExclusive_multiple(t *testing.T) {
 
 	var role types.Role
 	var rolePolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policies_exclusive.test"
 	roleResourceName := "aws_iam_role.test"
 	rolePolicyResourceName := "aws_iam_role_policy.test"
 	rolePolicyResourceName2 := "aws_iam_role_policy.test2"
 	rolePolicyResourceName3 := "aws_iam_role_policy.test3"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePoliciesExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePoliciesExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePoliciesExclusiveConfig_multiple(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoleExists(ctx, roleResourceName, &role),
-					testAccCheckRolePolicyExists(ctx, rolePolicyResourceName, &rolePolicy),
-					testAccCheckRolePoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckRoleExists(ctx, t, roleResourceName, &role),
+					testAccCheckRolePolicyExists(ctx, t, rolePolicyResourceName, &rolePolicy),
+					testAccCheckRolePoliciesExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "role_name", roleResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_names.*", rolePolicyResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_names.*", rolePolicyResourceName2, names.AttrName),
@@ -137,9 +135,9 @@ func TestAccIAMRolePoliciesExclusive_multiple(t *testing.T) {
 			{
 				Config: testAccRolePoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoleExists(ctx, roleResourceName, &role),
-					testAccCheckRolePolicyExists(ctx, rolePolicyResourceName, &rolePolicy),
-					testAccCheckRolePoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckRoleExists(ctx, t, roleResourceName, &role),
+					testAccCheckRolePolicyExists(ctx, t, rolePolicyResourceName, &rolePolicy),
+					testAccCheckRolePoliciesExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "role_name", roleResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_names.*", rolePolicyResourceName, names.AttrName),
 				),
@@ -152,23 +150,23 @@ func TestAccIAMRolePoliciesExclusive_empty(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var role types.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policies_exclusive.test"
 	roleResourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePoliciesExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePoliciesExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePoliciesExclusiveConfig_empty(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoleExists(ctx, roleResourceName, &role),
-					testAccCheckRolePoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckRoleExists(ctx, t, roleResourceName, &role),
+					testAccCheckRolePoliciesExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "role_name", roleResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "policy_names.#", "0"),
 				),
@@ -185,30 +183,30 @@ func TestAccIAMRolePoliciesExclusive_outOfBandRemoval(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var role types.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policies_exclusive.test"
 	roleResourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoleExists(ctx, roleResourceName, &role),
-					testAccCheckRolePoliciesExclusiveExists(ctx, resourceName),
-					testAccCheckRolePolicyRemoveInlinePolicy(ctx, &role, rName),
+					testAccCheckRoleExists(ctx, t, roleResourceName, &role),
+					testAccCheckRolePoliciesExclusiveExists(ctx, t, resourceName),
+					testAccCheckRolePolicyRemoveInlinePolicy(ctx, t, &role, rName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccRolePoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoleExists(ctx, roleResourceName, &role),
-					testAccCheckRolePoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckRoleExists(ctx, t, roleResourceName, &role),
+					testAccCheckRolePoliciesExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "role_name", roleResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "policy_names.#", "1"),
 				),
@@ -222,31 +220,31 @@ func TestAccIAMRolePoliciesExclusive_outOfBandAddition(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var role types.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	policyName := rName + "-out-of-band"
 	resourceName := "aws_iam_role_policies_exclusive.test"
 	roleResourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoleExists(ctx, roleResourceName, &role),
-					testAccCheckRolePoliciesExclusiveExists(ctx, resourceName),
-					testAccCheckRolePolicyAddInlinePolicy(ctx, &role, policyName),
+					testAccCheckRoleExists(ctx, t, roleResourceName, &role),
+					testAccCheckRolePoliciesExclusiveExists(ctx, t, resourceName),
+					testAccCheckRolePolicyAddInlinePolicy(ctx, t, &role, policyName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccRolePoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoleExists(ctx, roleResourceName, &role),
-					testAccCheckRolePoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckRoleExists(ctx, t, roleResourceName, &role),
+					testAccCheckRolePoliciesExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "role_name", roleResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "policy_names.#", "1"),
 				),
@@ -255,9 +253,9 @@ func TestAccIAMRolePoliciesExclusive_outOfBandAddition(t *testing.T) {
 	})
 }
 
-func testAccCheckRolePoliciesExclusiveDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckRolePoliciesExclusiveDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_role_policies_exclusive" {
@@ -280,7 +278,7 @@ func testAccCheckRolePoliciesExclusiveDestroy(ctx context.Context) resource.Test
 	}
 }
 
-func testAccCheckRolePoliciesExclusiveExists(ctx context.Context, name string) resource.TestCheckFunc {
+func testAccCheckRolePoliciesExclusiveExists(ctx context.Context, t *testing.T, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -292,7 +290,7 @@ func testAccCheckRolePoliciesExclusiveExists(ctx context.Context, name string) r
 			return create.Error(names.IAM, create.ErrActionCheckingExistence, tfiam.ResNameRolePoliciesExclusive, name, errors.New("not set"))
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 		out, err := tfiam.FindRolePoliciesByName(ctx, conn, roleName)
 		if err != nil {
 			return create.Error(names.IAM, create.ErrActionCheckingExistence, tfiam.ResNameRolePoliciesExclusive, roleName, err)

--- a/internal/service/iam/role_policy.go
+++ b/internal/service/iam/role_policy.go
@@ -17,7 +17,6 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
@@ -41,7 +40,6 @@ const (
 // @ImportIDHandler("rolePolicyImportID")
 // @Testing(existsType="string")
 // @Testing(preIdentityVersion="6.0.0")
-// @Testing(existsTakesT=false, destroyTakesT=false)
 func resourceRolePolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRolePolicyPut,
@@ -199,9 +197,8 @@ func findRolePolicyByTwoPartKey(ctx context.Context, conn *iam.Client, roleName,
 	output, err := conn.GetRolePolicy(ctx, input)
 
 	if errs.IsA[*awstypes.NoSuchEntityException](err) {
-		return "", &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return "", &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/iam/role_policy_attachment.go
+++ b/internal/service/iam/role_policy_attachment.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -33,7 +32,6 @@ import (
 // @IdAttrFormat("{role}/{policy_arn}")
 // @ImportIDHandler("rolePolicyAttachmentImportID")
 // @Testing(preIdentityVersion="6.0.0")
-// @Testing(existsTakesT=false, destroyTakesT=false)
 func resourceRolePolicyAttachment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRolePolicyAttachmentCreate,
@@ -173,9 +171,8 @@ func findAttachedRolePolicies(ctx context.Context, conn *iam.Client, input *iam.
 		page, err := pages.NextPage(ctx)
 
 		if errs.IsA[*awstypes.NoSuchEntityException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 

--- a/internal/service/iam/role_policy_attachment_identity_gen_test.go
+++ b/internal/service/iam/role_policy_attachment_identity_gen_test.go
@@ -33,7 +33,7 @@ func TestAccIAMRolePolicyAttachment_Identity_basic(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckRolePolicyAttachmentDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyAttachmentDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			// Step 1: Setup
@@ -43,7 +43,7 @@ func TestAccIAMRolePolicyAttachment_Identity_basic(t *testing.T) {
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRolePolicyAttachmentExists(ctx, resourceName),
+					testAccCheckRolePolicyAttachmentExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectAttributeFormat(resourceName, tfjsonpath.New(names.AttrID), "{role}/{policy_arn}"),
@@ -119,7 +119,7 @@ func TestAccIAMRolePolicyAttachment_Identity_ExistingResource_basic(t *testing.T
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRolePolicyAttachmentDestroy(ctx),
+		CheckDestroy: testAccCheckRolePolicyAttachmentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// Step 1: Create pre-Identity
 			{
@@ -128,7 +128,7 @@ func TestAccIAMRolePolicyAttachment_Identity_ExistingResource_basic(t *testing.T
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRolePolicyAttachmentExists(ctx, resourceName),
+					testAccCheckRolePolicyAttachmentExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),
@@ -177,7 +177,7 @@ func TestAccIAMRolePolicyAttachment_Identity_ExistingResource_noRefreshNoChange(
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRolePolicyAttachmentDestroy(ctx),
+		CheckDestroy: testAccCheckRolePolicyAttachmentDestroy(ctx, t),
 		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
 			Plan: resource.PlanOptions{
 				NoRefresh: true,
@@ -191,7 +191,7 @@ func TestAccIAMRolePolicyAttachment_Identity_ExistingResource_noRefreshNoChange(
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRolePolicyAttachmentExists(ctx, resourceName),
+					testAccCheckRolePolicyAttachmentExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),

--- a/internal/service/iam/role_policy_attachment_list_test.go
+++ b/internal/service/iam/role_policy_attachment_list_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/querycheck"
@@ -29,7 +28,7 @@ func TestAccIAMRolePolicyAttachment_List_basic(t *testing.T) {
 	awsManagedName1 := "aws_iam_role_policy_attachment.aws_managed[0]"
 	awsManagedName2 := "aws_iam_role_policy_attachment.aws_managed[1]"
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	identity1 := tfstatecheck.Identity()
 	identity2 := tfstatecheck.Identity()
@@ -42,7 +41,7 @@ func TestAccIAMRolePolicyAttachment_List_basic(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// Step 1: Setup
 			{

--- a/internal/service/iam/role_policy_attachment_test.go
+++ b/internal/service/iam/role_policy_attachment_test.go
@@ -12,11 +12,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
@@ -25,23 +23,23 @@ import (
 
 func TestAccIAMRolePolicyAttachment_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	roleName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName3 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy_attachment.test1"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePolicyAttachmentDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyAttachmentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePolicyAttachmentConfig_attach(roleName, policyName1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyAttachmentExists(ctx, resourceName),
-					testAccCheckRolePolicyAttachmentCount(ctx, roleName, 1),
+					testAccCheckRolePolicyAttachmentExists(ctx, t, resourceName),
+					testAccCheckRolePolicyAttachmentCount(ctx, t, roleName, 1),
 				),
 			},
 			{
@@ -68,8 +66,8 @@ func TestAccIAMRolePolicyAttachment_basic(t *testing.T) {
 			{
 				Config: testAccRolePolicyAttachmentConfig_attachUpdate(roleName, policyName1, policyName2, policyName3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyAttachmentExists(ctx, resourceName),
-					testAccCheckRolePolicyAttachmentCount(ctx, roleName, 2),
+					testAccCheckRolePolicyAttachmentExists(ctx, t, resourceName),
+					testAccCheckRolePolicyAttachmentCount(ctx, t, roleName, 2),
 				),
 			},
 		},
@@ -78,20 +76,20 @@ func TestAccIAMRolePolicyAttachment_basic(t *testing.T) {
 
 func TestAccIAMRolePolicyAttachment_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	roleName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy_attachment.test1"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePolicyAttachmentDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyAttachmentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePolicyAttachmentConfig_attach(roleName, policyName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyAttachmentExists(ctx, resourceName),
+					testAccCheckRolePolicyAttachmentExists(ctx, t, resourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceRolePolicyAttachment(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -102,21 +100,21 @@ func TestAccIAMRolePolicyAttachment_disappears(t *testing.T) {
 
 func TestAccIAMRolePolicyAttachment_Disappears_role(t *testing.T) {
 	ctx := acctest.Context(t)
-	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	roleName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy_attachment.test1"
 	iamRoleResourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePolicyAttachmentDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyAttachmentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePolicyAttachmentConfig_attach(roleName, policyName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyAttachmentExists(ctx, resourceName),
+					testAccCheckRolePolicyAttachmentExists(ctx, t, resourceName),
 					// DeleteConflict: Cannot delete entity, must detach all policies first.
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceRolePolicyAttachment(), resourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceRole(), iamRoleResourceName),
@@ -127,9 +125,9 @@ func TestAccIAMRolePolicyAttachment_Disappears_role(t *testing.T) {
 	})
 }
 
-func testAccCheckRolePolicyAttachmentDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckRolePolicyAttachmentDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_role_policy_attachment" {
@@ -153,14 +151,14 @@ func testAccCheckRolePolicyAttachmentDestroy(ctx context.Context) resource.TestC
 	}
 }
 
-func testAccCheckRolePolicyAttachmentExists(ctx context.Context, n string) resource.TestCheckFunc {
+func testAccCheckRolePolicyAttachmentExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		_, err := tfiam.FindAttachedRolePolicyByTwoPartKey(ctx, conn, rs.Primary.Attributes[names.AttrRole], rs.Primary.Attributes["policy_arn"])
 
@@ -168,9 +166,9 @@ func testAccCheckRolePolicyAttachmentExists(ctx context.Context, n string) resou
 	}
 }
 
-func testAccCheckRolePolicyAttachmentCount(ctx context.Context, roleName string, want int) resource.TestCheckFunc {
+func testAccCheckRolePolicyAttachmentCount(ctx context.Context, t *testing.T, roleName string, want int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		input := &iam.ListAttachedRolePoliciesInput{
 			RoleName: aws.String(roleName),

--- a/internal/service/iam/role_policy_attachments_exclusive.go
+++ b/internal/service/iam/role_policy_attachments_exclusive.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
@@ -192,9 +191,8 @@ func findRolePolicyAttachmentsByName(ctx context.Context, conn *iam.Client, role
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			if errs.IsA[*awstypes.NoSuchEntityException](err) {
-				return nil, &sdkretry.NotFoundError{
-					LastError:   err,
-					LastRequest: in,
+				return nil, &retry.NotFoundError{
+					LastError: err,
 				}
 			}
 			return policyARNs, err

--- a/internal/service/iam/role_policy_attachments_exclusive_test.go
+++ b/internal/service/iam/role_policy_attachments_exclusive_test.go
@@ -11,11 +11,9 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
@@ -25,25 +23,25 @@ import (
 func TestAccIAMRolePolicyAttachmentsExclusive_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy_attachments_exclusive.test"
 	roleResourceName := "aws_iam_role.test"
 	attachmentResourceName := "aws_iam_role_policy_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePolicyAttachmentsExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyAttachmentsExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePolicyAttachmentsExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckRolePolicyAttachmentCount(ctx, rName, 1),
-					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckRolePolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckRolePolicyAttachmentCount(ctx, t, rName, 1),
+					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "role_name", roleResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_arns.*", attachmentResourceName, "policy_arn"),
 				),
@@ -62,25 +60,25 @@ func TestAccIAMRolePolicyAttachmentsExclusive_basic(t *testing.T) {
 func TestAccIAMRolePolicyAttachmentsExclusive_disappears_Role(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy_attachments_exclusive.test"
 	roleResourceName := "aws_iam_role.test"
 	attachmentResourceName := "aws_iam_role_policy_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePolicyAttachmentsExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyAttachmentsExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePolicyAttachmentsExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckRolePolicyAttachmentCount(ctx, rName, 1),
-					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckRolePolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckRolePolicyAttachmentCount(ctx, t, rName, 1),
+					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					// Managed policies must be detached before role can be deleted
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceRolePolicyAttachment(), attachmentResourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceRole(), roleResourceName),
@@ -94,25 +92,25 @@ func TestAccIAMRolePolicyAttachmentsExclusive_disappears_Role(t *testing.T) {
 func TestAccIAMRolePolicyAttachmentsExclusive_disappears_Policy(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy_attachments_exclusive.test"
 	policyResourceName := "aws_iam_policy.test"
 	attachmentResourceName := "aws_iam_role_policy_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePolicyAttachmentsExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyAttachmentsExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePolicyAttachmentsExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckRolePolicyAttachmentCount(ctx, rName, 1),
-					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckRolePolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckRolePolicyAttachmentCount(ctx, t, rName, 1),
+					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					// Managed policy must be detached before it can be deleted
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceRolePolicyAttachment(), attachmentResourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourcePolicy(), policyResourceName),
@@ -126,29 +124,29 @@ func TestAccIAMRolePolicyAttachmentsExclusive_disappears_Policy(t *testing.T) {
 func TestAccIAMRolePolicyAttachmentsExclusive_multiple(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy_attachments_exclusive.test"
 	roleResourceName := "aws_iam_role.test"
 	attachmentResourceName := "aws_iam_role_policy_attachment.test"
 	attachmentResourceName2 := "aws_iam_role_policy_attachment.test2"
 	attachmentResourceName3 := "aws_iam_role_policy_attachment.test3"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePolicyAttachmentsExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyAttachmentsExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePolicyAttachmentsExclusiveConfig_multiple(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckRolePolicyAttachmentExists(ctx, attachmentResourceName2),
-					testAccCheckRolePolicyAttachmentExists(ctx, attachmentResourceName3),
-					testAccCheckRolePolicyAttachmentCount(ctx, rName, 3),
-					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckRolePolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckRolePolicyAttachmentExists(ctx, t, attachmentResourceName2),
+					testAccCheckRolePolicyAttachmentExists(ctx, t, attachmentResourceName3),
+					testAccCheckRolePolicyAttachmentCount(ctx, t, rName, 3),
+					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "role_name", roleResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_arns.*", attachmentResourceName, "policy_arn"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_arns.*", attachmentResourceName2, "policy_arn"),
@@ -165,9 +163,9 @@ func TestAccIAMRolePolicyAttachmentsExclusive_multiple(t *testing.T) {
 			{
 				Config: testAccRolePolicyAttachmentsExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckRolePolicyAttachmentCount(ctx, rName, 1),
-					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckRolePolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckRolePolicyAttachmentCount(ctx, t, rName, 1),
+					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "role_name", roleResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_arns.*", attachmentResourceName, "policy_arn"),
 				),
@@ -179,22 +177,22 @@ func TestAccIAMRolePolicyAttachmentsExclusive_multiple(t *testing.T) {
 func TestAccIAMRolePolicyAttachmentsExclusive_empty(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy_attachments_exclusive.test"
 	roleResourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePolicyAttachmentsExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyAttachmentsExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePolicyAttachmentsExclusiveConfig_empty(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "role_name", roleResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "policy_arns.#", "0"),
 				),
@@ -211,35 +209,35 @@ func TestAccIAMRolePolicyAttachmentsExclusive_outOfBandRemoval(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var role types.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy_attachments_exclusive.test"
 	roleResourceName := "aws_iam_role.test"
 	attachmentResourceName := "aws_iam_role_policy_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePolicyAttachmentsExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoleExists(ctx, roleResourceName, &role),
-					testAccCheckRolePolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckRolePolicyAttachmentCount(ctx, rName, 1),
-					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, resourceName),
-					testAccCheckRolePolicyDetachManagedPolicy(ctx, &role, rName),
+					testAccCheckRoleExists(ctx, t, roleResourceName, &role),
+					testAccCheckRolePolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckRolePolicyAttachmentCount(ctx, t, rName, 1),
+					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, t, resourceName),
+					testAccCheckRolePolicyDetachManagedPolicy(ctx, t, &role, rName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccRolePolicyAttachmentsExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoleExists(ctx, roleResourceName, &role),
-					testAccCheckRolePolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckRolePolicyAttachmentCount(ctx, rName, 1),
-					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckRoleExists(ctx, t, roleResourceName, &role),
+					testAccCheckRolePolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckRolePolicyAttachmentCount(ctx, t, rName, 1),
+					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "role_name", roleResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "policy_arns.#", "1"),
 				),
@@ -253,31 +251,31 @@ func TestAccIAMRolePolicyAttachmentsExclusive_outOfBandAddition(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var role types.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	oobPolicyName := rName + "-out-of-band"
 	resourceName := "aws_iam_role_policy_attachments_exclusive.test"
 	roleResourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePolicyAttachmentsExclusiveConfig_outOfBandAddition(rName, oobPolicyName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoleExists(ctx, roleResourceName, &role),
-					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, resourceName),
-					testAccCheckRolePolicyAttachManagedPolicy(ctx, &role, oobPolicyName),
+					testAccCheckRoleExists(ctx, t, roleResourceName, &role),
+					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, t, resourceName),
+					testAccCheckRolePolicyAttachManagedPolicy(ctx, t, &role, oobPolicyName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccRolePolicyAttachmentsExclusiveConfig_outOfBandAddition(rName, oobPolicyName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoleExists(ctx, roleResourceName, &role),
-					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckRoleExists(ctx, t, roleResourceName, &role),
+					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "role_name", roleResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "policy_arns.#", "1"),
 				),
@@ -286,9 +284,9 @@ func TestAccIAMRolePolicyAttachmentsExclusive_outOfBandAddition(t *testing.T) {
 	})
 }
 
-func testAccCheckRolePolicyAttachmentsExclusiveDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckRolePolicyAttachmentsExclusiveDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_role_policy_attachments_exclusive" {
@@ -311,7 +309,7 @@ func testAccCheckRolePolicyAttachmentsExclusiveDestroy(ctx context.Context) reso
 	}
 }
 
-func testAccCheckRolePolicyAttachmentsExclusiveExists(ctx context.Context, name string) resource.TestCheckFunc {
+func testAccCheckRolePolicyAttachmentsExclusiveExists(ctx context.Context, t *testing.T, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -323,7 +321,7 @@ func testAccCheckRolePolicyAttachmentsExclusiveExists(ctx context.Context, name 
 			return create.Error(names.IAM, create.ErrActionCheckingExistence, tfiam.ResNameRolePolicyAttachmentsExclusive, name, errors.New("not set"))
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 		out, err := tfiam.FindRolePolicyAttachmentsByName(ctx, conn, roleName)
 		if err != nil {
 			return create.Error(names.IAM, create.ErrActionCheckingExistence, tfiam.ResNameRolePolicyAttachmentsExclusive, roleName, err)

--- a/internal/service/iam/role_policy_identity_gen_test.go
+++ b/internal/service/iam/role_policy_identity_gen_test.go
@@ -34,7 +34,7 @@ func TestAccIAMRolePolicy_Identity_basic(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			// Step 1: Setup
@@ -44,7 +44,7 @@ func TestAccIAMRolePolicy_Identity_basic(t *testing.T) {
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRolePolicyExists(ctx, resourceName, &v),
+					testAccCheckRolePolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectAttributeFormat(resourceName, tfjsonpath.New(names.AttrID), "{role}:{name}"),
@@ -121,7 +121,7 @@ func TestAccIAMRolePolicy_Identity_ExistingResource_basic(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRolePolicyDestroy(ctx),
+		CheckDestroy: testAccCheckRolePolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// Step 1: Create pre-Identity
 			{
@@ -130,7 +130,7 @@ func TestAccIAMRolePolicy_Identity_ExistingResource_basic(t *testing.T) {
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRolePolicyExists(ctx, resourceName, &v),
+					testAccCheckRolePolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),
@@ -180,7 +180,7 @@ func TestAccIAMRolePolicy_Identity_ExistingResource_noRefreshNoChange(t *testing
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRolePolicyDestroy(ctx),
+		CheckDestroy: testAccCheckRolePolicyDestroy(ctx, t),
 		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
 			Plan: resource.PlanOptions{
 				NoRefresh: true,
@@ -194,7 +194,7 @@ func TestAccIAMRolePolicy_Identity_ExistingResource_noRefreshNoChange(t *testing
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRolePolicyExists(ctx, resourceName, &v),
+					testAccCheckRolePolicyExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),

--- a/internal/service/iam/role_policy_list_test.go
+++ b/internal/service/iam/role_policy_list_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/querycheck"
@@ -24,7 +23,7 @@ func TestAccIAMRolePolicy_List_basic(t *testing.T) {
 
 	resourceName1 := "aws_iam_role_policy.test[0]"
 	resourceName2 := "aws_iam_role_policy.test[1]"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -34,7 +33,7 @@ func TestAccIAMRolePolicy_List_basic(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRolePolicyDestroy(ctx),
+		CheckDestroy: testAccCheckRolePolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// Step 1: Setup
 			{

--- a/internal/service/iam/role_policy_test.go
+++ b/internal/service/iam/role_policy_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
 	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -30,19 +28,19 @@ import (
 func TestAccIAMRolePolicy_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var rolePolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyExists(ctx, resourceName, &rolePolicy),
+					testAccCheckRolePolicyExists(ctx, t, resourceName, &rolePolicy),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, ""),
 				),
@@ -59,19 +57,19 @@ func TestAccIAMRolePolicy_basic(t *testing.T) {
 func TestAccIAMRolePolicy_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var rolePolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyExists(ctx, resourceName, &rolePolicy),
+					testAccCheckRolePolicyExists(ctx, t, resourceName, &rolePolicy),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceRolePolicy(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -83,19 +81,19 @@ func TestAccIAMRolePolicy_disappears(t *testing.T) {
 func TestAccIAMRolePolicy_nameGenerated(t *testing.T) {
 	ctx := acctest.Context(t)
 	var rolePolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePolicyConfig_nameGenerated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyExists(ctx, resourceName, &rolePolicy),
+					testAccCheckRolePolicyExists(ctx, t, resourceName, &rolePolicy),
 					acctest.CheckResourceAttrNameGenerated(resourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, id.UniqueIdPrefix),
 				),
@@ -112,19 +110,19 @@ func TestAccIAMRolePolicy_nameGenerated(t *testing.T) {
 func TestAccIAMRolePolicy_namePrefix(t *testing.T) {
 	ctx := acctest.Context(t)
 	var rolePolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePolicyConfig_namePrefix(rName, "tf-acc-test-prefix-"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyExists(ctx, resourceName, &rolePolicy),
+					testAccCheckRolePolicyExists(ctx, t, resourceName, &rolePolicy),
 					acctest.CheckResourceAttrNameFromPrefix(resourceName, names.AttrName, "tf-acc-test-prefix-"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, "tf-acc-test-prefix-"),
 				),
@@ -141,19 +139,19 @@ func TestAccIAMRolePolicy_namePrefix(t *testing.T) {
 func TestAccIAMRolePolicy_policyOrder(t *testing.T) {
 	ctx := acctest.Context(t)
 	var rolePolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePolicyConfig_order(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyExists(ctx, resourceName, &rolePolicy),
+					testAccCheckRolePolicyExists(ctx, t, resourceName, &rolePolicy),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -178,13 +176,13 @@ func TestAccIAMRolePolicy_policyOrder(t *testing.T) {
 
 func TestAccIAMRolePolicy_invalidJSON(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccRolePolicyConfig_invalidJSON(rName),
@@ -196,13 +194,13 @@ func TestAccIAMRolePolicy_invalidJSON(t *testing.T) {
 
 func TestAccIAMRolePolicy_Policy_invalidResource(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccRolePolicyConfig_invalidResource(rName),
@@ -220,19 +218,19 @@ func TestAccIAMRolePolicy_Policy_invalidResource(t *testing.T) {
 func TestAccIAMRolePolicy_unknownsInPolicy(t *testing.T) {
 	ctx := acctest.Context(t)
 	var rolePolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckRolePolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRolePolicyConfig_unknowns(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyExists(ctx, resourceName, &rolePolicy),
+					testAccCheckRolePolicyExists(ctx, t, resourceName, &rolePolicy),
 				),
 			},
 		},
@@ -243,16 +241,16 @@ func TestAccIAMRolePolicy_unknownsInPolicy(t *testing.T) {
 func TestAccIAMRolePolicy_Identity_old(t *testing.T) {
 	ctx := acctest.Context(t)
 	var rolePolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRolePolicyDestroy(ctx),
+		CheckDestroy: testAccCheckRolePolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
@@ -263,7 +261,7 @@ func TestAccIAMRolePolicy_Identity_old(t *testing.T) {
 				},
 				Config: testAccRolePolicyConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRolePolicyExists(ctx, resourceName, &rolePolicy),
+					testAccCheckRolePolicyExists(ctx, t, resourceName, &rolePolicy),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),
@@ -273,7 +271,7 @@ func TestAccIAMRolePolicy_Identity_old(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				Config:                   testAccRolePolicyConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRolePolicyExists(ctx, resourceName, &rolePolicy),
+					testAccCheckRolePolicyExists(ctx, t, resourceName, &rolePolicy),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -297,9 +295,9 @@ func TestAccIAMRolePolicy_Identity_old(t *testing.T) {
 	})
 }
 
-func testAccCheckRolePolicyDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckRolePolicyDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_role_policy" {
@@ -328,7 +326,7 @@ func testAccCheckRolePolicyDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckRolePolicyExists(ctx context.Context, n string, v *string) resource.TestCheckFunc {
+func testAccCheckRolePolicyExists(ctx context.Context, t *testing.T, n string, v *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -340,7 +338,7 @@ func testAccCheckRolePolicyExists(ctx context.Context, n string, v *string) reso
 			return err
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		output, err := tfiam.FindRolePolicyByTwoPartKey(ctx, conn, roleName, policyName)
 

--- a/internal/service/iam/role_tags_gen_test.go
+++ b/internal/service/iam/role_tags_gen_test.go
@@ -33,7 +33,7 @@ func TestAccIAMRole_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -45,7 +45,7 @@ func TestAccIAMRole_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -89,7 +89,7 @@ func TestAccIAMRole_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -137,7 +137,7 @@ func TestAccIAMRole_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -178,7 +178,7 @@ func TestAccIAMRole_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -219,7 +219,7 @@ func TestAccIAMRole_Tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -231,7 +231,7 @@ func TestAccIAMRole_Tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -290,7 +290,7 @@ func TestAccIAMRole_Tags_emptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -300,7 +300,7 @@ func TestAccIAMRole_Tags_emptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -357,7 +357,7 @@ func TestAccIAMRole_Tags_addOnUpdate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -367,7 +367,7 @@ func TestAccIAMRole_Tags_addOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -391,7 +391,7 @@ func TestAccIAMRole_Tags_addOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -442,7 +442,7 @@ func TestAccIAMRole_Tags_EmptyTag_onCreate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -454,7 +454,7 @@ func TestAccIAMRole_Tags_EmptyTag_onCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -494,7 +494,7 @@ func TestAccIAMRole_Tags_EmptyTag_onCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -535,7 +535,7 @@ func TestAccIAMRole_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -547,7 +547,7 @@ func TestAccIAMRole_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -579,7 +579,7 @@ func TestAccIAMRole_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -625,7 +625,7 @@ func TestAccIAMRole_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -676,7 +676,7 @@ func TestAccIAMRole_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -688,7 +688,7 @@ func TestAccIAMRole_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -719,7 +719,7 @@ func TestAccIAMRole_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -769,7 +769,7 @@ func TestAccIAMRole_Tags_DefaultTags_providerOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -782,7 +782,7 @@ func TestAccIAMRole_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -826,7 +826,7 @@ func TestAccIAMRole_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -872,7 +872,7 @@ func TestAccIAMRole_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -912,7 +912,7 @@ func TestAccIAMRole_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -954,7 +954,7 @@ func TestAccIAMRole_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -969,7 +969,7 @@ func TestAccIAMRole_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1023,7 +1023,7 @@ func TestAccIAMRole_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1076,7 +1076,7 @@ func TestAccIAMRole_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1118,7 +1118,7 @@ func TestAccIAMRole_Tags_DefaultTags_overlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1133,7 +1133,7 @@ func TestAccIAMRole_Tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1186,7 +1186,7 @@ func TestAccIAMRole_Tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1243,7 +1243,7 @@ func TestAccIAMRole_Tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1298,7 +1298,7 @@ func TestAccIAMRole_Tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1310,7 +1310,7 @@ func TestAccIAMRole_Tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1343,7 +1343,7 @@ func TestAccIAMRole_Tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1392,7 +1392,7 @@ func TestAccIAMRole_Tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1405,7 +1405,7 @@ func TestAccIAMRole_Tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1433,7 +1433,7 @@ func TestAccIAMRole_Tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1485,7 +1485,7 @@ func TestAccIAMRole_Tags_DefaultTags_emptyResourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1500,7 +1500,7 @@ func TestAccIAMRole_Tags_DefaultTags_emptyResourceTag(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1554,7 +1554,7 @@ func TestAccIAMRole_Tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1567,7 +1567,7 @@ func TestAccIAMRole_Tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1615,7 +1615,7 @@ func TestAccIAMRole_Tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1630,7 +1630,7 @@ func TestAccIAMRole_Tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1681,7 +1681,7 @@ func TestAccIAMRole_Tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1696,7 +1696,7 @@ func TestAccIAMRole_Tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T)
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1747,7 +1747,7 @@ func TestAccIAMRole_Tags_ComputedTag_onCreate(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1757,7 +1757,7 @@ func TestAccIAMRole_Tags_ComputedTag_onCreate(t *testing.T) {
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1806,7 +1806,7 @@ func TestAccIAMRole_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1818,7 +1818,7 @@ func TestAccIAMRole_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1850,7 +1850,7 @@ func TestAccIAMRole_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1907,7 +1907,7 @@ func TestAccIAMRole_Tags_ComputedTag_OnUpdate_replace(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1919,7 +1919,7 @@ func TestAccIAMRole_Tags_ComputedTag_OnUpdate_replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1949,7 +1949,7 @@ func TestAccIAMRole_Tags_ComputedTag_OnUpdate_replace(t *testing.T) {
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1998,7 +1998,7 @@ func TestAccIAMRole_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2017,7 +2017,7 @@ func TestAccIAMRole_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2066,7 +2066,7 @@ func TestAccIAMRole_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2115,7 +2115,7 @@ func TestAccIAMRole_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2164,7 +2164,7 @@ func TestAccIAMRole_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2181,7 +2181,7 @@ func TestAccIAMRole_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2244,7 +2244,7 @@ func TestAccIAMRole_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2307,7 +2307,7 @@ func TestAccIAMRole_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &v),
+					testAccCheckRoleExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/iam/role_test.go
+++ b/internal/service/iam/role_test.go
@@ -13,12 +13,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
@@ -28,19 +26,19 @@ import (
 func TestAccIAMRole_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &conf),
+					testAccCheckRoleExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/"),
 					resource.TestCheckResourceAttrSet(resourceName, "create_date"),
 					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "iam", "role/{name}"),
@@ -58,19 +56,19 @@ func TestAccIAMRole_basic(t *testing.T) {
 func TestAccIAMRole_description(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_description(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &conf),
+					testAccCheckRoleExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "This 1s a D3scr!pti0n with weird content: &@90ë\"'{«¡Çø}"),
 				),
@@ -83,7 +81,7 @@ func TestAccIAMRole_description(t *testing.T) {
 			{
 				Config: testAccRoleConfig_updatedDescription(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &conf),
+					testAccCheckRoleExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "This 1s an Upd@ted D3scr!pti0n with weird content: &90ë\"'{«¡Çø}"),
 				),
@@ -91,7 +89,7 @@ func TestAccIAMRole_description(t *testing.T) {
 			{
 				Config: testAccRoleConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &conf),
+					testAccCheckRoleExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "create_date"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 				),
@@ -105,16 +103,16 @@ func TestAccIAMRole_nameGenerated(t *testing.T) {
 	var conf awstypes.Role
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_nameGenerated(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &conf),
+					testAccCheckRoleExists(ctx, t, resourceName, &conf),
 					acctest.CheckResourceAttrNameGenerated(resourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, "terraform-"),
 				),
@@ -133,16 +131,16 @@ func TestAccIAMRole_namePrefix(t *testing.T) {
 	var conf awstypes.Role
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_namePrefix(acctest.ResourcePrefix),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &conf),
+					testAccCheckRoleExists(ctx, t, resourceName, &conf),
 					acctest.CheckResourceAttrNameFromPrefix(resourceName, names.AttrName, acctest.ResourcePrefix),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, acctest.ResourcePrefix),
 				),
@@ -159,19 +157,19 @@ func TestAccIAMRole_namePrefix(t *testing.T) {
 func TestAccIAMRole_testNameChange(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_pre(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &conf),
+					testAccCheckRoleExists(ctx, t, resourceName, &conf),
 				),
 			},
 			{
@@ -183,7 +181,7 @@ func TestAccIAMRole_testNameChange(t *testing.T) {
 			{
 				Config: testAccRoleConfig_post(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &conf),
+					testAccCheckRoleExists(ctx, t, resourceName, &conf),
 				),
 			},
 		},
@@ -195,19 +193,19 @@ func TestAccIAMRole_testNameChange(t *testing.T) {
 func TestAccIAMRole_diffs(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_diffs(rName, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &conf),
+					testAccCheckRoleExists(ctx, t, resourceName, &conf),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -218,7 +216,7 @@ func TestAccIAMRole_diffs(t *testing.T) {
 			{
 				Config: testAccRoleConfig_diffs(rName, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &conf),
+					testAccCheckRoleExists(ctx, t, resourceName, &conf),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -248,19 +246,19 @@ func TestAccIAMRole_diffs(t *testing.T) {
 func TestAccIAMRole_diffsCondition(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_diffsCondition(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &conf),
+					testAccCheckRoleExists(ctx, t, resourceName, &conf),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -285,13 +283,13 @@ func TestAccIAMRole_diffsCondition(t *testing.T) {
 
 func TestAccIAMRole_badJSON(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccRoleConfig_badJSON(rName),
@@ -305,19 +303,19 @@ func TestAccIAMRole_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var role awstypes.Role
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceRole(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -329,20 +327,20 @@ func TestAccIAMRole_disappears(t *testing.T) {
 func TestAccIAMRole_policiesForceDetach(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_forceDetachPolicies(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &conf),
-					testAccAddRolePolicy(ctx, resourceName),
+					testAccCheckRoleExists(ctx, t, resourceName, &conf),
+					testAccAddRolePolicy(ctx, t, resourceName),
 				),
 			},
 			{
@@ -358,14 +356,14 @@ func TestAccIAMRole_policiesForceDetach(t *testing.T) {
 func TestAccIAMRole_maxSessionDuration(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccRoleConfig_maxSessionDuration(rName, 3599),
@@ -378,7 +376,7 @@ func TestAccIAMRole_maxSessionDuration(t *testing.T) {
 			{
 				Config: testAccRoleConfig_maxSessionDuration(rName, 3700),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &conf),
+					testAccCheckRoleExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "max_session_duration", "3700"),
 				),
 			},
@@ -390,7 +388,7 @@ func TestAccIAMRole_maxSessionDuration(t *testing.T) {
 			{
 				Config: testAccRoleConfig_maxSessionDuration(rName, 3701),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &conf),
+					testAccCheckRoleExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "max_session_duration", "3701"),
 				),
 			},
@@ -407,23 +405,23 @@ func TestAccIAMRole_permissionsBoundary(t *testing.T) {
 	ctx := acctest.Context(t)
 	var role awstypes.Role
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
 	permissionsBoundary1 := fmt.Sprintf("arn:%s:iam::aws:policy/AdministratorAccess", acctest.Partition())
 	permissionsBoundary2 := fmt.Sprintf("arn:%s:iam::aws:policy/ReadOnlyAccess", acctest.Partition())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// Test creation
 			{
 				Config: testAccRoleConfig_permissionsBoundary(rName, permissionsBoundary1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", permissionsBoundary1),
 					testAccCheckRolePermissionsBoundary(&role, permissionsBoundary1),
 				),
@@ -432,7 +430,7 @@ func TestAccIAMRole_permissionsBoundary(t *testing.T) {
 			{
 				Config: testAccRoleConfig_permissionsBoundary(rName, permissionsBoundary2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", permissionsBoundary2),
 					testAccCheckRolePermissionsBoundary(&role, permissionsBoundary2),
 				),
@@ -447,7 +445,7 @@ func TestAccIAMRole_permissionsBoundary(t *testing.T) {
 			{
 				Config: testAccRoleConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", ""),
 					testAccCheckRolePermissionsBoundary(&role, ""),
 				),
@@ -456,7 +454,7 @@ func TestAccIAMRole_permissionsBoundary(t *testing.T) {
 			{
 				Config: testAccRoleConfig_permissionsBoundary(rName, permissionsBoundary1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", permissionsBoundary1),
 					testAccCheckRolePermissionsBoundary(&role, permissionsBoundary1),
 				),
@@ -465,7 +463,7 @@ func TestAccIAMRole_permissionsBoundary(t *testing.T) {
 			{
 				PreConfig: func() {
 					// delete the boundary manually
-					conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+					conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 					input := &iam.DeleteRolePermissionsBoundaryInput{
 						RoleName: role.RoleName,
 					}
@@ -477,7 +475,7 @@ func TestAccIAMRole_permissionsBoundary(t *testing.T) {
 				Config: testAccRoleConfig_permissionsBoundary(rName, permissionsBoundary1),
 				// check the boundary was restored
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", permissionsBoundary1),
 					testAccCheckRolePermissionsBoundary(&role, permissionsBoundary1),
 				),
@@ -486,7 +484,7 @@ func TestAccIAMRole_permissionsBoundary(t *testing.T) {
 			{
 				Config: testAccRoleConfig_permissionsBoundary(rName, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", ""),
 					testAccCheckRolePermissionsBoundary(&role, ""),
 				),
@@ -498,22 +496,22 @@ func TestAccIAMRole_permissionsBoundary(t *testing.T) {
 func TestAccIAMRole_InlinePolicy_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var role awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName3 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_policyInline(rName, policyName1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 					resource.TestCheckResourceAttr(resourceName, "inline_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "managed_policy_arns.#", "0"),
@@ -522,7 +520,7 @@ func TestAccIAMRole_InlinePolicy_basic(t *testing.T) {
 			{
 				Config: testAccRoleConfig_policyInlineUpdate(rName, policyName2, policyName3),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 					resource.TestCheckResourceAttr(resourceName, "inline_policy.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "managed_policy_arns.#", "0"),
 				),
@@ -530,7 +528,7 @@ func TestAccIAMRole_InlinePolicy_basic(t *testing.T) {
 			{
 				Config: testAccRoleConfig_policyInlineUpdateDown(rName, policyName3),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 					resource.TestCheckResourceAttr(resourceName, "inline_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "managed_policy_arns.#", "0"),
 				),
@@ -549,19 +547,19 @@ func TestAccIAMRole_InlinePolicy_basic(t *testing.T) {
 func TestAccIAMRole_InlinePolicy_ignoreOrder(t *testing.T) {
 	ctx := acctest.Context(t)
 	var role awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_policyInlineActionOrder(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 					resource.TestCheckResourceAttr(resourceName, "inline_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "managed_policy_arns.#", "0"),
@@ -609,19 +607,19 @@ func TestAccIAMRole_InlinePolicy_ignoreOrder(t *testing.T) {
 func TestAccIAMRole_InlinePolicy_empty(t *testing.T) {
 	ctx := acctest.Context(t)
 	var role awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_policyEmptyInline(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 				),
 			},
 		},
@@ -630,13 +628,13 @@ func TestAccIAMRole_InlinePolicy_empty(t *testing.T) {
 
 func TestAccIAMRole_InlinePolicy_malformed(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccRoleConfig_policyInlineMalformed(rName, rName),
@@ -649,22 +647,22 @@ func TestAccIAMRole_InlinePolicy_malformed(t *testing.T) {
 func TestAccIAMRole_ManagedPolicy_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var role awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName3 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_policyManaged(rName, policyName1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "managed_policy_arns.#", "1"),
 				),
@@ -672,14 +670,14 @@ func TestAccIAMRole_ManagedPolicy_basic(t *testing.T) {
 			{
 				Config: testAccRoleConfig_policyManagedUpdate(rName, policyName1, policyName2, policyName3),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 					resource.TestCheckResourceAttr(resourceName, "managed_policy_arns.#", "2"),
 				),
 			},
 			{
 				Config: testAccRoleConfig_policyManagedUpdateDown(rName, policyName1, policyName2, policyName3),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 					resource.TestCheckResourceAttr(resourceName, "managed_policy_arns.#", "1"),
 				),
 			},
@@ -697,28 +695,28 @@ func TestAccIAMRole_ManagedPolicy_basic(t *testing.T) {
 func TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack(t *testing.T) {
 	ctx := acctest.Context(t)
 	var role awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_policyManaged(rName, policyName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
-					testAccCheckRolePolicyDetachManagedPolicy(ctx, &role, policyName),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
+					testAccCheckRolePolicyDetachManagedPolicy(ctx, t, &role, policyName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccRoleConfig_policyManaged(rName, policyName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 					resource.TestCheckResourceAttr(resourceName, "managed_policy_arns.#", "1"),
 				),
 			},
@@ -731,28 +729,28 @@ func TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack(t *testing.T) {
 func TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack(t *testing.T) {
 	ctx := acctest.Context(t)
 	var role awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_policyInline(rName, policyName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
-					testAccCheckRolePolicyRemoveInlinePolicy(ctx, &role, policyName),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
+					testAccCheckRolePolicyRemoveInlinePolicy(ctx, t, &role, policyName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccRoleConfig_policyInline(rName, policyName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 					resource.TestCheckResourceAttr(resourceName, "inline_policy.#", "1"),
 				),
 			},
@@ -765,29 +763,29 @@ func TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack(t *testing.T) {
 func TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved(t *testing.T) {
 	ctx := acctest.Context(t)
 	var role awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_policyExtraManaged(rName, policyName1, policyName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
-					testAccCheckRolePolicyAttachManagedPolicy(ctx, &role, policyName2),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
+					testAccCheckRolePolicyAttachManagedPolicy(ctx, t, &role, policyName2),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccRoleConfig_policyExtraManaged(rName, policyName1, policyName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 					resource.TestCheckResourceAttr(resourceName, "managed_policy_arns.#", "1"),
 				),
 			},
@@ -800,29 +798,29 @@ func TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved(t *testing.T) {
 func TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved(t *testing.T) {
 	ctx := acctest.Context(t)
 	var role awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_policyInline(rName, policyName1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
-					testAccCheckRolePolicyAddInlinePolicy(ctx, &role, policyName2),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
+					testAccCheckRolePolicyAddInlinePolicy(ctx, t, &role, policyName2),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccRoleConfig_policyInline(rName, policyName1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 					resource.TestCheckResourceAttr(resourceName, "inline_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "managed_policy_arns.#", "0"),
 				),
@@ -836,37 +834,37 @@ func TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved(t *testing.T) {
 func TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored(t *testing.T) {
 	ctx := acctest.Context(t)
 	var role awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_policyNoInline(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
-					testAccCheckRolePolicyAddInlinePolicy(ctx, &role, policyName1),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
+					testAccCheckRolePolicyAddInlinePolicy(ctx, t, &role, policyName1),
 				),
 			},
 			{
 				Config: testAccRoleConfig_policyNoInline(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
-					testAccCheckRolePolicyAddInlinePolicy(ctx, &role, policyName2),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
+					testAccCheckRolePolicyAddInlinePolicy(ctx, t, &role, policyName2),
 				),
 			},
 			{
 				Config: testAccRoleConfig_policyNoInline(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
-					testAccCheckRolePolicyRemoveInlinePolicy(ctx, &role, policyName1),
-					testAccCheckRolePolicyRemoveInlinePolicy(ctx, &role, policyName2),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
+					testAccCheckRolePolicyRemoveInlinePolicy(ctx, t, &role, policyName1),
+					testAccCheckRolePolicyRemoveInlinePolicy(ctx, t, &role, policyName2),
 				),
 			},
 		},
@@ -878,28 +876,28 @@ func TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored(t *testing.T) {
 func TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored(t *testing.T) {
 	ctx := acctest.Context(t)
 	var role awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_policyNoManaged(rName, policyName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
-					testAccCheckRolePolicyAttachManagedPolicy(ctx, &role, policyName),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
+					testAccCheckRolePolicyAttachManagedPolicy(ctx, t, &role, policyName),
 				),
 			},
 			{
 				Config: testAccRoleConfig_policyNoManaged(rName, policyName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
-					testAccCheckRolePolicyDetachManagedPolicy(ctx, &role, policyName),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
+					testAccCheckRolePolicyDetachManagedPolicy(ctx, t, &role, policyName),
 				),
 			},
 		},
@@ -911,28 +909,28 @@ func TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored(t *testing.T) {
 func TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty(t *testing.T) {
 	ctx := acctest.Context(t)
 	var role awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_policyEmptyInline(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
-					testAccCheckRolePolicyAddInlinePolicy(ctx, &role, policyName),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
+					testAccCheckRolePolicyAddInlinePolicy(ctx, t, &role, policyName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccRoleConfig_policyEmptyInline(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 				),
 			},
 		},
@@ -944,28 +942,28 @@ func TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty(t *testing.T) {
 func TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty(t *testing.T) {
 	ctx := acctest.Context(t)
 	var role awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfig_policyEmptyManaged(rName, policyName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
-					testAccCheckRolePolicyAttachManagedPolicy(ctx, &role, policyName),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
+					testAccCheckRolePolicyAttachManagedPolicy(ctx, t, &role, policyName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccRoleConfig_policyEmptyManaged(rName, policyName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &role),
+					testAccCheckRoleExists(ctx, t, resourceName, &role),
 				),
 			},
 		},
@@ -975,13 +973,13 @@ func TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty(t *testing.T) {
 func TestAccIAMRole_Identity_ExistingResource_NoRefresh_OnError(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
 			Plan: resource.PlanOptions{
 				NoRefresh: true,
@@ -997,7 +995,7 @@ func TestAccIAMRole_Identity_ExistingResource_NoRefresh_OnError(t *testing.T) {
 				},
 				Config: testAccRoleConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &conf),
+					testAccCheckRoleExists(ctx, t, resourceName, &conf),
 				),
 			},
 			{
@@ -1012,13 +1010,13 @@ func TestAccIAMRole_Identity_ExistingResource_NoRefresh_OnError(t *testing.T) {
 func TestAccIAMRole_Identity_ExistingResource_OnError(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		CheckDestroy: testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
@@ -1029,7 +1027,7 @@ func TestAccIAMRole_Identity_ExistingResource_OnError(t *testing.T) {
 				},
 				Config: testAccRoleConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRoleExists(ctx, resourceName, &conf),
+					testAccCheckRoleExists(ctx, t, resourceName, &conf),
 				),
 			},
 			{
@@ -1041,9 +1039,9 @@ func TestAccIAMRole_Identity_ExistingResource_OnError(t *testing.T) {
 	})
 }
 
-func testAccCheckRoleDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckRoleDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_role" {
@@ -1067,7 +1065,7 @@ func testAccCheckRoleDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckRoleExists(ctx context.Context, n string, v *awstypes.Role) resource.TestCheckFunc {
+func testAccCheckRoleExists(ctx context.Context, t *testing.T, n string, v *awstypes.Role) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -1078,7 +1076,7 @@ func testAccCheckRoleExists(ctx context.Context, n string, v *awstypes.Role) res
 			return fmt.Errorf("No IAM Role ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		output, err := tfiam.FindRoleByName(ctx, conn, rs.Primary.ID)
 
@@ -1093,7 +1091,7 @@ func testAccCheckRoleExists(ctx context.Context, n string, v *awstypes.Role) res
 }
 
 // Attach inline policy out of band (outside of terraform)
-func testAccAddRolePolicy(ctx context.Context, n string) resource.TestCheckFunc {
+func testAccAddRolePolicy(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -1103,7 +1101,7 @@ func testAccAddRolePolicy(ctx context.Context, n string) resource.TestCheckFunc 
 			return fmt.Errorf("No Role name is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		input := &iam.PutRolePolicyInput{
 			RoleName: aws.String(rs.Primary.ID),
@@ -1139,9 +1137,9 @@ func testAccCheckRolePermissionsBoundary(role *awstypes.Role, expectedPermission
 	}
 }
 
-func testAccCheckRolePolicyDetachManagedPolicy(ctx context.Context, role *awstypes.Role, policyName string) resource.TestCheckFunc {
+func testAccCheckRolePolicyDetachManagedPolicy(ctx context.Context, t *testing.T, role *awstypes.Role, policyName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		var managedARN string
 		input := &iam.ListAttachedRolePoliciesInput{
@@ -1181,9 +1179,9 @@ func testAccCheckRolePolicyDetachManagedPolicy(ctx context.Context, role *awstyp
 	}
 }
 
-func testAccCheckRolePolicyAttachManagedPolicy(ctx context.Context, role *awstypes.Role, policyName string) resource.TestCheckFunc {
+func testAccCheckRolePolicyAttachManagedPolicy(ctx context.Context, t *testing.T, role *awstypes.Role, policyName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		var managedARN string
 		input := &iam.ListPoliciesInput{
@@ -1225,9 +1223,9 @@ func testAccCheckRolePolicyAttachManagedPolicy(ctx context.Context, role *awstyp
 	}
 }
 
-func testAccCheckRolePolicyAddInlinePolicy(ctx context.Context, role *awstypes.Role, inlinePolicy string) resource.TestCheckFunc {
+func testAccCheckRolePolicyAddInlinePolicy(ctx context.Context, t *testing.T, role *awstypes.Role, inlinePolicy string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		_, err := conn.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
 			PolicyDocument: aws.String(testAccRolePolicyExtraInlineConfig()),
@@ -1239,9 +1237,9 @@ func testAccCheckRolePolicyAddInlinePolicy(ctx context.Context, role *awstypes.R
 	}
 }
 
-func testAccCheckRolePolicyRemoveInlinePolicy(ctx context.Context, role *awstypes.Role, inlinePolicy string) resource.TestCheckFunc {
+func testAccCheckRolePolicyRemoveInlinePolicy(ctx context.Context, t *testing.T, role *awstypes.Role, inlinePolicy string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		_, err := conn.DeleteRolePolicy(ctx, &iam.DeleteRolePolicyInput{
 			PolicyName: aws.String(inlinePolicy),

--- a/internal/service/iam/roles_data_source_test.go
+++ b/internal/service/iam/roles_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -21,7 +20,7 @@ func TestAccIAMRolesDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_roles.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -41,11 +40,11 @@ func TestAccIAMRolesDataSource_basic(t *testing.T) {
 
 func TestAccIAMRolesDataSource_nameRegex(t *testing.T) {
 	ctx := acctest.Context(t)
-	rCount := sdkacctest.RandIntRange(1, 4)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rCount := acctest.RandIntRange(t, 1, 4)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_iam_roles.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -65,12 +64,12 @@ func TestAccIAMRolesDataSource_nameRegex(t *testing.T) {
 
 func TestAccIAMRolesDataSource_pathPrefix(t *testing.T) {
 	ctx := acctest.Context(t)
-	rCount := sdkacctest.RandIntRange(1, 4)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rPathPrefix := sdkacctest.RandomWithPrefix("tf-acc-path")
+	rCount := acctest.RandIntRange(t, 1, 4)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rPathPrefix := acctest.RandomWithPrefix(t, "tf-acc-path")
 	dataSourceName := "data.aws_iam_roles.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -92,7 +91,7 @@ func TestAccIAMRolesDataSource_nonExistentPathPrefix(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_roles.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -110,12 +109,12 @@ func TestAccIAMRolesDataSource_nonExistentPathPrefix(t *testing.T) {
 
 func TestAccIAMRolesDataSource_nameRegexAndPathPrefix(t *testing.T) {
 	ctx := acctest.Context(t)
-	rCount := sdkacctest.RandIntRange(1, 4)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rPathPrefix := sdkacctest.RandomWithPrefix("tf-acc-path")
+	rCount := acctest.RandIntRange(t, 1, 4)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rPathPrefix := acctest.RandomWithPrefix(t, "tf-acc-path")
 	dataSourceName := "data.aws_iam_roles.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/iam/saml_provider.go
+++ b/internal/service/iam/saml_provider.go
@@ -17,7 +17,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -34,7 +33,6 @@ import (
 // @Testing(tagsTest=false)
 // @ArnIdentity
 // @Testing(preIdentityVersion="v6.4.0")
-// @Testing(existsTakesT=false, destroyTakesT=false)
 func resourceSAMLProvider() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSAMLProviderCreate,
@@ -205,9 +203,8 @@ func findSAMLProviderByARN(ctx context.Context, conn *iam.Client, arn string) (*
 	output, err := conn.GetSAMLProvider(ctx, input)
 
 	if errs.IsA[*awstypes.NoSuchEntityException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/iam/saml_provider_data_source_test.go
+++ b/internal/service/iam/saml_provider_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -15,12 +14,12 @@ import (
 
 func TestAccIAMSAMLProviderDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	idpEntityID := fmt.Sprintf("https://%s", acctest.RandomDomainName())
 	dataSourceName := "data.aws_iam_saml_provider.test"
 	resourceName := "aws_iam_saml_provider.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/iam/saml_provider_identity_gen_test.go
+++ b/internal/service/iam/saml_provider_identity_gen_test.go
@@ -33,7 +33,7 @@ func TestAccIAMSAMLProvider_Identity_basic(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckSAMLProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckSAMLProviderDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			// Step 1: Setup
@@ -43,7 +43,7 @@ func TestAccIAMSAMLProvider_Identity_basic(t *testing.T) {
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckSAMLProviderExists(ctx, resourceName),
+					testAccCheckSAMLProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
@@ -116,7 +116,7 @@ func TestAccIAMSAMLProvider_Identity_ExistingResource_basic(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckSAMLProviderDestroy(ctx),
+		CheckDestroy: testAccCheckSAMLProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// Step 1: Create pre-Identity
 			{
@@ -125,7 +125,7 @@ func TestAccIAMSAMLProvider_Identity_ExistingResource_basic(t *testing.T) {
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckSAMLProviderExists(ctx, resourceName),
+					testAccCheckSAMLProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),
@@ -171,7 +171,7 @@ func TestAccIAMSAMLProvider_Identity_ExistingResource_noRefreshNoChange(t *testi
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckSAMLProviderDestroy(ctx),
+		CheckDestroy: testAccCheckSAMLProviderDestroy(ctx, t),
 		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
 			Plan: resource.PlanOptions{
 				NoRefresh: true,
@@ -185,7 +185,7 @@ func TestAccIAMSAMLProvider_Identity_ExistingResource_noRefreshNoChange(t *testi
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckSAMLProviderExists(ctx, resourceName),
+					testAccCheckSAMLProviderExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),

--- a/internal/service/iam/saml_provider_test.go
+++ b/internal/service/iam/saml_provider_test.go
@@ -8,11 +8,9 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -20,21 +18,21 @@ import (
 
 func TestAccIAMSAMLProvider_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
 	idpEntityIdModified := fmt.Sprintf("https://%s", acctest.RandomDomainName())
 	resourceName := "aws_iam_saml_provider.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSAMLProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckSAMLProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSAMLProviderConfig_basic(rName, idpEntityId),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSAMLProviderExists(ctx, resourceName),
+					testAccCheckSAMLProviderExists(ctx, t, resourceName),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("saml-provider/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttrSet(resourceName, "saml_metadata_document"),
@@ -46,7 +44,7 @@ func TestAccIAMSAMLProvider_basic(t *testing.T) {
 			{
 				Config: testAccSAMLProviderConfig_update(rName, idpEntityIdModified),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSAMLProviderExists(ctx, resourceName),
+					testAccCheckSAMLProviderExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttrSet(resourceName, "saml_metadata_document"),
 					resource.TestCheckResourceAttrSet(resourceName, "saml_provider_uuid"),
@@ -63,20 +61,20 @@ func TestAccIAMSAMLProvider_basic(t *testing.T) {
 
 func TestAccIAMSAMLProvider_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
 	resourceName := "aws_iam_saml_provider.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSAMLProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckSAMLProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSAMLProviderConfig_tags1(rName, idpEntityId, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSAMLProviderExists(ctx, resourceName),
+					testAccCheckSAMLProviderExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
 				),
@@ -89,7 +87,7 @@ func TestAccIAMSAMLProvider_tags(t *testing.T) {
 			{
 				Config: testAccSAMLProviderConfig_tags2(rName, idpEntityId, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSAMLProviderExists(ctx, resourceName),
+					testAccCheckSAMLProviderExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
@@ -98,7 +96,7 @@ func TestAccIAMSAMLProvider_tags(t *testing.T) {
 			{
 				Config: testAccSAMLProviderConfig_tags1(rName, idpEntityId, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSAMLProviderExists(ctx, resourceName),
+					testAccCheckSAMLProviderExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
 				),
@@ -109,20 +107,20 @@ func TestAccIAMSAMLProvider_tags(t *testing.T) {
 
 func TestAccIAMSAMLProvider_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
 	resourceName := "aws_iam_saml_provider.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSAMLProviderDestroy(ctx),
+		CheckDestroy:             testAccCheckSAMLProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSAMLProviderConfig_basic(rName, idpEntityId),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSAMLProviderExists(ctx, resourceName),
+					testAccCheckSAMLProviderExists(ctx, t, resourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceSAMLProvider(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -131,9 +129,9 @@ func TestAccIAMSAMLProvider_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckSAMLProviderDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckSAMLProviderDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_saml_provider" {
@@ -157,14 +155,14 @@ func testAccCheckSAMLProviderDestroy(ctx context.Context) resource.TestCheckFunc
 	}
 }
 
-func testAccCheckSAMLProviderExists(ctx context.Context, n string) resource.TestCheckFunc {
+func testAccCheckSAMLProviderExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not Found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		_, err := tfiam.FindSAMLProviderByARN(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/iam/security_token_service_preferences_test.go
+++ b/internal/service/iam/security_token_service_preferences_test.go
@@ -15,7 +15,7 @@ func TestAccIAMSecurityTokenServicePreferences_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_security_token_service_preferences.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/iam/server_certificate.go
+++ b/internal/service/iam/server_certificate.go
@@ -18,7 +18,6 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -35,7 +34,6 @@ import (
 // @SDKResource("aws_iam_server_certificate", name="Server Certificate")
 // @Tags(identifierAttribute="name", resourceType="ServerCertificate")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/iam/types;types.ServerCertificate", tlsKey=true, importStateId="rName", importIgnore="private_key")
-// @Testing(existsTakesT=false, destroyTakesT=false)
 func resourceServerCertificate() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceServerCertificateCreate,
@@ -296,9 +294,8 @@ func findServerCertificate(ctx context.Context, conn *iam.Client, input *iam.Get
 	output, err := conn.GetServerCertificate(ctx, input)
 
 	if errs.IsA[*awstypes.NoSuchEntityException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/iam/server_certificate_data_source_test.go
+++ b/internal/service/iam/server_certificate_data_source_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -16,7 +15,7 @@ import (
 
 func TestAccIAMServerCertificateDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
@@ -24,11 +23,11 @@ func TestAccIAMServerCertificateDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_iam_server_certificate.test"
 	resourceName := "aws_iam_server_certificate.test_cert"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerCertificateDataSourceConfig_cert(rName, key, certificate),
@@ -48,11 +47,11 @@ func TestAccIAMServerCertificateDataSource_basic(t *testing.T) {
 
 func TestAccIAMServerCertificateDataSource_matchNamePrefix(t *testing.T) {
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccServerCertificateDataSourceConfig_certMatchNamePrefix,
@@ -64,18 +63,18 @@ func TestAccIAMServerCertificateDataSource_matchNamePrefix(t *testing.T) {
 
 func TestAccIAMServerCertificateDataSource_path(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	path := "/test-path/"
 	pathPrefix := "/test-path/"
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerCertificateDataSourceConfig_certPath(rName, path, pathPrefix, key, certificate),

--- a/internal/service/iam/server_certificate_tags_gen_test.go
+++ b/internal/service/iam/server_certificate_tags_gen_test.go
@@ -35,7 +35,7 @@ func TestAccIAMServerCertificate_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -49,7 +49,7 @@ func TestAccIAMServerCertificate_tags(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -101,7 +101,7 @@ func TestAccIAMServerCertificate_tags(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -157,7 +157,7 @@ func TestAccIAMServerCertificate_tags(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -206,7 +206,7 @@ func TestAccIAMServerCertificate_tags(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -255,7 +255,7 @@ func TestAccIAMServerCertificate_Tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -269,7 +269,7 @@ func TestAccIAMServerCertificate_Tags_null(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -338,7 +338,7 @@ func TestAccIAMServerCertificate_Tags_emptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -350,7 +350,7 @@ func TestAccIAMServerCertificate_Tags_emptyMap(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -417,7 +417,7 @@ func TestAccIAMServerCertificate_Tags_addOnUpdate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -429,7 +429,7 @@ func TestAccIAMServerCertificate_Tags_addOnUpdate(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -455,7 +455,7 @@ func TestAccIAMServerCertificate_Tags_addOnUpdate(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -514,7 +514,7 @@ func TestAccIAMServerCertificate_Tags_EmptyTag_onCreate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -528,7 +528,7 @@ func TestAccIAMServerCertificate_Tags_EmptyTag_onCreate(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -576,7 +576,7 @@ func TestAccIAMServerCertificate_Tags_EmptyTag_onCreate(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -625,7 +625,7 @@ func TestAccIAMServerCertificate_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -639,7 +639,7 @@ func TestAccIAMServerCertificate_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -673,7 +673,7 @@ func TestAccIAMServerCertificate_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -727,7 +727,7 @@ func TestAccIAMServerCertificate_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -786,7 +786,7 @@ func TestAccIAMServerCertificate_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -800,7 +800,7 @@ func TestAccIAMServerCertificate_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -833,7 +833,7 @@ func TestAccIAMServerCertificate_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -891,7 +891,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_providerOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -906,7 +906,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -958,7 +958,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1012,7 +1012,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1060,7 +1060,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1110,7 +1110,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1127,7 +1127,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1189,7 +1189,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1250,7 +1250,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1300,7 +1300,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_overlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1317,7 +1317,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_overlapping(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1378,7 +1378,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_overlapping(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1443,7 +1443,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_overlapping(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1506,7 +1506,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_updateToProviderOnly(t *testin
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1520,7 +1520,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_updateToProviderOnly(t *testin
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1555,7 +1555,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_updateToProviderOnly(t *testin
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1612,7 +1612,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_updateToResourceOnly(t *testin
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1627,7 +1627,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_updateToResourceOnly(t *testin
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1657,7 +1657,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_updateToResourceOnly(t *testin
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1717,7 +1717,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_emptyResourceTag(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1734,7 +1734,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_emptyResourceTag(t *testing.T)
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1796,7 +1796,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_emptyProviderOnlyTag(t *testin
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1811,7 +1811,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_emptyProviderOnlyTag(t *testin
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1867,7 +1867,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_nullOverlappingResourceTag(t *
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1884,7 +1884,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_nullOverlappingResourceTag(t *
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1943,7 +1943,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_nullNonOverlappingResourceTag(
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1960,7 +1960,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_nullNonOverlappingResourceTag(
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -2019,7 +2019,7 @@ func TestAccIAMServerCertificate_Tags_ComputedTag_onCreate(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -2031,7 +2031,7 @@ func TestAccIAMServerCertificate_Tags_ComputedTag_onCreate(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2088,7 +2088,7 @@ func TestAccIAMServerCertificate_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -2102,7 +2102,7 @@ func TestAccIAMServerCertificate_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2136,7 +2136,7 @@ func TestAccIAMServerCertificate_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2201,7 +2201,7 @@ func TestAccIAMServerCertificate_Tags_ComputedTag_OnUpdate_replace(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -2215,7 +2215,7 @@ func TestAccIAMServerCertificate_Tags_ComputedTag_OnUpdate_replace(t *testing.T)
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2247,7 +2247,7 @@ func TestAccIAMServerCertificate_Tags_ComputedTag_OnUpdate_replace(t *testing.T)
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2304,7 +2304,7 @@ func TestAccIAMServerCertificate_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2325,7 +2325,7 @@ func TestAccIAMServerCertificate_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2376,7 +2376,7 @@ func TestAccIAMServerCertificate_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2427,7 +2427,7 @@ func TestAccIAMServerCertificate_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2478,7 +2478,7 @@ func TestAccIAMServerCertificate_Tags_IgnoreTags_Overlap_resourceTag(t *testing.
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy: testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2497,7 +2497,7 @@ func TestAccIAMServerCertificate_Tags_IgnoreTags_Overlap_resourceTag(t *testing.
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2562,7 +2562,7 @@ func TestAccIAMServerCertificate_Tags_IgnoreTags_Overlap_resourceTag(t *testing.
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2627,7 +2627,7 @@ func TestAccIAMServerCertificate_Tags_IgnoreTags_Overlap_resourceTag(t *testing.
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/iam/server_certificate_test.go
+++ b/internal/service/iam/server_certificate_test.go
@@ -12,11 +12,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -26,21 +24,21 @@ func TestAccIAMServerCertificate_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v1, v2 awstypes.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rNameUpdated := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rNameUpdated := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerCertificateConfig_basic(rName, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v1),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v1),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("server-certificate/%s", rName)),
 					acctest.CheckResourceAttrRFC3339(resourceName, "expiration"),
 					acctest.CheckResourceAttrRFC3339(resourceName, "upload_date"),
@@ -61,7 +59,7 @@ func TestAccIAMServerCertificate_basic(t *testing.T) {
 			{
 				Config: testAccServerCertificateConfig_basic(rNameUpdated, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v2),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v2),
 					testAccCheckServerCertficateNotRecreated(&v1, &v2),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("server-certificate/%s", rNameUpdated)),
 					acctest.CheckResourceAttrRFC3339(resourceName, "expiration"),
@@ -84,16 +82,16 @@ func TestAccIAMServerCertificate_nameGenerated(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerCertificateConfig_nameGenerated(key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &cert),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &cert),
 					acctest.CheckResourceAttrNameGenerated(resourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, id.UniqueIdPrefix),
 				),
@@ -110,18 +108,18 @@ func TestAccIAMServerCertificate_namePrefix(t *testing.T) {
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 	namePrefix := "tf-acc-test-prefix-"
 	namePrefixUpdated := "tf-acc-test-prefix-updated-"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerCertificateConfig_namePrefix(namePrefix, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v1),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v1),
 					acctest.CheckResourceAttrNameFromPrefix(resourceName, names.AttrName, namePrefix),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, namePrefix),
 				),
@@ -129,7 +127,7 @@ func TestAccIAMServerCertificate_namePrefix(t *testing.T) {
 			{
 				Config: testAccServerCertificateConfig_namePrefix(namePrefixUpdated, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v2),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v2),
 					testAccCheckServerCertficateNotRecreated(&v1, &v2),
 					acctest.CheckResourceAttrNameFromPrefix(resourceName, names.AttrName, namePrefixUpdated),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, namePrefixUpdated),
@@ -139,7 +137,7 @@ func TestAccIAMServerCertificate_namePrefix(t *testing.T) {
 			{
 				Config: testAccServerCertificateConfig_basic(rName, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v3),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v3),
 					testAccCheckServerCertficateNotRecreated(&v2, &v3),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, ""),
@@ -149,7 +147,7 @@ func TestAccIAMServerCertificate_namePrefix(t *testing.T) {
 			{
 				Config: testAccServerCertificateConfig_namePrefix(namePrefix, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v4),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v4),
 					testAccCheckServerCertficateNotRecreated(&v4, &v4),
 					acctest.CheckResourceAttrNameFromPrefix(resourceName, names.AttrName, namePrefix),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, namePrefix),
@@ -163,20 +161,20 @@ func TestAccIAMServerCertificate_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var cert awstypes.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerCertificateConfig_basic(rName, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &cert),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &cert),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceServerCertificate(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -188,21 +186,21 @@ func TestAccIAMServerCertificate_disappears(t *testing.T) {
 func TestAccIAMServerCertificate_file(t *testing.T) {
 	ctx := acctest.Context(t)
 	var cert awstypes.ServerCertificate
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	unixFile := "test-fixtures/iam-ssl-unix-line-endings.pem"
 	winFile := "test-fixtures/iam-ssl-windows-line-endings.pem.winfile"
 	resourceName := "aws_iam_server_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerCertificateConfig_file(rName, unixFile),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &cert),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &cert),
 				),
 			},
 			{
@@ -215,7 +213,7 @@ func TestAccIAMServerCertificate_file(t *testing.T) {
 			{
 				Config: testAccServerCertificateConfig_file(rName, winFile),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &cert),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &cert),
 				),
 			},
 		},
@@ -226,23 +224,23 @@ func TestAccIAMServerCertificate_path(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v1, v2, v3 awstypes.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rNameUpdated := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rNameUpdated := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 	path := "/test/"
 	pathUpdated := "/test/updated/"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerCertificateConfig_path(rName, path, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v1),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, path),
 				),
 			},
@@ -256,7 +254,7 @@ func TestAccIAMServerCertificate_path(t *testing.T) {
 			{
 				Config: testAccServerCertificateConfig_path(rName, pathUpdated, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v2),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v2),
 					testAccCheckServerCertficateNotRecreated(&v1, &v2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, pathUpdated),
 				),
@@ -265,7 +263,7 @@ func TestAccIAMServerCertificate_path(t *testing.T) {
 			{
 				Config: testAccServerCertificateConfig_path(rNameUpdated, path, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerCertificateExists(ctx, resourceName, &v3),
+					testAccCheckServerCertificateExists(ctx, t, resourceName, &v3),
 					testAccCheckServerCertficateNotRecreated(&v2, &v3),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rNameUpdated),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, path),
@@ -275,7 +273,7 @@ func TestAccIAMServerCertificate_path(t *testing.T) {
 	})
 }
 
-func testAccCheckServerCertificateExists(ctx context.Context, n string, v *awstypes.ServerCertificate) resource.TestCheckFunc {
+func testAccCheckServerCertificateExists(ctx context.Context, t *testing.T, n string, v *awstypes.ServerCertificate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -286,7 +284,7 @@ func testAccCheckServerCertificateExists(ctx context.Context, n string, v *awsty
 			return fmt.Errorf("No IAM Server Certificate ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		output, err := tfiam.FindServerCertificateByName(ctx, conn, rs.Primary.Attributes[names.AttrName])
 
@@ -300,9 +298,9 @@ func testAccCheckServerCertificateExists(ctx context.Context, n string, v *awsty
 	}
 }
 
-func testAccCheckServerCertificateDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckServerCertificateDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_server_certificate" {

--- a/internal/service/iam/service_linked_role_identity_gen_test.go
+++ b/internal/service/iam/service_linked_role_identity_gen_test.go
@@ -33,7 +33,7 @@ func TestAccIAMServiceLinkedRole_Identity_basic(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			// Step 1: Setup
@@ -43,7 +43,7 @@ func TestAccIAMServiceLinkedRole_Identity_basic(t *testing.T) {
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
@@ -116,7 +116,7 @@ func TestAccIAMServiceLinkedRole_Identity_ExistingResource_basic(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// Step 1: Create pre-Identity
 			{
@@ -125,7 +125,7 @@ func TestAccIAMServiceLinkedRole_Identity_ExistingResource_basic(t *testing.T) {
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),
@@ -171,7 +171,7 @@ func TestAccIAMServiceLinkedRole_Identity_ExistingResource_noRefreshNoChange(t *
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
 			Plan: resource.PlanOptions{
 				NoRefresh: true,
@@ -185,7 +185,7 @@ func TestAccIAMServiceLinkedRole_Identity_ExistingResource_noRefreshNoChange(t *
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),

--- a/internal/service/iam/service_linked_role_tags_gen_test.go
+++ b/internal/service/iam/service_linked_role_tags_gen_test.go
@@ -31,7 +31,7 @@ func TestAccIAMServiceLinkedRole_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -43,7 +43,7 @@ func TestAccIAMServiceLinkedRole_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -87,7 +87,7 @@ func TestAccIAMServiceLinkedRole_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -135,7 +135,7 @@ func TestAccIAMServiceLinkedRole_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -176,7 +176,7 @@ func TestAccIAMServiceLinkedRole_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -216,7 +216,7 @@ func TestAccIAMServiceLinkedRole_Tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -228,7 +228,7 @@ func TestAccIAMServiceLinkedRole_Tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -286,7 +286,7 @@ func TestAccIAMServiceLinkedRole_Tags_emptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -296,7 +296,7 @@ func TestAccIAMServiceLinkedRole_Tags_emptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -352,7 +352,7 @@ func TestAccIAMServiceLinkedRole_Tags_addOnUpdate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -362,7 +362,7 @@ func TestAccIAMServiceLinkedRole_Tags_addOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -386,7 +386,7 @@ func TestAccIAMServiceLinkedRole_Tags_addOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -436,7 +436,7 @@ func TestAccIAMServiceLinkedRole_Tags_EmptyTag_onCreate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -448,7 +448,7 @@ func TestAccIAMServiceLinkedRole_Tags_EmptyTag_onCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -488,7 +488,7 @@ func TestAccIAMServiceLinkedRole_Tags_EmptyTag_onCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -528,7 +528,7 @@ func TestAccIAMServiceLinkedRole_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -540,7 +540,7 @@ func TestAccIAMServiceLinkedRole_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -572,7 +572,7 @@ func TestAccIAMServiceLinkedRole_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -618,7 +618,7 @@ func TestAccIAMServiceLinkedRole_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -668,7 +668,7 @@ func TestAccIAMServiceLinkedRole_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -680,7 +680,7 @@ func TestAccIAMServiceLinkedRole_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -711,7 +711,7 @@ func TestAccIAMServiceLinkedRole_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -760,7 +760,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_providerOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -773,7 +773,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -817,7 +817,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -863,7 +863,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -903,7 +903,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -944,7 +944,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -959,7 +959,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1013,7 +1013,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1066,7 +1066,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1107,7 +1107,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_overlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1122,7 +1122,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1175,7 +1175,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1232,7 +1232,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1286,7 +1286,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_updateToProviderOnly(t *testin
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1298,7 +1298,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_updateToProviderOnly(t *testin
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1331,7 +1331,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_updateToProviderOnly(t *testin
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1379,7 +1379,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_updateToResourceOnly(t *testin
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1392,7 +1392,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_updateToResourceOnly(t *testin
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1420,7 +1420,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_updateToResourceOnly(t *testin
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1471,7 +1471,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_emptyResourceTag(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1486,7 +1486,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_emptyResourceTag(t *testing.T)
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1539,7 +1539,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_emptyProviderOnlyTag(t *testin
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1552,7 +1552,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_emptyProviderOnlyTag(t *testin
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1599,7 +1599,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_nullOverlappingResourceTag(t *
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1614,7 +1614,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_nullOverlappingResourceTag(t *
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1664,7 +1664,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_nullNonOverlappingResourceTag(
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1679,7 +1679,7 @@ func TestAccIAMServiceLinkedRole_Tags_DefaultTags_nullNonOverlappingResourceTag(
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1729,7 +1729,7 @@ func TestAccIAMServiceLinkedRole_Tags_ComputedTag_onCreate(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1739,7 +1739,7 @@ func TestAccIAMServiceLinkedRole_Tags_ComputedTag_onCreate(t *testing.T) {
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1787,7 +1787,7 @@ func TestAccIAMServiceLinkedRole_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1799,7 +1799,7 @@ func TestAccIAMServiceLinkedRole_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1831,7 +1831,7 @@ func TestAccIAMServiceLinkedRole_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1887,7 +1887,7 @@ func TestAccIAMServiceLinkedRole_Tags_ComputedTag_OnUpdate_replace(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1899,7 +1899,7 @@ func TestAccIAMServiceLinkedRole_Tags_ComputedTag_OnUpdate_replace(t *testing.T)
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1929,7 +1929,7 @@ func TestAccIAMServiceLinkedRole_Tags_ComputedTag_OnUpdate_replace(t *testing.T)
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1977,7 +1977,7 @@ func TestAccIAMServiceLinkedRole_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -1996,7 +1996,7 @@ func TestAccIAMServiceLinkedRole_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2045,7 +2045,7 @@ func TestAccIAMServiceLinkedRole_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2094,7 +2094,7 @@ func TestAccIAMServiceLinkedRole_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2142,7 +2142,7 @@ func TestAccIAMServiceLinkedRole_Tags_IgnoreTags_Overlap_resourceTag(t *testing.
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2159,7 +2159,7 @@ func TestAccIAMServiceLinkedRole_Tags_IgnoreTags_Overlap_resourceTag(t *testing.
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2222,7 +2222,7 @@ func TestAccIAMServiceLinkedRole_Tags_IgnoreTags_Overlap_resourceTag(t *testing.
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2285,7 +2285,7 @@ func TestAccIAMServiceLinkedRole_Tags_IgnoreTags_Overlap_resourceTag(t *testing.
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/iam/service_linked_role_test.go
+++ b/internal/service/iam/service_linked_role_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -87,11 +86,11 @@ func TestAccIAMServiceLinkedRole_basic(t *testing.T) {
 	path := fmt.Sprintf("/aws-service-role/%s/", awsServiceName)
 	arnResource := fmt.Sprintf("role%s%s", path, name)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {
@@ -108,7 +107,7 @@ func TestAccIAMServiceLinkedRole_basic(t *testing.T) {
 				},
 				Config: testAccServiceLinkedRoleConfig_basic(awsServiceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", arnResource),
 					resource.TestCheckResourceAttr(resourceName, "aws_service_name", awsServiceName),
 					acctest.CheckResourceAttrRFC3339(resourceName, "create_date"),
@@ -132,20 +131,20 @@ func TestAccIAMServiceLinkedRole_customSuffix(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
 	awsServiceName := "autoscaling.amazonaws.com"
-	customSuffix := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	customSuffix := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	name := fmt.Sprintf("AWSServiceRoleForAutoScaling_%s", customSuffix)
 	path := fmt.Sprintf("/aws-service-role/%s/", awsServiceName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceLinkedRoleConfig_customSuffix(awsServiceName, customSuffix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("role%s%s", path, name)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, name),
 				),
@@ -166,16 +165,16 @@ func TestAccIAMServiceLinkedRole_CustomSuffix_diffSuppressFunc(t *testing.T) {
 	awsServiceName := "custom-resource.application-autoscaling.amazonaws.com"
 	name := "AWSServiceRoleForApplicationAutoScaling_CustomResource"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceLinkedRoleConfig_basic(awsServiceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "iam", fmt.Sprintf("role/aws-service-role/%s/%s", awsServiceName, name)),
 					resource.TestCheckResourceAttr(resourceName, "custom_suffix", "CustomResource"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, name),
@@ -194,25 +193,25 @@ func TestAccIAMServiceLinkedRole_description(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
 	awsServiceName := "autoscaling.amazonaws.com"
-	customSuffix := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	customSuffix := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceLinkedRoleConfig_description(awsServiceName, customSuffix, "description1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description1"),
 				),
 			},
 			{
 				Config: testAccServiceLinkedRoleConfig_description(awsServiceName, customSuffix, "description2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description2"),
 				),
 			},
@@ -229,18 +228,18 @@ func TestAccIAMServiceLinkedRole_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
 	awsServiceName := "autoscaling.amazonaws.com"
-	customSuffix := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	customSuffix := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceLinkedRoleConfig_customSuffix(awsServiceName, customSuffix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					testAccCheckServiceLinkedRoleExists(ctx, t, resourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceServiceLinkedRole(), resourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceServiceLinkedRole(), resourceName),
 				),
@@ -250,9 +249,9 @@ func TestAccIAMServiceLinkedRole_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckServiceLinkedRoleDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckServiceLinkedRoleDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_service_linked_role" {
@@ -281,14 +280,14 @@ func testAccCheckServiceLinkedRoleDestroy(ctx context.Context) resource.TestChec
 	}
 }
 
-func testAccCheckServiceLinkedRoleExists(ctx context.Context, n string) resource.TestCheckFunc {
+func testAccCheckServiceLinkedRoleExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		_, roleName, _, err := tfiam.ServiceLinkedRoleParseResourceID(rs.Primary.ID)
 		if err != nil {

--- a/internal/service/iam/service_specific_credential.go
+++ b/internal/service/iam/service_specific_credential.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -288,9 +287,8 @@ func findServiceSpecificCredentials(ctx context.Context, conn *iam.Client, input
 	})
 
 	if errs.IsA[*awstypes.NoSuchEntityException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/iam/service_specific_credential_test.go
+++ b/internal/service/iam/service_specific_credential_test.go
@@ -9,11 +9,9 @@ import (
 	"testing"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -24,18 +22,18 @@ func TestAccIAMServiceSpecificCredential_basic(t *testing.T) {
 	var cred awstypes.ServiceSpecificCredentialMetadata
 
 	resourceName := "aws_iam_service_specific_credential.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServiceSpecificCredentialDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceSpecificCredentialDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceSpecificCredentialConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceSpecificCredentialExists(ctx, resourceName, &cred),
+					testAccCheckServiceSpecificCredentialExists(ctx, t, resourceName, &cred),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, "aws_iam_user.test", names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrServiceName, "codecommit.amazonaws.com"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "Active"),
@@ -59,18 +57,18 @@ func TestAccIAMServiceSpecificCredential_multi(t *testing.T) {
 
 	resourceName := "aws_iam_service_specific_credential.test"
 	resourceName2 := "aws_iam_service_specific_credential.test2"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServiceSpecificCredentialDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceSpecificCredentialDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceSpecificCredentialConfig_multi(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceSpecificCredentialExists(ctx, resourceName, &cred),
+					testAccCheckServiceSpecificCredentialExists(ctx, t, resourceName, &cred),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, "aws_iam_user.test", names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrServiceName, "codecommit.amazonaws.com"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "Active"),
@@ -98,18 +96,18 @@ func TestAccIAMServiceSpecificCredential_status(t *testing.T) {
 	var cred awstypes.ServiceSpecificCredentialMetadata
 
 	resourceName := "aws_iam_service_specific_credential.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServiceSpecificCredentialDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceSpecificCredentialDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceSpecificCredentialConfig_status(rName, "Inactive"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceSpecificCredentialExists(ctx, resourceName, &cred),
+					testAccCheckServiceSpecificCredentialExists(ctx, t, resourceName, &cred),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "Inactive"),
 				),
 			},
@@ -122,14 +120,14 @@ func TestAccIAMServiceSpecificCredential_status(t *testing.T) {
 			{
 				Config: testAccServiceSpecificCredentialConfig_status(rName, "Active"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceSpecificCredentialExists(ctx, resourceName, &cred),
+					testAccCheckServiceSpecificCredentialExists(ctx, t, resourceName, &cred),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "Active"),
 				),
 			},
 			{
 				Config: testAccServiceSpecificCredentialConfig_status(rName, "Inactive"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceSpecificCredentialExists(ctx, resourceName, &cred),
+					testAccCheckServiceSpecificCredentialExists(ctx, t, resourceName, &cred),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "Inactive"),
 				),
 			},
@@ -142,18 +140,18 @@ func TestAccIAMServiceSpecificCredential_disappears(t *testing.T) {
 	var cred awstypes.ServiceSpecificCredentialMetadata
 	resourceName := "aws_iam_service_specific_credential.test"
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServiceSpecificCredentialDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceSpecificCredentialDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceSpecificCredentialConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceSpecificCredentialExists(ctx, resourceName, &cred),
+					testAccCheckServiceSpecificCredentialExists(ctx, t, resourceName, &cred),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceServiceSpecificCredential(), resourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceServiceSpecificCredential(), resourceName),
 				),
@@ -163,14 +161,14 @@ func TestAccIAMServiceSpecificCredential_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckServiceSpecificCredentialExists(ctx context.Context, n string, v *awstypes.ServiceSpecificCredentialMetadata) resource.TestCheckFunc {
+func testAccCheckServiceSpecificCredentialExists(ctx context.Context, t *testing.T, n string, v *awstypes.ServiceSpecificCredentialMetadata) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		output, err := tfiam.FindServiceSpecificCredentialByThreePartKey(ctx, conn, rs.Primary.Attributes[names.AttrServiceName], rs.Primary.Attributes[names.AttrUserName], rs.Primary.Attributes["service_specific_credential_id"])
 
@@ -184,9 +182,9 @@ func testAccCheckServiceSpecificCredentialExists(ctx context.Context, n string, 
 	}
 }
 
-func testAccCheckServiceSpecificCredentialDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckServiceSpecificCredentialDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_service_specific_credential" {
@@ -258,18 +256,18 @@ func TestAccIAMServiceSpecificCredential_bedrockWithExpiration(t *testing.T) {
 	var cred awstypes.ServiceSpecificCredentialMetadata
 
 	resourceName := "aws_iam_service_specific_credential.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServiceSpecificCredentialDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceSpecificCredentialDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceSpecificCredentialConfig_bedrockWithExpiration(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceSpecificCredentialExists(ctx, resourceName, &cred),
+					testAccCheckServiceSpecificCredentialExists(ctx, t, resourceName, &cred),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, "aws_iam_user.test", names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrServiceName, "bedrock.amazonaws.com"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "Active"),

--- a/internal/service/iam/session_context_data_source_test.go
+++ b/internal/service/iam/session_context_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
@@ -101,11 +100,11 @@ func TestAssumedRoleRoleSessionName(t *testing.T) {
 
 func TestAccIAMSessionContextDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_iam_session_context.test"
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -125,11 +124,11 @@ func TestAccIAMSessionContextDataSource_basic(t *testing.T) {
 
 func TestAccIAMSessionContextDataSource_withPath(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_iam_session_context.test"
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -148,11 +147,11 @@ func TestAccIAMSessionContextDataSource_withPath(t *testing.T) {
 
 func TestAccIAMSessionContextDataSource_notAssumedRole(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_iam_session_context.test"
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -171,11 +170,11 @@ func TestAccIAMSessionContextDataSource_notAssumedRole(t *testing.T) {
 
 func TestAccIAMSessionContextDataSource_notAssumedRoleWithPath(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_iam_session_context.test"
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -194,10 +193,10 @@ func TestAccIAMSessionContextDataSource_notAssumedRoleWithPath(t *testing.T) {
 
 func TestAccIAMSessionContextDataSource_notAssumedRoleUser(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_iam_session_context.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/iam/signing_certificate.go
+++ b/internal/service/iam/signing_certificate.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
@@ -231,9 +230,8 @@ func findSigningCertificates(ctx context.Context, conn *iam.Client, input *iam.L
 		page, err := pages.NextPage(ctx)
 
 		if errs.IsA[*awstypes.NoSuchEntityException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 

--- a/internal/service/iam/signing_certificate_test.go
+++ b/internal/service/iam/signing_certificate_test.go
@@ -9,11 +9,9 @@ import (
 	"testing"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -24,20 +22,20 @@ func TestAccIAMSigningCertificate_basic(t *testing.T) {
 	var cred awstypes.SigningCertificate
 
 	resourceName := "aws_iam_signing_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSigningCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckSigningCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSigningCertificateConfig_basic(rName, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSigningCertificateExists(ctx, resourceName, &cred),
+					testAccCheckSigningCertificateExists(ctx, t, resourceName, &cred),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, "aws_iam_user.test", names.AttrName),
 					resource.TestCheckResourceAttrSet(resourceName, "certificate_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "certificate_body"),
@@ -58,20 +56,20 @@ func TestAccIAMSigningCertificate_status(t *testing.T) {
 	var cred awstypes.SigningCertificate
 
 	resourceName := "aws_iam_signing_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSigningCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckSigningCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSigningCertificateConfig_status(rName, "Inactive", certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSigningCertificateExists(ctx, resourceName, &cred),
+					testAccCheckSigningCertificateExists(ctx, t, resourceName, &cred),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "Inactive"),
 				),
 			},
@@ -83,14 +81,14 @@ func TestAccIAMSigningCertificate_status(t *testing.T) {
 			{
 				Config: testAccSigningCertificateConfig_status(rName, "Active", certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSigningCertificateExists(ctx, resourceName, &cred),
+					testAccCheckSigningCertificateExists(ctx, t, resourceName, &cred),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "Active"),
 				),
 			},
 			{
 				Config: testAccSigningCertificateConfig_status(rName, "Inactive", certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSigningCertificateExists(ctx, resourceName, &cred),
+					testAccCheckSigningCertificateExists(ctx, t, resourceName, &cred),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "Inactive"),
 				),
 			},
@@ -103,20 +101,20 @@ func TestAccIAMSigningCertificate_disappears(t *testing.T) {
 	var cred awstypes.SigningCertificate
 	resourceName := "aws_iam_signing_certificate.test"
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSigningCertificateDestroy(ctx),
+		CheckDestroy:             testAccCheckSigningCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSigningCertificateConfig_basic(rName, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSigningCertificateExists(ctx, resourceName, &cred),
+					testAccCheckSigningCertificateExists(ctx, t, resourceName, &cred),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceSigningCertificate(), resourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceSigningCertificate(), resourceName),
 				),
@@ -126,14 +124,14 @@ func TestAccIAMSigningCertificate_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckSigningCertificateExists(ctx context.Context, n string, v *awstypes.SigningCertificate) resource.TestCheckFunc {
+func testAccCheckSigningCertificateExists(ctx context.Context, t *testing.T, n string, v *awstypes.SigningCertificate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		output, err := tfiam.FindSigningCertificateByTwoPartKey(ctx, conn, rs.Primary.Attributes[names.AttrUserName], rs.Primary.Attributes["certificate_id"])
 
@@ -147,9 +145,9 @@ func testAccCheckSigningCertificateExists(ctx context.Context, n string, v *awst
 	}
 }
 
-func testAccCheckSigningCertificateDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckSigningCertificateDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_signing_certificate" {

--- a/internal/service/iam/user.go
+++ b/internal/service/iam/user.go
@@ -17,7 +17,6 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -32,7 +31,6 @@ import (
 // @SDKResource("aws_iam_user", name="User")
 // @Tags(identifierAttribute="id", resourceType="User")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/iam/types;types.User", importIgnore="force_destroy")
-// @Testing(existsTakesT=false, destroyTakesT=false)
 func resourceUser() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceUserCreate,
@@ -285,9 +283,8 @@ func findUser(ctx context.Context, conn *iam.Client, input *iam.GetUserInput) (*
 	output, err := conn.GetUser(ctx, input)
 
 	if errs.IsA[*awstypes.NoSuchEntityException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/iam/user_data_source_test.go
+++ b/internal/service/iam/user_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -18,9 +17,9 @@ func TestAccIAMUserDataSource_basic(t *testing.T) {
 	resourceName := "aws_iam_user.test"
 	dataSourceName := "data.aws_iam_user.test"
 
-	userName := fmt.Sprintf("test-datasource-user-%d", sdkacctest.RandInt())
+	userName := fmt.Sprintf("test-datasource-user-%d", acctest.RandInt(t))
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/iam/user_login_profile_test.go
+++ b/internal/service/iam/user_login_profile_test.go
@@ -17,11 +17,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -82,18 +80,18 @@ func TestAccIAMUserLoginProfile_basic(t *testing.T) {
 	var conf iam.GetLoginProfileOutput
 
 	resourceName := "aws_iam_user_login_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserLoginProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckUserLoginProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserLoginProfileConfig_required(rName, testPubKey1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserLoginProfileExists(ctx, resourceName, &conf),
+					testAccCheckUserLoginProfileExists(ctx, t, resourceName, &conf),
 					testDecryptPasswordAndTest(ctx, resourceName, "aws_iam_access_key.test", testPrivKey1),
 					resource.TestCheckResourceAttrSet(resourceName, "encrypted_password"),
 					resource.TestCheckResourceAttrSet(resourceName, "key_fingerprint"),
@@ -122,18 +120,18 @@ func TestAccIAMUserLoginProfile_keybase(t *testing.T) {
 	var conf iam.GetLoginProfileOutput
 
 	resourceName := "aws_iam_user_login_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserLoginProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckUserLoginProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserLoginProfileConfig_keybase(rName, "keybase:terraformacctest"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserLoginProfileExists(ctx, resourceName, &conf),
+					testAccCheckUserLoginProfileExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "encrypted_password"),
 					resource.TestCheckResourceAttrSet(resourceName, "key_fingerprint"),
 					resource.TestCheckResourceAttr(resourceName, "password_length", "20"),
@@ -158,13 +156,13 @@ func TestAccIAMUserLoginProfile_keybase(t *testing.T) {
 
 func TestAccIAMUserLoginProfile_keybaseDoesntExist(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserLoginProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckUserLoginProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				// We own this account but it doesn't have any key associated with it
@@ -177,13 +175,13 @@ func TestAccIAMUserLoginProfile_keybaseDoesntExist(t *testing.T) {
 
 func TestAccIAMUserLoginProfile_notAKey(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserLoginProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckUserLoginProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				// We own this account but it doesn't have any key associated with it
@@ -199,18 +197,18 @@ func TestAccIAMUserLoginProfile_passwordLength(t *testing.T) {
 	var conf iam.GetLoginProfileOutput
 
 	resourceName := "aws_iam_user_login_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserLoginProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckUserLoginProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserLoginProfileConfig_passwordLength(rName, testPubKey1, 128),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserLoginProfileExists(ctx, resourceName, &conf),
+					testAccCheckUserLoginProfileExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "password_length", "128"),
 				),
 			},
@@ -235,18 +233,18 @@ func TestAccIAMUserLoginProfile_nogpg(t *testing.T) {
 	var conf iam.GetLoginProfileOutput
 
 	resourceName := "aws_iam_user_login_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserLoginProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckUserLoginProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserLoginProfileConfig_noGPG(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserLoginProfileExists(ctx, resourceName, &conf),
+					testAccCheckUserLoginProfileExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "password_length", "20"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrPassword),
 				),
@@ -271,18 +269,18 @@ func TestAccIAMUserLoginProfile_disappears(t *testing.T) {
 	var conf iam.GetLoginProfileOutput
 
 	resourceName := "aws_iam_user_login_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserLoginProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckUserLoginProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserLoginProfileConfig_required(rName, testPubKey1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserLoginProfileExists(ctx, resourceName, &conf),
+					testAccCheckUserLoginProfileExists(ctx, t, resourceName, &conf),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceUserLoginProfile(), resourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceUserLoginProfile(), resourceName),
 				),
@@ -297,18 +295,18 @@ func TestAccIAMUserLoginProfile_passwordResetRequired(t *testing.T) {
 	var conf iam.GetLoginProfileOutput
 
 	resourceName := "aws_iam_user_login_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserLoginProfileDestroy(ctx),
+		CheckDestroy:             testAccCheckUserLoginProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserLoginProfileConfig_passwordResetRequired(rName, testPubKey1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserLoginProfileExists(ctx, resourceName, &conf),
+					testAccCheckUserLoginProfileExists(ctx, t, resourceName, &conf),
 					testDecryptPasswordAndTest(ctx, resourceName, "aws_iam_access_key.test", testPrivKey1),
 					resource.TestCheckResourceAttrSet(resourceName, "encrypted_password"),
 					resource.TestCheckResourceAttrSet(resourceName, "key_fingerprint"),
@@ -333,9 +331,9 @@ func TestAccIAMUserLoginProfile_passwordResetRequired(t *testing.T) {
 	})
 }
 
-func testAccCheckUserLoginProfileDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckUserLoginProfileDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_user_login_profile" {
@@ -423,7 +421,7 @@ func testDecryptPasswordAndTest(ctx context.Context, nProfile, nAccessKey, key s
 	}
 }
 
-func testAccCheckUserLoginProfileExists(ctx context.Context, n string, res *iam.GetLoginProfileOutput) resource.TestCheckFunc {
+func testAccCheckUserLoginProfileExists(ctx context.Context, t *testing.T, n string, res *iam.GetLoginProfileOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -434,7 +432,7 @@ func testAccCheckUserLoginProfileExists(ctx context.Context, n string, res *iam.
 			return errors.New("No UserName is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 		resp, err := conn.GetLoginProfile(ctx, &iam.GetLoginProfileInput{
 			UserName: aws.String(rs.Primary.ID),
 		})

--- a/internal/service/iam/user_policies_exclusive.go
+++ b/internal/service/iam/user_policies_exclusive.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
@@ -202,9 +201,8 @@ func findUserPoliciesByName(ctx context.Context, conn *iam.Client, userName stri
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			if errs.IsA[*awstypes.NoSuchEntityException](err) {
-				return nil, &sdkretry.NotFoundError{
-					LastError:   err,
-					LastRequest: in,
+				return nil, &retry.NotFoundError{
+					LastError: err,
 				}
 			}
 			return policyNames, err

--- a/internal/service/iam/user_policies_exclusive_test.go
+++ b/internal/service/iam/user_policies_exclusive_test.go
@@ -13,11 +13,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
@@ -29,25 +27,25 @@ func TestAccIAMUserPoliciesExclusive_basic(t *testing.T) {
 
 	var user types.User
 	var userPolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user_policies_exclusive.test"
 	userResourceName := "aws_iam_user.test"
 	userPolicyResourceName := "aws_iam_user_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserPoliciesExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckUserPoliciesExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserPoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, userResourceName, &user),
-					testAccCheckUserPolicyExists(ctx, userPolicyResourceName, &userPolicy),
-					testAccCheckUserPoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckUserExists(ctx, t, userResourceName, &user),
+					testAccCheckUserPolicyExists(ctx, t, userPolicyResourceName, &userPolicy),
+					testAccCheckUserPoliciesExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, userResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_names.*", userPolicyResourceName, names.AttrName),
 				),
@@ -68,25 +66,25 @@ func TestAccIAMUserPoliciesExclusive_disappears_User(t *testing.T) {
 
 	var user types.User
 	var userPolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user_policies_exclusive.test"
 	userResourceName := "aws_iam_user.test"
 	userPolicyResourceName := "aws_iam_user_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserPoliciesExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckUserPoliciesExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserPoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, userResourceName, &user),
-					testAccCheckUserPolicyExists(ctx, userPolicyResourceName, &userPolicy),
-					testAccCheckUserPoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckUserExists(ctx, t, userResourceName, &user),
+					testAccCheckUserPolicyExists(ctx, t, userPolicyResourceName, &userPolicy),
+					testAccCheckUserPoliciesExclusiveExists(ctx, t, resourceName),
 					// Inline policy must be deleted before the user can be
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceUserPolicy(), userPolicyResourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceUser(), userResourceName),
@@ -102,27 +100,27 @@ func TestAccIAMUserPoliciesExclusive_multiple(t *testing.T) {
 
 	var user types.User
 	var userPolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user_policies_exclusive.test"
 	userResourceName := "aws_iam_user.test"
 	userPolicyResourceName := "aws_iam_user_policy.test"
 	userPolicyResourceName2 := "aws_iam_user_policy.test2"
 	userPolicyResourceName3 := "aws_iam_user_policy.test3"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserPoliciesExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckUserPoliciesExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserPoliciesExclusiveConfig_multiple(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, userResourceName, &user),
-					testAccCheckUserPolicyExists(ctx, userPolicyResourceName, &userPolicy),
-					testAccCheckUserPoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckUserExists(ctx, t, userResourceName, &user),
+					testAccCheckUserPolicyExists(ctx, t, userPolicyResourceName, &userPolicy),
+					testAccCheckUserPoliciesExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, userResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_names.*", userPolicyResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_names.*", userPolicyResourceName2, names.AttrName),
@@ -139,9 +137,9 @@ func TestAccIAMUserPoliciesExclusive_multiple(t *testing.T) {
 			{
 				Config: testAccUserPoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, userResourceName, &user),
-					testAccCheckUserPolicyExists(ctx, userPolicyResourceName, &userPolicy),
-					testAccCheckUserPoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckUserExists(ctx, t, userResourceName, &user),
+					testAccCheckUserPolicyExists(ctx, t, userPolicyResourceName, &userPolicy),
+					testAccCheckUserPoliciesExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, userResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_names.*", userPolicyResourceName, names.AttrName),
 				),
@@ -154,23 +152,23 @@ func TestAccIAMUserPoliciesExclusive_empty(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var user types.User
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user_policies_exclusive.test"
 	userResourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserPoliciesExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckUserPoliciesExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserPoliciesExclusiveConfig_empty(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, userResourceName, &user),
-					testAccCheckUserPoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckUserExists(ctx, t, userResourceName, &user),
+					testAccCheckUserPoliciesExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, userResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "policy_names.#", "0"),
 				),
@@ -187,30 +185,30 @@ func TestAccIAMUserPoliciesExclusive_outOfBandRemoval(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var user types.User
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user_policies_exclusive.test"
 	userResourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserPoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, userResourceName, &user),
-					testAccCheckUserPoliciesExclusiveExists(ctx, resourceName),
-					testAccCheckUserPolicyRemoveInlinePolicy(ctx, &user, rName),
+					testAccCheckUserExists(ctx, t, userResourceName, &user),
+					testAccCheckUserPoliciesExclusiveExists(ctx, t, resourceName),
+					testAccCheckUserPolicyRemoveInlinePolicy(ctx, t, &user, rName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccUserPoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, userResourceName, &user),
-					testAccCheckUserPoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckUserExists(ctx, t, userResourceName, &user),
+					testAccCheckUserPoliciesExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, userResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "policy_names.#", "1"),
 				),
@@ -224,31 +222,31 @@ func TestAccIAMUserPoliciesExclusive_outOfBandAddition(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var user types.User
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	policyName := rName + "-out-of-band"
 	resourceName := "aws_iam_user_policies_exclusive.test"
 	userResourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserPoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, userResourceName, &user),
-					testAccCheckUserPoliciesExclusiveExists(ctx, resourceName),
-					testAccCheckUserPolicyAddInlinePolicy(ctx, &user, policyName),
+					testAccCheckUserExists(ctx, t, userResourceName, &user),
+					testAccCheckUserPoliciesExclusiveExists(ctx, t, resourceName),
+					testAccCheckUserPolicyAddInlinePolicy(ctx, t, &user, policyName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccUserPoliciesExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, userResourceName, &user),
-					testAccCheckUserPoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckUserExists(ctx, t, userResourceName, &user),
+					testAccCheckUserPoliciesExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, userResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "policy_names.#", "1"),
 				),
@@ -257,9 +255,9 @@ func TestAccIAMUserPoliciesExclusive_outOfBandAddition(t *testing.T) {
 	})
 }
 
-func testAccCheckUserPoliciesExclusiveDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckUserPoliciesExclusiveDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_user_policies_exclusive" {
@@ -282,7 +280,7 @@ func testAccCheckUserPoliciesExclusiveDestroy(ctx context.Context) resource.Test
 	}
 }
 
-func testAccCheckUserPoliciesExclusiveExists(ctx context.Context, name string) resource.TestCheckFunc {
+func testAccCheckUserPoliciesExclusiveExists(ctx context.Context, t *testing.T, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -294,7 +292,7 @@ func testAccCheckUserPoliciesExclusiveExists(ctx context.Context, name string) r
 			return create.Error(names.IAM, create.ErrActionCheckingExistence, tfiam.ResNameUserPoliciesExclusive, name, errors.New("not set"))
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 		out, err := tfiam.FindUserPoliciesByName(ctx, conn, userName)
 		if err != nil {
 			return create.Error(names.IAM, create.ErrActionCheckingExistence, tfiam.ResNameUserPoliciesExclusive, userName, err)
@@ -309,9 +307,9 @@ func testAccCheckUserPoliciesExclusiveExists(ctx context.Context, name string) r
 	}
 }
 
-func testAccCheckUserPolicyAddInlinePolicy(ctx context.Context, user *types.User, inlinePolicy string) resource.TestCheckFunc {
+func testAccCheckUserPolicyAddInlinePolicy(ctx context.Context, t *testing.T, user *types.User, inlinePolicy string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		_, err := conn.PutUserPolicy(ctx, &iam.PutUserPolicyInput{
 			PolicyDocument: aws.String(testAccUserPolicyExtraInlineConfig()),
@@ -323,9 +321,9 @@ func testAccCheckUserPolicyAddInlinePolicy(ctx context.Context, user *types.User
 	}
 }
 
-func testAccCheckUserPolicyRemoveInlinePolicy(ctx context.Context, user *types.User, inlinePolicy string) resource.TestCheckFunc {
+func testAccCheckUserPolicyRemoveInlinePolicy(ctx context.Context, t *testing.T, user *types.User, inlinePolicy string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		_, err := conn.DeleteUserPolicy(ctx, &iam.DeleteUserPolicyInput{
 			PolicyName: aws.String(inlinePolicy),

--- a/internal/service/iam/user_policy.go
+++ b/internal/service/iam/user_policy.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
@@ -191,9 +190,8 @@ func findUserPolicy(ctx context.Context, conn *iam.Client, input *iam.GetUserPol
 	output, err := conn.GetUserPolicy(ctx, input)
 
 	if errs.IsA[*awstypes.NoSuchEntityException](err) {
-		return "", &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return "", &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/iam/user_policy_attachment.go
+++ b/internal/service/iam/user_policy_attachment.go
@@ -16,7 +16,6 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -186,9 +185,8 @@ func findAttachedUserPolicies(ctx context.Context, conn *iam.Client, input *iam.
 		page, err := pages.NextPage(ctx)
 
 		if errs.IsA[*awstypes.NoSuchEntityException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 

--- a/internal/service/iam/user_policy_attachments_exclusive.go
+++ b/internal/service/iam/user_policy_attachments_exclusive.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
@@ -192,9 +191,8 @@ func findUserPolicyAttachmentsByName(ctx context.Context, conn *iam.Client, user
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			if errs.IsA[*awstypes.NoSuchEntityException](err) {
-				return nil, &sdkretry.NotFoundError{
-					LastError:   err,
-					LastRequest: in,
+				return nil, &retry.NotFoundError{
+					LastError: err,
 				}
 			}
 			return policyARNs, err

--- a/internal/service/iam/user_policy_attachments_exclusive_test.go
+++ b/internal/service/iam/user_policy_attachments_exclusive_test.go
@@ -13,11 +13,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
@@ -27,25 +25,25 @@ import (
 func TestAccIAMUserPolicyAttachmentsExclusive_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user_policy_attachments_exclusive.test"
 	userResourceName := "aws_iam_user.test"
 	attachmentResourceName := "aws_iam_user_policy_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserPolicyAttachmentsExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckUserPolicyAttachmentsExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserPolicyAttachmentsExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserPolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckUserPolicyAttachmentCount(ctx, rName, 1),
-					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckUserPolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckUserPolicyAttachmentCount(ctx, t, rName, 1),
+					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, userResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_arns.*", attachmentResourceName, "policy_arn"),
 				),
@@ -64,25 +62,25 @@ func TestAccIAMUserPolicyAttachmentsExclusive_basic(t *testing.T) {
 func TestAccIAMUserPolicyAttachmentsExclusive_disappears_User(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user_policy_attachments_exclusive.test"
 	userResourceName := "aws_iam_user.test"
 	attachmentResourceName := "aws_iam_user_policy_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserPolicyAttachmentsExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckUserPolicyAttachmentsExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserPolicyAttachmentsExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserPolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckUserPolicyAttachmentCount(ctx, rName, 1),
-					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckUserPolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckUserPolicyAttachmentCount(ctx, t, rName, 1),
+					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					// Managed policies must be detached before user can be deleted
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceUserPolicyAttachment(), attachmentResourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceUser(), userResourceName),
@@ -96,25 +94,25 @@ func TestAccIAMUserPolicyAttachmentsExclusive_disappears_User(t *testing.T) {
 func TestAccIAMUserPolicyAttachmentsExclusive_disappears_Policy(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user_policy_attachments_exclusive.test"
 	policyResourceName := "aws_iam_policy.test"
 	attachmentResourceName := "aws_iam_user_policy_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserPolicyAttachmentsExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckUserPolicyAttachmentsExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserPolicyAttachmentsExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserPolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckUserPolicyAttachmentCount(ctx, rName, 1),
-					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckUserPolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckUserPolicyAttachmentCount(ctx, t, rName, 1),
+					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					// Managed policy must be detached before it can be deleted
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceUserPolicyAttachment(), attachmentResourceName),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourcePolicy(), policyResourceName),
@@ -128,29 +126,29 @@ func TestAccIAMUserPolicyAttachmentsExclusive_disappears_Policy(t *testing.T) {
 func TestAccIAMUserPolicyAttachmentsExclusive_multiple(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user_policy_attachments_exclusive.test"
 	userResourceName := "aws_iam_user.test"
 	attachmentResourceName := "aws_iam_user_policy_attachment.test"
 	attachmentResourceName2 := "aws_iam_user_policy_attachment.test2"
 	attachmentResourceName3 := "aws_iam_user_policy_attachment.test3"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserPolicyAttachmentsExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckUserPolicyAttachmentsExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserPolicyAttachmentsExclusiveConfig_multiple(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserPolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckUserPolicyAttachmentExists(ctx, attachmentResourceName2),
-					testAccCheckUserPolicyAttachmentExists(ctx, attachmentResourceName3),
-					testAccCheckUserPolicyAttachmentCount(ctx, rName, 3),
-					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckUserPolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckUserPolicyAttachmentExists(ctx, t, attachmentResourceName2),
+					testAccCheckUserPolicyAttachmentExists(ctx, t, attachmentResourceName3),
+					testAccCheckUserPolicyAttachmentCount(ctx, t, rName, 3),
+					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, userResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_arns.*", attachmentResourceName, "policy_arn"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_arns.*", attachmentResourceName2, "policy_arn"),
@@ -167,9 +165,9 @@ func TestAccIAMUserPolicyAttachmentsExclusive_multiple(t *testing.T) {
 			{
 				Config: testAccUserPolicyAttachmentsExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserPolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckUserPolicyAttachmentCount(ctx, rName, 1),
-					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckUserPolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckUserPolicyAttachmentCount(ctx, t, rName, 1),
+					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, userResourceName, names.AttrName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_arns.*", attachmentResourceName, "policy_arn"),
 				),
@@ -181,22 +179,22 @@ func TestAccIAMUserPolicyAttachmentsExclusive_multiple(t *testing.T) {
 func TestAccIAMUserPolicyAttachmentsExclusive_empty(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user_policy_attachments_exclusive.test"
 	userResourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserPolicyAttachmentsExclusiveDestroy(ctx),
+		CheckDestroy:             testAccCheckUserPolicyAttachmentsExclusiveDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserPolicyAttachmentsExclusiveConfig_empty(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, userResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "policy_arns.#", "0"),
 				),
@@ -213,35 +211,35 @@ func TestAccIAMUserPolicyAttachmentsExclusive_outOfBandRemoval(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var user types.User
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user_policy_attachments_exclusive.test"
 	userResourceName := "aws_iam_user.test"
 	attachmentResourceName := "aws_iam_user_policy_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserPolicyAttachmentsExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, userResourceName, &user),
-					testAccCheckUserPolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckUserPolicyAttachmentCount(ctx, rName, 1),
-					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, resourceName),
-					testAccCheckUserPolicyDetachManagedPolicy(ctx, &user, rName),
+					testAccCheckUserExists(ctx, t, userResourceName, &user),
+					testAccCheckUserPolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckUserPolicyAttachmentCount(ctx, t, rName, 1),
+					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
+					testAccCheckUserPolicyDetachManagedPolicy(ctx, t, &user, rName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccUserPolicyAttachmentsExclusiveConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, userResourceName, &user),
-					testAccCheckUserPolicyAttachmentExists(ctx, attachmentResourceName),
-					testAccCheckUserPolicyAttachmentCount(ctx, rName, 1),
-					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckUserExists(ctx, t, userResourceName, &user),
+					testAccCheckUserPolicyAttachmentExists(ctx, t, attachmentResourceName),
+					testAccCheckUserPolicyAttachmentCount(ctx, t, rName, 1),
+					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, userResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "policy_arns.#", "1"),
 				),
@@ -255,31 +253,31 @@ func TestAccIAMUserPolicyAttachmentsExclusive_outOfBandAddition(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var user types.User
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	oobPolicyName := rName + "-out-of-band"
 	resourceName := "aws_iam_user_policy_attachments_exclusive.test"
 	userResourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserPolicyAttachmentsExclusiveConfig_outOfBandAddition(rName, oobPolicyName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, userResourceName, &user),
-					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, resourceName),
-					testAccCheckUserPolicyAttachManagedPolicy(ctx, &user, oobPolicyName),
+					testAccCheckUserExists(ctx, t, userResourceName, &user),
+					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
+					testAccCheckUserPolicyAttachManagedPolicy(ctx, t, &user, oobPolicyName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccUserPolicyAttachmentsExclusiveConfig_outOfBandAddition(rName, oobPolicyName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, userResourceName, &user),
-					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, resourceName),
+					testAccCheckUserExists(ctx, t, userResourceName, &user),
+					testAccCheckUserPolicyAttachmentsExclusiveExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, userResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "policy_arns.#", "1"),
 				),
@@ -288,9 +286,9 @@ func TestAccIAMUserPolicyAttachmentsExclusive_outOfBandAddition(t *testing.T) {
 	})
 }
 
-func testAccCheckUserPolicyAttachmentsExclusiveDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckUserPolicyAttachmentsExclusiveDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_user_policy_attachments_exclusive" {
@@ -313,7 +311,7 @@ func testAccCheckUserPolicyAttachmentsExclusiveDestroy(ctx context.Context) reso
 	}
 }
 
-func testAccCheckUserPolicyAttachmentsExclusiveExists(ctx context.Context, name string) resource.TestCheckFunc {
+func testAccCheckUserPolicyAttachmentsExclusiveExists(ctx context.Context, t *testing.T, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -325,7 +323,7 @@ func testAccCheckUserPolicyAttachmentsExclusiveExists(ctx context.Context, name 
 			return create.Error(names.IAM, create.ErrActionCheckingExistence, tfiam.ResNameUserPolicyAttachmentsExclusive, name, errors.New("not set"))
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 		out, err := tfiam.FindUserPolicyAttachmentsByName(ctx, conn, userName)
 		if err != nil {
 			return create.Error(names.IAM, create.ErrActionCheckingExistence, tfiam.ResNameUserPolicyAttachmentsExclusive, userName, err)
@@ -340,9 +338,9 @@ func testAccCheckUserPolicyAttachmentsExclusiveExists(ctx context.Context, name 
 	}
 }
 
-func testAccCheckUserPolicyDetachManagedPolicy(ctx context.Context, user *types.User, policyName string) resource.TestCheckFunc {
+func testAccCheckUserPolicyDetachManagedPolicy(ctx context.Context, t *testing.T, user *types.User, policyName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		var managedARN string
 		input := &iam.ListAttachedUserPoliciesInput{
@@ -382,9 +380,9 @@ func testAccCheckUserPolicyDetachManagedPolicy(ctx context.Context, user *types.
 	}
 }
 
-func testAccCheckUserPolicyAttachManagedPolicy(ctx context.Context, user *types.User, policyName string) resource.TestCheckFunc {
+func testAccCheckUserPolicyAttachManagedPolicy(ctx context.Context, t *testing.T, user *types.User, policyName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		var managedARN string
 		input := &iam.ListPoliciesInput{

--- a/internal/service/iam/user_policy_test.go
+++ b/internal/service/iam/user_policy_test.go
@@ -13,12 +13,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -27,17 +25,17 @@ import (
 func TestAccIAMUserPolicy_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var userPolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	policy1 := `{"Version":"2012-10-17","Statement":{"Action":"*","Effect":"Allow","Resource":"*"}}`
 	policy2 := `{"Version":"2012-10-17","Statement":{"Action":"iam:*","Effect":"Allow","Resource":"*"}}`
 	resourceName := "aws_iam_user_policy.test"
 	userResourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckUserPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccUserPolicyConfig_basic(rName, strconv.Quote("NonJSONString")),
@@ -46,8 +44,8 @@ func TestAccIAMUserPolicy_basic(t *testing.T) {
 			{
 				Config: testAccUserPolicyConfig_basic(rName, strconv.Quote(policy1)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserPolicyExists(ctx, resourceName, &userPolicy),
-					testAccCheckUserPolicyExpectedPolicies(ctx, userResourceName, 1),
+					testAccCheckUserPolicyExists(ctx, t, resourceName, &userPolicy),
+					testAccCheckUserPolicyExpectedPolicies(ctx, t, userResourceName, 1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, ""),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPolicy, policy1),
@@ -62,8 +60,8 @@ func TestAccIAMUserPolicy_basic(t *testing.T) {
 			{
 				Config: testAccUserPolicyConfig_basic(rName, strconv.Quote(policy2)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserPolicyExists(ctx, resourceName, &userPolicy),
-					testAccCheckUserPolicyExpectedPolicies(ctx, userResourceName, 1),
+					testAccCheckUserPolicyExists(ctx, t, resourceName, &userPolicy),
+					testAccCheckUserPolicyExpectedPolicies(ctx, t, userResourceName, 1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPolicy, policy2),
 				),
 			},
@@ -74,20 +72,20 @@ func TestAccIAMUserPolicy_basic(t *testing.T) {
 func TestAccIAMUserPolicy_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var userPolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	policy := `{"Version":"2012-10-17","Statement":{"Action":"*","Effect":"Allow","Resource":"*"}}`
 	resourceName := "aws_iam_user_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckUserPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserPolicyConfig_basic(rName, strconv.Quote(policy)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserPolicyExists(ctx, resourceName, &userPolicy),
+					testAccCheckUserPolicyExists(ctx, t, resourceName, &userPolicy),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceUserPolicy(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -99,22 +97,22 @@ func TestAccIAMUserPolicy_disappears(t *testing.T) {
 func TestAccIAMUserPolicy_nameGenerated(t *testing.T) {
 	ctx := acctest.Context(t)
 	var userPolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	policy := `{"Version":"2012-10-17","Statement":{"Action":"*","Effect":"Allow","Resource":"*"}}`
 	resourceName := "aws_iam_user_policy.test"
 	userResourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckUserPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserPolicyConfig_nameGenerated(rName, strconv.Quote(policy)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserPolicyExists(ctx, resourceName, &userPolicy),
-					testAccCheckUserPolicyExpectedPolicies(ctx, userResourceName, 1),
+					testAccCheckUserPolicyExists(ctx, t, resourceName, &userPolicy),
+					testAccCheckUserPolicyExpectedPolicies(ctx, t, userResourceName, 1),
 					acctest.CheckResourceAttrNameGenerated(resourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, id.UniqueIdPrefix),
 				),
@@ -131,22 +129,22 @@ func TestAccIAMUserPolicy_nameGenerated(t *testing.T) {
 func TestAccIAMUserPolicy_namePrefix(t *testing.T) {
 	ctx := acctest.Context(t)
 	var userPolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	policy := `{"Version":"2012-10-17","Statement":{"Action":"*","Effect":"Allow","Resource":"*"}}`
 	resourceName := "aws_iam_user_policy.test"
 	userResourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckUserPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserPolicyConfig_namePrefix(rName, "tf-acc-test-prefix-", strconv.Quote(policy)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserPolicyExists(ctx, resourceName, &userPolicy),
-					testAccCheckUserPolicyExpectedPolicies(ctx, userResourceName, 1),
+					testAccCheckUserPolicyExists(ctx, t, resourceName, &userPolicy),
+					testAccCheckUserPolicyExpectedPolicies(ctx, t, userResourceName, 1),
 					acctest.CheckResourceAttrNameFromPrefix(resourceName, names.AttrName, "tf-acc-test-prefix-"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, "tf-acc-test-prefix-"),
 				),
@@ -163,25 +161,25 @@ func TestAccIAMUserPolicy_namePrefix(t *testing.T) {
 func TestAccIAMUserPolicy_multiplePolicies(t *testing.T) {
 	ctx := acctest.Context(t)
 	var userPolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	policy1 := `{"Version":"2012-10-17","Statement":{"Action":"*","Effect":"Allow","Resource":"*"}}`
 	policy2 := `{"Version":"2012-10-17","Statement":{"Action":"iam:*","Effect":"Allow","Resource":"*"}}`
 	resourceName1 := "aws_iam_user_policy.test1"
 	resourceName2 := "aws_iam_user_policy.test2"
 	userResourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckUserPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserPolicyConfig_multiplePolicies(rName, strconv.Quote(policy1), strconv.Quote(policy2)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserPolicyExists(ctx, resourceName1, &userPolicy),
-					testAccCheckUserPolicyExists(ctx, resourceName2, &userPolicy),
-					testAccCheckUserPolicyExpectedPolicies(ctx, userResourceName, 2),
+					testAccCheckUserPolicyExists(ctx, t, resourceName1, &userPolicy),
+					testAccCheckUserPolicyExists(ctx, t, resourceName2, &userPolicy),
+					testAccCheckUserPolicyExpectedPolicies(ctx, t, userResourceName, 2),
 					resource.TestCheckResourceAttr(resourceName1, names.AttrPolicy, policy1),
 					resource.TestCheckResourceAttr(resourceName2, names.AttrPolicy, policy2),
 				),
@@ -189,9 +187,9 @@ func TestAccIAMUserPolicy_multiplePolicies(t *testing.T) {
 			{
 				Config: testAccUserPolicyConfig_multiplePolicies(rName, strconv.Quote(policy2), strconv.Quote(policy2)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserPolicyExists(ctx, resourceName1, &userPolicy),
-					testAccCheckUserPolicyExists(ctx, resourceName2, &userPolicy),
-					testAccCheckUserPolicyExpectedPolicies(ctx, userResourceName, 2),
+					testAccCheckUserPolicyExists(ctx, t, resourceName1, &userPolicy),
+					testAccCheckUserPolicyExists(ctx, t, resourceName2, &userPolicy),
+					testAccCheckUserPolicyExpectedPolicies(ctx, t, userResourceName, 2),
 					resource.TestCheckResourceAttr(resourceName1, names.AttrPolicy, policy2),
 					resource.TestCheckResourceAttr(resourceName2, names.AttrPolicy, policy2),
 				),
@@ -203,21 +201,21 @@ func TestAccIAMUserPolicy_multiplePolicies(t *testing.T) {
 func TestAccIAMUserPolicy_policyOrder(t *testing.T) {
 	ctx := acctest.Context(t)
 	var userPolicy string
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user_policy.test"
 	userResourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckUserPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserPolicyConfig_order(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserPolicyExists(ctx, resourceName, &userPolicy),
-					testAccCheckUserPolicyExpectedPolicies(ctx, userResourceName, 1),
+					testAccCheckUserPolicyExists(ctx, t, resourceName, &userPolicy),
+					testAccCheckUserPolicyExpectedPolicies(ctx, t, userResourceName, 1),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -240,14 +238,14 @@ func TestAccIAMUserPolicy_policyOrder(t *testing.T) {
 	})
 }
 
-func testAccCheckUserPolicyExists(ctx context.Context, n string, v *string) resource.TestCheckFunc {
+func testAccCheckUserPolicyExists(ctx context.Context, t *testing.T, n string, v *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		output, err := tfiam.FindUserPolicyByTwoPartKey(ctx, conn, rs.Primary.Attributes["user"], rs.Primary.Attributes[names.AttrName])
 
@@ -261,9 +259,9 @@ func testAccCheckUserPolicyExists(ctx context.Context, n string, v *string) reso
 	}
 }
 
-func testAccCheckUserPolicyDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckUserPolicyDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_user_policy" {
@@ -287,14 +285,14 @@ func testAccCheckUserPolicyDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckUserPolicyExpectedPolicies(ctx context.Context, n string, want int) resource.TestCheckFunc {
+func testAccCheckUserPolicyExpectedPolicies(ctx context.Context, t *testing.T, n string, want int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		var got int
 

--- a/internal/service/iam/user_ssh_key.go
+++ b/internal/service/iam/user_ssh_key.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
@@ -220,9 +219,8 @@ func findSSHPublicKeyByThreePartKey(ctx context.Context, conn *iam.Client, id, e
 	output, err := conn.GetSSHPublicKey(ctx, input)
 
 	if errs.IsA[*awstypes.NoSuchEntityException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/iam/user_ssh_key_data_source_test.go
+++ b/internal/service/iam/user_ssh_key_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -18,13 +17,13 @@ func TestAccIAMUserSSHKeyDataSource_basic(t *testing.T) {
 	resourceName := "aws_iam_user_ssh_key.test"
 	dataSourceName := "data.aws_iam_user_ssh_key.test"
 
-	username := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	username := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	publicKey, _, err := RandSSHKeyPairSize(2048, acctest.DefaultEmailAddress)
 	if err != nil {
 		t.Fatalf("error generating random SSH key: %s", err)
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/iam/user_tags_gen_test.go
+++ b/internal/service/iam/user_tags_gen_test.go
@@ -33,7 +33,7 @@ func TestAccIAMUser_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -45,7 +45,7 @@ func TestAccIAMUser_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -92,7 +92,7 @@ func TestAccIAMUser_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -143,7 +143,7 @@ func TestAccIAMUser_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -187,7 +187,7 @@ func TestAccIAMUser_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -231,7 +231,7 @@ func TestAccIAMUser_Tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -243,7 +243,7 @@ func TestAccIAMUser_Tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -305,7 +305,7 @@ func TestAccIAMUser_Tags_emptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -315,7 +315,7 @@ func TestAccIAMUser_Tags_emptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -375,7 +375,7 @@ func TestAccIAMUser_Tags_addOnUpdate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -385,7 +385,7 @@ func TestAccIAMUser_Tags_addOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -409,7 +409,7 @@ func TestAccIAMUser_Tags_addOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -463,7 +463,7 @@ func TestAccIAMUser_Tags_EmptyTag_onCreate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -475,7 +475,7 @@ func TestAccIAMUser_Tags_EmptyTag_onCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -518,7 +518,7 @@ func TestAccIAMUser_Tags_EmptyTag_onCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -562,7 +562,7 @@ func TestAccIAMUser_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -574,7 +574,7 @@ func TestAccIAMUser_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -606,7 +606,7 @@ func TestAccIAMUser_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -655,7 +655,7 @@ func TestAccIAMUser_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -709,7 +709,7 @@ func TestAccIAMUser_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -721,7 +721,7 @@ func TestAccIAMUser_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -752,7 +752,7 @@ func TestAccIAMUser_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -805,7 +805,7 @@ func TestAccIAMUser_Tags_DefaultTags_providerOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckUserDestroy(ctx),
+		CheckDestroy: testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -818,7 +818,7 @@ func TestAccIAMUser_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -865,7 +865,7 @@ func TestAccIAMUser_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -914,7 +914,7 @@ func TestAccIAMUser_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -957,7 +957,7 @@ func TestAccIAMUser_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1002,7 +1002,7 @@ func TestAccIAMUser_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckUserDestroy(ctx),
+		CheckDestroy: testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1017,7 +1017,7 @@ func TestAccIAMUser_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1074,7 +1074,7 @@ func TestAccIAMUser_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1130,7 +1130,7 @@ func TestAccIAMUser_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1175,7 +1175,7 @@ func TestAccIAMUser_Tags_DefaultTags_overlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckUserDestroy(ctx),
+		CheckDestroy: testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1190,7 +1190,7 @@ func TestAccIAMUser_Tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1246,7 +1246,7 @@ func TestAccIAMUser_Tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1306,7 +1306,7 @@ func TestAccIAMUser_Tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1364,7 +1364,7 @@ func TestAccIAMUser_Tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckUserDestroy(ctx),
+		CheckDestroy: testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1376,7 +1376,7 @@ func TestAccIAMUser_Tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1409,7 +1409,7 @@ func TestAccIAMUser_Tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1461,7 +1461,7 @@ func TestAccIAMUser_Tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckUserDestroy(ctx),
+		CheckDestroy: testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1474,7 +1474,7 @@ func TestAccIAMUser_Tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1502,7 +1502,7 @@ func TestAccIAMUser_Tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1557,7 +1557,7 @@ func TestAccIAMUser_Tags_DefaultTags_emptyResourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckUserDestroy(ctx),
+		CheckDestroy: testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1572,7 +1572,7 @@ func TestAccIAMUser_Tags_DefaultTags_emptyResourceTag(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1629,7 +1629,7 @@ func TestAccIAMUser_Tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckUserDestroy(ctx),
+		CheckDestroy: testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1642,7 +1642,7 @@ func TestAccIAMUser_Tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1693,7 +1693,7 @@ func TestAccIAMUser_Tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckUserDestroy(ctx),
+		CheckDestroy: testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1708,7 +1708,7 @@ func TestAccIAMUser_Tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1762,7 +1762,7 @@ func TestAccIAMUser_Tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckUserDestroy(ctx),
+		CheckDestroy: testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1777,7 +1777,7 @@ func TestAccIAMUser_Tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T)
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1831,7 +1831,7 @@ func TestAccIAMUser_Tags_ComputedTag_onCreate(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckUserDestroy(ctx),
+		CheckDestroy: testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1841,7 +1841,7 @@ func TestAccIAMUser_Tags_ComputedTag_onCreate(t *testing.T) {
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1893,7 +1893,7 @@ func TestAccIAMUser_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckUserDestroy(ctx),
+		CheckDestroy: testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1905,7 +1905,7 @@ func TestAccIAMUser_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1937,7 +1937,7 @@ func TestAccIAMUser_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1997,7 +1997,7 @@ func TestAccIAMUser_Tags_ComputedTag_OnUpdate_replace(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckUserDestroy(ctx),
+		CheckDestroy: testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -2009,7 +2009,7 @@ func TestAccIAMUser_Tags_ComputedTag_OnUpdate_replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2039,7 +2039,7 @@ func TestAccIAMUser_Tags_ComputedTag_OnUpdate_replace(t *testing.T) {
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2091,7 +2091,7 @@ func TestAccIAMUser_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckUserDestroy(ctx),
+		CheckDestroy: testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2110,7 +2110,7 @@ func TestAccIAMUser_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2159,7 +2159,7 @@ func TestAccIAMUser_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2208,7 +2208,7 @@ func TestAccIAMUser_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2257,7 +2257,7 @@ func TestAccIAMUser_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckUserDestroy(ctx),
+		CheckDestroy: testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2274,7 +2274,7 @@ func TestAccIAMUser_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2337,7 +2337,7 @@ func TestAccIAMUser_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2400,7 +2400,7 @@ func TestAccIAMUser_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &v),
+					testAccCheckUserExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/iam/user_test.go
+++ b/internal/service/iam/user_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -20,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -32,22 +30,22 @@ func TestAccIAMUser_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.User
 
-	name1 := fmt.Sprintf("test-user-%d", sdkacctest.RandInt())
-	name2 := fmt.Sprintf("test-user-%d", sdkacctest.RandInt())
+	name1 := fmt.Sprintf("test-user-%d", acctest.RandInt(t))
+	name2 := fmt.Sprintf("test-user-%d", acctest.RandInt(t))
 	path1 := "/"
 	path2 := "/path2/"
 	resourceName := "aws_iam_user.user"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_basic(name1, path1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, "aws_iam_user.user", &conf),
+					testAccCheckUserExists(ctx, t, "aws_iam_user.user", &conf),
 					testAccCheckUserAttributes(&conf, name1, "/"),
 				),
 			},
@@ -61,7 +59,7 @@ func TestAccIAMUser_basic(t *testing.T) {
 			{
 				Config: testAccUserConfig_basic(name2, path2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, "aws_iam_user.user", &conf),
+					testAccCheckUserExists(ctx, t, "aws_iam_user.user", &conf),
 					testAccCheckUserAttributes(&conf, name2, "/path2/"),
 				),
 			},
@@ -73,19 +71,19 @@ func TestAccIAMUser_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user.user"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_basic(rName, "/"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceUser(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -98,20 +96,20 @@ func TestAccIAMUser_ForceDestroy_accessKey(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_forceDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
-					testAccCheckUserCreatesAccessKey(ctx, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
+					testAccCheckUserCreatesAccessKey(ctx, t, &user),
 				),
 			},
 			{
@@ -129,20 +127,20 @@ func TestAccIAMUser_ForceDestroy_loginProfile(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_forceDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
-					testAccCheckUserCreatesLoginProfile(ctx, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
+					testAccCheckUserCreatesLoginProfile(ctx, t, &user),
 				),
 			},
 			{
@@ -160,20 +158,20 @@ func TestAccIAMUser_ForceDestroy_mfaDevice(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_forceDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
-					testAccCheckUserCreatesMFADevice(ctx, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
+					testAccCheckUserCreatesMFADevice(ctx, t, &user),
 				),
 			},
 			{
@@ -191,20 +189,20 @@ func TestAccIAMUser_ForceDestroy_sshKey(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_forceDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
-					testAccCheckUserUploadsSSHKey(ctx, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
+					testAccCheckUserUploadsSSHKey(ctx, t, &user),
 				),
 			},
 			{
@@ -221,20 +219,20 @@ func TestAccIAMUser_ForceDestroy_serviceSpecificCred(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_forceDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
-					testAccCheckUserServiceSpecificCredential(ctx, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
+					testAccCheckUserServiceSpecificCredential(ctx, t, &user),
 				),
 			},
 			{
@@ -251,19 +249,19 @@ func TestAccIAMUser_ForceDestroy_signingCertificate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_forceDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					testAccCheckUserUploadSigningCertificate(ctx, t, &user),
 				),
 			},
@@ -282,20 +280,20 @@ func TestAccIAMUser_ForceDestroy_policyAttached(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_forceDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
-					testAccCheckUserAttachPolicy(ctx, &user), // externally attach a policy
+					testAccCheckUserExists(ctx, t, resourceName, &user),
+					testAccCheckUserAttachPolicy(ctx, t, &user), // externally attach a policy
 				),
 			},
 		},
@@ -306,20 +304,20 @@ func TestAccIAMUser_ForceDestroy_policyInline(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_forceDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
-					testAccCheckUserInlinePolicy(ctx, &user), // externally put an inline policy
+					testAccCheckUserExists(ctx, t, resourceName, &user),
+					testAccCheckUserInlinePolicy(ctx, t, &user), // externally put an inline policy
 				),
 			},
 		},
@@ -330,21 +328,21 @@ func TestAccIAMUser_ForceDestroy_policyInlineAttached(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_forceDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
-					testAccCheckUserInlinePolicy(ctx, &user), // externally put an inline policy
-					testAccCheckUserAttachPolicy(ctx, &user), // externally attach a policy
+					testAccCheckUserExists(ctx, t, resourceName, &user),
+					testAccCheckUserInlinePolicy(ctx, t, &user), // externally put an inline policy
+					testAccCheckUserAttachPolicy(ctx, t, &user), // externally attach a policy
 				),
 			},
 		},
@@ -355,21 +353,21 @@ func TestAccIAMUser_nameChange(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.User
 
-	name1 := fmt.Sprintf("test-user-%d", sdkacctest.RandInt())
-	name2 := fmt.Sprintf("test-user-%d", sdkacctest.RandInt())
+	name1 := fmt.Sprintf("test-user-%d", acctest.RandInt(t))
+	name2 := fmt.Sprintf("test-user-%d", acctest.RandInt(t))
 	path := "/"
 	resourceName := "aws_iam_user.user"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_basic(name1, path),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, "aws_iam_user.user", &conf),
+					testAccCheckUserExists(ctx, t, "aws_iam_user.user", &conf),
 				),
 			},
 			{
@@ -382,7 +380,7 @@ func TestAccIAMUser_nameChange(t *testing.T) {
 			{
 				Config: testAccUserConfig_basic(name2, path),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, "aws_iam_user.user", &conf),
+					testAccCheckUserExists(ctx, t, "aws_iam_user.user", &conf),
 				),
 			},
 		},
@@ -393,21 +391,21 @@ func TestAccIAMUser_pathChange(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.User
 
-	name := fmt.Sprintf("test-user-%d", sdkacctest.RandInt())
+	name := fmt.Sprintf("test-user-%d", acctest.RandInt(t))
 	path1 := "/"
 	path2 := "/updated/"
 	resourceName := "aws_iam_user.user"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_basic(name, path1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, "aws_iam_user.user", &conf),
+					testAccCheckUserExists(ctx, t, "aws_iam_user.user", &conf),
 				),
 			},
 			{
@@ -420,7 +418,7 @@ func TestAccIAMUser_pathChange(t *testing.T) {
 			{
 				Config: testAccUserConfig_basic(name, path2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, "aws_iam_user.user", &conf),
+					testAccCheckUserExists(ctx, t, "aws_iam_user.user", &conf),
 				),
 			},
 		},
@@ -431,23 +429,23 @@ func TestAccIAMUser_permissionsBoundary(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_user.user"
 
 	permissionsBoundary1 := fmt.Sprintf("arn:%s:iam::aws:policy/AdministratorAccess", acctest.Partition())
 	permissionsBoundary2 := fmt.Sprintf("arn:%s:iam::aws:policy/ReadOnlyAccess", acctest.Partition())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// Test creation
 			{
 				Config: testAccUserConfig_permissionsBoundary(rName, permissionsBoundary1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", permissionsBoundary1),
 					testAccCheckUserPermissionsBoundary(&user, permissionsBoundary1),
 				),
@@ -463,7 +461,7 @@ func TestAccIAMUser_permissionsBoundary(t *testing.T) {
 			{
 				Config: testAccUserConfig_permissionsBoundary(rName, permissionsBoundary2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", permissionsBoundary2),
 					testAccCheckUserPermissionsBoundary(&user, permissionsBoundary2),
 				),
@@ -479,7 +477,7 @@ func TestAccIAMUser_permissionsBoundary(t *testing.T) {
 			{
 				Config: testAccUserConfig_basic(rName, "/"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", ""),
 					testAccCheckUserPermissionsBoundary(&user, ""),
 				),
@@ -488,7 +486,7 @@ func TestAccIAMUser_permissionsBoundary(t *testing.T) {
 			{
 				Config: testAccUserConfig_permissionsBoundary(rName, permissionsBoundary1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", permissionsBoundary1),
 					testAccCheckUserPermissionsBoundary(&user, permissionsBoundary1),
 				),
@@ -497,7 +495,7 @@ func TestAccIAMUser_permissionsBoundary(t *testing.T) {
 			{
 				PreConfig: func() {
 					// delete the boundary manually
-					conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+					conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 					input := &iam.DeleteUserPermissionsBoundaryInput{
 						UserName: user.UserName,
 					}
@@ -509,7 +507,7 @@ func TestAccIAMUser_permissionsBoundary(t *testing.T) {
 				Config: testAccUserConfig_permissionsBoundary(rName, permissionsBoundary1),
 				// check the boundary was restored
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", permissionsBoundary1),
 					testAccCheckUserPermissionsBoundary(&user, permissionsBoundary1),
 				),
@@ -518,7 +516,7 @@ func TestAccIAMUser_permissionsBoundary(t *testing.T) {
 			{
 				Config: testAccUserConfig_permissionsBoundary(rName, ""),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", ""),
 					testAccCheckUserPermissionsBoundary(&user, ""),
 				),
@@ -532,20 +530,20 @@ func TestAccIAMUser_nameAndTags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var u awstypes.User
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	rNameUpdated := rName + "-updated"
 	resourceName := "aws_iam_user.user"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_nameAndTags(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, "aws_iam_user.user", &u),
+					testAccCheckUserExists(ctx, t, "aws_iam_user.user", &u),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -566,7 +564,7 @@ func TestAccIAMUser_nameAndTags(t *testing.T) {
 			{
 				Config: testAccUserConfig_nameAndTags(rNameUpdated, acctest.CtKey1, acctest.CtValue1Updated),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, "aws_iam_user.user", &u),
+					testAccCheckUserExists(ctx, t, "aws_iam_user.user", &u),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -588,9 +586,9 @@ func TestAccIAMUser_nameAndTags(t *testing.T) {
 	})
 }
 
-func testAccCheckUserDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckUserDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_iam_user" {
@@ -614,7 +612,7 @@ func testAccCheckUserDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckUserExists(ctx context.Context, n string, v *awstypes.User) resource.TestCheckFunc {
+func testAccCheckUserExists(ctx context.Context, t *testing.T, n string, v *awstypes.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -625,7 +623,7 @@ func testAccCheckUserExists(ctx context.Context, n string, v *awstypes.User) res
 			return fmt.Errorf("No IAM User ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		output, err := tfiam.FindUserByName(ctx, conn, rs.Primary.ID)
 
@@ -669,9 +667,9 @@ func testAccCheckUserPermissionsBoundary(user *awstypes.User, expectedPermission
 	}
 }
 
-func testAccCheckUserCreatesAccessKey(ctx context.Context, user *awstypes.User) resource.TestCheckFunc {
+func testAccCheckUserCreatesAccessKey(ctx context.Context, t *testing.T, user *awstypes.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		input := &iam.CreateAccessKeyInput{
 			UserName: user.UserName,
@@ -685,9 +683,9 @@ func testAccCheckUserCreatesAccessKey(ctx context.Context, user *awstypes.User) 
 	}
 }
 
-func testAccCheckUserCreatesLoginProfile(ctx context.Context, user *awstypes.User) resource.TestCheckFunc {
+func testAccCheckUserCreatesLoginProfile(ctx context.Context, t *testing.T, user *awstypes.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 		password, err := tfiam.GeneratePassword(32)
 		if err != nil {
 			return err
@@ -705,9 +703,9 @@ func testAccCheckUserCreatesLoginProfile(ctx context.Context, user *awstypes.Use
 	}
 }
 
-func testAccCheckUserCreatesMFADevice(ctx context.Context, user *awstypes.User) resource.TestCheckFunc {
+func testAccCheckUserCreatesMFADevice(ctx context.Context, t *testing.T, user *awstypes.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		createVirtualMFADeviceInput := &iam.CreateVirtualMFADeviceInput{
 			Path:                 user.Path,
@@ -745,14 +743,14 @@ func testAccCheckUserCreatesMFADevice(ctx context.Context, user *awstypes.User) 
 }
 
 // Creates an IAM User SSH Key outside of Terraform to verify that it is deleted when `force_destroy` is set
-func testAccCheckUserUploadsSSHKey(ctx context.Context, user *awstypes.User) resource.TestCheckFunc {
+func testAccCheckUserUploadsSSHKey(ctx context.Context, t *testing.T, user *awstypes.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		publicKey, _, err := RandSSHKeyPairSize(2048, acctest.DefaultEmailAddress)
 		if err != nil {
 			return fmt.Errorf("error generating random SSH key: %w", err)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		input := &iam.UploadSSHPublicKeyInput{
 			UserName:         user.UserName,
@@ -769,9 +767,9 @@ func testAccCheckUserUploadsSSHKey(ctx context.Context, user *awstypes.User) res
 }
 
 // Creates an IAM User Service Specific Credential outside of Terraform to verify that it is deleted when `force_destroy` is set
-func testAccCheckUserServiceSpecificCredential(ctx context.Context, user *awstypes.User) resource.TestCheckFunc {
+func testAccCheckUserServiceSpecificCredential(ctx context.Context, t *testing.T, user *awstypes.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		input := &iam.CreateServiceSpecificCredentialInput{
 			UserName:    user.UserName,
@@ -789,7 +787,7 @@ func testAccCheckUserServiceSpecificCredential(ctx context.Context, user *awstyp
 
 func testAccCheckUserUploadSigningCertificate(ctx context.Context, t *testing.T, user *awstypes.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 		certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
@@ -807,9 +805,9 @@ func testAccCheckUserUploadSigningCertificate(ctx context.Context, t *testing.T,
 	}
 }
 
-func testAccCheckUserAttachPolicy(ctx context.Context, user *awstypes.User) resource.TestCheckFunc {
+func testAccCheckUserAttachPolicy(ctx context.Context, t *testing.T, user *awstypes.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		doc := `{"Version":"2012-10-17","Statement":[{"Action":["iam:ChangePassword"],"Resource":"*","Effect":"Allow"}]}`
 
@@ -838,9 +836,9 @@ func testAccCheckUserAttachPolicy(ctx context.Context, user *awstypes.User) reso
 	}
 }
 
-func testAccCheckUserInlinePolicy(ctx context.Context, user *awstypes.User) resource.TestCheckFunc {
+func testAccCheckUserInlinePolicy(ctx context.Context, t *testing.T, user *awstypes.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
 
 		doc := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":["ec2:DescribeElasticGpus","ec2:DescribeFastSnapshotRestores","ec2:DescribeScheduledInstances","ec2:DescribeScheduledInstanceAvailability"],"Resource":"*"}}`
 

--- a/internal/service/iam/users_data_source_test.go
+++ b/internal/service/iam/users_data_source_test.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -17,10 +16,10 @@ import (
 func TestAccIAMUsersDataSource_nameRegex(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_users.test"
-	rCount := strconv.Itoa(sdkacctest.RandIntRange(1, 4))
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rCount := strconv.Itoa(acctest.RandIntRange(t, 1, 4))
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -39,11 +38,11 @@ func TestAccIAMUsersDataSource_nameRegex(t *testing.T) {
 func TestAccIAMUsersDataSource_pathPrefix(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_users.test"
-	rCount := strconv.Itoa(sdkacctest.RandIntRange(1, 4))
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rPathPrefix := sdkacctest.RandomWithPrefix("tf-acc-path")
+	rCount := strconv.Itoa(acctest.RandIntRange(t, 1, 4))
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rPathPrefix := acctest.RandomWithPrefix(t, "tf-acc-path")
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -63,7 +62,7 @@ func TestAccIAMUsersDataSource_nonExistentNameRegex(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_users.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -83,7 +82,7 @@ func TestAccIAMUsersDataSource_nonExistentPathPrefix(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_users.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/iam/virtual_mfa_device.go
+++ b/internal/service/iam/virtual_mfa_device.go
@@ -33,7 +33,6 @@ import (
 // @SDKResource("aws_iam_virtual_mfa_device", name="Virtual MFA Device")
 // @Tags(identifierAttribute="id", resourceType="VirtualMFADevice")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/iam/types;types.VirtualMFADevice", importIgnore="base_32_string_seed;qr_code_png")
-// @Testing(existsTakesT=false, destroyTakesT=false)
 func resourceVirtualMFADevice() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceVirtualMFADeviceCreate,

--- a/internal/service/iam/virtual_mfa_device_tags_gen_test.go
+++ b/internal/service/iam/virtual_mfa_device_tags_gen_test.go
@@ -33,7 +33,7 @@ func TestAccIAMVirtualMFADevice_tags(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -45,7 +45,7 @@ func TestAccIAMVirtualMFADevice_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -92,7 +92,7 @@ func TestAccIAMVirtualMFADevice_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -143,7 +143,7 @@ func TestAccIAMVirtualMFADevice_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -187,7 +187,7 @@ func TestAccIAMVirtualMFADevice_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -231,7 +231,7 @@ func TestAccIAMVirtualMFADevice_Tags_null(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -243,7 +243,7 @@ func TestAccIAMVirtualMFADevice_Tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -305,7 +305,7 @@ func TestAccIAMVirtualMFADevice_Tags_emptyMap(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -315,7 +315,7 @@ func TestAccIAMVirtualMFADevice_Tags_emptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -375,7 +375,7 @@ func TestAccIAMVirtualMFADevice_Tags_addOnUpdate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -385,7 +385,7 @@ func TestAccIAMVirtualMFADevice_Tags_addOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -409,7 +409,7 @@ func TestAccIAMVirtualMFADevice_Tags_addOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -463,7 +463,7 @@ func TestAccIAMVirtualMFADevice_Tags_EmptyTag_onCreate(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -475,7 +475,7 @@ func TestAccIAMVirtualMFADevice_Tags_EmptyTag_onCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -518,7 +518,7 @@ func TestAccIAMVirtualMFADevice_Tags_EmptyTag_onCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -562,7 +562,7 @@ func TestAccIAMVirtualMFADevice_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -574,7 +574,7 @@ func TestAccIAMVirtualMFADevice_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -606,7 +606,7 @@ func TestAccIAMVirtualMFADevice_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -655,7 +655,7 @@ func TestAccIAMVirtualMFADevice_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -709,7 +709,7 @@ func TestAccIAMVirtualMFADevice_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -721,7 +721,7 @@ func TestAccIAMVirtualMFADevice_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -752,7 +752,7 @@ func TestAccIAMVirtualMFADevice_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -805,7 +805,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_providerOnly(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -818,7 +818,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -865,7 +865,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -914,7 +914,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -957,7 +957,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1002,7 +1002,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1017,7 +1017,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1074,7 +1074,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1130,7 +1130,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1175,7 +1175,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_overlapping(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1190,7 +1190,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1246,7 +1246,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1306,7 +1306,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1364,7 +1364,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_updateToProviderOnly(t *testing
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1376,7 +1376,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_updateToProviderOnly(t *testing
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1409,7 +1409,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_updateToProviderOnly(t *testing
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1461,7 +1461,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_updateToResourceOnly(t *testing
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1474,7 +1474,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_updateToResourceOnly(t *testing
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1502,7 +1502,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_updateToResourceOnly(t *testing
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1557,7 +1557,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_emptyResourceTag(t *testing.T) 
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1572,7 +1572,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_emptyResourceTag(t *testing.T) 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1629,7 +1629,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_emptyProviderOnlyTag(t *testing
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1642,7 +1642,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_emptyProviderOnlyTag(t *testing
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1693,7 +1693,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_nullOverlappingResourceTag(t *t
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1708,7 +1708,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_nullOverlappingResourceTag(t *t
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1762,7 +1762,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_nullNonOverlappingResourceTag(t
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1777,7 +1777,7 @@ func TestAccIAMVirtualMFADevice_Tags_DefaultTags_nullNonOverlappingResourceTag(t
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1831,7 +1831,7 @@ func TestAccIAMVirtualMFADevice_Tags_ComputedTag_onCreate(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1841,7 +1841,7 @@ func TestAccIAMVirtualMFADevice_Tags_ComputedTag_onCreate(t *testing.T) {
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1893,7 +1893,7 @@ func TestAccIAMVirtualMFADevice_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1905,7 +1905,7 @@ func TestAccIAMVirtualMFADevice_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1937,7 +1937,7 @@ func TestAccIAMVirtualMFADevice_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1997,7 +1997,7 @@ func TestAccIAMVirtualMFADevice_Tags_ComputedTag_OnUpdate_replace(t *testing.T) 
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -2009,7 +2009,7 @@ func TestAccIAMVirtualMFADevice_Tags_ComputedTag_OnUpdate_replace(t *testing.T) 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2039,7 +2039,7 @@ func TestAccIAMVirtualMFADevice_Tags_ComputedTag_OnUpdate_replace(t *testing.T) 
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2091,7 +2091,7 @@ func TestAccIAMVirtualMFADevice_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T)
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2110,7 +2110,7 @@ func TestAccIAMVirtualMFADevice_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T)
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2159,7 +2159,7 @@ func TestAccIAMVirtualMFADevice_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T)
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2208,7 +2208,7 @@ func TestAccIAMVirtualMFADevice_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T)
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2257,7 +2257,7 @@ func TestAccIAMVirtualMFADevice_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T
 		},
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
-		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2274,7 +2274,7 @@ func TestAccIAMVirtualMFADevice_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2337,7 +2337,7 @@ func TestAccIAMVirtualMFADevice_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2400,7 +2400,7 @@ func TestAccIAMVirtualMFADevice_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					testAccCheckVirtualMFADeviceExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{


### PR DESCRIPTION

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Enables `go-vcr` for the `iam` service.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/25602
Relates https://github.com/hashicorp/terraform-provider-aws/issues/43717


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% VCR_MODE=REPLAY_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/ make t K=iam T=TestAccIAMRole_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-go-vcr-iam 🌿...
TF_ACC=1 go1.25.7 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRole_'  -timeout 360m -vet=off
2026/02/18 09:42:30 Creating Terraform AWS Provider (SDKv2-style)...
2026/02/18 09:42:30 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIAMRole_Identity_basic
=== PAUSE TestAccIAMRole_Identity_basic
=== RUN   TestAccIAMRole_Identity_ExistingResource_basic
    role_identity_gen_test.go:115: no cassette found on disk for TestAccIAMRole_Identity_ExistingResource_basic, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_Identity_ExistingResource_basic.seed: no such file or directory
--- FAIL: TestAccIAMRole_Identity_ExistingResource_basic (0.00s)
=== RUN   TestAccIAMRole_Identity_ExistingResource_noRefreshNoChange
    role_identity_gen_test.go:196: no cassette found on disk for TestAccIAMRole_Identity_ExistingResource_noRefreshNoChange, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_Identity_ExistingResource_noRefreshNoChange.seed: no such file or directory
--- FAIL: TestAccIAMRole_Identity_ExistingResource_noRefreshNoChange (0.00s)
=== RUN   TestAccIAMRole_List_basic
    role_list_test.go:27: no cassette found on disk for TestAccIAMRole_List_basic, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_List_basic.seed: no such file or directory
--- FAIL: TestAccIAMRole_List_basic (0.00s)
=== RUN   TestAccIAMRole_tags
=== PAUSE TestAccIAMRole_tags
=== RUN   TestAccIAMRole_Tags_null
=== PAUSE TestAccIAMRole_Tags_null
=== RUN   TestAccIAMRole_Tags_emptyMap
=== PAUSE TestAccIAMRole_Tags_emptyMap
=== RUN   TestAccIAMRole_Tags_addOnUpdate
=== PAUSE TestAccIAMRole_Tags_addOnUpdate
=== RUN   TestAccIAMRole_Tags_EmptyTag_onCreate
=== PAUSE TestAccIAMRole_Tags_EmptyTag_onCreate
=== RUN   TestAccIAMRole_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccIAMRole_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccIAMRole_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccIAMRole_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccIAMRole_Tags_DefaultTags_providerOnly
    role_tags_gen_test.go:764: no cassette found on disk for TestAccIAMRole_Tags_DefaultTags_providerOnly, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_Tags_DefaultTags_providerOnly.seed: no such file or directory
--- FAIL: TestAccIAMRole_Tags_DefaultTags_providerOnly (0.00s)
=== RUN   TestAccIAMRole_Tags_DefaultTags_nonOverlapping
    role_tags_gen_test.go:949: no cassette found on disk for TestAccIAMRole_Tags_DefaultTags_nonOverlapping, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_Tags_DefaultTags_nonOverlapping.seed: no such file or directory
--- FAIL: TestAccIAMRole_Tags_DefaultTags_nonOverlapping (0.00s)
=== RUN   TestAccIAMRole_Tags_DefaultTags_overlapping
    role_tags_gen_test.go:1113: no cassette found on disk for TestAccIAMRole_Tags_DefaultTags_overlapping, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_Tags_DefaultTags_overlapping.seed: no such file or directory
--- FAIL: TestAccIAMRole_Tags_DefaultTags_overlapping (0.00s)
=== RUN   TestAccIAMRole_Tags_DefaultTags_updateToProviderOnly
    role_tags_gen_test.go:1293: no cassette found on disk for TestAccIAMRole_Tags_DefaultTags_updateToProviderOnly, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_Tags_DefaultTags_updateToProviderOnly.seed: no such file or directory
--- FAIL: TestAccIAMRole_Tags_DefaultTags_updateToProviderOnly (0.00s)
=== RUN   TestAccIAMRole_Tags_DefaultTags_updateToResourceOnly
    role_tags_gen_test.go:1387: no cassette found on disk for TestAccIAMRole_Tags_DefaultTags_updateToResourceOnly, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_Tags_DefaultTags_updateToResourceOnly.seed: no such file or directory
--- FAIL: TestAccIAMRole_Tags_DefaultTags_updateToResourceOnly (0.00s)
=== RUN   TestAccIAMRole_Tags_DefaultTags_emptyResourceTag
    role_tags_gen_test.go:1480: no cassette found on disk for TestAccIAMRole_Tags_DefaultTags_emptyResourceTag, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_Tags_DefaultTags_emptyResourceTag.seed: no such file or directory
--- FAIL: TestAccIAMRole_Tags_DefaultTags_emptyResourceTag (0.00s)
=== RUN   TestAccIAMRole_Tags_DefaultTags_emptyProviderOnlyTag
    role_tags_gen_test.go:1549: no cassette found on disk for TestAccIAMRole_Tags_DefaultTags_emptyProviderOnlyTag, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_Tags_DefaultTags_emptyProviderOnlyTag.seed: no such file or directory
--- FAIL: TestAccIAMRole_Tags_DefaultTags_emptyProviderOnlyTag (0.00s)
=== RUN   TestAccIAMRole_Tags_DefaultTags_nullOverlappingResourceTag
    role_tags_gen_test.go:1610: no cassette found on disk for TestAccIAMRole_Tags_DefaultTags_nullOverlappingResourceTag, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_Tags_DefaultTags_nullOverlappingResourceTag.seed: no such file or directory
--- FAIL: TestAccIAMRole_Tags_DefaultTags_nullOverlappingResourceTag (0.00s)
=== RUN   TestAccIAMRole_Tags_DefaultTags_nullNonOverlappingResourceTag
    role_tags_gen_test.go:1676: no cassette found on disk for TestAccIAMRole_Tags_DefaultTags_nullNonOverlappingResourceTag, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_Tags_DefaultTags_nullNonOverlappingResourceTag.seed: no such file or directory
--- FAIL: TestAccIAMRole_Tags_DefaultTags_nullNonOverlappingResourceTag (0.00s)
=== RUN   TestAccIAMRole_Tags_ComputedTag_onCreate
    role_tags_gen_test.go:1742: no cassette found on disk for TestAccIAMRole_Tags_ComputedTag_onCreate, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_Tags_ComputedTag_onCreate.seed: no such file or directory
--- FAIL: TestAccIAMRole_Tags_ComputedTag_onCreate (0.00s)
=== RUN   TestAccIAMRole_Tags_ComputedTag_OnUpdate_add
    role_tags_gen_test.go:1801: no cassette found on disk for TestAccIAMRole_Tags_ComputedTag_OnUpdate_add, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_Tags_ComputedTag_OnUpdate_add.seed: no such file or directory
--- FAIL: TestAccIAMRole_Tags_ComputedTag_OnUpdate_add (0.00s)
=== RUN   TestAccIAMRole_Tags_ComputedTag_OnUpdate_replace
    role_tags_gen_test.go:1902: no cassette found on disk for TestAccIAMRole_Tags_ComputedTag_OnUpdate_replace, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_Tags_ComputedTag_OnUpdate_replace.seed: no such file or directory
--- FAIL: TestAccIAMRole_Tags_ComputedTag_OnUpdate_replace (0.00s)
=== RUN   TestAccIAMRole_Tags_IgnoreTags_Overlap_defaultTag
    role_tags_gen_test.go:1993: no cassette found on disk for TestAccIAMRole_Tags_IgnoreTags_Overlap_defaultTag, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_Tags_IgnoreTags_Overlap_defaultTag.seed: no such file or directory
--- FAIL: TestAccIAMRole_Tags_IgnoreTags_Overlap_defaultTag (0.00s)
=== RUN   TestAccIAMRole_Tags_IgnoreTags_Overlap_resourceTag
    role_tags_gen_test.go:2159: no cassette found on disk for TestAccIAMRole_Tags_IgnoreTags_Overlap_resourceTag, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_Tags_IgnoreTags_Overlap_resourceTag.seed: no such file or directory
--- FAIL: TestAccIAMRole_Tags_IgnoreTags_Overlap_resourceTag (0.00s)
=== RUN   TestAccIAMRole_basic
=== PAUSE TestAccIAMRole_basic
=== RUN   TestAccIAMRole_description
=== PAUSE TestAccIAMRole_description
=== RUN   TestAccIAMRole_nameGenerated
=== PAUSE TestAccIAMRole_nameGenerated
=== RUN   TestAccIAMRole_namePrefix
=== PAUSE TestAccIAMRole_namePrefix
=== RUN   TestAccIAMRole_testNameChange
=== PAUSE TestAccIAMRole_testNameChange
=== RUN   TestAccIAMRole_diffs
=== PAUSE TestAccIAMRole_diffs
=== RUN   TestAccIAMRole_diffsCondition
=== PAUSE TestAccIAMRole_diffsCondition
=== RUN   TestAccIAMRole_badJSON
=== PAUSE TestAccIAMRole_badJSON
=== RUN   TestAccIAMRole_disappears
=== PAUSE TestAccIAMRole_disappears
=== RUN   TestAccIAMRole_policiesForceDetach
=== PAUSE TestAccIAMRole_policiesForceDetach
=== RUN   TestAccIAMRole_maxSessionDuration
=== PAUSE TestAccIAMRole_maxSessionDuration
=== RUN   TestAccIAMRole_permissionsBoundary
=== PAUSE TestAccIAMRole_permissionsBoundary
=== RUN   TestAccIAMRole_InlinePolicy_basic
=== PAUSE TestAccIAMRole_InlinePolicy_basic
=== RUN   TestAccIAMRole_InlinePolicy_ignoreOrder
=== PAUSE TestAccIAMRole_InlinePolicy_ignoreOrder
=== RUN   TestAccIAMRole_InlinePolicy_empty
=== PAUSE TestAccIAMRole_InlinePolicy_empty
=== RUN   TestAccIAMRole_InlinePolicy_malformed
=== PAUSE TestAccIAMRole_InlinePolicy_malformed
=== RUN   TestAccIAMRole_ManagedPolicy_basic
=== PAUSE TestAccIAMRole_ManagedPolicy_basic
=== RUN   TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack
=== PAUSE TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack
=== RUN   TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack
=== PAUSE TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack
=== RUN   TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved
=== PAUSE TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved
=== RUN   TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved
=== PAUSE TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved
=== RUN   TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored
=== PAUSE TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored
=== RUN   TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored
=== PAUSE TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored
=== RUN   TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty
=== PAUSE TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty
=== RUN   TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty
=== PAUSE TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty
=== RUN   TestAccIAMRole_Identity_ExistingResource_NoRefresh_OnError
    role_test.go:976: no cassette found on disk for TestAccIAMRole_Identity_ExistingResource_NoRefresh_OnError, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_Identity_ExistingResource_NoRefresh_OnError.seed: no such file or directory
--- FAIL: TestAccIAMRole_Identity_ExistingResource_NoRefresh_OnError (0.00s)
=== RUN   TestAccIAMRole_Identity_ExistingResource_OnError
    role_test.go:1013: no cassette found on disk for TestAccIAMRole_Identity_ExistingResource_OnError, please replay this testcase in RECORD_ONLY mode - open /Users/jaredbaker/development/_vcr-testdata/TestAccIAMRole_Identity_ExistingResource_OnError.seed: no such file or directory
--- FAIL: TestAccIAMRole_Identity_ExistingResource_OnError (0.00s)
=== CONT  TestAccIAMRole_Identity_basic
=== CONT  TestAccIAMRole_policiesForceDetach
=== CONT  TestAccIAMRole_basic
=== CONT  TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack
=== CONT  TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty
=== CONT  TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored
=== CONT  TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty
=== CONT  TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved
=== CONT  TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored
=== CONT  TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved
=== CONT  TestAccIAMRole_InlinePolicy_ignoreOrder
=== CONT  TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack
=== CONT  TestAccIAMRole_InlinePolicy_malformed
=== CONT  TestAccIAMRole_InlinePolicy_empty
=== CONT  TestAccIAMRole_description
=== CONT  TestAccIAMRole_ManagedPolicy_basic
=== CONT  TestAccIAMRole_Tags_EmptyTag_onCreate
=== CONT  TestAccIAMRole_disappears
=== CONT  TestAccIAMRole_diffsCondition
=== CONT  TestAccIAMRole_badJSON
    role_test.go:288: provider meta not found for test TestAccIAMRole_badJSON
    role_test.go:288: persisting randomness seed
--- PASS: TestAccIAMRole_badJSON (4.35s)
=== CONT  TestAccIAMRole_diffs
=== NAME  TestAccIAMRole_policiesForceDetach
    role_test.go:333: Step 1/2 error: Check failed: Check 2/2 error: operation error IAM: PutRolePolicy, https response error StatusCode: 0, RequestID: , request send failed, Post "https://iam.amazonaws.com/": requested interaction not found
=== NAME  TestAccIAMRole_InlinePolicy_malformed
    role_test.go:633: stopping VCR recorder
    role_test.go:633: persisting randomness seed
--- PASS: TestAccIAMRole_InlinePolicy_malformed (18.06s)
=== CONT  TestAccIAMRole_testNameChange
=== NAME  TestAccIAMRole_policiesForceDetach
    panic.go:615: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: deleting IAM Role (tf-acc-test-4972364352007210697): detaching IAM Policy (arn:aws:iam::727561393803:policy/tf-acc-test-4972364352007210697) from Role (tf-acc-test-4972364352007210697): operation error IAM: DetachRolePolicy, https response error StatusCode: 0, RequestID: , request send failed, Post "https://iam.amazonaws.com/": requested interaction not found

--- FAIL: TestAccIAMRole_policiesForceDetach (21.96s)
=== CONT  TestAccIAMRole_namePrefix
=== NAME  TestAccIAMRole_InlinePolicy_empty
    role_test.go:613: stopping VCR recorder
    role_test.go:613: persisting randomness seed
--- PASS: TestAccIAMRole_InlinePolicy_empty (35.15s)
=== CONT  TestAccIAMRole_nameGenerated
=== NAME  TestAccIAMRole_disappears
    role_test.go:309: stopping VCR recorder
    role_test.go:309: persisting randomness seed
--- PASS: TestAccIAMRole_disappears (38.22s)
=== CONT  TestAccIAMRole_Tags_emptyMap
=== NAME  TestAccIAMRole_basic
    role_test.go:32: stopping VCR recorder
    role_test.go:32: persisting randomness seed
--- PASS: TestAccIAMRole_basic (44.79s)
=== CONT  TestAccIAMRole_Tags_addOnUpdate
=== NAME  TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored
    role_test.go:883: stopping VCR recorder
    role_test.go:883: persisting randomness seed
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored (59.36s)
=== CONT  TestAccIAMRole_Tags_EmptyTag_OnUpdate_replace
=== NAME  TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved
    role_test.go:771: stopping VCR recorder
    role_test.go:771: persisting randomness seed
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved (63.91s)
=== CONT  TestAccIAMRole_Tags_null
=== NAME  TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty
    role_test.go:916: stopping VCR recorder
    role_test.go:916: persisting randomness seed
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty (67.02s)
=== CONT  TestAccIAMRole_permissionsBoundary
=== NAME  TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack
    role_test.go:736: stopping VCR recorder
    role_test.go:736: persisting randomness seed
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack (67.06s)
=== CONT  TestAccIAMRole_InlinePolicy_basic
=== NAME  TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty
    role_test.go:949: stopping VCR recorder
    role_test.go:949: persisting randomness seed
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty (67.12s)
=== CONT  TestAccIAMRole_tags
=== NAME  TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack
    role_test.go:702: stopping VCR recorder
    role_test.go:702: persisting randomness seed
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack (67.66s)
=== CONT  TestAccIAMRole_Tags_EmptyTag_OnUpdate_add
=== NAME  TestAccIAMRole_namePrefix
    role_test.go:134: stopping VCR recorder
    role_test.go:134: persisting randomness seed
--- PASS: TestAccIAMRole_namePrefix (45.72s)
=== CONT  TestAccIAMRole_maxSessionDuration
=== NAME  TestAccIAMRole_Identity_basic
    role_identity_gen_test.go:33: stopping VCR recorder
    role_identity_gen_test.go:33: persisting randomness seed
--- PASS: TestAccIAMRole_Identity_basic (74.66s)
=== NAME  TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved
    role_test.go:806: stopping VCR recorder
    role_test.go:806: persisting randomness seed
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved (77.70s)
=== NAME  TestAccIAMRole_diffsCondition
    role_test.go:252: stopping VCR recorder
    role_test.go:252: persisting randomness seed
--- PASS: TestAccIAMRole_diffsCondition (80.42s)
=== NAME  TestAccIAMRole_nameGenerated
    role_test.go:106: stopping VCR recorder
    role_test.go:106: persisting randomness seed
--- PASS: TestAccIAMRole_nameGenerated (45.30s)
=== NAME  TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored
    role_test.go:842: stopping VCR recorder
    role_test.go:842: persisting randomness seed
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored (83.62s)
=== NAME  TestAccIAMRole_testNameChange
    role_test.go:163: stopping VCR recorder
    role_test.go:163: persisting randomness seed
--- PASS: TestAccIAMRole_testNameChange (67.84s)
=== NAME  TestAccIAMRole_Tags_EmptyTag_onCreate
    role_tags_gen_test.go:439: stopping VCR recorder
    role_tags_gen_test.go:439: persisting randomness seed
--- PASS: TestAccIAMRole_Tags_EmptyTag_onCreate (93.02s)
=== NAME  TestAccIAMRole_ManagedPolicy_basic
    role_test.go:656: stopping VCR recorder
    role_test.go:656: persisting randomness seed
--- PASS: TestAccIAMRole_ManagedPolicy_basic (96.03s)
=== NAME  TestAccIAMRole_description
    role_test.go:62: stopping VCR recorder
    role_test.go:62: persisting randomness seed
--- PASS: TestAccIAMRole_description (96.16s)
=== NAME  TestAccIAMRole_diffs
    role_test.go:199: stopping VCR recorder
    role_test.go:199: persisting randomness seed
--- PASS: TestAccIAMRole_diffs (95.23s)
=== NAME  TestAccIAMRole_Tags_emptyMap
    role_tags_gen_test.go:287: stopping VCR recorder
    role_tags_gen_test.go:287: persisting randomness seed
--- PASS: TestAccIAMRole_Tags_emptyMap (63.27s)
=== NAME  TestAccIAMRole_InlinePolicy_ignoreOrder
    role_test.go:553: stopping VCR recorder
    role_test.go:553: persisting randomness seed
--- PASS: TestAccIAMRole_InlinePolicy_ignoreOrder (103.06s)
=== NAME  TestAccIAMRole_tags
    role_tags_gen_test.go:30: Step 3/8 error: Error running apply: exit status 1

        Error: updating tags for IAM (Identity & Access Management) Role (tf-acc-test-3163883475412668902): tagging resource (tf-acc-test-3163883475412668902): operation error IAM: TagRole, https response error StatusCode: 0, RequestID: , request send failed, Post "https://iam.amazonaws.com/": requested interaction not found

          with aws_iam_role.test,
          on main_gen.tf line 4, in resource "aws_iam_role" "test":
           4: resource "aws_iam_role" "test" {

    panic.go:615: Error running post-test destroy, there may be dangling resources: IAM Role tf-acc-test-3163883475412668902 still exists
--- FAIL: TestAccIAMRole_tags (41.47s)
=== NAME  TestAccIAMRole_Tags_addOnUpdate
    role_tags_gen_test.go:354: stopping VCR recorder
    role_tags_gen_test.go:354: persisting randomness seed
--- PASS: TestAccIAMRole_Tags_addOnUpdate (64.18s)
=== NAME  TestAccIAMRole_Tags_null
    role_tags_gen_test.go:216: stopping VCR recorder
    role_tags_gen_test.go:216: persisting randomness seed
--- PASS: TestAccIAMRole_Tags_null (46.89s)
=== NAME  TestAccIAMRole_Tags_EmptyTag_OnUpdate_replace
    role_tags_gen_test.go:673: stopping VCR recorder
    role_tags_gen_test.go:673: persisting randomness seed
--- PASS: TestAccIAMRole_Tags_EmptyTag_OnUpdate_replace (53.54s)
=== NAME  TestAccIAMRole_maxSessionDuration
    role_test.go:362: stopping VCR recorder
    role_test.go:362: persisting randomness seed
--- PASS: TestAccIAMRole_maxSessionDuration (50.34s)
=== NAME  TestAccIAMRole_InlinePolicy_basic
    role_test.go:505: stopping VCR recorder
    role_test.go:505: persisting randomness seed
--- PASS: TestAccIAMRole_InlinePolicy_basic (55.09s)
=== NAME  TestAccIAMRole_Tags_EmptyTag_OnUpdate_add
    role_tags_gen_test.go:532: stopping VCR recorder
    role_tags_gen_test.go:532: persisting randomness seed
--- PASS: TestAccIAMRole_Tags_EmptyTag_OnUpdate_add (62.71s)
=== NAME  TestAccIAMRole_permissionsBoundary
    role_test.go:414: stopping VCR recorder
    role_test.go:414: persisting randomness seed
--- PASS: TestAccIAMRole_permissionsBoundary (76.55s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/iam        150.638s
```

Note: Some failures in replay mode are still expected at this point. No regressions were observed in non-VCR based test execution.

```console
% make t K=iam T=TestAccIAMRole_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-go-vcr-iam 🌿...
TF_ACC=1 go1.25.7 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRole_'  -timeout 360m -vet=off
2026/02/18 10:17:00 Creating Terraform AWS Provider (SDKv2-style)...
2026/02/18 10:17:00 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccIAMRole_InlinePolicy_empty (40.35s)
=== CONT  TestAccIAMRole_InlinePolicy_malformed
--- PASS: TestAccIAMRole_Tags_DefaultTags_nullNonOverlappingResourceTag (56.80s)
=== CONT  TestAccIAMRole_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccIAMRole_InlinePolicy_malformed (19.32s)
=== CONT  TestAccIAMRole_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccIAMRole_Tags_DefaultTags_emptyProviderOnlyTag (60.53s)
=== CONT  TestAccIAMRole_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccIAMRole_Identity_ExistingResource_OnError (64.58s)
=== CONT  TestAccIAMRole_basic
--- PASS: TestAccIAMRole_Tags_ComputedTag_onCreate (64.87s)
=== CONT  TestAccIAMRole_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored (67.02s)
=== CONT  TestAccIAMRole_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccIAMRole_Identity_ExistingResource_NoRefresh_OnError (68.56s)
=== CONT  TestAccIAMRole_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty (75.32s)
=== CONT  TestAccIAMRole_Identity_ExistingResource_noRefreshNoChange
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty (75.63s)
=== CONT  TestAccIAMRole_List_basic
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack (75.87s)
=== CONT  TestAccIAMRole_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved (75.93s)
=== CONT  TestAccIAMRole_Tags_emptyMap
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved (76.03s)
=== CONT  TestAccIAMRole_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack (76.16s)
=== CONT  TestAccIAMRole_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccIAMRole_Identity_basic (85.25s)
=== CONT  TestAccIAMRole_Tags_DefaultTags_providerOnly
--- PASS: TestAccIAMRole_Tags_addOnUpdate (89.95s)
=== CONT  TestAccIAMRole_disappears
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored (93.28s)
=== CONT  TestAccIAMRole_InlinePolicy_ignoreOrder
--- PASS: TestAccIAMRole_description (110.56s)
=== CONT  TestAccIAMRole_InlinePolicy_basic
--- PASS: TestAccIAMRole_basic (46.65s)
=== CONT  TestAccIAMRole_permissionsBoundary
--- PASS: TestAccIAMRole_ManagedPolicy_basic (112.96s)
=== CONT  TestAccIAMRole_maxSessionDuration
--- PASS: TestAccIAMRole_List_basic (40.93s)
=== CONT  TestAccIAMRole_policiesForceDetach
--- PASS: TestAccIAMRole_Tags_DefaultTags_emptyResourceTag (57.00s)
=== CONT  TestAccIAMRole_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccIAMRole_Tags_DefaultTags_nullOverlappingResourceTag (57.12s)
=== CONT  TestAccIAMRole_diffs
--- PASS: TestAccIAMRole_disappears (39.14s)
=== CONT  TestAccIAMRole_badJSON
--- PASS: TestAccIAMRole_badJSON (2.88s)
=== CONT  TestAccIAMRole_diffsCondition
--- PASS: TestAccIAMRole_Tags_DefaultTags_updateToResourceOnly (89.53s)
=== CONT  TestAccIAMRole_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccIAMRole_Identity_ExistingResource_noRefreshNoChange (76.22s)
=== CONT  TestAccIAMRole_namePrefix
--- PASS: TestAccIAMRole_Tags_DefaultTags_overlapping (152.86s)
=== CONT  TestAccIAMRole_testNameChange
--- PASS: TestAccIAMRole_Tags_emptyMap (80.68s)
=== CONT  TestAccIAMRole_Identity_ExistingResource_basic
--- PASS: TestAccIAMRole_Tags_ComputedTag_OnUpdate_replace (92.37s)
=== CONT  TestAccIAMRole_nameGenerated
--- PASS: TestAccIAMRole_policiesForceDetach (46.18s)
=== CONT  TestAccIAMRole_Tags_null
--- PASS: TestAccIAMRole_Tags_ComputedTag_OnUpdate_add (94.68s)
=== CONT  TestAccIAMRole_Tags_EmptyTag_onCreate
--- PASS: TestAccIAMRole_Tags_EmptyTag_OnUpdate_replace (96.85s)
--- PASS: TestAccIAMRole_Tags_IgnoreTags_Overlap_defaultTag (113.10s)
--- PASS: TestAccIAMRole_tags (196.70s)
--- PASS: TestAccIAMRole_Tags_IgnoreTags_Overlap_resourceTag (132.73s)
--- PASS: TestAccIAMRole_namePrefix (48.68s)
--- PASS: TestAccIAMRole_maxSessionDuration (92.54s)
--- PASS: TestAccIAMRole_nameGenerated (46.36s)
--- PASS: TestAccIAMRole_diffsCondition (75.56s)
--- PASS: TestAccIAMRole_InlinePolicy_ignoreOrder (117.43s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (101.37s)
--- PASS: TestAccIAMRole_Tags_DefaultTags_nonOverlapping (141.18s)
--- PASS: TestAccIAMRole_testNameChange (67.66s)
--- PASS: TestAccIAMRole_Tags_DefaultTags_updateToProviderOnly (74.23s)
--- PASS: TestAccIAMRole_diffs (96.55s)
--- PASS: TestAccIAMRole_Tags_null (61.94s)
--- PASS: TestAccIAMRole_Tags_EmptyTag_OnUpdate_add (108.07s)
--- PASS: TestAccIAMRole_Tags_EmptyTag_onCreate (60.07s)
--- PASS: TestAccIAMRole_Tags_DefaultTags_providerOnly (149.57s)
--- PASS: TestAccIAMRole_permissionsBoundary (130.45s)
--- PASS: TestAccIAMRole_Identity_ExistingResource_basic (87.85s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        251.282s
```
