### PR TITLE
Go-VCR: Support per-step provider factories

### DIFF
--- a/internal/acctest/vcr.go
+++ b/internal/acctest/vcr.go
@@ -173,40 +173,14 @@ func vcrProviderConfigureContextFunc(provider *schema.Provider, configureContext
 		// Reuse the existing VCR-enabled HTTP client if one was already created
 		// for a prior step, otherwise create a new one with a recorder.
 		var httpClient *http.Client
+		var err error
 		if ok {
 			httpClient = store.meta.HTTPClient(ctx)
 		} else {
-			vcrMode, err := vcr.Mode()
+			httpClient, err = vcrHTTPClient(ctx, testName)
 			if err != nil {
 				return nil, sdkdiag.AppendFromErr(diags, err)
 			}
-
-			// Real transport config, cribbed from aws-sdk-go-base.
-			httpClient = cleanhttp.DefaultPooledClient()
-			transport := httpClient.Transport.(*http.Transport)
-			transport.MaxIdleConnsPerHost = 10
-			if transport.TLSClientConfig == nil {
-				transport.TLSClientConfig = &tls.Config{
-					MinVersion: tls.VersionTLS13,
-				}
-			}
-
-			cassetteName := filepath.Join(vcr.Path(), vcrFileName(testName))
-
-			// Create a VCR recorder around a default HTTP client.
-			r, err := recorder.New(cassetteName,
-				recorder.WithHook(vcrSensitiveHeaderHook, recorder.AfterCaptureHook),
-				recorder.WithMatcher(vcrMatcherFunc(ctx)),
-				recorder.WithMode(vcrMode),
-				recorder.WithRealTransport(httpClient.Transport),
-				recorder.WithSkipRequestLatency(true),
-			)
-
-			if err != nil {
-				return nil, sdkdiag.AppendFromErr(diags, err)
-			}
-
-			httpClient.Transport = r
 		}
 
 		// Use the wrapped HTTP Client for AWS APIs.
@@ -307,6 +281,40 @@ func vcrMatcherFunc(ctx context.Context) recorder.MatcherFunc {
 
 		return false
 	}
+}
+
+func vcrHTTPClient(ctx context.Context, testName string) (*http.Client, error) {
+	vcrMode, err := vcr.Mode()
+	if err != nil {
+		return nil, err
+	}
+
+	// Real transport config, cribbed from aws-sdk-go-base.
+	httpClient := cleanhttp.DefaultPooledClient()
+	transport := httpClient.Transport.(*http.Transport)
+	transport.MaxIdleConnsPerHost = 10
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{
+			MinVersion: tls.VersionTLS13,
+		}
+	}
+
+	cassetteName := filepath.Join(vcr.Path(), vcrFileName(testName))
+
+	// Create a VCR recorder around a default HTTP client.
+	r, err := recorder.New(cassetteName,
+		recorder.WithHook(vcrSensitiveHeaderHook, recorder.AfterCaptureHook),
+		recorder.WithMatcher(vcrMatcherFunc(ctx)),
+		recorder.WithMode(vcrMode),
+		recorder.WithRealTransport(httpClient.Transport),
+		recorder.WithSkipRequestLatency(true),
+	)
+	if err != nil {
+		return httpClient, err
+	}
+
+	httpClient.Transport = r
+	return httpClient, nil
 }
 
 // vcrRandomnessSource returns a rand.Source for VCR testing


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Allows `go-vcr` to operate on tests where `ProtoV5ProviderFactory` is defined at each `TestStep`.

**AI Disclosure:** Copilot was used to author portions of this change. All modifications were hand reviewed and tested.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #25602 
Closes #43371



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

The `_Tags_DefaultTags` tests all use per-step provider factories so that the `default_tags` argument can be modified between steps.

```console
% VCR_MODE=RECORD_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/ make t K=logs T=TestAccLogsLogGroup_Tags_DefaultTags_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-vcr-per-step-factories 🌿...
TF_ACC=1 go1.25.7 test ./internal/service/logs/... -v -count 1 -parallel 20 -run='TestAccLogsLogGroup_Tags_DefaultTags_'  -timeout 360m -vet=off
2026/03/05 13:33:05 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/05 13:33:05 Initializing Terraform AWS Provider (SDKv2-style)...

=== NAME  TestAccLogsLogGroup_Tags_DefaultTags_emptyResourceTag
    group_tags_gen_test.go:1482: stopping VCR recorder
    group_tags_gen_test.go:1482: persisting randomness seed
--- PASS: TestAccLogsLogGroup_Tags_DefaultTags_emptyResourceTag (24.82s)
=== NAME  TestAccLogsLogGroup_Tags_DefaultTags_nullNonOverlappingResourceTag
    group_tags_gen_test.go:1678: stopping VCR recorder
    group_tags_gen_test.go:1678: persisting randomness seed
--- PASS: TestAccLogsLogGroup_Tags_DefaultTags_nullNonOverlappingResourceTag (25.16s)
=== NAME  TestAccLogsLogGroup_Tags_DefaultTags_emptyProviderOnlyTag
    group_tags_gen_test.go:1551: stopping VCR recorder
    group_tags_gen_test.go:1551: persisting randomness seed
--- PASS: TestAccLogsLogGroup_Tags_DefaultTags_emptyProviderOnlyTag (26.01s)
=== NAME  TestAccLogsLogGroup_Tags_DefaultTags_nullOverlappingResourceTag
    group_tags_gen_test.go:1612: stopping VCR recorder
    group_tags_gen_test.go:1612: persisting randomness seed
--- PASS: TestAccLogsLogGroup_Tags_DefaultTags_nullOverlappingResourceTag (26.04s)
=== NAME  TestAccLogsLogGroup_Tags_DefaultTags_updateToResourceOnly
    group_tags_gen_test.go:1389: stopping VCR recorder
    group_tags_gen_test.go:1389: persisting randomness seed
--- PASS: TestAccLogsLogGroup_Tags_DefaultTags_updateToResourceOnly (34.21s)
=== NAME  TestAccLogsLogGroup_Tags_DefaultTags_updateToProviderOnly
    group_tags_gen_test.go:1295: stopping VCR recorder
    group_tags_gen_test.go:1295: persisting randomness seed
--- PASS: TestAccLogsLogGroup_Tags_DefaultTags_updateToProviderOnly (35.79s)
=== NAME  TestAccLogsLogGroup_Tags_DefaultTags_overlapping
    group_tags_gen_test.go:1115: stopping VCR recorder
    group_tags_gen_test.go:1115: persisting randomness seed
--- PASS: TestAccLogsLogGroup_Tags_DefaultTags_overlapping (51.58s)
=== NAME  TestAccLogsLogGroup_Tags_DefaultTags_nonOverlapping
    group_tags_gen_test.go:951: stopping VCR recorder
    group_tags_gen_test.go:951: persisting randomness seed
--- PASS: TestAccLogsLogGroup_Tags_DefaultTags_nonOverlapping (52.07s)
=== NAME  TestAccLogsLogGroup_Tags_DefaultTags_providerOnly
    group_tags_gen_test.go:766: stopping VCR recorder
    group_tags_gen_test.go:766: persisting randomness seed
--- PASS: TestAccLogsLogGroup_Tags_DefaultTags_providerOnly (62.96s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       68.222s
```
