### PR TITLE
docs: update outdated branch naming guidance in raising a pull request guide

### DIFF
--- a/docs/raising-a-pull-request.md
+++ b/docs/raising-a-pull-request.md
@@ -5,20 +5,16 @@
 
 1. [Fork the GitHub repository](https://help.github.com/en/articles/fork-a-repo) allowing you to make the changes in your own copy of the repository.
 
-1. Create a branch using the following naming prefixes:
+1. Create a branch for your changes.
+Branch names should be descriptive and related to the change being made. For example:
 
-    - f = feature
-    - b = bug fix
-    - d = documentation
-    - t = tests
-    - td = technical debt
-    - v = dependencies ("vendoring" previously)
-
-    Some indicative example branch names would be `f-aws_emr_instance_group-refactor` or `td-staticcheck-st1008`
+    - fix-aws-instance-timeout
+    - docs-update-pull-request-guide
+    - feature-add-ecs-capacity-provider
 
 1. Make the changes you would like to include in the provider, add new tests as required, and make sure that all relevant existing tests are passing.
 
-1. [Create a pull request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork). Please ensure (if possible) that the 'Allow edits from maintainers' checkbox is checked. This will allow the maintainers to make changes and merge the PR without requiring action from the contributor.
+1. [Create a pull request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork). If available, enabling the "Allow edits from maintainers" option can make it easier for maintainers to apply small fixes during review. This will allow the maintainers to make changes and merge the PR without requiring action from the contributor.
    You are welcome to submit your pull request for commentary or review before
    it is fully completed by creating a [draft pull request](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests).
    Please include specific questions or items you'd like feedback on.


### PR DESCRIPTION
…t guide

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

### Description

This updates the branch naming guidance in the "Raising a Pull Request" documentation.

The previous prefix-based convention (f-, b-, td-, etc.) is no longer commonly used in the repository and could confuse new contributors. The documentation now recommends using clear and descriptive branch names instead.

Example branch names were updated accordingly.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #46642

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
