### PR TITLE
fix: Can't update aws_controltower_baseline resource version

### DIFF
--- a/.changelog/46608.txt
+++ b/.changelog/46608.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_controltower_baseline: Allow in-place updates of `baseline_version` instead of forcing resource replacement
+```

--- a/internal/service/controltower/baseline.go
+++ b/internal/service/controltower/baseline.go
@@ -70,9 +70,6 @@ func (r *resourceBaseline) Schema(ctx context.Context, _ resource.SchemaRequest,
 			},
 			"baseline_version": schema.StringAttribute{
 				Required: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"operation_identifier": schema.StringAttribute{
 				Computed: true,

--- a/internal/service/controltower/baseline_test.go
+++ b/internal/service/controltower/baseline_test.go
@@ -205,6 +205,45 @@ func testAccCheckBaselineExists(ctx context.Context, t *testing.T, name string, 
 	}
 }
 
+func testAccBaseline_updateBaselineVersion(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var baseline types.EnabledBaselineDetails
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_controltower_baseline.test"
+	baselineARN := acctest.SkipIfEnvVarNotSet(t, "TF_AWS_CONTROLTOWER_BASELINE_ENABLE_BASELINE_ARN")
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ControlTowerEndpointID)
+			testAccEnabledBaselinesPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ControlTowerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBaselineDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBaselineConfig_baselineVersion(rName, baselineARN, "4.0"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBaselineExists(ctx, t, resourceName, &baseline),
+					resource.TestCheckResourceAttr(resourceName, "baseline_version", "4.0"),
+				),
+			},
+			{
+				Config: testAccBaselineConfig_baselineVersion(rName, baselineARN, "5.0"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBaselineExists(ctx, t, resourceName, &baseline),
+					resource.TestCheckResourceAttr(resourceName, "baseline_version", "5.0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccEnabledBaselinesPreCheck(ctx context.Context, t *testing.T) {
 	conn := acctest.ProviderMeta(ctx, t).ControlTowerClient(ctx)
 
@@ -314,4 +353,32 @@ resource "aws_controltower_baseline" "test" {
   ]
 }
 `, rName, baselineARN, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccBaselineConfig_baselineVersion(rName, baselineARN, baselineVersion string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+data "aws_organizations_organization" "current" {}
+
+resource "aws_organizations_organizational_unit" "test" {
+  name      = %[1]q
+  parent_id = data.aws_organizations_organization.current.roots[0].id
+}
+
+resource "aws_controltower_baseline" "test" {
+  baseline_identifier = "arn:${data.aws_partition.current.id}:controltower:${data.aws_region.current.region}::baseline/17BSJV3IGJ2QSGA2"
+  baseline_version    = %[3]q
+  target_identifier   = aws_organizations_organizational_unit.test.arn
+  parameters {
+    key   = "IdentityCenterEnabledBaselineArn"
+    value = %[2]q
+  }
+  depends_on = [
+    aws_organizations_organizational_unit.test
+  ]
+}
+`, rName, baselineARN, baselineVersion)
 }

--- a/internal/service/controltower/controltower_test.go
+++ b/internal/service/controltower/controltower_test.go
@@ -24,9 +24,10 @@ func TestAccControlTower_serial(t *testing.T) {
 			"parameters":         testAccControl_parameters,
 		},
 		"Baseline": {
-			acctest.CtBasic:      testAccBaseline_basic,
-			acctest.CtDisappears: testAccBaseline_disappears,
-			"tags":               testAccBaseline_tags,
+			acctest.CtBasic:            testAccBaseline_basic,
+			acctest.CtDisappears:       testAccBaseline_disappears,
+			"tags":                     testAccBaseline_tags,
+			"updateBaselineVersion":    testAccBaseline_updateBaselineVersion,
 		},
 	}
 


### PR DESCRIPTION
## Summary

Fixes #45871.

## Changes

```
74703b4c7 fix: address issue #45871 - Can't update aws_controltower_baseline resource ve
 internal/service/controltower/baseline.go          |  3 -
 internal/service/controltower/baseline_test.go     | 67 ++++++++++++++++++++++
 internal/service/controltower/controltower_test.go |  7 ++-
 3 files changed, 71 insertions(+), 6 deletions(-)
```
