### PR TITLE
Fix: Jsondecode in ephemeral secretsmanager_secret_version docs

### DIFF
--- a/website/docs/ephemeral-resources/secretsmanager_secret_version.html.markdown
+++ b/website/docs/ephemeral-resources/secretsmanager_secret_version.html.markdown
@@ -39,7 +39,7 @@ Reading key-value pairs from JSON back into a native Terraform map can be accomp
 
 ```terraform
 output "example" {
-  value = ephemeral.aws_secretsmanager_secret_version.example.secret_string["key1"]
+  value = jsondecode(ephemeral.aws_secretsmanager_secret_version.example.secret_string)["key1"]
 }
 ```
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

N/A

### Description

Actually use the `jsondecode` function in the ephemeral `aws_secretsmanager_secret_version` docs.  This matches the `data` version.