### PR TITLE
fix(iot): allow substitution templates in cloudwatch_metric metric_timestamp

### DIFF
--- a/.changelog/45375.txt
+++ b/.changelog/45375.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iot_topic_rule: Remove `ValidUTCTimestamp` validation from `cloudwatch_metric.metric_timestamp` to allow IoT substitution templates (e.g., `${timestamp()}`)
+```

--- a/internal/service/iot/topic_rule.go
+++ b/internal/service/iot/topic_rule.go
@@ -150,7 +150,6 @@ func resourceTopicRule() *schema.Resource {
 							"metric_timestamp": {
 								Type:         schema.TypeString,
 								Optional:     true,
-								ValidateFunc: verify.ValidUTCTimestamp,
 							},
 							"metric_unit": {
 								Type:     schema.TypeString,
@@ -361,7 +360,6 @@ func resourceTopicRule() *schema.Resource {
 										"metric_timestamp": {
 											Type:         schema.TypeString,
 											Optional:     true,
-											ValidateFunc: verify.ValidUTCTimestamp,
 										},
 										"metric_unit": {
 											Type:     schema.TypeString,


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. This PR only removes a client-side validation function that was incorrectly rejecting valid AWS IoT substitution template expressions.

### Description

Removes the `ValidUTCTimestamp` validation from the `metric_timestamp` field in `aws_iot_topic_rule`'s `cloudwatch_metric` action.

The AWS IoT Rules Engine supports [substitution templates](https://docs.aws.amazon.com/iot/latest/developerguide/iot-substitution-templates.html) in `metric_timestamp` (e.g., `${timestamp()}`), as documented in the [CloudWatch Metrics rule action reference](https://docs.aws.amazon.com/iot/latest/developerguide/cloudwatch-metrics-rule-action.html). However, the client-side `ValidUTCTimestamp` validator rejects any value that isn't a strict UTC timestamp string, causing deployments to fail when users pass valid substitution template expressions.

The fix removes the client-side validation and relies on the AWS API's own validation, which correctly accepts both UTC timestamps and substitution templates.

### Relations

Closes #45375

### References

- [CloudWatch Metrics rule action](https://docs.aws.amazon.com/iot/latest/developerguide/cloudwatch-metrics-rule-action.html) -- confirms `metricTimestamp` supports substitution templates
- [IoT SQL Substitution Templates](https://docs.aws.amazon.com/iot/latest/developerguide/iot-substitution-templates.html) -- CloudWatch Metrics is listed as one of 22 actions supporting substitution templates
- [CloudwatchMetricAction API](https://docs.aws.amazon.com/iot/latest/apireference/API_CloudwatchMetricAction.html) -- `metricTimestamp` is type String, optional

### Output from Acceptance Testing

Acceptance tests require AWS credentials and IoT infrastructure. The change only removes a client-side validator -- no logic changes to resource CRUD operations. Existing `TestAccIoTTopicRule_cloudWatchMetric` test does not set `metric_timestamp` and is unaffected.