### PR TITLE
r/aws_lambda_function(test): update expected source code hash values

### DIFF
--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -31,6 +31,16 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+var (
+	// expectedSourceCodeHash is a lookup of expected hash values for each test fixture
+	expectedSourceCodeHash = map[string]string{
+		"lambda_func.js":          "8k4rLrkGteQRbNk8b1suO+fzwOMbF1/4jUoNm7LlWYM=",
+		"lambda_func_modified.js": "iuqvZS4PYKsiYL2YMow4YuB6ZdPzjDTiH5QhuQfLmdQ=",
+		"lambda_func.py":          "DhHL9LXWkDreFoZIv0PWn6wQx9ycpZSnt65JhKkkyRA=",
+		"lambda_func_modified.py": "9DEXvbwU6j4yE7XFZtj1MBTrhyHjwhdvOyuA8AhhhNE=",
+	}
+)
+
 func init() {
 	acctest.RegisterServiceErrorCheckFunc(names.LambdaServiceID, testAccErrorCheckSkip)
 }
@@ -1978,7 +1988,7 @@ func TestAccLambdaFunction_LocalUpdate_sourceCodeHash(t *testing.T) {
 				Config: testAccFunctionConfig_local(path, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
-					testAccCheckSourceCodeHash(&conf, "MbW0T1Pcy1QPtrFC9dT7hUfircj1NXss2uXgakqzAbk="),
+					testAccCheckSourceCodeHash(&conf, expectedSourceCodeHash["lambda_func.js"]),
 				),
 			},
 			{
@@ -1997,7 +2007,7 @@ func TestAccLambdaFunction_LocalUpdate_sourceCodeHash(t *testing.T) {
 				Config: testAccFunctionConfig_local(path, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
-					testAccCheckSourceCodeHash(&conf, "7qn3LZOWCpWK5nm49qjw+VrbPQHfdu2ZrDjBsSUveKM="),
+					testAccCheckSourceCodeHash(&conf, expectedSourceCodeHash["lambda_func_modified.js"]),
 					func(s *terraform.State) error {
 						return testAccCheckAttributeIsDateAfter(s, resourceName, "last_modified", timeBeforeUpdate)
 					},
@@ -2045,7 +2055,7 @@ func TestAccLambdaFunction_LocalUpdate_codeSha256(t *testing.T) {
 				Config: testAccFunctionConfig_local_codeSHA256(path, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
-					testAccCheckSourceCodeHash(&conf, "MbW0T1Pcy1QPtrFC9dT7hUfircj1NXss2uXgakqzAbk="),
+					testAccCheckSourceCodeHash(&conf, expectedSourceCodeHash["lambda_func.js"]),
 				),
 			},
 			{
@@ -2064,7 +2074,7 @@ func TestAccLambdaFunction_LocalUpdate_codeSha256(t *testing.T) {
 				Config: testAccFunctionConfig_local_codeSHA256(path, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
-					testAccCheckSourceCodeHash(&conf, "7qn3LZOWCpWK5nm49qjw+VrbPQHfdu2ZrDjBsSUveKM="),
+					testAccCheckSourceCodeHash(&conf, expectedSourceCodeHash["lambda_func_modified.js"]),
 					func(s *terraform.State) error {
 						return testAccCheckAttributeIsDateAfter(s, resourceName, "last_modified", timeBeforeUpdate)
 					},
@@ -2112,7 +2122,7 @@ func TestAccLambdaFunction_LocalUpdate_sourceCodeHashToCodeSha256(t *testing.T) 
 				Config: testAccFunctionConfig_local(path, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
-					testAccCheckSourceCodeHash(&conf, "MbW0T1Pcy1QPtrFC9dT7hUfircj1NXss2uXgakqzAbk="),
+					testAccCheckSourceCodeHash(&conf, expectedSourceCodeHash["lambda_func.js"]),
 				),
 			},
 			{
@@ -2132,7 +2142,7 @@ func TestAccLambdaFunction_LocalUpdate_sourceCodeHashToCodeSha256(t *testing.T) 
 				Config: testAccFunctionConfig_local_codeSHA256(path, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
-					testAccCheckSourceCodeHash(&conf, "7qn3LZOWCpWK5nm49qjw+VrbPQHfdu2ZrDjBsSUveKM="),
+					testAccCheckSourceCodeHash(&conf, expectedSourceCodeHash["lambda_func_modified.js"]),
 					func(s *terraform.State) error {
 						return testAccCheckAttributeIsDateAfter(s, resourceName, "last_modified", timeBeforeUpdate)
 					},
@@ -2184,7 +2194,7 @@ func TestAccLambdaFunction_LocalUpdate_nameOnly(t *testing.T) {
 				Config: testAccFunctionConfig_localNameOnly(path, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
-					testAccCheckSourceCodeHash(&conf, "MbW0T1Pcy1QPtrFC9dT7hUfircj1NXss2uXgakqzAbk="),
+					testAccCheckSourceCodeHash(&conf, expectedSourceCodeHash["lambda_func.js"]),
 				),
 			},
 			{
@@ -2202,7 +2212,7 @@ func TestAccLambdaFunction_LocalUpdate_nameOnly(t *testing.T) {
 				Config: testAccFunctionConfig_localNameOnly(updatedPath, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
-					testAccCheckSourceCodeHash(&conf, "7qn3LZOWCpWK5nm49qjw+VrbPQHfdu2ZrDjBsSUveKM="),
+					testAccCheckSourceCodeHash(&conf, expectedSourceCodeHash["lambda_func_modified.js"]),
 				),
 			},
 		},
@@ -2242,7 +2252,7 @@ func TestAccLambdaFunction_LocalUpdate_publish(t *testing.T) {
 				Config: testAccFunctionConfig_localPublish(path, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
-					testAccCheckSourceCodeHash(&conf, "dLPb9UCUTa8WVNATdCYpZIcIxLWEoR4TLDWvr9rajBw="),
+					testAccCheckSourceCodeHash(&conf, expectedSourceCodeHash["lambda_func.py"]),
 				),
 			},
 			{
@@ -2261,7 +2271,7 @@ func TestAccLambdaFunction_LocalUpdate_publish(t *testing.T) {
 				Config: testAccFunctionConfig_localPublish(path, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
-					testAccCheckSourceCodeHash(&conf, "7x43uxhWHTejc6xUvJlAcRvdVmRpqwGIYHpok5qDiYs="),
+					testAccCheckSourceCodeHash(&conf, expectedSourceCodeHash["lambda_func_modified.py"]),
 					func(s *terraform.State) error {
 						return testAccCheckAttributeIsDateAfter(s, resourceName, "last_modified", timeBeforeUpdate)
 					},
@@ -2301,7 +2311,7 @@ func TestAccLambdaFunction_S3Update_basic(t *testing.T) {
 				Config: testAccFunctionConfig_s3(key, path, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
-					testAccCheckSourceCodeHash(&conf, "MbW0T1Pcy1QPtrFC9dT7hUfircj1NXss2uXgakqzAbk="),
+					testAccCheckSourceCodeHash(&conf, expectedSourceCodeHash["lambda_func.js"]),
 				),
 			},
 			{
@@ -2320,7 +2330,7 @@ func TestAccLambdaFunction_S3Update_basic(t *testing.T) {
 				Config: testAccFunctionConfig_s3(key, path, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
-					testAccCheckSourceCodeHash(&conf, "7qn3LZOWCpWK5nm49qjw+VrbPQHfdu2ZrDjBsSUveKM="),
+					testAccCheckSourceCodeHash(&conf, expectedSourceCodeHash["lambda_func_modified.js"]),
 				),
 			},
 		},
@@ -2357,7 +2367,7 @@ func TestAccLambdaFunction_S3Update_unversioned(t *testing.T) {
 				Config: testAccFunctionConfig_s3UnversionedTPL(rName, key, path),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
-					testAccCheckSourceCodeHash(&conf, "MbW0T1Pcy1QPtrFC9dT7hUfircj1NXss2uXgakqzAbk="),
+					testAccCheckSourceCodeHash(&conf, expectedSourceCodeHash["lambda_func.js"]),
 				),
 			},
 			{
@@ -2376,7 +2386,7 @@ func TestAccLambdaFunction_S3Update_unversioned(t *testing.T) {
 				Config: testAccFunctionConfig_s3UnversionedTPL(rName, key2, path),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
-					testAccCheckSourceCodeHash(&conf, "7qn3LZOWCpWK5nm49qjw+VrbPQHfdu2ZrDjBsSUveKM="),
+					testAccCheckSourceCodeHash(&conf, expectedSourceCodeHash["lambda_func_modified.js"]),
 				),
 			},
 		},


### PR DESCRIPTION

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Following the addition of copyright headers to the test fixtures used in various Lambda function acceptance tests, the expected source code hash values all required an update.




### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #46561



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=lambda T="TestAccLambdaFunction_LocalUpdate_|TestAccLambdaFunction_S3Update_"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-lambda-localupdate 🌿...
TF_ACC=1 go1.25.7 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunction_LocalUpdate_|TestAccLambdaFunction_S3Update_'  -timeout 360m -vet=off
2026/02/23 10:27:55 Creating Terraform AWS Provider (SDKv2-style)...
2026/02/23 10:27:56 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccLambdaFunction_S3Update_unversioned (60.88s)
--- PASS: TestAccLambdaFunction_S3Update_basic (62.98s)
--- PASS: TestAccLambdaFunction_LocalUpdate_publish (123.84s)
--- PASS: TestAccLambdaFunction_LocalUpdate_nameOnly (129.55s)
--- PASS: TestAccLambdaFunction_LocalUpdate_sourceCodeHash (135.52s)
--- PASS: TestAccLambdaFunction_LocalUpdate_sourceCodeHashToCodeSha256 (141.51s)
--- PASS: TestAccLambdaFunction_LocalUpdate_codeSha256 (147.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     154.672s
```