### PR TITLE
[Docs] aws_ssm_association: Add references to the AWS documentation for `key` and `values` in the `target` block

### DIFF
--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -272,7 +272,7 @@ Output Location (`output_location`) is an S3 bucket where you want to store the 
 
 Targets specify what instance IDs or tags to apply the document to and has these keys:
 
-* `key` - (Required) User-defined criteria for sending commands that target managed nodes that meet the criteria. See the [AWS documentation](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_Target.html) for the list of available keys. 
+* `key` - (Required) User-defined criteria for sending commands that target managed nodes that meet the criteria. See the [AWS documentation](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_Target.html) for the list of available keys.
 * `values` - (Required) List of values that correspond to the specified `key`. See the [AWS documentation](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_Target.html) for details.
 
 ## Attribute Reference


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
This PR updates the documentation for `aws_ssm_association` to add references to the AWS documentation for `key` and `values` in the `target` block.

* In the current documentation, `key` is described as follows:

  > Either `InstanceIds` or `tag:Tag Name` to specify an EC2 tag

However, AWS Systems Manager now supports many more valid keys.
To avoid misleading or outdated information, this PR adds a reference to [the official AWS documentation](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_Target.html) that lists all supported keys and describes details for values.


### Relations

Closes #46578

### References

https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_Target.html
