### PR TITLE
New ephemeral resource `aws_credentials`

### DIFF
--- a/.changelog/46830.txt
+++ b/.changelog/46830.txt
@@ -1,0 +1,3 @@
+```release-note:new-ephemeral
+aws_credentials
+```

--- a/internal/service/meta/credentials_ephemeral.go
+++ b/internal/service/meta/credentials_ephemeral.go
@@ -1,0 +1,75 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package meta
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+)
+
+// Function annotations are used for ephemeral registration to the Provider. DO NOT EDIT.
+// @EphemeralResource(aws_credentials, name="Credentials")
+func newEphemeralCredentials(_ context.Context) (ephemeral.EphemeralResourceWithConfigure, error) {
+	return &ephemeralCredentials{}, nil
+}
+
+type ephemeralCredentials struct {
+	framework.EphemeralResourceWithModel[ephemeralCredentialsModel]
+}
+
+func (e *ephemeralCredentials) Schema(ctx context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"access_key_id": schema.StringAttribute{
+				Computed:  true,
+				Sensitive: true,
+			},
+			"secret_access_key": schema.StringAttribute{
+				Computed:  true,
+				Sensitive: true,
+			},
+			"session_token": schema.StringAttribute{
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func (e *ephemeralCredentials) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+	var data ephemeralCredentialsModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	credentialsProvider := e.Meta().CredentialsProvider(ctx)
+	if credentialsProvider == nil {
+		resp.Diagnostics.AddError("Missing Credentials Provider", "No AWS credentials provider is configured.")
+		return
+	}
+
+	creds, err := credentialsProvider.Retrieve(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to Retrieve Credentials", err.Error())
+		return
+	}
+
+	data.AccessKeyID = types.StringValue(creds.AccessKeyID)
+	data.SecretAccessKey = types.StringValue(creds.SecretAccessKey)
+	data.SessionToken = types.StringValue(creds.SessionToken)
+
+	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
+}
+
+type ephemeralCredentialsModel struct {
+	framework.WithRegionModel
+	AccessKeyID     types.String `tfsdk:"access_key_id"`
+	SecretAccessKey types.String `tfsdk:"secret_access_key"`
+	SessionToken    types.String `tfsdk:"session_token"`
+}

--- a/internal/service/meta/credentials_ephemeral_test.go
+++ b/internal/service/meta/credentials_ephemeral_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package meta_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfmeta "github.com/hashicorp/terraform-provider-aws/internal/service/meta"
+)
+
+func TestAccCredentialsEphemeral_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	echoResourceName := "echo.test"
+	dataPath := tfjsonpath.New("data")
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck: acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories(ctx, acctest.ProviderNameEcho),
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCredentialsEphemeralConfig_basic(),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(echoResourceName, dataPath.AtMapKey("access_key_id"), knownvalue.StringRegexp(regexache.MustCompile(`^A[KS]IA[0-7A-Z]{16}$`))),
+					statecheck.ExpectKnownValue(echoResourceName, dataPath.AtMapKey("secret_access_key"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(echoResourceName, dataPath.AtMapKey("session_token"), knownvalue.NotNull()),
+				},
+			},
+		},
+	})
+}
+
+func TestAccCredentialsEphemeral_region(t *testing.T) {
+	ctx := acctest.Context(t)
+	echoResourceName := "echo.test"
+	dataPath := tfjsonpath.New("data")
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck: acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories(ctx, acctest.ProviderNameEcho),
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCredentialsEphemeralConfig_region(),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(echoResourceName, dataPath.AtMapKey("access_key_id"), knownvalue.StringRegexp(regexache.MustCompile(`^A[KS]IA[0-7A-Z]{16}$`))),
+					statecheck.ExpectKnownValue(echoResourceName, dataPath.AtMapKey("secret_access_key"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(echoResourceName, dataPath.AtMapKey("session_token"), knownvalue.NotNull()),
+				},
+			},
+		},
+	})
+}
+
+func testAccCredentialsEphemeralConfig_basic() string {
+	return acctest.ConfigCompose(
+		acctest.ConfigWithEchoProvider("ephemeral.aws_credentials.test"),
+		`
+ephemeral "aws_credentials" "test" {}
+`)
+}
+
+func testAccCredentialsEphemeralConfig_region() string {
+	return acctest.ConfigCompose(
+		acctest.ConfigWithEchoProvider("ephemeral.aws_credentials.test"),
+		fmt.Sprintf(`
+ephemeral "aws_credentials" "test" {
+  region = %[1]q
+}
+`, acctest.Region()))
+}

--- a/internal/service/meta/service_package_gen.go
+++ b/internal/service/meta/service_package_gen.go
@@ -14,6 +14,17 @@ import (
 
 type servicePackage struct{}
 
+func (p *servicePackage) EphemeralResources(ctx context.Context) []*inttypes.ServicePackageEphemeralResource {
+	return []*inttypes.ServicePackageEphemeralResource{
+		{
+			Factory:  newEphemeralCredentials,
+			TypeName: "aws_credentials",
+			Name:     "Credentials",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+	}
+}
+
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
 	return []*inttypes.ServicePackageFrameworkDataSource{
 		{

--- a/website/docs/ephemeral-resources/meta_credentials.html.markdown
+++ b/website/docs/ephemeral-resources/meta_credentials.html.markdown
@@ -1,0 +1,35 @@
+---
+subcategory: "Meta Data Sources"
+layout: "aws"
+page_title: "AWS: aws_credentials"
+description: |-
+  Retrieve the current AWS SDK session credentials.
+---
+
+# Ephemeral: aws_credentials
+
+Retrieve the current AWS SDK session credentials configured in the provider.
+
+~> **NOTE:** Ephemeral resources are a new feature and may evolve as we continue to explore their most effective uses. [Learn more](https://developer.hashicorp.com/terraform/language/resources/ephemeral).
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+ephemeral "aws_credentials" "example" {}
+```
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `access_key_id` - AWS access key ID for the current session credentials.
+* `secret_access_key` - AWS secret access key for the current session credentials.
+* `session_token` - AWS session token for the current session credentials. Empty if the credentials are not temporary.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

The new ephemeral resource `aws_credentials` exposes the session credentials configured by the AWS provider so that they can be used directly in other contexts. Ephemeral resources are not stored in the state and all the credential attributes are marked as sensitive. Arguably this offers a net security benefit because it provides a consistent way to securely pass AWS session credentials to other processes (such as the AWS CLI invoked as a local-exec provisioner), whereas at present those processes need to be passed credentials in a less secure way (e.g. through module inputs). 

### Description
Implement a new ephemeral resource `aws_credentials` to access the session credentials that the AWS provider is currently configured to use (optionally for a specific region).

### Relations
Closes #46739

### References
- https://github.com/hashicorp/terraform-provider-aws/pull/10694
- https://github.com/hashicorp/terraform-provider-aws/pull/8517
- https://github.com/hashicorp/terraform-provider-aws/issues/8242

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccCredentialsEphemeral PKG=meta
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-new-ephemeral-aws_credentials 🌿...
TF_ACC=1 go1.25.7 test ./internal/service/meta/... -v -count 1 -parallel 20 -run='TestAccCredentialsEphemeral'  -timeout 360m -vet=off
2026/03/09 21:30:24 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/09 21:30:24 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCredentialsEphemeral_basic
=== PAUSE TestAccCredentialsEphemeral_basic
=== RUN   TestAccCredentialsEphemeral_region
=== PAUSE TestAccCredentialsEphemeral_region
=== CONT  TestAccCredentialsEphemeral_basic
=== CONT  TestAccCredentialsEphemeral_region
--- PASS: TestAccCredentialsEphemeral_region (23.67s)
--- PASS: TestAccCredentialsEphemeral_basic (24.42s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	37.841s
```
