### PR TITLE
Fix Route53 Recovery Control Config Routing Control panic

### DIFF
--- a/.changelog/47038.txt
+++ b/.changelog/47038.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53recoverycontrolconfig_routing_control: Fix panic on concurrent creates when API returns ConflictException
+```

--- a/internal/service/route53recoverycontrolconfig/routing_control.go
+++ b/internal/service/route53recoverycontrolconfig/routing_control.go
@@ -75,12 +75,12 @@ func resourceRoutingControlCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	output, err := conn.CreateRoutingControl(ctx, input)
-	result := output.RoutingControl
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Route53 Recovery Control Config Routing Control: %s", err)
 	}
 
+	result := output.RoutingControl
 	if result == nil {
 		return sdkdiag.AppendErrorf(diags, "creating Route53 Recovery Control Config Routing Control: empty response")
 	}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When creating multiple `aws_route53recoverycontrolconfig_routing_control` resources in parallel, the AWS API returns a 409 ConflictException for concurrent mutations on the same cluster. The provider was trying to access `output.RoutingControl` before checking if the API call failed, which caused a nil pointer dereference and crashed the plugin. This crash then cascaded to all other in-flight creates, showing up as "Request cancelled" errors. The fix is simple: check for errors first, then access the output. Now when concurrent creates hit a 409, users get a proper error message instead of a panic, and the other resources can complete successfully.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47034

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T='TestAccRoute53RecoveryControlConfig_serial/RoutingControl' K=route53recoverycontrolconfig
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-r53recoverycontrol-routing-ctrl-panic 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/route53recoverycontrolconfig/... -v -count 1 -parallel 20 -run='TestAccRoute53RecoveryControlConfig_serial/RoutingControl'  -timeout 360m -vet=off
2026/03/20 16:54:36 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/20 16:54:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRoute53RecoveryControlConfig_serial
=== PAUSE TestAccRoute53RecoveryControlConfig_serial
=== CONT  TestAccRoute53RecoveryControlConfig_serial
=== RUN   TestAccRoute53RecoveryControlConfig_serial/RoutingControl
=== RUN   TestAccRoute53RecoveryControlConfig_serial/RoutingControl/basic
=== RUN   TestAccRoute53RecoveryControlConfig_serial/RoutingControl/disappears
=== RUN   TestAccRoute53RecoveryControlConfig_serial/RoutingControl/nonDefaultControlPane
--- PASS: TestAccRoute53RecoveryControlConfig_serial (279.03s)
    --- PASS: TestAccRoute53RecoveryControlConfig_serial/RoutingControl (279.03s)
        --- PASS: TestAccRoute53RecoveryControlConfig_serial/RoutingControl/basic (83.30s)
        --- PASS: TestAccRoute53RecoveryControlConfig_serial/RoutingControl/disappears (80.02s)
        --- PASS: TestAccRoute53RecoveryControlConfig_serial/RoutingControl/nonDefaultControlPane (115.71s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53recoverycontrolconfig	285.894s
```
