### PR TITLE
resource/aws_glue_catalog_level_table_optimizer: add new resource

### DIFF
--- a/.changelog/47060.txt
+++ b/.changelog/47060.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+resource/aws_glue_catalog_level_table_optimizer: add new resource
+```

--- a/internal/service/glue/catalog_level_table_optimizer.go
+++ b/internal/service/glue/catalog_level_table_optimizer.go
@@ -1,0 +1,324 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package glue
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/glue"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/glue/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_glue_catalog_level_table_optimizer", name="Catalog Level Table Optimizer")
+func newCatalogLevelTableOptimizerResource(context.Context) (resource.ResourceWithConfigure, error) {
+	r := &catalogLevelTableOptimizerResource{}
+	return r, nil
+}
+
+const (
+	ResNameCatalogLevelTableOptimizer = "Catalog Level Table Optimizer"
+)
+
+type catalogLevelTableOptimizerResource struct {
+	framework.ResourceWithModel[catalogLevelTableOptimizerResourceModel]
+}
+
+func (r *catalogLevelTableOptimizerResource) Schema(ctx context.Context, _ resource.SchemaRequest, response *resource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrCatalogID: schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"iceberg_optimization": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[icebergOptimizationData](ctx),
+				Validators: []validator.List{
+					listvalidator.IsRequired(),
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrRoleARN: schema.StringAttribute{
+							CustomType: fwtypes.ARNType,
+							Required:   true,
+						},
+						"compaction": schema.MapAttribute{
+							ElementType: types.StringType,
+							Optional:    true,
+						},
+						"retention": schema.MapAttribute{
+							ElementType: types.StringType,
+							Optional:    true,
+						},
+						"orphan_file_deletion": schema.MapAttribute{
+							ElementType: types.StringType,
+							Optional:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *catalogLevelTableOptimizerResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	conn := r.Meta().GlueClient(ctx)
+	var plan catalogLevelTableOptimizerResourceModel
+
+	response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	icebergOpts, diags := plan.IcebergOptimization.ToPtr(ctx)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	compaction := fwflex.ExpandFrameworkStringValueMap(ctx, icebergOpts.Compaction)
+	retention := fwflex.ExpandFrameworkStringValueMap(ctx, icebergOpts.Retention)
+	orphan := fwflex.ExpandFrameworkStringValueMap(ctx, icebergOpts.OrphanFileDeletion)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	input := &glue.UpdateCatalogInput{
+		CatalogId: aws.String(plan.CatalogID.ValueString()),
+		CatalogInput: &awstypes.CatalogInput{
+			CatalogProperties: &awstypes.CatalogProperties{
+				IcebergOptimizationProperties: &awstypes.IcebergOptimizationProperties{
+					RoleArn:            aws.String(icebergOpts.RoleARN.ValueString()),
+					Compaction:         compaction,
+					Retention:          retention,
+					OrphanFileDeletion: orphan,
+				},
+			},
+		},
+	}
+
+	_, err := conn.UpdateCatalog(ctx, input)
+	if err != nil {
+		response.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Glue, create.ErrActionCreating, ResNameCatalogLevelTableOptimizer, plan.CatalogID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, &plan)...)
+}
+
+func (r *catalogLevelTableOptimizerResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	conn := r.Meta().GlueClient(ctx)
+	var data catalogLevelTableOptimizerResourceModel
+
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	output, err := findCatalogLevelTableOptimizer(ctx, conn, data.CatalogID.ValueString())
+
+	if retry.NotFound(err) {
+		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		response.State.RemoveResource(ctx)
+		return
+	}
+
+	if err != nil {
+		response.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Glue, create.ErrActionReading, ResNameCatalogLevelTableOptimizer, data.CatalogID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	props := output.Catalog.CatalogProperties
+	if props == nil || props.IcebergOptimizationProperties == nil {
+		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		response.State.RemoveResource(ctx)
+		return
+	}
+
+	ice := props.IcebergOptimizationProperties
+
+	compaction := fwflex.FlattenFrameworkStringValueMap(ctx, ice.Compaction)
+	retention := fwflex.FlattenFrameworkStringValueMap(ctx, ice.Retention)
+	orphan := fwflex.FlattenFrameworkStringValueMap(ctx, ice.OrphanFileDeletion)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	iceData := &icebergOptimizationData{
+		RoleARN:            fwtypes.ARNValue(aws.ToString(ice.RoleArn)),
+		Compaction:         compaction,
+		Retention:          retention,
+		OrphanFileDeletion: orphan,
+	}
+
+	iceList, d := fwtypes.NewListNestedObjectValueOfPtr(ctx, iceData)
+	response.Diagnostics.Append(d...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	data.IcebergOptimization = iceList
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+func (r *catalogLevelTableOptimizerResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	conn := r.Meta().GlueClient(ctx)
+	var plan, state catalogLevelTableOptimizerResourceModel
+
+	response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)
+	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.IcebergOptimization.Equal(state.IcebergOptimization) {
+		icebergOpts, diags := plan.IcebergOptimization.ToPtr(ctx)
+		response.Diagnostics.Append(diags...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		compaction := fwflex.ExpandFrameworkStringValueMap(ctx, icebergOpts.Compaction)
+		retention := fwflex.ExpandFrameworkStringValueMap(ctx, icebergOpts.Retention)
+		orphan := fwflex.ExpandFrameworkStringValueMap(ctx, icebergOpts.OrphanFileDeletion)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		input := &glue.UpdateCatalogInput{
+			CatalogId: aws.String(plan.CatalogID.ValueString()),
+			CatalogInput: &awstypes.CatalogInput{
+				CatalogProperties: &awstypes.CatalogProperties{
+					IcebergOptimizationProperties: &awstypes.IcebergOptimizationProperties{
+						RoleArn:            aws.String(icebergOpts.RoleARN.ValueString()),
+						Compaction:         compaction,
+						Retention:          retention,
+						OrphanFileDeletion: orphan,
+					},
+				},
+			},
+		}
+
+		_, err := conn.UpdateCatalog(ctx, input)
+		if err != nil {
+			response.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.Glue, create.ErrActionUpdating, ResNameCatalogLevelTableOptimizer, plan.CatalogID.ValueString(), err),
+				err.Error(),
+			)
+			return
+		}
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, &plan)...)
+}
+
+func (r *catalogLevelTableOptimizerResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	conn := r.Meta().GlueClient(ctx)
+	var data catalogLevelTableOptimizerResourceModel
+
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "deleting Glue Catalog Level Table Optimizer", map[string]any{
+		names.AttrCatalogID: data.CatalogID.ValueString(),
+	})
+
+	// Deletion clears the IcebergOptimizationProperties by setting them to empty
+	_, err := conn.UpdateCatalog(ctx, &glue.UpdateCatalogInput{
+		CatalogId: aws.String(data.CatalogID.ValueString()),
+		CatalogInput: &awstypes.CatalogInput{
+			CatalogProperties: &awstypes.CatalogProperties{
+				IcebergOptimizationProperties: &awstypes.IcebergOptimizationProperties{},
+			},
+		},
+	})
+
+	if errs.IsA[*awstypes.EntityNotFoundException](err) {
+		return
+	}
+
+	if err != nil {
+		response.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Glue, create.ErrActionDeleting, ResNameCatalogLevelTableOptimizer, data.CatalogID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *catalogLevelTableOptimizerResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
+	// Import by catalog_id
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root(names.AttrCatalogID), request.ID)...)
+}
+
+func findCatalogLevelTableOptimizer(ctx context.Context, conn *glue.Client, catalogID string) (*glue.GetCatalogOutput, error) {
+	input := &glue.GetCatalogInput{
+		CatalogId: aws.String(catalogID),
+	}
+
+	output, err := conn.GetCatalog(ctx, input)
+
+	if errs.IsA[*awstypes.EntityNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError: err,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Catalog == nil {
+		return nil, &retry.NotFoundError{}
+	}
+
+	return output, nil
+}
+
+type catalogLevelTableOptimizerResourceModel struct {
+	framework.WithRegionModel
+	CatalogID           types.String                                                `tfsdk:"catalog_id"`
+	IcebergOptimization fwtypes.ListNestedObjectValueOf[icebergOptimizationData]    `tfsdk:"iceberg_optimization"`
+}
+
+type icebergOptimizationData struct {
+	RoleARN            fwtypes.ARN       `tfsdk:"role_arn"`
+	Compaction         types.Map         `tfsdk:"compaction"`
+	Retention          types.Map         `tfsdk:"retention"`
+	OrphanFileDeletion types.Map         `tfsdk:"orphan_file_deletion"`
+}

--- a/internal/service/glue/catalog_level_table_optimizer_test.go
+++ b/internal/service/glue/catalog_level_table_optimizer_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package glue_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/glue"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func TestAccGlueCatalogLevelTableOptimizer_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_glue_catalog_level_table_optimizer.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, "glue"),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCatalogLevelTableOptimizerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCatalogLevelTableOptimizerConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogLevelTableOptimizerExists(ctx, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "catalog_id"),
+					resource.TestCheckResourceAttr(resourceName, "iceberg_optimization.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccGlueCatalogLevelTableOptimizer_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_glue_catalog_level_table_optimizer.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, "glue"),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCatalogLevelTableOptimizerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCatalogLevelTableOptimizerConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogLevelTableOptimizerExists(ctx, resourceName),
+				),
+			},
+			{
+				Config: testAccCatalogLevelTableOptimizerConfig_updated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogLevelTableOptimizerExists(ctx, resourceName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCatalogLevelTableOptimizerDestroy(ctx context.Context) resource.TestCheckDestroyFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).GlueClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_glue_catalog_level_table_optimizer" {
+				continue
+			}
+
+			out, err := conn.GetCatalog(ctx, &glue.GetCatalogInput{
+				CatalogId: &rs.Primary.ID,
+			})
+			if err != nil {
+				return nil
+			}
+			if out.Catalog.CatalogProperties == nil {
+				return nil
+			}
+			if out.Catalog.CatalogProperties.IcebergOptimizationProperties == nil {
+				return nil
+			}
+			if out.Catalog.CatalogProperties.IcebergOptimizationProperties.RoleArn == nil {
+				return nil
+			}
+			return fmt.Errorf("Glue Catalog Level Table Optimizer %s still exists", rs.Primary.ID)
+		}
+		return nil
+	}
+}
+
+func testAccCheckCatalogLevelTableOptimizerExists(ctx context.Context, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).GlueClient(ctx)
+
+		out, err := conn.GetCatalog(ctx, &glue.GetCatalogInput{
+			CatalogId: &rs.Primary.ID,
+		})
+		if err != nil {
+			return err
+		}
+		if out.Catalog.CatalogProperties == nil || out.Catalog.CatalogProperties.IcebergOptimizationProperties == nil {
+			return fmt.Errorf("Glue Catalog Level Table Optimizer %s not found", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCatalogLevelTableOptimizerConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "glue.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_glue_catalog_level_table_optimizer" "test" {
+  catalog_id = data.aws_caller_identity.current.account_id
+
+  iceberg_optimization {
+    role_arn = aws_iam_role.test.arn
+
+    compaction = {
+      enabled = "true"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccCatalogLevelTableOptimizerConfig_updated(rName string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "glue.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_glue_catalog_level_table_optimizer" "test" {
+  catalog_id = data.aws_caller_identity.current.account_id
+
+  iceberg_optimization {
+    role_arn = aws_iam_role.test.arn
+
+    compaction = {
+      enabled = "true"
+    }
+
+    retention = {
+      enabled = "true"
+    }
+  }
+}
+`, rName)
+}

--- a/internal/service/glue/service_package_gen.go
+++ b/internal/service/glue/service_package_gen.go
@@ -34,6 +34,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.ServicePackageFrameworkResource {
 	return []*inttypes.ServicePackageFrameworkResource{
 		{
+			Factory:  newCatalogLevelTableOptimizerResource,
+			TypeName: "aws_glue_catalog_level_table_optimizer",
+			Name:     "Catalog Level Table Optimizer",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+		{
 			Factory:  newCatalogTableOptimizerResource,
 			TypeName: "aws_glue_catalog_table_optimizer",
 			Name:     "Catalog Table Optimizer",

--- a/website/docs/r/glue_catalog_level_table_optimizer.html.markdown
+++ b/website/docs/r/glue_catalog_level_table_optimizer.html.markdown
@@ -1,0 +1,88 @@
+---
+subcategory: "Glue"
+layout: "aws"
+page_title: "AWS: aws_glue_catalog_level_table_optimizer"
+description: |-
+  Manages catalog-level Iceberg table optimization settings in AWS Glue.
+---
+
+# Resource: aws_glue_catalog_level_table_optimizer
+
+Manages catalog-level Iceberg table optimization settings in AWS Glue, including compaction, retention, and orphan file deletion.
+
+## Example Usage
+```terraform
+resource "aws_iam_role" "glue_optimizer" {
+  name = "glue-catalog-optimizer"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "glue.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_glue_catalog_level_table_optimizer" "example" {
+  catalog_id = data.aws_caller_identity.current.account_id
+
+  iceberg_optimization {
+    role_arn = aws_iam_role.glue_optimizer.arn
+
+    compaction = {
+      enabled               = "true"
+      strategy              = "binpack"
+      minInputFiles         = "100"
+    }
+
+    retention = {
+      enabled                          = "true"
+      snapshotRetentionPeriodInDays    = "7"
+      numberOfSnapshotsToRetain        = "1"
+    }
+
+    orphan_file_deletion = {
+      enabled                            = "true"
+      orphanFileRetentionPeriodInDays    = "3"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `catalog_id` - (Required, Forces new resource) The ID of the Glue catalog.
+
+### iceberg_optimization
+
+* `role_arn` - (Required) The ARN of the IAM role used to perform Iceberg table optimization operations.
+* `compaction` - (Optional) A map of key-value pairs specifying compaction configuration parameters.
+* `retention` - (Optional) A map of key-value pairs specifying retention configuration parameters.
+* `orphan_file_deletion` - (Optional) A map of key-value pairs specifying orphan file deletion configuration parameters.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - The catalog ID.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Glue Catalog Level Table Optimizers using the `catalog_id`. For example:
+```terraform
+import {
+  to = aws_glue_catalog_level_table_optimizer.example
+  id = "123456789012"
+}
+```
+
+Using `terraform import`:
+```console
+% terraform import aws_glue_catalog_level_table_optimizer.example 123456789012
+```


### PR DESCRIPTION
## Description

Adds a new resource `aws_glue_catalog_level_table_optimizer` to manage
catalog-level Iceberg table optimization settings in AWS Glue.

Catalog-level optimizers enable automatic compaction, retention, and
orphan file deletion for all Iceberg tables in a Glue catalog, improving
query performance and controlling storage costs without configuring
each table individually.

## Related Issue

Fixes #46875

## Changes

- New resource `aws_glue_catalog_level_table_optimizer` with `Create`,
  `Read`, `Update`, and `Delete` operations
- Uses `UpdateCatalog` API for create/update/delete and `GetCatalog` for read
- Supports `compaction`, `retention`, and `orphan_file_deletion` as
  map-based configuration blocks matching the AWS API structure
- Supports import via `terraform import`
- Acceptance tests added for basic and update scenarios
- Documentation added

## Usage Example

\```terraform
resource "aws_iam_role" "glue_optimizer" {
  name = "glue-catalog-optimizer"

  assume_role_policy = jsonencode({
    Version = "2012-10-17"
    Statement = [{
      Action    = "sts:AssumeRole"
      Effect    = "Allow"
      Principal = { Service = "glue.amazonaws.com" }
    }]
  })
}

resource "aws_glue_catalog_level_table_optimizer" "example" {
  catalog_id = data.aws_caller_identity.current.account_id

  iceberg_optimization {
    role_arn = aws_iam_role.glue_optimizer.arn

    compaction = {
      enabled  = "true"
      strategy = "binpack"
    }

    retention = {
      enabled                       = "true"
      snapshotRetentionPeriodInDays = "7"
    }

    orphan_file_deletion = {
      enabled                         = "true"
      orphanFileRetentionPeriodInDays = "3"
    }
  }
}

data "aws_caller_identity" "current" {}
\```

## Checklist

- [x] New resource implemented
- [x] Acceptance tests added
- [x] Documentation added
- [x] Builds cleanly with `go build ./...`