### PR TITLE
aws_mq_broker change user block to optional

### DIFF
--- a/.changelog/46883.txt
+++ b/.changelog/46883.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_mq_broker: Change `user` block to Optional
+```

--- a/.changelog/46883.txt
+++ b/.changelog/46883.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_mq_broker: Change `user` block to Optional
 ```
+
+```release-note:bug
+resource/aws_mq_broker: Fix non-idempotent behavior for RabbitMQ brokers with `user` block
+```

--- a/internal/service/mq/broker.go
+++ b/internal/service/mq/broker.go
@@ -327,7 +327,7 @@ func resourceBroker() *schema.Resource {
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"user": {
 				Type:     schema.TypeSet,
-				Required: true,
+				Optional: true,
 				Set:      resourceUserHash,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					// AWS currently does not support updating the RabbitMQ users beyond resource creation.

--- a/internal/service/mq/broker.go
+++ b/internal/service/mq/broker.go
@@ -329,16 +329,6 @@ func resourceBroker() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Set:      resourceUserHash,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// AWS currently does not support updating the RabbitMQ users beyond resource creation.
-					// User list is not returned back after creation.
-					// Updates to users can only be in the RabbitMQ UI.
-					if v := d.Get("engine_type").(string); strings.EqualFold(v, string(types.EngineTypeRabbitmq)) && d.Get(names.AttrARN).(string) != "" {
-						return true
-					}
-
-					return false
-				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"console_access": {
@@ -522,14 +512,18 @@ func resourceBrokerRead(ctx context.Context, d *schema.ResourceData, meta any) d
 		return sdkdiag.AppendErrorf(diags, "setting maintenance_window_start_time: %s", err)
 	}
 
-	rawUsers, err := expandUsersForBroker(ctx, conn, d.Id(), output.Users)
+	// AWS does not return user information for RabbitMQ brokers after creation.
+	// Skip setting user state to prevent non-idempotent behavior.
+	if !strings.EqualFold(string(output.EngineType), string(types.EngineTypeRabbitmq)) || d.IsNewResource() {
+		rawUsers, err := expandUsersForBroker(ctx, conn, d.Id(), output.Users)
 
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading MQ Broker (%s) users: %s", d.Id(), err)
-	}
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "reading MQ Broker (%s) users: %s", d.Id(), err)
+		}
 
-	if err := d.Set("user", flattenUsers(rawUsers, d.Get("user").(*schema.Set).List())); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting user: %s", err)
+		if err := d.Set("user", flattenUsers(rawUsers, d.Get("user").(*schema.Set).List())); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting user: %s", err)
+		}
 	}
 
 	setTagsOut(ctx, output.Tags)

--- a/internal/service/mq/broker_test.go
+++ b/internal/service/mq/broker_test.go
@@ -346,10 +346,6 @@ func TestNormalizeEngineVersion(t *testing.T) {
 }
 
 const (
-	testAccBrokerVersionNewer = "5.17.6" // before changing, check b/c must be valid on GovCloud
-	// testAccBrokerVersionOlder = "5.16.7"  // before changing, check b/c must be valid on GovCloud
-	testAccRabbitVersion = "3.11.20" // before changing, check b/c must be valid on GovCloud
-
 	testAccActiveVersionNormalized5_18 = "5.18"
 	testAccRabbitVersionNormalized3_13 = "3.13"
 	testAccNoAutoMinorVersionUpgrade   = "false"

--- a/internal/service/mq/broker_test.go
+++ b/internal/service/mq/broker_test.go
@@ -375,7 +375,7 @@ func TestAccMQBroker_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_basic(rName, testAccBrokerVersionNewer),
+				Config: testAccBrokerConfig_basic(rName, testAccActiveVersionNormalized5_18),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "mq", regexache.MustCompile(`broker:+.`)),
@@ -389,7 +389,7 @@ func TestAccMQBroker_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "encryption_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_options.0.use_aws_owned_key", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccBrokerVersionNewer),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccActiveVersionNormalized5_18),
 					resource.TestCheckResourceAttr(resourceName, "host_instance_type", "mq.t3.micro"),
 					resource.TestCheckResourceAttr(resourceName, "instances.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "instances.0.console_url",
@@ -454,7 +454,7 @@ func TestAccMQBroker_normalizedEngineVersion(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_autoMinorVersionUpgrade(rName, testAccActiveVersionNormalized5_18, true),
+				Config: testAccBrokerConfig_autoMinorVersionUpgrade(rName, testAccActiveVersionNormalized5_18, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
@@ -496,7 +496,7 @@ func TestAccMQBroker_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_basic(rName, testAccBrokerVersionNewer),
+				Config: testAccBrokerConfig_basic(rName, testAccActiveVersionNormalized5_18),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfmq.ResourceBroker(), resourceName),
@@ -528,7 +528,7 @@ func TestAccMQBroker_tags(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_tags1(rName, testAccBrokerVersionNewer, acctest.CtKey1, acctest.CtValue1),
+				Config: testAccBrokerConfig_tags1(rName, testAccActiveVersionNormalized5_18, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
@@ -542,7 +542,7 @@ func TestAccMQBroker_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{names.AttrApplyImmediately, "user"},
 			},
 			{
-				Config: testAccBrokerConfig_tags2(rName, testAccBrokerVersionNewer, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
+				Config: testAccBrokerConfig_tags2(rName, testAccActiveVersionNormalized5_18, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
@@ -551,7 +551,7 @@ func TestAccMQBroker_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccBrokerConfig_tags1(rName, testAccBrokerVersionNewer, acctest.CtKey2, acctest.CtValue2),
+				Config: testAccBrokerConfig_tags1(rName, testAccActiveVersionNormalized5_18, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
@@ -583,7 +583,7 @@ func TestAccMQBroker_throughputOptimized(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_ebs(rName, testAccBrokerVersionNewer),
+				Config: testAccBrokerConfig_ebs(rName, testAccActiveVersionNormalized5_18),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtFalse),
@@ -595,7 +595,7 @@ func TestAccMQBroker_throughputOptimized(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "encryption_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_options.0.use_aws_owned_key", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccBrokerVersionNewer),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccActiveVersionNormalized5_18),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStorageType, "ebs"),
 					resource.TestCheckResourceAttr(resourceName, "host_instance_type", "mq.m5.large"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_start_time.#", "1"),
@@ -667,7 +667,7 @@ func TestAccMQBroker_AllFields_defaultVPC(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_allFieldsDefaultVPC(rName, testAccBrokerVersionNewer, rName, cfgBodyBefore),
+				Config: testAccBrokerConfig_allFieldsDefaultVPC(rName, testAccActiveVersionNormalized5_18, rName, cfgBodyBefore, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
@@ -677,7 +677,7 @@ func TestAccMQBroker_AllFields_defaultVPC(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.revision", "2"),
 					resource.TestCheckResourceAttr(resourceName, "deployment_mode", "ACTIVE_STANDBY_MULTI_AZ"),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccBrokerVersionNewer),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccActiveVersionNormalized5_18),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStorageType, "efs"),
 					resource.TestCheckResourceAttr(resourceName, "host_instance_type", "mq.t3.micro"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_start_time.#", "1"),
@@ -738,7 +738,7 @@ func TestAccMQBroker_AllFields_defaultVPC(t *testing.T) {
 			},
 			{
 				// Update configuration in-place
-				Config: testAccBrokerConfig_allFieldsDefaultVPC(rName, testAccBrokerVersionNewer, rName, cfgBodyAfter),
+				Config: testAccBrokerConfig_allFieldsDefaultVPC(rName, testAccActiveVersionNormalized5_18, rName, cfgBodyAfter, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
@@ -749,7 +749,7 @@ func TestAccMQBroker_AllFields_defaultVPC(t *testing.T) {
 			},
 			{
 				// Replace configuration
-				Config: testAccBrokerConfig_allFieldsDefaultVPC(rName, testAccBrokerVersionNewer, rNameUpdated, cfgBodyAfter),
+				Config: testAccBrokerConfig_allFieldsDefaultVPC(rName, testAccActiveVersionNormalized5_18, rNameUpdated, cfgBodyAfter, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
@@ -796,7 +796,7 @@ func TestAccMQBroker_AllFields_customVPC(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_allFieldsCustomVPC(rName, testAccBrokerVersionNewer, rName, cfgBodyBefore, "CET"),
+				Config: testAccBrokerConfig_allFieldsCustomVPC(rName, testAccActiveVersionNormalized5_18, rName, cfgBodyBefore, "CET", testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
@@ -806,7 +806,7 @@ func TestAccMQBroker_AllFields_customVPC(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.revision", "2"),
 					resource.TestCheckResourceAttr(resourceName, "deployment_mode", "ACTIVE_STANDBY_MULTI_AZ"),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccBrokerVersionNewer),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccActiveVersionNormalized5_18),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStorageType, "efs"),
 					resource.TestCheckResourceAttr(resourceName, "host_instance_type", "mq.t3.micro"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_start_time.#", "1"),
@@ -867,7 +867,7 @@ func TestAccMQBroker_AllFields_customVPC(t *testing.T) {
 			},
 			{
 				// Update configuration in-place
-				Config: testAccBrokerConfig_allFieldsCustomVPC(rName, testAccBrokerVersionNewer, rName, cfgBodyAfter, "GMT"),
+				Config: testAccBrokerConfig_allFieldsCustomVPC(rName, testAccActiveVersionNormalized5_18, rName, cfgBodyAfter, "GMT", testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
@@ -882,7 +882,7 @@ func TestAccMQBroker_AllFields_customVPC(t *testing.T) {
 			},
 			{
 				// Replace configuration
-				Config: testAccBrokerConfig_allFieldsCustomVPC(rName, testAccBrokerVersionNewer, rNameUpdated, cfgBodyAfter, "GMT"),
+				Config: testAccBrokerConfig_allFieldsCustomVPC(rName, testAccActiveVersionNormalized5_18, rNameUpdated, cfgBodyAfter, "GMT", testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
@@ -917,7 +917,7 @@ func TestAccMQBroker_EncryptionOptions_kmsKeyID(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_encryptionOptionsKMSKeyID(rName, testAccBrokerVersionNewer),
+				Config: testAccBrokerConfig_encryptionOptionsKMSKeyID(rName, testAccActiveVersionNormalized5_18),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "encryption_options.#", "1"),
@@ -956,7 +956,7 @@ func TestAccMQBroker_EncryptionOptions_managedKeyDisabled(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_encryptionOptionsManagedKey(rName, testAccBrokerVersionNewer, false),
+				Config: testAccBrokerConfig_encryptionOptionsManagedKey(rName, testAccActiveVersionNormalized5_18, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "encryption_options.#", "1"),
@@ -994,7 +994,7 @@ func TestAccMQBroker_EncryptionOptions_managedKeyEnabled(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_encryptionOptionsManagedKey(rName, testAccBrokerVersionNewer, true),
+				Config: testAccBrokerConfig_encryptionOptionsManagedKey(rName, testAccActiveVersionNormalized5_18, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "encryption_options.#", "1"),
@@ -1032,7 +1032,7 @@ func TestAccMQBroker_Update_users(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_updateUsers1(rName, testAccBrokerVersionNewer),
+				Config: testAccBrokerConfig_updateUsers1(rName, testAccActiveVersionNormalized5_18),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "1"),
@@ -1052,7 +1052,7 @@ func TestAccMQBroker_Update_users(t *testing.T) {
 			},
 			// Adding new user + modify existing
 			{
-				Config: testAccBrokerConfig_updateUsers2(rName, testAccBrokerVersionNewer),
+				Config: testAccBrokerConfig_updateUsers2(rName, testAccActiveVersionNormalized5_18),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "2"),
@@ -1072,7 +1072,7 @@ func TestAccMQBroker_Update_users(t *testing.T) {
 			},
 			// Deleting user + modify existing
 			{
-				Config: testAccBrokerConfig_updateUsers3(rName, testAccBrokerVersionNewer),
+				Config: testAccBrokerConfig_updateUsers3(rName, testAccActiveVersionNormalized5_18),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "1"),
@@ -1110,7 +1110,7 @@ func TestAccMQBroker_Update_securityGroup(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_basic(rName, testAccBrokerVersionNewer),
+				Config: testAccBrokerConfig_basic(rName, testAccActiveVersionNormalized5_18),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
@@ -1123,7 +1123,7 @@ func TestAccMQBroker_Update_securityGroup(t *testing.T) {
 				ImportStateVerifyIgnore: []string{names.AttrApplyImmediately, "user"},
 			},
 			{
-				Config: testAccBrokerConfig_updateSecurityGroups(rName, testAccBrokerVersionNewer),
+				Config: testAccBrokerConfig_updateSecurityGroups(rName, testAccActiveVersionNormalized5_18),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "2"),
@@ -1132,7 +1132,7 @@ func TestAccMQBroker_Update_securityGroup(t *testing.T) {
 			// Trigger a reboot and ensure the password change was applied
 			// User hashcode can be retrieved by calling resourceUserHash
 			{
-				Config: testAccBrokerConfig_updateUsersSecurityGroups(rName, testAccBrokerVersionNewer),
+				Config: testAccBrokerConfig_updateUsersSecurityGroups(rName, testAccActiveVersionNormalized5_18),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
@@ -1182,10 +1182,10 @@ func TestAccMQBroker_Update_engineVersion(t *testing.T) {
 				ImportStateVerifyIgnore: []string{names.AttrApplyImmediately, "user"},
 			},
 			{
-				Config: testAccBrokerConfig_engineVersionUpdate(rName, testAccBrokerVersionNewer),
+				Config: testAccBrokerConfig_engineVersionUpdate(rName, testAccActiveVersionNormalized5_18),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, resourceName, &broker),
-					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccBrokerVersionNewer),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccActiveVersionNormalized5_18),
 				),
 			},
 		},
@@ -1214,14 +1214,14 @@ func TestAccMQBroker_Update_hostInstanceType(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_instanceType(rName, testAccBrokerVersionNewer, "mq.t3.micro"),
+				Config: testAccBrokerConfig_instanceType(rName, testAccActiveVersionNormalized5_18, "mq.t3.micro"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker1),
 					resource.TestCheckResourceAttr(resourceName, "host_instance_type", "mq.t3.micro"),
 				),
 			},
 			{
-				Config: testAccBrokerConfig_instanceType(rName, testAccBrokerVersionNewer, "mq.t3.micro"),
+				Config: testAccBrokerConfig_instanceType(rName, testAccActiveVersionNormalized5_18, "mq.t3.micro"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker2),
 					testAccCheckBrokerNotRecreated(&broker1, &broker2),
@@ -1253,12 +1253,12 @@ func TestAccMQBroker_RabbitMQ_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_rabbit(rName, testAccRabbitVersion),
+				Config: testAccBrokerConfig_rabbit(rName, testAccRabbitVersionNormalized3_13),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "RabbitMQ"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccRabbitVersion),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccRabbitVersionNormalized3_13),
 					resource.TestCheckResourceAttr(resourceName, "host_instance_type", "mq.t3.micro"),
 					resource.TestCheckResourceAttr(resourceName, "instances.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "instances.0.endpoints.#", "1"),
@@ -1299,13 +1299,13 @@ func TestAccMQBroker_RabbitMQ_autoMinorVersionUpgrade(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_rabbitAutoMinorVersionUpgrade(rName, testAccRabbitVersion, true),
+				Config: testAccBrokerConfig_rabbitAutoMinorVersionUpgrade(rName, testAccRabbitVersionNormalized3_13, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "RabbitMQ"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
-					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccRabbitVersion),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccRabbitVersionNormalized3_13),
 					resource.TestCheckResourceAttr(resourceName, "host_instance_type", "mq.t3.micro"),
 					resource.TestCheckResourceAttr(resourceName, "instances.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "instances.0.endpoints.#", "1"),
@@ -1346,7 +1346,7 @@ func TestAccMQBroker_RabbitMQ_normalizedEngineVersion(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_rabbitAutoMinorVersionUpgrade(rName, testAccRabbitVersionNormalized3_13, true),
+				Config: testAccBrokerConfig_rabbitAutoMinorVersionUpgrade(rName, testAccRabbitVersionNormalized3_13, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
@@ -1388,14 +1388,14 @@ func TestAccMQBroker_RabbitMQ_config(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_rabbitConfig(rName, testAccRabbitVersion),
+				Config: testAccBrokerConfig_rabbitConfig(rName, testAccRabbitVersionNormalized3_13),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "configuration.0.id", regexache.MustCompile(`^c-[0-9a-z-]+$`)),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.revision", "2"),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "RabbitMQ"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccRabbitVersion),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccRabbitVersionNormalized3_13),
 					resource.TestCheckResourceAttr(resourceName, "host_instance_type", "mq.t3.micro"),
 					resource.TestCheckResourceAttr(resourceName, "instances.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "instances.0.endpoints.#", "1"),
@@ -1436,7 +1436,7 @@ func TestAccMQBroker_RabbitMQ_configNoUserBlock(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_rabbitNoUserBlock(rName, testAccRabbitVersion, acctest.CtTrue),
+				Config: testAccBrokerConfig_rabbitNoUserBlock(rName, testAccRabbitVersionNormalized3_13, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "0"),
@@ -1473,12 +1473,12 @@ func TestAccMQBroker_RabbitMQ_logs(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_rabbitLogs(rName, testAccRabbitVersion),
+				Config: testAccBrokerConfig_rabbitLogs(rName, testAccRabbitVersionNormalized3_13),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "RabbitMQ"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccRabbitVersion),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccRabbitVersionNormalized3_13),
 					resource.TestCheckResourceAttr(resourceName, "host_instance_type", "mq.t3.micro"),
 					resource.TestCheckResourceAttr(resourceName, "instances.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "instances.0.endpoints.#", "1"),
@@ -1519,13 +1519,13 @@ func TestAccMQBroker_RabbitMQ_validationAuditLog(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccBrokerConfig_rabbitAuditLog(rName, testAccRabbitVersion, true),
+				Config:      testAccBrokerConfig_rabbitAuditLog(rName, testAccRabbitVersionNormalized3_13, true),
 				ExpectError: regexache.MustCompile(`logs.audit: Can not be configured when engine is RabbitMQ`),
 			},
 			{
 				// Special case: allow explicitly setting logs.0.audit to false,
 				// though the AWS API does not accept the parameter.
-				Config: testAccBrokerConfig_rabbitAuditLog(rName, testAccRabbitVersion, false),
+				Config: testAccBrokerConfig_rabbitAuditLog(rName, testAccRabbitVersionNormalized3_13, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "logs.#", "1"),
@@ -1558,7 +1558,7 @@ func TestAccMQBroker_RabbitMQ_cluster(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_rabbitCluster(rName, testAccRabbitVersion),
+				Config: testAccBrokerConfig_rabbitCluster(rName, testAccRabbitVersionNormalized3_13),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtFalse),
@@ -1567,7 +1567,7 @@ func TestAccMQBroker_RabbitMQ_cluster(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "encryption_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_options.0.use_aws_owned_key", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "RabbitMQ"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccRabbitVersion),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccRabbitVersionNormalized3_13),
 					resource.TestCheckResourceAttr(resourceName, "host_instance_type", "mq.m5.large"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_start_time.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
@@ -1625,7 +1625,7 @@ func TestAccMQBroker_ldap(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_ldapNoUserBlock(rName, testAccBrokerVersionNewer, "anyusername", acctest.CtTrue),
+				Config: testAccBrokerConfig_ldapNoUserBlock(rName, testAccActiveVersionNormalized5_18, "anyusername", testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
@@ -1647,7 +1647,7 @@ func TestAccMQBroker_ldap(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccBrokerConfig_ldapUserBlock(rName, testAccBrokerVersionNewer, "anyusername", acctest.CtTrue),
+				Config: testAccBrokerConfig_ldapUserBlock(rName, testAccActiveVersionNormalized5_18, "anyusername", testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
@@ -1697,7 +1697,7 @@ func TestAccMQBroker_dataReplicationMode(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_dataReplicationMode(rName, testAccBrokerVersionNewer, string(types.DataReplicationModeCrdr)),
+				Config: testAccBrokerConfig_dataReplicationMode(rName, testAccActiveVersionNormalized5_18, string(types.DataReplicationModeCrdr)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					testAccCheckBrokerExistsWithProvider(ctx, primaryBrokerResourceName, &brokerAlternate, acctest.RegionProviderFunc(ctx, acctest.AlternateRegion(), &providers)),
@@ -1710,7 +1710,7 @@ func TestAccMQBroker_dataReplicationMode(t *testing.T) {
 				),
 			},
 			{
-				Config:                  testAccBrokerConfig_dataReplicationMode(rName, testAccBrokerVersionNewer, string(types.DataReplicationModeCrdr)),
+				Config:                  testAccBrokerConfig_dataReplicationMode(rName, testAccActiveVersionNormalized5_18, string(types.DataReplicationModeCrdr)),
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -1731,7 +1731,7 @@ func TestAccMQBroker_dataReplicationMode(t *testing.T) {
 					// in the opposite order, so delete the primary out of band instead.
 					testAccDeleteBrokerWithProvider(ctx, t, &brokerAlternate, acctest.RegionProviderFunc(ctx, acctest.AlternateRegion(), &providers))
 				},
-				Config:             testAccBrokerConfig_dataReplicationMode(rName, testAccBrokerVersionNewer, string(types.DataReplicationModeNone)),
+				Config:             testAccBrokerConfig_dataReplicationMode(rName, testAccActiveVersionNormalized5_18, string(types.DataReplicationModeNone)),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/service/mq/broker_test.go
+++ b/internal/service/mq/broker_test.go
@@ -1415,6 +1415,43 @@ func TestAccMQBroker_RabbitMQ_config(t *testing.T) {
 	})
 }
 
+func TestAccMQBroker_RabbitMQ_configNoUserBlock(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var broker mq.DescribeBrokerOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_mq_broker.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.MQEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.MQServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBrokerConfig_rabbitNoUserBlock(rName, testAccRabbitVersion, acctest.CtTrue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
+					resource.TestCheckResourceAttr(resourceName, "user.#", "0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrApplyImmediately, "user"},
+			},
+		},
+	})
+}
+
 func TestAccMQBroker_RabbitMQ_logs(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -1588,10 +1625,10 @@ func TestAccMQBroker_ldap(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_ldap(rName, testAccBrokerVersionNewer, "anyusername"),
+				Config: testAccBrokerConfig_ldapNoUserBlock(rName, testAccBrokerVersionNewer, "anyusername", acctest.CtTrue),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
-					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "authentication_strategy", "ldap"),
 					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.hosts.#", "2"),
@@ -1606,6 +1643,29 @@ func TestAccMQBroker_ldap(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_role_name", "user.role.name"),
 					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_search_matching", "user.search.matching"),
 					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_search_subtree", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "user.#", "0"),
+				),
+			},
+			{
+				Config: testAccBrokerConfig_ldapUserBlock(rName, testAccBrokerVersionNewer, "anyusername", acctest.CtTrue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
+					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_strategy", "ldap"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.hosts.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.hosts.0", "my.ldap.server-1.com"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.hosts.1", "my.ldap.server-2.com"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.role_base", "role.base"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.role_name", "role.name"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.role_search_matching", "role.search.matching"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.role_search_subtree", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.service_account_username", "anyusername"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_base", "user.base"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_role_name", "user.role.name"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_search_matching", "user.search.matching"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_search_subtree", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "user.#", "1"),
 				),
 			},
 		},
@@ -2176,6 +2236,42 @@ resource "aws_mq_broker" "test" {
 `, rName, version, useAwsOwnedKey)
 }
 
+func testAccBrokerConfig_rabbitNoUserBlock(rName, version, autoMinorVersionUpgrade string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = %[1]q
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_mq_configuration" "test" {
+  name           = %[1]q
+  engine_type    = "RabbitMQ"
+  engine_version = %[2]q
+  data           = <<DATA
+	auth_backends.1 = oauth2
+
+	DATA
+}
+
+resource "aws_mq_broker" "test" {
+  apply_immediately          = true
+  broker_name                = %[1]q
+  engine_type                = "RabbitMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.t3.micro"
+  security_groups            = [aws_security_group.test.id]
+  auto_minor_version_upgrade = %[3]s
+  configuration {
+    id       = aws_mq_configuration.test.id
+    revision = aws_mq_configuration.test.latest_revision
+  }
+}
+`, rName, version, autoMinorVersionUpgrade)
+}
+
 func testAccBrokerConfig_updateUsers1(rName, version string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
@@ -2589,7 +2685,7 @@ data "aws_vpc" "default" {
 `, rName, version)
 }
 
-func testAccBrokerConfig_ldap(rName, version, ldapUsername string) string {
+func testAccBrokerConfig_ldapNoUserBlock(rName, version, ldapUsername, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -2600,13 +2696,56 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_mq_broker" "test" {
-  apply_immediately       = true
-  authentication_strategy = "ldap"
-  broker_name             = %[1]q
-  engine_type             = "ActiveMQ"
-  engine_version          = %[2]q
-  host_instance_type      = "mq.t3.micro"
-  security_groups         = [aws_security_group.test.id]
+  apply_immediately          = true
+  authentication_strategy    = "ldap"
+  broker_name                = %[1]q
+  engine_type                = "ActiveMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.t3.micro"
+  security_groups            = [aws_security_group.test.id]
+  auto_minor_version_upgrade = %[4]s
+
+
+  logs {
+    general = true
+  }
+
+  ldap_server_metadata {
+    hosts                    = ["my.ldap.server-1.com", "my.ldap.server-2.com"]
+    role_base                = "role.base"
+    role_name                = "role.name"
+    role_search_matching     = "role.search.matching"
+    role_search_subtree      = true
+    service_account_password = "supersecret"
+    service_account_username = %[3]q
+    user_base                = "user.base"
+    user_role_name           = "user.role.name"
+    user_search_matching     = "user.search.matching"
+    user_search_subtree      = true
+  }
+}
+`, rName, version, ldapUsername, autoMinorVersionUpgrade)
+}
+
+func testAccBrokerConfig_ldapUserBlock(rName, version, ldapUsername, autoMinorVersionUpgrade string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = %[1]q
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_mq_broker" "test" {
+  apply_immediately          = true
+  authentication_strategy    = "ldap"
+  broker_name                = %[1]q
+  engine_type                = "ActiveMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.t3.micro"
+  security_groups            = [aws_security_group.test.id]
+  auto_minor_version_upgrade = %[4]s
 
   logs {
     general = true
@@ -2631,7 +2770,7 @@ resource "aws_mq_broker" "test" {
     user_search_subtree      = true
   }
 }
-`, rName, version, ldapUsername)
+`, rName, version, ldapUsername, autoMinorVersionUpgrade)
 }
 
 func testAccBrokerConfig_instanceType(rName, version, instanceType string) string {

--- a/internal/service/mq/broker_test.go
+++ b/internal/service/mq/broker_test.go
@@ -1886,13 +1886,13 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_mq_broker" "test" {
-  broker_name             = %[1]q
-  engine_type             = "ActiveMQ"
-  engine_version          = %[2]q
-  host_instance_type      = "mq.t3.micro"
-  security_groups         = [aws_security_group.test.id]
-  authentication_strategy = "simple"
-  storage_type            = "efs"
+  broker_name                = %[1]q
+  engine_type                = "ActiveMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.t3.micro"
+  security_groups            = [aws_security_group.test.id]
+  authentication_strategy    = "simple"
+  storage_type               = "efs"
   auto_minor_version_upgrade = %[3]s
 
   logs {
@@ -1950,13 +1950,13 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_mq_broker" "test" {
-  broker_name        = %[1]q
-  engine_type        = "ActiveMQ"
-  engine_version     = %[2]q
-  storage_type       = "ebs"
-  host_instance_type = "mq.m5.large"
-  security_groups    = [aws_security_group.test.id]
-	auto_minor_version_upgrade = %[3]s
+  broker_name                = %[1]q
+  engine_type                = "ActiveMQ"
+  engine_version             = %[2]q
+  storage_type               = "ebs"
+  host_instance_type         = "mq.m5.large"
+  security_groups            = [aws_security_group.test.id]
+  auto_minor_version_upgrade = %[3]s
 
   logs {
     general = true
@@ -2184,12 +2184,12 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_mq_broker" "test" {
-  broker_name        = %[1]q
-  engine_type        = "ActiveMQ"
-  engine_version     = %[2]q
-  host_instance_type = "mq.t3.micro"
-  security_groups    = [aws_security_group.test.id]
-	auto_minor_version_upgrade = %[3]s
+  broker_name                = %[1]q
+  engine_type                = "ActiveMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.t3.micro"
+  security_groups            = [aws_security_group.test.id]
+  auto_minor_version_upgrade = %[3]s
 
   encryption_options {
     kms_key_id        = aws_kms_key.test.arn
@@ -2219,12 +2219,12 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_mq_broker" "test" {
-  broker_name        = %[1]q
-  engine_type        = "ActiveMQ"
-  engine_version     = %[2]q
-  host_instance_type = "mq.t3.micro"
-  security_groups    = [aws_security_group.test.id]
-	auto_minor_version_upgrade = %[3]s
+  broker_name                = %[1]q
+  engine_type                = "ActiveMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.t3.micro"
+  security_groups            = [aws_security_group.test.id]
+  auto_minor_version_upgrade = %[3]s
 
   encryption_options {
     use_aws_owned_key = %[4]t
@@ -2289,13 +2289,13 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_mq_broker" "test" {
-  apply_immediately  = true
-  broker_name        = %[1]q
-  engine_type        = "ActiveMQ"
-  engine_version     = %[2]q
-  host_instance_type = "mq.t3.micro"
-  security_groups    = [aws_security_group.test.id]
-	auto_minor_version_upgrade = %[3]s
+  apply_immediately          = true
+  broker_name                = %[1]q
+  engine_type                = "ActiveMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.t3.micro"
+  security_groups            = [aws_security_group.test.id]
+  auto_minor_version_upgrade = %[3]s
 
   user {
     username = "first"
@@ -2316,13 +2316,13 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_mq_broker" "test" {
-  apply_immediately  = true
-  broker_name        = %[1]q
-  engine_type        = "ActiveMQ"
-  engine_version     = %[2]q
-  host_instance_type = "mq.t3.micro"
-  security_groups    = [aws_security_group.test.id]
-	auto_minor_version_upgrade = %[3]s
+  apply_immediately          = true
+  broker_name                = %[1]q
+  engine_type                = "ActiveMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.t3.micro"
+  security_groups            = [aws_security_group.test.id]
+  auto_minor_version_upgrade = %[3]s
 
   user {
     console_access = true
@@ -2349,13 +2349,13 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_mq_broker" "test" {
-  apply_immediately  = true
-  broker_name        = %[1]q
-  engine_type        = "ActiveMQ"
-  engine_version     = %[2]q
-  host_instance_type = "mq.t3.micro"
-  security_groups    = [aws_security_group.test.id]
-	auto_minor_version_upgrade = %[3]s
+  apply_immediately          = true
+  broker_name                = %[1]q
+  engine_type                = "ActiveMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.t3.micro"
+  security_groups            = [aws_security_group.test.id]
+  auto_minor_version_upgrade = %[3]s
 
   user {
     username = "second"
@@ -2377,13 +2377,13 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_mq_broker" "test" {
-  apply_immediately  = true
-  broker_name        = %[1]q
-  engine_type        = "ActiveMQ"
-  engine_version     = %[2]q
-  host_instance_type = "mq.t3.micro"
-  security_groups    = [aws_security_group.test.id]
-	auto_minor_version_upgrade = %[5]s
+  apply_immediately          = true
+  broker_name                = %[1]q
+  engine_type                = "ActiveMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.t3.micro"
+  security_groups            = [aws_security_group.test.id]
+  auto_minor_version_upgrade = %[5]s
 
   user {
     username = "Test"
@@ -2408,13 +2408,13 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_mq_broker" "test" {
-  apply_immediately  = true
-  broker_name        = %[1]q
-  engine_type        = "ActiveMQ"
-  engine_version     = %[2]q
-  host_instance_type = "mq.t3.micro"
-  security_groups    = [aws_security_group.test.id]
-	auto_minor_version_upgrade = %[7]s
+  apply_immediately          = true
+  broker_name                = %[1]q
+  engine_type                = "ActiveMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.t3.micro"
+  security_groups            = [aws_security_group.test.id]
+  auto_minor_version_upgrade = %[7]s
 
   user {
     username = "Test"
@@ -2448,13 +2448,13 @@ resource "aws_security_group" "test2" {
 }
 
 resource "aws_mq_broker" "test" {
-  apply_immediately  = true
-  broker_name        = %[1]q
-  engine_type        = "ActiveMQ"
-  engine_version     = %[2]q
-  host_instance_type = "mq.t3.micro"
-  security_groups    = [aws_security_group.test.id, aws_security_group.test2.id]
-	auto_minor_version_upgrade = %[3]s
+  apply_immediately          = true
+  broker_name                = %[1]q
+  engine_type                = "ActiveMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.t3.micro"
+  security_groups            = [aws_security_group.test.id, aws_security_group.test2.id]
+  auto_minor_version_upgrade = %[3]s
 
   logs {
     general = true
@@ -2487,13 +2487,13 @@ resource "aws_security_group" "test2" {
 }
 
 resource "aws_mq_broker" "test" {
-  apply_immediately  = true
-  broker_name        = %[1]q
-  engine_type        = "ActiveMQ"
-  engine_version     = %[2]q
-  host_instance_type = "mq.t3.micro"
-  security_groups    = [aws_security_group.test2.id]
-	auto_minor_version_upgrade = %[3]s
+  apply_immediately          = true
+  broker_name                = %[1]q
+  engine_type                = "ActiveMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.t3.micro"
+  security_groups            = [aws_security_group.test2.id]
+  auto_minor_version_upgrade = %[3]s
 
   logs {
     general = true
@@ -2518,12 +2518,12 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_mq_broker" "test" {
-  broker_name        = %[1]q
-  engine_type        = "RabbitMQ"
-  engine_version     = %[2]q
-  host_instance_type = "mq.t3.micro"
-  security_groups    = [aws_security_group.test.id]
-	auto_minor_version_upgrade = %[3]s
+  broker_name                = %[1]q
+  engine_type                = "RabbitMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.t3.micro"
+  security_groups            = [aws_security_group.test.id]
+  auto_minor_version_upgrade = %[3]s
 
   user {
     username = "Test"
@@ -2583,12 +2583,12 @@ resource "aws_mq_configuration" "test" {
 }
 
 resource "aws_mq_broker" "test" {
-  broker_name        = %[1]q
-  engine_type        = "RabbitMQ"
-  engine_version     = %[2]q
-  host_instance_type = "mq.t3.micro"
-  security_groups    = [aws_security_group.test.id]
-	auto_minor_version_upgrade = %[3]s
+  broker_name                = %[1]q
+  engine_type                = "RabbitMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.t3.micro"
+  security_groups            = [aws_security_group.test.id]
+  auto_minor_version_upgrade = %[3]s
 
   configuration {
     id       = aws_mq_configuration.test.id
@@ -2606,12 +2606,12 @@ resource "aws_mq_broker" "test" {
 func testAccBrokerConfig_rabbitLogs(rName, version, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_mq_broker" "test" {
-  broker_name        = %[1]q
-  engine_type        = "RabbitMQ"
-  engine_version     = %[2]q
-  host_instance_type = "mq.t3.micro"
-  security_groups    = [aws_security_group.test.id]
-	auto_minor_version_upgrade = %[3]s
+  broker_name                = %[1]q
+  engine_type                = "RabbitMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.t3.micro"
+  security_groups            = [aws_security_group.test.id]
+  auto_minor_version_upgrade = %[3]s
 
   logs {
     general = true
@@ -2636,12 +2636,12 @@ resource "aws_security_group" "test" {
 func testAccBrokerConfig_rabbitAuditLog(rName, version, autoMinorVersionUpgrade string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_mq_broker" "test" {
-  broker_name        = %[1]q
-  engine_type        = "RabbitMQ"
-  engine_version     = %[2]q
-  host_instance_type = "mq.t3.micro"
-  security_groups    = [aws_security_group.test.id]
-	auto_minor_version_upgrade = %[3]s
+  broker_name                = %[1]q
+  engine_type                = "RabbitMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.t3.micro"
+  security_groups            = [aws_security_group.test.id]
+  auto_minor_version_upgrade = %[3]s
 
   logs {
     general = true
@@ -2675,14 +2675,14 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_mq_broker" "test" {
-  broker_name        = %[1]q
-  engine_type        = "RabbitMQ"
-  engine_version     = %[2]q
-  host_instance_type = "mq.m5.large"
-  security_groups    = [aws_security_group.test.id]
-  storage_type       = "ebs"
-  deployment_mode    = "CLUSTER_MULTI_AZ"
-	auto_minor_version_upgrade = %[3]s
+  broker_name                = %[1]q
+  engine_type                = "RabbitMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.m5.large"
+  security_groups            = [aws_security_group.test.id]
+  storage_type               = "ebs"
+  deployment_mode            = "CLUSTER_MULTI_AZ"
+  auto_minor_version_upgrade = %[3]s
 
   user {
     username = "Test"
@@ -2802,13 +2802,13 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_mq_broker" "test" {
-  broker_name        = %[1]q
-  apply_immediately  = true
-  engine_type        = "ActiveMQ"
-  engine_version     = %[2]q
-  host_instance_type = %[3]q
-  security_groups    = [aws_security_group.test.id]
-	auto_minor_version_upgrade = %[4]s
+  broker_name                = %[1]q
+  apply_immediately          = true
+  engine_type                = "ActiveMQ"
+  engine_version             = %[2]q
+  host_instance_type         = %[3]q
+  security_groups            = [aws_security_group.test.id]
+  auto_minor_version_upgrade = %[4]s
 
   logs {
     general = true
@@ -2841,14 +2841,14 @@ resource "aws_security_group" "primary" {
 resource "aws_mq_broker" "primary" {
   provider = awsalternate
 
-  apply_immediately  = true
-  broker_name        = "%[1]s-primary"
-  engine_type        = "ActiveMQ"
-  engine_version     = %[2]q
-  host_instance_type = "mq.m5.large"
-  security_groups    = [aws_security_group.primary.id]
-  deployment_mode    = "ACTIVE_STANDBY_MULTI_AZ"
-	auto_minor_version_upgrade = %[4]s
+  apply_immediately          = true
+  broker_name                = "%[1]s-primary"
+  engine_type                = "ActiveMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.m5.large"
+  security_groups            = [aws_security_group.primary.id]
+  deployment_mode            = "ACTIVE_STANDBY_MULTI_AZ"
+  auto_minor_version_upgrade = %[4]s
 
   logs {
     general = true
@@ -2874,14 +2874,14 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_mq_broker" "test" {
-  apply_immediately  = true
-  broker_name        = %[1]q
-  engine_type        = "ActiveMQ"
-  engine_version     = %[2]q
-  host_instance_type = "mq.m5.large"
-  security_groups    = [aws_security_group.test.id]
-  deployment_mode    = "ACTIVE_STANDBY_MULTI_AZ"
-	auto_minor_version_upgrade = %[4]s
+  apply_immediately          = true
+  broker_name                = %[1]q
+  engine_type                = "ActiveMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.m5.large"
+  security_groups            = [aws_security_group.test.id]
+  deployment_mode            = "ACTIVE_STANDBY_MULTI_AZ"
+  auto_minor_version_upgrade = %[4]s
 
   data_replication_mode               = %[3]q
   data_replication_primary_broker_arn = aws_mq_broker.primary.arn

--- a/internal/service/mq/broker_test.go
+++ b/internal/service/mq/broker_test.go
@@ -1587,7 +1587,7 @@ func TestAccMQBroker_RabbitMQ_cluster(t *testing.T) {
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "mq", regexache.MustCompile(`broker:+.`)),
 					resource.TestCheckResourceAttr(resourceName, "instances.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "instances.0.console_url",
-						regexache.MustCompile(`^https://[0-9a-f-]+\.mq.[0-9a-z-]+.amazonaws.com$`)),
+						regexache.MustCompile(`^https://[0-9a-f-]+\.mq.[0-9a-z-]+.(?:amazonaws\.com|on\.aws)$`)),
 					resource.TestCheckResourceAttr(resourceName, "instances.0.endpoints.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "instances.0.endpoints.0", regexache.MustCompile(`^amqps://[0-9a-z.-]+:5671$`)),
 				),

--- a/internal/service/mq/broker_test.go
+++ b/internal/service/mq/broker_test.go
@@ -352,6 +352,8 @@ const (
 
 	testAccActiveVersionNormalized5_18 = "5.18"
 	testAccRabbitVersionNormalized3_13 = "3.13"
+	testAccNoAutoMinorVersionUpgrade   = "false"
+	testAccAutoMinorVersionUpgrade     = "true"
 )
 
 func TestAccMQBroker_basic(t *testing.T) {
@@ -375,11 +377,11 @@ func TestAccMQBroker_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_basic(rName, testAccActiveVersionNormalized5_18),
+				Config: testAccBrokerConfig_basic(rName, testAccActiveVersionNormalized5_18, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "mq", regexache.MustCompile(`broker:+.`)),
-					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, testAccAutoMinorVersionUpgrade),
 					resource.TestCheckResourceAttr(resourceName, "authentication_strategy", "simple"),
 					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
@@ -457,7 +459,7 @@ func TestAccMQBroker_normalizedEngineVersion(t *testing.T) {
 				Config: testAccBrokerConfig_autoMinorVersionUpgrade(rName, testAccActiveVersionNormalized5_18, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
-					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, testAccAutoMinorVersionUpgrade),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
 					// Starting in v5.18, the engine version should be normalized to remove
 					// the patch version as AWS automatically handles patch updates when
@@ -496,7 +498,7 @@ func TestAccMQBroker_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_basic(rName, testAccActiveVersionNormalized5_18),
+				Config: testAccBrokerConfig_basic(rName, testAccActiveVersionNormalized5_18, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfmq.ResourceBroker(), resourceName),
@@ -528,7 +530,7 @@ func TestAccMQBroker_tags(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_tags1(rName, testAccActiveVersionNormalized5_18, acctest.CtKey1, acctest.CtValue1),
+				Config: testAccBrokerConfig_tags1(rName, testAccActiveVersionNormalized5_18, acctest.CtKey1, acctest.CtValue1, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
@@ -542,7 +544,7 @@ func TestAccMQBroker_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{names.AttrApplyImmediately, "user"},
 			},
 			{
-				Config: testAccBrokerConfig_tags2(rName, testAccActiveVersionNormalized5_18, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
+				Config: testAccBrokerConfig_tags2(rName, testAccActiveVersionNormalized5_18, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
@@ -551,7 +553,7 @@ func TestAccMQBroker_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccBrokerConfig_tags1(rName, testAccActiveVersionNormalized5_18, acctest.CtKey2, acctest.CtValue2),
+				Config: testAccBrokerConfig_tags1(rName, testAccActiveVersionNormalized5_18, acctest.CtKey2, acctest.CtValue2, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
@@ -583,10 +585,10 @@ func TestAccMQBroker_throughputOptimized(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_ebs(rName, testAccActiveVersionNormalized5_18),
+				Config: testAccBrokerConfig_ebs(rName, testAccActiveVersionNormalized5_18, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
-					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, testAccAutoMinorVersionUpgrade),
 					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "configuration.0.id", regexache.MustCompile(`^c-[0-9a-z-]+$`)),
@@ -670,7 +672,7 @@ func TestAccMQBroker_AllFields_defaultVPC(t *testing.T) {
 				Config: testAccBrokerConfig_allFieldsDefaultVPC(rName, testAccActiveVersionNormalized5_18, rName, cfgBodyBefore, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
-					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, testAccAutoMinorVersionUpgrade),
 					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "configuration.0.id", regexache.MustCompile(`^c-[0-9a-z-]+$`)),
@@ -799,7 +801,7 @@ func TestAccMQBroker_AllFields_customVPC(t *testing.T) {
 				Config: testAccBrokerConfig_allFieldsCustomVPC(rName, testAccActiveVersionNormalized5_18, rName, cfgBodyBefore, "CET", testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
-					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, testAccAutoMinorVersionUpgrade),
 					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "configuration.0.id", regexache.MustCompile(`^c-[0-9a-z-]+$`)),
@@ -917,7 +919,7 @@ func TestAccMQBroker_EncryptionOptions_kmsKeyID(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_encryptionOptionsKMSKeyID(rName, testAccActiveVersionNormalized5_18),
+				Config: testAccBrokerConfig_encryptionOptionsKMSKeyID(rName, testAccActiveVersionNormalized5_18, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "encryption_options.#", "1"),
@@ -956,7 +958,7 @@ func TestAccMQBroker_EncryptionOptions_managedKeyDisabled(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_encryptionOptionsManagedKey(rName, testAccActiveVersionNormalized5_18, false),
+				Config: testAccBrokerConfig_encryptionOptionsManagedKey(rName, testAccActiveVersionNormalized5_18, testAccAutoMinorVersionUpgrade, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "encryption_options.#", "1"),
@@ -994,7 +996,7 @@ func TestAccMQBroker_EncryptionOptions_managedKeyEnabled(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_encryptionOptionsManagedKey(rName, testAccActiveVersionNormalized5_18, true),
+				Config: testAccBrokerConfig_encryptionOptionsManagedKey(rName, testAccActiveVersionNormalized5_18, testAccAutoMinorVersionUpgrade, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "encryption_options.#", "1"),
@@ -1032,7 +1034,7 @@ func TestAccMQBroker_Update_users(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_updateUsers1(rName, testAccActiveVersionNormalized5_18),
+				Config: testAccBrokerConfig_updateUsers1(rName, testAccActiveVersionNormalized5_18, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "1"),
@@ -1052,7 +1054,7 @@ func TestAccMQBroker_Update_users(t *testing.T) {
 			},
 			// Adding new user + modify existing
 			{
-				Config: testAccBrokerConfig_updateUsers2(rName, testAccActiveVersionNormalized5_18),
+				Config: testAccBrokerConfig_updateUsers2(rName, testAccActiveVersionNormalized5_18, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "2"),
@@ -1072,7 +1074,7 @@ func TestAccMQBroker_Update_users(t *testing.T) {
 			},
 			// Deleting user + modify existing
 			{
-				Config: testAccBrokerConfig_updateUsers3(rName, testAccActiveVersionNormalized5_18),
+				Config: testAccBrokerConfig_updateUsers3(rName, testAccActiveVersionNormalized5_18, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "1"),
@@ -1110,7 +1112,7 @@ func TestAccMQBroker_Update_securityGroup(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_basic(rName, testAccActiveVersionNormalized5_18),
+				Config: testAccBrokerConfig_basic(rName, testAccActiveVersionNormalized5_18, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
@@ -1123,7 +1125,7 @@ func TestAccMQBroker_Update_securityGroup(t *testing.T) {
 				ImportStateVerifyIgnore: []string{names.AttrApplyImmediately, "user"},
 			},
 			{
-				Config: testAccBrokerConfig_updateSecurityGroups(rName, testAccActiveVersionNormalized5_18),
+				Config: testAccBrokerConfig_updateSecurityGroups(rName, testAccActiveVersionNormalized5_18, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "2"),
@@ -1132,7 +1134,7 @@ func TestAccMQBroker_Update_securityGroup(t *testing.T) {
 			// Trigger a reboot and ensure the password change was applied
 			// User hashcode can be retrieved by calling resourceUserHash
 			{
-				Config: testAccBrokerConfig_updateUsersSecurityGroups(rName, testAccActiveVersionNormalized5_18),
+				Config: testAccBrokerConfig_updateUsersSecurityGroups(rName, testAccActiveVersionNormalized5_18, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
@@ -1214,14 +1216,14 @@ func TestAccMQBroker_Update_hostInstanceType(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_instanceType(rName, testAccActiveVersionNormalized5_18, "mq.t3.micro"),
+				Config: testAccBrokerConfig_instanceType(rName, testAccActiveVersionNormalized5_18, "mq.t3.micro", testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker1),
 					resource.TestCheckResourceAttr(resourceName, "host_instance_type", "mq.t3.micro"),
 				),
 			},
 			{
-				Config: testAccBrokerConfig_instanceType(rName, testAccActiveVersionNormalized5_18, "mq.t3.micro"),
+				Config: testAccBrokerConfig_instanceType(rName, testAccActiveVersionNormalized5_18, "mq.t3.micro", testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker2),
 					testAccCheckBrokerNotRecreated(&broker1, &broker2),
@@ -1253,7 +1255,7 @@ func TestAccMQBroker_RabbitMQ_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_rabbit(rName, testAccRabbitVersionNormalized3_13),
+				Config: testAccBrokerConfig_rabbit(rName, testAccRabbitVersionNormalized3_13, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
@@ -1304,7 +1306,7 @@ func TestAccMQBroker_RabbitMQ_autoMinorVersionUpgrade(t *testing.T) {
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "RabbitMQ"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, testAccAutoMinorVersionUpgrade),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, testAccRabbitVersionNormalized3_13),
 					resource.TestCheckResourceAttr(resourceName, "host_instance_type", "mq.t3.micro"),
 					resource.TestCheckResourceAttr(resourceName, "instances.#", "1"),
@@ -1349,7 +1351,7 @@ func TestAccMQBroker_RabbitMQ_normalizedEngineVersion(t *testing.T) {
 				Config: testAccBrokerConfig_rabbitAutoMinorVersionUpgrade(rName, testAccRabbitVersionNormalized3_13, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
-					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, testAccAutoMinorVersionUpgrade),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "RabbitMQ"),
 					// Starting in v3.13, the engine version should be normalized to remove
 					// the patch version as AWS automatically handles patch updates when
@@ -1388,7 +1390,7 @@ func TestAccMQBroker_RabbitMQ_config(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_rabbitConfig(rName, testAccRabbitVersionNormalized3_13),
+				Config: testAccBrokerConfig_rabbitConfig(rName, testAccRabbitVersionNormalized3_13, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
@@ -1473,7 +1475,7 @@ func TestAccMQBroker_RabbitMQ_logs(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_rabbitLogs(rName, testAccRabbitVersionNormalized3_13),
+				Config: testAccBrokerConfig_rabbitLogs(rName, testAccRabbitVersionNormalized3_13, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
@@ -1519,13 +1521,13 @@ func TestAccMQBroker_RabbitMQ_validationAuditLog(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccBrokerConfig_rabbitAuditLog(rName, testAccRabbitVersionNormalized3_13, true),
+				Config:      testAccBrokerConfig_rabbitAuditLog(rName, testAccRabbitVersionNormalized3_13, testAccAutoMinorVersionUpgrade, true),
 				ExpectError: regexache.MustCompile(`logs.audit: Can not be configured when engine is RabbitMQ`),
 			},
 			{
 				// Special case: allow explicitly setting logs.0.audit to false,
 				// though the AWS API does not accept the parameter.
-				Config: testAccBrokerConfig_rabbitAuditLog(rName, testAccRabbitVersionNormalized3_13, false),
+				Config: testAccBrokerConfig_rabbitAuditLog(rName, testAccRabbitVersionNormalized3_13, testAccAutoMinorVersionUpgrade, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "logs.#", "1"),
@@ -1558,10 +1560,10 @@ func TestAccMQBroker_RabbitMQ_cluster(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_rabbitCluster(rName, testAccRabbitVersionNormalized3_13),
+				Config: testAccBrokerConfig_rabbitCluster(rName, testAccRabbitVersionNormalized3_13, testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
-					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, testAccAutoMinorVersionUpgrade),
 					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "deployment_mode", "CLUSTER_MULTI_AZ"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_options.#", "1"),
@@ -1628,7 +1630,7 @@ func TestAccMQBroker_ldap(t *testing.T) {
 				Config: testAccBrokerConfig_ldapNoUserBlock(rName, testAccActiveVersionNormalized5_18, "anyusername", testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
-					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, testAccAutoMinorVersionUpgrade),
 					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "authentication_strategy", "ldap"),
 					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.hosts.#", "2"),
@@ -1650,7 +1652,7 @@ func TestAccMQBroker_ldap(t *testing.T) {
 				Config: testAccBrokerConfig_ldapUserBlock(rName, testAccActiveVersionNormalized5_18, "anyusername", testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
-					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, testAccAutoMinorVersionUpgrade),
 					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "authentication_strategy", "ldap"),
 					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.hosts.#", "2"),
@@ -1697,7 +1699,7 @@ func TestAccMQBroker_dataReplicationMode(t *testing.T) {
 		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_dataReplicationMode(rName, testAccActiveVersionNormalized5_18, string(types.DataReplicationModeCrdr)),
+				Config: testAccBrokerConfig_dataReplicationMode(rName, testAccActiveVersionNormalized5_18, string(types.DataReplicationModeCrdr), testAccAutoMinorVersionUpgrade),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					testAccCheckBrokerExistsWithProvider(ctx, primaryBrokerResourceName, &brokerAlternate, acctest.RegionProviderFunc(ctx, acctest.AlternateRegion(), &providers)),
@@ -1710,7 +1712,7 @@ func TestAccMQBroker_dataReplicationMode(t *testing.T) {
 				),
 			},
 			{
-				Config:                  testAccBrokerConfig_dataReplicationMode(rName, testAccActiveVersionNormalized5_18, string(types.DataReplicationModeCrdr)),
+				Config:                  testAccBrokerConfig_dataReplicationMode(rName, testAccActiveVersionNormalized5_18, string(types.DataReplicationModeCrdr), testAccAutoMinorVersionUpgrade),
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -1731,7 +1733,7 @@ func TestAccMQBroker_dataReplicationMode(t *testing.T) {
 					// in the opposite order, so delete the primary out of band instead.
 					testAccDeleteBrokerWithProvider(ctx, t, &brokerAlternate, acctest.RegionProviderFunc(ctx, acctest.AlternateRegion(), &providers))
 				},
-				Config:             testAccBrokerConfig_dataReplicationMode(rName, testAccActiveVersionNormalized5_18, string(types.DataReplicationModeNone)),
+				Config:             testAccBrokerConfig_dataReplicationMode(rName, testAccActiveVersionNormalized5_18, string(types.DataReplicationModeNone), testAccAutoMinorVersionUpgrade),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
@@ -1873,7 +1875,7 @@ func testAccCheckBrokerNotRecreated(before, after *mq.DescribeBrokerOutput) reso
 	}
 }
 
-func testAccBrokerConfig_basic(rName, version string) string {
+func testAccBrokerConfig_basic(rName, version, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -1891,6 +1893,7 @@ resource "aws_mq_broker" "test" {
   security_groups         = [aws_security_group.test.id]
   authentication_strategy = "simple"
   storage_type            = "efs"
+  auto_minor_version_upgrade = %[3]s
 
   logs {
     general = true
@@ -1901,10 +1904,10 @@ resource "aws_mq_broker" "test" {
     password = "TestTest1234"
   }
 }
-`, rName, version)
+`, rName, version, autoMinorVersionUpgrade)
 }
 
-func testAccBrokerConfig_autoMinorVersionUpgrade(rName, version string, autoMinorVersionUpgrade bool) string {
+func testAccBrokerConfig_autoMinorVersionUpgrade(rName, version, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -1922,7 +1925,7 @@ resource "aws_mq_broker" "test" {
   security_groups            = [aws_security_group.test.id]
   authentication_strategy    = "simple"
   storage_type               = "efs"
-  auto_minor_version_upgrade = %[3]t
+  auto_minor_version_upgrade = %[3]s
 
   logs {
     general = true
@@ -1936,7 +1939,7 @@ resource "aws_mq_broker" "test" {
 `, rName, version, autoMinorVersionUpgrade)
 }
 
-func testAccBrokerConfig_ebs(rName, version string) string {
+func testAccBrokerConfig_ebs(rName, version, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -1953,6 +1956,7 @@ resource "aws_mq_broker" "test" {
   storage_type       = "ebs"
   host_instance_type = "mq.m5.large"
   security_groups    = [aws_security_group.test.id]
+	auto_minor_version_upgrade = %[3]s
 
   logs {
     general = true
@@ -1963,7 +1967,7 @@ resource "aws_mq_broker" "test" {
     password = "TestTest1234"
   }
 }
-`, rName, version)
+`, rName, version, autoMinorVersionUpgrade)
 }
 
 /*
@@ -1998,7 +2002,7 @@ resource "aws_mq_broker" "test" {
 }
 */
 
-func testAccBrokerConfig_allFieldsDefaultVPC(rName, version, cfgName, cfgBody string) string {
+func testAccBrokerConfig_allFieldsDefaultVPC(rName, version, cfgName, cfgBody, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   count = 2
@@ -2021,7 +2025,7 @@ DATA
 }
 
 resource "aws_mq_broker" "test" {
-  auto_minor_version_upgrade = true
+  auto_minor_version_upgrade = %[5]s
   apply_immediately          = true
   broker_name                = %[1]q
 
@@ -2057,7 +2061,7 @@ resource "aws_mq_broker" "test" {
     groups         = ["first", "second", "third"]
   }
 }
-`, rName, version, cfgName, cfgBody)
+`, rName, version, cfgName, cfgBody, autoMinorVersionUpgrade)
 }
 
 func testAccBrokerConfig_baseCustomVPC(rName string) string {
@@ -2103,7 +2107,7 @@ resource "aws_security_group" "test" {
 `, rName))
 }
 
-func testAccBrokerConfig_allFieldsCustomVPC(rName, version, cfgName, cfgBody, tz string) string {
+func testAccBrokerConfig_allFieldsCustomVPC(rName, version, cfgName, cfgBody, tz, autoMinorVersionUpgrade string) string {
 	return acctest.ConfigCompose(testAccBrokerConfig_baseCustomVPC(rName), fmt.Sprintf(`
 resource "aws_mq_configuration" "test" {
   name           = %[3]q
@@ -2116,7 +2120,7 @@ DATA
 }
 
 resource "aws_mq_broker" "test" {
-  auto_minor_version_upgrade = true
+  auto_minor_version_upgrade = %[6]s
   apply_immediately          = true
   broker_name                = %[1]q
 
@@ -2160,10 +2164,10 @@ resource "aws_mq_broker" "test" {
 
   depends_on = [aws_internet_gateway.test]
 }
-`, rName, version, cfgName, cfgBody, tz))
+`, rName, version, cfgName, cfgBody, tz, autoMinorVersionUpgrade))
 }
 
-func testAccBrokerConfig_encryptionOptionsKMSKeyID(rName, version string) string {
+func testAccBrokerConfig_encryptionOptionsKMSKeyID(rName, version, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -2185,6 +2189,7 @@ resource "aws_mq_broker" "test" {
   engine_version     = %[2]q
   host_instance_type = "mq.t3.micro"
   security_groups    = [aws_security_group.test.id]
+	auto_minor_version_upgrade = %[3]s
 
   encryption_options {
     kms_key_id        = aws_kms_key.test.arn
@@ -2200,10 +2205,10 @@ resource "aws_mq_broker" "test" {
     password = "TestTest1234"
   }
 }
-`, rName, version)
+`, rName, version, autoMinorVersionUpgrade)
 }
 
-func testAccBrokerConfig_encryptionOptionsManagedKey(rName, version string, useAwsOwnedKey bool) string {
+func testAccBrokerConfig_encryptionOptionsManagedKey(rName, version, autoMinorVersionUpgrade string, useAwsOwnedKey bool) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -2219,9 +2224,10 @@ resource "aws_mq_broker" "test" {
   engine_version     = %[2]q
   host_instance_type = "mq.t3.micro"
   security_groups    = [aws_security_group.test.id]
+	auto_minor_version_upgrade = %[3]s
 
   encryption_options {
-    use_aws_owned_key = %[3]t
+    use_aws_owned_key = %[4]t
   }
 
   logs {
@@ -2233,7 +2239,7 @@ resource "aws_mq_broker" "test" {
     password = "TestTest1234"
   }
 }
-`, rName, version, useAwsOwnedKey)
+`, rName, version, autoMinorVersionUpgrade, useAwsOwnedKey)
 }
 
 func testAccBrokerConfig_rabbitNoUserBlock(rName, version, autoMinorVersionUpgrade string) string {
@@ -2272,7 +2278,7 @@ resource "aws_mq_broker" "test" {
 `, rName, version, autoMinorVersionUpgrade)
 }
 
-func testAccBrokerConfig_updateUsers1(rName, version string) string {
+func testAccBrokerConfig_updateUsers1(rName, version, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -2289,16 +2295,17 @@ resource "aws_mq_broker" "test" {
   engine_version     = %[2]q
   host_instance_type = "mq.t3.micro"
   security_groups    = [aws_security_group.test.id]
+	auto_minor_version_upgrade = %[3]s
 
   user {
     username = "first"
     password = "TestTest1111"
   }
 }
-`, rName, version)
+`, rName, version, autoMinorVersionUpgrade)
 }
 
-func testAccBrokerConfig_updateUsers2(rName, version string) string {
+func testAccBrokerConfig_updateUsers2(rName, version, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -2315,6 +2322,7 @@ resource "aws_mq_broker" "test" {
   engine_version     = %[2]q
   host_instance_type = "mq.t3.micro"
   security_groups    = [aws_security_group.test.id]
+	auto_minor_version_upgrade = %[3]s
 
   user {
     console_access = true
@@ -2327,10 +2335,10 @@ resource "aws_mq_broker" "test" {
     password = "TestTest2222"
   }
 }
-`, rName, version)
+`, rName, version, autoMinorVersionUpgrade)
 }
 
-func testAccBrokerConfig_updateUsers3(rName, version string) string {
+func testAccBrokerConfig_updateUsers3(rName, version, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -2347,6 +2355,7 @@ resource "aws_mq_broker" "test" {
   engine_version     = %[2]q
   host_instance_type = "mq.t3.micro"
   security_groups    = [aws_security_group.test.id]
+	auto_minor_version_upgrade = %[3]s
 
   user {
     username = "second"
@@ -2354,10 +2363,10 @@ resource "aws_mq_broker" "test" {
     groups   = ["admin"]
   }
 }
-`, rName, version)
+`, rName, version, autoMinorVersionUpgrade)
 }
 
-func testAccBrokerConfig_tags1(rName, version, tagKey1, tagValue1 string) string {
+func testAccBrokerConfig_tags1(rName, version, tagKey1, tagValue1, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -2374,6 +2383,7 @@ resource "aws_mq_broker" "test" {
   engine_version     = %[2]q
   host_instance_type = "mq.t3.micro"
   security_groups    = [aws_security_group.test.id]
+	auto_minor_version_upgrade = %[5]s
 
   user {
     username = "Test"
@@ -2384,10 +2394,10 @@ resource "aws_mq_broker" "test" {
     %[3]q = %[4]q
   }
 }
-`, rName, version, tagKey1, tagValue1)
+`, rName, version, tagKey1, tagValue1, autoMinorVersionUpgrade)
 }
 
-func testAccBrokerConfig_tags2(rName, version, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccBrokerConfig_tags2(rName, version, tagKey1, tagValue1, tagKey2, tagValue2, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -2404,6 +2414,7 @@ resource "aws_mq_broker" "test" {
   engine_version     = %[2]q
   host_instance_type = "mq.t3.micro"
   security_groups    = [aws_security_group.test.id]
+	auto_minor_version_upgrade = %[7]s
 
   user {
     username = "Test"
@@ -2415,10 +2426,10 @@ resource "aws_mq_broker" "test" {
     %[5]q = %[6]q
   }
 }
-`, rName, version, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, version, tagKey1, tagValue1, tagKey2, tagValue2, autoMinorVersionUpgrade)
 }
 
-func testAccBrokerConfig_updateSecurityGroups(rName, version string) string {
+func testAccBrokerConfig_updateSecurityGroups(rName, version, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -2443,6 +2454,7 @@ resource "aws_mq_broker" "test" {
   engine_version     = %[2]q
   host_instance_type = "mq.t3.micro"
   security_groups    = [aws_security_group.test.id, aws_security_group.test2.id]
+	auto_minor_version_upgrade = %[3]s
 
   logs {
     general = true
@@ -2453,10 +2465,10 @@ resource "aws_mq_broker" "test" {
     password = "TestTest1234"
   }
 }
-`, rName, version)
+`, rName, version, autoMinorVersionUpgrade)
 }
 
-func testAccBrokerConfig_updateUsersSecurityGroups(rName, version string) string {
+func testAccBrokerConfig_updateUsersSecurityGroups(rName, version, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -2481,6 +2493,7 @@ resource "aws_mq_broker" "test" {
   engine_version     = %[2]q
   host_instance_type = "mq.t3.micro"
   security_groups    = [aws_security_group.test2.id]
+	auto_minor_version_upgrade = %[3]s
 
   logs {
     general = true
@@ -2491,10 +2504,10 @@ resource "aws_mq_broker" "test" {
     password = "TestTest9999"
   }
 }
-`, rName, version)
+`, rName, version, autoMinorVersionUpgrade)
 }
 
-func testAccBrokerConfig_rabbit(rName, version string) string {
+func testAccBrokerConfig_rabbit(rName, version, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -2510,16 +2523,17 @@ resource "aws_mq_broker" "test" {
   engine_version     = %[2]q
   host_instance_type = "mq.t3.micro"
   security_groups    = [aws_security_group.test.id]
+	auto_minor_version_upgrade = %[3]s
 
   user {
     username = "Test"
     password = "TestTest1234"
   }
 }
-`, rName, version)
+`, rName, version, autoMinorVersionUpgrade)
 }
 
-func testAccBrokerConfig_rabbitAutoMinorVersionUpgrade(rName, version string, autoMinorVersionUpgrade bool) string {
+func testAccBrokerConfig_rabbitAutoMinorVersionUpgrade(rName, version, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -2535,7 +2549,7 @@ resource "aws_mq_broker" "test" {
   engine_version             = %[2]q
   host_instance_type         = "mq.t3.micro"
   security_groups            = [aws_security_group.test.id]
-  auto_minor_version_upgrade = %[3]t
+  auto_minor_version_upgrade = %[3]s
 
   user {
     username = "Test"
@@ -2545,7 +2559,7 @@ resource "aws_mq_broker" "test" {
 `, rName, version, autoMinorVersionUpgrade)
 }
 
-func testAccBrokerConfig_rabbitConfig(rName, version string) string {
+func testAccBrokerConfig_rabbitConfig(rName, version, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -2574,6 +2588,7 @@ resource "aws_mq_broker" "test" {
   engine_version     = %[2]q
   host_instance_type = "mq.t3.micro"
   security_groups    = [aws_security_group.test.id]
+	auto_minor_version_upgrade = %[3]s
 
   configuration {
     id       = aws_mq_configuration.test.id
@@ -2585,10 +2600,10 @@ resource "aws_mq_broker" "test" {
     password = "TestTest1234"
   }
 }
-`, rName, version)
+`, rName, version, autoMinorVersionUpgrade)
 }
 
-func testAccBrokerConfig_rabbitLogs(rName, version string) string {
+func testAccBrokerConfig_rabbitLogs(rName, version, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_mq_broker" "test" {
   broker_name        = %[1]q
@@ -2596,6 +2611,7 @@ resource "aws_mq_broker" "test" {
   engine_version     = %[2]q
   host_instance_type = "mq.t3.micro"
   security_groups    = [aws_security_group.test.id]
+	auto_minor_version_upgrade = %[3]s
 
   logs {
     general = true
@@ -2614,10 +2630,10 @@ resource "aws_security_group" "test" {
     Name = %[1]q
   }
 }
-`, rName, version)
+`, rName, version, autoMinorVersionUpgrade)
 }
 
-func testAccBrokerConfig_rabbitAuditLog(rName, version string, enabled bool) string {
+func testAccBrokerConfig_rabbitAuditLog(rName, version, autoMinorVersionUpgrade string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_mq_broker" "test" {
   broker_name        = %[1]q
@@ -2625,10 +2641,11 @@ resource "aws_mq_broker" "test" {
   engine_version     = %[2]q
   host_instance_type = "mq.t3.micro"
   security_groups    = [aws_security_group.test.id]
+	auto_minor_version_upgrade = %[3]s
 
   logs {
     general = true
-    audit   = %[3]t
+    audit   = %[4]t
   }
 
   user {
@@ -2644,10 +2661,10 @@ resource "aws_security_group" "test" {
     Name = %[1]q
   }
 }
-`, rName, version, enabled)
+`, rName, version, autoMinorVersionUpgrade, enabled)
 }
 
-func testAccBrokerConfig_rabbitCluster(rName, version string) string {
+func testAccBrokerConfig_rabbitCluster(rName, version, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -2665,6 +2682,7 @@ resource "aws_mq_broker" "test" {
   security_groups    = [aws_security_group.test.id]
   storage_type       = "ebs"
   deployment_mode    = "CLUSTER_MULTI_AZ"
+	auto_minor_version_upgrade = %[3]s
 
   user {
     username = "Test"
@@ -2682,7 +2700,7 @@ data "aws_subnets" "default" {
 data "aws_vpc" "default" {
   default = true
 }
-`, rName, version)
+`, rName, version, autoMinorVersionUpgrade)
 }
 
 func testAccBrokerConfig_ldapNoUserBlock(rName, version, ldapUsername, autoMinorVersionUpgrade string) string {
@@ -2773,7 +2791,7 @@ resource "aws_mq_broker" "test" {
 `, rName, version, ldapUsername, autoMinorVersionUpgrade)
 }
 
-func testAccBrokerConfig_instanceType(rName, version, instanceType string) string {
+func testAccBrokerConfig_instanceType(rName, version, instanceType, autoMinorVersionUpgrade string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -2790,6 +2808,7 @@ resource "aws_mq_broker" "test" {
   engine_version     = %[2]q
   host_instance_type = %[3]q
   security_groups    = [aws_security_group.test.id]
+	auto_minor_version_upgrade = %[4]s
 
   logs {
     general = true
@@ -2800,12 +2819,12 @@ resource "aws_mq_broker" "test" {
     password = "TestTest1234"
   }
 }
-`, rName, version, instanceType)
+`, rName, version, instanceType, autoMinorVersionUpgrade)
 }
 
 // testAccBrokerConfig_dataReplicationMode creates a primary and replica broker
 // in different regions, linking the former using the data replication arguments
-func testAccBrokerConfig_dataReplicationMode(rName, version, dataReplicationMode string) string {
+func testAccBrokerConfig_dataReplicationMode(rName, version, dataReplicationMode, autoMinorVersionUpgrade string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigMultipleRegionProvider(2),
 		fmt.Sprintf(`
@@ -2829,6 +2848,7 @@ resource "aws_mq_broker" "primary" {
   host_instance_type = "mq.m5.large"
   security_groups    = [aws_security_group.primary.id]
   deployment_mode    = "ACTIVE_STANDBY_MULTI_AZ"
+	auto_minor_version_upgrade = %[4]s
 
   logs {
     general = true
@@ -2861,6 +2881,7 @@ resource "aws_mq_broker" "test" {
   host_instance_type = "mq.m5.large"
   security_groups    = [aws_security_group.test.id]
   deployment_mode    = "ACTIVE_STANDBY_MULTI_AZ"
+	auto_minor_version_upgrade = %[4]s
 
   data_replication_mode               = %[3]q
   data_replication_primary_broker_arn = aws_mq_broker.primary.arn
@@ -2879,5 +2900,5 @@ resource "aws_mq_broker" "test" {
     replication_user = true
   }
 }
-`, rName, version, dataReplicationMode))
+`, rName, version, dataReplicationMode, autoMinorVersionUpgrade))
 }

--- a/internal/service/mq/broker_test.go
+++ b/internal/service/mq/broker_test.go
@@ -348,8 +348,8 @@ func TestNormalizeEngineVersion(t *testing.T) {
 const (
 	testAccActiveVersionNormalized5_18 = "5.18"
 	testAccRabbitVersionNormalized3_13 = "3.13"
-	testAccNoAutoMinorVersionUpgrade   = "false"
-	testAccAutoMinorVersionUpgrade     = "true"
+	// testAccNoAutoMinorVersionUpgrade   = acctest.CtFalse
+	testAccAutoMinorVersionUpgrade = acctest.CtTrue
 )
 
 func TestAccMQBroker_basic(t *testing.T) {

--- a/website/docs/r/mq_broker.html.markdown
+++ b/website/docs/r/mq_broker.html.markdown
@@ -129,7 +129,6 @@ The following arguments are required:
 * `engine_type` - (Required) Type of broker engine. Valid values are `ActiveMQ` and `RabbitMQ`.
 * `engine_version` - (Required) Version of the broker engine.
 * `host_instance_type` - (Required) Broker's instance type. For example, `mq.t3.micro`, `mq.m5.large`.
-* `user` - (Required) Configuration block for broker users. For `engine_type` of `RabbitMQ`, Amazon MQ does not return broker users preventing this resource from making user updates and drift detection. Detailed below.
 
 The following arguments are optional:
 
@@ -150,6 +149,7 @@ The following arguments are optional:
 * `storage_type` - (Optional) Storage type of the broker. For `engine_type` `ActiveMQ`, valid values are `efs` and `ebs` (AWS-default is `efs`). For `engine_type` `RabbitMQ`, only `ebs` is supported. When using `ebs`, only the `mq.m5` broker instance type family is supported.
 * `subnet_ids` - (Optional) List of subnet IDs in which to launch the broker. A `SINGLE_INSTANCE` deployment requires one subnet. An `ACTIVE_STANDBY_MULTI_AZ` deployment requires multiple subnets.
 * `tags` - (Optional) Map of tags to assign to the broker. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `user` - (Optional) Configuration block for broker users. For `engine_type` of `RabbitMQ`, Amazon MQ does not return broker users preventing this resource from making user updates and drift detection. Detailed below.
 
 ### configuration
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
None

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Makes user block an optional attribute for instances where the authentication method is LDAP (ActiveMQ) or config managed (RabbitMQ).
<br/>

Additionally, the PR includes acceptance test changes addressing unrelated failures that could have been masking regressions.
1. Invalid broker engine versions.
  `Invalid broker engine version [3.11.20] for RABBITMQ (valid: 4.2, 3.13)`
  `Invalid broker engine version [5.17.6] for ACTIVEMQ (valid: 5.19, 5.18)`

1. `autoMinorVersionUpgrade` must be set to true for ActiveMQ brokers version 5.18 and above and for RabbitMQ brokers version 3.13 and above.
  `RabbitMQ 3.13 requires autoMinorVersionUpgrade set to true`
  `ActiveMQ 5.18 requires autoMinorVersionUpgrade set to true`


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #46882
Closes #46061

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

See related issue

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

> [!IMPORTANT]
> Remaining failures all target RabbitMQ and are related to #46061. I reverted [diff](https://github.com/hashicorp/terraform-provider-aws/pull/46883/changes#diff-e1de2cb97b74e6228f0643eaf90ccc366261256c6af7d72a2525ef1976915086L330) after updating the acceptance tests and confirmed the same "refresh plan was not empty" errors were present. 
>
> <details><summary>All failed tests match this example. Removed from output below for readability.</summary>
>
> ```log
>    broker_test.go:1336: Step 1/2 error: After applying this test step, the refresh plan was not empty.
>        stdout
>        
>        
>        Terraform used the selected providers to generate the following execution
>        plan. Resource actions are indicated with the following symbols:
>          ~ update in-place
>        
>        Terraform will perform the following actions:
>        
>          # aws_mq_broker.test will be updated in-place
>          ~ resource "aws_mq_broker" "test" {
>                id                            = "b-002f75bc-9aa9-4763-991c-0fe3801ab3ca"
>                tags                          = {}
>                # (18 unchanged attributes hidden)
>        
>                # (4 unchanged blocks hidden)
>            }
>        
>        Plan: 0 to add, 1 to change, 0 to destroy.
>
</details>

```console
% make testacc TESTS='^TestAccMQBroker_' PKG=mq
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-mq-broker-user-block-optional 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/mq/... -v -count 1 -parallel 20 -run='^TestAccMQBroker_'  -timeout 360m -vet=off
2026/03/12 19:44:57 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/12 19:44:57 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccMQBroker_basic
=== PAUSE TestAccMQBroker_basic
=== RUN   TestAccMQBroker_normalizedEngineVersion
=== PAUSE TestAccMQBroker_normalizedEngineVersion
=== RUN   TestAccMQBroker_disappears
=== PAUSE TestAccMQBroker_disappears
=== RUN   TestAccMQBroker_tags
=== PAUSE TestAccMQBroker_tags
=== RUN   TestAccMQBroker_throughputOptimized
=== PAUSE TestAccMQBroker_throughputOptimized
=== RUN   TestAccMQBroker_AllFields_defaultVPC
=== PAUSE TestAccMQBroker_AllFields_defaultVPC
=== RUN   TestAccMQBroker_AllFields_customVPC
=== PAUSE TestAccMQBroker_AllFields_customVPC
=== RUN   TestAccMQBroker_EncryptionOptions_kmsKeyID
=== PAUSE TestAccMQBroker_EncryptionOptions_kmsKeyID
=== RUN   TestAccMQBroker_EncryptionOptions_managedKeyDisabled
=== PAUSE TestAccMQBroker_EncryptionOptions_managedKeyDisabled
=== RUN   TestAccMQBroker_EncryptionOptions_managedKeyEnabled
=== PAUSE TestAccMQBroker_EncryptionOptions_managedKeyEnabled
=== RUN   TestAccMQBroker_Update_users
=== PAUSE TestAccMQBroker_Update_users
=== RUN   TestAccMQBroker_Update_securityGroup
=== PAUSE TestAccMQBroker_Update_securityGroup
=== RUN   TestAccMQBroker_Update_hostInstanceType
=== PAUSE TestAccMQBroker_Update_hostInstanceType
=== RUN   TestAccMQBroker_RabbitMQ_basic
=== PAUSE TestAccMQBroker_RabbitMQ_basic
=== RUN   TestAccMQBroker_RabbitMQ_autoMinorVersionUpgrade
=== PAUSE TestAccMQBroker_RabbitMQ_autoMinorVersionUpgrade
=== RUN   TestAccMQBroker_RabbitMQ_normalizedEngineVersion
=== PAUSE TestAccMQBroker_RabbitMQ_normalizedEngineVersion
=== RUN   TestAccMQBroker_RabbitMQ_config
=== PAUSE TestAccMQBroker_RabbitMQ_config
=== RUN   TestAccMQBroker_RabbitMQ_configNoUserBlock
=== PAUSE TestAccMQBroker_RabbitMQ_configNoUserBlock
=== RUN   TestAccMQBroker_RabbitMQ_logs
=== PAUSE TestAccMQBroker_RabbitMQ_logs
=== RUN   TestAccMQBroker_RabbitMQ_validationAuditLog
=== PAUSE TestAccMQBroker_RabbitMQ_validationAuditLog
=== RUN   TestAccMQBroker_RabbitMQ_cluster
=== PAUSE TestAccMQBroker_RabbitMQ_cluster
=== RUN   TestAccMQBroker_ldap
=== PAUSE TestAccMQBroker_ldap
=== RUN   TestAccMQBroker_dataReplicationMode
=== PAUSE TestAccMQBroker_dataReplicationMode
=== CONT  TestAccMQBroker_basic
=== CONT  TestAccMQBroker_ldap
=== CONT  TestAccMQBroker_RabbitMQ_logs
=== CONT  TestAccMQBroker_EncryptionOptions_kmsKeyID
=== CONT  TestAccMQBroker_dataReplicationMode
=== CONT  TestAccMQBroker_RabbitMQ_validationAuditLog
=== CONT  TestAccMQBroker_RabbitMQ_configNoUserBlock
=== CONT  TestAccMQBroker_RabbitMQ_config
=== CONT  TestAccMQBroker_RabbitMQ_normalizedEngineVersion
=== CONT  TestAccMQBroker_RabbitMQ_autoMinorVersionUpgrade
=== CONT  TestAccMQBroker_RabbitMQ_basic
=== CONT  TestAccMQBroker_RabbitMQ_cluster
=== CONT  TestAccMQBroker_AllFields_customVPC
=== CONT  TestAccMQBroker_Update_securityGroup
=== CONT  TestAccMQBroker_Update_users
=== CONT  TestAccMQBroker_EncryptionOptions_managedKeyEnabled
=== CONT  TestAccMQBroker_EncryptionOptions_managedKeyDisabled
=== CONT  TestAccMQBroker_tags
=== CONT  TestAccMQBroker_AllFields_defaultVPC
=== CONT  TestAccMQBroker_Update_hostInstanceType
=== NAME  TestAccMQBroker_RabbitMQ_validationAuditLog
--- FAIL: TestAccMQBroker_RabbitMQ_validationAuditLog (647.41s)
=== CONT  TestAccMQBroker_throughputOptimized
=== NAME  TestAccMQBroker_RabbitMQ_logs
=== NAME  TestAccMQBroker_RabbitMQ_autoMinorVersionUpgrade
=== NAME  TestAccMQBroker_RabbitMQ_cluster
--- PASS: TestAccMQBroker_RabbitMQ_configNoUserBlock (710.59s)
=== CONT  TestAccMQBroker_disappears
=== NAME  TestAccMQBroker_RabbitMQ_basic
=== NAME  TestAccMQBroker_RabbitMQ_config
--- FAIL: TestAccMQBroker_RabbitMQ_cluster (734.01s)
=== CONT  TestAccMQBroker_normalizedEngineVersion
--- FAIL: TestAccMQBroker_RabbitMQ_autoMinorVersionUpgrade (749.02s)
--- FAIL: TestAccMQBroker_RabbitMQ_logs (754.16s)
--- FAIL: TestAccMQBroker_RabbitMQ_basic (777.47s)
=== NAME  TestAccMQBroker_RabbitMQ_normalizedEngineVersion
--- FAIL: TestAccMQBroker_RabbitMQ_config (804.98s)
--- FAIL: TestAccMQBroker_RabbitMQ_normalizedEngineVersion (881.95s)
--- PASS: TestAccMQBroker_EncryptionOptions_managedKeyEnabled (941.28s)
--- PASS: TestAccMQBroker_tags (1019.19s)
--- PASS: TestAccMQBroker_basic (1020.23s)
--- PASS: TestAccMQBroker_EncryptionOptions_managedKeyDisabled (1029.69s)
--- PASS: TestAccMQBroker_EncryptionOptions_kmsKeyID (1035.59s)
--- PASS: TestAccMQBroker_Update_hostInstanceType (1041.54s)
--- PASS: TestAccMQBroker_Update_securityGroup (1210.75s)
--- PASS: TestAccMQBroker_ldap (1239.98s)
--- PASS: TestAccMQBroker_Update_users (1392.07s)
--- PASS: TestAccMQBroker_throughputOptimized (898.79s)
--- PASS: TestAccMQBroker_AllFields_defaultVPC (1633.26s)
--- PASS: TestAccMQBroker_AllFields_customVPC (1713.80s)
--- PASS: TestAccMQBroker_normalizedEngineVersion (994.77s)
--- PASS: TestAccMQBroker_disappears (1044.64s)
--- PASS: TestAccMQBroker_dataReplicationMode (2254.42s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/mq	2261.611s
FAIL
make: *** [testacc] Error 1

```
