### PR TITLE
resource/aws_budgets_budget: Add `metrics` attribute

### DIFF
--- a/.changelog/47047.txt
+++ b/.changelog/47047.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_budgets_budget: Add missing metrics parameter required for filter_expression
+```

--- a/.changelog/47047.txt
+++ b/.changelog/47047.txt
@@ -1,3 +1,7 @@
+```release-note:enhancement
+resource/aws_budgets_budget: Add `metrics` attribute
+```
+
 ```release-note:bug
-resource/aws_budgets_budget: Add missing metrics parameter required for filter_expression
+resource/aws_budgets_budget: Add missing metrics attribute required for filter_expression
 ```

--- a/internal/service/budgets/budget.go
+++ b/internal/service/budgets/budget.go
@@ -134,10 +134,11 @@ func resourceBudget() *schema.Resource {
 				},
 			},
 			"cost_types": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Optional: true,
-				MaxItems: 1,
+				Type:          schema.TypeList,
+				Computed:      true,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"metrics"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"include_credit": {
@@ -312,9 +313,21 @@ func resourceBudget() *schema.Resource {
 				Optional:      true,
 				MaxItems:      1,
 				ConflictsWith: []string{"cost_filter"},
+				RequiredWith:  []string{"metrics"},
 				// AWS Budgets API enforces: "Expression nested depth cannot be more than 2" which is not mentioned in docs
 				// Schema level 3 = AWS depth 2 (because operators added when level > 1)
 				Elem: filterExpressionElem(filterExpressionDepth),
+			},
+			"metrics": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"cost_types"},
+				RequiredWith:  []string{"filter_expression"},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: enum.Validate[awstypes.Metric](),
+				},
 			},
 		},
 	}
@@ -547,6 +560,10 @@ func resourceBudgetRead(ctx context.Context, d *schema.ResourceData, meta any) d
 
 	if err := d.Set("filter_expression", flattenFilterExpression(budget.FilterExpression)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting filter_expression: %s", err)
+	}
+
+	if err := d.Set("metrics", budget.Metrics); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting metrics: %s", err)
 	}
 
 	notifications, err := findNotificationsByTwoPartKey(ctx, conn, accountID, budgetName)
@@ -1143,6 +1160,10 @@ func expandBudgetUnmarshal(d *schema.ResourceData) (*awstypes.Budget, error) {
 
 	if v, ok := d.GetOk("filter_expression"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 		budget.FilterExpression = expandFilterExpression(v.([]any)[0].(map[string]any))
+	}
+
+	if v, ok := d.GetOk("metrics"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		budget.Metrics = []awstypes.Metric{awstypes.Metric(v.([]any)[0].(string))}
 	}
 
 	return budget, nil

--- a/internal/service/budgets/budget_test.go
+++ b/internal/service/budgets/budget_test.go
@@ -573,6 +573,8 @@ func TestAccBudgetsBudget_filterExpression(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "limit_amount", "1000.0"),
 					resource.TestCheckResourceAttr(resourceName, "limit_unit", "USD"),
 					resource.TestCheckResourceAttr(resourceName, "time_unit", "MONTHLY"),
+					resource.TestCheckResourceAttr(resourceName, "metrics.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metrics.0", "UnblendedCost"),
 					resource.TestCheckResourceAttr(resourceName, "filter_expression.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "filter_expression.0.or.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "filter_expression.0.or.0.and.#", "3"),
@@ -600,6 +602,8 @@ func TestAccBudgetsBudget_filterExpression(t *testing.T) {
 				Config: testAccBudgetConfig_filterExpressionUpdated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBudgetExists(ctx, t, resourceName, &budget),
+					resource.TestCheckResourceAttr(resourceName, "metrics.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metrics.0", "NetUnblendedCost"),
 					resource.TestCheckResourceAttr(resourceName, "filter_expression.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "filter_expression.0.or.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "filter_expression.0.or.0.tags.#", "1"),
@@ -608,6 +612,56 @@ func TestAccBudgetsBudget_filterExpression(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "filter_expression.0.or.1.cost_categories.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "filter_expression.0.or.1.cost_categories.0.key", "Environment"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "filter_expression.0.or.1.cost_categories.0.values.*", "staging"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBudgetsBudget_metrics(t *testing.T) {
+	ctx := acctest.Context(t)
+	var budget awstypes.Budget
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_budgets_budget.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.BudgetsEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BudgetsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBudgetDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBudgetConfig_metrics(rName, "UnblendedCost"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckBudgetExists(ctx, t, resourceName, &budget),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "budget_type", "COST"),
+					resource.TestCheckResourceAttr(resourceName, "limit_amount", "1000.0"),
+					resource.TestCheckResourceAttr(resourceName, "limit_unit", "USD"),
+					resource.TestCheckResourceAttr(resourceName, "time_unit", "MONTHLY"),
+					resource.TestCheckResourceAttr(resourceName, "metrics.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metrics.0", "UnblendedCost"),
+					resource.TestCheckResourceAttr(resourceName, "filter_expression.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter_expression.0.dimensions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter_expression.0.dimensions.0.key", "SERVICE"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "filter_expression.0.dimensions.0.values.*", "Amazon Elastic Compute Cloud - Compute"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBudgetConfig_metrics(rName, "NetUnblendedCost"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckBudgetExists(ctx, t, resourceName, &budget),
+					resource.TestCheckResourceAttr(resourceName, "metrics.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metrics.0", "NetUnblendedCost"),
+					resource.TestCheckResourceAttr(resourceName, "filter_expression.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter_expression.0.dimensions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter_expression.0.dimensions.0.key", "SERVICE"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "filter_expression.0.dimensions.0.values.*", "Amazon Elastic Compute Cloud - Compute"),
 				),
 			},
 		},
@@ -915,6 +969,7 @@ resource "aws_budgets_budget" "test" {
   limit_amount = "1000.0"
   limit_unit   = "USD"
   time_unit    = "MONTHLY"
+  metrics      = ["UnblendedCost"]
 
   filter_expression {
     or {
@@ -958,6 +1013,7 @@ resource "aws_budgets_budget" "test" {
   limit_amount = "1000.0"
   limit_unit   = "USD"
   time_unit    = "MONTHLY"
+  metrics      = ["NetUnblendedCost"]
 
   filter_expression {
     or {
@@ -975,6 +1031,26 @@ resource "aws_budgets_budget" "test" {
   }
 }
 `, rName)
+}
+
+func testAccBudgetConfig_metrics(rName, metric string) string {
+	return fmt.Sprintf(`
+resource "aws_budgets_budget" "test" {
+	name         = %[1]q
+	budget_type  = "COST"
+	limit_amount = "1000.0"
+	limit_unit   = "USD"
+	time_unit    = "MONTHLY"
+	metrics      = [%[2]q]
+
+	filter_expression {
+		dimensions {
+			key    = "SERVICE"
+			values = ["Amazon Elastic Compute Cloud - Compute"]
+		}
+	}
+}
+`, rName, metric)
 }
 
 func generateStartTimes(resourceName, amount string, now time.Time) (string, []resource.TestCheckFunc) {

--- a/internal/service/budgets/budget_test.go
+++ b/internal/service/budgets/budget_test.go
@@ -1036,19 +1036,19 @@ resource "aws_budgets_budget" "test" {
 func testAccBudgetConfig_metrics(rName, metric string) string {
 	return fmt.Sprintf(`
 resource "aws_budgets_budget" "test" {
-	name         = %[1]q
-	budget_type  = "COST"
-	limit_amount = "1000.0"
-	limit_unit   = "USD"
-	time_unit    = "MONTHLY"
-	metrics      = [%[2]q]
+  name         = %[1]q
+  budget_type  = "COST"
+  limit_amount = "1000.0"
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+  metrics      = [%[2]q]
 
-	filter_expression {
-		dimensions {
-			key    = "SERVICE"
-			values = ["Amazon Elastic Compute Cloud - Compute"]
-		}
-	}
+  filter_expression {
+    dimensions {
+      key    = "SERVICE"
+      values = ["Amazon Elastic Compute Cloud - Compute"]
+    }
+  }
 }
 `, rName, metric)
 }

--- a/website/docs/r/budgets_budget.html.markdown
+++ b/website/docs/r/budgets_budget.html.markdown
@@ -173,7 +173,7 @@ resource "aws_budgets_budget" "cost" {
 }
 ```
 
-Create a budget with a simple dimension filter
+Create a budget with a simple dimension filter for unblended costs
 
 ```terraform
 resource "aws_budgets_budget" "simple" {
@@ -183,6 +183,7 @@ resource "aws_budgets_budget" "simple" {
   limit_unit   = "USD"
   time_unit    = "MONTHLY"
 
+  metrics = ["UnblendedCost"]
   filter_expression {
     dimensions {
       key    = "SERVICE"
@@ -192,7 +193,7 @@ resource "aws_budgets_budget" "simple" {
 }
 ```
 
-Create a budget with AND filter
+Create a budget with AND filter for unblended costs
 
 ```terraform
 resource "aws_budgets_budget" "and_example" {
@@ -202,6 +203,7 @@ resource "aws_budgets_budget" "and_example" {
   limit_unit   = "USD"
   time_unit    = "MONTHLY"
 
+  metrics = ["UnblendedCost"]
   # Each `and` block is one operand. AND requires at least 2 operands.
   filter_expression {
     and {
@@ -220,7 +222,7 @@ resource "aws_budgets_budget" "and_example" {
 }
 ```
 
-Create a budget with OR filter
+Create a budget with OR filter for unblended costs
 
 ```terraform
 resource "aws_budgets_budget" "or_example" {
@@ -230,6 +232,7 @@ resource "aws_budgets_budget" "or_example" {
   limit_unit   = "USD"
   time_unit    = "MONTHLY"
 
+  metrics = ["UnblendedCost"]
   # Each `or` block is one operand. OR requires at least 2 operands.
   filter_expression {
     or {
@@ -248,7 +251,7 @@ resource "aws_budgets_budget" "or_example" {
 }
 ```
 
-Create a budget with NOT filter
+Create a budget with NOT filter for unblended costs
 
 ```terraform
 resource "aws_budgets_budget" "not_example" {
@@ -258,6 +261,7 @@ resource "aws_budgets_budget" "not_example" {
   limit_unit   = "USD"
   time_unit    = "MONTHLY"
 
+  metrics = ["UnblendedCost"]
   filter_expression {
     not {
       dimensions {
@@ -269,7 +273,7 @@ resource "aws_budgets_budget" "not_example" {
 }
 ```
 
-Create a budget with a compound filter
+Create a budget with a compound filter for unblended costs
 
 ```terraform
 resource "aws_budgets_budget" "compound_example" {
@@ -279,6 +283,7 @@ resource "aws_budgets_budget" "compound_example" {
   limit_unit   = "USD"
   time_unit    = "MONTHLY"
 
+  metrics = ["UnblendedCost"]
   filter_expression {
     # First OR operand: an AND expression
     or {
@@ -336,7 +341,8 @@ The following arguments are optional:
 * `billing_view_arn` - (Optional) ARN of the billing view.
 * `cost_filter` - (Optional) A list of [CostFilter](#cost-filter) name/values pair to apply to budget. Conflicts with `filter_expression`.
 * `cost_types` - (Optional) Object containing [CostTypes](#cost-types) The types of cost included in a budget, such as tax and subscriptions.
-* `filter_expression` - (Optional) Object containing [Filter Expression](#filter-expression) to apply to budget. Conflicts with `cost_filter`.
+* `filter_expression` - (Optional) Object containing [Filter Expression](#filter-expression) to apply to budget. Conflicts with `cost_filter` and requires `metrics`.
+* `metrics` - (Optional) List containing definition for how the budget data is aggregated. Conflicts with `cost_types` and requires `filter_expression`.
 * `limit_amount` - (Optional) The amount of cost or usage being measured for a budget.
 * `limit_unit` - (Optional) The unit of measurement used for the budget forecast, actual spend, or budget threshold, such as dollars or GB. See [Spend](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/data-type-spend.html) documentation.
 * `name` - (Optional) The name of a budget. Unique within accounts.
@@ -449,6 +455,10 @@ The `filter_expression` block maps directly to the [AWS Expression](https://docs
 * `values` - (Optional) A list of cost category values to match. At least one value is required.
 
 Refer to [AWS Expression documentation](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_budgets_Expression.html) for further detail.
+
+#### Metrics
+
+`filter_expression` requires `metrics` to be set as well. Value is list type and can have only one element. Possible values: "UnblendedCost", "BlendedCost", "AmortizedCost", "NetUnblendedCost", "NetAmortizedCost", "UsageQuantity", "NormalizedUsageAmount", "Hours".
 
 ## Import
 

--- a/website/docs/r/budgets_budget.html.markdown
+++ b/website/docs/r/budgets_budget.html.markdown
@@ -193,7 +193,7 @@ resource "aws_budgets_budget" "simple" {
 }
 ```
 
-Create a budget with AND filter for unblended costs
+Create a budget with AND filter for blended costs
 
 ```terraform
 resource "aws_budgets_budget" "and_example" {
@@ -203,7 +203,7 @@ resource "aws_budgets_budget" "and_example" {
   limit_unit   = "USD"
   time_unit    = "MONTHLY"
 
-  metrics = ["UnblendedCost"]
+  metrics = ["BlendedCost"]
   # Each `and` block is one operand. AND requires at least 2 operands.
   filter_expression {
     and {
@@ -222,7 +222,7 @@ resource "aws_budgets_budget" "and_example" {
 }
 ```
 
-Create a budget with OR filter for unblended costs
+Create a budget with OR filter for amortized costs
 
 ```terraform
 resource "aws_budgets_budget" "or_example" {
@@ -232,7 +232,7 @@ resource "aws_budgets_budget" "or_example" {
   limit_unit   = "USD"
   time_unit    = "MONTHLY"
 
-  metrics = ["UnblendedCost"]
+  metrics = ["AmortizedCost"]
   # Each `or` block is one operand. OR requires at least 2 operands.
   filter_expression {
     or {
@@ -251,7 +251,7 @@ resource "aws_budgets_budget" "or_example" {
 }
 ```
 
-Create a budget with NOT filter for unblended costs
+Create a budget with NOT filter for net unblended costs
 
 ```terraform
 resource "aws_budgets_budget" "not_example" {
@@ -261,7 +261,7 @@ resource "aws_budgets_budget" "not_example" {
   limit_unit   = "USD"
   time_unit    = "MONTHLY"
 
-  metrics = ["UnblendedCost"]
+  metrics = ["NetUnblendedCost"]
   filter_expression {
     not {
       dimensions {
@@ -273,7 +273,7 @@ resource "aws_budgets_budget" "not_example" {
 }
 ```
 
-Create a budget with a compound filter for unblended costs
+Create a budget with a compound filter for net amortized costs
 
 ```terraform
 resource "aws_budgets_budget" "compound_example" {
@@ -283,7 +283,7 @@ resource "aws_budgets_budget" "compound_example" {
   limit_unit   = "USD"
   time_unit    = "MONTHLY"
 
-  metrics = ["UnblendedCost"]
+  metrics = ["NetAmortizedCost"]
   filter_expression {
     # First OR operand: an AND expression
     or {

--- a/website/docs/r/budgets_budget.html.markdown
+++ b/website/docs/r/budgets_budget.html.markdown
@@ -458,7 +458,7 @@ Refer to [AWS Expression documentation](https://docs.aws.amazon.com/aws-cost-man
 
 #### Metrics
 
-`filter_expression` requires `metrics` to be set as well. Value is list type and can have only one element. Possible values: "UnblendedCost", "BlendedCost", "AmortizedCost", "NetUnblendedCost", "NetAmortizedCost", "UsageQuantity", "NormalizedUsageAmount", "Hours".
+`metrics` defines how AWS calculates the budget amount. Set `metrics` when using `filter_expression`. This argument is a list with a single value. Valid values are `UnblendedCost`, `BlendedCost`, `AmortizedCost`, `NetUnblendedCost`, `NetAmortizedCost`, `UsageQuantity`, `NormalizedUsageAmount`, and `Hours`.
 
 ## Import
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Add metrics parameter for budget
* Define "filter_expression", "metrics" fields as interdependent (according to AWS docs)

### Relations

Closes #46866

### References

`filter_expression` was added in #46501

### Output from Acceptance Testing

TODO: Will add after tests

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
