### PR TITLE
r/aws_bedrockagentcore_agent_runtime: Add `authorizer_config.custom_jwt_authorizer.allowed_scopes` argument

### DIFF
--- a/.changelog/46828.txt
+++ b/.changelog/46828.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_agent_runtime: Add `authorizer_config.custom_jwt_authorizer.allowed_scopes` argument
+```

--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -240,6 +240,10 @@ func (r *agentRuntimeResource) Schema(ctx context.Context, request resource.Sche
 										CustomType: fwtypes.SetOfStringType,
 										Optional:   true,
 									},
+									"allowed_scopes": schema.SetAttribute{
+										CustomType: fwtypes.SetOfStringType,
+										Optional:   true,
+									},
 									"discovery_url": schema.StringAttribute{
 										Required: true,
 									},
@@ -796,6 +800,7 @@ func (m authorizerConfigurationModel) Expand(ctx context.Context) (any, diag.Dia
 type customJWTAuthorizerConfigurationModel struct {
 	AllowedAudience fwtypes.SetOfString `tfsdk:"allowed_audience"`
 	AllowedClients  fwtypes.SetOfString `tfsdk:"allowed_clients"`
+	AllowedScopes   fwtypes.SetOfString `tfsdk:"allowed_scopes"`
 	DiscoveryURL    types.String        `tfsdk:"discovery_url"`
 }
 

--- a/internal/service/bedrockagentcore/agent_runtime_test.go
+++ b/internal/service/bedrockagentcore/agent_runtime_test.go
@@ -321,7 +321,7 @@ func TestAccBedrockAgentCoreAgentRuntime_authorizerConfiguration(t *testing.T) {
 		CheckDestroy:             testAccCheckAgentRuntimeDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgentRuntimeConfig_authorizerConfiguration(rName, rImageUri, "https://accounts.google.com/.well-known/openid-configuration", "weather", "sports", "client-999", "client-888"),
+				Config: testAccAgentRuntimeConfig_authorizerConfiguration(rName, rImageUri, "https://accounts.google.com/.well-known/openid-configuration", "weather", "sports", "client-999", "client-888", "openid", names.AttrEmail),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAgentRuntimeExists(ctx, t, resourceName, &agentRuntime),
 				),
@@ -343,6 +343,10 @@ func TestAccBedrockAgentCoreAgentRuntime_authorizerConfiguration(t *testing.T) {
 										knownvalue.StringExact("client-888"),
 										knownvalue.StringExact("client-999"),
 									}),
+									"allowed_scopes": knownvalue.SetExact([]knownvalue.Check{
+										knownvalue.StringExact("openid"),
+										knownvalue.StringExact(names.AttrEmail),
+									}),
 									"discovery_url": knownvalue.StringExact("https://accounts.google.com/.well-known/openid-configuration"),
 								}),
 							}),
@@ -358,7 +362,7 @@ func TestAccBedrockAgentCoreAgentRuntime_authorizerConfiguration(t *testing.T) {
 				ImportStateVerifyIdentifierAttribute: "agent_runtime_id",
 			},
 			{
-				Config: testAccAgentRuntimeConfig_authorizerConfiguration(rName, rImageUri, "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration", "finance", "technology", "client-111", "client-222"),
+				Config: testAccAgentRuntimeConfig_authorizerConfiguration(rName, rImageUri, "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration", "finance", "technology", "client-111", "client-222", "openid", names.AttrProfile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAgentRuntimeExists(ctx, t, resourceName, &agentRuntime),
 				),
@@ -379,6 +383,10 @@ func TestAccBedrockAgentCoreAgentRuntime_authorizerConfiguration(t *testing.T) {
 									"allowed_clients": knownvalue.SetExact([]knownvalue.Check{
 										knownvalue.StringExact("client-111"),
 										knownvalue.StringExact("client-222"),
+									}),
+									"allowed_scopes": knownvalue.SetExact([]knownvalue.Check{
+										knownvalue.StringExact("openid"),
+										knownvalue.StringExact(names.AttrProfile),
 									}),
 									"discovery_url": knownvalue.StringExact("https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration"),
 								}),
@@ -967,7 +975,7 @@ resource "aws_bedrockagentcore_agent_runtime" "test" {
 `, rName, envKey, envValue, rImageUri))
 }
 
-func testAccAgentRuntimeConfig_authorizerConfiguration(rName, rImageUri, discoveryUrl, audience1, audience2, client1, client2 string) string {
+func testAccAgentRuntimeConfig_authorizerConfiguration(rName, rImageUri, discoveryUrl, audience1, audience2, client1, client2, scope1, scope2 string) string {
 	return acctest.ConfigCompose(testAccAgentRuntimeConfig_baseIAMRole(rName), fmt.Sprintf(`
 resource "aws_bedrockagentcore_agent_runtime" "test" {
   agent_runtime_name = %[1]q
@@ -984,6 +992,7 @@ resource "aws_bedrockagentcore_agent_runtime" "test" {
       discovery_url    = %[3]q
       allowed_audience = [%[4]q, %[5]q]
       allowed_clients  = [%[6]q, %[7]q]
+      allowed_scopes   = [%[8]q, %[9]q]
     }
   }
 
@@ -991,7 +1000,7 @@ resource "aws_bedrockagentcore_agent_runtime" "test" {
     network_mode = "PUBLIC"
   }
 }
-`, rName, rImageUri, discoveryUrl, audience1, audience2, client1, client2))
+`, rName, rImageUri, discoveryUrl, audience1, audience2, client1, client2, scope1, scope2))
 }
 
 func testAccAgentRuntimeConfig_protocolConfiguration(rName, rImageUri, serverProtocol string) string {

--- a/website/docs/r/bedrockagentcore_agent_runtime.html.markdown
+++ b/website/docs/r/bedrockagentcore_agent_runtime.html.markdown
@@ -93,6 +93,7 @@ resource "aws_bedrockagentcore_agent_runtime" "example" {
       discovery_url    = "https://accounts.google.com/.well-known/openid-configuration"
       allowed_audience = ["my-app", "mobile-app"]
       allowed_clients  = ["client-123", "client-456"]
+      allowed_scopes   = ["openid", "email"]
     }
   }
 
@@ -200,6 +201,7 @@ The `custom_jwt_authorizer` block supports the following:
 * `discovery_url` - (Required) URL used to fetch OpenID Connect configuration or authorization server metadata. Must end with `.well-known/openid-configuration`.
 * `allowed_audience` - (Optional) Set of allowed audience values for JWT token validation.
 * `allowed_clients` - (Optional) Set of allowed client IDs for JWT token validation.
+* `allowed_scopes` - (Optional) Set of scopes that are allowed to access the token.
 
 ### `lifecycle_configuration`
 


### PR DESCRIPTION




<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds `allowed_scopes` to be set in the custom JWT authorizer configuration.

```terraform
resource "aws_bedrockagentcore_agent_runtime" "test" {
  ### other config ###

  authorizer_configuration {
    custom_jwt_authorizer {
      discovery_url    = ""
      allowed_scopes   = ["openid", "email"]
    }
  }
}
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #46827

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_CustomJWTAuthorizerConfiguration.html
- https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/getting-started-custom.html (For acceptance test image setup)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
AWS_BEDROCK_AGENTCORE_RUNTIME_IMAGE_V1_URI=<redacted>.dkr.ecr.us-west-2.amazonaws.com/jb-test-strands-agent:latest make t K=bedrockagentcore T=TestAccBedrockAgentCoreAgentRuntime_authorizerConfiguration
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 tmp1 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/bedrockagentcore/... -v -count 1 -parallel 20 -run='TestAccBedrockAgentCoreAgentRuntime_authorizerConfiguration'  -timeout 360m -vet=off
2026/03/09 15:01:36 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/09 15:01:36 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccBedrockAgentCoreAgentRuntime_authorizerConfiguration (50.97s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore   57.866s
```

```console
% AWS_BEDROCK_AGENTCORE_RUNTIME_IMAGE_V1_URI=<redacted>.dkr.ecr.us-west-2.amazonaws.com/jb-test-strands-agent:latest make t K=bedrockagentcore T=TestAccBedrockAgentCoreAgentRuntime_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-bedrockagentcore-runtime-allowed_scopes 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/bedrockagentcore/... -v -count 1 -parallel 20 -run='TestAccBedrockAgentCoreAgentRuntime_'  -timeout 360m -vet=off
2026/03/09 15:16:55 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/09 15:16:55 Initializing Terraform AWS Provider (SDKv2-style)...

=== CONT  TestAccBedrockAgentCoreAgentRuntime_disappears
    agent_runtime_test.go:82: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: deleting Bedrock AgentCore Agent Runtime

        ID: tf_acc_test_5243252872440332914-gyGAk16Fbk
        Cause: operation error Bedrock AgentCore Control: DeleteAgentRuntime, ,
        AccessDeniedException: User:
        arn:aws:sts::<redacted>:assumed-role/<redacted>
        is not authorized to perform: bedrock-agentcore:DeleteAgentRuntime"

--- FAIL: TestAccBedrockAgentCoreAgentRuntime_disappears (40.19s)
--- PASS: TestAccBedrockAgentCoreAgentRuntime_basic (42.49s)
--- PASS: TestAccBedrockAgentCoreAgentRuntime_description (55.23s)
--- PASS: TestAccBedrockAgentCoreAgentRuntime_protocolConfiguration (55.38s)
--- PASS: TestAccBedrockAgentCoreAgentRuntime_authorizerConfiguration (56.86s)
--- PASS: TestAccBedrockAgentCoreAgentRuntime_environmentVariables (58.32s)
--- PASS: TestAccBedrockAgentCoreAgentRuntime_tags (341.97s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore   348.822s
```

Note: the `_disappears` test is failing persistently during post-test destroy. However, I'm hesitant to add handling for what seems to be an incorrect, or at least misleading, permissions error. My role does have `bedrock-agentcore:DeleteAgentRuntime` as evidenced by the other passing tests, and typically this would be a "NotFound" error that is handled gracefully by the `CheckDestroy` function. Perhaps there is some eventual consistency at play here following the initial runtime destruction that should be accounted for, but without further investigation I'm not going make changes at this time.