### PR TITLE
Add panic guard for managed certificate enabled

### DIFF
--- a/.changelog/46982.txt
+++ b/.changelog/46982.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudfront_distribution_tenant: Fix panic when managed certificate is not found during creation
+```

--- a/internal/service/cloudfront/cloudfront_test.go
+++ b/internal/service/cloudfront/cloudfront_test.go
@@ -18,5 +18,6 @@ func init() {
 func testAccErrorCheckSkipFunction(t *testing.T) resource.ErrorCheckFunc {
 	return acctest.ErrorCheckSkipMessagesContaining(t,
 		"InvalidParameterValueException: Unsupported source arn",
+		"no matching Route 53 Hosted Zone found",
 	)
 }

--- a/internal/service/cloudfront/distribution_tenant.go
+++ b/internal/service/cloudfront/distribution_tenant.go
@@ -837,6 +837,11 @@ func waitForManagedCertificateIssued(ctx context.Context, conn *cloudfront.Clien
 }
 
 func updateDistributionTenantWithManagedCertificate(ctx context.Context, conn *cloudfront.Client, dtOutput *cloudfront.GetDistributionTenantOutput, mcOutput *cloudfront.GetManagedCertificateDetailsOutput) error {
+	if mcOutput == nil {
+		// No managed certificate found, nothing to update
+		return nil
+	}
+
 	// Check if we need to update the certificate ARN
 	if !needToUpdateCertificateARN(dtOutput.DistributionTenant, aws.ToString(mcOutput.ManagedCertificateDetails.CertificateArn)) {
 		// Certificate ARN already matches, nothing to do

--- a/internal/service/cloudfront/distribution_tenant.go
+++ b/internal/service/cloudfront/distribution_tenant.go
@@ -838,7 +838,6 @@ func waitForManagedCertificateIssued(ctx context.Context, conn *cloudfront.Clien
 
 func updateDistributionTenantWithManagedCertificate(ctx context.Context, conn *cloudfront.Client, dtOutput *cloudfront.GetDistributionTenantOutput, mcOutput *cloudfront.GetManagedCertificateDetailsOutput) error {
 	if mcOutput == nil {
-		// No managed certificate found, nothing to update
 		return nil
 	}
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The provider was panicking when creating a CloudFront distribution tenant with managed certificates enabled. The issue was that when AWS returns "certificate not found" (because domains are already covered by existing certs), the code returned nil but then tried to dereference that `nil` pointer without checking. Added a simple nil check to handle this case gracefully.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #46790

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccCloudFrontDistributionTenant_ K=cloudfront P=15
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-cloudfront-dist-tenant-panic 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/cloudfront/... -v -count 1 -parallel 15 -run='TestAccCloudFrontDistributionTenant_'  -timeout 360m -vet=off
2026/03/18 16:47:22 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/18 16:47:22 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudFrontDistributionTenant_basic
=== PAUSE TestAccCloudFrontDistributionTenant_basic
=== RUN   TestAccCloudFrontDistributionTenant_disappears
=== PAUSE TestAccCloudFrontDistributionTenant_disappears
=== RUN   TestAccCloudFrontDistributionTenant_customCertificate
=== PAUSE TestAccCloudFrontDistributionTenant_customCertificate
=== RUN   TestAccCloudFrontDistributionTenant_customCertificateWithWebACL
=== PAUSE TestAccCloudFrontDistributionTenant_customCertificateWithWebACL
=== RUN   TestAccCloudFrontDistributionTenant_tags
=== PAUSE TestAccCloudFrontDistributionTenant_tags
=== CONT  TestAccCloudFrontDistributionTenant_basic
=== CONT  TestAccCloudFrontDistributionTenant_customCertificateWithWebACL
=== CONT  TestAccCloudFrontDistributionTenant_customCertificate
=== CONT  TestAccCloudFrontDistributionTenant_disappears
=== CONT  TestAccCloudFrontDistributionTenant_tags
--- PASS: TestAccCloudFrontDistributionTenant_customCertificate (952.46s)
--- PASS: TestAccCloudFrontDistributionTenant_customCertificateWithWebACL (953.53s)
--- PASS: TestAccCloudFrontDistributionTenant_basic (1015.12s)
--- PASS: TestAccCloudFrontDistributionTenant_disappears (1019.36s)
--- PASS: TestAccCloudFrontDistributionTenant_tags (1456.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	1462.805s
```
