### PR TITLE
docs: add missing monitor dimensions to CE anomaly monitor

### DIFF
--- a/website/docs/r/ce_anomaly_monitor.html.markdown
+++ b/website/docs/r/ce_anomaly_monitor.html.markdown
@@ -55,7 +55,7 @@ This resource supports the following arguments:
 
 * `name` - (Required) The name of the monitor.
 * `monitor_type` - (Required) The possible type values. Valid values: `DIMENSIONAL` | `CUSTOM`.
-* `monitor_dimension` - (Required, if `monitor_type` is `DIMENSIONAL`) The dimensions to evaluate. Valid values: `SERVICE`.
+* `monitor_dimension` - (Required, if `monitor_type` is `DIMENSIONAL`) The dimensions to evaluate. Valid values: `COST_CATEGORY`, `LINKED_ACCOUNT`, `SERVICE`, `TAG`.
 * `monitor_specification` - (Required, if `monitor_type` is `CUSTOM`) A valid JSON representation for the [Expression](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_Expression.html) object.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls implemented.

### Description

Add missing monitor dimensions ("COST_CATEGORY", "LINKED_ACCOUNT", "TAG") to the documentation of  resource [`aws_ce_anomaly_monitor`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ce_anomaly_monitor).

(`monitor_dimension` validates [internally](https://github.com/hashicorp/terraform-provider-aws/blob/f00da3d93f8638f61bf61323ea91a71dda2559ee/internal/service/ce/anomaly_monitor.go#L54) using [`awstypes.MonitorDimension`](https://github.com/aws/aws-sdk-go-v2/blob/38de242faf3a1397673276165379524b2d581a72/service/costexplorer/types/enums.go#L640))


### Relations

Relates #46767 , potentially also closes it.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

Not applicable. Only documentation is updated.