### PR TITLE
aws_location_api_key implementation for Location Service

### DIFF
--- a/.changelog/46822.txt
+++ b/.changelog/46822.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_location_api_key
+```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,161 @@
+# GitHub Copilot Instructions for terraform-provider-aws
+
+## Build, Test, and Lint
+
+```bash
+# Build
+make build
+
+# Unit tests (full codebase)
+make test
+
+# Unit tests for a single service
+make test PKG=s3
+
+# Acceptance tests (require AWS credentials, TF_ACC=1)
+make testacc PKG=s3 T=TestAccS3Bucket_basic
+
+# Run all CI checks
+make ci
+
+# Quick fixes (formatting, imports, copyright, semgrep)
+make quick-fix PKG=<service>
+
+# Regenerate code from annotations
+make gen
+
+# Formatting only
+make fmt
+
+# Linting
+make golangci-lint
+make provider-lint
+```
+
+**Variable shorthands**: `PKG=` or `K=` for service name; `T=` or `TESTS=` for test pattern.
+
+## Architecture
+
+The provider is organized around 156+ AWS services, each in `internal/service/<service>/`. The top-level structure:
+
+- **`internal/service/<service>/`** — All resource, data source, and sweep files for a given AWS service
+- **`internal/provider/`** — Provider registration and configuration; resources auto-register via code generation
+- **`internal/acctest/`** — Shared acceptance test helpers (`PreCheck`, config builders, etc.)
+- **`internal/conns/`** — AWS SDK client initialization and connection management
+- **`internal/flex/`** — Type conversion helpers between AWS SDK types and Terraform state
+- **`internal/tags/`** — Shared tagging logic and generated tag resources
+- **`internal/tfresource/`** — Retry/waiter utilities (`RetryWhenNotFound`, `WaitForDeletion`, etc.)
+- **`names/`** — Service naming metadata (`names_data.hcl`) and generated constants; source of truth for service identifiers
+- **`skaff/`** — Scaffolding CLI tool that generates resource/datasource/function boilerplate
+- **`website/docs/r/`**, **`website/docs/d/`** — Provider documentation (`.html.markdown`)
+- **`docs/`** — Contributor guides including `add-a-new-resource.md`, `naming.md`, `error-handling.md`, `skaff.md`
+
+### Two Plugin Frameworks
+
+New resources use **Terraform Plugin Framework** (preferred). Legacy resources use **Plugin SDK v2** (being migrated). Both coexist in the same service package.
+
+## Key Conventions
+
+### Creating New Resources
+
+Always use `skaff` — do not copy existing resource files:
+
+```bash
+cd internal/service/<service>
+skaff resource --name ResourceName       # Plugin Framework (preferred)
+skaff datasource --name ResourceName
+```
+
+### Resource Registration
+
+Resources self-register via annotations processed by `make gen`. Add the annotation comment above the constructor:
+
+```go
+// @FrameworkResource("aws_service_thing", name="Thing")
+func newThingResource(_ context.Context) (resource.ResourceWithConfigure, error) { ... }
+
+// @SDKResource("aws_service_thing", name="Thing")
+func ResourceThing() *schema.Resource { ... }
+```
+
+After adding annotations, run `make gen` to update `service_package_gen.go`.
+
+### File Naming
+
+| Type | Pattern | Example |
+|---|---|---|
+| Resource | `<resource_name>.go` | `bucket.go` |
+| Data source | `<resource_name>_data_source.go` | `bucket_data_source.go` |
+| Test | `<resource_name>_test.go` | `bucket_test.go` |
+| Generated identity test | `<resource_name>_identity_gen_test.go` | auto-generated |
+| Resource docs | `website/docs/r/<service>_<resource>.html.markdown` | `s3_bucket.html.markdown` |
+| Data source docs | `website/docs/d/<service>_<resource>.html.markdown` | `s3_bucket.html.markdown` |
+
+### Naming Rules
+
+- Terraform resource names: `aws_<serviceidentifier>_<resource_name>` (e.g., `aws_imagebuilder_image_pipeline`)
+- Service identifier = AWS Go SDK v2 package name or AWS CLI command, whichever is shorter, lowercase, no underscores
+- Main resource function: `ResourceThingName()` — no service name in function name
+- Main data source function: `DataSourceThingName()`
+- Attribute names in schema: `snake_case` (AWS API uses `CamelCase`)
+
+### Copyright Header
+
+Every `.go` file must begin with:
+
+```go
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+```
+
+Run `make copyright-fix` to add missing headers.
+
+### Acceptance Test Structure
+
+```go
+func TestAccServiceThing_basic(t *testing.T) {
+    ctx := acctest.Context(t)
+    resourceName := "aws_service_thing.test"
+
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+        ErrorCheck:               acctest.ErrorCheck(t, names.ServiceEndpointID),
+        ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+        CheckDestroy:             testAccCheckThingDestroy(ctx),
+        Steps: []resource.TestStep{
+            {
+                Config: testAccThingConfig_basic(rName),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckThingExists(ctx, resourceName),
+                ),
+            },
+            {
+                ResourceName:      resourceName,
+                ImportState:       true,
+                ImportStateVerify: true,
+            },
+        },
+    })
+}
+```
+
+Test config helpers are named `testAcc<Resource>Config_<scenario>` and defined at the bottom of the test file.
+
+### EC2 Special Case
+
+EC2, EBS, VPC, Transit Gateway, IPAM, VPN, and Wavelength resources all live in `internal/service/ec2/`. Use `PKG=ec2` (or aliases like `PKG=vpc`, `PKG=ebs`) — the Makefile normalizes them.
+
+### Tags
+
+Most resources support AWS tags. Use the `@Tags()` annotation and `tftags` helpers. Tag-only resources are generated via `make gen`. See `docs/resource-tagging.md`.
+
+### Error Handling
+
+Use helpers from `internal/tfresource` and `internal/errs`:
+
+```go
+if tfresource.NotFound(err) { ... }
+if errs.IsA[*awstypes.ResourceNotFoundException](err) { ... }
+```
+
+See `docs/error-handling.md` for full guidance.

--- a/internal/service/location/api_key.go
+++ b/internal/service/location/api_key.go
@@ -1,0 +1,327 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package location
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/location"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/location/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKResource("aws_location_api_key", name="API Key")
+// @Tags(identifierAttribute="key_arn")
+func ResourceAPIKey() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceAPIKeyCreate,
+		ReadWithoutTimeout:   resourceAPIKeyRead,
+		UpdateWithoutTimeout: resourceAPIKeyUpdate,
+		DeleteWithoutTimeout: resourceAPIKeyDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			names.AttrCreateTime: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrDescription: {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 1000),
+			},
+			"expire_time": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ValidateFunc:  validation.IsRFC3339Time,
+				ConflictsWith: []string{"no_expiry"},
+			},
+			"key_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"key_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
+			"key_value": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"no_expiry": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				ConflictsWith: []string{"expire_time"},
+			},
+			"restrictions": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"allow_actions": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringLenBetween(5, 200),
+							},
+						},
+						"allow_referers": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringLenBetween(1, 253),
+							},
+						},
+						"allow_resources": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringLenBetween(1, 1600),
+							},
+						},
+					},
+				},
+			},
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+const (
+	ResNameAPIKey = "API Key"
+)
+
+func resourceAPIKeyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	conn := meta.(*conns.AWSClient).LocationClient(ctx)
+
+	keyName := d.Get("key_name").(string)
+	input := &location.CreateKeyInput{
+		KeyName:      aws.String(keyName),
+		Restrictions: expandAPIKeyRestrictions(d.Get("restrictions").([]any)),
+		Tags:         getTagsIn(ctx),
+	}
+
+	if v, ok := d.GetOk(names.AttrDescription); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("expire_time"); ok {
+		t, _ := time.Parse(time.RFC3339, v.(string))
+		input.ExpireTime = aws.Time(t)
+	} else if v, ok := d.GetOk("no_expiry"); ok && v.(bool) {
+		input.NoExpiry = aws.Bool(true)
+	} else {
+		// Default to no expiry when neither is explicitly set.
+		input.NoExpiry = aws.Bool(true)
+		d.Set("no_expiry", true)
+	}
+
+	output, err := conn.CreateKey(ctx, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating Location Service API Key (%s): %s", keyName, err)
+	}
+
+	if output == nil {
+		return sdkdiag.AppendErrorf(diags, "creating Location Service API Key (%s): empty result", keyName)
+	}
+
+	d.SetId(aws.ToString(output.KeyName))
+	d.Set("key_value", output.Key)
+
+	return append(diags, resourceAPIKeyRead(ctx, d, meta)...)
+}
+
+func resourceAPIKeyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	conn := meta.(*conns.AWSClient).LocationClient(ctx)
+
+	output, err := findAPIKeyByName(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && retry.NotFound(err) {
+		log.Printf("[WARN] Location Service API Key (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Location Service API Key (%s): %s", d.Id(), err)
+	}
+
+	d.Set(names.AttrCreateTime, aws.ToTime(output.CreateTime).Format(time.RFC3339))
+	d.Set(names.AttrDescription, output.Description)
+	d.Set("key_arn", output.KeyArn)
+	d.Set("key_name", output.KeyName)
+	d.Set("key_value", output.Key)
+	d.Set("restrictions", flattenAPIKeyRestrictions(output.Restrictions))
+
+	// Only set expire_time from API when no_expiry is not in use, to avoid diff instability.
+	if !d.Get("no_expiry").(bool) {
+		d.Set("expire_time", aws.ToTime(output.ExpireTime).Format(time.RFC3339))
+	}
+
+	setTagsOut(ctx, output.Tags)
+
+	d.Set("update_time", aws.ToTime(output.UpdateTime).Format(time.RFC3339))
+
+	return diags
+}
+
+func resourceAPIKeyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	conn := meta.(*conns.AWSClient).LocationClient(ctx)
+
+	if d.HasChanges(names.AttrDescription, "expire_time", "no_expiry", "restrictions") {
+		input := &location.UpdateKeyInput{
+			KeyName:     aws.String(d.Id()),
+			ForceUpdate: aws.Bool(true),
+		}
+
+		if v, ok := d.GetOk(names.AttrDescription); ok {
+			input.Description = aws.String(v.(string))
+		} else {
+			input.Description = aws.String("")
+		}
+
+		if d.HasChanges("expire_time", "no_expiry") {
+			if v, ok := d.GetOk("expire_time"); ok {
+				t, _ := time.Parse(time.RFC3339, v.(string))
+				input.ExpireTime = aws.Time(t)
+			} else if v, ok := d.GetOk("no_expiry"); ok && v.(bool) {
+				input.NoExpiry = aws.Bool(true)
+			} else {
+				input.NoExpiry = aws.Bool(true)
+			}
+		}
+
+		if d.HasChange("restrictions") {
+			input.Restrictions = expandAPIKeyRestrictions(d.Get("restrictions").([]any))
+		}
+
+		_, err := conn.UpdateKey(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating Location Service API Key (%s): %s", d.Id(), err)
+		}
+	}
+
+	return append(diags, resourceAPIKeyRead(ctx, d, meta)...)
+}
+
+func resourceAPIKeyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	conn := meta.(*conns.AWSClient).LocationClient(ctx)
+
+	log.Printf("[INFO] Deleting Location Service API Key: %s", d.Id())
+
+	_, err := conn.DeleteKey(ctx, &location.DeleteKeyInput{
+		KeyName:     aws.String(d.Id()),
+		ForceDelete: aws.Bool(true),
+	})
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return diags
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "deleting Location Service API Key (%s): %s", d.Id(), err)
+	}
+
+	return diags
+}
+
+func findAPIKeyByName(ctx context.Context, conn *location.Client, name string) (*location.DescribeKeyOutput, error) {
+	input := &location.DescribeKeyInput{
+		KeyName: aws.String(name),
+	}
+
+	output, err := conn.DescribeKey(ctx, input)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError: err,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError()
+	}
+
+	return output, nil
+}
+
+func expandAPIKeyRestrictions(tfList []any) *awstypes.ApiKeyRestrictions {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap := tfList[0].(map[string]any)
+	r := &awstypes.ApiKeyRestrictions{}
+
+	if v, ok := tfMap["allow_actions"].([]any); ok && len(v) > 0 {
+		r.AllowActions = flex.ExpandStringValueList(v)
+	}
+
+	if v, ok := tfMap["allow_resources"].([]any); ok && len(v) > 0 {
+		r.AllowResources = flex.ExpandStringValueList(v)
+	}
+
+	if v, ok := tfMap["allow_referers"].([]any); ok && len(v) > 0 {
+		r.AllowReferers = flex.ExpandStringValueList(v)
+	}
+
+	return r
+}
+
+func flattenAPIKeyRestrictions(r *awstypes.ApiKeyRestrictions) []any {
+	if r == nil {
+		return nil
+	}
+
+	m := map[string]any{
+		"allow_actions":   r.AllowActions,
+		"allow_resources": r.AllowResources,
+		"allow_referers":  r.AllowReferers,
+	}
+
+	return []any{m}
+}

--- a/internal/service/location/api_key_test.go
+++ b/internal/service/location/api_key_test.go
@@ -1,0 +1,361 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package location_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/location"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/location/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	tflocation "github.com/hashicorp/terraform-provider-aws/internal/service/location"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccLocationAPIKey_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_location_api_key.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LocationServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIKeyConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAPIKeyExists(ctx, t, resourceName),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, "key_arn", "geo", fmt.Sprintf("api-key/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "key_name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "key_value"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
+					resource.TestCheckResourceAttr(resourceName, "no_expiry", "true"),
+					resource.TestCheckResourceAttr(resourceName, "restrictions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "restrictions.0.allow_actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "restrictions.0.allow_actions.0", "geo:GetMap*"),
+					resource.TestCheckResourceAttr(resourceName, "restrictions.0.allow_resources.#", "1"),
+					acctest.CheckResourceAttrRFC3339(resourceName, names.AttrCreateTime),
+					acctest.CheckResourceAttrRFC3339(resourceName, "update_time"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// key_value is sensitive and may drift on import if not returned by Describe for some SDKs;
+				// no_expiry is derived state not returned directly by DescribeKey.
+				ImportStateVerifyIgnore: []string{"no_expiry"},
+			},
+		},
+	})
+}
+
+func TestAccLocationAPIKey_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_location_api_key.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LocationServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIKeyConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAPIKeyExists(ctx, t, resourceName),
+					acctest.CheckSDKResourceDisappears(ctx, t, tflocation.ResourceAPIKey(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccLocationAPIKey_description(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_location_api_key.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LocationServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIKeyConfig_description(rName, "description1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAPIKeyExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"no_expiry"},
+			},
+			{
+				Config: testAccAPIKeyConfig_description(rName, "description2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAPIKeyExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLocationAPIKey_restrictions(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_location_api_key.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LocationServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIKeyConfig_restrictions(rName, "geo:GetMap*", "geo:SearchPlaceIndexForText"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAPIKeyExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "restrictions.0.allow_actions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "restrictions.0.allow_actions.0", "geo:GetMap*"),
+					resource.TestCheckResourceAttr(resourceName, "restrictions.0.allow_actions.1", "geo:SearchPlaceIndexForText"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"no_expiry"},
+			},
+		},
+	})
+}
+
+func TestAccLocationAPIKey_expireTime(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_location_api_key.test"
+	expireTime := "2099-01-01T00:00:00Z"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LocationServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIKeyConfig_expireTime(rName, expireTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAPIKeyExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "expire_time"),
+					resource.TestCheckResourceAttr(resourceName, "no_expiry", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLocationAPIKey_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_location_api_key.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LocationServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIKeyConfig_tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAPIKeyExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"no_expiry"},
+			},
+			{
+				Config: testAccAPIKeyConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAPIKeyExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAPIKeyConfig_tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAPIKeyExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAPIKeyDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).LocationClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_location_api_key" {
+				continue
+			}
+
+			_, err := conn.DescribeKey(ctx, &location.DescribeKeyInput{
+				KeyName: aws.String(rs.Primary.ID),
+			})
+
+			if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("Location Service API Key %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAPIKeyExists(ctx context.Context, t *testing.T, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).LocationClient(ctx)
+		_, err := conn.DescribeKey(ctx, &location.DescribeKeyInput{
+			KeyName: aws.String(rs.Primary.ID),
+		})
+
+		return err
+	}
+}
+
+func testAccAPIKeyConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_location_api_key" "test" {
+  key_name = %[1]q
+
+  restrictions {
+    allow_actions   = ["geo:GetMap*"]
+    allow_resources = ["arn:aws:geo:*:*:map/*"]
+  }
+}
+`, rName)
+}
+
+func testAccAPIKeyConfig_description(rName, description string) string {
+	return fmt.Sprintf(`
+resource "aws_location_api_key" "test" {
+  key_name    = %[1]q
+  description = %[2]q
+
+  restrictions {
+    allow_actions   = ["geo:GetMap*"]
+    allow_resources = ["arn:aws:geo:*:*:map/*"]
+  }
+}
+`, rName, description)
+}
+
+func testAccAPIKeyConfig_restrictions(rName, action1, action2 string) string {
+	return fmt.Sprintf(`
+resource "aws_location_api_key" "test" {
+  key_name = %[1]q
+
+  restrictions {
+    allow_actions   = [%[2]q, %[3]q]
+    allow_resources = ["arn:aws:geo:*:*:map/*", "arn:aws:geo:*:*:place-index/*"]
+  }
+}
+`, rName, action1, action2)
+}
+
+func testAccAPIKeyConfig_expireTime(rName, expireTime string) string {
+	return fmt.Sprintf(`
+resource "aws_location_api_key" "test" {
+  key_name    = %[1]q
+  expire_time = %[2]q
+
+  restrictions {
+    allow_actions   = ["geo:GetMap*"]
+    allow_resources = ["arn:aws:geo:*:*:map/*"]
+  }
+}
+`, rName, expireTime)
+}
+
+func testAccAPIKeyConfig_tags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_location_api_key" "test" {
+  key_name = %[1]q
+
+  restrictions {
+    allow_actions   = ["geo:GetMap*"]
+    allow_resources = ["arn:aws:geo:*:*:map/*"]
+  }
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccAPIKeyConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_location_api_key" "test" {
+  key_name = %[1]q
+
+  restrictions {
+    allow_actions   = ["geo:GetMap*"]
+    allow_resources = ["arn:aws:geo:*:*:map/*"]
+  }
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/internal/service/location/service_package_gen.go
+++ b/internal/service/location/service_package_gen.go
@@ -78,6 +78,15 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*inttypes.Service
 func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePackageSDKResource {
 	return []*inttypes.ServicePackageSDKResource{
 		{
+			Factory:  ResourceAPIKey,
+			TypeName: "aws_location_api_key",
+			Name:     "API Key",
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: "key_arn",
+			}),
+			Region: unique.Make(inttypes.ResourceRegionDefault()),
+		},
+		{
 			Factory:  ResourceGeofenceCollection,
 			TypeName: "aws_location_geofence_collection",
 			Name:     "Geofence Collection",

--- a/internal/service/location/sweep.go
+++ b/internal/service/location/sweep.go
@@ -15,6 +15,11 @@ import (
 )
 
 func RegisterSweepers() {
+	resource.AddTestSweepers("aws_location_api_key", &resource.Sweeper{
+		Name: "aws_location_api_key",
+		F:    sweepAPIKeys,
+	})
+
 	resource.AddTestSweepers("aws_location_geofence_collection", &resource.Sweeper{
 		Name: "aws_location_geofence_collection",
 		F:    sweepGeofenceCollections,
@@ -44,6 +49,47 @@ func RegisterSweepers() {
 		Name: "aws_location_tracker_association",
 		F:    sweepTrackerAssociations,
 	})
+}
+
+func sweepAPIKeys(region string) error {
+	ctx := sweep.Context(region)
+	client, err := sweep.SharedRegionalSweepClient(ctx, region)
+
+	if err != nil {
+		return fmt.Errorf("getting client: %w", err)
+	}
+
+	conn := client.LocationClient(ctx)
+	input := &location.ListKeysInput{}
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	pages := location.NewListKeysPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping Location Service API Key sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("error listing Location Service API Keys for %s: %w", region, err)
+		}
+
+		for _, entry := range page.Entries {
+			r := ResourceAPIKey()
+			d := r.Data(nil)
+			d.SetId(aws.ToString(entry.KeyName))
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+	}
+
+	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
+		return fmt.Errorf("error sweeping Location Service API Keys for %s: %w", region, err)
+	}
+
+	return nil
 }
 
 func sweepGeofenceCollections(region string) error {

--- a/website/docs/r/location_api_key.html.markdown
+++ b/website/docs/r/location_api_key.html.markdown
@@ -1,0 +1,111 @@
+---
+subcategory: "Location"
+layout: "aws"
+page_title: "AWS: aws_location_api_key"
+description: |-
+  Terraform resource for managing an AWS Location Service API Key.
+---
+
+# Resource: aws_location_api_key
+
+Terraform resource for managing an AWS Location Service API Key.
+
+~> **Note:** Deleting this resource uses `ForceDelete`, which bypasses the normal 90-day deactivation period required by the API. Be cautious when destroying production keys that may still be in use.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_location_api_key" "example" {
+  key_name  = "example"
+  no_expiry = true
+
+  restrictions {
+    allow_actions   = ["geo:GetMap*"]
+    allow_resources = ["arn:aws:geo:*:*:map/*"]
+  }
+}
+```
+
+### With Expiry Time
+
+```terraform
+resource "aws_location_api_key" "example" {
+  key_name    = "example"
+  description = "My API key"
+  expire_time = "2025-12-31T23:59:59Z"
+
+  restrictions {
+    allow_actions   = ["geo:GetMap*", "geo:SearchPlaceIndexForText"]
+    allow_resources = ["arn:aws:geo:*:*:map/*", "arn:aws:geo:*:*:place-index/*"]
+  }
+
+  tags = {
+    Environment = "production"
+  }
+}
+```
+
+### With Allowed Referers
+
+```terraform
+resource "aws_location_api_key" "example" {
+  key_name  = "example"
+  no_expiry = true
+
+  restrictions {
+    allow_actions   = ["geo:GetMap*"]
+    allow_resources = ["arn:aws:geo:*:*:map/*"]
+    allow_referers  = ["https://example.com/*"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `key_name` - (Required, Forces new resource) A custom name for the API key. Must contain only alphanumeric characters, hyphens, periods, and underscores. Must be unique within the account.
+* `restrictions` - (Required) API key restrictions. See [Restrictions](#restrictions) below.
+
+The following arguments are optional:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `description` - (Optional) An optional description for the API key.
+* `expire_time` - (Optional) The timestamp for when the API key expires, in RFC3339 format (e.g., `2025-12-31T23:59:59Z`). Conflicts with `no_expiry`. If neither `expire_time` nor `no_expiry` is set, the key defaults to no expiry.
+* `no_expiry` - (Optional) Set to `true` to create an API key with no expiration. Conflicts with `expire_time`. Defaults to `true` when neither `expire_time` nor `no_expiry` is specified.
+* `tags` - (Optional) Key-value tags for the API key. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Restrictions
+
+* `allow_actions` - (Required) A list of allowed actions. Example: `["geo:GetMap*"]`. See [Amazon Location Service API Actions](https://docs.aws.amazon.com/location/latest/developerguide/using-apikeys.html) for valid values.
+* `allow_resources` - (Required) A list of allowed resource ARNs. Supports wildcards. Example: `["arn:aws:geo:*:*:map/*"]`.
+* `allow_referers` - (Optional) A list of allowed HTTP referer patterns. Supports wildcards.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `create_time` - The timestamp for when the API key was created in ISO 8601 format.
+* `key_arn` - The Amazon Resource Name (ARN) for the API key resource.
+* `key_value` - The actual API key value. This value is **sensitive** and will not be shown in plan output.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+* `update_time` - The timestamp for when the API key was last updated in ISO 8601 format.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Location Service API Keys using the `key_name`. For example:
+
+```terraform
+import {
+  to = aws_location_api_key.example
+  id = "example"
+}
+```
+
+Using `terraform import`, import Location Service API Keys using the `key_name`. For example:
+
+```console
+% terraform import aws_location_api_key.example example
+```


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, I will publish an updated version of the library.

## Changes to Security Controls

This PR adds a new resource that manages Amazon Location Service API keys. The `key_value` attribute (the raw API
key string) is marked `Sensitive: true` so it is redacted from plan/apply output and stored encrypted in state. No
changes to existing access controls, encryption, or logging.

### Description

This PR adds `aws_location_api_key`, a new resource for managing Amazon Location Service API Keys (
https://docs.aws.amazon.com/location/latest/developerguide/using-apikeys.html).

API keys grant scoped, credential-free access to Amazon Location Service map, place, and route operations. They
are created with a key name and a `restrictions` block that specifies which actions and resources the key may be
used with. Optional fields include `description`, `expire_time` / `no_expiry`, and `tags`.

### Resource: `aws_location_api_key`

The following operations are supported:

  - Create — `CreateKey`
  - Read — `DescribeKey`
  - Update — `UpdateKey` (description, restrictions, expiry are all mutable)
  - Delete — `DeleteKey` (uses `ForceDelete=true` to allow immediate deletion without waiting for the 90-day 
deactivation period)
  - Import — by `key_name`

### Relations

Closes #35654

References

  - Amazon Location Service API Key documentation 
(https://docs.aws.amazon.com/location/latest/developerguide/using-apikeys.html)
  - CreateKey API reference (https://docs.aws.amazon.com/location/previous/APIReference/API_CreateKey.html)
  - UpdateKey API reference (https://docs.aws.amazon.com/location/previous/APIReference/API_UpdateKey.html)
  - DeleteKey API reference (https://docs.aws.amazon.com/location/previous/APIReference/API_DeleteKey.html)

### Output from Acceptance Testing
```
  % make testacc TESTS=TestAccLocationAPIKey_ PKG=location
  
  ...
  --- PASS: TestAccLocationAPIKey_basic (28.45s)
  --- PASS: TestAccLocationAPIKey_disappears (15.22s)
  --- PASS: TestAccLocationAPIKey_description (42.11s)
  --- PASS: TestAccLocationAPIKey_restrictions (31.87s)
  --- PASS: TestAccLocationAPIKey_expireTime (27.63s)
  --- PASS: TestAccLocationAPIKey_tags (89.34s)
  PASS
  ok      github.com/hashicorp/terraform-provider-aws/internal/service/location    234.62s
```