### PR TITLE
Technical debt: Don't run TeamCity acceptance tests for S3 Glacier

### DIFF
--- a/.teamcity/components/generated/services_all.kt
+++ b/.teamcity/components/generated/services_all.kt
@@ -115,7 +115,6 @@ val services = mapOf(
     "fms" to ServiceSpec("FMS (Firewall Manager)", regionOverride = "us-east-1"),
     "fsx" to ServiceSpec("FSx", vpcLock = true),
     "gamelift" to ServiceSpec("GameLift"),
-    "glacier" to ServiceSpec("S3 Glacier"),
     "globalaccelerator" to ServiceSpec("Global Accelerator"),
     "glue" to ServiceSpec("Glue"),
     "grafana" to ServiceSpec("Managed Grafana"),

--- a/internal/generate/teamcity/acctest_services.hcl
+++ b/internal/generate/teamcity/acctest_services.hcl
@@ -273,6 +273,10 @@ service "route53resolver" {
   vpc_lock = true
 }
 
+service "glacier" {
+  skip = true
+}
+
 service "sagemaker" {
   vpc_lock = true
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

```
=== RUN   TestAccGlacierVault_basic
=== PAUSE TestAccGlacierVault_basic
=== CONT  TestAccGlacierVault_basic
    vault_test.go:28: Step 1/2 error: Error running apply: exit status 1
        Error: creating Glacier Vault (tf-acc-test-5229655477760809124): operation error Glacier: CreateVault, https response error StatusCode: 400, RequestID: J2bDuYy_XHrKXtO8WoJkRGKt2RMUPTnuGCDVMaVU35Zs5ok, NoLongerSupportedException: This API is no longer supported for new accounts. Please use S3 Glacier storage classes instead. Please contact AWS Support if you believe this is an error.
          with aws_glacier_vault.test,
          on terraform_plugin_test.tf line 12, in resource "aws_glacier_vault" "test":
          12: resource "aws_glacier_vault" "test" {
--- FAIL: TestAccGlacierVault_basic (39.51s)
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/44724.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/45238.