### PR TITLE
arcregionswitch: enable `go-vcr` support

### DIFF
--- a/.ci/semgrep/acctest/vcr/random.yml
+++ b/.ci/semgrep/acctest/vcr/random.yml
@@ -15,7 +15,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/arcregionswitch"
         - "/internal/service/docdb"
         - "/internal/service/ec2"
         - "/internal/service/networkflowmonitor"
@@ -34,7 +33,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/arcregionswitch"
         - "/internal/service/docdb"
         - "/internal/service/ec2"
         - "/internal/service/networkflowmonitor"
@@ -53,7 +51,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/arcregionswitch"
         - "/internal/service/docdb"
         - "/internal/service/ec2"
         - "/internal/service/networkflowmonitor"

--- a/.ci/semgrep/acctest/vcr/test.yml
+++ b/.ci/semgrep/acctest/vcr/test.yml
@@ -15,7 +15,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/arcregionswitch"
         - "/internal/service/docdb"
         - "/internal/service/ec2"
         - "/internal/service/networkflowmonitor"
@@ -34,7 +33,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/arcregionswitch"
         - "/internal/service/docdb"
         - "/internal/service/ec2"
         - "/internal/service/networkflowmonitor"
@@ -53,7 +51,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/arcregionswitch"
         - "/internal/service/docdb"
         - "/internal/service/ec2"
         - "/internal/service/networkflowmonitor"

--- a/internal/service/arcregionswitch/plan.go
+++ b/internal/service/arcregionswitch/plan.go
@@ -43,7 +43,6 @@ import (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/arcregionswitch/types;awstypes;awstypes.Plan")
 // @Testing(altRegionTfVars=true)
 // @Testing(preIdentityVersion="6.30.0")
-// @Testing(existsTakesT=false, destroyTakesT=false)
 // @Testing(preCheck="testAccPreCheck")
 func newResourcePlan(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resourcePlan{}
@@ -1815,7 +1814,7 @@ func waitPlanCreated(ctx context.Context, conn *arcregionswitch.Client, arn stri
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{},
 		Target:  []string{"exists"},
-		Refresh: statusPlan(ctx, conn, arn),
+		Refresh: statusPlan(conn, arn),
 		Timeout: timeout,
 	}
 
@@ -1846,7 +1845,7 @@ func waitPlanCreated(ctx context.Context, conn *arcregionswitch.Client, arn stri
 		healthCheckConf := &retry.StateChangeConf{
 			Pending: []string{"pending"},
 			Target:  []string{"allocated"},
-			Refresh: statusRoute53HealthChecks(ctx, conn, arn, expectedCount),
+			Refresh: statusRoute53HealthChecks(conn, arn, expectedCount),
 			Timeout: timeout,
 		}
 
@@ -1859,8 +1858,8 @@ func waitPlanCreated(ctx context.Context, conn *arcregionswitch.Client, arn stri
 	return plan, nil
 }
 
-func statusRoute53HealthChecks(ctx context.Context, conn *arcregionswitch.Client, arn string, expectedCount int) retry.StateRefreshFunc {
-	return func(_ context.Context) (any, string, error) {
+func statusRoute53HealthChecks(conn *arcregionswitch.Client, arn string, expectedCount int) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		healthChecks, err := findRoute53HealthChecksByARN(ctx, conn, arn)
 		if err != nil {
 			return nil, "", smarterr.NewError(err)
@@ -1883,8 +1882,8 @@ func statusRoute53HealthChecks(ctx context.Context, conn *arcregionswitch.Client
 	}
 }
 
-func statusPlan(ctx context.Context, conn *arcregionswitch.Client, arn string) retry.StateRefreshFunc {
-	return func(_ context.Context) (any, string, error) {
+func statusPlan(conn *arcregionswitch.Client, arn string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		plan, err := findPlanByARN(ctx, conn, arn)
 		if retry.NotFound(err) {
 			return nil, "", nil
@@ -1901,7 +1900,7 @@ func waitPlanDeletable(ctx context.Context, conn *arcregionswitch.Client, arn st
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{"health_check_allocation_in_progress"},
 		Target:  []string{"deletable"},
-		Refresh: statusPlanDeletable(ctx, conn, arn),
+		Refresh: statusPlanDeletable(conn, arn),
 		Timeout: timeout,
 	}
 
@@ -1914,8 +1913,8 @@ func waitPlanDeletable(ctx context.Context, conn *arcregionswitch.Client, arn st
 	return nil, smarterr.NewError(err)
 }
 
-func statusPlanDeletable(ctx context.Context, conn *arcregionswitch.Client, arn string) retry.StateRefreshFunc {
-	return func(_ context.Context) (any, string, error) {
+func statusPlanDeletable(conn *arcregionswitch.Client, arn string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		plan, err := findPlanByARN(ctx, conn, arn)
 		if retry.NotFound(err) {
 			return nil, "", nil

--- a/internal/service/arcregionswitch/plan_data_source_test.go
+++ b/internal/service/arcregionswitch/plan_data_source_test.go
@@ -19,14 +19,14 @@ func TestAccARCRegionSwitchPlanDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_arcregionswitch_plan.test"
 	resourceName := "aws_arcregionswitch_plan.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitch),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPlanDataSourceConfig_basic(rName),
@@ -63,14 +63,14 @@ func TestAccARCRegionSwitchPlanDataSource_regionOverride(t *testing.T) {
 					ctx := acctest.Context(t)
 					rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-					resource.ParallelTest(t, resource.TestCase{
+					acctest.ParallelTest(ctx, t, resource.TestCase{
 						PreCheck: func() {
 							acctest.PreCheck(ctx, t)
 							testAccPreCheck(ctx, t)
 						},
 						ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitch),
 						ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-						CheckDestroy:             testAccCheckPlanDestroy(ctx),
+						CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 						Steps: []resource.TestStep{
 							{
 								// Cross-region test cases will succeed because `aws_arcregionswitch_plan` is global

--- a/internal/service/arcregionswitch/plan_identity_gen_test.go
+++ b/internal/service/arcregionswitch/plan_identity_gen_test.go
@@ -38,7 +38,7 @@ func TestAccARCRegionSwitchPlan_Identity_basic(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			// Step 1: Setup
@@ -49,7 +49,7 @@ func TestAccARCRegionSwitchPlan_Identity_basic(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
@@ -131,7 +131,7 @@ func TestAccARCRegionSwitchPlan_Identity_regionOverride(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			// Step 1: Setup
@@ -208,7 +208,7 @@ func TestAccARCRegionSwitchPlan_Identity_ExistingResource_basic(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy: testAccCheckPlanDestroy(ctx),
+		CheckDestroy: testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// Step 1: Create pre-Identity
 			{
@@ -218,7 +218,7 @@ func TestAccARCRegionSwitchPlan_Identity_ExistingResource_basic(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),
@@ -270,7 +270,7 @@ func TestAccARCRegionSwitchPlan_Identity_ExistingResource_noRefreshNoChange(t *t
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy: testAccCheckPlanDestroy(ctx),
+		CheckDestroy: testAccCheckPlanDestroy(ctx, t),
 		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
 			Plan: resource.PlanOptions{
 				NoRefresh: true,
@@ -285,7 +285,7 @@ func TestAccARCRegionSwitchPlan_Identity_ExistingResource_noRefreshNoChange(t *t
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoIdentity(resourceName),

--- a/internal/service/arcregionswitch/plan_tags_gen_test.go
+++ b/internal/service/arcregionswitch/plan_tags_gen_test.go
@@ -37,7 +37,7 @@ func TestAccARCRegionSwitchPlan_tags(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -50,7 +50,7 @@ func TestAccARCRegionSwitchPlan_tags(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -98,7 +98,7 @@ func TestAccARCRegionSwitchPlan_tags(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -150,7 +150,7 @@ func TestAccARCRegionSwitchPlan_tags(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -195,7 +195,7 @@ func TestAccARCRegionSwitchPlan_tags(t *testing.T) {
 					"secondary_region":     config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -243,7 +243,7 @@ func TestAccARCRegionSwitchPlan_Tags_null(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -256,7 +256,7 @@ func TestAccARCRegionSwitchPlan_Tags_null(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -317,7 +317,7 @@ func TestAccARCRegionSwitchPlan_Tags_emptyMap(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -328,7 +328,7 @@ func TestAccARCRegionSwitchPlan_Tags_emptyMap(t *testing.T) {
 					"secondary_region":     config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -379,7 +379,7 @@ func TestAccARCRegionSwitchPlan_Tags_addOnUpdate(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -390,7 +390,7 @@ func TestAccARCRegionSwitchPlan_Tags_addOnUpdate(t *testing.T) {
 					"secondary_region":     config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -414,7 +414,7 @@ func TestAccARCRegionSwitchPlan_Tags_addOnUpdate(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -472,7 +472,7 @@ func TestAccARCRegionSwitchPlan_Tags_EmptyTag_onCreate(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -485,7 +485,7 @@ func TestAccARCRegionSwitchPlan_Tags_EmptyTag_onCreate(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -530,7 +530,7 @@ func TestAccARCRegionSwitchPlan_Tags_EmptyTag_onCreate(t *testing.T) {
 					"secondary_region":     config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -578,7 +578,7 @@ func TestAccARCRegionSwitchPlan_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -591,7 +591,7 @@ func TestAccARCRegionSwitchPlan_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -624,7 +624,7 @@ func TestAccARCRegionSwitchPlan_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -676,7 +676,7 @@ func TestAccARCRegionSwitchPlan_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -734,7 +734,7 @@ func TestAccARCRegionSwitchPlan_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -747,7 +747,7 @@ func TestAccARCRegionSwitchPlan_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -779,7 +779,7 @@ func TestAccARCRegionSwitchPlan_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -837,7 +837,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_providerOnly(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy: testAccCheckPlanDestroy(ctx),
+		CheckDestroy: testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -851,7 +851,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_providerOnly(t *testing.T) {
 					"secondary_region":     config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -899,7 +899,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_providerOnly(t *testing.T) {
 					"secondary_region":     config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -949,7 +949,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_providerOnly(t *testing.T) {
 					"secondary_region":     config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -993,7 +993,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_providerOnly(t *testing.T) {
 					"secondary_region":     config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1042,7 +1042,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy: testAccCheckPlanDestroy(ctx),
+		CheckDestroy: testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1058,7 +1058,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1116,7 +1116,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1173,7 +1173,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 					"secondary_region":     config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1222,7 +1222,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_overlapping(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy: testAccCheckPlanDestroy(ctx),
+		CheckDestroy: testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1238,7 +1238,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_overlapping(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1295,7 +1295,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_overlapping(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1356,7 +1356,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_overlapping(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1418,7 +1418,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_updateToProviderOnly(t *testing
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy: testAccCheckPlanDestroy(ctx),
+		CheckDestroy: testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1431,7 +1431,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_updateToProviderOnly(t *testing
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1465,7 +1465,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_updateToProviderOnly(t *testing
 					"secondary_region":     config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1521,7 +1521,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_updateToResourceOnly(t *testing
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy: testAccCheckPlanDestroy(ctx),
+		CheckDestroy: testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1535,7 +1535,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_updateToResourceOnly(t *testing
 					"secondary_region":     config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1564,7 +1564,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_updateToResourceOnly(t *testing
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1623,7 +1623,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_emptyResourceTag(t *testing.T) 
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy: testAccCheckPlanDestroy(ctx),
+		CheckDestroy: testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1639,7 +1639,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_emptyResourceTag(t *testing.T) 
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1701,7 +1701,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_emptyProviderOnlyTag(t *testing
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy: testAccCheckPlanDestroy(ctx),
+		CheckDestroy: testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1715,7 +1715,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_emptyProviderOnlyTag(t *testing
 					"secondary_region":     config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1771,7 +1771,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_nullOverlappingResourceTag(t *t
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy: testAccCheckPlanDestroy(ctx),
+		CheckDestroy: testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1787,7 +1787,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_nullOverlappingResourceTag(t *t
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1852,7 +1852,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_nullNonOverlappingResourceTag(t
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy: testAccCheckPlanDestroy(ctx),
+		CheckDestroy: testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1868,7 +1868,7 @@ func TestAccARCRegionSwitchPlan_Tags_DefaultTags_nullNonOverlappingResourceTag(t
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1935,7 +1935,7 @@ func TestAccARCRegionSwitchPlan_Tags_ComputedTag_onCreate(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy: testAccCheckPlanDestroy(ctx),
+		CheckDestroy: testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1946,7 +1946,7 @@ func TestAccARCRegionSwitchPlan_Tags_ComputedTag_onCreate(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2002,7 +2002,7 @@ func TestAccARCRegionSwitchPlan_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy: testAccCheckPlanDestroy(ctx),
+		CheckDestroy: testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -2015,7 +2015,7 @@ func TestAccARCRegionSwitchPlan_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2048,7 +2048,7 @@ func TestAccARCRegionSwitchPlan_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2112,7 +2112,7 @@ func TestAccARCRegionSwitchPlan_Tags_ComputedTag_OnUpdate_replace(t *testing.T) 
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy: testAccCheckPlanDestroy(ctx),
+		CheckDestroy: testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -2125,7 +2125,7 @@ func TestAccARCRegionSwitchPlan_Tags_ComputedTag_OnUpdate_replace(t *testing.T) 
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2156,7 +2156,7 @@ func TestAccARCRegionSwitchPlan_Tags_ComputedTag_OnUpdate_replace(t *testing.T) 
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2212,7 +2212,7 @@ func TestAccARCRegionSwitchPlan_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy: testAccCheckPlanDestroy(ctx),
+		CheckDestroy: testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2232,7 +2232,7 @@ func TestAccARCRegionSwitchPlan_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T)
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2282,7 +2282,7 @@ func TestAccARCRegionSwitchPlan_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T)
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2332,7 +2332,7 @@ func TestAccARCRegionSwitchPlan_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T)
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2385,7 +2385,7 @@ func TestAccARCRegionSwitchPlan_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.ARCRegionSwitchServiceID),
-		CheckDestroy: testAccCheckPlanDestroy(ctx),
+		CheckDestroy: testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2403,7 +2403,7 @@ func TestAccARCRegionSwitchPlan_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2462,7 +2462,7 @@ func TestAccARCRegionSwitchPlan_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2520,7 +2520,7 @@ func TestAccARCRegionSwitchPlan_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T
 					"secondary_region": config.StringVariable(acctest.AlternateRegion()),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &v),
+					testAccCheckPlanExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/arcregionswitch/plan_test.go
+++ b/internal/service/arcregionswitch/plan_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfarcregionswitch "github.com/hashicorp/terraform-provider-aws/internal/service/arcregionswitch"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -29,19 +28,19 @@ func TestAccARCRegionSwitchPlan_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, "tf-acc-test")
 	resourceName := "aws_arcregionswitch_plan.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitch),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &plan),
+					testAccCheckPlanExists(ctx, t, resourceName, &plan),
 					resource.TestCheckNoResourceAttr(resourceName, names.AttrDescription),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "recovery_approach", "activePassive"),
@@ -73,19 +72,19 @@ func TestAccARCRegionSwitchPlan_disappears(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, "tf-acc-test")
 	resourceName := "aws_arcregionswitch_plan.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitch),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &plan),
+					testAccCheckPlanExists(ctx, t, resourceName, &plan),
 					acctest.CheckFrameworkResourceDisappears(ctx, t, tfarcregionswitch.ResourcePlan, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -100,19 +99,19 @@ func TestAccARCRegionSwitchPlan_update(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, "tf-acc-test")
 	resourceName := "aws_arcregionswitch_plan.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitch),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPlanConfig_update(rName, "Initial description", 30),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &plan),
+					testAccCheckPlanExists(ctx, t, resourceName, &plan),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Initial description"),
 					resource.TestCheckResourceAttr(resourceName, "recovery_time_objective_minutes", "30"),
 					resource.TestCheckResourceAttr(resourceName, "associated_alarms.#", "1"),
@@ -124,7 +123,7 @@ func TestAccARCRegionSwitchPlan_update(t *testing.T) {
 			{
 				Config: testAccPlanConfig_update(rName, "Updated description", 60),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &plan),
+					testAccCheckPlanExists(ctx, t, resourceName, &plan),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Updated description"),
 					resource.TestCheckResourceAttr(resourceName, "recovery_time_objective_minutes", "60"),
 					resource.TestCheckResourceAttr(resourceName, "associated_alarms.#", "2"),
@@ -147,19 +146,19 @@ func TestAccARCRegionSwitchPlan_minimalRegions(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, "tf-acc-test")
 	resourceName := "aws_arcregionswitch_plan.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitch),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPlanConfig_minimalRegions(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &plan),
+					testAccCheckPlanExists(ctx, t, resourceName, &plan),
 					resource.TestCheckResourceAttr(resourceName, "regions.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "primary_region", acctest.AlternateRegion()),
 					resource.TestCheckResourceAttr(resourceName, "workflow.#", "2"),
@@ -175,19 +174,19 @@ func TestAccARCRegionSwitchPlan_multipleWorkflowsSameAction(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, "tf-acc-test")
 	resourceName := "aws_arcregionswitch_plan.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitch),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPlanConfig_multipleWorkflowsSameAction(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &plan),
+					testAccCheckPlanExists(ctx, t, resourceName, &plan),
 					resource.TestCheckResourceAttr(resourceName, "workflow.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "workflow.*", map[string]string{
 						"workflow_target_action": "activate",
@@ -213,19 +212,19 @@ func TestAccARCRegionSwitchPlan_route53HealthCheck(t *testing.T) {
 	dataSourceName := "data.aws_arcregionswitch_route53_health_checks.test"
 	zoneName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitch),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPlanConfig_route53HealthCheck(rName, zoneName, acctest.AlternateRegion(), acctest.Region()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &plan),
+					testAccCheckPlanExists(ctx, t, resourceName, &plan),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "recovery_approach", "activeActive"),
 					resource.TestCheckResourceAttr(resourceName, "regions.#", "2"),
@@ -261,19 +260,19 @@ func TestAccARCRegionSwitchPlan_complex(t *testing.T) {
 	zoneName := acctest.RandomDomain()
 	recordName := zoneName.RandomSubdomain()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitch),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPlanConfig_complex(rName, acctest.AlternateRegion(), acctest.Region(), zoneName.String(), recordName.String()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &plan),
+					testAccCheckPlanExists(ctx, t, resourceName, &plan),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "recovery_approach", "activeActive"),
 					resource.TestCheckResourceAttr(resourceName, "regions.#", "2"),
@@ -418,7 +417,7 @@ func TestAccARCRegionSwitchPlan_validation(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, "tf-acc-test")
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -449,14 +448,14 @@ func TestAccARCRegionSwitchPlan_regionOverride(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_arcregionswitch_plan.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitch),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPlanConfig_regionOverride(rName, acctest.AlternateRegion()),
@@ -467,7 +466,7 @@ func TestAccARCRegionSwitchPlan_regionOverride(t *testing.T) {
 					},
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &plan),
+					testAccCheckPlanExists(ctx, t, resourceName, &plan),
 					resource.TestCheckResourceAttr(resourceName, names.AttrRegion, acctest.AlternateRegion()),
 				),
 			},
@@ -497,7 +496,7 @@ func TestAccARCRegionSwitchPlan_regionOverride(t *testing.T) {
 					},
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPlanExists(ctx, resourceName, &plan),
+					testAccCheckPlanExists(ctx, t, resourceName, &plan),
 					resource.TestCheckResourceAttr(resourceName, names.AttrRegion, acctest.Region()),
 				),
 			},
@@ -505,9 +504,9 @@ func TestAccARCRegionSwitchPlan_regionOverride(t *testing.T) {
 	})
 }
 
-func testAccCheckPlanDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckPlanDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ARCRegionSwitchClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ARCRegionSwitchClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_arcregionswitch_plan" {
@@ -525,7 +524,7 @@ func testAccCheckPlanDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckPlanExists(ctx context.Context, n string, v *awstypes.Plan) resource.TestCheckFunc {
+func testAccCheckPlanExists(ctx context.Context, t *testing.T, n string, v *awstypes.Plan) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -536,7 +535,7 @@ func testAccCheckPlanExists(ctx context.Context, n string, v *awstypes.Plan) res
 			return fmt.Errorf("No ARC Region Switch Plan ARN is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ARCRegionSwitchClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ARCRegionSwitchClient(ctx)
 
 		output, err := tfarcregionswitch.FindPlanByARN(ctx, conn, rs.Primary.Attributes[names.AttrARN])
 
@@ -551,7 +550,7 @@ func testAccCheckPlanExists(ctx context.Context, n string, v *awstypes.Plan) res
 }
 
 func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ARCRegionSwitchClient(ctx)
+	conn := acctest.ProviderMeta(ctx, t).ARCRegionSwitchClient(ctx)
 
 	input := arcregionswitch.ListPlansInput{}
 	_, err := conn.ListPlans(ctx, &input)

--- a/internal/service/arcregionswitch/route53_health_checks_data_source_test.go
+++ b/internal/service/arcregionswitch/route53_health_checks_data_source_test.go
@@ -23,14 +23,14 @@ func TestAccARCRegionSwitchRoute53HealthChecksDataSource_basic(t *testing.T) {
 	zoneName := acctest.RandomDomain()
 	recordName := zoneName.RandomSubdomain()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitch),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckPlanDestroy(ctx),
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53HealthChecksDataSourceConfig_basic(rName, zoneName.String(), recordName.String()),
@@ -74,14 +74,14 @@ func TestAccARCRegionSwitchRoute53HealthChecksDataSource_regionOverride(t *testi
 					zoneName := acctest.RandomDomain()
 					recordName := zoneName.RandomSubdomain()
 
-					resource.ParallelTest(t, resource.TestCase{
+					acctest.ParallelTest(ctx, t, resource.TestCase{
 						PreCheck: func() {
 							acctest.PreCheck(ctx, t)
 							testAccPreCheck(ctx, t)
 						},
 						ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitch),
 						ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-						CheckDestroy:             testAccCheckPlanDestroy(ctx),
+						CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
 						Steps: []resource.TestStep{
 							{
 								// Cross-region test cases will succeed because `aws_arcregionswitch_route53_health_checks` is global


### PR DESCRIPTION

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Enables `go-vcr` for the `arcregionswitch` service.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/25602
Relates https://github.com/hashicorp/terraform-provider-aws/issues/43717
