### PR TITLE
list-resource/aws_s3_bucket: Fix test

### DIFF
--- a/internal/service/s3/bucket_list_test.go
+++ b/internal/service/s3/bucket_list_test.go
@@ -225,8 +225,8 @@ func TestAccS3Bucket_List_regionOverride(t *testing.T) {
 					"region":         config.StringVariable(acctest.AlternateRegion()),
 				},
 				QueryResultChecks: []querycheck.QueryResultCheck{
-					tfquerycheck.ExpectIdentityFunc("aws_s3_bucket_policy.test", identity1.Checks()),
-					tfquerycheck.ExpectIdentityFunc("aws_s3_bucket_policy.test", identity2.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_s3_bucket.test", identity1.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_s3_bucket.test", identity2.Checks()),
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Fixes acceptance test `TestAccS3Bucket_List_regionOverride`

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=s3 TESTS=TestAccS3Bucket_List_

--- PASS: TestAccS3Bucket_List_regionOverride (20.71s)
--- PASS: TestAccS3Bucket_List_includeResource (30.01s)
--- PASS: TestAccS3Bucket_List_basic (30.49s)
```
