### PR TITLE
[Docs] aws_guardduty_filter: Clarify that an integer value given as a string can be accepted as a value of `less_than` etc.

### DIFF
--- a/website/docs/r/guardduty_filter.html.markdown
+++ b/website/docs/r/guardduty_filter.html.markdown
@@ -64,10 +64,10 @@ The `criterion` block supports the following:
 * `field` - (Required) The name of the field to be evaluated. The full list of field names can be found in [AWS documentation](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_filter-findings.html#filter_criteria).
 * `equals` - (Optional) List of string values to be evaluated.
 * `not_equals` - (Optional) List of string values to be evaluated.
-* `greater_than` - (Optional) A value to be evaluated. Accepts either an integer or a date in [RFC 3339 format](https://tools.ietf.org/html/rfc3339#section-5.8).
-* `greater_than_or_equal` - (Optional) A value to be evaluated. Accepts either an integer or a date in [RFC 3339 format](https://tools.ietf.org/html/rfc3339#section-5.8).
-* `less_than` - (Optional) A value to be evaluated. Accepts either an integer or a date in [RFC 3339 format](https://tools.ietf.org/html/rfc3339#section-5.8).
-* `less_than_or_equal` - (Optional) A value to be evaluated. Accepts either an integer or a date in [RFC 3339 format](https://tools.ietf.org/html/rfc3339#section-5.8).
+* `greater_than` - (Optional) A value to be evaluated. Accepts either an integer given as a string (i.e., enclosed in quotations) or a date in [RFC 3339 format](https://tools.ietf.org/html/rfc3339#section-5.8).
+* `greater_than_or_equal` - (Optional) A value to be evaluated. Accepts either an integer given as a string (i.e., enclosed in quotations) or a date in [RFC 3339 format](https://tools.ietf.org/html/rfc3339#section-5.8).
+* `less_than` - (Optional) A value to be evaluated. Accepts either an integer given as a string (i.e., enclosed in quotations) or a date in [RFC 3339 format](https://tools.ietf.org/html/rfc3339#section-5.8).
+* `less_than_or_equal` - (Optional) A value to be evaluated. Accepts either an integer given as a string (i.e., enclosed in quotations) or a date in [RFC 3339 format](https://tools.ietf.org/html/rfc3339#section-5.8).
 * `matches` - (Optional) List of string values to be evaluated as matching conditions.
 * `not_matches` - (Optional) List of string values to be evaluated as non-matching conditions.
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

In the current implementation, the `greater_than`, `greater_than_or_equal`, `less_than`, and `less_than_or_equal` arguments are defined as strings and validated using `ValidStringDateOrPositiveInt`.

[https://github.com/hashicorp/terraform-provider-aws/blob/a9e74da42c8fe92d04de746a5ae160ecb84b90a9/internal/service/guardduty/filter.go#L92-L112](https://github.com/hashicorp/terraform-provider-aws/blob/a9e74da42c8fe92d04de746a5ae160ecb84b90a9/internal/service/guardduty/filter.go#L92-L112)

However, the documentation states:

> [less_than](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_filter#less_than-1)- (Optional) A value to be evaluated. Accepts either an integer or a date in [RFC 3339 format](https://tools.ietf.org/html/rfc3339#section-5.8)

This description may suggest that an integer value can be provided directly. However, the value must be provided as a string (i.e., enclosed in quotation marks).

The example in the documentation also shows that an integer value for these arguments must be enclosed in quotation marks:

https://github.com/hashicorp/terraform-provider-aws/blob/a9e74da42c8fe92d04de746a5ae160ecb84b90a9/website/docs/r/guardduty_filter.html.markdown?plain=1#L39-L42

This PR updates the documentation to clarify that integer values must be provided as strings (i.e., enclosed in quotation marks) when used with these arguments.


### Relations

Relates #46842

