### PR TITLE
d/aws_dynamodb_backups: new data source

### DIFF
--- a/.changelog/47036.txt
+++ b/.changelog/47036.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_dynamodb_backups
+```

--- a/internal/service/dynamodb/backups_data_source.go
+++ b/internal/service/dynamodb/backups_data_source.go
@@ -1,0 +1,122 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dynamodb
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_dynamodb_backups", name="Backups")
+func newBackupsDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &backupsDataSource{}, nil
+}
+
+type backupsDataSource struct {
+	framework.DataSourceWithModel[backupsDataSourceModel]
+}
+
+func (d *backupsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"backup_summaries": framework.DataSourceComputedListOfObjectAttribute[backupSummaryModel](ctx),
+			"backup_type": schema.StringAttribute{
+				Optional:   true,
+				CustomType: fwtypes.StringEnumType[awstypes.BackupTypeFilter](),
+			},
+			names.AttrTableName: schema.StringAttribute{
+				Optional: true,
+			},
+			"time_range_lower_bound": schema.StringAttribute{
+				Optional:   true,
+				CustomType: timetypes.RFC3339Type{},
+			},
+			"time_range_upper_bound": schema.StringAttribute{
+				Optional:   true,
+				CustomType: timetypes.RFC3339Type{},
+			},
+		},
+	}
+}
+
+func (d *backupsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().DynamoDBClient(ctx)
+
+	var data backupsDataSourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Config.Get(ctx, &data))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var input dynamodb.ListBackupsInput
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Expand(ctx, data, &input))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findBackups(ctx, conn, &input)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err)
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &data.BackupSummaries))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
+}
+
+func findBackups(ctx context.Context, conn *dynamodb.Client, input *dynamodb.ListBackupsInput) ([]awstypes.BackupSummary, error) {
+	var output []awstypes.BackupSummary
+
+	err := listBackupsPages(ctx, conn, input, func(page *dynamodb.ListBackupsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		output = append(output, page.BackupSummaries...)
+		return !lastPage
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+type backupsDataSourceModel struct {
+	framework.WithRegionModel
+	BackupSummaries     fwtypes.ListNestedObjectValueOf[backupSummaryModel] `tfsdk:"backup_summaries"`
+	BackupType          fwtypes.StringEnum[awstypes.BackupTypeFilter]       `tfsdk:"backup_type"`
+	TableName           types.String                                        `tfsdk:"table_name"`
+	TimeRangeLowerBound timetypes.RFC3339                                   `tfsdk:"time_range_lower_bound"`
+	TimeRangeUpperBound timetypes.RFC3339                                   `tfsdk:"time_range_upper_bound"`
+}
+
+type backupSummaryModel struct {
+	BackupARN              types.String                              `tfsdk:"backup_arn"`
+	BackupCreationDateTime timetypes.RFC3339                         `tfsdk:"backup_creation_date_time"`
+	BackupExpiryDateTime   timetypes.RFC3339                         `tfsdk:"backup_expiry_date_time"`
+	BackupName             types.String                              `tfsdk:"backup_name"`
+	BackupSizeBytes        types.Int64                               `tfsdk:"backup_size_bytes"`
+	BackupStatus           fwtypes.StringEnum[awstypes.BackupStatus] `tfsdk:"backup_status"`
+	BackupType             fwtypes.StringEnum[awstypes.BackupType]   `tfsdk:"backup_type"`
+	TableARN               types.String                              `tfsdk:"table_arn"`
+	TableID                types.String                              `tfsdk:"table_id"`
+	TableName              types.String                              `tfsdk:"table_name"`
+}

--- a/internal/service/dynamodb/backups_data_source_test.go
+++ b/internal/service/dynamodb/backups_data_source_test.go
@@ -1,0 +1,105 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dynamodb_test
+
+import (
+	"fmt"
+	"testing"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/hashicorp/terraform-plugin-testing/compare"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccDynamoDBBackupsDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_dynamodb_backups.test"
+	tableResourceName := "aws_dynamodb_table.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupsDataSourceConfig_basic(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("backup_summaries"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"backup_arn":                knownvalue.NotNull(),
+							"backup_creation_date_time": knownvalue.NotNull(),
+							"backup_expiry_date_time":   knownvalue.Null(),
+							"backup_name":               knownvalue.StringExact(rName + "-backup"),
+							"backup_size_bytes":         knownvalue.NotNull(),
+							"backup_status":             knownvalue.NotNull(),
+							"backup_type":               tfknownvalue.StringExact(awstypes.BackupTypeUser),
+							"table_arn":                 knownvalue.NotNull(),
+							"table_id":                  knownvalue.NotNull(),
+							names.AttrTableName:         knownvalue.NotNull(),
+						}),
+					})),
+					statecheck.CompareValuePairs(
+						dataSourceName, tfjsonpath.New("backup_summaries").AtSliceIndex(0).AtMapKey("table_arn"),
+						tableResourceName, tfjsonpath.New(names.AttrARN),
+						compare.ValuesSame(),
+					),
+					statecheck.CompareValuePairs(
+						dataSourceName, tfjsonpath.New("backup_summaries").AtSliceIndex(0).AtMapKey(names.AttrTableName),
+						tableResourceName, tfjsonpath.New(names.AttrName),
+						compare.ValuesSame(),
+					),
+				},
+			},
+		},
+	})
+}
+
+func testAccBackupsDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name         = %[1]q
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+}
+
+action "aws_dynamodb_create_backup" "test" {
+  config {
+    table_name  = aws_dynamodb_table.test.name
+    backup_name = "%[1]s-backup"
+  }
+}
+
+resource "terraform_data" "trigger" {
+  input = "trigger"
+  lifecycle {
+    action_trigger {
+      events  = [before_create, before_update]
+      actions = [action.aws_dynamodb_create_backup.test]
+    }
+  }
+}
+
+data "aws_dynamodb_backups" "test" {
+  table_name = aws_dynamodb_table.test.name
+
+  depends_on = [terraform_data.trigger]
+}
+`, rName)
+}

--- a/internal/service/dynamodb/service_package_gen.go
+++ b/internal/service/dynamodb/service_package_gen.go
@@ -34,6 +34,12 @@ func (p *servicePackage) Actions(ctx context.Context) []*inttypes.ServicePackage
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
 	return []*inttypes.ServicePackageFrameworkDataSource{
 		{
+			Factory:  newBackupsDataSource,
+			TypeName: "aws_dynamodb_backups",
+			Name:     "Backups",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+		{
 			Factory:  newTablesDataSource,
 			TypeName: "aws_dynamodb_tables",
 			Name:     "Tables",

--- a/website/docs/d/dynamodb_backups.html.markdown
+++ b/website/docs/d/dynamodb_backups.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "DynamoDB"
+layout: "aws"
+page_title: "AWS: aws_dynamodb_backups"
+description: |-
+  Data source for listing AWS DynamoDB backups.
+---
+
+# Data Source: aws_dynamodb_backups
+
+Data source for listing AWS DynamoDB backups.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_dynamodb_backups" "example" {
+  table_name = "my-table"
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `backup_type` - (Optional) Backup type. Valid values: `USER`, `SYSTEM`, `AWS_BACKUP`, `ALL`.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `table_name` - (Optional) Name of the table to list backups for.
+* `time_range_lower_bound` - (Optional) Only backups created after this time are listed. Time must be in RFC3339 format.
+* `time_range_upper_bound` - (Optional) Only backups created before this time are listed. Time must be in RFC3339 format.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `backup_summaries` - List of backups. See below.
+
+### `backup_summaries` Attribute Reference
+
+* `backup_arn` - ARN of the backup.
+* `backup_creation_date_time` - Time at which the backup was created.
+* `backup_expiry_date_time` - Time at which the automatic on-demand backup created by DynamoDB will expire.
+* `backup_name` - Name of the specified backup.
+* `backup_size_bytes` - Size of the backup in bytes.
+* `backup_status` - Backup can be in one of the following states: `CREATING`, `DELETED`, `AVAILABLE`.
+* `backup_type` - BackupType: `USER`, `SYSTEM`, `AWS_BACKUP`.
+* `table_arn` - ARN associated with the table.
+* `table_id` - Unique identifier for the table.
+* `table_name` - Name of the table.


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This data source enables listing of DynamoDB table backups, including filtering by table name, time range, or backup type.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47009
Relates #29883
Relates https://github.com/hashicorp/terraform-provider-aws/pull/45001

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListBackups.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make t K=dynamodb T=TestAccDynamoDBBackupsDataSource_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-dynamodb_backups-data 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBBackupsDataSource_basic'  -timeout 360m -vet=off
2026/03/20 15:21:26 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/20 15:21:26 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccDynamoDBBackupsDataSource_basic (35.85s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   42.825s
```