### PR TITLE
wafv2: Add mutex to prevent WAFOptimisticLockException in web_acl_rule_group_association

### DIFF
--- a/.changelog/47037.txt
+++ b/.changelog/47037.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_wafv2_web_acl_rule_group_association: Fix `WAFOptimisticLockException` errors when multiple associations target the same Web ACL
+```

--- a/internal/service/wafv2/web_acl_rule_group_association.go
+++ b/internal/service/wafv2/web_acl_rule_group_association.go
@@ -926,8 +926,6 @@ func (r *resourceWebACLRuleGroupAssociation) Create(ctx context.Context, req res
 	}
 
 	// Serialize operations on this WebACL to prevent intra-provider race conditions.
-	// Multiple aws_wafv2_web_acl_rule_group_association resources targeting the same
-	// WebACL will race to update it, causing WAFOptimisticLockException errors.
 	mutex := getWebACLMutex(webACLID)
 	mutex.Lock()
 	defer mutex.Unlock()
@@ -1374,8 +1372,6 @@ func (r *resourceWebACLRuleGroupAssociation) Update(ctx context.Context, req res
 	}
 
 	// Serialize operations on this WebACL to prevent intra-provider race conditions.
-	// Multiple aws_wafv2_web_acl_rule_group_association resources targeting the same
-	// WebACL will race to update it, causing WAFOptimisticLockException errors.
 	mutex := getWebACLMutex(webACLID)
 	mutex.Lock()
 	defer mutex.Unlock()
@@ -1599,8 +1595,6 @@ func (r *resourceWebACLRuleGroupAssociation) Delete(ctx context.Context, req res
 	}
 
 	// Serialize operations on this WebACL to prevent intra-provider race conditions.
-	// Multiple aws_wafv2_web_acl_rule_group_association resources targeting the same
-	// WebACL will race to update it, causing WAFOptimisticLockException errors.
 	mutex := getWebACLMutex(webACLID)
 	mutex.Lock()
 	defer mutex.Unlock()

--- a/internal/service/wafv2/web_acl_rule_group_association.go
+++ b/internal/service/wafv2/web_acl_rule_group_association.go
@@ -925,6 +925,13 @@ func (r *resourceWebACLRuleGroupAssociation) Create(ctx context.Context, req res
 		return
 	}
 
+	// Serialize operations on this WebACL to prevent intra-provider race conditions.
+	// Multiple aws_wafv2_web_acl_rule_group_association resources targeting the same
+	// WebACL will race to update it, causing WAFOptimisticLockException errors.
+	mutex := getWebACLMutex(webACLID)
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	// Get current Web ACL configuration
 	webACL, err := findWebACLByThreePartKey(ctx, conn, webACLID, webACLName, webACLScope)
 	if err != nil {
@@ -1366,6 +1373,13 @@ func (r *resourceWebACLRuleGroupAssociation) Update(ctx context.Context, req res
 		return
 	}
 
+	// Serialize operations on this WebACL to prevent intra-provider race conditions.
+	// Multiple aws_wafv2_web_acl_rule_group_association resources targeting the same
+	// WebACL will race to update it, causing WAFOptimisticLockException errors.
+	mutex := getWebACLMutex(webACLID)
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	// Get current Web ACL configuration
 	webACL, err := findWebACLByThreePartKey(ctx, conn, webACLID, webACLName, webACLScope)
 	if err != nil {
@@ -1583,6 +1597,13 @@ func (r *resourceWebACLRuleGroupAssociation) Delete(ctx context.Context, req res
 		)
 		return
 	}
+
+	// Serialize operations on this WebACL to prevent intra-provider race conditions.
+	// Multiple aws_wafv2_web_acl_rule_group_association resources targeting the same
+	// WebACL will race to update it, causing WAFOptimisticLockException errors.
+	mutex := getWebACLMutex(webACLID)
+	mutex.Lock()
+	defer mutex.Unlock()
 
 	// Get the Web ACL
 	webACL, err := findWebACLByThreePartKey(ctx, conn, webACLID, webACLName, webACLScope)

--- a/internal/service/wafv2/web_acl_rule_group_association_test.go
+++ b/internal/service/wafv2/web_acl_rule_group_association_test.go
@@ -169,6 +169,35 @@ func TestAccWAFV2WebACLRuleGroupAssociation_basic(t *testing.T) {
 	})
 }
 
+func TestAccWAFV2WebACLRuleGroupAssociation_multipleAssociations(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v wafv2.GetWebACLOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName1 := "aws_wafv2_web_acl_rule_group_association.test1"
+	resourceName2 := "aws_wafv2_web_acl_rule_group_association.test2"
+	resourceName3 := "aws_wafv2_web_acl_rule_group_association.test3"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWebACLRuleGroupAssociationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWebACLRuleGroupAssociationConfig_multiple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLRuleGroupAssociationExists(ctx, t, resourceName1, &v),
+					testAccCheckWebACLRuleGroupAssociationExists(ctx, t, resourceName2, &v),
+					testAccCheckWebACLRuleGroupAssociationExists(ctx, t, resourceName3, &v),
+					resource.TestCheckResourceAttr(resourceName1, names.AttrPriority, "10"),
+					resource.TestCheckResourceAttr(resourceName2, names.AttrPriority, "20"),
+					resource.TestCheckResourceAttr(resourceName3, names.AttrPriority, "30"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccWAFV2WebACLRuleGroupAssociation_withVisibilityConfig(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v wafv2.GetWebACLOutput
@@ -2352,6 +2381,101 @@ resource "aws_wafv2_web_acl_rule_group_association" "test" {
         enable_machine_learning = true
       }
     }
+  }
+
+  override_action = "none"
+}
+`, rName)
+}
+
+func testAccWebACLRuleGroupAssociationConfig_multiple(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl" "test" {
+  name  = %[1]q
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = %[1]q
+    sampled_requests_enabled   = false
+  }
+
+  lifecycle {
+    ignore_changes = [rule]
+  }
+}
+
+resource "aws_wafv2_rule_group" "test1" {
+  capacity = 10
+  name     = "%[1]s-1"
+  scope    = "REGIONAL"
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "%[1]s-1"
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_wafv2_rule_group" "test2" {
+  capacity = 10
+  name     = "%[1]s-2"
+  scope    = "REGIONAL"
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "%[1]s-2"
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_wafv2_rule_group" "test3" {
+  capacity = 10
+  name     = "%[1]s-3"
+  scope    = "REGIONAL"
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "%[1]s-3"
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_wafv2_web_acl_rule_group_association" "test1" {
+  rule_name   = "%[1]s-association-1"
+  priority    = 10
+  web_acl_arn = aws_wafv2_web_acl.test.arn
+
+  rule_group_reference {
+    arn = aws_wafv2_rule_group.test1.arn
+  }
+
+  override_action = "none"
+}
+
+resource "aws_wafv2_web_acl_rule_group_association" "test2" {
+  rule_name   = "%[1]s-association-2"
+  priority    = 20
+  web_acl_arn = aws_wafv2_web_acl.test.arn
+
+  rule_group_reference {
+    arn = aws_wafv2_rule_group.test2.arn
+  }
+
+  override_action = "none"
+}
+
+resource "aws_wafv2_web_acl_rule_group_association" "test3" {
+  rule_name   = "%[1]s-association-3"
+  priority    = 30
+  web_acl_arn = aws_wafv2_web_acl.test.arn
+
+  rule_group_reference {
+    arn = aws_wafv2_rule_group.test3.arn
   }
 
   override_action = "none"


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When you have multiple `aws_wafv2_web_acl_rule_group_association` resources pointing to the same Web ACL, Terraform tries to update them in parallel. But here's the catch: these aren't truly independent resources - they all modify the same parent Web ACL. 

AWS WAFv2 uses optimistic locking (lock tokens) to prevent concurrent modifications. So when two associations try to update the Web  ACL at the same time, one gets the lock token, succeeds, and invalidates the other's token. The second one fails with `WAFOptimisticLockException`.

Users had to work around this with terraform apply `-parallelism=1`, forcing everything to run sequentially.

The fix was to add a mutex (lock) that serializes operations on the same Web ACL within the provider. Now when multiple associations target the same Web ACL:

1. First one grabs the mutex, does its update
2. Second one waits for the mutex, then does its update
3. Third one waits, then updates
4. And so on...

This is the same pattern already used by `aws_wafv2_web_acl_rule` - we just applied it to the association resource too. Three lines of code in each CRUD method (Create, Update, Delete) to lock/unlock the mutex.

No more race conditions, no more `WAFOptimisticLockException`, no more `-parallelism=1` workaround needed.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #45787

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccWAFV2WebACLRuleGroupAssociation K=wafv2                     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-web-acl-rule-group-assoc-olock 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACLRuleGroupAssociation'  -timeout 360m -vet=off
2026/03/20 16:07:31 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/20 16:07:31 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_basic
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_basic
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_multipleAssociations
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_multipleAssociations
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_withVisibilityConfig
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_withVisibilityConfig
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_disappears
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_disappears
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_overrideAction
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_overrideAction
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_ruleActionOverride
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_ruleActionOverride
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_ruleActionOverrideUpdate
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_ruleActionOverrideUpdate
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_priorityUpdate
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_priorityUpdate
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_overrideActionUpdate
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_overrideActionUpdate
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_ruleNameRequiresReplace
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_ruleNameRequiresReplace
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_webACLARNRequiresReplace
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_webACLARNRequiresReplace
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_basic
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_basic
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_withVersion
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_withVersion
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ruleActionOverride
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ruleActionOverride
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_basic
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_basic
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_AntiDDoSRuleSet
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_AntiDDoSRuleSet
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_basic
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_webACLARNRequiresReplace
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_ruleActionOverride
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_ruleNameRequiresReplace
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_overrideActionUpdate
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_priorityUpdate
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_ruleActionOverrideUpdate
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ruleActionOverride
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_basic
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_basic
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_AntiDDoSRuleSet
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_disappears
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_overrideAction
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_withVersion
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_withVisibilityConfig
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_multipleAssociations
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_basic (45.48s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ruleActionOverride (47.36s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_overrideAction (58.89s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_withVisibilityConfig (60.32s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_basic (63.30s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_disappears (70.52s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl (72.70s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_ruleActionOverride (73.25s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_withVersion (79.44s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_multipleAssociations (79.53s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_ruleActionOverrideUpdate (80.92s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_priorityUpdate (84.05s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_webACLARNRequiresReplace (86.05s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_AntiDDoSRuleSet (87.04s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_overrideActionUpdate (89.42s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet (91.50s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet (91.50s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_ruleNameRequiresReplace (97.27s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_basic (97.69s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafv2	104.517s
```
