### PR TITLE
fix: [Bug]: Route 53 Resolver rule resource defines bad defaults 

### DIFF
--- a/.changelog/46607.txt
+++ b/.changelog/46607.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53_resolver_rule: Remove hardcoded defaults for `target_ip.port` and `target_ip.protocol`, allowing the AWS API to apply context-sensitive defaults based on resolver endpoint configuration
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+* resource/aws_route53_resolver_rule: Remove hardcoded defaults for `target_ip.port` and `target_ip.protocol`, allowing the AWS API to apply context-sensitive defaults (e.g., port `443` for `DoH`) ([#41523](https://github.com/hashicorp/terraform-provider-aws/issues/41523))
 * resource/aws_bedrockagentcore_gateway_target: Add `credential_provider_configuration.oauth.default_return_url` and `credential_provider_configuration.oauth.grant_type` arguments ([#46127](https://github.com/hashicorp/terraform-provider-aws/issues/46127))
 * resource/aws_bedrockagentcore_gateway_target: Retry IAM eventual consistency errors on Create ([#46127](https://github.com/hashicorp/terraform-provider-aws/issues/46127))
 * resource/aws_subnet: Fixed IPv6 CIDR block validation and assignment to IPAM-provisioned subnets. ([#46556](https://github.com/hashicorp/terraform-provider-aws/issues/46556))

--- a/internal/service/route53resolver/rule.go
+++ b/internal/service/route53resolver/rule.go
@@ -103,13 +103,13 @@ func resourceRule() *schema.Resource {
 						names.AttrPort: {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Default:      53,
+							Computed:     true,
 							ValidateFunc: validation.IntBetween(1, 65535),
 						},
 						names.AttrProtocol: {
 							Type:             schema.TypeString,
 							Optional:         true,
-							Default:          awstypes.ProtocolDo53,
+							Computed:         true,
 							ValidateDiagFunc: enum.Validate[awstypes.Protocol](),
 						},
 					},
@@ -381,7 +381,7 @@ func expandRuleTargetIPs(vTargetIps *schema.Set) []awstypes.TargetAddress {
 		if vIpv6, ok := mTargetIp["ipv6"].(string); ok && vIpv6 != "" {
 			targetAddress.Ipv6 = aws.String(vIpv6)
 		}
-		if vPort, ok := mTargetIp[names.AttrPort].(int); ok {
+		if vPort, ok := mTargetIp[names.AttrPort].(int); ok && vPort != 0 {
 			targetAddress.Port = aws.Int32(int32(vPort))
 		}
 		if vProtocol, ok := mTargetIp[names.AttrProtocol].(string); ok && vProtocol != "" {

--- a/website/docs/r/route53_resolver_rule.html.markdown
+++ b/website/docs/r/route53_resolver_rule.html.markdown
@@ -77,8 +77,8 @@ The `target_ip` object supports the following:
 
 * `ip` - (Optional) One IPv4 address that you want to forward DNS queries to.
 * `ipv6` - (Optional) One IPv6 address that you want to forward DNS queries to.
-* `port` - (Optional) Port at `ip` that you want to forward DNS queries to. Default value is `53`.
-* `protocol` - (Optional) Protocol for the resolver endpoint. Valid values can be found in the [AWS documentation](https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53resolver_TargetAddress.html). Default value is `Do53`.
+* `port` - (Optional) Port at `ip` that you want to forward DNS queries to. If not specified, the AWS API assigns a default port based on the protocol (e.g., `53` for `Do53`, `443` for `DoH`).
+* `protocol` - (Optional) Protocol for the resolver endpoint. Valid values can be found in the [AWS documentation](https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53resolver_TargetAddress.html). If not specified, the AWS API assigns a default protocol based on the resolver endpoint configuration.
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Summary

Addresses #41523.

## Changes

```
a4348fce8 fix: remove hardcoded defaults for route53 resolver rule target port/protocol (#41523)
 CHANGELOG.md                                       | 1 +
 internal/service/route53resolver/rule.go           | 6 +++---
 website/docs/r/route53_resolver_rule.html.markdown | 4 ++--
 3 files changed, 6 insertions(+), 5 deletions(-)
```
