### PR TITLE
Ce cost allocation tag resource documentation update

### DIFF
--- a/website/docs/r/ce_cost_allocation_tag.html.markdown
+++ b/website/docs/r/ce_cost_allocation_tag.html.markdown
@@ -12,7 +12,6 @@ Provides a CE Cost Allocation Tag.
 
 ~> **NOTE:** After the user-defined tags are created and applied to resources, it can take up to 24 hours for the tag keys to appear on Cost Allocation tag page for activation.
 
-
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

### Description
Enhancement of documentation related to resource `aws_ce_cost_allocation_tag` by adding a note informing that ability to activate the Cost Allocation tag might not be immediately available and there might be a waiting period of 24 hours.

Information was taken from this AWS page:  https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/activating-tags.html

<img width="1541" height="78" alt="image" src="https://github.com/user-attachments/assets/6b63be8a-cd21-4abd-81df-08e936f51d78" />
