### PR TITLE
fix: aws_ecs_express_gateway_service inconsistent environment

### DIFF
--- a/.changelog/46771.txt
+++ b/.changelog/46771.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_express_gateway_service: Fix `Provider produced inconsistent result after apply` error when `environment` variables are defined in non-alphabetical order
+```

--- a/internal/service/ecs/express_gateway_service.go
+++ b/internal/service/ecs/express_gateway_service.go
@@ -6,9 +6,11 @@
 package ecs
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/YakDriver/smarterr"
@@ -273,6 +275,7 @@ func (r *expressGatewayServiceResource) Create(ctx context.Context, req resource
 
 	// Set values for unknowns.
 	if len(waitOut.ActiveConfigurations) > 0 {
+		orderExpressGatewayContainerEnvironmentVariables(&waitOut.ActiveConfigurations[0])
 		smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, waitOut.ActiveConfigurations[0], &plan))
 		if resp.Diagnostics.HasError() {
 			return
@@ -315,6 +318,7 @@ func (r *expressGatewayServiceResource) Read(ctx context.Context, req resource.R
 	}
 
 	if len(out.ActiveConfigurations) > 0 {
+		orderExpressGatewayContainerEnvironmentVariables(&out.ActiveConfigurations[0])
 		smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, out.ActiveConfigurations[0], &state))
 		if resp.Diagnostics.HasError() {
 			return
@@ -422,6 +426,7 @@ func (r *expressGatewayServiceResource) Update(ctx context.Context, req resource
 
 	// Set values for unknowns.
 	if len(waitOut.ActiveConfigurations) > 0 {
+		orderExpressGatewayContainerEnvironmentVariables(&waitOut.ActiveConfigurations[0])
 		smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, waitOut.ActiveConfigurations[0], &plan))
 		if resp.Diagnostics.HasError() {
 			return
@@ -772,6 +777,21 @@ type expressGatewayScalingTargetModel struct {
 type ingressPathSummaryModel struct {
 	AccessType fwtypes.StringEnum[awstypes.AccessType] `tfsdk:"access_type"`
 	Endpoint   types.String                            `tfsdk:"endpoint"`
+}
+
+// orderExpressGatewayContainerEnvironmentVariables sorts the environment variables and secrets
+// in an ExpressGatewayServiceConfiguration by name. This prevents spurious diffs when the API
+// returns environment variables in a different order than the Terraform configuration.
+func orderExpressGatewayContainerEnvironmentVariables(config *awstypes.ExpressGatewayServiceConfiguration) {
+	if config == nil || config.PrimaryContainer == nil {
+		return
+	}
+	slices.SortFunc(config.PrimaryContainer.Environment, func(a, b awstypes.KeyValuePair) int {
+		return cmp.Compare(aws.ToString(a.Name), aws.ToString(b.Name))
+	})
+	slices.SortFunc(config.PrimaryContainer.Secrets, func(a, b awstypes.Secret) int {
+		return cmp.Compare(aws.ToString(a.Name), aws.ToString(b.Name))
+	})
 }
 
 func retryExpressGatewayServiceCreate(ctx context.Context, conn *ecs.Client, input *ecs.CreateExpressGatewayServiceInput) (*ecs.CreateExpressGatewayServiceOutput, error) {

--- a/internal/service/ecs/express_gateway_service_test.go
+++ b/internal/service/ecs/express_gateway_service_test.go
@@ -354,6 +354,72 @@ func TestAccECSExpressGatewayService_checkIdempotency(t *testing.T) {
 	})
 }
 
+// TestAccECSExpressGatewayService_environmentVariableOrdering verifies that
+// environment variables defined in non-alphabetical order do not cause
+// "Provider produced inconsistent result after apply" errors.
+// See: https://github.com/hashicorp/terraform-provider-aws/issues/45792
+func TestAccECSExpressGatewayService_environmentVariableOrdering(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var service awstypes.ECSExpressGatewayService
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ecs_express_gateway_service.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ECSEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExpressGatewayServiceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExpressGatewayServiceConfig_environmentVariableOrdering(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckExpressGatewayServiceExists(ctx, t, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.0.name", "ALPHA"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.0.value", "first"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.1.name", "BETA"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.1.value", "second"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.2.name", "ZULU"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.2.value", "third"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			// Re-apply the same config to verify no diff is detected (the bug caused
+			// "Provider produced inconsistent result after apply" here).
+			{
+				Config: testAccExpressGatewayServiceConfig_environmentVariableOrdering(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportStateVerifyIdentifierAttribute: "service_arn",
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "service_arn"),
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIgnore: []string{
+					"wait_for_steady_state",
+					"current_deployment",
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckExpressGatewayServiceDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).ECSClient(ctx)
@@ -704,6 +770,38 @@ resource "aws_ecs_express_gateway_service" "duplicate" {
   depends_on = [
     aws_ecs_express_gateway_service.test
   ]
+}
+`)
+}
+
+// testAccExpressGatewayServiceConfig_environmentVariableOrdering creates an express
+// gateway service with environment variables intentionally in non-alphabetical order
+// (ZULU, BETA, ALPHA). The API returns them sorted alphabetically, so the provider
+// must sort them before storing in state to avoid spurious diffs.
+func testAccExpressGatewayServiceConfig_environmentVariableOrdering(rName string) string {
+	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName), `
+resource "aws_ecs_express_gateway_service" "test" {
+  execution_role_arn      = aws_iam_role.execution.arn
+  infrastructure_role_arn = aws_iam_role.infrastructure.arn
+
+  primary_container {
+    image = "public.ecr.aws/nginx/nginx:1.28-alpine3.21-slim"
+
+    environment {
+      name  = "ZULU"
+      value = "third"
+    }
+
+    environment {
+      name  = "BETA"
+      value = "second"
+    }
+
+    environment {
+      name  = "ALPHA"
+      value = "first"
+    }
+  }
 }
 `)
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The AWS `DescribeExpressGatewayService` API returns `PrimaryContainer.Environment` and `PrimaryContainer.Secrets` sorted alphabetically by name. When a user defines environment variables in a non-alphabetical order in their Terraform configuration, the provider stores them in the API-returned (alphabetical) order, which differs from the planned order. This causes Terraform to produce a `Provider produced inconsistent result after apply` error.

This fix sorts environment variables and secrets by name before flattening the API response into Terraform state, ensuring a consistent ordering across Create, Read, and Update operations. This approach is consistent with the existing pattern used in `aws_ecs_task_definition` (see `containerDefinitions.orderEnvironmentVariables()`).

An acceptance test has been added that creates a service with environment variables defined in non-alphabetical order and verifies that a subsequent plan is empty (no spurious diff).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.
--->

Closes #45792

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- Similar pattern in `aws_ecs_task_definition`: `orderEnvironmentVariables()` in `internal/service/ecs/container_definitions.go`

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

TBA

```console
% make testacc TESTS=TestAccECSExpressGatewayService_environmentVariableOrdering PKG=ecs

```
