### PR TITLE
r/controltower: allow in-place update of baseline_version

### DIFF
--- a/internal/service/controltower/baseline.go
+++ b/internal/service/controltower/baseline.go
@@ -70,9 +70,6 @@ func (r *resourceBaseline) Schema(ctx context.Context, _ resource.SchemaRequest,
 			},
 			"baseline_version": schema.StringAttribute{
 				Required: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"operation_identifier": schema.StringAttribute{
 				Computed: true,


### PR DESCRIPTION
Closes #45871

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls in this pull request.

### Description

This PR removes the `RequiresReplace` plan modifier from the `baseline_version` attribute of the `aws_controltower_baseline` resource. Previously, changing the `baseline_version` would force resource replacement, which would invoke `DisableBaseline` and fail when optional controls are enabled. Now, version changes will trigger an in-place update via the existing `Update` function which calls `UpdateEnabledBaseline`.

### Relations

Closes #45871

### References

- [AWS Control Tower UpdateEnabledBaseline API](https://docs.aws.amazon.com/controltower/latest/userguide/baseline-api-examples.html#update-enabled-baseline)

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccBaseline PKG=controltower

...
```