### PR TITLE
Add skip_arn_validation provider attribute

### DIFF
--- a/.changelog/39471.txt
+++ b/.changelog/39471.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+provider: Add `skip_arn_validation` attribute to skip static ARN format validation in provider configuration, enabling use with S3-compatible services that use non-standard ARN formats
+```

--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	SecretKey                      string
 	SharedConfigFiles              []string
 	SharedCredentialsFiles         []string
+	SkipArnValidation              bool
 	SkipCredsValidation            bool
 	SkipRegionValidation           bool
 	SkipRequestingAccountId        bool

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -181,6 +181,10 @@ func (*frameworkProvider) Schema(ctx context.Context, request provider.SchemaReq
 				Optional:    true,
 				Description: "List of paths to shared credentials files. If not set, defaults to [~/.aws/credentials].",
 			},
+			"skip_arn_validation": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Skip static validation of ARN format in the provider configuration. Used by users of alternative AWS-like APIs that use non-standard ARN formats.",
+			},
 			"skip_credentials_validation": schema.BoolAttribute{
 				Optional:    true,
 				Description: "Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS available/implemented.",

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -225,6 +225,12 @@ func NewProvider(ctx context.Context) (*schema.Provider, error) {
 					Description: "List of paths to shared credentials files. If not set, defaults to [~/.aws/credentials].",
 					Elem:        &schema.Schema{Type: schema.TypeString},
 				},
+				"skip_arn_validation": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Description: "Skip static validation of ARN format in the provider configuration. " +
+						"Used by users of alternative AWS-like APIs that use non-standard ARN formats.",
+				},
 				"skip_credentials_validation": {
 					Type:     schema.TypeBool,
 					Optional: true,
@@ -377,6 +383,7 @@ func (p *sdkProvider) configure(ctx context.Context, d *schema.ResourceData) (an
 		Region:                         d.Get("region").(string),
 		S3UsePathStyle:                 d.Get("s3_use_path_style").(bool),
 		SecretKey:                      d.Get("secret_key").(string),
+		SkipArnValidation:              d.Get("skip_arn_validation").(bool),
 		SkipCredsValidation:            d.Get("skip_credentials_validation").(bool),
 		SkipRegionValidation:           d.Get("skip_region_validation").(bool),
 		SkipRequestingAccountId:        d.Get("skip_requesting_account_id").(bool),
@@ -456,6 +463,23 @@ func (p *sdkProvider) configure(ctx context.Context, d *schema.ResourceData) (an
 			"tf_aws.assume_role_with_web_identity.role_arn":     config.AssumeRoleWithWebIdentity.RoleARN,
 			"tf_aws.assume_role_with_web_identity.session_name": config.AssumeRoleWithWebIdentity.SessionName,
 		})
+	}
+
+	if !config.SkipArnValidation {
+		for i, ar := range config.AssumeRole {
+			if _, errs := verify.ValidARN(ar.RoleARN, fmt.Sprintf("assume_role.%d.role_arn", i)); len(errs) > 0 {
+				for _, err := range errs {
+					diags = append(diags, diag.Diagnostic{Severity: diag.Error, Summary: err.Error()})
+				}
+			}
+		}
+		if config.AssumeRoleWithWebIdentity != nil && config.AssumeRoleWithWebIdentity.RoleARN != "" {
+			if _, errs := verify.ValidARN(config.AssumeRoleWithWebIdentity.RoleARN, "assume_role_with_web_identity.0.role_arn"); len(errs) > 0 {
+				for _, err := range errs {
+					diags = append(diags, diag.Diagnostic{Severity: diag.Error, Summary: err.Error()})
+				}
+			}
+		}
 	}
 
 	if v, ok := d.GetOk("default_tags"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
@@ -954,15 +978,13 @@ func assumeRoleSchema() *schema.Schema {
 					Optional:    true,
 					Description: "Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.",
 					Elem: &schema.Schema{
-						Type:         schema.TypeString,
-						ValidateFunc: verify.ValidARN,
+						Type: schema.TypeString,
 					},
 				},
 				"role_arn": {
-					Type:         schema.TypeString,
-					Optional:     true, // For historical reasons, we allow an empty `assume_role` block
-					Description:  "Amazon Resource Name (ARN) of an IAM Role to assume prior to making API calls.",
-					ValidateFunc: verify.ValidARN,
+					Type:        schema.TypeString,
+					Optional:    true, // For historical reasons, we allow an empty `assume_role` block
+					Description: "Amazon Resource Name (ARN) of an IAM Role to assume prior to making API calls.",
 				},
 				"session_name": {
 					Type:         schema.TypeString,
@@ -1017,15 +1039,13 @@ func assumeRoleWithWebIdentitySchema() *schema.Schema {
 					Optional:    true,
 					Description: "Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.",
 					Elem: &schema.Schema{
-						Type:         schema.TypeString,
-						ValidateFunc: verify.ValidARN,
+						Type: schema.TypeString,
 					},
 				},
 				"role_arn": {
-					Type:         schema.TypeString,
-					Optional:     true, // For historical reasons, we allow an empty `assume_role_with_web_identity` block
-					Description:  "Amazon Resource Name (ARN) of an IAM Role to assume prior to making API calls.",
-					ValidateFunc: verify.ValidARN,
+					Type:        schema.TypeString,
+					Optional:    true, // For historical reasons, we allow an empty `assume_role_with_web_identity` block
+					Description: "Amazon Resource Name (ARN) of an IAM Role to assume prior to making API calls.",
 				},
 				"session_name": {
 					Type:         schema.TypeString,


### PR DESCRIPTION
Community Note

- Please vote on this pull request by adding a :+1: reaction to the original pull request comment to help the community and maintainers prioritize this request.
- Please do not leave "+1" or "me too" comments, they generate extra noise for pull request followers and do not help prioritize the request.

Closes #39471

## Description

Adds a new `skip_arn_validation` boolean attribute to the provider configuration, following the existing `skip_*` pattern (e.g., `skip_region_validation`, `skip_credentials_validation`).

When set to `true`, the provider skips static ARN format validation on `assume_role` and `assume_role_with_web_identity` role ARNs and policy ARNs. This enables users of S3-compatible services (Ceph RGW, Cloudian, Astran, etc.) that use non-standard ARN formats to configure the provider without validation errors.

### Problem

The provider's strict ARN validation rejects ARNs with non-standard formats like:
- `arn:aws:iam::RGW81032802024214957:role/MyRole` (Ceph RGW account IDs are not 12-digit)
- Custom partitions or non-standard ARN structures used by third-party S3-compatible services

Since `ValidateFunc` runs per-field before the provider's `configure()` function, it cannot check other provider fields like `skip_arn_validation`. The fix moves ARN validation out of the schema-level `ValidateFunc` and into the `configure()` function, where it can be made conditional.

### Approach

1. Added `skip_arn_validation` to both SDKv2 and Framework provider schemas
2. Added `SkipArnValidation` to the `Config` struct
3. Removed `ValidateFunc: verify.ValidARN` from `assume_role.role_arn`, `assume_role.policy_arns`, `assume_role_with_web_identity.role_arn`, and `assume_role_with_web_identity.policy_arns`
4. Added conditional ARN validation in `configure()` that only runs when `skip_arn_validation` is `false` (the default)

### Example Usage

```hcl
provider "aws" {
  skip_arn_validation         = true
  skip_credentials_validation = true
  skip_requesting_account_id  = true
  skip_region_validation      = true

  endpoints {
    s3  = "https://s3.example.com"
    iam = "https://s3.example.com"
    sts = "https://s3.example.com"
  }

  assume_role_with_web_identity {
    role_arn                = "arn:aws:iam::CUSTOM_ACCOUNT_ID:role/MyRole"
    web_identity_token_file = "/var/run/secrets/token"
  }
}
```

## Changes

| File | Change |
|------|--------|
| `internal/provider/sdkv2/provider.go` | Add schema field, wire config, remove ValidateFunc, add conditional validation |
| `internal/provider/framework/provider.go` | Add schema field |
| `internal/conns/config.go` | Add `SkipArnValidation` to Config struct |
| `.changelog/39471.txt` | Changelog entry |

## Testing

- `go build ./...` passes
- `go test ./internal/provider/sdkv2/... -run TestProvider` passes
- `go test ./internal/conns/... -count=1` passes
- `go vet ./...` passes

No new acceptance tests were added as testing requires a non-AWS S3-compatible endpoint with non-standard ARNs. The feature is gated behind an opt-in boolean flag and preserves existing behavior by default.

## Output from acceptance testing

```
$ go test ./internal/provider/sdkv2/... -run TestProvider -count=1 -timeout 120s
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	5.171s
```