### PR TITLE
r/aws_controltower_landing_zone : add `remediation_types` attribute

### DIFF
--- a/.changelog/46549.txt
+++ b/.changelog/46549.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_controltower_landing_zone: Add `remediation_types` attribute to support remediations of guardrail violations
+```

--- a/.changelog/46549.txt
+++ b/.changelog/46549.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_controltower_landing_zone: Add `remediation_types` attribute to support remediations of guardrail violations
+resource/aws_controltower_landing_zone: Add `remediation_types` attribute
 ```

--- a/internal/service/controltower/controltower_test.go
+++ b/internal/service/controltower/controltower_test.go
@@ -16,6 +16,7 @@ func TestAccControlTower_serial(t *testing.T) {
 		"LandingZone": {
 			acctest.CtBasic:      testAccLandingZone_basic,
 			acctest.CtDisappears: testAccLandingZone_disappears,
+			"remediationTypes":   testAccLandingZone_remediationTypes,
 			"tags":               testAccLandingZone_tags,
 		},
 		"Control": {

--- a/internal/service/controltower/landing_zone.go
+++ b/internal/service/controltower/landing_zone.go
@@ -73,6 +73,15 @@ func resourceLandingZone() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"remediation_types": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{"INHERITANCE_DRIFT"}, false),
+				},
+				Description: "Specifies the types of remediations to perform on guardrail violations. Currently only supports the INHERITANCE_DRIFT value.",
+			},
 			"manifest_json": {
 				Type:                  schema.TypeString,
 				Required:              true,
@@ -107,6 +116,15 @@ func resourceLandingZoneCreate(ctx context.Context, d *schema.ResourceData, meta
 		Manifest: manifest,
 		Tags:     getTagsIn(ctx),
 		Version:  aws.String(d.Get(names.AttrVersion).(string)),
+	}
+
+	// Add remediation types if specified
+	if v, ok := d.GetOk("remediation_types"); ok && v.(*schema.Set).Len() > 0 {
+		remediationTypes := make([]types.RemediationType, 0)
+		for _, t := range v.(*schema.Set).List() {
+			remediationTypes = append(remediationTypes, types.RemediationType(t.(string)))
+		}
+		input.RemediationTypes = remediationTypes
 	}
 
 	output, err := conn.CreateLandingZone(ctx, input)
@@ -154,6 +172,20 @@ func resourceLandingZoneRead(ctx context.Context, d *schema.ResourceData, meta a
 		d.Set("drift_status", nil)
 	}
 	d.Set("latest_available_version", landingZone.LatestAvailableVersion)
+
+	// Set remediation types if present
+	if landingZone.RemediationTypes != nil && len(landingZone.RemediationTypes) > 0 {
+		remediationTypeSet := schema.NewSet(schema.HashString, []interface{}{})
+		for _, rt := range landingZone.RemediationTypes {
+			remediationTypeSet.Add(string(rt))
+		}
+		if err := d.Set("remediation_types", remediationTypeSet); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting remediation_types: %s", err)
+		}
+	} else {
+		d.Set("remediation_types", nil)
+	}
+
 	if landingZone.Manifest != nil {
 		v, err := tfsmithy.DocumentToJSONString(landingZone.Manifest)
 
@@ -184,6 +216,15 @@ func resourceLandingZoneUpdate(ctx context.Context, d *schema.ResourceData, meta
 			LandingZoneIdentifier: aws.String(d.Id()),
 			Manifest:              manifest,
 			Version:               aws.String(d.Get(names.AttrVersion).(string)),
+		}
+
+		// Add remediation types if specified
+		if v, ok := d.GetOk("remediation_types"); ok && v.(*schema.Set).Len() > 0 {
+			remediationTypes := make([]types.RemediationType, 0)
+			for _, t := range v.(*schema.Set).List() {
+				remediationTypes = append(remediationTypes, types.RemediationType(t.(string)))
+			}
+			input.RemediationTypes = remediationTypes
 		}
 
 		output, err := conn.UpdateLandingZone(ctx, input)

--- a/internal/service/controltower/landing_zone.go
+++ b/internal/service/controltower/landing_zone.go
@@ -174,7 +174,7 @@ func resourceLandingZoneRead(ctx context.Context, d *schema.ResourceData, meta a
 	d.Set("latest_available_version", landingZone.LatestAvailableVersion)
 
 	// Set remediation types if present
-	if landingZone.RemediationTypes != nil && len(landingZone.RemediationTypes) > 0 {
+	if len(landingZone.RemediationTypes) > 0 {
 		remediationTypeSet := schema.NewSet(schema.HashString, []interface{}{})
 		for _, rt := range landingZone.RemediationTypes {
 			remediationTypeSet.Add(string(rt))

--- a/internal/service/controltower/landing_zone.go
+++ b/internal/service/controltower/landing_zone.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfsmithy "github.com/hashicorp/terraform-provider-aws/internal/smithy"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -77,10 +78,9 @@ func resourceLandingZone() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{"INHERITANCE_DRIFT"}, false),
+					Type:             schema.TypeString,
+					ValidateDiagFunc: enum.Validate[types.RemediationType](),
 				},
-				Description: "Specifies the types of remediations to perform on guardrail violations. Currently only supports the INHERITANCE_DRIFT value.",
 			},
 			"manifest_json": {
 				Type:                  schema.TypeString,
@@ -118,13 +118,8 @@ func resourceLandingZoneCreate(ctx context.Context, d *schema.ResourceData, meta
 		Version:  aws.String(d.Get(names.AttrVersion).(string)),
 	}
 
-	// Add remediation types if specified
 	if v, ok := d.GetOk("remediation_types"); ok && v.(*schema.Set).Len() > 0 {
-		remediationTypes := make([]types.RemediationType, 0)
-		for _, t := range v.(*schema.Set).List() {
-			remediationTypes = append(remediationTypes, types.RemediationType(t.(string)))
-		}
-		input.RemediationTypes = remediationTypes
+		input.RemediationTypes = flex.ExpandStringyValueSet[types.RemediationType](v.(*schema.Set))
 	}
 
 	output, err := conn.CreateLandingZone(ctx, input)
@@ -173,17 +168,8 @@ func resourceLandingZoneRead(ctx context.Context, d *schema.ResourceData, meta a
 	}
 	d.Set("latest_available_version", landingZone.LatestAvailableVersion)
 
-	// Set remediation types if present
-	if len(landingZone.RemediationTypes) > 0 {
-		remediationTypeSet := schema.NewSet(schema.HashString, []interface{}{})
-		for _, rt := range landingZone.RemediationTypes {
-			remediationTypeSet.Add(string(rt))
-		}
-		if err := d.Set("remediation_types", remediationTypeSet); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting remediation_types: %s", err)
-		}
-	} else {
-		d.Set("remediation_types", nil)
+	if err := d.Set("remediation_types", landingZone.RemediationTypes); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting remediation_types: %s", err)
 	}
 
 	if landingZone.Manifest != nil {
@@ -218,13 +204,8 @@ func resourceLandingZoneUpdate(ctx context.Context, d *schema.ResourceData, meta
 			Version:               aws.String(d.Get(names.AttrVersion).(string)),
 		}
 
-		// Add remediation types if specified
 		if v, ok := d.GetOk("remediation_types"); ok && v.(*schema.Set).Len() > 0 {
-			remediationTypes := make([]types.RemediationType, 0)
-			for _, t := range v.(*schema.Set).List() {
-				remediationTypes = append(remediationTypes, types.RemediationType(t.(string)))
-			}
-			input.RemediationTypes = remediationTypes
+			input.RemediationTypes = flex.ExpandStringyValueSet[types.RemediationType](v.(*schema.Set))
 		}
 
 		output, err := conn.UpdateLandingZone(ctx, input)

--- a/internal/service/controltower/landing_zone_test.go
+++ b/internal/service/controltower/landing_zone_test.go
@@ -78,6 +78,38 @@ func testAccLandingZone_disappears(t *testing.T) {
 	})
 }
 
+func testAccLandingZone_remediationTypes(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_controltower_landing_zone.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+			testAccPreCheck(ctx, t)
+			testAccPreCheckNoLandingZone(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ControlTowerServiceID),
+		CheckDestroy:             testAccCheckLandingZoneDestroy(ctx),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLandingZoneConfig_remediationTypes,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLandingZoneExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "remediation_types.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "remediation_types.*", "INHERITANCE_DRIFT"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccLandingZone_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_controltower_landing_zone.test"
@@ -196,6 +228,14 @@ resource "aws_controltower_landing_zone" "test" {
   manifest_json = file("${path.module}/test-fixtures/LandingZoneManifest.json")
 
   version = %[2]q
+}
+`, acctest.Region(), landingZoneVersion)
+
+var testAccLandingZoneConfig_remediationTypes = fmt.Sprintf(`
+resource "aws_controltower_landing_zone" "test" {
+  manifest_json = file("${path.module}/test-fixtures/LandingZoneManifest.json")
+  version = %[2]q
+  remediation_types = ["INHERITANCE_DRIFT"]
 }
 `, acctest.Region(), landingZoneVersion)
 

--- a/internal/service/controltower/landing_zone_test.go
+++ b/internal/service/controltower/landing_zone_test.go
@@ -90,13 +90,13 @@ func testAccLandingZone_remediationTypes(t *testing.T) {
 			testAccPreCheckNoLandingZone(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ControlTowerServiceID),
-		CheckDestroy:             testAccCheckLandingZoneDestroy(ctx),
+		CheckDestroy:             testAccCheckLandingZoneDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLandingZoneConfig_remediationTypes,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLandingZoneExists(ctx, resourceName),
+					testAccCheckLandingZoneExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "remediation_types.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "remediation_types.*", "INHERITANCE_DRIFT"),
 				),

--- a/internal/service/controltower/landing_zone_test.go
+++ b/internal/service/controltower/landing_zone_test.go
@@ -252,15 +252,14 @@ const landingZoneVersion = "4.0"
 var testAccLandingZoneConfig_basic = fmt.Sprintf(`
 resource "aws_controltower_landing_zone" "test" {
   manifest_json = file("${path.module}/test-fixtures/LandingZoneManifest.json")
-
-  version = %[2]q
+  version       = %[2]q
 }
 `, acctest.Region(), landingZoneVersion)
 
 var testAccLandingZoneConfig_remediationTypes = fmt.Sprintf(`
 resource "aws_controltower_landing_zone" "test" {
-  manifest_json = file("${path.module}/test-fixtures/LandingZoneManifest.json")
-  version = %[2]q
+  manifest_json     = file("${path.module}/test-fixtures/LandingZoneManifest.json")
+  version           = %[2]q
   remediation_types = ["INHERITANCE_DRIFT"]
 }
 `, acctest.Region(), landingZoneVersion)
@@ -268,9 +267,8 @@ resource "aws_controltower_landing_zone" "test" {
 func testAccLandingZoneConfig_tags1(tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_controltower_landing_zone" "test" {
-	manifest_json = file("${path.module}/test-fixtures/LandingZoneManifest.json")
-
-  version = %[2]q
+  manifest_json = file("${path.module}/test-fixtures/LandingZoneManifest.json")
+  version       = %[2]q
 
   tags = {
     %[3]q = %[4]q

--- a/internal/service/controltower/landing_zone_test.go
+++ b/internal/service/controltower/landing_zone_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/controltower"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
@@ -39,7 +40,7 @@ func testAccLandingZone_basic(t *testing.T) {
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "controltower", "landingzone/${id}"),
 					resource.TestCheckResourceAttr(resourceName, "drift_status.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "latest_available_version"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, "1.0"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, landingZoneVersion),
 				),
 			},
 			{
@@ -82,7 +83,7 @@ func testAccLandingZone_remediationTypes(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_controltower_landing_zone.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckOrganizationManagementAccount(ctx, t)
@@ -100,6 +101,31 @@ func testAccLandingZone_remediationTypes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "remediation_types.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "remediation_types.*", "INHERITANCE_DRIFT"),
 				),
+			},
+			{
+				Config: testAccLandingZoneConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLandingZoneExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "remediation_types.#", "0"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				Config: testAccLandingZoneConfig_remediationTypes,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLandingZoneExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "remediation_types.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "remediation_types.*", "INHERITANCE_DRIFT"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -221,7 +247,7 @@ func testAccCheckLandingZoneDestroy(ctx context.Context, t *testing.T) resource.
 	}
 }
 
-const landingZoneVersion = "3.3"
+const landingZoneVersion = "4.0"
 
 var testAccLandingZoneConfig_basic = fmt.Sprintf(`
 resource "aws_controltower_landing_zone" "test" {
@@ -242,7 +268,7 @@ resource "aws_controltower_landing_zone" "test" {
 func testAccLandingZoneConfig_tags1(tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_controltower_landing_zone" "test" {
-  manifest_json = jfile("${path.module}/test-fixtures/LandingZoneManifest.json")
+	manifest_json = file("${path.module}/test-fixtures/LandingZoneManifest.json")
 
   version = %[2]q
 

--- a/internal/service/controltower/landing_zone_test.go
+++ b/internal/service/controltower/landing_zone_test.go
@@ -37,7 +37,7 @@ func testAccLandingZone_basic(t *testing.T) {
 				Config: testAccLandingZoneConfig_basic,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLandingZoneExists(ctx, t, resourceName),
-					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "controltower", "landingzone/${id}"),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "controltower", "landingzone/{id}"),
 					resource.TestCheckResourceAttr(resourceName, "drift_status.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "latest_available_version"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, landingZoneVersion),

--- a/website/docs/r/controltower_landing_zone.html.markdown
+++ b/website/docs/r/controltower_landing_zone.html.markdown
@@ -15,8 +15,9 @@ Creates a new landing zone using Control Tower. For more information on usage, p
 
 ```terraform
 resource "aws_controltower_landing_zone" "example" {
-  manifest_json = file("${path.module}/LandingZoneManifest.json")
-  version       = "3.2"
+  manifest_json     = file("${path.module}/LandingZoneManifest.json")
+  version           = "3.2"
+  remediation_types = ["INHERITANCE_DRIFT"]
 }
 ```
 
@@ -26,6 +27,7 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `manifest_json` - (Required) The manifest JSON file is a text file that describes your AWS resources. For examples, review [Launch your landing zone](https://docs.aws.amazon.com/controltower/latest/userguide/lz-api-launch).
+* `remediation_types` - (Optional) A list of remediation types to perform on guardrail violations. Currently only supports the `INHERITANCE_DRIFT` value.
 * `version` - (Required) The landing zone version.
 * `tags` - (Optional) Tags to apply to the landing zone. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 

--- a/website/docs/r/controltower_landing_zone.html.markdown
+++ b/website/docs/r/controltower_landing_zone.html.markdown
@@ -27,7 +27,7 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `manifest_json` - (Required) The manifest JSON file is a text file that describes your AWS resources. For examples, review [Launch your landing zone](https://docs.aws.amazon.com/controltower/latest/userguide/lz-api-launch).
-* `remediation_types` - (Optional) A list of remediation types to perform on guardrail violations. Currently only supports the `INHERITANCE_DRIFT` value.
+* `remediation_types` - (Optional) Specifies list of remediation actions to apply. Currently only supports the `INHERITANCE_DRIFT` value.
 * `version` - (Required) The landing zone version.
 * `tags` - (Optional) Tags to apply to the landing zone. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 

--- a/website/docs/r/controltower_landing_zone.html.markdown
+++ b/website/docs/r/controltower_landing_zone.html.markdown
@@ -16,7 +16,7 @@ Creates a new landing zone using Control Tower. For more information on usage, p
 ```terraform
 resource "aws_controltower_landing_zone" "example" {
   manifest_json     = file("${path.module}/LandingZoneManifest.json")
-  version           = "3.2"
+  version           = "4.0"
   remediation_types = ["INHERITANCE_DRIFT"]
 }
 ```


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

### Description
Adds support for a new optional argument, `remediation_types`, to the `aws_controltower_landing_zone` resource.

AWS Control Tower v4 introduces support for remediation of guardrail violations at the landing zone level. This enhancement enabled Terraform users to configure remediation behavior directly via the provider.

The remediation_types argument accepts a list of remediation types supported by AWS Control Tower (e.g., `INHERITANCE_DRIFT`). Configuring this attribute allows:

- Enabling remediation of guardrail violations
- Supporting Automatic Account Enrollment within the Control Tower Landing Zone


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #46547
Closes #45641

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
[AWS API Changes](https://awsapichanges.info/archive/changes/f42053-controltower.html#CreateLandingZone)
[AWS Control Tower create Landing Zone request](https://docs.aws.amazon.com/controltower/latest/APIReference/API_CreateLandingZone.html#API_CreateLandingZone_RequestSyntax)
[Automatic account Enrollment](https://aws.amazon.com/about-aws/whats-new/2025/11/aws-control-tower-automatic-enrollment/)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Don't have the budget to run acceptance tests, so can't provide the output.
