### PR TITLE
docs: remove text from  argument "arn" in data source "aws_batch_job_definition"

### DIFF
--- a/website/docs/d/batch_job_definition.html.markdown
+++ b/website/docs/d/batch_job_definition.html.markdown
@@ -12,7 +12,7 @@ Terraform data source for managing an AWS Batch Job Definition.
 
 ## Example Usage
 
-### Lookup via Arn
+### Lookup via ARN
 
 ```terraform
 data "aws_batch_job_definition" "arn" {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

The description for the argument [`arn`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/batch_job_definition#arn-1) of the data source [`aws_batch_job_definition`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/batch_job_definition) contains 

> Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.

This is the "default"/ lorem ipsum text and this PR removes it.


### Relations

### References

### Output from Acceptance Testing

Not applicable. Only documentation is updated.