### PR TITLE
[Enhancement] aws_securityhub_insight: Add missing filters including `compliance_associated_standards_id`

### DIFF
--- a/.changelog/47027.txt
+++ b/.changelog/47027.txt
@@ -1,0 +1,19 @@
+```release-note:enhancement
+resource/aws_securityhub_insight: Add `filters.aws_account_name` configuration block
+```
+
+```release-note:enhancement
+resource/aws_securityhub_insight: Add `filters.compliance_associated_standards_id` configuration block
+```
+
+```release-note:enhancement
+resource/aws_securityhub_insight: Add `filters.compliance_security_control_id` configuration block
+```
+
+```release-note:enhancement
+resource/aws_securityhub_insight: Add `filters.compliance_security_control_parameters_name` configuration block
+```
+
+```release-note:enhancement
+resource/aws_securityhub_insight: Add `filters.compliance_security_control_parameters_value` configuration block
+```

--- a/internal/service/securityhub/insight.go
+++ b/internal/service/securityhub/insight.go
@@ -50,16 +50,21 @@ func resourceInsight() *schema.Resource {
 					MaxItems: 1,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
-							names.AttrAWSAccountID:                        stringFilterSchema(),
-							"company_name":                                stringFilterSchema(),
-							"compliance_status":                           stringFilterSchema(),
-							"confidence":                                  numberFilterSchema(),
-							names.AttrCreatedAt:                           dateFilterSchema(),
-							"criticality":                                 numberFilterSchema(),
-							names.AttrDescription:                         stringFilterSchema(),
-							"finding_provider_fields_confidence":          numberFilterSchema(),
-							"finding_provider_fields_criticality":         numberFilterSchema(),
-							"finding_provider_fields_related_findings_id": stringFilterSchema(),
+							names.AttrAWSAccountID:                                 stringFilterSchema(),
+							"aws_account_name":                                     stringFilterSchema(),
+							"company_name":                                         stringFilterSchema(),
+							"compliance_associated_standards_id":                   stringFilterSchema(),
+							"compliance_security_control_id":                       stringFilterSchema(),
+							"compliance_security_control_parameters_name":          stringFilterSchema(),
+							"compliance_security_control_parameters_value":         stringFilterSchema(),
+							"compliance_status":                                    stringFilterSchema(),
+							"confidence":                                           numberFilterSchema(),
+							names.AttrCreatedAt:                                    dateFilterSchema(),
+							"criticality":                                          numberFilterSchema(),
+							names.AttrDescription:                                  stringFilterSchema(),
+							"finding_provider_fields_confidence":                   numberFilterSchema(),
+							"finding_provider_fields_criticality":                  numberFilterSchema(),
+							"finding_provider_fields_related_findings_id":          stringFilterSchema(),
 							"finding_provider_fields_related_findings_product_arn": stringFilterSchema(),
 							"finding_provider_fields_severity_label":               stringFilterSchema(),
 							"finding_provider_fields_severity_original":            stringFilterSchema(),
@@ -519,8 +524,28 @@ func expandSecurityFindingFilters(l []any) *types.AwsSecurityFindingFilters {
 		filters.AwsAccountId = expandStringFilters(v.List())
 	}
 
+	if v, ok := tfMap["aws_account_name"].(*schema.Set); ok && v.Len() > 0 {
+		filters.AwsAccountName = expandStringFilters(v.List())
+	}
+
 	if v, ok := tfMap["company_name"].(*schema.Set); ok && v.Len() > 0 {
 		filters.CompanyName = expandStringFilters(v.List())
+	}
+
+	if v, ok := tfMap["compliance_associated_standards_id"].(*schema.Set); ok && v.Len() > 0 {
+		filters.ComplianceAssociatedStandardsId = expandStringFilters(v.List())
+	}
+
+	if v, ok := tfMap["compliance_security_control_id"].(*schema.Set); ok && v.Len() > 0 {
+		filters.ComplianceSecurityControlId = expandStringFilters(v.List())
+	}
+
+	if v, ok := tfMap["compliance_security_control_parameters_name"].(*schema.Set); ok && v.Len() > 0 {
+		filters.ComplianceSecurityControlParametersName = expandStringFilters(v.List())
+	}
+
+	if v, ok := tfMap["compliance_security_control_parameters_value"].(*schema.Set); ok && v.Len() > 0 {
+		filters.ComplianceSecurityControlParametersValue = expandStringFilters(v.List())
 	}
 
 	if v, ok := tfMap["compliance_status"].(*schema.Set); ok && v.Len() > 0 {
@@ -1144,16 +1169,21 @@ func flattenSecurityFindingFilters(filters *types.AwsSecurityFindingFilters) []a
 	}
 
 	m := map[string]any{
-		names.AttrAWSAccountID:                        flattenStringFilters(filters.AwsAccountId),
-		"company_name":                                flattenStringFilters(filters.CompanyName),
-		"compliance_status":                           flattenStringFilters(filters.ComplianceStatus),
-		"confidence":                                  flattenNumberFilters(filters.Confidence),
-		names.AttrCreatedAt:                           flattenDateFilters(filters.CreatedAt),
-		"criticality":                                 flattenNumberFilters(filters.Criticality),
-		names.AttrDescription:                         flattenStringFilters(filters.Description),
-		"finding_provider_fields_confidence":          flattenNumberFilters(filters.FindingProviderFieldsConfidence),
-		"finding_provider_fields_criticality":         flattenNumberFilters(filters.FindingProviderFieldsCriticality),
-		"finding_provider_fields_related_findings_id": flattenStringFilters(filters.FindingProviderFieldsRelatedFindingsId),
+		names.AttrAWSAccountID:                                 flattenStringFilters(filters.AwsAccountId),
+		"aws_account_name":                                     flattenStringFilters(filters.AwsAccountName),
+		"company_name":                                         flattenStringFilters(filters.CompanyName),
+		"compliance_associated_standards_id":                   flattenStringFilters(filters.ComplianceAssociatedStandardsId),
+		"compliance_security_control_id":                       flattenStringFilters(filters.ComplianceSecurityControlId),
+		"compliance_security_control_parameters_name":          flattenStringFilters(filters.ComplianceSecurityControlParametersName),
+		"compliance_security_control_parameters_value":         flattenStringFilters(filters.ComplianceSecurityControlParametersValue),
+		"compliance_status":                                    flattenStringFilters(filters.ComplianceStatus),
+		"confidence":                                           flattenNumberFilters(filters.Confidence),
+		names.AttrCreatedAt:                                    flattenDateFilters(filters.CreatedAt),
+		"criticality":                                          flattenNumberFilters(filters.Criticality),
+		names.AttrDescription:                                  flattenStringFilters(filters.Description),
+		"finding_provider_fields_confidence":                   flattenNumberFilters(filters.FindingProviderFieldsConfidence),
+		"finding_provider_fields_criticality":                  flattenNumberFilters(filters.FindingProviderFieldsCriticality),
+		"finding_provider_fields_related_findings_id":          flattenStringFilters(filters.FindingProviderFieldsRelatedFindingsId),
 		"finding_provider_fields_related_findings_product_arn": flattenStringFilters(filters.FindingProviderFieldsRelatedFindingsProductArn),
 		"finding_provider_fields_severity_label":               flattenStringFilters(filters.FindingProviderFieldsSeverityLabel),
 		"finding_provider_fields_severity_original":            flattenStringFilters(filters.FindingProviderFieldsSeverityOriginal),

--- a/internal/service/securityhub/insight_test.go
+++ b/internal/service/securityhub/insight_test.go
@@ -449,6 +449,96 @@ func testAccInsight_WorkflowStatus(t *testing.T) {
 	})
 }
 
+func testAccInsight_StringFilters(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_securityhub_insight.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecurityHubServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInsightDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInsightConfig_stringFilterEach(rName, "aws_account_name", string(types.StringFilterComparisonEquals), "test-account"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInsightExists(ctx, t, resourceName),
+					testAccCheckInsightARN(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "filters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.aws_account_name.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filters.0.aws_account_name.*", map[string]string{
+						"comparison":    string(types.StringFilterComparisonEquals),
+						names.AttrValue: "test-account",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "group_by_attribute", "AwsAccountId"),
+				),
+			},
+			{
+				Config: testAccInsightConfig_stringFilterEach(rName, "compliance_associated_standards_id", string(types.StringFilterComparisonEquals), "123"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInsightExists(ctx, t, resourceName),
+					testAccCheckInsightARN(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "filters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.compliance_associated_standards_id.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filters.0.compliance_associated_standards_id.*", map[string]string{
+						"comparison":    string(types.StringFilterComparisonEquals),
+						names.AttrValue: "123",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "group_by_attribute", "AwsAccountId"),
+				),
+			},
+			{
+				Config: testAccInsightConfig_stringFilterEach(rName, "compliance_security_control_id", string(types.StringFilterComparisonEquals), "123"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInsightExists(ctx, t, resourceName),
+					testAccCheckInsightARN(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "filters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.compliance_security_control_id.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filters.0.compliance_security_control_id.*", map[string]string{
+						"comparison":    string(types.StringFilterComparisonEquals),
+						names.AttrValue: "123",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "group_by_attribute", "AwsAccountId"),
+				),
+			},
+			{
+				Config: testAccInsightConfig_stringFilterEach(rName, "compliance_security_control_parameters_name", string(types.StringFilterComparisonEquals), "test-name"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInsightExists(ctx, t, resourceName),
+					testAccCheckInsightARN(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "filters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.compliance_security_control_parameters_name.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filters.0.compliance_security_control_parameters_name.*", map[string]string{
+						"comparison":    string(types.StringFilterComparisonEquals),
+						names.AttrValue: "test-name",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "group_by_attribute", "AwsAccountId"),
+				),
+			},
+			{
+				Config: testAccInsightConfig_stringFilterEach(rName, "compliance_security_control_parameters_value", string(types.StringFilterComparisonEquals), "test-value"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInsightExists(ctx, t, resourceName),
+					testAccCheckInsightARN(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "filters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.compliance_security_control_parameters_value.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filters.0.compliance_security_control_parameters_value.*", map[string]string{
+						"comparison":    string(types.StringFilterComparisonEquals),
+						names.AttrValue: "test-value",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "group_by_attribute", "AwsAccountId"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckInsightDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).SecurityHubClient(ctx)
@@ -726,4 +816,25 @@ resource "aws_securityhub_insight" "test" {
   depends_on = [aws_securityhub_account.test]
 }
 `, rName)
+}
+
+func testAccInsightConfig_stringFilterEach(rName, filterName, comparison, value string) string {
+	return fmt.Sprintf(`
+resource "aws_securityhub_account" "test" {}
+
+resource "aws_securityhub_insight" "test" {
+  filters {
+    %[2]s {
+      comparison = %[3]q
+      value      = %[4]q
+    }
+  }
+
+  group_by_attribute = "AwsAccountId"
+
+  name = %[1]q
+
+  depends_on = [aws_securityhub_account.test]
+}
+`, rName, filterName, comparison, value)
 }

--- a/internal/service/securityhub/securityhub_test.go
+++ b/internal/service/securityhub/securityhub_test.go
@@ -64,6 +64,7 @@ func TestAccSecurityHub_serial(t *testing.T) {
 			"Name":               testAccInsight_Name,
 			"NumberFilters":      testAccInsight_NumberFilters,
 			"WorkflowStatus":     testAccInsight_WorkflowStatus,
+			"StringFilters":      testAccInsight_StringFilters,
 		},
 		"InviteAccepter": {
 			acctest.CtBasic: testAccInviteAccepter_basic,

--- a/website/docs/r/securityhub_insight.html.markdown
+++ b/website/docs/r/securityhub_insight.html.markdown
@@ -139,7 +139,12 @@ The `filters` configuration block supports the following arguments:
 ~> **NOTE:** For each argument below, up to 20 can be provided.
 
 * `aws_account_id` - (Optional) AWS account ID that a finding is generated in. See [String_Filter](#string-filter-argument-reference) below for more details.
+* `aws_account_name` - (Optional) The name of the AWS account in which a finding is generated. See [String_Filter](#string-filter-argument-reference) below for more details.
 * `company_name` - (Optional) The name of the findings provider (company) that owns the solution (product) that generates findings. See [String_Filter](#string-filter-argument-reference) below for more details.
+* `compliance_associated_standards_id` - (Optional) The unique identifier of a standard in which a control is enabled. See [String_Filter](#string-filter-argument-reference) below for more details.
+* `compliance_security_control_id` - (Optional) The unique identifier of a control across standards. See [String_Filter](#string-filter-argument-reference) below for more details.
+* `compliance_security_control_parameters_name` - (Optional) The unique identifier of a control across standards. See [String_Filter](#string-filter-argument-reference) below for more details.
+* `compliance_security_control_parameters_value` - (Optional) The current value of a security control parameter. See [String_Filter](#string-filter-argument-reference) below for more details.
 * `compliance_status` - (Optional) Exclusive to findings that are generated as the result of a check run against a specific rule in a supported standard, such as CIS AWS Foundations. Contains security standard-related finding details. See [String Filter](#string-filter-argument-reference) below for more details.
 * `confidence` - (Optional) A finding's confidence. Confidence is defined as the likelihood that a finding accurately identifies the behavior or issue that it was intended to identify. Confidence is scored on a 0-100 basis using a ratio scale, where 0 means zero percent confidence and 100 means 100 percent confidence. See [Number Filter](#number-filter-argument-reference) below for more details.
 * `created_at` - (Optional) An ISO8601-formatted timestamp that indicates when the security-findings provider captured the potential security issue that a finding captured. See [Date Filter](#date-filter-argument-reference) below for more details.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
This PR adds the following blocks to the `filter` block, including `compliance_associated_standards_id` requested in #47017:

* aws_account_id
* compliance_associated_standards_id
* compliance_security_control_id
* compliance_security_control_parameters_name
* compliance_security_control_parameters_value

#### Acceptance tests
While checks for each filter block are not implemented in the current codebase, this PR adds acceptance tests for the newly added filter blocks.

Since not only adding schemas but also implementing expanders and flatteners is required, I believe that tests for the newly added blocks are essential.

### Relations

Closes #47017

### References
https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_CreateInsight.html

### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccSecurityHub_serial/Insight/StringFilters' PKG=securityhub
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_securityhub_insight-add_missing_filters 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/securityhub/... -v -count 1 -parallel 20 -run='TestAccSecurityHub_serial/Insight/StringFilters'  -timeout 360m -vet=off
2026/03/20 23:40:49 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/20 23:40:49 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSecurityHub_serial
=== PAUSE TestAccSecurityHub_serial
=== CONT  TestAccSecurityHub_serial
=== RUN   TestAccSecurityHub_serial/Insight
=== RUN   TestAccSecurityHub_serial/Insight/StringFilters
--- PASS: TestAccSecurityHub_serial (91.99s)
    --- PASS: TestAccSecurityHub_serial/Insight (91.99s)
        --- PASS: TestAccSecurityHub_serial/Insight/StringFilters (91.99s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/securityhub        96.490s

```
