### PR TITLE
fix: add UnsupportedOperation to EIP fallback checks

### DIFF
--- a/.changelog/46996.txt
+++ b/.changelog/46996.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_eip: Add `UnsupportedOperation` error handling for `DescribeAddressesAttribute` API call
+```

--- a/.changelog/46996.txt
+++ b/.changelog/46996.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_eip: Add `UnsupportedOperation` error handling for `DescribeAddressesAttribute` API call
+resource/aws_eip: Add `UnsupportedOperation` error handling for non-commercial AWS regions
 ```

--- a/internal/service/ec2/ec2_eip.go
+++ b/internal/service/ec2/ec2_eip.go
@@ -264,7 +264,7 @@ func resourceEIPRead(ctx context.Context, d *schema.ResourceData, meta any) diag
 		d.Set("ptr_record", strings.TrimSuffix(aws.ToString(addressAttr.PtrRecord), "."))
 	case retry.NotFound(err):
 		d.Set("ptr_record", nil)
-	case tfawserr.ErrMessageContains(err, "InvalidAction", "not valid for this web service"):
+	case tfawserr.ErrMessageContains(err, "InvalidAction", "not valid for this web service") || tfawserr.ErrCodeEquals(err, "UnsupportedOperation"):
 		d.Set("ptr_record", nil)
 	default:
 		return sdkdiag.AppendErrorf(diags, "reading EC2 EIP (%s) domain name attribute: %s", d.Id(), err)

--- a/internal/service/ec2/ec2_eip_data_source.go
+++ b/internal/service/ec2/ec2_eip_data_source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -155,6 +156,8 @@ func dataSourceEIPRead(ctx context.Context, d *schema.ResourceData, meta any) di
 		case err == nil:
 			d.Set("ptr_record", addressAttr.PtrRecord)
 		case retry.NotFound(err):
+			d.Set("ptr_record", nil)
+		case tfawserr.ErrMessageContains(err, "InvalidAction", "not valid for this web service") || tfawserr.ErrCodeEquals(err, "UnsupportedOperation"):
 			d.Set("ptr_record", nil)
 		default:
 			return sdkdiag.AppendErrorf(diags, "reading EC2 EIP (%s) domain name attribute: %s", d.Id(), err)


### PR DESCRIPTION
## Summary
Fixes #46963.
**Root cause:** EIP fallback only checked for `InvalidAction` error code, but aws-iso partition returns `UnsupportedOperation` instead, causing failures in non-commercial regions.
**Fix:** Added `UnsupportedOperation` to the fallback error code checks alongside `InvalidAction`.
## Changes
- `internal/service/ec2/ec2_eip.go`: Updated EIP resource fallback error handling to include `UnsupportedOperation`
- `internal/service/ec2/ec2_eip_data_source.go`: Added same fallback for EIP data source (was missing entirely)
## Testing
- Verified fix addresses reported scenario in non-commercial regions
- Change is minimal and follows existing fallback patterns

Made with [Cursor](https://cursor.com)