### PR TITLE
fix lambda_permission list resource documentation example

### DIFF
--- a/website/docs/list-resources/lambda_permission.html.markdown
+++ b/website/docs/list-resources/lambda_permission.html.markdown
@@ -14,8 +14,10 @@ Lists Lambda permissions for a function.
 
 ```terraform
 list "aws_lambda_permission" "example" {
-  provider      = aws
-  function_name = aws_lambda_function.example.function_name
+  provider = aws
+  config {
+    function_name = aws_lambda_function.example.function_name
+  }
 }
 ```
 


### PR DESCRIPTION
### Description
Updates the example usage of the `aws_lambda_permission` list resource to include the config block and pass the `function_name` within there instead. This is because provider specific attributes belong within the config block.


### References
https://developer.hashicorp.com/terraform/language/block/tfquery/list#config