### PR TITLE
resource/aws_instance: fix cpu_options partial update sending only one of CoreCount or ThreadsPerCore

### DIFF
--- a/.changelog/46879.txt
+++ b/.changelog/46879.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_instance: Fix ` MissingParameter: When specifying CpuOptions you must specify both CoreCount and ThreadsPerCore` errors when updating `cpu_options.core_count` or `cpu_options.threads_per_core`
+```

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1993,16 +1993,17 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta an
 				InstanceId: aws.String(d.Id()),
 			}
 
-			if d.HasChange("cpu_options.0.core_count") {
+			// The AWS API requires both CoreCount and ThreadsPerCore to be specified
+			// together when modifying CPU options, so always send both when either changes.
+			// Both attributes are Optional+Computed, so even if only one is in the
+			// configuration, the other will be populated from state (read back from AWS).
+			if d.HasChange("cpu_options.0.core_count") || d.HasChange("cpu_options.0.threads_per_core") {
 				input.CoreCount = aws.Int32(int32(tfMap["core_count"].(int)))
+				input.ThreadsPerCore = aws.Int32(int32(tfMap["threads_per_core"].(int)))
 			}
 
 			if d.HasChange("cpu_options.0.nested_virtualization") {
 				input.NestedVirtualization = awstypes.NestedVirtualizationSpecification(tfMap["nested_virtualization"].(string))
-			}
-
-			if d.HasChange("cpu_options.0.threads_per_core") {
-				input.ThreadsPerCore = aws.Int32(int32(tfMap["threads_per_core"].(int)))
 			}
 
 			_, err := conn.ModifyInstanceCpuOptions(ctx, &input)

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1997,7 +1997,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta an
 			// together when modifying CPU options, so always send both when either changes.
 			// Both attributes are Optional+Computed, so even if only one is in the
 			// configuration, the other will be populated from state (read back from AWS).
-			if d.HasChange("cpu_options.0.core_count") || d.HasChange("cpu_options.0.threads_per_core") {
+			if d.HasChanges("cpu_options.0.core_count", "cpu_options.0.threads_per_core") {
 				input.CoreCount = aws.Int32(int32(tfMap["core_count"].(int)))
 				input.ThreadsPerCore = aws.Int32(int32(tfMap["threads_per_core"].(int)))
 			}

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -4966,6 +4966,122 @@ func TestAccEC2Instance_cpuOptionsCoreThreads(t *testing.T) {
 	})
 }
 
+func TestAccEC2Instance_cpuOptionsCoreCountOnly(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.Instance
+	resourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	var (
+		originalCoreCount      int32 = 2
+		updatedCoreCount       int32 = 3
+		originalThreadsPerCore int32 = 2
+	)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_cpuOptionsCoreThreads(rName, originalCoreCount, originalThreadsPerCore),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, t, resourceName, &v),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("cpu_options"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectPartial(map[string]knownvalue.Check{
+						"core_count":       knownvalue.Int32Exact(originalCoreCount),
+						"threads_per_core": knownvalue.Int32Exact(originalThreadsPerCore),
+					})})),
+				},
+			},
+			{
+				// Update only core_count, keeping threads_per_core the same.
+				// This verifies that the provider sends both CoreCount and ThreadsPerCore
+				// to the AWS API even when only one of them changes.
+				Config: testAccInstanceConfig_cpuOptionsCoreThreads(rName, updatedCoreCount, originalThreadsPerCore),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, t, resourceName, &v),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("cpu_options"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectPartial(map[string]knownvalue.Check{
+						"core_count":       knownvalue.Int32Exact(updatedCoreCount),
+						"threads_per_core": knownvalue.Int32Exact(originalThreadsPerCore),
+					})})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccEC2Instance_cpuOptionsThreadsPerCoreOnly(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.Instance
+	resourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	var (
+		originalCoreCount      int32 = 2
+		originalThreadsPerCore int32 = 2
+		updatedThreadsPerCore  int32 = 1
+	)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_cpuOptionsCoreThreads(rName, originalCoreCount, originalThreadsPerCore),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, t, resourceName, &v),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("cpu_options"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectPartial(map[string]knownvalue.Check{
+						"core_count":       knownvalue.Int32Exact(originalCoreCount),
+						"threads_per_core": knownvalue.Int32Exact(originalThreadsPerCore),
+					})})),
+				},
+			},
+			{
+				// Update only threads_per_core, keeping core_count the same.
+				// This verifies that the provider sends both CoreCount and ThreadsPerCore
+				// to the AWS API even when only one of them changes.
+				Config: testAccInstanceConfig_cpuOptionsCoreThreads(rName, originalCoreCount, updatedThreadsPerCore),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, t, resourceName, &v),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("cpu_options"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectPartial(map[string]knownvalue.Check{
+						"core_count":       knownvalue.Int32Exact(originalCoreCount),
+						"threads_per_core": knownvalue.Int32Exact(updatedThreadsPerCore),
+					})})),
+				},
+			},
+		},
+	})
+}
+
 func TestAccEC2Instance_cpuOptionsCoreThreadsUnspecifiedToSpecified(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fix `aws_instance.cpu_options` update so that changing either `core_count` or `threads_per_core` alone no longer fails with a `MissingParameter` error from the AWS API.

This change:

- sends both `CoreCount` and `ThreadsPerCore` whenever either value changes, using the current state value for the unchanged field
- aligns the update path with the create path (`expandCPUOptions`), which already pairs both fields together
- adds `TestAccEC2Instance_cpuOptionsCoreCountOnly` to verify updating only `core_count` while keeping `threads_per_core` unchanged
- adds `TestAccEC2Instance_cpuOptionsThreadsPerCoreOnly` to verify updating only `threads_per_core` while keeping `core_count` unchanged


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #46821

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

<https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-cpu-options-rules.html>
<https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyInstanceCpuOptions.html>


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS="TestAccEC2Instance_cpuOptionsCoreCountOnly|TestAccEC2Instance_cpuOptionsThreadsPerCoreOnly|TestAccEC2Instance_cpuOptionsCoreThreads" PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Building provider...
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws_instance-cpu_options_partial_update 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Instance_cpuOptionsCoreCountOnly|TestAccEC2Instance_cpuOptionsThreadsPerCoreOnly|TestAccEC2Instance_cpuOptionsCoreThreads'  -timeout 360m -vet=off
2026/03/12 00:20:54 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/12 00:20:54 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEC2Instance_cpuOptionsCoreThreads
=== PAUSE TestAccEC2Instance_cpuOptionsCoreThreads
=== RUN   TestAccEC2Instance_cpuOptionsCoreCountOnly
=== PAUSE TestAccEC2Instance_cpuOptionsCoreCountOnly
=== RUN   TestAccEC2Instance_cpuOptionsThreadsPerCoreOnly
=== PAUSE TestAccEC2Instance_cpuOptionsThreadsPerCoreOnly
=== RUN   TestAccEC2Instance_cpuOptionsCoreThreadsUnspecifiedToSpecified
=== PAUSE TestAccEC2Instance_cpuOptionsCoreThreadsUnspecifiedToSpecified
=== CONT  TestAccEC2Instance_cpuOptionsCoreThreads
=== CONT  TestAccEC2Instance_cpuOptionsThreadsPerCoreOnly
=== CONT  TestAccEC2Instance_cpuOptionsCoreThreadsUnspecifiedToSpecified
=== CONT  TestAccEC2Instance_cpuOptionsCoreCountOnly
--- PASS: TestAccEC2Instance_cpuOptionsCoreThreadsUnspecifiedToSpecified (100.10s)
--- PASS: TestAccEC2Instance_cpuOptionsCoreThreads (136.30s)
--- PASS: TestAccEC2Instance_cpuOptionsThreadsPerCoreOnly (150.18s)
--- PASS: TestAccEC2Instance_cpuOptionsCoreCountOnly (150.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	150.666s

...
```

<details> 
  <summary>AI Usage</summary>
  Claude Opus 4.6 was used to help narrow down the issue and generate boilerplate for acceptance tests.

  Prompt:

    While using latest aws terraform provider I've faced the issue:
    Changing either `cpu_options.core_count` or `cpu_options.threads_per_core` alone fails.
    ```console
    Error: updating EC2 Instance (<INSTANCE_ID>): modifying CPU options: operation error EC2: ModifyInstanceCpuOptions, https response error StatusCode: 400, RequestID: 73c8ae1b-ec4f-4d77-81a3-1a4a8a9c0f46, api error MissingParameter: When specifying CpuOptions you must specify both CoreCount and ThreadsPerCore.
    ```
    
    I have pulled provider code and looking into it, it seems like the first files to look into the issue is ec2_instance_migrate.go and ec2_instance.go
    Also, there are tests for these at ec2_instance_test.go and ec2_instance_migrate_test.go
    
    While you research I'll go ahead and run terraform apply with debug tracing on to get more info on issue
</details>