### PR TITLE
 new list resource: aws_ssm_document

### DIFF
--- a/.changelog/46974.txt
+++ b/.changelog/46974.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_ssm_document
+```

--- a/internal/service/ssm/document.go
+++ b/internal/service/ssm/document.go
@@ -326,69 +326,7 @@ func resourceDocumentRead(ctx context.Context, d *schema.ResourceData, meta any)
 		return sdkdiag.AppendErrorf(diags, "reading SSM Document (%s): %s", d.Id(), err)
 	}
 
-	documentType, name := doc.DocumentType, aws.ToString(doc.Name)
-	d.Set(names.AttrARN, documentARN(ctx, meta.(*conns.AWSClient), documentType, name))
-	d.Set(names.AttrCreatedDate, aws.ToTime(doc.CreatedDate).Format(time.RFC3339))
-	d.Set("default_version", doc.DefaultVersion)
-	d.Set(names.AttrDescription, doc.Description)
-	d.Set("document_format", doc.DocumentFormat)
-	d.Set("document_type", documentType)
-	d.Set("document_version", doc.DocumentVersion)
-	d.Set("hash", doc.Hash)
-	d.Set("hash_type", doc.HashType)
-	d.Set("latest_version", doc.LatestVersion)
-	d.Set(names.AttrName, name)
-	d.Set(names.AttrOwner, doc.Owner)
-	if err := d.Set(names.AttrParameter, flattenDocumentParameters(doc.Parameters)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting parameter: %s", err)
-	}
-	d.Set("platform_types", doc.PlatformTypes)
-	d.Set("schema_version", doc.SchemaVersion)
-	d.Set(names.AttrStatus, doc.Status)
-	d.Set("target_type", doc.TargetType)
-	d.Set("version_name", doc.VersionName)
-
-	{
-		input := &ssm.GetDocumentInput{
-			DocumentFormat:  awstypes.DocumentFormat(d.Get("document_format").(string)),
-			DocumentVersion: aws.String("$LATEST"),
-			Name:            aws.String(d.Id()),
-		}
-
-		output, err := conn.GetDocument(ctx, input)
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "reading SSM Document (%s) content: %s", d.Id(), err)
-		}
-
-		d.Set(names.AttrContent, output.Content)
-	}
-
-	{
-		input := &ssm.DescribeDocumentPermissionInput{
-			Name:           aws.String(d.Id()),
-			PermissionType: awstypes.DocumentPermissionTypeShare,
-		}
-
-		output, err := conn.DescribeDocumentPermission(ctx, input)
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "reading SSM Document (%s) permissions: %s", d.Id(), err)
-		}
-
-		if accountsIDs := output.AccountIds; len(accountsIDs) > 0 {
-			d.Set(names.AttrPermissions, map[string]any{
-				"account_ids":  strings.Join(accountsIDs, ","),
-				names.AttrType: awstypes.DocumentPermissionTypeShare,
-			})
-		} else {
-			d.Set(names.AttrPermissions, nil)
-		}
-	}
-
-	setTagsOut(ctx, doc.Tags)
-
-	return diags
+	return append(diags, resourceDocumentFlatten(ctx, conn, d, meta.(*conns.AWSClient), doc)...)
 }
 
 func resourceDocumentUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -722,4 +660,72 @@ func documentARN(ctx context.Context, c *conns.AWSClient, documentType awstypes.
 	}
 
 	return c.RegionalARN(ctx, "ssm", resource)
+}
+
+func resourceDocumentFlatten(ctx context.Context, conn *ssm.Client, d *schema.ResourceData, awsClient *conns.AWSClient, output *awstypes.DocumentDescription) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	documentType, name := output.DocumentType, aws.ToString(output.Name)
+	d.Set(names.AttrARN, documentARN(ctx, awsClient, documentType, name))
+	d.Set(names.AttrCreatedDate, aws.ToTime(output.CreatedDate).Format(time.RFC3339))
+	d.Set("default_version", output.DefaultVersion)
+	d.Set(names.AttrDescription, output.Description)
+	d.Set("document_format", output.DocumentFormat)
+	d.Set("document_type", documentType)
+	d.Set("document_version", output.DocumentVersion)
+	d.Set("hash", output.Hash)
+	d.Set("hash_type", output.HashType)
+	d.Set("latest_version", output.LatestVersion)
+	d.Set(names.AttrName, name)
+	d.Set(names.AttrOwner, output.Owner)
+	if err := d.Set(names.AttrParameter, flattenDocumentParameters(output.Parameters)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting parameter: %s", err)
+	}
+	d.Set("platform_types", output.PlatformTypes)
+	d.Set("schema_version", output.SchemaVersion)
+	d.Set(names.AttrStatus, output.Status)
+	d.Set("target_type", output.TargetType)
+	d.Set("version_name", output.VersionName)
+
+	{
+		input := &ssm.GetDocumentInput{
+			DocumentFormat:  awstypes.DocumentFormat(d.Get("document_format").(string)),
+			DocumentVersion: aws.String("$LATEST"),
+			Name:            aws.String(d.Id()),
+		}
+
+		output, err := conn.GetDocument(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "reading SSM Document (%s) content: %s", d.Id(), err)
+		}
+
+		d.Set(names.AttrContent, output.Content)
+	}
+
+	{
+		input := &ssm.DescribeDocumentPermissionInput{
+			Name:           aws.String(d.Id()),
+			PermissionType: awstypes.DocumentPermissionTypeShare,
+		}
+
+		output, err := conn.DescribeDocumentPermission(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "reading SSM Document (%s) permissions: %s", d.Id(), err)
+		}
+
+		if accountsIDs := output.AccountIds; len(accountsIDs) > 0 {
+			d.Set(names.AttrPermissions, map[string]any{
+				"account_ids":  strings.Join(accountsIDs, ","),
+				names.AttrType: awstypes.DocumentPermissionTypeShare,
+			})
+		} else {
+			d.Set(names.AttrPermissions, nil)
+		}
+	}
+
+	setTagsOut(ctx, output.Tags)
+
+	return diags
 }

--- a/internal/service/ssm/document_list.go
+++ b/internal/service/ssm/document_list.go
@@ -1,0 +1,128 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ssm
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKListResource("aws_ssm_document")
+func newDocumentResourceAsListResource() inttypes.ListResourceForSDK {
+	l := documentListResource{}
+	l.SetResourceSchema(resourceDocument())
+
+	return &l
+}
+
+type documentListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+type documentListResourceModel struct {
+	framework.WithRegionModel
+}
+
+func (l *documentListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	awsClient := l.Meta()
+	conn := awsClient.SSMClient(ctx)
+
+	var query documentListResourceModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	tflog.Info(ctx, "Listing SSM documents")
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		input := &ssm.ListDocumentsInput{
+			Filters: []awstypes.DocumentKeyValuesFilter{{
+				Key:    aws.String("Owner"),
+				Values: []string{"Self"},
+			}},
+		}
+
+		for item, err := range listDocuments(ctx, conn, input) {
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+
+			name := aws.ToString(item.Name)
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrName), name)
+
+			result := request.NewListResult(ctx)
+			rd := l.ResourceData()
+			rd.SetId(name)
+			rd.Set(names.AttrName, name)
+
+			if request.IncludeResource {
+				doc, err := findDocumentByName(ctx, conn, name)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					result = fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("reading SSM Document (%s): %w", name, err))
+					yield(result)
+					return
+				}
+
+				diags := resourceDocumentFlatten(ctx, conn, rd, awsClient, doc)
+				if diags.HasError() {
+					result = fwdiag.NewListResultSDKDiagnostics(diags)
+					yield(result)
+					return
+				}
+			}
+
+			result.DisplayName = name
+
+			l.SetResult(ctx, awsClient, request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+func listDocuments(ctx context.Context, conn *ssm.Client, input *ssm.ListDocumentsInput) iter.Seq2[awstypes.DocumentIdentifier, error] {
+	return func(yield func(awstypes.DocumentIdentifier, error) bool) {
+		pages := ssm.NewListDocumentsPaginator(conn, input)
+		for pages.HasMorePages() {
+			page, err := pages.NextPage(ctx)
+			if err != nil {
+				yield(awstypes.DocumentIdentifier{}, fmt.Errorf("listing SSM Documents: %w", err))
+				return
+			}
+
+			for _, item := range page.DocumentIdentifiers {
+				if !yield(item, nil) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/service/ssm/document_list.go
+++ b/internal/service/ssm/document_list.go
@@ -12,9 +12,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
@@ -35,6 +40,33 @@ type documentListResource struct {
 
 type documentListResourceModel struct {
 	framework.WithRegionModel
+	Filters fwtypes.ListNestedObjectValueOf[documentFiltersModel] `tfsdk:"filter"`
+}
+
+type documentFiltersModel struct {
+	Key   types.String         `tfsdk:"key"`
+	Value fwtypes.ListOfString `tfsdk:"value"`
+}
+
+func (l *documentListResource) ListResourceConfigSchema(ctx context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = listschema.Schema{
+		Blocks: map[string]listschema.Block{
+			names.AttrFilter: listschema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[documentFiltersModel](ctx),
+				NestedObject: listschema.NestedBlockObject{
+					Attributes: map[string]listschema.Attribute{
+						names.AttrKey: listschema.StringAttribute{
+							Required: true,
+						},
+						names.AttrValues: listschema.ListAttribute{
+							CustomType: fwtypes.ListOfStringType,
+							Required:   true,
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func (l *documentListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
@@ -49,17 +81,24 @@ func (l *documentListResource) List(ctx context.Context, request list.ListReques
 		}
 	}
 
+	var input ssm.ListDocumentsInput
+	if diags := fwflex.Expand(ctx, query, &input); diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	// if there are no filters set, default to returning documents that are owned by self
+	if len(input.Filters) == 0 {
+		input.Filters = append(input.Filters, awstypes.DocumentKeyValuesFilter{
+			Key:    aws.String("Owner"),
+			Values: []string{"Self"},
+		})
+	}
+
 	tflog.Info(ctx, "Listing SSM documents")
 
 	stream.Results = func(yield func(list.ListResult) bool) {
-		input := &ssm.ListDocumentsInput{
-			Filters: []awstypes.DocumentKeyValuesFilter{{
-				Key:    aws.String("Owner"),
-				Values: []string{"Self"},
-			}},
-		}
-
-		for item, err := range listDocuments(ctx, conn, input) {
+		for item, err := range listDocuments(ctx, conn, &input) {
 			if err != nil {
 				result := fwdiag.NewListResultErrorDiagnostic(err)
 				yield(result)
@@ -85,11 +124,11 @@ func (l *documentListResource) List(ctx context.Context, request list.ListReques
 					return
 				}
 
-				diags := resourceDocumentFlatten(ctx, conn, rd, awsClient, doc)
-				if diags.HasError() {
-					result = fwdiag.NewListResultSDKDiagnostics(diags)
-					yield(result)
-					return
+				if diags := resourceDocumentFlatten(ctx, conn, rd, awsClient, doc); diags.HasError() {
+					tflog.Error(ctx, "Flatten SSM Document", map[string]any{
+						"diags": sdkdiag.DiagnosticsString(diags),
+					})
+					continue
 				}
 			}
 

--- a/internal/service/ssm/document_list.go
+++ b/internal/service/ssm/document_list.go
@@ -44,8 +44,8 @@ type documentListResourceModel struct {
 }
 
 type documentFiltersModel struct {
-	Key   types.String         `tfsdk:"key"`
-	Value fwtypes.ListOfString `tfsdk:"value"`
+	Key    types.String         `tfsdk:"key"`
+	Values fwtypes.ListOfString `tfsdk:"values"`
 }
 
 func (l *documentListResource) ListResourceConfigSchema(ctx context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {

--- a/internal/service/ssm/document_list_test.go
+++ b/internal/service/ssm/document_list_test.go
@@ -193,3 +193,62 @@ func TestAccSSMDocument_List_regionOverride(t *testing.T) {
 		},
 	})
 }
+
+func TestAccSSMDocument_List_filtered(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceNameExpected1 := "aws_ssm_document.expected[0]"
+	resourceNameExpected2 := "aws_ssm_document.expected[1]"
+	resourceNameNotExpected1 := "aws_ssm_document.not_expected[0]"
+	resourceNameNotExpected2 := "aws_ssm_document.not_expected[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identityExpected1 := tfstatecheck.Identity()
+	identityExpected2 := tfstatecheck.Identity()
+	identityNotExpected1 := tfstatecheck.Identity()
+	identityNotExpected2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy:             testAccCheckDocumentDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Document/list_filtered/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identityExpected1.GetIdentity(resourceNameExpected1),
+					statecheck.ExpectKnownValue(resourceNameExpected1, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("ssm", "document/"+rName+"-expected-0")),
+
+					identityExpected2.GetIdentity(resourceNameExpected2),
+					statecheck.ExpectKnownValue(resourceNameExpected2, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("ssm", "document/"+rName+"-expected-1")),
+
+					identityNotExpected1.GetIdentity(resourceNameNotExpected1),
+					statecheck.ExpectKnownValue(resourceNameNotExpected1, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("ssm", "document/"+rName+"-other-0")),
+
+					identityNotExpected2.GetIdentity(resourceNameNotExpected2),
+					statecheck.ExpectKnownValue(resourceNameNotExpected2, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("ssm", "document/"+rName+"-other-1")),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Document/list_filtered/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_document.test", identityExpected1.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_document.test", identityExpected2.Checks()),
+					tfquerycheck.ExpectNoIdentityFunc("aws_ssm_document.test", identityNotExpected1.Checks()),
+					tfquerycheck.ExpectNoIdentityFunc("aws_ssm_document.test", identityNotExpected2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/ssm/document_list_test.go
+++ b/internal/service/ssm/document_list_test.go
@@ -1,0 +1,195 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ssm_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSSMDocument_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_ssm_document.test[0]"
+	resourceName2 := "aws_ssm_document.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy:             testAccCheckDocumentDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Document/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("ssm", "document/"+rName+"-0")),
+
+					identity2.GetIdentity(resourceName2),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("ssm", "document/"+rName+"-1")),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Document/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_document.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_ssm_document.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					tfquerycheck.ExpectNoResourceObject("aws_ssm_document.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_document.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_ssm_document.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringExact(rName+"-1")),
+					tfquerycheck.ExpectNoResourceObject("aws_ssm_document.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSSMDocument_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_ssm_document.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy:             testAccCheckDocumentDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Document/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("ssm", "document/"+rName+"-0")),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Document/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_document.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_ssm_document.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					querycheck.ExpectResourceKnownValues("aws_ssm_document.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("ssm", "document/"+rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("document_format"), knownvalue.StringExact("JSON")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("document_type"), knownvalue.StringExact("Command")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrStatus), knownvalue.StringExact("Active")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTagsAll), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSSMDocument_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_ssm_document.test[0]"
+	resourceName2 := "aws_ssm_document.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Document/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNAlternateRegionExact("ssm", "document/"+rName+"-0")),
+
+					identity2.GetIdentity(resourceName2),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNAlternateRegionExact("ssm", "document/"+rName+"-1")),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Document/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_document.test", identity1.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_document.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/ssm/service_package_gen.go
+++ b/internal/service/ssm/service_package_gen.go
@@ -226,6 +226,17 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttypes.ServicePackageSDKListResource] {
 	return slices.Values([]*inttypes.ServicePackageSDKListResource{
 		{
+			Factory:  newDocumentResourceAsListResource,
+			TypeName: "aws_ssm_document",
+			Name:     "Document",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrID,
+				ResourceType:        "Document",
+			}),
+			Identity: inttypes.RegionalSingleParameterIdentity(names.AttrName),
+		},
+		{
 			Factory:  newParameterResourceAsListResource,
 			TypeName: "aws_ssm_parameter",
 			Name:     "Parameter",

--- a/internal/service/ssm/testdata/Document/list_basic/main.tf
+++ b/internal/service/ssm/testdata/Document/list_basic/main.tf
@@ -1,0 +1,41 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ssm_document" "test" {
+  count = var.resource_count
+
+  document_type = "Command"
+  name          = "${var.rName}-${count.index}"
+
+  content = <<DOC
+{
+  "schemaVersion": "1.2",
+  "description": "Check ip configuration of a Linux instance.",
+  "parameters": {},
+  "runtimeConfig": {
+    "aws:runShellScript": {
+      "properties": [
+        {
+          "id": "0.aws:runShellScript",
+          "runCommand": [
+            "ifconfig"
+          ]
+        }
+      ]
+    }
+  }
+}
+DOC
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/ssm/testdata/Document/list_basic/query.tfquery.hcl
+++ b/internal/service/ssm/testdata/Document/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ssm_document" "test" {
+  provider = aws
+}

--- a/internal/service/ssm/testdata/Document/list_filtered/main.tf
+++ b/internal/service/ssm/testdata/Document/list_filtered/main.tf
@@ -1,0 +1,62 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ssm_document" "expected" {
+  count = 2
+
+  document_type = "Command"
+  name          = "${var.rName}-expected-${count.index}"
+
+  content = <<DOC
+{
+  "schemaVersion": "1.2",
+  "description": "Check ip configuration of a Linux instance.",
+  "parameters": {},
+  "runtimeConfig": {
+    "aws:runShellScript": {
+      "properties": [
+        {
+          "id": "0.aws:runShellScript",
+          "runCommand": [
+            "ifconfig"
+          ]
+        }
+      ]
+    }
+  }
+}
+DOC
+}
+
+resource "aws_ssm_document" "not_expected" {
+  count = 2
+
+  document_type = "Command"
+  name          = "${var.rName}-other-${count.index}"
+
+  content = <<DOC
+{
+  "schemaVersion": "1.2",
+  "description": "Check ip configuration of a Linux instance.",
+  "parameters": {},
+  "runtimeConfig": {
+    "aws:runShellScript": {
+      "properties": [
+        {
+          "id": "0.aws:runShellScript",
+          "runCommand": [
+            "ifconfig"
+          ]
+        }
+      ]
+    }
+  }
+}
+DOC
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/ssm/testdata/Document/list_filtered/query.tfquery.hcl
+++ b/internal/service/ssm/testdata/Document/list_filtered/query.tfquery.hcl
@@ -1,0 +1,13 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ssm_document" "test" {
+  provider = aws
+
+  config {
+    filter {
+      key    = "Name"
+      values = ["${var.rName}-expected-"]
+    }
+  }
+}

--- a/internal/service/ssm/testdata/Document/list_include_resource/main.tf
+++ b/internal/service/ssm/testdata/Document/list_include_resource/main.tf
@@ -1,0 +1,49 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ssm_document" "test" {
+  count = var.resource_count
+
+  document_type = "Command"
+  name          = "${var.rName}-${count.index}"
+
+  content = <<DOC
+{
+  "schemaVersion": "1.2",
+  "description": "Check ip configuration of a Linux instance.",
+  "parameters": {},
+  "runtimeConfig": {
+    "aws:runShellScript": {
+      "properties": [
+        {
+          "id": "0.aws:runShellScript",
+          "runCommand": [
+            "ifconfig"
+          ]
+        }
+      ]
+    }
+  }
+}
+DOC
+
+  tags = var.resource_tags
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "resource_tags" {
+  description = "Tags to set on resource"
+  type        = map(string)
+  nullable    = false
+}

--- a/internal/service/ssm/testdata/Document/list_include_resource/query.tfquery.hcl
+++ b/internal/service/ssm/testdata/Document/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ssm_document" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/ssm/testdata/Document/list_region_override/main.tf
+++ b/internal/service/ssm/testdata/Document/list_region_override/main.tf
@@ -1,0 +1,48 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ssm_document" "test" {
+  count  = var.resource_count
+  region = var.region
+
+  document_type = "Command"
+  name          = "${var.rName}-${count.index}"
+
+  content = <<DOC
+{
+  "schemaVersion": "1.2",
+  "description": "Check ip configuration of a Linux instance.",
+  "parameters": {},
+  "runtimeConfig": {
+    "aws:runShellScript": {
+      "properties": [
+        {
+          "id": "0.aws:runShellScript",
+          "runCommand": [
+            "ifconfig"
+          ]
+        }
+      ]
+    }
+  }
+}
+DOC
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/ssm/testdata/Document/list_region_override/query.tfquery.hcl
+++ b/internal/service/ssm/testdata/Document/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ssm_document" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}

--- a/website/docs/list-resources/ssm_document.html.markdown
+++ b/website/docs/list-resources/ssm_document.html.markdown
@@ -18,8 +18,31 @@ list "aws_ssm_document" "example" {
 }
 ```
 
+### Filter by name prefix
+
+```terraform
+list "aws_ssm_document" "example" {
+  provider = aws
+
+  config {
+    filter {
+      key    = "Name"
+      values = ["example-prefix-"]
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 This list resource supports the following arguments:
 
 * `region` - (Optional) Region to query. Defaults to provider region.
+* `filter` - (Optional) One or more filters to apply to the search. If omitted, the list returns self-owned SSM documents by default.
+
+### `filter` Block
+
+The `filter` block supports the following arguments:
+
+* `key` - (Required) Filter key to apply. Valid values are the keys accepted by the SSM `ListDocuments` API, such as `Name`, `Owner`, `PlatformTypes`, `DocumentType`, `TargetType`, or `tag:<tag-key>`.
+* `values` - (Required) One or more values for the selected filter key. For the `Name` key, a prefix match is supported by the SSM API.

--- a/website/docs/list-resources/ssm_document.html.markdown
+++ b/website/docs/list-resources/ssm_document.html.markdown
@@ -1,0 +1,25 @@
+---
+subcategory: "SSM (Systems Manager)"
+layout: "aws"
+page_title: "AWS: aws_ssm_document"
+description: |-
+  Lists SSM (Systems Manager) Document resources.
+---
+
+# List Resource: aws_ssm_document
+
+Lists SSM (Systems Manager) Document resources.
+
+## Example Usage
+
+```terraform
+list "aws_ssm_document" "example" {
+  provider = aws
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.

--- a/website/docs/list-resources/ssm_document.html.markdown
+++ b/website/docs/list-resources/ssm_document.html.markdown
@@ -37,8 +37,8 @@ list "aws_ssm_document" "example" {
 
 This list resource supports the following arguments:
 
-* `region` - (Optional) Region to query. Defaults to provider region.
 * `filter` - (Optional) One or more filters to apply to the search. If omitted, the list returns self-owned SSM documents by default.
+* `region` - (Optional) Region to query. Defaults to provider region.
 
 ### `filter` Block
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

- Add list resource support for `aws_ssm_document` using the generated `skaff list --name Document` scaffold as the starting point.
- Implement SSM document listing in `internal/service/ssm/document_list.go`, including support for custom `filter` blocks and the default `Owner=Self` behavior when no filters are provided.
- Register the new list resource, add acceptance coverage for `basic`, `includeResource`, `regionOverride`, and `filtered` scenarios, and add SSM document list testdata for each case.
- Update the `aws_ssm_document` list-resource documentation to include the new `filter` configuration and an example using the `Name` filter.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

```console
% make testacc PKG=ssm TESTARGS='-run=TestAccSSMDocument_List_'

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-list-resource-ssm_document 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/ssm/... -v -count 1 -parallel 20  -run=TestAccSSMDocument_List_ -timeout 360m -vet=off
2026/03/18 10:21:32 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/18 10:21:32 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSSMDocument_List_basic
=== PAUSE TestAccSSMDocument_List_basic
=== RUN   TestAccSSMDocument_List_includeResource
=== PAUSE TestAccSSMDocument_List_includeResource
=== RUN   TestAccSSMDocument_List_regionOverride
=== PAUSE TestAccSSMDocument_List_regionOverride
=== CONT  TestAccSSMDocument_List_basic
=== CONT  TestAccSSMDocument_List_regionOverride
=== CONT  TestAccSSMDocument_List_includeResource
--- PASS: TestAccSSMDocument_List_regionOverride (21.10s)
--- PASS: TestAccSSMDocument_List_basic (21.56s)
--- PASS: TestAccSSMDocument_List_includeResource (22.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	31.206s

% make testacc PKG=ssm TESTARGS='-run=TestAccSSMDocument_List_filtered'

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-list-resource-ssm_document 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/ssm/... -v -count 1 -parallel 20  -run=TestAccSSMDocument_List_filtered -timeout 360m -vet=off
2026/03/18 10:31:09 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/18 10:31:09 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSSMDocument_List_filtered
=== PAUSE TestAccSSMDocument_List_filtered
=== CONT  TestAccSSMDocument_List_filtered
--- PASS: TestAccSSMDocument_List_filtered (19.65s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	27.840s
```
