### PR TITLE
resource/aws_vpclattice_target_group_attachment: Enable destruction of attachments in UNUSED state

### DIFF
--- a/.changelog/46667.txt
+++ b/.changelog/46667.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_subnet: Fix IPv6 CIDR block disassociation issue.
+```

--- a/.changelog/46701.txt
+++ b/.changelog/46701.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpclattice_target_group_attachment: Fix destruction of VPC Lattice Target Group attachments in UNUSED state
+```

--- a/internal/service/ec2/vpc_subnet.go
+++ b/internal/service/ec2/vpc_subnet.go
@@ -350,13 +350,28 @@ func resourceSubnetUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 	// Check if ipv6_cidr_block needs to be modified. When Optional+Computed, removal from config doesn't trigger HasChange()
 	rawConfig := d.GetRawConfig()
 	if currentIPv6, ipv6InConfig := d.Get("ipv6_cidr_block").(string), !rawConfig.GetAttr("ipv6_cidr_block").IsNull(); d.HasChange("ipv6_cidr_block") || (currentIPv6 != "" && !ipv6InConfig) {
-		targetValue := ""
-		if ipv6InConfig {
-			targetValue = d.Get("ipv6_cidr_block").(string)
+		// When ipv6_cidr_block is absent from config but was computed via IPAM
+		// or ipv6_native, skip modification to avoid disassociating the
+		// provider-managed CIDR. This mirrors the guard in resourceSubnetCreate.
+		computedIPv6CidrBlock := false
+		if !ipv6InConfig {
+			if _, ok := d.GetOk("ipv6_ipam_pool_id"); ok {
+				computedIPv6CidrBlock = true
+			}
+			if _, ok := d.GetOk("ipv6_native"); ok {
+				computedIPv6CidrBlock = true
+			}
 		}
 
-		if err := modifySubnetIPv6CIDRBlockAssociation(ctx, conn, d.Id(), d.Get("ipv6_cidr_block_association_id").(string), targetValue); err != nil {
-			return sdkdiag.AppendFromErr(diags, err)
+		if !computedIPv6CidrBlock {
+			targetValue := ""
+			if ipv6InConfig {
+				targetValue = d.Get("ipv6_cidr_block").(string)
+			}
+
+			if err := modifySubnetIPv6CIDRBlockAssociation(ctx, conn, d.Id(), d.Get("ipv6_cidr_block_association_id").(string), targetValue); err != nil {
+				return sdkdiag.AppendFromErr(diags, err)
+			}
 		}
 	}
 

--- a/internal/service/vpclattice/target_group_attachment.go
+++ b/internal/service/vpclattice/target_group_attachment.go
@@ -262,7 +262,7 @@ func waitTargetGroupAttachmentCreated(ctx context.Context, conn *vpclattice.Clie
 
 func waitTargetGroupAttachmentDeleted(ctx context.Context, conn *vpclattice.Client, targetGroupID, targetID string, targetPort int32, timeout time.Duration) (*types.TargetSummary, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(types.TargetStatusDraining, types.TargetStatusInitial),
+		Pending: enum.Slice(types.TargetStatusDraining, types.TargetStatusHealthy, types.TargetStatusInitial, types.TargetStatusUnavailable, types.TargetStatusUnhealthy, types.TargetStatusUnused),
 		Target:  []string{},
 		Refresh: statusTarget(conn, targetGroupID, targetID, targetPort),
 		Timeout: timeout,


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
When you are trying to delete the VPC Lattice target group attachment in `UNUSED` state, it returns the error:
```
 │ Error: waiting for VPC Lattice Target Group Attachment (tg-02149798d913b3868/i-0297940039f1ed696/80) delete: unexpected state 'UNUSED', wanted target ''. last error: TargetGroupNotInUse
``` 
It is caused by `waitTargetGroupAttachmentDeleted` function. The `Pending` list only includes `Draining` and `Initial`. When the waiter polls the target status and finds `UNUSED`, it's an "unexpected state". The `StateChangeConf` treats any state not in Pending or Target as an error.

Scenario where it pops out:
1. Service network association is destroyed first, causing the target to become `UNUSED`
2. Terraform calls `DeregisterTargets` (succeeds)
3. The delete waiter polls the target status and gets `UNUSED`
5. Since `UNUSED` is not in Pending, the waiter immediately errors out.

The proposed fix is to add all possible pre-deregistration states to the Pending list. A target could be in `Healthy`, `Unhealthy`, `Unused`, or `Unavailable` when `DeregisterTargets` is called, and it needs time to transition through `Draining` before finally disappearing.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
