### PR TITLE
Minor update aws_networkmanager_attachment_routing_policy_label (Attachment state management)

### DIFF
--- a/.changelog/46672.txt
+++ b/.changelog/46672.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_networkmanager_attachment_routing_policy_label: Fix attachment state waiter to handle all Cloud WAN attachment lifecycle states
+```

--- a/internal/service/networkmanager/attachment_routing_policy_label.go
+++ b/internal/service/networkmanager/attachment_routing_policy_label.go
@@ -261,8 +261,8 @@ func statusAttachment(conn *networkmanager.Client, coreNetworkID, attachmentID s
 
 func waitAttachmentAvailable(ctx context.Context, conn *networkmanager.Client, coreNetworkID, attachmentID string, timeout time.Duration) (*awstypes.Attachment, error) { //nolint:unparam
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(awstypes.AttachmentStatePendingNetworkUpdate, awstypes.AttachmentStateUpdating),
-		Target:  enum.Slice(awstypes.AttachmentStateAvailable),
+		Pending: enum.Slice(awstypes.AttachmentStateCreating, awstypes.AttachmentStateUpdating, awstypes.AttachmentStatePendingNetworkUpdate),
+		Target:  enum.Slice(awstypes.AttachmentStateAvailable, awstypes.AttachmentStatePendingAttachmentAcceptance, awstypes.AttachmentStatePendingTagAcceptance),
 		Timeout: timeout,
 		Refresh: statusAttachment(conn, coreNetworkID, attachmentID),
 	}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

The resource only handle some of the Cloud WAN attachment states, throwing errors in edge cases. With this minor change, now it handles all possible attachment states.

*Minor update*

### Relations

### References

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccNetworkManagerAttachmentRoutingPolicyLabel PKG=networkmanager
2026/02/26 15:07:23 Creating Terraform AWS Provider (SDKv2-style)...
2026/02/26 15:07:23 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccNetworkManagerAttachmentRoutingPolicyLabel_basic
=== PAUSE TestAccNetworkManagerAttachmentRoutingPolicyLabel_basic
=== RUN   TestAccNetworkManagerAttachmentRoutingPolicyLabel_disappears
=== PAUSE TestAccNetworkManagerAttachmentRoutingPolicyLabel_disappears
=== RUN   TestAccNetworkManagerAttachmentRoutingPolicyLabel_update
=== PAUSE TestAccNetworkManagerAttachmentRoutingPolicyLabel_update
=== CONT  TestAccNetworkManagerAttachmentRoutingPolicyLabel_basic
=== CONT  TestAccNetworkManagerAttachmentRoutingPolicyLabel_update
=== CONT  TestAccNetworkManagerAttachmentRoutingPolicyLabel_disappears
--- PASS: TestAccNetworkManagerAttachmentRoutingPolicyLabel_basic (1224.91s)
--- PASS: TestAccNetworkManagerAttachmentRoutingPolicyLabel_disappears (1232.00s)
--- PASS: TestAccNetworkManagerAttachmentRoutingPolicyLabel_update (1619.91s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager     1627.373s
...
```
