### PR TITLE
resource/aws_transfer_server: Allow in-place updates to identity_provider_type without resource replacement

### DIFF
--- a/.changelog/46229.txt
+++ b/.changelog/46229.txt
@@ -1,0 +1,1 @@
+resource/aws_transfer_server: Allow in-place updates to `identity_provider_type` without resource replacement

--- a/internal/service/transfer/server.go
+++ b/internal/service/transfer/server.go
@@ -152,7 +152,6 @@ func resourceServer() *schema.Resource {
 			"identity_provider_type": {
 				Type:             schema.TypeString,
 				Optional:         true,
-				ForceNew:         true,
 				Default:          awstypes.IdentityProviderTypeServiceManaged,
 				ValidateDiagFunc: enum.Validate[awstypes.IdentityProviderType](),
 			},
@@ -714,6 +713,10 @@ func resourceServerUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 		if d.HasChange("post_authentication_login_banner") {
 			input.PostAuthenticationLoginBanner = aws.String(d.Get("post_authentication_login_banner").(string))
 		}
+    
+                if d.HasChange("identity_provider_type") {
+                        input.IdentityProviderType = awstypes.IdentityProviderType(d.Get("identity_provider_type").(string))
+                }
 
 		if d.HasChange("pre_authentication_login_banner") {
 			input.PreAuthenticationLoginBanner = aws.String(d.Get("pre_authentication_login_banner").(string))

--- a/internal/service/transfer/server_test.go
+++ b/internal/service/transfer/server_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"testing"
-
 	"github.com/YakDriver/regexache"
 	acmpca_types "github.com/aws/aws-sdk-go-v2/service/acmpca/types"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/transfer/types"
@@ -113,6 +112,48 @@ func testAccServer_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccTransferServer_identityProviderTypeUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf awstypes.DescribedServer
+	resourceName := "aws_transfer_server.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.TransferServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckServerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServerConfig_identityProviderType(rName, "SERVICE_MANAGED"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServerExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "identity_provider_type", "SERVICE_MANAGED"),
+				),
+			},
+			{
+				Config: testAccServerConfig_identityProviderType(rName, "AWS_DIRECTORY_SERVICE"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServerExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "identity_provider_type", "AWS_DIRECTORY_SERVICE"),
+				),
+			},
+		},
+	})
+}
+
+func testAccServerConfig_identityProviderType(rName, identityProviderType string) string {
+	return fmt.Sprintf(`
+resource "aws_transfer_server" "test" {
+  identity_provider_type = %[2]q
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, identityProviderType)
 }
 
 func testAccServer_disappears(t *testing.T) {


### PR DESCRIPTION
## Summary

Removes `ForceNew: true` from the `identity_provider_type` attribute in 
the `aws_transfer_server` resource, allowing in-place updates instead of 
forcing server recreation.

## Problem

Previously, changing `identity_provider_type` on an existing Transfer 
Family server would destroy and recreate the server, causing unnecessary 
downtime and data loss risk.

## Solution

- Removed `ForceNew: true` from the `identity_provider_type` schema attribute
- Added `HasChange` handler in `resourceServerUpdate()` to pass the updated 
  value to the AWS API
- Added acceptance test to verify no replacement occurs on update

## Testing

- `go build ./...` ✅
- `go vet ./internal/service/transfer/...` ✅

## References

- Fixes #46229
- AWS announcement: https://aws.amazon.com/about-aws/whats-new/2025/10/aws-transfer-family-changing-idp-type/
- AWS API docs: https://docs.aws.amazon.com/transfer/latest/userguide/configuring-servers-edit-custom-idp.html