### PR TITLE
aws_dms_start_replication_task_assessment_run action

### DIFF
--- a/.changelog/47058.txt
+++ b/.changelog/47058.txt
@@ -1,0 +1,3 @@
+```release-note:new-action
+aws_dms_start_replication_task_assessment_run
+```

--- a/internal/service/dms/service_package_gen.go
+++ b/internal/service/dms/service_package_gen.go
@@ -20,6 +20,17 @@ import (
 
 type servicePackage struct{}
 
+func (p *servicePackage) Actions(ctx context.Context) []*inttypes.ServicePackageAction {
+	return []*inttypes.ServicePackageAction{
+		{
+			Factory:  newStartReplicationTaskAssessmentRunAction,
+			TypeName: "aws_dms_start_replication_task_assessment_run",
+			Name:     "Start Replication Task Assessment Run",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+	}
+}
+
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
 	return []*inttypes.ServicePackageFrameworkDataSource{}
 }

--- a/internal/service/dms/start_replication_task_assessment_run_action.go
+++ b/internal/service/dms/start_replication_task_assessment_run_action.go
@@ -1,0 +1,377 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dms
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	dmssdk "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/action/schema"
+	pfvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/actionwait"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwactions "github.com/hashicorp/terraform-provider-aws/internal/framework/actions"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+const (
+	replicationTaskAssessmentRunStatusCancelling        = "cancelling"
+	replicationTaskAssessmentRunStatusDeleting          = "deleting"
+	replicationTaskAssessmentRunStatusErrorExecuting    = "error-executing"
+	replicationTaskAssessmentRunStatusErrorProvisioning = "error-provisioning"
+	replicationTaskAssessmentRunStatusFailed            = "failed"
+	replicationTaskAssessmentRunStatusInvalidState      = "invalid state"
+	replicationTaskAssessmentRunStatusPassed            = "passed"
+	replicationTaskAssessmentRunStatusProvisioning      = "provisioning"
+	replicationTaskAssessmentRunStatusRunning           = "running"
+	replicationTaskAssessmentRunStatusStarting          = "starting"
+	replicationTaskAssessmentRunStatusWarning           = "warning"
+
+	defaultReplicationTaskAssessmentRunTimeout = 30 * time.Minute
+	assessmentRunPollInterval                  = 15 * time.Second
+	assessmentRunProgressInterval              = 30 * time.Second
+)
+
+// @Action(aws_dms_start_replication_task_assessment_run, name="Start Replication Task Assessment Run")
+func newStartReplicationTaskAssessmentRunAction(_ context.Context) (action.ActionWithConfigure, error) {
+	return &startReplicationTaskAssessmentRunAction{}, nil
+}
+
+var (
+	_ action.Action = (*startReplicationTaskAssessmentRunAction)(nil)
+)
+
+type startReplicationTaskAssessmentRunAction struct {
+	framework.ActionWithModel[startReplicationTaskAssessmentRunActionModel]
+}
+
+type startReplicationTaskAssessmentRunActionModel struct {
+	framework.WithRegionModel
+	AssessmentRunName    types.String         `tfsdk:"assessment_run_name"`
+	ReplicationTaskARN   types.String         `tfsdk:"replication_task_arn"`
+	ResultLocationBucket types.String         `tfsdk:"result_location_bucket"`
+	ServiceAccessRoleARN types.String         `tfsdk:"service_access_role_arn"`
+	IncludeOnly          fwtypes.ListOfString `tfsdk:"include_only"`
+	Exclude              fwtypes.ListOfString `tfsdk:"exclude"`
+	ResultEncryptionMode types.String         `tfsdk:"result_encryption_mode"`
+	ResultKMSKeyARN      types.String         `tfsdk:"result_kms_key_arn"`
+	ResultLocationFolder types.String         `tfsdk:"result_location_folder"`
+	Timeout              types.Int64          `tfsdk:"timeout"`
+}
+
+func (a *startReplicationTaskAssessmentRunAction) Schema(ctx context.Context, req action.SchemaRequest, resp *action.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Starts an AWS DMS premigration assessment run for a replication task and waits for the assessment run to reach a terminal state.",
+		Attributes: map[string]schema.Attribute{
+			"assessment_run_name": schema.StringAttribute{
+				Description: "Unique name for the assessment run.",
+				Required:    true,
+			},
+			"replication_task_arn": schema.StringAttribute{
+				Description: "ARN of the DMS replication task to assess.",
+				Required:    true,
+				Validators: []pfvalidator.String{
+					fwvalidators.ARN(),
+				},
+			},
+			"result_location_bucket": schema.StringAttribute{
+				Description: "Amazon S3 bucket where DMS stores the assessment results.",
+				Required:    true,
+			},
+			"service_access_role_arn": schema.StringAttribute{
+				Description: "ARN of the IAM role used by DMS to write assessment results and start the run.",
+				Required:    true,
+				Validators: []pfvalidator.String{
+					fwvalidators.ARN(),
+				},
+			},
+			"include_only": schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				Description: "Specific individual assessments to include in the run. Cannot be set with exclude.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"exclude": schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				Description: "Specific individual assessments to exclude from the run. Cannot be set with include_only.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"result_encryption_mode": schema.StringAttribute{
+				Description: fmt.Sprintf("Encryption mode for assessment results. Valid values are %q and %q.", encryptionModeSseKMS, encryptionModeSseS3),
+				Optional:    true,
+			},
+			"result_kms_key_arn": schema.StringAttribute{
+				Description: "ARN of the KMS key used when result_encryption_mode is SSE_KMS.",
+				Optional:    true,
+				Validators: []pfvalidator.String{
+					fwvalidators.ARN(),
+				},
+			},
+			"result_location_folder": schema.StringAttribute{
+				Description: "Folder within the S3 bucket where DMS stores the assessment results.",
+				Optional:    true,
+			},
+			names.AttrTimeout: schema.Int64Attribute{
+				Description: "Timeout in seconds to wait for the assessment run to complete.",
+				Optional:    true,
+				Validators: []pfvalidator.Int64{
+					int64validator.AtLeast(60),
+				},
+			},
+		},
+	}
+}
+
+func (a *startReplicationTaskAssessmentRunAction) Invoke(ctx context.Context, req action.InvokeRequest, resp *action.InvokeResponse) {
+	var config startReplicationTaskAssessmentRunActionModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !config.IncludeOnly.IsNull() && !config.Exclude.IsNull() {
+		resp.Diagnostics.AddError(
+			"Conflicting Assessment Selection",
+			"Only one of include_only or exclude can be configured for a DMS replication task assessment run.",
+		)
+		return
+	}
+
+	if !config.ResultKMSKeyARN.IsNull() {
+		mode := fwflex.StringValueOr(ctx, config.ResultEncryptionMode, "")
+		if mode != encryptionModeSseKMS {
+			resp.Diagnostics.AddError(
+				"Invalid KMS Encryption Configuration",
+				"result_kms_key_arn can only be specified when result_encryption_mode is SSE_KMS.",
+			)
+			return
+		}
+	}
+
+	if !config.ResultEncryptionMode.IsNull() {
+		mode := config.ResultEncryptionMode.ValueString()
+		if mode != encryptionModeSseKMS && mode != encryptionModeSseS3 {
+			resp.Diagnostics.AddError(
+				"Invalid Encryption Mode",
+				fmt.Sprintf("result_encryption_mode must be one of %q or %q.", encryptionModeSseKMS, encryptionModeSseS3),
+			)
+			return
+		}
+	}
+
+	conn := a.Meta().DMSClient(ctx)
+	assessmentRunName := fwflex.StringValueFromFramework(ctx, config.AssessmentRunName)
+	replicationTaskARN := fwflex.StringValueFromFramework(ctx, config.ReplicationTaskARN)
+	timeout := fwactions.TimeoutOr(config.Timeout, defaultReplicationTaskAssessmentRunTimeout)
+
+	tflog.Info(ctx, "Starting DMS replication task assessment run", map[string]any{
+		"assessment_run_name":  assessmentRunName,
+		"replication_task_arn": replicationTaskARN,
+		"timeout":              timeout.String(),
+	})
+
+	cb := fwactions.NewSendProgressFunc(resp)
+	cb(ctx, "Starting DMS assessment run %s...", assessmentRunName)
+
+	input := &dmssdk.StartReplicationTaskAssessmentRunInput{
+		AssessmentRunName:    aws.String(assessmentRunName),
+		ReplicationTaskArn:   aws.String(replicationTaskARN),
+		ResultLocationBucket: aws.String(fwflex.StringValueFromFramework(ctx, config.ResultLocationBucket)),
+		ServiceAccessRoleArn: aws.String(fwflex.StringValueFromFramework(ctx, config.ServiceAccessRoleARN)),
+	}
+
+	if !config.IncludeOnly.IsNull() && !config.IncludeOnly.IsUnknown() {
+		input.IncludeOnly = fwflex.ExpandFrameworkStringValueList(ctx, config.IncludeOnly)
+	}
+
+	if !config.Exclude.IsNull() && !config.Exclude.IsUnknown() {
+		input.Exclude = fwflex.ExpandFrameworkStringValueList(ctx, config.Exclude)
+	}
+
+	if !config.ResultEncryptionMode.IsNull() {
+		input.ResultEncryptionMode = config.ResultEncryptionMode.ValueStringPointer()
+	}
+
+	if !config.ResultKMSKeyARN.IsNull() {
+		input.ResultKmsKeyArn = config.ResultKMSKeyARN.ValueStringPointer()
+	}
+
+	if !config.ResultLocationFolder.IsNull() {
+		input.ResultLocationFolder = config.ResultLocationFolder.ValueStringPointer()
+	}
+
+	output, err := conn.StartReplicationTaskAssessmentRun(ctx, input)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to Start DMS Assessment Run",
+			fmt.Sprintf("Could not start DMS assessment run %s for replication task %s: %s", assessmentRunName, replicationTaskARN, err),
+		)
+		return
+	}
+
+	if output.ReplicationTaskAssessmentRun == nil || output.ReplicationTaskAssessmentRun.ReplicationTaskAssessmentRunArn == nil {
+		resp.Diagnostics.AddError(
+			"Missing Assessment Run ARN",
+			fmt.Sprintf("DMS started assessment run %s but did not return an assessment run ARN.", assessmentRunName),
+		)
+		return
+	}
+
+	assessmentRunARN := aws.ToString(output.ReplicationTaskAssessmentRun.ReplicationTaskAssessmentRunArn)
+	cb(ctx, "Assessment run %s started, waiting for completion...", assessmentRunARN)
+
+	fr, err := actionwait.WaitForStatus(ctx, func(ctx context.Context) (actionwait.FetchResult[*awstypes.ReplicationTaskAssessmentRun], error) {
+		run, err := findReplicationTaskAssessmentRunByARN(ctx, conn, assessmentRunARN)
+		if retry.NotFound(err) {
+			return actionwait.FetchResult[*awstypes.ReplicationTaskAssessmentRun]{
+				Status: actionwait.Status(replicationTaskAssessmentRunStatusStarting),
+			}, nil
+		}
+		if err != nil {
+			return actionwait.FetchResult[*awstypes.ReplicationTaskAssessmentRun]{}, fmt.Errorf("describing assessment run: %w", err)
+		}
+
+		return actionwait.FetchResult[*awstypes.ReplicationTaskAssessmentRun]{
+			Status: actionwait.Status(aws.ToString(run.Status)),
+			Value:  run,
+		}, nil
+	}, actionwait.Options[*awstypes.ReplicationTaskAssessmentRun]{
+		Timeout:          timeout,
+		Interval:         actionwait.FixedInterval(assessmentRunPollInterval),
+		ProgressInterval: assessmentRunProgressInterval,
+		SuccessStates: []actionwait.Status{
+			actionwait.Status(replicationTaskAssessmentRunStatusPassed),
+			actionwait.Status(replicationTaskAssessmentRunStatusWarning),
+		},
+		TransitionalStates: []actionwait.Status{
+			actionwait.Status(replicationTaskAssessmentRunStatusStarting),
+			actionwait.Status(replicationTaskAssessmentRunStatusProvisioning),
+			actionwait.Status(replicationTaskAssessmentRunStatusRunning),
+		},
+		FailureStates: []actionwait.Status{
+			actionwait.Status(replicationTaskAssessmentRunStatusCancelling),
+			actionwait.Status(replicationTaskAssessmentRunStatusDeleting),
+			actionwait.Status(replicationTaskAssessmentRunStatusFailed),
+			actionwait.Status(replicationTaskAssessmentRunStatusErrorProvisioning),
+			actionwait.Status(replicationTaskAssessmentRunStatusErrorExecuting),
+			actionwait.Status(replicationTaskAssessmentRunStatusInvalidState),
+		},
+		ProgressSink: func(fr actionwait.FetchResult[any], meta actionwait.ProgressMeta) {
+			cb(ctx, "Assessment run %s is currently %s", assessmentRunName, fr.Status)
+		},
+	})
+	if err != nil {
+		var timeoutErr *actionwait.TimeoutError
+		var failureErr *actionwait.FailureStateError
+		var unexpectedErr *actionwait.UnexpectedStateError
+
+		lastFailureMessage := ""
+		if fr.Value != nil {
+			lastFailureMessage = aws.ToString(fr.Value.LastFailureMessage)
+		}
+
+		suffix := ""
+		if lastFailureMessage != "" {
+			suffix = fmt.Sprintf(" Last failure message: %s", lastFailureMessage)
+		}
+
+		switch {
+		case errors.As(err, &timeoutErr):
+			resp.Diagnostics.AddError(
+				"Timeout Waiting for DMS Assessment Run",
+				fmt.Sprintf("DMS assessment run %s did not complete within %s.%s", assessmentRunName, timeout, suffix),
+			)
+		case errors.As(err, &failureErr):
+			resp.Diagnostics.AddError(
+				"DMS Assessment Run Failed",
+				fmt.Sprintf("DMS assessment run %s reached failure status %s.%s", assessmentRunName, failureErr.Status, suffix),
+			)
+		case errors.As(err, &unexpectedErr):
+			resp.Diagnostics.AddError(
+				"Unexpected DMS Assessment Run Status",
+				fmt.Sprintf("DMS assessment run %s entered unexpected status %s.%s", assessmentRunName, unexpectedErr.Status, suffix),
+			)
+		default:
+			resp.Diagnostics.AddError(
+				"Error Waiting for DMS Assessment Run",
+				fmt.Sprintf("Error while waiting for DMS assessment run %s: %s.%s", assessmentRunName, err, suffix),
+			)
+		}
+		return
+	}
+
+	cb(ctx, "Assessment run %s completed with status %s", assessmentRunName, fr.Status)
+
+	logFields := map[string]any{
+		"assessment_run_arn":  assessmentRunARN,
+		"assessment_run_name": assessmentRunName,
+		"status":              fr.Status,
+	}
+	if fr.Value != nil && fr.Value.AssessmentProgress != nil {
+		logFields["individual_assessment_completed_count"] = fr.Value.AssessmentProgress.IndividualAssessmentCompletedCount
+		logFields["individual_assessment_count"] = fr.Value.AssessmentProgress.IndividualAssessmentCount
+	}
+
+	tflog.Info(ctx, "DMS replication task assessment run completed", logFields)
+}
+
+func findReplicationTaskAssessmentRunByARN(ctx context.Context, conn *dmssdk.Client, arn string) (*awstypes.ReplicationTaskAssessmentRun, error) {
+	input := &dmssdk.DescribeReplicationTaskAssessmentRunsInput{
+		Filters: []awstypes.Filter{
+			{
+				Name:   aws.String("replication-task-assessment-run-arn"),
+				Values: []string{arn},
+			},
+		},
+	}
+
+	return findReplicationTaskAssessmentRun(ctx, conn, input)
+}
+
+func findReplicationTaskAssessmentRun(ctx context.Context, conn *dmssdk.Client, input *dmssdk.DescribeReplicationTaskAssessmentRunsInput) (*awstypes.ReplicationTaskAssessmentRun, error) {
+	output, err := findReplicationTaskAssessmentRuns(ctx, conn, input)
+	if err != nil {
+		return nil, err
+	}
+
+	return tfresource.AssertSingleValueResult(output)
+}
+
+func findReplicationTaskAssessmentRuns(ctx context.Context, conn *dmssdk.Client, input *dmssdk.DescribeReplicationTaskAssessmentRunsInput) ([]awstypes.ReplicationTaskAssessmentRun, error) {
+	var output []awstypes.ReplicationTaskAssessmentRun
+
+	pages := dmssdk.NewDescribeReplicationTaskAssessmentRunsPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if errs.IsA[*awstypes.ResourceNotFoundFault](err) {
+			return nil, &retry.NotFoundError{LastError: err}
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, page.ReplicationTaskAssessmentRuns...)
+	}
+
+	return output, nil
+}

--- a/internal/service/dms/start_replication_task_assessment_run_action.go
+++ b/internal/service/dms/start_replication_task_assessment_run_action.go
@@ -185,7 +185,7 @@ func (a *startReplicationTaskAssessmentRunAction) Invoke(ctx context.Context, re
 	tflog.Info(ctx, "Starting DMS replication task assessment run", map[string]any{
 		"assessment_run_name":  assessmentRunName,
 		"replication_task_arn": replicationTaskARN,
-		"timeout":              timeout.String(),
+		names.AttrTimeout:      timeout.String(),
 	})
 
 	cb := fwactions.NewSendProgressFunc(resp)
@@ -302,7 +302,7 @@ func (a *startReplicationTaskAssessmentRunAction) Invoke(ctx context.Context, re
 	logFields := map[string]any{
 		"assessment_run_arn":  assessmentRunARN,
 		"assessment_run_name": assessmentRunName,
-		"status":              fr.Status,
+		names.AttrStatus:      fr.Status,
 	}
 	if fr.Value != nil && fr.Value.AssessmentProgress != nil {
 		logFields["individual_assessment_completed_count"] = fr.Value.AssessmentProgress.IndividualAssessmentCompletedCount

--- a/internal/service/dms/start_replication_task_assessment_run_action.go
+++ b/internal/service/dms/start_replication_task_assessment_run_action.go
@@ -13,9 +13,10 @@ import (
 	dmssdk "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice/types"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/action"
 	"github.com/hashicorp/terraform-plugin-framework/action/schema"
-	pfvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/actionwait"
@@ -72,8 +73,8 @@ type startReplicationTaskAssessmentRunActionModel struct {
 	ResultLocationBucket types.String         `tfsdk:"result_location_bucket"`
 	ResultLocationFolder types.String         `tfsdk:"result_location_folder"`
 	ServiceAccessRoleARN fwtypes.ARN          `tfsdk:"service_access_role_arn"`
-	Tags                 tftags.Map           `tfsdk:"tags"`
-	Timeout              types.Int64          `tfsdk:"timeout"`
+	Tags                 tftags.Map           `tfsdk:"tags" autoflex:"-"`
+	Timeout              types.Int64          `tfsdk:"timeout" autoflex:"-"`
 }
 
 func (a *startReplicationTaskAssessmentRunAction) Schema(ctx context.Context, req action.SchemaRequest, resp *action.SchemaResponse) {
@@ -104,6 +105,9 @@ func (a *startReplicationTaskAssessmentRunAction) Schema(ctx context.Context, re
 			"result_encryption_mode": schema.StringAttribute{
 				Description: fmt.Sprintf("Encryption mode for assessment results. Valid values are %q and %q.", encryptionModeSseKMS, encryptionModeSseS3),
 				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf(encryptionModeSseKMS, encryptionModeSseS3),
+				},
 			},
 			"result_kms_key_arn": schema.StringAttribute{
 				Description: "ARN of the KMS key used when result_encryption_mode is SSE_KMS.",
@@ -127,7 +131,7 @@ func (a *startReplicationTaskAssessmentRunAction) Schema(ctx context.Context, re
 			names.AttrTimeout: schema.Int64Attribute{
 				Description: "Timeout in seconds to wait for the assessment run to complete.",
 				Optional:    true,
-				Validators: []pfvalidator.Int64{
+				Validators: []validator.Int64{
 					int64validator.AtLeast(60),
 				},
 			},
@@ -152,22 +156,11 @@ func (a *startReplicationTaskAssessmentRunAction) Invoke(ctx context.Context, re
 	}
 
 	if !config.ResultKMSKeyARN.IsNull() {
-		mode := fwflex.StringValueOr(ctx, config.ResultEncryptionMode, "")
+		mode := config.ResultEncryptionMode.ValueString()
 		if mode != encryptionModeSseKMS {
 			resp.Diagnostics.AddError(
 				"Invalid KMS Encryption Configuration",
 				"result_kms_key_arn can only be specified when result_encryption_mode is SSE_KMS.",
-			)
-			return
-		}
-	}
-
-	if !config.ResultEncryptionMode.IsNull() {
-		mode := config.ResultEncryptionMode.ValueString()
-		if mode != encryptionModeSseKMS && mode != encryptionModeSseS3 {
-			resp.Diagnostics.AddError(
-				"Invalid Encryption Mode",
-				fmt.Sprintf("result_encryption_mode must be one of %q or %q.", encryptionModeSseKMS, encryptionModeSseS3),
 			)
 			return
 		}

--- a/internal/service/dms/start_replication_task_assessment_run_action.go
+++ b/internal/service/dms/start_replication_task_assessment_run_action.go
@@ -64,14 +64,14 @@ type startReplicationTaskAssessmentRunAction struct {
 type startReplicationTaskAssessmentRunActionModel struct {
 	framework.WithRegionModel
 	AssessmentRunName    types.String         `tfsdk:"assessment_run_name"`
-	ReplicationTaskARN   types.String         `tfsdk:"replication_task_arn"`
-	ResultLocationBucket types.String         `tfsdk:"result_location_bucket"`
-	ServiceAccessRoleARN types.String         `tfsdk:"service_access_role_arn"`
-	IncludeOnly          fwtypes.ListOfString `tfsdk:"include_only"`
 	Exclude              fwtypes.ListOfString `tfsdk:"exclude"`
+	IncludeOnly          fwtypes.ListOfString `tfsdk:"include_only"`
+	ReplicationTaskARN   types.String         `tfsdk:"replication_task_arn"`
 	ResultEncryptionMode types.String         `tfsdk:"result_encryption_mode"`
 	ResultKMSKeyARN      types.String         `tfsdk:"result_kms_key_arn"`
+	ResultLocationBucket types.String         `tfsdk:"result_location_bucket"`
 	ResultLocationFolder types.String         `tfsdk:"result_location_folder"`
+	ServiceAccessRoleARN types.String         `tfsdk:"service_access_role_arn"`
 	Timeout              types.Int64          `tfsdk:"timeout"`
 }
 
@@ -83,23 +83,11 @@ func (a *startReplicationTaskAssessmentRunAction) Schema(ctx context.Context, re
 				Description: "Unique name for the assessment run.",
 				Required:    true,
 			},
-			"replication_task_arn": schema.StringAttribute{
-				Description: "ARN of the DMS replication task to assess.",
-				Required:    true,
-				Validators: []pfvalidator.String{
-					fwvalidators.ARN(),
-				},
-			},
-			"result_location_bucket": schema.StringAttribute{
-				Description: "Amazon S3 bucket where DMS stores the assessment results.",
-				Required:    true,
-			},
-			"service_access_role_arn": schema.StringAttribute{
-				Description: "ARN of the IAM role used by DMS to write assessment results and start the run.",
-				Required:    true,
-				Validators: []pfvalidator.String{
-					fwvalidators.ARN(),
-				},
+			"exclude": schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				Description: "Specific individual assessments to exclude from the run. Cannot be set with include_only.",
+				Optional:    true,
+				ElementType: types.StringType,
 			},
 			"include_only": schema.ListAttribute{
 				CustomType:  fwtypes.ListOfStringType,
@@ -107,11 +95,12 @@ func (a *startReplicationTaskAssessmentRunAction) Schema(ctx context.Context, re
 				Optional:    true,
 				ElementType: types.StringType,
 			},
-			"exclude": schema.ListAttribute{
-				CustomType:  fwtypes.ListOfStringType,
-				Description: "Specific individual assessments to exclude from the run. Cannot be set with include_only.",
-				Optional:    true,
-				ElementType: types.StringType,
+			"replication_task_arn": schema.StringAttribute{
+				Description: "ARN of the DMS replication task to assess.",
+				Required:    true,
+				Validators: []pfvalidator.String{
+					fwvalidators.ARN(),
+				},
 			},
 			"result_encryption_mode": schema.StringAttribute{
 				Description: fmt.Sprintf("Encryption mode for assessment results. Valid values are %q and %q.", encryptionModeSseKMS, encryptionModeSseS3),
@@ -124,9 +113,20 @@ func (a *startReplicationTaskAssessmentRunAction) Schema(ctx context.Context, re
 					fwvalidators.ARN(),
 				},
 			},
+			"result_location_bucket": schema.StringAttribute{
+				Description: "Amazon S3 bucket where DMS stores the assessment results.",
+				Required:    true,
+			},
 			"result_location_folder": schema.StringAttribute{
 				Description: "Folder within the S3 bucket where DMS stores the assessment results.",
 				Optional:    true,
+			},
+			"service_access_role_arn": schema.StringAttribute{
+				Description: "ARN of the IAM role used by DMS to write assessment results and start the run.",
+				Required:    true,
+				Validators: []pfvalidator.String{
+					fwvalidators.ARN(),
+				},
 			},
 			names.AttrTimeout: schema.Int64Attribute{
 				Description: "Timeout in seconds to wait for the assessment run to complete.",
@@ -191,34 +191,13 @@ func (a *startReplicationTaskAssessmentRunAction) Invoke(ctx context.Context, re
 	cb := fwactions.NewSendProgressFunc(resp)
 	cb(ctx, "Starting DMS assessment run %s...", assessmentRunName)
 
-	input := &dmssdk.StartReplicationTaskAssessmentRunInput{
-		AssessmentRunName:    aws.String(assessmentRunName),
-		ReplicationTaskArn:   aws.String(replicationTaskARN),
-		ResultLocationBucket: aws.String(fwflex.StringValueFromFramework(ctx, config.ResultLocationBucket)),
-		ServiceAccessRoleArn: aws.String(fwflex.StringValueFromFramework(ctx, config.ServiceAccessRoleARN)),
+	var input dmssdk.StartReplicationTaskAssessmentRunInput
+	resp.Diagnostics.Append(fwflex.Expand(ctx, config, &input)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	if !config.IncludeOnly.IsNull() && !config.IncludeOnly.IsUnknown() {
-		input.IncludeOnly = fwflex.ExpandFrameworkStringValueList(ctx, config.IncludeOnly)
-	}
-
-	if !config.Exclude.IsNull() && !config.Exclude.IsUnknown() {
-		input.Exclude = fwflex.ExpandFrameworkStringValueList(ctx, config.Exclude)
-	}
-
-	if !config.ResultEncryptionMode.IsNull() {
-		input.ResultEncryptionMode = config.ResultEncryptionMode.ValueStringPointer()
-	}
-
-	if !config.ResultKMSKeyARN.IsNull() {
-		input.ResultKmsKeyArn = config.ResultKMSKeyARN.ValueStringPointer()
-	}
-
-	if !config.ResultLocationFolder.IsNull() {
-		input.ResultLocationFolder = config.ResultLocationFolder.ValueStringPointer()
-	}
-
-	output, err := conn.StartReplicationTaskAssessmentRun(ctx, input)
+	output, err := conn.StartReplicationTaskAssessmentRun(ctx, &input)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to Start DMS Assessment Run",

--- a/internal/service/dms/start_replication_task_assessment_run_action.go
+++ b/internal/service/dms/start_replication_task_assessment_run_action.go
@@ -24,8 +24,8 @@ import (
 	fwactions "github.com/hashicorp/terraform-provider-aws/internal/framework/actions"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
-	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -66,12 +66,13 @@ type startReplicationTaskAssessmentRunActionModel struct {
 	AssessmentRunName    types.String         `tfsdk:"assessment_run_name"`
 	Exclude              fwtypes.ListOfString `tfsdk:"exclude"`
 	IncludeOnly          fwtypes.ListOfString `tfsdk:"include_only"`
-	ReplicationTaskARN   types.String         `tfsdk:"replication_task_arn"`
+	ReplicationTaskARN   fwtypes.ARN          `tfsdk:"replication_task_arn"`
 	ResultEncryptionMode types.String         `tfsdk:"result_encryption_mode"`
-	ResultKMSKeyARN      types.String         `tfsdk:"result_kms_key_arn"`
+	ResultKMSKeyARN      fwtypes.ARN          `tfsdk:"result_kms_key_arn"`
 	ResultLocationBucket types.String         `tfsdk:"result_location_bucket"`
 	ResultLocationFolder types.String         `tfsdk:"result_location_folder"`
-	ServiceAccessRoleARN types.String         `tfsdk:"service_access_role_arn"`
+	ServiceAccessRoleARN fwtypes.ARN          `tfsdk:"service_access_role_arn"`
+	Tags                 tftags.Map           `tfsdk:"tags"`
 	Timeout              types.Int64          `tfsdk:"timeout"`
 }
 
@@ -98,9 +99,7 @@ func (a *startReplicationTaskAssessmentRunAction) Schema(ctx context.Context, re
 			"replication_task_arn": schema.StringAttribute{
 				Description: "ARN of the DMS replication task to assess.",
 				Required:    true,
-				Validators: []pfvalidator.String{
-					fwvalidators.ARN(),
-				},
+				CustomType:  fwtypes.ARNType,
 			},
 			"result_encryption_mode": schema.StringAttribute{
 				Description: fmt.Sprintf("Encryption mode for assessment results. Valid values are %q and %q.", encryptionModeSseKMS, encryptionModeSseS3),
@@ -109,9 +108,7 @@ func (a *startReplicationTaskAssessmentRunAction) Schema(ctx context.Context, re
 			"result_kms_key_arn": schema.StringAttribute{
 				Description: "ARN of the KMS key used when result_encryption_mode is SSE_KMS.",
 				Optional:    true,
-				Validators: []pfvalidator.String{
-					fwvalidators.ARN(),
-				},
+				CustomType:  fwtypes.ARNType,
 			},
 			"result_location_bucket": schema.StringAttribute{
 				Description: "Amazon S3 bucket where DMS stores the assessment results.",
@@ -124,10 +121,9 @@ func (a *startReplicationTaskAssessmentRunAction) Schema(ctx context.Context, re
 			"service_access_role_arn": schema.StringAttribute{
 				Description: "ARN of the IAM role used by DMS to write assessment results and start the run.",
 				Required:    true,
-				Validators: []pfvalidator.String{
-					fwvalidators.ARN(),
-				},
+				CustomType:  fwtypes.ARNType,
 			},
+			names.AttrTags: tftags.TagsAttribute(),
 			names.AttrTimeout: schema.Int64Attribute{
 				Description: "Timeout in seconds to wait for the assessment run to complete.",
 				Optional:    true,
@@ -195,6 +191,13 @@ func (a *startReplicationTaskAssessmentRunAction) Invoke(ctx context.Context, re
 	resp.Diagnostics.Append(fwflex.Expand(ctx, config, &input)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	defaultTagsConfig := a.Meta().DefaultTagsConfig(ctx)
+	tags := tftags.New(ctx, getContextTags(ctx)).Merge(tftags.New(ctx, config.Tags))
+	tags = defaultTagsConfig.MergeTags(tags)
+	if len(tags) > 0 {
+		input.Tags = svcTags(tags.IgnoreAWS())
 	}
 
 	output, err := conn.StartReplicationTaskAssessmentRun(ctx, &input)
@@ -353,4 +356,11 @@ func findReplicationTaskAssessmentRuns(ctx context.Context, conn *dmssdk.Client,
 	}
 
 	return output, nil
+}
+
+func getContextTags(ctx context.Context) tftags.KeyValueTags {
+	if inContext, ok := tftags.FromContext(ctx); ok {
+		return inContext.TagsIn.UnwrapOrDefault()
+	}
+	return nil
 }

--- a/internal/service/dms/start_replication_task_assessment_run_action_test.go
+++ b/internal/service/dms/start_replication_task_assessment_run_action_test.go
@@ -1,0 +1,223 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dms_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	dmssdk "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlySuccess(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_dms_replication_task.test"
+	assessmentRunName := fmt.Sprintf("%s-assessment", rName)
+	var v awstypes.ReplicationTask
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		CheckDestroy: testAccCheckReplicationTaskDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStartReplicationTaskAssessmentRunActionConfig_includeOnly(rName, assessmentRunName, "mysql-check-binlog-format"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckReplicationTaskExists(ctx, t, resourceName, &v),
+					testAccCheckReplicationTaskAssessmentRunExists(ctx, t, resourceName, "aws_s3_bucket.test", "aws_iam_role.test", assessmentRunName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlyFailure(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	assessmentRunName := fmt.Sprintf("%s-assessment", rName)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		CheckDestroy: testAccCheckReplicationTaskDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccStartReplicationTaskAssessmentRunActionConfig_includeOnly(rName, assessmentRunName, "mysql-check-target-network-parameter"),
+				ExpectError: regexache.MustCompile(`DMS Assessment Run Failed: DMS assessment run\s+.* reached failure status failed\.`),
+			},
+		},
+	})
+}
+
+func testAccCheckReplicationTaskAssessmentRunExists(ctx context.Context, t *testing.T, replicationTaskResourceName, bucketResourceName, roleResourceName, assessmentRunName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		taskRS, ok := s.RootModule().Resources[replicationTaskResourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", replicationTaskResourceName)
+		}
+
+		bucketRS, ok := s.RootModule().Resources[bucketResourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", bucketResourceName)
+		}
+
+		roleRS, ok := s.RootModule().Resources[roleResourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", roleResourceName)
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).DMSClient(ctx)
+		replicationTaskARN := taskRS.Primary.Attributes["replication_task_arn"]
+		resultBucket := bucketRS.Primary.Attributes["bucket"]
+		serviceAccessRoleARN := roleRS.Primary.Attributes[names.AttrARN]
+
+		timeout := time.After(10 * time.Minute)
+		ticker := time.NewTicker(15 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-timeout:
+				return fmt.Errorf("timeout waiting for DMS assessment run %q for replication task %s", assessmentRunName, replicationTaskARN)
+			case <-ticker.C:
+				output, err := conn.DescribeReplicationTaskAssessmentRuns(ctx, &dmssdk.DescribeReplicationTaskAssessmentRunsInput{
+					Filters: []awstypes.Filter{
+						{
+							Name:   aws.String("replication-task-arn"),
+							Values: []string{replicationTaskARN},
+						},
+					},
+				})
+				if err != nil {
+					continue
+				}
+
+				for _, run := range output.ReplicationTaskAssessmentRuns {
+					if aws.ToString(run.AssessmentRunName) != assessmentRunName {
+						continue
+					}
+
+					if aws.ToString(run.ReplicationTaskAssessmentRunArn) == "" {
+						return fmt.Errorf("assessment run %q returned an empty ARN", assessmentRunName)
+					}
+
+					if aws.ToString(run.ReplicationTaskArn) != replicationTaskARN {
+						return fmt.Errorf("expected replication task ARN %s, got %s", replicationTaskARN, aws.ToString(run.ReplicationTaskArn))
+					}
+
+					if aws.ToString(run.ResultLocationBucket) != resultBucket {
+						return fmt.Errorf("expected result bucket %s, got %s", resultBucket, aws.ToString(run.ResultLocationBucket))
+					}
+
+					if aws.ToString(run.ServiceAccessRoleArn) != serviceAccessRoleARN {
+						return fmt.Errorf("expected service access role ARN %s, got %s", serviceAccessRoleARN, aws.ToString(run.ServiceAccessRoleArn))
+					}
+
+					switch status := aws.ToString(run.Status); status {
+					case "passed", "warning":
+						return nil
+					case "starting", "provisioning", "running":
+						continue
+					default:
+						return fmt.Errorf("assessment run %q reached unexpected status %q: %s", assessmentRunName, status, aws.ToString(run.LastFailureMessage))
+					}
+				}
+			}
+		}
+	}
+}
+
+func testAccStartReplicationTaskAssessmentRunActionConfig_includeOnly(rName, assessmentRunName, includeOnly string) string {
+	return acctest.ConfigCompose(testAccReplicationTaskConfig_start(rName, false, "1"), fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+  force_destroy = true
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "dms.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:GetBucketLocation",
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ]
+      Resource = [
+        aws_s3_bucket.test.arn,
+        "${aws_s3_bucket.test.arn}/*"
+      ]
+    }]
+  })
+}
+
+action "aws_dms_start_replication_task_assessment_run" "test" {
+  config {
+    assessment_run_name     = %[2]q
+    replication_task_arn    = aws_dms_replication_task.test.replication_task_arn
+	include_only            = [%[3]q]
+    result_location_bucket  = aws_s3_bucket.test.bucket
+    result_location_folder  = "assessment-results"
+    service_access_role_arn = aws_iam_role.test.arn
+    timeout                 = 1800
+  }
+}
+
+resource "terraform_data" "trigger" {
+  lifecycle {
+    action_trigger {
+      events  = [after_create]
+      actions = [action.aws_dms_start_replication_task_assessment_run.test]
+    }
+  }
+
+  depends_on = [
+    aws_dms_replication_task.test,
+    aws_iam_role_policy.test
+  ]
+}
+`, rName, assessmentRunName, includeOnly))
+}

--- a/internal/service/dms/start_replication_task_assessment_run_action_test.go
+++ b/internal/service/dms/start_replication_task_assessment_run_action_test.go
@@ -88,7 +88,7 @@ func testAccCheckReplicationTaskAssessmentRunExists(ctx context.Context, t *test
 
 		conn := acctest.ProviderMeta(ctx, t).DMSClient(ctx)
 		replicationTaskARN := taskRS.Primary.Attributes["replication_task_arn"]
-		resultBucket := bucketRS.Primary.Attributes["bucket"]
+		resultBucket := bucketRS.Primary.Attributes[names.AttrBucket]
 		serviceAccessRoleARN := roleRS.Primary.Attributes[names.AttrARN]
 
 		timeout := time.After(10 * time.Minute)
@@ -100,14 +100,15 @@ func testAccCheckReplicationTaskAssessmentRunExists(ctx context.Context, t *test
 			case <-timeout:
 				return fmt.Errorf("timeout waiting for DMS assessment run %q for replication task %s", assessmentRunName, replicationTaskARN)
 			case <-ticker.C:
-				output, err := conn.DescribeReplicationTaskAssessmentRuns(ctx, &dmssdk.DescribeReplicationTaskAssessmentRunsInput{
+				input := dmssdk.DescribeReplicationTaskAssessmentRunsInput{
 					Filters: []awstypes.Filter{
 						{
 							Name:   aws.String("replication-task-arn"),
 							Values: []string{replicationTaskARN},
 						},
 					},
-				})
+				}
+				output, err := conn.DescribeReplicationTaskAssessmentRuns(ctx, &input)
 				if err != nil {
 					continue
 				}
@@ -198,7 +199,7 @@ action "aws_dms_start_replication_task_assessment_run" "test" {
   config {
     assessment_run_name     = %[2]q
     replication_task_arn    = aws_dms_replication_task.test.replication_task_arn
-	include_only            = [%[3]q]
+    include_only            = [%[3]q]
     result_location_bucket  = aws_s3_bucket.test.bucket
     result_location_folder  = "assessment-results"
     service_access_role_arn = aws_iam_role.test.arn

--- a/internal/service/dms/start_replication_task_assessment_run_action_test.go
+++ b/internal/service/dms/start_replication_task_assessment_run_action_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -19,8 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
-
-const testTagKey1 = "tf-acc-test"
 
 func TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlySuccess(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -42,7 +39,7 @@ func TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlySuccess(t *tes
 				Config: testAccStartReplicationTaskAssessmentRunActionConfig_includeOnly(rName, assessmentRunName, "mysql-check-binlog-format"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReplicationTaskExists(ctx, t, resourceName, &v),
-					testAccCheckReplicationTaskAssessmentRunExists(ctx, t, resourceName, "aws_s3_bucket.test", "aws_iam_role.test", assessmentRunName, map[string]string{testTagKey1: rName}),
+					testAccCheckReplicationTaskAssessmentRunExists(ctx, t, resourceName, "aws_s3_bucket.test", "aws_iam_role.test", assessmentRunName, map[string]string{acctest.CtKey1: acctest.CtValue1}),
 				),
 			},
 		},
@@ -93,85 +90,74 @@ func testAccCheckReplicationTaskAssessmentRunExists(ctx context.Context, t *test
 		resultBucket := bucketRS.Primary.Attributes[names.AttrBucket]
 		serviceAccessRoleARN := roleRS.Primary.Attributes[names.AttrARN]
 
-		timeout := time.After(10 * time.Minute)
-		ticker := time.NewTicker(15 * time.Second)
-		defer ticker.Stop()
+		input := dmssdk.DescribeReplicationTaskAssessmentRunsInput{
+			Filters: []awstypes.Filter{
+				{
+					Name:   aws.String("replication-task-arn"),
+					Values: []string{replicationTaskARN},
+				},
+			},
+		}
+		output, err := conn.DescribeReplicationTaskAssessmentRuns(ctx, &input)
+		if err != nil {
+			return fmt.Errorf("describing DMS assessment runs for replication task %s: %w", replicationTaskARN, err)
+		}
 
-		for {
-			select {
-			case <-timeout:
-				return fmt.Errorf("timeout waiting for DMS assessment run %q for replication task %s", assessmentRunName, replicationTaskARN)
-			case <-ticker.C:
-				input := dmssdk.DescribeReplicationTaskAssessmentRunsInput{
-					Filters: []awstypes.Filter{
-						{
-							Name:   aws.String("replication-task-arn"),
-							Values: []string{replicationTaskARN},
-						},
-					},
+		for _, run := range output.ReplicationTaskAssessmentRuns {
+			if aws.ToString(run.AssessmentRunName) != assessmentRunName {
+				continue
+			}
+
+			if aws.ToString(run.ReplicationTaskAssessmentRunArn) == "" {
+				return fmt.Errorf("assessment run %q returned an empty ARN", assessmentRunName)
+			}
+
+			if aws.ToString(run.ReplicationTaskArn) != replicationTaskARN {
+				return fmt.Errorf("expected replication task ARN %s, got %s", replicationTaskARN, aws.ToString(run.ReplicationTaskArn))
+			}
+
+			if aws.ToString(run.ResultLocationBucket) != resultBucket {
+				return fmt.Errorf("expected result bucket %s, got %s", resultBucket, aws.ToString(run.ResultLocationBucket))
+			}
+
+			if aws.ToString(run.ServiceAccessRoleArn) != serviceAccessRoleARN {
+				return fmt.Errorf("expected service access role ARN %s, got %s", serviceAccessRoleARN, aws.ToString(run.ServiceAccessRoleArn))
+			}
+
+			if len(expectedTags) > 0 {
+				input := dmssdk.ListTagsForResourceInput{
+					ResourceArn: run.ReplicationTaskAssessmentRunArn,
 				}
-				output, err := conn.DescribeReplicationTaskAssessmentRuns(ctx, &input)
+				tagsOutput, err := conn.ListTagsForResource(ctx, &input)
 				if err != nil {
-					continue
+					return fmt.Errorf("listing tags for assessment run %q: %w", assessmentRunName, err)
 				}
 
-				for _, run := range output.ReplicationTaskAssessmentRuns {
-					if aws.ToString(run.AssessmentRunName) != assessmentRunName {
-						continue
+				actualTags := make(map[string]string, len(tagsOutput.TagList))
+				for _, tag := range tagsOutput.TagList {
+					actualTags[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+				}
+
+				for key, expectedValue := range expectedTags {
+					actualValue, ok := actualTags[key]
+					if !ok {
+						return fmt.Errorf("expected assessment run %q to have tag %q", assessmentRunName, key)
 					}
-
-					if aws.ToString(run.ReplicationTaskAssessmentRunArn) == "" {
-						return fmt.Errorf("assessment run %q returned an empty ARN", assessmentRunName)
-					}
-
-					if aws.ToString(run.ReplicationTaskArn) != replicationTaskARN {
-						return fmt.Errorf("expected replication task ARN %s, got %s", replicationTaskARN, aws.ToString(run.ReplicationTaskArn))
-					}
-
-					if aws.ToString(run.ResultLocationBucket) != resultBucket {
-						return fmt.Errorf("expected result bucket %s, got %s", resultBucket, aws.ToString(run.ResultLocationBucket))
-					}
-
-					if aws.ToString(run.ServiceAccessRoleArn) != serviceAccessRoleARN {
-						return fmt.Errorf("expected service access role ARN %s, got %s", serviceAccessRoleARN, aws.ToString(run.ServiceAccessRoleArn))
-					}
-
-					if len(expectedTags) > 0 {
-						input := dmssdk.ListTagsForResourceInput{
-							ResourceArn: run.ReplicationTaskAssessmentRunArn,
-						}
-						tagsOutput, err := conn.ListTagsForResource(ctx, &input)
-						if err != nil {
-							return fmt.Errorf("listing tags for assessment run %q: %w", assessmentRunName, err)
-						}
-
-						actualTags := make(map[string]string, len(tagsOutput.TagList))
-						for _, tag := range tagsOutput.TagList {
-							actualTags[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
-						}
-
-						for key, expectedValue := range expectedTags {
-							actualValue, ok := actualTags[key]
-							if !ok {
-								return fmt.Errorf("expected assessment run %q to have tag %q", assessmentRunName, key)
-							}
-							if actualValue != expectedValue {
-								return fmt.Errorf("expected assessment run %q tag %q to be %q, got %q", assessmentRunName, key, expectedValue, actualValue)
-							}
-						}
-					}
-
-					switch status := aws.ToString(run.Status); status {
-					case "passed", "warning":
-						return nil
-					case "starting", "provisioning", "running":
-						continue
-					default:
-						return fmt.Errorf("assessment run %q reached unexpected status %q: %s", assessmentRunName, status, aws.ToString(run.LastFailureMessage))
+					if actualValue != expectedValue {
+						return fmt.Errorf("expected assessment run %q tag %q to be %q, got %q", assessmentRunName, key, expectedValue, actualValue)
 					}
 				}
 			}
+
+			switch status := aws.ToString(run.Status); status {
+			case "passed", "warning":
+				return nil
+			default:
+				return fmt.Errorf("assessment run %q reached unexpected final status %q: %s", assessmentRunName, status, aws.ToString(run.LastFailureMessage))
+			}
 		}
+
+		return fmt.Errorf("assessment run %q not found for replication task %s", assessmentRunName, replicationTaskARN)
 	}
 }
 
@@ -231,7 +217,7 @@ action "aws_dms_start_replication_task_assessment_run" "test" {
     result_location_folder  = "assessment-results"
     service_access_role_arn = aws_iam_role.test.arn
     tags = {
-      %[4]q = %[1]q
+      %[4]q = %[5]q
     }
     timeout = 1800
   }
@@ -250,5 +236,5 @@ resource "terraform_data" "trigger" {
     aws_iam_role_policy.test
   ]
 }
-`, rName, assessmentRunName, includeOnly, testTagKey1))
+`, rName, assessmentRunName, includeOnly, acctest.CtKey1, acctest.CtValue1))
 }

--- a/internal/service/dms/start_replication_task_assessment_run_action_test.go
+++ b/internal/service/dms/start_replication_task_assessment_run_action_test.go
@@ -153,7 +153,7 @@ func testAccStartReplicationTaskAssessmentRunActionConfig_includeOnly(rName, ass
 data "aws_partition" "current" {}
 
 resource "aws_s3_bucket" "test" {
-  bucket = %[1]q
+  bucket        = %[1]q
   force_destroy = true
 }
 

--- a/internal/service/dms/start_replication_task_assessment_run_action_test.go
+++ b/internal/service/dms/start_replication_task_assessment_run_action_test.go
@@ -137,9 +137,10 @@ func testAccCheckReplicationTaskAssessmentRunExists(ctx context.Context, t *test
 					}
 
 					if len(expectedTags) > 0 {
-						tagsOutput, err := conn.ListTagsForResource(ctx, &dmssdk.ListTagsForResourceInput{
+						input := dmssdk.ListTagsForResourceInput{
 							ResourceArn: run.ReplicationTaskAssessmentRunArn,
-						})
+						}
+						tagsOutput, err := conn.ListTagsForResource(ctx, &input)
 						if err != nil {
 							return fmt.Errorf("listing tags for assessment run %q: %w", assessmentRunName, err)
 						}

--- a/internal/service/dms/start_replication_task_assessment_run_action_test.go
+++ b/internal/service/dms/start_replication_task_assessment_run_action_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+const testTagKey1 = "tf-acc-test"
+
 func TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlySuccess(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -40,7 +42,7 @@ func TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlySuccess(t *tes
 				Config: testAccStartReplicationTaskAssessmentRunActionConfig_includeOnly(rName, assessmentRunName, "mysql-check-binlog-format"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReplicationTaskExists(ctx, t, resourceName, &v),
-					testAccCheckReplicationTaskAssessmentRunExists(ctx, t, resourceName, "aws_s3_bucket.test", "aws_iam_role.test", assessmentRunName),
+					testAccCheckReplicationTaskAssessmentRunExists(ctx, t, resourceName, "aws_s3_bucket.test", "aws_iam_role.test", assessmentRunName, map[string]string{testTagKey1: rName}),
 				),
 			},
 		},
@@ -69,7 +71,7 @@ func TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlyFailure(t *tes
 	})
 }
 
-func testAccCheckReplicationTaskAssessmentRunExists(ctx context.Context, t *testing.T, replicationTaskResourceName, bucketResourceName, roleResourceName, assessmentRunName string) resource.TestCheckFunc {
+func testAccCheckReplicationTaskAssessmentRunExists(ctx context.Context, t *testing.T, replicationTaskResourceName, bucketResourceName, roleResourceName, assessmentRunName string, expectedTags map[string]string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		taskRS, ok := s.RootModule().Resources[replicationTaskResourceName]
 		if !ok {
@@ -132,6 +134,30 @@ func testAccCheckReplicationTaskAssessmentRunExists(ctx context.Context, t *test
 
 					if aws.ToString(run.ServiceAccessRoleArn) != serviceAccessRoleARN {
 						return fmt.Errorf("expected service access role ARN %s, got %s", serviceAccessRoleARN, aws.ToString(run.ServiceAccessRoleArn))
+					}
+
+					if len(expectedTags) > 0 {
+						tagsOutput, err := conn.ListTagsForResource(ctx, &dmssdk.ListTagsForResourceInput{
+							ResourceArn: run.ReplicationTaskAssessmentRunArn,
+						})
+						if err != nil {
+							return fmt.Errorf("listing tags for assessment run %q: %w", assessmentRunName, err)
+						}
+
+						actualTags := make(map[string]string, len(tagsOutput.TagList))
+						for _, tag := range tagsOutput.TagList {
+							actualTags[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+						}
+
+						for key, expectedValue := range expectedTags {
+							actualValue, ok := actualTags[key]
+							if !ok {
+								return fmt.Errorf("expected assessment run %q to have tag %q", assessmentRunName, key)
+							}
+							if actualValue != expectedValue {
+								return fmt.Errorf("expected assessment run %q tag %q to be %q, got %q", assessmentRunName, key, expectedValue, actualValue)
+							}
+						}
 					}
 
 					switch status := aws.ToString(run.Status); status {
@@ -203,7 +229,10 @@ action "aws_dms_start_replication_task_assessment_run" "test" {
     result_location_bucket  = aws_s3_bucket.test.bucket
     result_location_folder  = "assessment-results"
     service_access_role_arn = aws_iam_role.test.arn
-    timeout                 = 1800
+    tags = {
+      %[4]q = %[1]q
+    }
+    timeout = 1800
   }
 }
 
@@ -220,5 +249,5 @@ resource "terraform_data" "trigger" {
     aws_iam_role_policy.test
   ]
 }
-`, rName, assessmentRunName, includeOnly))
+`, rName, assessmentRunName, includeOnly, testTagKey1))
 }

--- a/website/docs/actions/dms_start_replication_task_assessment_run.html.markdown
+++ b/website/docs/actions/dms_start_replication_task_assessment_run.html.markdown
@@ -1,0 +1,109 @@
+---
+subcategory: "DMS (Database Migration)"
+layout: "aws"
+page_title: "AWS: aws_dms_start_replication_task_assessment_run"
+description: |-
+  Starts pre-migration assessment for existing replication task.
+---
+
+# Action: aws_dms_start_replication_task_assessment_run
+
+Starts an AWS DMS premigration assessment run for a replication task and waits for the assessment run to reach a terminal state.
+
+For information about DMS pre-migration assessment, see the [Amazon Data Migration Tasks](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.html). For specific information about creating pre-migration assessment requests, see the [StartReplicationTaskAssessmentRun](https://docs.aws.amazon.com/dms/latest/APIReference/API_StartReplicationTaskAssessmentRun.html) page in the Amazon DMS API Reference.
+
+~> **Note:** DMS premigration assessment requests can take several minutes to complete. This action will wait for the assessment to finish before continuing.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_s3_bucket" "assessment_results" {
+  bucket = "example-dms-assessment-results"
+}
+
+resource "aws_iam_role" "dms_assessment" {
+  name = "example-dms-assessment-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "dms.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "dms_assessment" {
+  name = "example-dms-assessment-policy"
+  role = aws_iam_role.dms_assessment.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:GetBucketLocation",
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ]
+      Resource = [
+        aws_s3_bucket.assessment_results.arn,
+        "${aws_s3_bucket.assessment_results.arn}/*"
+      ]
+    }]
+  })
+}
+
+resource "aws_dms_replication_task" "example" {
+  # ... replication task configuration
+}
+
+action "aws_dms_start_replication_task_assessment_run" "example" {
+  config {
+    assessment_run_name     = "example-assessment-run"
+    replication_task_arn    = aws_dms_replication_task.example.replication_task_arn
+    result_location_bucket  = aws_s3_bucket.assessment_results.bucket
+    result_location_folder  = "premigration-assessments"
+    service_access_role_arn = aws_iam_role.dms_assessment.arn
+    timeout                 = 1800
+  }
+}
+
+resource "terraform_data" "example" {
+  lifecycle {
+    action_trigger {
+      events  = [after_create]
+      actions = [action.aws_dms_start_replication_task_assessment_run.example]
+    }
+  }
+
+  depends_on = [
+    aws_dms_replication_task.example,
+    aws_iam_role_policy.dms_assessment
+  ]
+}
+```
+
+## Argument Reference
+
+This action supports the following arguments:
+
+* `assessment_run_name` - (Required) Unique name for the DMS premigration assessment run.
+* `exclude` - (Optional) List of individual assessment names to exclude from the run. Cannot be set with `include_only`.
+* `include_only` - (Optional) List of individual assessment names to include in the run. Cannot be set with `exclude`.
+* `replication_task_arn` - (Required) ARN of the DMS replication task to assess.
+* `result_encryption_mode` - (Optional) Encryption mode for assessment results. Valid values are `SSE_KMS` and `SSE_S3`.
+* `result_kms_key_arn` - (Optional) ARN of the KMS key used to encrypt assessment results when `result_encryption_mode` is `SSE_KMS`.
+* `result_location_bucket` - (Required) Name of the S3 bucket where DMS stores assessment results.
+* `result_location_folder` - (Optional) Folder prefix within the S3 bucket where DMS stores assessment results.
+* `service_access_role_arn` - (Required) ARN of the IAM role that DMS assumes to write assessment results and start the run.
+* `timeout` - (Optional) Timeout in seconds to wait for the assessment run to complete. Defaults to 1800 seconds (30 minutes). Must be at least 60 seconds.
+
+~> **Note:** `result_kms_key_arn` can only be specified when `result_encryption_mode` is `SSE_KMS`.

--- a/website/docs/actions/dms_start_replication_task_assessment_run.html.markdown
+++ b/website/docs/actions/dms_start_replication_task_assessment_run.html.markdown
@@ -104,6 +104,7 @@ This action supports the following arguments:
 * `result_location_bucket` - (Required) Name of the S3 bucket where DMS stores assessment results.
 * `result_location_folder` - (Optional) Folder prefix within the S3 bucket where DMS stores assessment results.
 * `service_access_role_arn` - (Required) ARN of the IAM role that DMS assumes to write assessment results and start the run.
+* `tags` - (Optional) Map of tags assigned to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `timeout` - (Optional) Timeout in seconds to wait for the assessment run to complete. Defaults to 1800 seconds (30 minutes). Must be at least 60 seconds.
 
 ~> **Note:** `result_kms_key_arn` can only be specified when `result_encryption_mode` is `SSE_KMS`.

--- a/website/docs/actions/dms_start_replication_task_assessment_run.html.markdown
+++ b/website/docs/actions/dms_start_replication_task_assessment_run.html.markdown
@@ -3,7 +3,7 @@ subcategory: "DMS (Database Migration)"
 layout: "aws"
 page_title: "AWS: aws_dms_start_replication_task_assessment_run"
 description: |-
-  Starts pre-migration assessment for existing replication task.
+  Starts an AWS DMS premigration assessment run for a replication task and waits for it to reach a terminal state.
 ---
 
 # Action: aws_dms_start_replication_task_assessment_run


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

New action for triggering pre-migration assessment run on DMS.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://hashicorp.atlassian.net/browse/FRB-6899

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/dms/latest/APIReference/API_StartReplicationTaskAssessmentRun.html
https://docs.aws.amazon.com/dms/latest/APIReference/API_DescribeReplicationTaskAssessmentRuns.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlySuccess K=dms
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-start-assessment-run 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/dms/... -v -count 1 -parallel 20 -run='TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlySuccess'  -timeout 360m -vet=off
2026/03/22 01:28:55 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/22 01:28:55 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlySuccess
=== PAUSE TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlySuccess
=== CONT TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlySuccess
--- PASS: TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlySuccess (1392.71s)
PASS
ok github.com/hashicorp/terraform-provider-aws/internal/service/dms 1397.597s
% make t T=TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlyFailure K=dms
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-start-assessment-run 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/dms/... -v -count 1 -parallel 20 -run='TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlyFailure'  -timeout 360m -vet=off
2026/03/22 19:25:31 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/22 19:25:31 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlyFailure
=== PAUSE TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlyFailure
=== CONT  TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlyFailure
--- PASS: TestAccDMSStartReplicationTaskAssessmentRunAction_includeOnlyFailure (1319.25s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dms        1324.092s
...
```