### PR TITLE
Adds normalization of zero-value attr.Value fields to null in framework + unit tests

### DIFF
--- a/internal/framework/with_list.go
+++ b/internal/framework/with_list.go
@@ -5,11 +5,15 @@ package framework
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"slices"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/provider/framework/listresource"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 )
@@ -66,6 +70,7 @@ func (w *WithList) SetResult(ctx context.Context, awsClient *conns.AWSClient, in
 
 	diags.Append(w.runResultInterceptors(ctx, listresource.Before, awsClient, includeResource, data, result)...)
 	if diags.HasError() {
+		result.Diagnostics.Append(diags...)
 		return
 	}
 
@@ -74,15 +79,83 @@ func (w *WithList) SetResult(ctx context.Context, awsClient *conns.AWSClient, in
 		return
 	}
 
-	// TODO: The Identity interceptor currently reads values from the resource, so it needs to be populated.
-	// Technically, only the Identity attributes need to be set, but calling `Set` with uninitialized typed collections causes a panic
+	diags.Append(setZeroValueAttrFieldsToNull(ctx, data)...)
+	if diags.HasError() {
+		result.Diagnostics.Append(diags...)
+		return
+	}
+
 	diags.Append(result.Resource.Set(ctx, data)...)
 	if diags.HasError() {
+		result.Diagnostics.Append(diags...)
 		return
 	}
 
 	diags.Append(w.runResultInterceptors(ctx, listresource.After, awsClient, includeResource, data, result)...)
 	if diags.HasError() {
+		result.Diagnostics.Append(diags...)
 		return
+	}
+}
+
+func setZeroValueAttrFieldsToNull(ctx context.Context, target any) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	value := reflect.ValueOf(target)
+	if !value.IsValid() || value.Kind() != reflect.Ptr || value.IsNil() {
+		return diags
+	}
+
+	walkStructSetZeroAttrNull(ctx, value.Elem(), &diags)
+
+	return diags
+}
+
+func walkStructSetZeroAttrNull(ctx context.Context, value reflect.Value, diags *diag.Diagnostics) {
+	if diags.HasError() || !value.IsValid() || value.Kind() != reflect.Struct {
+		return
+	}
+
+	for index := 0; index < value.NumField(); index++ {
+		field := value.Field(index)
+		if !field.CanSet() {
+			continue
+		}
+
+		if field.Kind() != reflect.Struct {
+			continue
+		}
+
+		if attrValue, ok := field.Interface().(attr.Value); ok {
+			if field.IsZero() {
+				nullValue, err := fwtypes.NullValueOf(ctx, attrValue)
+				if err != nil {
+					diags.AddError("Normalizing List Result", err.Error())
+					return
+				}
+
+				if nullValue == nil {
+					continue
+				}
+
+				nullValueReflect := reflect.ValueOf(nullValue)
+				switch {
+				case nullValueReflect.Type().AssignableTo(field.Type()):
+					field.Set(nullValueReflect)
+				case nullValueReflect.Type().ConvertibleTo(field.Type()):
+					field.Set(nullValueReflect.Convert(field.Type()))
+				default:
+					diags.AddError("Normalizing List Result", fmt.Sprintf("cannot assign null value of type %T to field type %s", nullValue, field.Type()))
+					return
+				}
+			}
+
+			continue
+		}
+
+		walkStructSetZeroAttrNull(ctx, field, diags)
+		if diags.HasError() {
+			return
+		}
 	}
 }

--- a/internal/framework/with_list.go
+++ b/internal/framework/with_list.go
@@ -102,7 +102,16 @@ func setZeroValueAttrFieldsToNull(ctx context.Context, target any) diag.Diagnost
 	var diags diag.Diagnostics
 
 	value := reflect.ValueOf(target)
-	if !value.IsValid() || value.Kind() != reflect.Ptr || value.IsNil() {
+	if !value.IsValid() {
+		return diags
+	}
+
+	if value.Kind() != reflect.Ptr {
+		diags.AddError("Normalizing List Result", fmt.Sprintf("target must be a pointer, got %T", target))
+		return diags
+	}
+
+	if value.IsNil() {
 		return diags
 	}
 

--- a/internal/framework/with_list_test.go
+++ b/internal/framework/with_list_test.go
@@ -11,120 +11,211 @@ import (
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 )
 
+type testNestedModel struct {
+	Field1 types.String `tfsdk:"field1"`
+	Field2 types.Int32  `tfsdk:"field2"`
+}
+
+type testListModel struct {
+	Name   types.String                                     `tfsdk:"name"`
+	Tags   fwtypes.MapValueOf[types.String]                 `tfsdk:"tags"`
+	Config fwtypes.ObjectValueOf[testNestedModel]           `tfsdk:"config"`
+	Rules  fwtypes.ListNestedObjectValueOf[testNestedModel] `tfsdk:"rules"`
+	Nested testNestedModel                                  `tfsdk:"nested"`
+}
+
+type testMixedFieldModel struct {
+	Name   types.String `tfsdk:"name"`
+	Count  int          `tfsdk:"count"`
+	hidden types.String `tfsdk:"hidden"`
+}
+
+type testDeepLeafModel struct {
+	Field1 types.String `tfsdk:"field1"`
+	Field2 types.Int32  `tfsdk:"field2"`
+}
+
+type testDeepMiddleModel struct {
+	Leaf testDeepLeafModel `tfsdk:"leaf"`
+}
+
+type testDeepRootModel struct {
+	Name   types.String        `tfsdk:"name"`
+	Middle testDeepMiddleModel `tfsdk:"middle"`
+}
+
 func TestSetZeroValueAttrFieldsToNull(t *testing.T) {
 	t.Parallel()
 
-	type nestedModel struct {
-		Field1 types.String `tfsdk:"field1"`
-		Field2 types.Int32  `tfsdk:"field2"`
-	}
-
-	type listModel struct {
-		Name   types.String                                 `tfsdk:"name"`
-		Tags   fwtypes.MapValueOf[types.String]             `tfsdk:"tags"`
-		Config fwtypes.ObjectValueOf[nestedModel]           `tfsdk:"config"`
-		Rules  fwtypes.ListNestedObjectValueOf[nestedModel] `tfsdk:"rules"`
-		Nested nestedModel                                  `tfsdk:"nested"`
-	}
-
 	ctx := context.Background()
-	data := &listModel{
-		Name: types.StringValue("example"),
+
+	tests := map[string]struct {
+		data     *testListModel
+		expected *testListModel
+	}{
+		"zero attr fields become null": {
+			data: &testListModel{
+				Name: types.StringValue("example"),
+			},
+			expected: expectedTestListModel(ctx, types.StringValue("example")),
+		},
+		"null values remain null": {
+			data: &testListModel{
+				Name: types.StringNull(),
+			},
+			expected: expectedTestListModel(ctx, types.StringNull()),
+		},
+		"unknown values remain unknown": {
+			data: &testListModel{
+				Name: types.StringUnknown(),
+			},
+			expected: expectedTestListModel(ctx, types.StringUnknown()),
+		},
 	}
 
-	if diags := setZeroValueAttrFieldsToNull(ctx, data); diags.HasError() {
-		t.Fatalf("unexpected diagnostics: %v", diags)
-	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	if !data.Name.Equal(types.StringValue("example")) {
-		t.Fatalf("expected Name to be unchanged")
-	}
-	if !data.Tags.IsNull() {
-		t.Errorf("expected Tags to be null")
-	}
-	if !data.Config.IsNull() {
-		t.Errorf("expected Config to be null")
-	}
-	if !data.Rules.IsNull() {
-		t.Errorf("expected Rules to be null")
-	}
-	if !data.Nested.Field1.IsNull() {
-		t.Errorf("expected Nested.Field1 to be null")
-	}
-	if !data.Nested.Field2.IsNull() {
-		t.Errorf("expected Nested.Field2 to be null")
+			if diags := setZeroValueAttrFieldsToNull(ctx, test.data); diags.HasError() {
+				t.Fatalf("unexpected error: %v", diags)
+			}
+
+			assertTestListModelEqual(t, test.data, test.expected)
+		})
 	}
 }
 
-func TestSetZeroValueAttrFieldsToNull_NonPointer(t *testing.T) {
+func TestSetZeroValueAttrFieldsToNull_IgnoresInvalidTargets(t *testing.T) {
 	t.Parallel()
 
-	type listModel struct {
-		Name types.String `tfsdk:"name"`
+	ctx := context.Background()
+
+	tests := map[string]struct {
+		target any
+	}{
+		"non-pointer": {
+			target: testListModel{},
+		},
+		"nil pointer": {
+			target: (*testListModel)(nil),
+		},
+		"pointer to non-struct": {
+			target: func() any {
+				v := 42
+				return &v
+			}(),
+		},
 	}
 
-	ctx := context.Background()
-	data := listModel{}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	if diags := setZeroValueAttrFieldsToNull(ctx, data); diags.HasError() {
-		t.Fatalf("unexpected diagnostics: %v", diags)
+			if diags := setZeroValueAttrFieldsToNull(ctx, test.target); diags.HasError() {
+				t.Fatalf("unexpected error: %v", diags)
+			}
+		})
 	}
 }
 
-func TestSetZeroValueAttrFieldsToNull_NilPointer(t *testing.T) {
+func TestSetZeroValueAttrFieldsToNull_AdditionalCases(t *testing.T) {
 	t.Parallel()
-
-	type listModel struct {
-		Name types.String `tfsdk:"name"`
-	}
 
 	ctx := context.Background()
 
-	var data *listModel
+	tests := map[string]struct {
+		target any
+		assert func(*testing.T, any)
+	}{
+		"skips unsettable and non-struct fields": {
+			target: &testMixedFieldModel{
+				Count:  42,
+				hidden: types.String{},
+			},
+			assert: func(t *testing.T, target any) {
+				t.Helper()
 
-	if diags := setZeroValueAttrFieldsToNull(ctx, data); diags.HasError() {
-		t.Fatalf("unexpected diagnostics: %v", diags)
+				data := target.(*testMixedFieldModel)
+
+				if !data.Name.IsNull() {
+					t.Fatalf("expected Name to be normalized to null")
+				}
+				if got, want := data.Count, 42; got != want {
+					t.Fatalf("expected Count to remain %d, got %d", want, got)
+				}
+				if !data.hidden.Equal(types.String{}) {
+					t.Fatalf("expected hidden field to remain zero value")
+				}
+			},
+		},
+		"recurses two levels deep": {
+			target: &testDeepRootModel{
+				Name: types.StringValue("example"),
+			},
+			assert: func(t *testing.T, target any) {
+				t.Helper()
+
+				data := target.(*testDeepRootModel)
+
+				if !data.Name.Equal(types.StringValue("example")) {
+					t.Fatalf("expected Name to remain unchanged")
+				}
+				if !data.Middle.Leaf.Field1.IsNull() {
+					t.Fatalf("expected Middle.Leaf.Field1 to be normalized to null")
+				}
+				if !data.Middle.Leaf.Field2.IsNull() {
+					t.Fatalf("expected Middle.Leaf.Field2 to be normalized to null")
+				}
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if diags := setZeroValueAttrFieldsToNull(ctx, test.target); diags.HasError() {
+				t.Fatalf("unexpected error: %v", diags)
+			}
+
+			test.assert(t, test.target)
+		})
 	}
 }
 
-func TestSetZeroValueAttrFieldsToNull_AlreadyNull(t *testing.T) {
-	t.Parallel()
-
-	type listModel struct {
-		Name types.String `tfsdk:"name"`
-	}
-
-	ctx := context.Background()
-	data := &listModel{
-		Name: types.StringNull(),
-	}
-
-	if diags := setZeroValueAttrFieldsToNull(ctx, data); diags.HasError() {
-		t.Fatalf("unexpected diagnostics: %v", diags)
-	}
-
-	if !data.Name.IsNull() {
-		t.Errorf("expected Name to remain null")
+func expectedTestListModel(ctx context.Context, name types.String) *testListModel {
+	return &testListModel{
+		Name:   name,
+		Tags:   fwtypes.NewMapValueOfNull[types.String](ctx),
+		Config: fwtypes.NewObjectValueOfNull[testNestedModel](ctx),
+		Rules:  fwtypes.NewListNestedObjectValueOfNull[testNestedModel](ctx),
+		Nested: testNestedModel{
+			Field1: types.StringNull(),
+			Field2: types.Int32Null(),
+		},
 	}
 }
 
-func TestSetZeroValueAttrFieldsToNull_UnknownValue(t *testing.T) {
-	t.Parallel()
+func assertTestListModelEqual(t *testing.T, got, want *testListModel) {
+	t.Helper()
 
-	type listModel struct {
-		Name types.String `tfsdk:"name"`
+	if !got.Name.Equal(want.Name) {
+		t.Fatalf("expected Name to equal %s, got %s", want.Name, got.Name)
 	}
-
-	ctx := context.Background()
-	data := &listModel{
-		Name: types.StringUnknown(),
+	if !got.Tags.Equal(want.Tags) {
+		t.Fatalf("expected Tags to equal %s, got %s", want.Tags, got.Tags)
 	}
-
-	if diags := setZeroValueAttrFieldsToNull(ctx, data); diags.HasError() {
-		t.Fatalf("unexpected diagnostics: %v", diags)
+	if !got.Config.Equal(want.Config) {
+		t.Fatalf("expected Config to equal %s, got %s", want.Config, got.Config)
 	}
-
-	if !data.Name.IsUnknown() {
-		t.Errorf("expected Name to remain unknown")
+	if !got.Rules.Equal(want.Rules) {
+		t.Fatalf("expected Rules to equal %s, got %s", want.Rules, got.Rules)
+	}
+	if !got.Nested.Field1.Equal(want.Nested.Field1) {
+		t.Fatalf("expected Nested.Field1 to equal %s, got %s", want.Nested.Field1, got.Nested.Field1)
+	}
+	if !got.Nested.Field2.Equal(want.Nested.Field2) {
+		t.Fatalf("expected Nested.Field2 to equal %s, got %s", want.Nested.Field2, got.Nested.Field2)
 	}
 }

--- a/internal/framework/with_list_test.go
+++ b/internal/framework/with_list_test.go
@@ -1,0 +1,150 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package framework
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+)
+
+func TestSetZeroValueAttrFieldsToNull(t *testing.T) {
+	t.Parallel()
+
+	type nestedModel struct {
+		Field1 types.String `tfsdk:"field1"`
+		Field2 types.Int32  `tfsdk:"field2"`
+	}
+
+	type listModel struct {
+		Name   types.String                                 `tfsdk:"name"`
+		Tags   fwtypes.MapValueOf[types.String]             `tfsdk:"tags"`
+		Config fwtypes.ObjectValueOf[nestedModel]           `tfsdk:"config"`
+		Rules  fwtypes.ListNestedObjectValueOf[nestedModel] `tfsdk:"rules"`
+		Nested nestedModel                                  `tfsdk:"nested"`
+	}
+
+	ctx := context.Background()
+	data := &listModel{
+		Name: types.StringValue("example"),
+	}
+
+	if diags := setZeroValueAttrFieldsToNull(ctx, data); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if !data.Name.Equal(types.StringValue("example")) {
+		t.Fatalf("expected Name to be unchanged")
+	}
+	if !data.Tags.IsNull() {
+		t.Errorf("expected Tags to be null")
+	}
+	if !data.Config.IsNull() {
+		t.Errorf("expected Config to be null")
+	}
+	if !data.Rules.IsNull() {
+		t.Errorf("expected Rules to be null")
+	}
+	if !data.Nested.Field1.IsNull() {
+		t.Errorf("expected Nested.Field1 to be null")
+	}
+	if !data.Nested.Field2.IsNull() {
+		t.Errorf("expected Nested.Field2 to be null")
+	}
+}
+
+func TestSetZeroValueAttrFieldsToNull_NonPointer(t *testing.T) {
+	t.Parallel()
+
+	type listModel struct {
+		Name types.String `tfsdk:"name"`
+	}
+
+	ctx := context.Background()
+	data := listModel{}
+
+	if diags := setZeroValueAttrFieldsToNull(ctx, data); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+}
+
+func TestSetZeroValueAttrFieldsToNull_NilPointer(t *testing.T) {
+	t.Parallel()
+
+	type listModel struct {
+		Name types.String `tfsdk:"name"`
+	}
+
+	ctx := context.Background()
+
+	var data *listModel = nil
+
+	if diags := setZeroValueAttrFieldsToNull(ctx, data); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+}
+
+func TestSetZeroValueAttrFieldsToNull_UnexportedField(t *testing.T) {
+	t.Parallel()
+
+	type modelWithPrivateField struct {
+		Public  types.String `tfsdk:"public"`
+		private types.String
+	}
+
+	ctx := context.Background()
+	data := &modelWithPrivateField{}
+
+	if diags := setZeroValueAttrFieldsToNull(ctx, data); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if !data.Public.IsNull() {
+		t.Errorf("expected Public field to be null")
+	}
+}
+
+func TestSetZeroValueAttrFieldsToNull_AlreadyNull(t *testing.T) {
+	t.Parallel()
+
+	type listModel struct {
+		Name types.String `tfsdk:"name"`
+	}
+
+	ctx := context.Background()
+	data := &listModel{
+		Name: types.StringNull(),
+	}
+
+	if diags := setZeroValueAttrFieldsToNull(ctx, data); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if !data.Name.IsNull() {
+		t.Errorf("expected Name to remain null")
+	}
+}
+
+func TestSetZeroValueAttrFieldsToNull_UnknownValue(t *testing.T) {
+	t.Parallel()
+
+	type listModel struct {
+		Name types.String `tfsdk:"name"`
+	}
+
+	ctx := context.Background()
+	data := &listModel{
+		Name: types.StringUnknown(),
+	}
+
+	if diags := setZeroValueAttrFieldsToNull(ctx, data); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if !data.Name.IsUnknown() {
+		t.Errorf("expected Name to remain unknown")
+	}
+}

--- a/internal/framework/with_list_test.go
+++ b/internal/framework/with_list_test.go
@@ -80,30 +80,10 @@ func TestSetZeroValueAttrFieldsToNull_NilPointer(t *testing.T) {
 
 	ctx := context.Background()
 
-	var data *listModel = nil
+	var data *listModel
 
 	if diags := setZeroValueAttrFieldsToNull(ctx, data); diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)
-	}
-}
-
-func TestSetZeroValueAttrFieldsToNull_UnexportedField(t *testing.T) {
-	t.Parallel()
-
-	type modelWithPrivateField struct {
-		Public  types.String `tfsdk:"public"`
-		private types.String
-	}
-
-	ctx := context.Background()
-	data := &modelWithPrivateField{}
-
-	if diags := setZeroValueAttrFieldsToNull(ctx, data); diags.HasError() {
-		t.Fatalf("unexpected diagnostics: %v", diags)
-	}
-
-	if !data.Public.IsNull() {
-		t.Errorf("expected Public field to be null")
 	}
 }
 

--- a/internal/framework/with_list_test.go
+++ b/internal/framework/with_list_test.go
@@ -94,9 +94,6 @@ func TestSetZeroValueAttrFieldsToNull_IgnoresInvalidTargets(t *testing.T) {
 	tests := map[string]struct {
 		target any
 	}{
-		"non-pointer": {
-			target: testListModel{},
-		},
 		"nil pointer": {
 			target: (*testListModel)(nil),
 		},
@@ -125,9 +122,18 @@ func TestSetZeroValueAttrFieldsToNull_AdditionalCases(t *testing.T) {
 	ctx := context.Background()
 
 	tests := map[string]struct {
-		target any
-		assert func(*testing.T, any)
+		target               any
+		assert               func(*testing.T, any)
+		expectError          bool
+		expectedErrorSummary string
+		expectedErrorDetail  string
 	}{
+		"returns error for non-pointer": {
+			target:               testListModel{},
+			expectError:          true,
+			expectedErrorSummary: "Normalizing List Result",
+			expectedErrorDetail:  "target must be a pointer, got framework.testListModel",
+		},
 		"skips unsettable and non-struct fields": {
 			target: &testMixedFieldModel{
 				Count:  42,
@@ -175,7 +181,29 @@ func TestSetZeroValueAttrFieldsToNull_AdditionalCases(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			if diags := setZeroValueAttrFieldsToNull(ctx, test.target); diags.HasError() {
+			diags := setZeroValueAttrFieldsToNull(ctx, test.target)
+
+			if test.expectError {
+				if !diags.HasError() {
+					t.Fatal("expected diagnostics")
+				}
+
+				if got, want := diags.ErrorsCount(), 1; got != want {
+					t.Fatalf("expected %d errors, got %d", want, got)
+				}
+
+				err := diags.Errors()[0]
+				if got, want := err.Summary(), test.expectedErrorSummary; got != want {
+					t.Fatalf("expected summary %q, got %q", want, got)
+				}
+				if got, want := err.Detail(), test.expectedErrorDetail; got != want {
+					t.Fatalf("expected detail %q, got %q", want, got)
+				}
+
+				return
+			}
+
+			if diags.HasError() {
 				t.Fatalf("unexpected error: %v", diags)
 			}
 


### PR DESCRIPTION

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->



## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

### Description

Adds normalization of zero-value attr.Value fields to null in framework and unit tests

- Recursively sets zero-value attr.Value struct fields to null in SetResult
- Adds unit tests for setZeroValueAttrFieldsToNull and related edge cases

No service level changes would be required for list implementation zero value handling after merging this.

More context : https://github.com/hashicorp/terraform-provider-aws/pull/46892#discussion_r2955205629


### References



### Output from Testing

```console
go test ./internal/framework/...
ok      github.com/hashicorp/terraform-provider-aws/internal/framework  3.780s
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/actions  2.214s
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/flex     2.830s
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/planmodifiers    1.608s
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/planmodifiers/boolplanmodifier   3.921s
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/planmodifiers/int32planmodifier  4.596s
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/planmodifiers/int64planmodifier  2.892s
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/planmodifiers/stringplanmodifier 2.065s
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/privatestate     1.443s
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/types    3.349s
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/validators       1.029s
?       github.com/hashicorp/terraform-provider-aws/internal/framework/validators/internal      [no test files]
?       github.com/hashicorp/terraform-provider-aws/internal/framework/validators/objectvalidator       [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/validators/stringvalidator       4.197s
```

# Verifying Existing List implementations

## Framework based (@FrameworkListResource)

```console
make testacc PKG=batch TESTS=TestAccBatchJobQueue_List_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-framework-list-null-fix 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/batch/... -v -count 1 -parallel 20 -run='TestAccBatchJobQueue_List_'  -timeout 360m -vet=off
2026/03/19 17:55:28 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/19 17:55:28 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBatchJobQueue_List_basic
=== PAUSE TestAccBatchJobQueue_List_basic
=== RUN   TestAccBatchJobQueue_List_regionOverride
=== PAUSE TestAccBatchJobQueue_List_regionOverride
=== CONT  TestAccBatchJobQueue_List_basic
=== CONT  TestAccBatchJobQueue_List_regionOverride
--- PASS: TestAccBatchJobQueue_List_basic (164.14s)
--- PASS: TestAccBatchJobQueue_List_regionOverride (174.67s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      179.646s
```


```console
make testacc PKG=cloudfront TESTS=TestAccCloudFrontKeyValueStore_List_     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-framework-list-null-fix 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontKeyValueStore_List_'  -timeout 360m -vet=off
2026/03/19 17:56:57 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/19 17:56:57 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudFrontKeyValueStore_List_basic
=== PAUSE TestAccCloudFrontKeyValueStore_List_basic
=== CONT  TestAccCloudFrontKeyValueStore_List_basic
--- PASS: TestAccCloudFrontKeyValueStore_List_basic (111.83s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 117.535s
```

```console
make t K=s3 TESTS=TestAccS3BucketLifecycleConfiguration_List_     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-framework-list-null-fix 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketLifecycleConfiguration_List_'  -timeout 360m -vet=off
2026/03/19 18:41:31 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/19 18:41:31 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3BucketLifecycleConfiguration_List_basic
=== PAUSE TestAccS3BucketLifecycleConfiguration_List_basic
=== RUN   TestAccS3BucketLifecycleConfiguration_List_includeResource
=== PAUSE TestAccS3BucketLifecycleConfiguration_List_includeResource
=== RUN   TestAccS3BucketLifecycleConfiguration_List_regionOverride
=== PAUSE TestAccS3BucketLifecycleConfiguration_List_regionOverride
=== CONT  TestAccS3BucketLifecycleConfiguration_List_basic
=== CONT  TestAccS3BucketLifecycleConfiguration_List_regionOverride
=== CONT  TestAccS3BucketLifecycleConfiguration_List_includeResource
--- PASS: TestAccS3BucketLifecycleConfiguration_List_regionOverride (112.65s)
--- PASS: TestAccS3BucketLifecycleConfiguration_List_includeResource (121.51s)
--- PASS: TestAccS3BucketLifecycleConfiguration_List_basic (123.18s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 128.633s
```


```console
make testacc PKG=workmail TESTS=TestAccWorkMailOrganization_List_    
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-framework-list-null-fix 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/workmail/... -v -count 1 -parallel 20 -run='TestAccWorkMailOrganization_List_'  -timeout 360m -vet=off
2026/03/19 18:43:41 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/19 18:43:41 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccWorkMailOrganization_List_basic
=== PAUSE TestAccWorkMailOrganization_List_basic
=== RUN   TestAccWorkMailOrganization_List_includeResource
=== PAUSE TestAccWorkMailOrganization_List_includeResource
=== RUN   TestAccWorkMailOrganization_List_regionOverride
=== PAUSE TestAccWorkMailOrganization_List_regionOverride
=== CONT  TestAccWorkMailOrganization_List_basic
=== CONT  TestAccWorkMailOrganization_List_regionOverride
=== CONT  TestAccWorkMailOrganization_List_includeResource
--- PASS: TestAccWorkMailOrganization_List_basic (55.82s)
--- PASS: TestAccWorkMailOrganization_List_includeResource (56.19s)
--- PASS: TestAccWorkMailOrganization_List_regionOverride (57.78s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/workmail   63.204s
```

```console
make testacc PKG=ec2 TESTS=TestAccVPCSecurityGroupEgressRule_List_     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-framework-list-null-fix 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCSecurityGroupEgressRule_List_'  -timeout 360m -vet=off
2026/03/19 18:46:33 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/19 18:46:33 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCSecurityGroupEgressRule_List_basic
=== PAUSE TestAccVPCSecurityGroupEgressRule_List_basic
=== RUN   TestAccVPCSecurityGroupEgressRule_List_filter
=== PAUSE TestAccVPCSecurityGroupEgressRule_List_filter
=== RUN   TestAccVPCSecurityGroupEgressRule_List_regionOverride
=== PAUSE TestAccVPCSecurityGroupEgressRule_List_regionOverride
=== CONT  TestAccVPCSecurityGroupEgressRule_List_basic
=== CONT  TestAccVPCSecurityGroupEgressRule_List_regionOverride
=== CONT  TestAccVPCSecurityGroupEgressRule_List_filter
--- PASS: TestAccVPCSecurityGroupEgressRule_List_basic (39.32s)
--- PASS: TestAccVPCSecurityGroupEgressRule_List_filter (40.93s)
--- PASS: TestAccVPCSecurityGroupEgressRule_List_regionOverride (43.76s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        48.973s
```

```console
make testacc PKG=opensearchserverless TES
TS=TestAccOpenSearchServerlessCollection_List_     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-framework-list-null-fix 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/opensearchserverless/... -v -count 1 -parallel 20 -run='TestAccOpenSearchServerlessCollection_List_'  -timeout 360m -vet=off
2026/03/19 18:44:32 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/19 18:44:32 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccOpenSearchServerlessCollection_List_basic
=== PAUSE TestAccOpenSearchServerlessCollection_List_basic
=== CONT  TestAccOpenSearchServerlessCollection_List_basic
--- PASS: TestAccOpenSearchServerlessCollection_List_basic (447.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearchserverless     453.062s
```


```console
make testacc PKG=wafv2 TESTS=TestAccWAFV2WebACLRule_List_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-framework-list-null-fix 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACLRule_List_'  -timeout 360m -vet=off
2026/03/19 19:22:03 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/19 19:22:03 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccWAFV2WebACLRule_List_basic
=== PAUSE TestAccWAFV2WebACLRule_List_basic
=== RUN   TestAccWAFV2WebACLRule_List_includeResource
=== PAUSE TestAccWAFV2WebACLRule_List_includeResource
=== RUN   TestAccWAFV2WebACLRule_List_regionOverride
=== PAUSE TestAccWAFV2WebACLRule_List_regionOverride
=== CONT  TestAccWAFV2WebACLRule_List_basic
=== CONT  TestAccWAFV2WebACLRule_List_regionOverride
=== CONT  TestAccWAFV2WebACLRule_List_includeResource
--- PASS: TestAccWAFV2WebACLRule_List_includeResource (50.27s)
--- PASS: TestAccWAFV2WebACLRule_List_basic (68.01s)
--- PASS: TestAccWAFV2WebACLRule_List_regionOverride (68.67s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      74.191s
```


## SDK based (@SDKListResource) 

### SDK based shouldn't be affected by this change , still have tested few of them.

```console
make testacc PKG=cloudwatch TESTS=TestAccCloudWatchMetricAlarm_List_    
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-framework-list-null-fix 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/cloudwatch/... -v -count 1 -parallel 20 -run='TestAccCloudWatchMetricAlarm_List_'  -timeout 360m -vet=off
2026/03/19 18:51:36 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/19 18:51:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudWatchMetricAlarm_List_basic
=== PAUSE TestAccCloudWatchMetricAlarm_List_basic
=== RUN   TestAccCloudWatchMetricAlarm_List_includeResource
=== PAUSE TestAccCloudWatchMetricAlarm_List_includeResource
=== RUN   TestAccCloudWatchMetricAlarm_List_regionOverride
=== PAUSE TestAccCloudWatchMetricAlarm_List_regionOverride
=== CONT  TestAccCloudWatchMetricAlarm_List_basic
=== CONT  TestAccCloudWatchMetricAlarm_List_regionOverride
=== CONT  TestAccCloudWatchMetricAlarm_List_includeResource
--- PASS: TestAccCloudWatchMetricAlarm_List_regionOverride (25.39s)
--- PASS: TestAccCloudWatchMetricAlarm_List_includeResource (25.79s)
--- PASS: TestAccCloudWatchMetricAlarm_List_basic (26.06s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch 31.276s
```


```console
make testacc PKG=codebuild TESTS=TestAccCodeBuildProject_List_    
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-framework-list-null-fix 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/codebuild/... -v -count 1 -parallel 20 -run='TestAccCodeBuildProject_List_'  -timeout 360m -vet=off
2026/03/19 18:55:28 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/19 18:55:28 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCodeBuildProject_List_basic
=== PAUSE TestAccCodeBuildProject_List_basic
=== CONT  TestAccCodeBuildProject_List_basic
--- PASS: TestAccCodeBuildProject_List_basic (43.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codebuild  49.275s
```

```console
make testacc PKG=ec2 TESTS=TestAccVPC_List_    
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-framework-list-null-fix 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPC_List_'  -timeout 360m -vet=off
2026/03/19 18:56:08 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/19 18:56:08 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPC_List_basic
=== PAUSE TestAccVPC_List_basic
=== RUN   TestAccVPC_List_includeResource
=== PAUSE TestAccVPC_List_includeResource
=== RUN   TestAccVPC_List_regionOverride
=== PAUSE TestAccVPC_List_regionOverride
=== RUN   TestAccVPC_List_filtered
=== PAUSE TestAccVPC_List_filtered
=== RUN   TestAccVPC_List_DefaultVPC_exclude
=== PAUSE TestAccVPC_List_DefaultVPC_exclude
=== RUN   TestAccVPC_List_vpcIDs
=== PAUSE TestAccVPC_List_vpcIDs
=== RUN   TestAccVPC_List_filteredVPCIDs
=== PAUSE TestAccVPC_List_filteredVPCIDs
=== RUN   TestAccVPC_List_Filtered_isDefault
=== PAUSE TestAccVPC_List_Filtered_isDefault
=== CONT  TestAccVPC_List_basic
=== CONT  TestAccVPC_List_DefaultVPC_exclude
=== CONT  TestAccVPC_List_filteredVPCIDs
=== CONT  TestAccVPC_List_Filtered_isDefault
=== CONT  TestAccVPC_List_vpcIDs
=== CONT  TestAccVPC_List_regionOverride
=== CONT  TestAccVPC_List_filtered
=== CONT  TestAccVPC_List_includeResource
--- PASS: TestAccVPC_List_Filtered_isDefault (3.20s)
--- PASS: TestAccVPC_List_DefaultVPC_exclude (35.48s)
--- PASS: TestAccVPC_List_vpcIDs (35.49s)
--- PASS: TestAccVPC_List_basic (37.65s)
--- PASS: TestAccVPC_List_filtered (37.70s)
--- PASS: TestAccVPC_List_regionOverride (37.85s)
--- PASS: TestAccVPC_List_filteredVPCIDs (38.12s)
--- PASS: TestAccVPC_List_includeResource (52.81s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        58.209s
```

```console
make testacc PKG=iam TESTS=TestAccIAMRole_List_    
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-framework-list-null-fix 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRole_List_'  -timeout 360m -vet=off
2026/03/19 18:56:54 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/19 18:56:54 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIAMRole_List_basic
=== PAUSE TestAccIAMRole_List_basic
=== RUN   TestAccIAMRole_List_includeResource
=== PAUSE TestAccIAMRole_List_includeResource
=== CONT  TestAccIAMRole_List_basic
=== CONT  TestAccIAMRole_List_includeResource
--- PASS: TestAccIAMRole_List_includeResource (27.88s)
--- PASS: TestAccIAMRole_List_basic (28.18s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        33.731s
```

```console
make testacc PKG=iam TESTS=TestAccIAMPolicy_List_    
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-framework-list-null-fix 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMPolicy_List_'  -timeout 360m -vet=off
2026/03/19 18:58:47 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/19 18:58:47 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIAMPolicy_List_basic
=== PAUSE TestAccIAMPolicy_List_basic
=== RUN   TestAccIAMPolicy_List_pathPrefix
=== PAUSE TestAccIAMPolicy_List_pathPrefix
=== CONT  TestAccIAMPolicy_List_basic
=== CONT  TestAccIAMPolicy_List_pathPrefix
--- PASS: TestAccIAMPolicy_List_basic (26.26s)
--- PASS: TestAccIAMPolicy_List_pathPrefix (26.57s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        31.741s
```

```console
make testacc PKG=lambda TESTS=TestAccLambdaFunction_List_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-framework-list-null-fix 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunction_List_'  -timeout 360m -vet=off
2026/03/19 18:59:22 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/19 18:59:22 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaFunction_List_basic
=== PAUSE TestAccLambdaFunction_List_basic
=== RUN   TestAccLambdaFunction_List_includeResource
=== PAUSE TestAccLambdaFunction_List_includeResource
=== RUN   TestAccLambdaFunction_List_regionOverride
=== PAUSE TestAccLambdaFunction_List_regionOverride
=== CONT  TestAccLambdaFunction_List_basic
=== CONT  TestAccLambdaFunction_List_regionOverride
=== CONT  TestAccLambdaFunction_List_includeResource
--- PASS: TestAccLambdaFunction_List_basic (61.36s)
--- PASS: TestAccLambdaFunction_List_includeResource (66.15s)
--- PASS: TestAccLambdaFunction_List_regionOverride (83.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     88.786s
```

```console
make testacc PKG=route53 TESTS=TestAccRoute53Record_List_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-framework-list-null-fix 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/route53/... -v -count 1 -parallel 20 -run='TestAccRoute53Record_List_'  -timeout 360m -vet=off
2026/03/19 19:00:46 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/19 19:00:46 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRoute53Record_List_basic
=== PAUSE TestAccRoute53Record_List_basic
=== CONT  TestAccRoute53Record_List_basic
--- PASS: TestAccRoute53Record_List_basic (164.84s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    170.318s
```

```console
make testacc PKG=ssm TESTS=TestAccSSMDocument_List_     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-framework-list-null-fix 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMDocument_List_'  -timeout 360m -vet=off
2026/03/19 19:03:07 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/19 19:03:07 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSSMDocument_List_basic
=== PAUSE TestAccSSMDocument_List_basic
=== RUN   TestAccSSMDocument_List_includeResource
=== PAUSE TestAccSSMDocument_List_includeResource
=== RUN   TestAccSSMDocument_List_regionOverride
=== PAUSE TestAccSSMDocument_List_regionOverride
=== RUN   TestAccSSMDocument_List_filtered
=== PAUSE TestAccSSMDocument_List_filtered
=== CONT  TestAccSSMDocument_List_basic
=== CONT  TestAccSSMDocument_List_regionOverride
=== CONT  TestAccSSMDocument_List_includeResource
=== CONT  TestAccSSMDocument_List_filtered
--- PASS: TestAccSSMDocument_List_regionOverride (26.87s)
--- PASS: TestAccSSMDocument_List_basic (27.69s)
--- PASS: TestAccSSMDocument_List_filtered (28.88s)
--- PASS: TestAccSSMDocument_List_includeResource (33.36s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        38.908s
```

```console
make testacc PKG=sqs TESTS=TestAccSQSQueue_List_       
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-framework-list-null-fix 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/sqs/... -v -count 1 -parallel 20 -run='TestAccSQSQueue_List_'  -timeout 360m -vet=off
2026/03/19 19:02:27 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/19 19:02:27 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSQSQueue_List_basic
=== PAUSE TestAccSQSQueue_List_basic
=== CONT  TestAccSQSQueue_List_basic
--- PASS: TestAccSQSQueue_List_basic (185.84s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sqs        191.428s
```




