### PR TITLE
r/aws_emrcontainers_job_template: Add parameter_configuration support

### DIFF
--- a/.changelog/46933.txt
+++ b/.changelog/46933.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_emrcontainers_job_template: Add `parameter_configuration` attribute to `job_template_data`
+```

--- a/internal/service/emrcontainers/job_template.go
+++ b/internal/service/emrcontainers/job_template.go
@@ -231,6 +231,31 @@ func resourceJobTemplate() *schema.Resource {
 							ForceNew: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"parameter_configuration": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									names.AttrName: {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+									},
+									names.AttrType: {
+										Type:             schema.TypeString,
+										Required:         true,
+										ForceNew:         true,
+										ValidateDiagFunc: enum.Validate[awstypes.TemplateParameterDataType](),
+									},
+									names.AttrDefaultValue: {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
 						"release_label": {
 							Type:     schema.TypeString,
 							Required: true,
@@ -406,6 +431,10 @@ func expandJobTemplateData(tfMap map[string]any) *awstypes.JobTemplateData {
 
 	if v, ok := tfMap["job_tags"].(map[string]any); ok && len(v) > 0 {
 		apiObject.JobTags = flex.ExpandStringValueMap(v)
+	}
+
+	if v, ok := tfMap["parameter_configuration"].(*schema.Set); ok && v.Len() > 0 {
+		apiObject.ParameterConfiguration = expandParameterConfiguration(v)
 	}
 
 	if v, ok := tfMap["release_label"].(string); ok && v != "" {
@@ -607,11 +636,72 @@ func flattenJobTemplateData(apiObject *awstypes.JobTemplateData) map[string]any 
 		tfMap["job_tags"] = v
 	}
 
+	if v := apiObject.ParameterConfiguration; v != nil {
+		tfMap["parameter_configuration"] = flattenParameterConfiguration(v)
+	}
+
 	if v := apiObject.ReleaseLabel; v != nil {
 		tfMap["release_label"] = aws.ToString(v)
 	}
 
 	return tfMap
+}
+
+func expandParameterConfiguration(tfSet *schema.Set) map[string]awstypes.TemplateParameterConfiguration {
+	if tfSet.Len() == 0 {
+		return nil
+	}
+
+	apiObjects := make(map[string]awstypes.TemplateParameterConfiguration)
+
+	for _, tfMapRaw := range tfSet.List() {
+		tfMap, ok := tfMapRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, ok := tfMap[names.AttrName].(string)
+		if !ok || name == "" {
+			continue
+		}
+
+		apiObject := awstypes.TemplateParameterConfiguration{}
+
+		if v, ok := tfMap[names.AttrType].(string); ok && v != "" {
+			apiObject.Type = awstypes.TemplateParameterDataType(v)
+		}
+
+		if v, ok := tfMap[names.AttrDefaultValue].(string); ok && v != "" {
+			apiObject.DefaultValue = aws.String(v)
+		}
+
+		apiObjects[name] = apiObject
+	}
+
+	return apiObjects
+}
+
+func flattenParameterConfiguration(apiObjects map[string]awstypes.TemplateParameterConfiguration) []map[string]any {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []map[string]any
+
+	for name, apiObject := range apiObjects {
+		tfMap := map[string]any{
+			names.AttrName: name,
+			names.AttrType: string(apiObject.Type),
+		}
+
+		if v := apiObject.DefaultValue; v != nil {
+			tfMap[names.AttrDefaultValue] = aws.ToString(v)
+		}
+
+		tfList = append(tfList, tfMap)
+	}
+
+	return tfList
 }
 
 func flattenConfigurationOverrides(apiObject *awstypes.ParametricConfigurationOverrides) map[string]any {

--- a/internal/service/emrcontainers/job_template_test.go
+++ b/internal/service/emrcontainers/job_template_test.go
@@ -167,6 +167,37 @@ func TestAccEMRContainersJobTemplate_tags(t *testing.T) {
 	})
 }
 
+func TestAccEMRContainersJobTemplate_parameterConfiguration(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.JobTemplate
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_emrcontainers_job_template.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EMRContainersServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckJobTemplateDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobTemplateConfig_parameterConfiguration(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckJobTemplateExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "job_template_data.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "job_template_data.0.parameter_configuration.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckJobTemplateExists(ctx context.Context, t *testing.T, n string, v *awstypes.JobTemplate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -291,6 +322,38 @@ resource "aws_emrcontainers_job_template" "test" {
           log_stream_name_prefix = "spark-job-logs"
         }
       }
+    }
+  }
+
+  name = %[1]q
+}
+`, rName))
+}
+
+func testAccJobTemplateConfig_parameterConfiguration(rName string) string {
+	return acctest.ConfigCompose(
+		testAccJobTemplateConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_emrcontainers_job_template" "test" {
+  job_template_data {
+    execution_role_arn = aws_iam_role.test.arn
+    release_label      = "emr-6.10.0-latest"
+
+    job_driver {
+      spark_sql_job_driver {
+        entry_point = "${EntryPointUri}"
+      }
+    }
+
+    parameter_configuration {
+      name          = "EntryPointUri"
+      type          = "STRING"
+      default_value = "s3://my-bucket/my-script.sql"
+    }
+
+    parameter_configuration {
+      name = "SparkCores"
+      type = "NUMBER"
     }
   }
 

--- a/website/docs/r/emrcontainers_job_template.html.markdown
+++ b/website/docs/r/emrcontainers_job_template.html.markdown
@@ -47,6 +47,7 @@ This resource supports the following arguments:
 * `execution_role_arn` - (Required) The execution role ARN of the job run.
 * `job_driver` - (Required) Specify the driver that the job runs on. Exactly one of the two available job drivers is required, either sparkSqlJobDriver or sparkSubmitJobDriver.
 * `job_tags` - (Optional) The tags assigned to jobs started using the job template.
+* `parameter_configuration` - (Optional) The configuration of parameters existing in the job template. See [`parameter_configuration`](#parameter_configuration-arguments) below.
 * `release_label` - (Required) The release version of Amazon EMR.
 
 #### configuration_overrides Arguments
@@ -90,6 +91,12 @@ This resource supports the following arguments:
 * `entry_point` - (Required) The entry point of job application.
 * `entry_point_arguments` - (Optional) The arguments for job application.
 * `spark_submit_parameters` - (Optional) The Spark submit parameters that are used for job runs.
+
+#### parameter_configuration Arguments
+
+* `name` - (Required) The name of the parameter. Referenced as `${ParameterName}` in job template fields.
+* `type` - (Required) The type of the parameter. Valid values: `STRING`, `NUMBER`.
+* `default_value` - (Optional) The default value for the parameter.
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

The AWS SDK exposes `ParameterConfiguration` on `JobTemplateData` but the Terraform resource doesn't model it. Without this field, users can't define template parameters (referenced as `${ParameterName}` placeholders) and `StartJobRun` with `--job-template-parameters` fails with "Parameter not defined".

This adds `parameter_configuration` as an optional `TypeSet` block under `job_template_data` with three attributes:
* `name` — the parameter name (map key in the API)
* `type` — `STRING` or `NUMBER` (validated via `enum.Validate`)
* `default_value` — optional default

Used `TypeSet` of blocks with a `name` key attribute since SDKv2 doesn't support maps of blocks natively. Same pattern as `securityhub/configuration_policy.go`.

### Relations

Closes #46502

### References

* AWS SDK: `JobTemplateData.ParameterConfiguration` — `map[string]TemplateParameterConfiguration` (already in sdk v1.40.15)
* AWS docs: https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/job-templates.html

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccEMRContainersJobTemplate_parameterConfiguration PKG=emrcontainers

...
```