### PR TITLE
fix(elasticache): read reservation after create to populate computed attributes

### DIFF
--- a/.changelog/47012.txt
+++ b/.changelog/47012.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_reserved_cache_node: Fix `Provider returned invalid result object after apply` errors where computed attributes remained unknown after create
+```

--- a/internal/service/elasticache/reserved_cache_node.go
+++ b/internal/service/elasticache/reserved_cache_node.go
@@ -153,8 +153,10 @@ func (r *reservedCacheNodeResource) Create(ctx context.Context, request resource
 		return
 	}
 
+	reservedCacheNodeID := aws.ToString(resp.ReservedCacheNode.ReservedCacheNodeId)
+
 	createTimeout := r.CreateTimeout(ctx, data.Timeouts)
-	if err := waitReservedCacheNodeCreated(ctx, conn, aws.ToString(resp.ReservedCacheNode.ReservedCacheNodeId), createTimeout); err != nil {
+	if err := waitReservedCacheNodeCreated(ctx, conn, reservedCacheNodeID, createTimeout); err != nil {
 		response.Diagnostics.AddError(
 			"Creating ElastiCache Reserved Cache Node",
 			fmt.Sprintf("Creating ElastiCache Reserved Cache Node with Offering ID %q failed while waiting for completion.\nError: %s", data.ReservedCacheNodesOfferingID.ValueString(), err.Error()),
@@ -162,12 +164,21 @@ func (r *reservedCacheNodeResource) Create(ctx context.Context, request resource
 		return
 	}
 
-	response.Diagnostics.Append(flex.Flatten(ctx, resp.ReservedCacheNode, &data, r.flexOpts()...)...)
+	reservation, err := findReservedCacheNodeByID(ctx, conn, reservedCacheNodeID)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Creating ElastiCache Reserved Cache Node",
+			fmt.Sprintf("reading ElastiCache Reserved Cache Node (%s): %s", reservedCacheNodeID, err.Error()),
+		)
+		return
+	}
+
+	response.Diagnostics.Append(flex.Flatten(ctx, reservation, &data)...)
 	if response.Diagnostics.HasError() {
 		return
 	}
 
-	duration := time.Duration(aws.ToInt32(resp.ReservedCacheNode.Duration)) * time.Second
+	duration := time.Duration(aws.ToInt32(reservation.Duration)) * time.Second
 	data.Duration = fwtypes.RFC3339DurationTimeDurationValue(duration)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)


### PR DESCRIPTION
## Description

Fixes #47006

The `Create` function for `aws_elasticache_reserved_cache_node` was flattening state from the initial `PurchaseReservedCacheNodesOffering` API response. After the waiter confirms the reservation is active, the function continued to use the stale initial response to populate state, which could leave computed attributes as unknown values.

This change performs a fresh `DescribeReservedCacheNodes` read after the waiter completes (consistent with how the `Read` function works) to ensure all computed attributes (`arn`, `cache_node_type`, `duration`, `fixed_price`, `offering_type`, `product_description`, `recurring_charges`, `start_time`, `state`, `usage_price`) are fully populated.

Also aligns the `Create` flatten call with `Read` by dropping `flexOpts`, since both operate on the same `awstypes.ReservedCacheNode` struct from `DescribeReservedCacheNodes`.

## Changes

- After `waitReservedCacheNodeCreated`, call `findReservedCacheNodeByID` to get fresh data
- Flatten from the fresh `DescribeReservedCacheNodes` response instead of the stale `PurchaseReservedCacheNodesOffering` response
- Drop `flexOpts` from the flatten call to match `Read` behavior

## Testing

- Code compiles successfully
- The fix follows the same pattern used by the `Read` function which works correctly

## Release Note

```release-note:bug
resource/aws_elasticache_reserved_cache_node: Fix `Provider returned invalid result object after apply` errors where computed attributes remained unknown after create
```