### PR TITLE
resource/aws_odb_cloud_vm_cluster: Add system_version argument

### DIFF
--- a/.changelog/46880.txt
+++ b/.changelog/46880.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_odb_cloud_vm_cluster: Add `system_version` argument
+```

--- a/internal/service/odb/cloud_vm_cluster.go
+++ b/internal/service/odb/cloud_vm_cluster.go
@@ -370,11 +370,13 @@ func (r *resourceCloudVmCluster) Schema(ctx context.Context, req resource.Schema
 				Description: "The local node storage allocated to the VM cluster, in gigabytes (GB).",
 			},
 			"system_version": schema.StringAttribute{
+				Optional: true,
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),
 				},
-				Description: "The operating system version of the image chosen for the VM cluster.",
+				Description: "The operating system version of the image for the VM cluster. To get the list of valid values, use the ListSystemVersions operation, specifying the GI version and Exadata infrastructure shape. If not specified, the default system version is used. Changing this will create a new resource.",
 			},
 			"scan_listener_port_tcp": schema.Int32Attribute{
 				Computed: true,

--- a/internal/service/odb/cloud_vm_cluster_test.go
+++ b/internal/service/odb/cloud_vm_cluster_test.go
@@ -332,6 +332,44 @@ func TestAccODBCloudVmCluster_usingARN(t *testing.T) {
 	})
 }
 
+func TestAccODBCloudVmCluster_systemVersion(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+	var cloudvmcluster odbtypes.CloudVmCluster
+	vmcClusterDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.vmClusterDisplayNamePrefix)
+	publicKey, _, err := sdkacctest.RandSSHKeyPair(acctest.DefaultEmailAddress)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	resourceName := "aws_odb_cloud_vm_cluster.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			vmClusterTestEntity.testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: vmClusterTestEntity.cloudVmClusterWithSystemVersion(vmcClusterDisplayName, publicKey),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, resourceName, &cloudvmcluster),
+					resource.TestCheckResourceAttr(resourceName, "system_version", "25.1.14.0.0.260206"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccODBCloudVmCluster_variables(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -567,6 +605,49 @@ resource "aws_odb_cloud_vm_cluster" "test" {
     is_diagnostics_events_enabled = true
     is_health_monitoring_enabled  = true
     is_incident_logs_enabled      = true
+  }
+}
+`, exaInfra, odbNet, vmClusterDisplayName, sshKey)
+	return res
+}
+
+func (cloudVmClusterResourceTest) cloudVmClusterWithSystemVersion(vmClusterDisplayName, sshKey string) string {
+	exaInfraDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.exaInfraDisplayNamePrefix)
+	odbNetDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.odbNetDisplayNamePrefix)
+	exaInfra := vmClusterTestEntity.exaInfra(exaInfraDisplayName)
+	odbNet := vmClusterTestEntity.oracleDBNetwork(odbNetDisplayName)
+
+	res := fmt.Sprintf(`
+
+%s
+
+%s
+
+
+data "aws_odb_db_servers" "test" {
+  cloud_exadata_infrastructure_id = aws_odb_cloud_exadata_infrastructure.test.id
+}
+
+resource "aws_odb_cloud_vm_cluster" "test" {
+  display_name                    = %[3]q
+  cloud_exadata_infrastructure_id = aws_odb_cloud_exadata_infrastructure.test.id
+  cpu_core_count                  = 6
+  gi_version                      = "23.0.0.0"
+  hostname_prefix                 = "apollo12"
+  ssh_public_keys                 = ["%[4]s"]
+  odb_network_id                  = aws_odb_network.test.id
+  is_local_backup_enabled         = true
+  is_sparse_diskgroup_enabled     = true
+  license_model                   = "LICENSE_INCLUDED"
+  data_storage_size_in_tbs        = 20.0
+  db_servers                      = [for db_server in data.aws_odb_db_servers.test.db_servers : db_server.id]
+  db_node_storage_size_in_gbs     = 120.0
+  memory_size_in_gbs              = 60
+  system_version                  = "25.1.14.0.0.260206"
+  data_collection_options {
+    is_diagnostics_events_enabled = false
+    is_health_monitoring_enabled  = false
+    is_incident_logs_enabled      = false
   }
 }
 `, exaInfra, odbNet, vmClusterDisplayName, sshKey)

--- a/website/docs/r/odb_cloud_vm_cluster.html.markdown
+++ b/website/docs/r/odb_cloud_vm_cluster.html.markdown
@@ -58,6 +58,7 @@ resource "aws_odb_cloud_vm_cluster" "with_all_parameters" {
   cluster_name                    = "julia-13"
   timezone                        = "UTC"
   scan_listener_port_tcp          = 1521
+  system_version                  = "25.1.14.0.0.260206"
   tags = {
     "env" = "dev"
   }
@@ -95,6 +96,7 @@ The following arguments are optional:
 * `license_model` - (Optional) The Oracle license model to apply to the VM cluster. Default: LICENSE_INCLUDED. Changing this will create a new resource.
 * `memory_size_in_gbs` - (Optional) The amount of memory, in gigabytes (GBs), to allocate for the VM cluster. Changing this will create a new resource.
 * `scan_listener_port_tcp` - (Optional) The port number for TCP connections to the single client access name (SCAN) listener. Valid values: 1024–8999, except 2484, 6100, 6200, 7060, 7070, 7085, and 7879. Default: 1521. Changing this will create a new resource.
+* `system_version` - (Optional) The operating system version of the image for the VM cluster. To get the list of valid values, use the `ListSystemVersions` operation, specifying the GI version and Exadata infrastructure shape. If not specified, the default system version is used. Changing this will create a new resource.
 * `timezone` - (Optional) The configured time zone of the VM cluster. Changing this will create a new resource.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `tags` - (Optional) A map of tags to assign to the exadata infrastructure. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
@@ -123,7 +125,6 @@ This data source exports the following attributes in addition to the arguments a
 * `status` - The current lifecycle status of the VM cluster.
 * `status_reason` - Additional information regarding the current status of the VM cluster.
 * `storage_size_in_gbs` - The local node storage allocated to the VM cluster, in gigabytes (GB).
-* `system_version` - The operating system version of the image chosen for the VM cluster.
 * `vip_ids` - The virtual IP (VIP) addresses assigned to the VM cluster. CRS assigns one VIP per node for failover support.
 * `created_at` - The timestamp when the VM cluster was created.
 * `gi_version_computed` - A complete software version of Oracle Grid Infrastructure (GI).


### PR DESCRIPTION
Closes #46880

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
TF_ACC=1 go test ./internal/service/odb/... -v -count 1 -parallel 2

0 -run='TestAccODBCloudVmCluster_systemVersion' -short -timeout 360m

2026/03/11 21:26:44 Creating Terraform AWS Provider (SDKv2-style)...

2026/03/11 21:26:44 Initializing Terraform AWS Provider (SDKv2-style)...

=== RUN   TestAccODBCloudVmCluster_systemVersion

    cloud_vm_cluster_test.go:338: skipping long-running test in short mode

--- SKIP: TestAccODBCloudVmCluster_systemVersion (0.00s)

PASS

ok      github.com/hashicorp/terraform-provider-aws/internal/service/odb        5.399s
...
```
