### PR TITLE
networkflowmonitor: enable `go-vcr` support

### DIFF
--- a/.ci/semgrep/acctest/vcr/random.yml
+++ b/.ci/semgrep/acctest/vcr/random.yml
@@ -15,7 +15,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"
 
   - id: use-acctest-randint
@@ -31,7 +30,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"
 
   - id: use-acctest-randintrange
@@ -47,7 +45,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"
 
   - id: use-acctest-randstring
@@ -63,7 +60,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"
 
   - id: use-acctest-randstringfromcharset
@@ -79,7 +75,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"
 
   - id: use-acctest-charsetalpha
@@ -95,7 +90,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"
 
   - id: use-acctest-charsetalphanum
@@ -111,5 +105,4 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"

--- a/.ci/semgrep/acctest/vcr/test.yml
+++ b/.ci/semgrep/acctest/vcr/test.yml
@@ -15,7 +15,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"
 
   - id: use-acctest-paralleltest
@@ -31,7 +30,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"
 
   - id: use-acctest-providermeta
@@ -47,5 +45,4 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/networkflowmonitor"
         - "/internal/service/odb"

--- a/internal/service/networkflowmonitor/monitor.go
+++ b/internal/service/networkflowmonitor/monitor.go
@@ -26,7 +26,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
@@ -314,9 +313,8 @@ func findMonitor(ctx context.Context, conn *networkflowmonitor.Client, input *ne
 	output, err := conn.GetMonitor(ctx, input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 
@@ -331,8 +329,8 @@ func findMonitor(ctx context.Context, conn *networkflowmonitor.Client, input *ne
 	return output, nil
 }
 
-func statusMonitor(ctx context.Context, conn *networkflowmonitor.Client, name string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusMonitor(conn *networkflowmonitor.Client, name string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findMonitorByName(ctx, conn, name)
 
 		if retry.NotFound(err) {
@@ -348,10 +346,10 @@ func statusMonitor(ctx context.Context, conn *networkflowmonitor.Client, name st
 }
 
 func waitMonitorCreated(ctx context.Context, conn *networkflowmonitor.Client, name string, timeout time.Duration) (*networkflowmonitor.GetMonitorOutput, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.MonitorStatusPending),
 		Target:  enum.Slice(awstypes.MonitorStatusActive),
-		Refresh: statusMonitor(ctx, conn, name),
+		Refresh: statusMonitor(conn, name),
 		Timeout: timeout,
 	}
 
@@ -365,10 +363,10 @@ func waitMonitorCreated(ctx context.Context, conn *networkflowmonitor.Client, na
 }
 
 func waitMonitorUpdated(ctx context.Context, conn *networkflowmonitor.Client, name string, timeout time.Duration) (*networkflowmonitor.GetMonitorOutput, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.MonitorStatusPending),
 		Target:  enum.Slice(awstypes.MonitorStatusActive),
-		Refresh: statusMonitor(ctx, conn, name),
+		Refresh: statusMonitor(conn, name),
 		Timeout: timeout,
 	}
 
@@ -382,10 +380,10 @@ func waitMonitorUpdated(ctx context.Context, conn *networkflowmonitor.Client, na
 }
 
 func waitMonitorDeleted(ctx context.Context, conn *networkflowmonitor.Client, name string, timeout time.Duration) (*networkflowmonitor.GetMonitorOutput, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.MonitorStatusDeleting),
 		Target:  []string{},
-		Refresh: statusMonitor(ctx, conn, name),
+		Refresh: statusMonitor(conn, name),
 		Timeout: timeout,
 	}
 

--- a/internal/service/networkflowmonitor/monitor_test.go
+++ b/internal/service/networkflowmonitor/monitor_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/networkflowmonitor"
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfnetworkflowmonitor "github.com/hashicorp/terraform-provider-aws/internal/service/networkflowmonitor"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -27,10 +25,10 @@ import (
 
 func testAccMonitor_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_networkflowmonitor_monitor.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartition(t, endpoints.AwsPartitionID)
@@ -38,12 +36,12 @@ func testAccMonitor_basic(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkFlowMonitorServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMonitorDestroy(ctx),
+		CheckDestroy:             testAccCheckMonitorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMonitorConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMonitorExists(ctx, resourceName),
+					testAccCheckMonitorExists(ctx, t, resourceName),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -69,10 +67,10 @@ func testAccMonitor_basic(t *testing.T) {
 
 func testAccMonitor_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_networkflowmonitor_monitor.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartition(t, endpoints.AwsPartitionID)
@@ -80,12 +78,12 @@ func testAccMonitor_disappears(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkFlowMonitorServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMonitorDestroy(ctx),
+		CheckDestroy:             testAccCheckMonitorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMonitorConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMonitorExists(ctx, resourceName),
+					testAccCheckMonitorExists(ctx, t, resourceName),
 					acctest.CheckFrameworkResourceDisappears(ctx, t, tfnetworkflowmonitor.ResourceMonitor, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -104,22 +102,22 @@ func testAccMonitor_disappears(t *testing.T) {
 
 func testAccMonitor_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_networkflowmonitor_monitor.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkFlowMonitorServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMonitorDestroy(ctx),
+		CheckDestroy:             testAccCheckMonitorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMonitorConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMonitorExists(ctx, resourceName),
+					testAccCheckMonitorExists(ctx, t, resourceName),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -143,7 +141,7 @@ func testAccMonitor_tags(t *testing.T) {
 			{
 				Config: testAccMonitorConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMonitorExists(ctx, resourceName),
+					testAccCheckMonitorExists(ctx, t, resourceName),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -160,7 +158,7 @@ func testAccMonitor_tags(t *testing.T) {
 			{
 				Config: testAccMonitorConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMonitorExists(ctx, resourceName),
+					testAccCheckMonitorExists(ctx, t, resourceName),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -179,22 +177,22 @@ func testAccMonitor_tags(t *testing.T) {
 
 func testAccMonitor_update(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_networkflowmonitor_monitor.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkFlowMonitorServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMonitorDestroy(ctx),
+		CheckDestroy:             testAccCheckMonitorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMonitorConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMonitorExists(ctx, resourceName),
+					testAccCheckMonitorExists(ctx, t, resourceName),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -209,7 +207,7 @@ func testAccMonitor_update(t *testing.T) {
 			{
 				Config: testAccMonitorConfig_updated1(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMonitorExists(ctx, resourceName),
+					testAccCheckMonitorExists(ctx, t, resourceName),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -224,7 +222,7 @@ func testAccMonitor_update(t *testing.T) {
 			{
 				Config: testAccMonitorConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMonitorExists(ctx, resourceName),
+					testAccCheckMonitorExists(ctx, t, resourceName),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -239,7 +237,7 @@ func testAccMonitor_update(t *testing.T) {
 			{
 				Config: testAccMonitorConfig_updated2(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMonitorExists(ctx, resourceName),
+					testAccCheckMonitorExists(ctx, t, resourceName),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -255,14 +253,14 @@ func testAccMonitor_update(t *testing.T) {
 	})
 }
 
-func testAccCheckMonitorExists(ctx context.Context, n string) resource.TestCheckFunc {
+func testAccCheckMonitorExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).NetworkFlowMonitorClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).NetworkFlowMonitorClient(ctx)
 
 		_, err := tfnetworkflowmonitor.FindMonitorByName(ctx, conn, rs.Primary.Attributes["monitor_name"])
 
@@ -270,9 +268,9 @@ func testAccCheckMonitorExists(ctx context.Context, n string) resource.TestCheck
 	}
 }
 
-func testAccCheckMonitorDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckMonitorDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).NetworkFlowMonitorClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).NetworkFlowMonitorClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_networkflowmonitor_monitor" {
@@ -486,7 +484,7 @@ resource "aws_networkflowmonitor_monitor" "test" {
 }
 
 func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).NetworkFlowMonitorClient(ctx)
+	conn := acctest.ProviderMeta(ctx, t).NetworkFlowMonitorClient(ctx)
 
 	input := networkflowmonitor.ListMonitorsInput{}
 

--- a/internal/service/networkflowmonitor/scope.go
+++ b/internal/service/networkflowmonitor/scope.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
@@ -305,8 +304,8 @@ func findScope(ctx context.Context, conn *networkflowmonitor.Client, input *netw
 	output, err := conn.GetScope(ctx, input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 
@@ -321,8 +320,8 @@ func findScope(ctx context.Context, conn *networkflowmonitor.Client, input *netw
 	return output, nil
 }
 
-func statusScope(ctx context.Context, conn *networkflowmonitor.Client, id string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusScope(conn *networkflowmonitor.Client, id string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findScopeByID(ctx, conn, id)
 
 		if retry.NotFound(err) {
@@ -338,10 +337,10 @@ func statusScope(ctx context.Context, conn *networkflowmonitor.Client, id string
 }
 
 func waitScopeCreated(ctx context.Context, conn *networkflowmonitor.Client, id string, timeout time.Duration) (*networkflowmonitor.GetScopeOutput, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.ScopeStatusInProgress),
 		Target:  enum.Slice(awstypes.ScopeStatusSucceeded),
-		Refresh: statusScope(ctx, conn, id),
+		Refresh: statusScope(conn, id),
 		Timeout: timeout,
 	}
 
@@ -355,10 +354,10 @@ func waitScopeCreated(ctx context.Context, conn *networkflowmonitor.Client, id s
 }
 
 func waitScopeUpdated(ctx context.Context, conn *networkflowmonitor.Client, id string, timeout time.Duration) (*networkflowmonitor.GetScopeOutput, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.ScopeStatusInProgress),
 		Target:  enum.Slice(awstypes.ScopeStatusSucceeded),
-		Refresh: statusScope(ctx, conn, id),
+		Refresh: statusScope(conn, id),
 		Timeout: timeout,
 	}
 
@@ -372,10 +371,10 @@ func waitScopeUpdated(ctx context.Context, conn *networkflowmonitor.Client, id s
 }
 
 func waitScopeDeleted(ctx context.Context, conn *networkflowmonitor.Client, id string, timeout time.Duration) (*networkflowmonitor.GetScopeOutput, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.ScopeStatusDeactivating),
 		Target:  []string{},
-		Refresh: statusScope(ctx, conn, id),
+		Refresh: statusScope(conn, id),
 		Timeout: timeout,
 	}
 

--- a/internal/service/networkflowmonitor/scope_test.go
+++ b/internal/service/networkflowmonitor/scope_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfnetworkflowmonitor "github.com/hashicorp/terraform-provider-aws/internal/service/networkflowmonitor"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -28,7 +27,7 @@ func testAccScope_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkflowmonitor_scope.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartition(t, endpoints.AwsPartitionID)
@@ -36,12 +35,12 @@ func testAccScope_basic(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkFlowMonitorServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckScopeDestroy(ctx),
+		CheckDestroy:             testAccCheckScopeDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccScopeConfig_basic(acctest.Region()),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckScopeExists(ctx, resourceName),
+					testAccCheckScopeExists(ctx, t, resourceName),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -70,7 +69,7 @@ func testAccScope_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkflowmonitor_scope.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartition(t, endpoints.AwsPartitionID)
@@ -78,12 +77,12 @@ func testAccScope_disappears(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkFlowMonitorServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckScopeDestroy(ctx),
+		CheckDestroy:             testAccCheckScopeDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccScopeConfig_basic(endpoints.UsWest2RegionID),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScopeExists(ctx, resourceName),
+					testAccCheckScopeExists(ctx, t, resourceName),
 					acctest.CheckFrameworkResourceDisappears(ctx, t, tfnetworkflowmonitor.ResourceScope, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -104,7 +103,7 @@ func testAccScope_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkflowmonitor_scope.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartition(t, endpoints.AwsPartitionID)
@@ -112,12 +111,12 @@ func testAccScope_tags(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkFlowMonitorServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckScopeDestroy(ctx),
+		CheckDestroy:             testAccCheckScopeDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccScopeConfig_tags1(acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScopeExists(ctx, resourceName),
+					testAccCheckScopeExists(ctx, t, resourceName),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -140,7 +139,7 @@ func testAccScope_tags(t *testing.T) {
 			{
 				Config: testAccScopeConfig_tags2(acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScopeExists(ctx, resourceName),
+					testAccCheckScopeExists(ctx, t, resourceName),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -157,7 +156,7 @@ func testAccScope_tags(t *testing.T) {
 			{
 				Config: testAccScopeConfig_tags1(acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScopeExists(ctx, resourceName),
+					testAccCheckScopeExists(ctx, t, resourceName),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -174,14 +173,14 @@ func testAccScope_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckScopeExists(ctx context.Context, n string) resource.TestCheckFunc {
+func testAccCheckScopeExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).NetworkFlowMonitorClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).NetworkFlowMonitorClient(ctx)
 
 		_, err := tfnetworkflowmonitor.FindScopeByID(ctx, conn, rs.Primary.Attributes["scope_id"])
 
@@ -189,9 +188,9 @@ func testAccCheckScopeExists(ctx context.Context, n string) resource.TestCheckFu
 	}
 }
 
-func testAccCheckScopeDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckScopeDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).NetworkFlowMonitorClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).NetworkFlowMonitorClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_networkflowmonitor_scope" {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Enables go-vcr for the `networkflowmonitor` service.


**AI Disclosure:** AI agents were used to execute the migration workflow and run tests. All code changes and test results were subsequently hand reviewed for correctness.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/25602
Relates https://github.com/hashicorp/terraform-provider-aws/issues/43717

