### PR TITLE
[Docs] aws_networkfirewall_vpc_endpoint_association: Fix typo in `association_sync_states`

### DIFF
--- a/website/docs/r/networkfirewall_vpc_endpoint_association.html.markdown
+++ b/website/docs/r/networkfirewall_vpc_endpoint_association.html.markdown
@@ -57,7 +57,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `vpc_endpoint_association_arn` - ARN of the VPC Endpoint Association.
 * `vpc_endpoint_association_id` - The unique identifier of the VPC endpoint association.
 * `vpc_endpoint_association_status` - Nested list of information about the current status of the VPC Endpoint Association.
-    * `association_sync_states` - Set of subnets configured for use by the VPC Endpoint Association.
+    * `association_sync_state` - Set of subnets configured for use by the VPC Endpoint Association.
         * `attachment` - Nested list describing the attachment status of the firewall's VPC Endpoint Association with a single VPC subnet.
             * `endpoint_id` - The identifier of the VPC endpoint that AWS Network Firewall has instantiated in the subnet. You use this to identify the firewall endpoint in the VPC route tables, when you redirect the VPC traffic through the endpoint.
             * `subnet_id` - The unique identifier of the subnet that you've specified to be used for a VPC Endpoint Association endpoint.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
Fix typo: `association_sync_states` -> `association_sync_state`

https://github.com/hashicorp/terraform-provider-aws/blob/72daa5ae99e3f50965c0dd8e3670b392d51872c3/internal/service/networkfirewall/vpc_endpoint_association.go#L408-L410

### Relations
Closes #46966
