### PR TITLE
docs: remove documentation for not supported argument in aws_apigatewayv2_routing_rule

### DIFF
--- a/website/docs/r/apigatewayv2_routing_rule.html.markdown
+++ b/website/docs/r/apigatewayv2_routing_rule.html.markdown
@@ -50,7 +50,6 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `domain_name_id` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
 * `priority` - (Optional) The order of rule evaluation. Priority is evaluated from the lowest value to the highest value. Rules can't have the same priority. Value must be between 1 and 1,000,000.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.


### Description

Remove the optional argument [`domain_name_id`](https://registry.terraform.io/providers/-/aws/latest/docs/resources/apigatewayv2_routing_rule#domain_name_id-1) of resource [`aws_apigatewayv2_routing_rule`](https://registry.terraform.io/providers/-/aws/latest/docs/resources/apigatewayv2_routing_rule)


- The argument was added during the initial development of the resource and  documentation. 
- As part of the pull request review the argument was removed from code/ schema, but not from the documentation.

### Relations

n.a.

### References

- [Pull request](https://github.com/hashicorp/terraform-provider-aws/pull/42961) that added the new resource & documentation
- [Pull request update](https://github.com/hashicorp/terraform-provider-aws/pull/42961/changes/b9671b3598bb8dc3b17ba841acefd7b09eef6a3d) showing the removal of  `domain_name_id` from the schema

### Output from Acceptance Testing

Not applicable. Only documentation is updated.