### PR TITLE
ec2: final `go-vcr` compatible helper cleanup

### DIFF
--- a/.ci/semgrep/acctest/vcr/random.yml
+++ b/.ci/semgrep/acctest/vcr/random.yml
@@ -15,7 +15,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/ec2"
         - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"
 
@@ -32,7 +31,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/ec2"
         - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"
 
@@ -49,7 +47,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/ec2"
         - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"
 
@@ -66,7 +63,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/ec2"
         - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"
 
@@ -83,7 +79,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/ec2"
         - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"
 
@@ -100,7 +95,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/ec2"
         - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"
 
@@ -117,6 +111,5 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/ec2"
         - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"

--- a/.ci/semgrep/acctest/vcr/test.yml
+++ b/.ci/semgrep/acctest/vcr/test.yml
@@ -15,7 +15,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/ec2"
         - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"
 
@@ -32,7 +31,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/ec2"
         - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"
 
@@ -49,6 +47,5 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/ec2"
         - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"

--- a/internal/service/ec2/verifiedaccess_group_test.go
+++ b/internal/service/ec2/verifiedaccess_group_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -104,7 +103,7 @@ func testAccVerifiedAccessGroup_updateKMS(t *testing.T, semaphore tfsync.Semapho
 	resourceName := "aws_verifiedaccess_group.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	policyDoc := "permit(principal, action, resource) \nwhen {\ncontext.http_request.method == \"GET\"\n};"
-	description := sdkacctest.RandString(100)
+	description := acctest.RandString(t, 100)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -242,7 +241,7 @@ func testAccVerifiedAccessGroup_policy(t *testing.T, semaphore tfsync.Semaphore)
 	var v awstypes.VerifiedAccessGroup
 	resourceName := "aws_verifiedaccess_group.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	description := sdkacctest.RandString(100)
+	description := acctest.RandString(t, 100)
 	policyDoc := "permit(principal, action, resource) \nwhen {\ncontext.http_request.method == \"GET\"\n};"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -278,7 +277,7 @@ func testAccVerifiedAccessGroup_updatePolicy(t *testing.T, semaphore tfsync.Sema
 	var v awstypes.VerifiedAccessGroup
 	resourceName := "aws_verifiedaccess_group.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	description := sdkacctest.RandString(100)
+	description := acctest.RandString(t, 100)
 	policyDoc := "permit(principal, action, resource) \nwhen {\ncontext.http_request.method == \"GET\"\n};"
 	policyDocUpdate := "permit(principal, action, resource) \nwhen {\ncontext.http_request.method == \"POST\"\n};"
 
@@ -328,7 +327,7 @@ func testAccVerifiedAccessGroup_setPolicy(t *testing.T, semaphore tfsync.Semapho
 	var v awstypes.VerifiedAccessGroup
 	resourceName := "aws_verifiedaccess_group.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	description := sdkacctest.RandString(100)
+	description := acctest.RandString(t, 100)
 	policyDoc := "permit(principal, action, resource) \nwhen {\ncontext.http_request.method == \"GET\"\n};"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/ec2/verifiedaccess_trust_provider_test.go
+++ b/internal/service/ec2/verifiedaccess_trust_provider_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -26,7 +25,7 @@ func TestAccVerifiedAccessTrustProvider_basic(t *testing.T) {
 
 	trustProviderType := "user"
 	userTrustProviderType := "iam-identity-center"
-	description := sdkacctest.RandString(10)
+	description := acctest.RandString(t, 10)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -66,7 +65,7 @@ func TestAccVerifiedAccessTrustProvider_deviceOptions(t *testing.T) {
 
 	trustProviderType := "device"
 	deviceTrustProviderType := "jamf"
-	tenantId := sdkacctest.RandString(10)
+	tenantId := acctest.RandString(t, 10)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -105,7 +104,7 @@ func TestAccVerifiedAccessTrustProvider_disappears(t *testing.T) {
 
 	trustProviderType := "user"
 	userTrustProviderType := "iam-identity-center"
-	description := sdkacctest.RandString(10)
+	description := acctest.RandString(t, 10)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -138,10 +137,10 @@ func TestAccVerifiedAccessTrustProvider_oidcOptions(t *testing.T) {
 	trustProviderType := "user"
 	userTrustProviderType := "oidc"
 	authorizationEndpoint := "https://authorization.example.com"
-	clientId := sdkacctest.RandString(10)
-	clientSecret := sdkacctest.RandString(10)
+	clientId := acctest.RandString(t, 10)
+	clientSecret := acctest.RandString(t, 10)
 	issuer := "https://issuer.example.com"
-	scope := sdkacctest.RandString(10)
+	scope := acctest.RandString(t, 10)
 	tokenEndpoint := "https://token.example.com"
 	userInfoEndpoint := "https://user.example.com"
 
@@ -188,7 +187,7 @@ func TestAccVerifiedAccessTrustProvider_tags(t *testing.T) {
 
 	trustProviderType := "user"
 	userTrustProviderType := "iam-identity-center"
-	description := sdkacctest.RandString(10)
+	description := acctest.RandString(t, 10)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/ec2/vpc_endpoint_test.go
+++ b/internal/service/ec2/vpc_endpoint_test.go
@@ -13,7 +13,6 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -1631,7 +1630,7 @@ func TestAccVPCEndpoint_interfacePrivateDNS(t *testing.T) {
 	ctx := acctest.Context(t)
 	var endpoint awstypes.VpcEndpoint
 	resourceName := "aws_vpc_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/ec2/vpc_traffic_mirror_session_test.go
+++ b/internal/service/ec2/vpc_traffic_mirror_session_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -28,7 +27,7 @@ func TestAccVPCTrafficMirrorSession_basic(t *testing.T) {
 	resourceName := "aws_ec2_traffic_mirror_session.test"
 	description := "test session"
 	session := acctest.RandIntRange(t, 1, 32766)
-	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(10))
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(t, 10))
 	pLen := acctest.RandIntRange(t, 1, 255)
 	vni := acctest.RandIntRange(t, 1, 16777216)
 
@@ -91,7 +90,7 @@ func TestAccVPCTrafficMirrorSession_tags(t *testing.T) {
 	var v awstypes.TrafficMirrorSession
 	resourceName := "aws_ec2_traffic_mirror_session.test"
 	session := acctest.RandIntRange(t, 1, 32766)
-	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(10))
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(t, 10))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -141,7 +140,7 @@ func TestAccVPCTrafficMirrorSession_disappears(t *testing.T) {
 	var v awstypes.TrafficMirrorSession
 	resourceName := "aws_ec2_traffic_mirror_session.test"
 	session := acctest.RandIntRange(t, 1, 32766)
-	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(10))
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(t, 10))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -169,7 +168,7 @@ func TestAccVPCTrafficMirrorSession_updateTrafficMirrorTarget(t *testing.T) {
 	var v1, v2 awstypes.TrafficMirrorSession
 	resourceName := "aws_ec2_traffic_mirror_session.test"
 	session := acctest.RandIntRange(t, 1, 32766)
-	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(10))
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(t, 10))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/ec2/vpc_traffic_mirror_target_test.go
+++ b/internal/service/ec2/vpc_traffic_mirror_target_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -25,7 +24,7 @@ func TestAccVPCTrafficMirrorTarget_nlb(t *testing.T) {
 	var v awstypes.TrafficMirrorTarget
 	resourceName := "aws_ec2_traffic_mirror_target.test"
 	description := "test nlb target"
-	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(10))
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(t, 10))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -60,7 +59,7 @@ func TestAccVPCTrafficMirrorTarget_eni(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.TrafficMirrorTarget
 	resourceName := "aws_ec2_traffic_mirror_target.test"
-	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(10))
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(t, 10))
 	description := "test eni target"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -94,7 +93,7 @@ func TestAccVPCTrafficMirrorTarget_tags(t *testing.T) {
 	var v awstypes.TrafficMirrorTarget
 	resourceName := "aws_ec2_traffic_mirror_target.test"
 	description := "test nlb target"
-	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(10))
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(t, 10))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -144,7 +143,7 @@ func TestAccVPCTrafficMirrorTarget_disappears(t *testing.T) {
 	var v awstypes.TrafficMirrorTarget
 	resourceName := "aws_ec2_traffic_mirror_target.test"
 	description := "test nlb target"
-	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(10))
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(t, 10))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -170,7 +169,7 @@ func TestAccVPCTrafficMirrorTarget_disappears(t *testing.T) {
 func TestAccVPCTrafficMirrorTarget_gwlb(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ec2_traffic_mirror_target.test"
-	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(10))
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(t, 10))
 	description := "test gwlb endpoint target"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/ec2/vpnsite_connection_test.go
+++ b/internal/service/ec2/vpnsite_connection_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -748,7 +747,7 @@ func TestAccSiteVPNConnection_tunnelOptions(t *testing.T) {
 				ExpectError: regexache.MustCompile(`expected length of \w+ to be in the range \(8 - 64\)`),
 			},
 			{
-				Config:      testAccVPNConnectionConfig_singleTunnelOptions(rName, rBgpAsn, sdkacctest.RandStringFromCharSet(65, sdkacctest.CharSetAlpha), "169.254.254.0/30"),
+				Config:      testAccVPNConnectionConfig_singleTunnelOptions(rName, rBgpAsn, acctest.RandStringFromCharSet(t, 65, acctest.CharSetAlpha), "169.254.254.0/30"),
 				ExpectError: regexache.MustCompile(`expected length of \w+ to be in the range \(8 - 64\)`),
 			},
 			{

--- a/internal/service/ec2/vpnsite_customer_gateway_test.go
+++ b/internal/service/ec2/vpnsite_customer_gateway_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/YakDriver/regexache"
 	acmpca_types "github.com/aws/aws-sdk-go-v2/service/acmpca/types"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -226,7 +225,7 @@ func TestAccSiteVPNCustomerGateway_certificate(t *testing.T) {
 	acmSubordinateCAResourceName := "aws_acmpca_certificate_authority.test"
 	acmCertificateResourceName := "aws_acm_certificate.test"
 	rootDomain := acctest.RandomDomainName()
-	subDomain := fmt.Sprintf("%s.%s", sdkacctest.RandString(8), rootDomain)
+	subDomain := fmt.Sprintf("%s.%s", acctest.RandString(t, 8), rootDomain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },


### PR DESCRIPTION



<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Removes the Go-VCR semgrep rule exclusions for `internal/service/ec2` and tidies up the last few remaining references to Plugin SDK test helpers.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/25602
Relates https://github.com/hashicorp/terraform-provider-aws/issues/43717
Relates #46717


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% go test ./internal/service/ec2/...
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        11.119s
```
