### PR TITLE
r/aws_dynamodb_table: add `restore_backup_arn` argument

### DIFF
--- a/.changelog/47068.txt
+++ b/.changelog/47068.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dynamodb_table: Add `restore_backup_arn` argument
+```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -108,6 +108,9 @@ func resourceTable() *schema.Resource {
 			customdiff.ForceNewIfChange("restore_source_table_arn", func(_ context.Context, old, new, meta any) bool {
 				return old.(string) != new.(string) && new.(string) != ""
 			}),
+			customdiff.ForceNewIfChange("restore_backup_arn", func(_ context.Context, old, new, meta any) bool {
+				return old.(string) != new.(string) && new.(string) != ""
+			}),
 			customdiff.ForceNewIfChange("warm_throughput.0.read_units_per_second", func(_ context.Context, old, new, meta any) bool {
 				// warm_throughput can only be increased, not decreased
 				// i.e., "api error ValidationException: One or more parameter values were invalid: Requested ReadUnitsPerSecond for WarmThroughput for table is lower than current WarmThroughput, decreasing WarmThroughput is not supported"
@@ -270,7 +273,7 @@ func resourceTable() *schema.Resource {
 					Type:          schema.TypeList,
 					Optional:      true,
 					MaxItems:      1,
-					ConflictsWith: []string{"restore_source_name", "restore_source_table_arn"},
+					ConflictsWith: []string{"restore_backup_arn", "restore_source_name", "restore_source_table_arn"},
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"input_compression_type": {
@@ -466,16 +469,22 @@ func resourceTable() *schema.Resource {
 					ForceNew:     true,
 					ValidateFunc: verify.ValidUTCTimestamp,
 				},
+				"restore_backup_arn": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ValidateFunc:  verify.ValidARN,
+					ConflictsWith: []string{"import_table", "restore_source_name", "restore_source_table_arn"},
+				},
 				"restore_source_table_arn": {
 					Type:          schema.TypeString,
 					Optional:      true,
 					ValidateFunc:  verify.ValidARN,
-					ConflictsWith: []string{"import_table", "restore_source_name"},
+					ConflictsWith: []string{"import_table", "restore_backup_arn", "restore_source_name"},
 				},
 				"restore_source_name": {
 					Type:          schema.TypeString,
 					Optional:      true,
-					ConflictsWith: []string{"import_table", "restore_source_table_arn"},
+					ConflictsWith: []string{"import_table", "restore_backup_arn", "restore_source_table_arn"},
 				},
 				"restore_to_latest_time": {
 					Type:     schema.TypeBool,
@@ -709,6 +718,72 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 
 		_, err := tfresource.RetryWhen(ctx, createTableTimeout, func(ctx context.Context) (any, error) {
 			return conn.RestoreTableToPointInTime(ctx, input)
+		}, func(err error) (bool, error) {
+			if tfawserr.ErrCodeEquals(err, errCodeThrottlingException) {
+				return true, err
+			}
+			if errs.IsAErrorMessageContains[*awstypes.LimitExceededException](err, "can be created, updated, or deleted simultaneously") {
+				return true, err
+			}
+			if errs.IsAErrorMessageContains[*awstypes.LimitExceededException](err, "indexed tables that can be created simultaneously") {
+				return true, err
+			}
+
+			return false, err
+		})
+
+		if err != nil {
+			return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionCreating, resNameTable, tableName, err)
+		}
+	} else if backupARN, ok := d.GetOk("restore_backup_arn"); ok {
+		input := &dynamodb.RestoreTableFromBackupInput{
+			TargetTableName: aws.String(tableName),
+			BackupArn:       aws.String(backupARN.(string)),
+		}
+
+		billingModeOverride := awstypes.BillingMode(d.Get("billing_mode").(string))
+
+		if v, ok := d.GetOk("global_secondary_index"); ok {
+			globalSecondaryIndexes := []awstypes.GlobalSecondaryIndex{}
+			gsiSet := v.(*schema.Set)
+
+			for _, gsiObject := range gsiSet.List() {
+				gsi := gsiObject.(map[string]any)
+				if err := validateGSIProvisionedThroughput(gsi, billingModeOverride); err != nil {
+					return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionCreating, resNameTable, d.Get(names.AttrName).(string), err)
+				}
+
+				gsiObject := expandGlobalSecondaryIndex(gsi, billingModeOverride)
+				globalSecondaryIndexes = append(globalSecondaryIndexes, *gsiObject)
+			}
+			input.GlobalSecondaryIndexOverride = globalSecondaryIndexes
+		}
+
+		if v, ok := d.GetOk("local_secondary_index"); ok {
+			lsiSet := v.(*schema.Set)
+			input.LocalSecondaryIndexOverride = expandLocalSecondaryIndexes(lsiSet.List(), keySchemaMap)
+		}
+
+		if v, ok := d.GetOk("on_demand_throughput"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.OnDemandThroughputOverride = expandOnDemandThroughput(v.([]any)[0].(map[string]any))
+		}
+
+		if _, ok := d.GetOk("write_capacity"); ok {
+			if _, ok := d.GetOk("read_capacity"); ok {
+				capacityMap := map[string]any{
+					"write_capacity": d.Get("write_capacity"),
+					"read_capacity":  d.Get("read_capacity"),
+				}
+				input.ProvisionedThroughputOverride = expandProvisionedThroughput(capacityMap, billingModeOverride)
+			}
+		}
+
+		if v, ok := d.GetOk("server_side_encryption"); ok {
+			input.SSESpecificationOverride = expandEncryptAtRestOptions(v.([]any))
+		}
+
+		_, err := tfresource.RetryWhen(ctx, createTableTimeout, func(ctx context.Context) (any, error) {
+			return conn.RestoreTableFromBackup(ctx, input)
 		}, func(err error) (bool, error) {
 			if tfawserr.ErrCodeEquals(err, errCodeThrottlingException) {
 				return true, err

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -1934,6 +1934,7 @@ func TestAccDynamoDBTable_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName, "range_key"),
 					resource.TestCheckResourceAttr(resourceName, "read_capacity", "1"),
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "restore_backup_arn"),
 					resource.TestCheckNoResourceAttr(resourceName, "restore_date_time"),
 					resource.TestCheckNoResourceAttr(resourceName, "restore_source_name"),
 					resource.TestCheckNoResourceAttr(resourceName, "restore_to_latest_time"),
@@ -7972,6 +7973,44 @@ func TestAccDynamoDBTable_Replica_deletionProtection(t *testing.T) {
 	})
 }
 
+func TestAccDynamoDBTable_restoreBackupARN(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var conf awstypes.TableDescription
+	resourceName := "aws_dynamodb_table.test"
+	resourceNameRestore := "aws_dynamodb_table.test_restore"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rNameRestore := fmt.Sprintf("%s-restore", rName)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_restoreBackupARN(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceNameRestore, names.AttrName, rNameRestore),
+					acctest.MatchResourceAttrRegionalARNRegion(ctx, resourceName, names.AttrARN, "dynamodb", acctest.Region(), regexache.MustCompile(`table/.+$`)),
+					acctest.MatchResourceAttrRegionalARNRegion(ctx, resourceNameRestore, names.AttrARN, "dynamodb", acctest.Region(), regexache.MustCompile(`table/.+$`)),
+					acctest.MatchResourceAttrRegionalARNRegion(ctx, resourceNameRestore, "restore_backup_arn", "dynamodb", acctest.Region(), regexache.MustCompile(`table/.+/backup/.+$`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccDynamoDBTable_tableClassInfrequentAccess(t *testing.T) {
 	ctx := acctest.Context(t)
 	var table awstypes.TableDescription
@@ -12880,6 +12919,51 @@ resource "aws_dynamodb_table" "test_restore" {
   }
 }
 `, rName))
+}
+
+func testAccTableConfig_restoreBackupARN(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = %[1]q
+  read_capacity  = 2
+  write_capacity = 2
+  hash_key       = "TestTableHashKey"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+}
+
+action "aws_dynamodb_create_backup" "test" {
+  config {
+    table_name  = aws_dynamodb_table.test.name
+    backup_name = "%[1]s-backup"
+  }
+}
+
+resource "terraform_data" "backup_trigger" {
+  input = "trigger-backup"
+
+  lifecycle {
+    action_trigger {
+      events  = [after_create]
+      actions = [action.aws_dynamodb_create_backup.test]
+    }
+  }
+}
+
+data "aws_dynamodb_backups" "test" {
+  table_name = aws_dynamodb_table.test.name
+
+  depends_on = [terraform_data.backup_trigger]
+}
+
+resource "aws_dynamodb_table" "test_restore" {
+  name               = "%[1]s-restore"
+  restore_backup_arn = data.aws_dynamodb_backups.test.backup_summaries[0].backup_arn
+}
+`, rName)
 }
 
 func testAccTableConfig_replica2_NoMultipleRegionProvider(rName string) string {

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -363,6 +363,7 @@ The following arguments are optional:
 * `range_key` - (Optional, Forces new resource) Attribute to use as the range (sort) key. Must also be defined as an `attribute`, see below.
 * `read_capacity` - (Optional) Number of read units for this table. If the `billing_mode` is `PROVISIONED`, this field is required.
 * `replica` - (Optional) Configuration block(s) with [DynamoDB Global Tables V2 (version 2019.11.21)](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html) replication configurations. See below.
+* `restore_backup_arn` - (Optional) ARN of backup to restore.
 * `restore_date_time` - (Optional) Time of the point-in-time recovery point to restore.
 * `restore_source_name` - (Optional) Name of the table to restore. Must match the name of an existing table.
 * `restore_source_table_arn` - (Optional) ARN of the source table to restore. Must be supplied for cross-region restores.


### PR DESCRIPTION



<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This argument will allow creation of a table from a backup. Although the [`RestoreTableFromBackup`](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_RestoreTableFromBackup.html) API expects a `BackupArn` parameter, the corresponding Terraform argument was prefixed with `restore_` to align with other arguments used for restoring tables from an existing source (e.g. `restore_source_name`, `restore_source_table_arn`).

The [`aws_dynamodb_create_backup` action](https://registry.terraform.io/providers/-/aws/latest/docs/actions/dynamodb_create_backup) can be used to provision on-demand backups for use with this argument.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29883
Depends on #47036

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_RestoreTableFromBackup.html
- https://registry.terraform.io/providers/-/aws/latest/docs/actions/dynamodb_create_backup

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=dynamodb T=TestAccDynamoDBTable_restoreBackupARN
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-dynamodb-backup 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_restoreBackupARN'  -timeout 360m -vet=off
2026/03/23 13:34:30 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/23 13:34:30 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccDynamoDBTable_restoreBackupARN (479.84s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   487.047s
```

```console
% make t K=dynamodb T=TestAccDynamoDBTable_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-dynamodb-backup 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_'  -timeout 360m -vet=off
2026/03/23 15:00:05 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/23 15:00:05 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccDynamoDBTable_GSI_unknown (58.98s)
=== CONT  TestAccDynamoDBTable_gsiWarmThroughput_switchBilling
--- PASS: TestAccDynamoDBTable_tableClass_migrate (61.40s)
=== CONT  TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed
--- PASS: TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed_onUpdate (62.76s)
=== CONT  TestAccDynamoDBTable_nameKnownAfterApply
--- PASS: TestAccDynamoDBTable_warmThroughputDefault (64.02s)
=== CONT  TestAccDynamoDBTable_tableClass_ConcurrentModification
--- PASS: TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed (3.24s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_twoOfTwo
--- PASS: TestAccDynamoDBTable_GSI_keySchema_unknown (68.13s)
=== CONT  TestAccDynamoDBTable_tableClassExplicitDefault
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (97.31s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_twoOfTwo
--- PASS: TestAccDynamoDBTable_nameKnownAfterApply (40.77s)
=== CONT  TestAccDynamoDBTable_gsiWarmThroughput_billingPayPerRequest
--- PASS: TestAccDynamoDBTable_tableClassExplicitDefault (62.60s)
=== CONT  TestAccDynamoDBTable_gsiWarmThroughput_billingProvisioned
--- PASS: TestAccDynamoDBTable_tableClass_ConcurrentModification (92.71s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_CreateEventuallyConsistent
--- PASS: TestAccDynamoDBTable_warmThroughput (168.45s)
=== CONT  TestAccDynamoDBTable_Replica_deletionProtection
--- PASS: TestAccDynamoDBTable_tags (171.98s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_NotEnoughReplicas
--- PASS: TestAccDynamoDBTable_Replica_MRSC_NotEnoughReplicas (91.65s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_TooManyReplicas
--- PASS: TestAccDynamoDBTable_importTable (266.65s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_MixedConsistencyModes
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_switchBilling (263.81s)
=== CONT  TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
--- PASS: TestAccDynamoDBTable_restoreBackupARN (334.46s)
=== CONT  TestAccDynamoDBTable_Replica_multiple
--- PASS: TestAccDynamoDBTable_Replica_MRSC_MixedConsistencyModes (71.02s)
=== CONT  TestAccDynamoDBTable_Replica_single
=== NAME  TestAccDynamoDBTable_Replica_MRSC_TooManyReplicas
    table_test.go:7756: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: deleting AWS DynamoDB Table (tf-acc-test-149678333752074817): deleting replica(s): operation error DynamoDB: UpdateTable, https response error StatusCode: 400, RequestID: IADTQ35TU0B0CT413ULDATSCDJVV4KQNSO5AEMVJF66Q9ASUAAJG, api error ValidationException: Cannot add or delete the local region through ReplicaUpdates. Use CreateTable, DeleteTable, or UpdateTable as required.

--- FAIL: TestAccDynamoDBTable_Replica_MRSC_TooManyReplicas (74.35s)
=== CONT  TestAccDynamoDBTable_restoreCrossRegion
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica (360.75s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_oneOfTwo
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_oneOfTwo (387.94s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_pitrKMS
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_propagateToAddedReplica (392.42s)
=== CONT  TestAccDynamoDBTable_lsiNonKeyAttributes
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_nonPropagatedTagsAreUnmanaged (405.52s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_pitrKMS
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_notPropagatedToAddedReplica (410.16s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_pitr
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_nonPropagatedTagsAreUnmanaged (420.40s)
=== CONT  TestAccDynamoDBTable_attributeUpdateValidation
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (21.32s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_pitr
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_twoOfTwo (391.50s)
=== CONT  TestAccDynamoDBTable_lsiUpdate
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_twoOfTwo (360.70s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_doubleAddCMK
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (112.25s)
=== CONT  TestAccDynamoDBTable_attributeUpdate
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (198.67s)
=== CONT  TestAccDynamoDBTable_TTL_validate
--- PASS: TestAccDynamoDBTable_TTL_validate (5.99s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_doubleAddCMK
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_billingProvisioned (458.52s)
=== CONT  TestAccDynamoDBTable_TTL_updateDisable
=== CONT  TestAccDynamoDBTable_Replica_MRSC_Create_witness_too_many_replicas
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tagsUpdate (609.22s)
--- PASS: TestAccDynamoDBTable_lsiUpdate (158.96s)
=== CONT  TestAccDynamoDBTable_TTL_updateEnable
--- PASS: TestAccDynamoDBTable_Replica_MRSC_CreateEventuallyConsistent (512.79s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_Create_witness
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create_witness_too_many_replicas (94.48s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_Create
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tagsUpdate (719.08s)
=== CONT  TestAccDynamoDBTable_TTL_disabled
--- PASS: TestAccDynamoDBTable_TTL_updateEnable (119.53s)
=== CONT  TestAccDynamoDBTable_Replica_tagsUpdate
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_oneOfTwo (414.09s)
=== CONT  TestAccDynamoDBTable_TTL_enabled
--- PASS: TestAccDynamoDBTable_TTL_disabled (75.77s)
=== CONT  TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
--- PASS: TestAccDynamoDBTable_TTL_enabled (68.77s)
=== CONT  TestAccDynamoDBTable_Replica_tags_nonPropagatedTagsAreUnmanaged
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_pitr (437.05s)
=== CONT  TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
--- PASS: TestAccDynamoDBTable_backupEncryption (853.86s)
=== CONT  TestAccDynamoDBTable_Replica_tags_notPropagatedToAddedReplica
--- PASS: TestAccDynamoDBTable_Replica_MRSC_pitr (426.99s)
=== CONT  TestAccDynamoDBTable_Replica_tags_propagateToAddedReplica
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (77.73s)
=== CONT  TestAccDynamoDBTable_extended
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_billingPayPerRequest (783.95s)
=== CONT  TestAccDynamoDBTable_Replica_tags_updateIsPropagated_twoOfTwo
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (895.87s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create_witness (261.34s)
=== CONT  TestAccDynamoDBTable_Replica_tags_updateIsPropagated_oneOfTwo
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_pitrKMS (580.20s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create (295.55s)
=== CONT  TestAccDynamoDBTable_Replica_pitrKMS
--- PASS: TestAccDynamoDBTable_Replica_MRSC_pitrKMS (621.24s)
=== CONT  TestAccDynamoDBTable_Replica_pitr
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (202.54s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
--- PASS: TestAccDynamoDBTable_Replica_single (803.64s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (174.57s)
=== CONT  TestAccDynamoDBTable_Replica_doubleAddCMK
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (342.84s)
=== CONT  TestAccDynamoDBTable_enablePITRWithCustomRecoveryPeriod
--- PASS: TestAccDynamoDBTable_extended (358.45s)
=== CONT  TestAccDynamoDBTable_Replica_singleCMK
--- PASS: TestAccDynamoDBTable_restoreCrossRegion (912.48s)
=== CONT  TestAccDynamoDBTable_enablePITR
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (174.60s)
=== CONT  TestAccDynamoDBTable_Replica_singleDefaultKeyEncryptedAmazonOwned
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (176.27s)
=== CONT  TestAccDynamoDBTable_GSIvalidate_keySchema_tooManyRangeKeys
--- PASS: TestAccDynamoDBTable_GSIvalidate_keySchema_tooManyRangeKeys (1.91s)
=== CONT  TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted
--- PASS: TestAccDynamoDBTable_enablePITRWithCustomRecoveryPeriod (137.36s)
=== CONT  TestAccDynamoDBTable_GSI_validate_keySchema_tooManyHashKeys
--- PASS: TestAccDynamoDBTable_GSI_validate_keySchema_tooManyHashKeys (1.84s)
=== CONT  TestAccDynamoDBTable_GSI_validate_exactlyOneOfKeySchemaHashKey
--- PASS: TestAccDynamoDBTable_GSI_validate_exactlyOneOfKeySchemaHashKey (1.60s)
=== CONT  TestAccDynamoDBTable_Replica_singleStreamSpecification
--- PASS: TestAccDynamoDBTable_enablePITR (112.11s)
=== CONT  TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema
--- PASS: TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema (1.43s)
=== CONT  TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_removeKey
--- PASS: TestAccDynamoDBTable_Replica_tags_propagateToAddedReplica (519.04s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_addHashKey
--- PASS: TestAccDynamoDBTable_Replica_tags_nonPropagatedTagsAreUnmanaged (548.29s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_removeGSI
--- PASS: TestAccDynamoDBTable_Replica_tags_notPropagatedToAddedReplica (539.60s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_removeRangeKey
--- PASS: TestAccDynamoDBTable_Replica_MRSC_doubleAddCMK (956.71s)
=== CONT  TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_addHashKey
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_doubleAddCMK (888.03s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_addRangeKey
--- PASS: TestAccDynamoDBTable_attributeUpdate (960.79s)
=== CONT  TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_noChange
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeGSI (107.76s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleRangeKeys
--- PASS: TestAccDynamoDBTable_Replica_tags_updateIsPropagated_twoOfTwo (621.47s)
=== CONT  TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_noChange
--- PASS: TestAccDynamoDBTable_Replica_singleCMK (280.82s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_maxSet
--- PASS: TestAccDynamoDBTable_Replica_tags_updateIsPropagated_oneOfTwo (581.40s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleRangeKey
--- PASS: TestAccDynamoDBTable_Replica_multiple (1178.06s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_removeHashKey
--- PASS: TestAccDynamoDBTable_Replica_deletionProtection (1344.15s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleHashKey
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (779.51s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_noChange (82.19s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleHashKeys
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleRangeKeys (60.67s)
=== CONT  TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_emptyProviderOnlyTag (58.12s)
=== CONT  TestAccDynamoDBTable_disappears
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleHashKey (75.54s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_providerOnly
--- PASS: TestAccDynamoDBTable_GSI_keySchema_maxSet (85.62s)
=== CONT  TestAccDynamoDBTable_deletion_protection
--- PASS: TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_noChange (95.02s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleRangeKey (93.46s)
=== CONT  TestAccDynamoDBTable_basic
--- PASS: TestAccDynamoDBTable_disappears (47.23s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleHashKeys (75.15s)
=== CONT  TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccDynamoDBTable_Replica_singleStreamSpecification (294.17s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted (309.32s)
=== CONT  TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccDynamoDBTable_Replica_pitr (603.55s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_overlapping
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_emptyResourceTag (59.13s)
=== CONT  TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccDynamoDBTable_basic (57.48s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccDynamoDBTable_deletion_protection (81.73s)
=== CONT  TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (163.41s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncryptedAmazonOwned (468.80s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccDynamoDBTable_Replica_pitrKMS (754.25s)
=== CONT  TestAccDynamoDBTable_Tags_ComputedTag_onCreate
--- PASS: TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_removeKey (399.24s)
=== CONT  TestAccDynamoDBTable_streamSpecificationDiffs
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_updateToResourceOnly (154.96s)
=== CONT  TestAccDynamoDBTable_onDemandThroughput
--- PASS: TestAccDynamoDBTable_GSI_keySchema_addHashKey (392.52s)
=== CONT  TestAccDynamoDBTable_gsiUpdateOtherAttributes
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeRangeKey (417.90s)
=== CONT  TestAccDynamoDBTable_streamSpecification
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_updateToProviderOnly (188.00s)
=== CONT  TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_DifferentFromTable
--- PASS: TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_addHashKey (410.89s)
=== CONT  TestAccDynamoDBTable_gsiOnDemandThroughput
--- PASS: TestAccDynamoDBTable_GSI_keySchema_addRangeKey (420.41s)
=== CONT  TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_SameAsTable
--- PASS: TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_defaultTag (254.35s)
=== CONT  TestAccDynamoDBTable_streamSpecificationValidation
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nullNonOverlappingResourceTag (159.83s)
=== CONT  TestAccDynamoDBTable_Tags_EmptyTag_onCreate
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nullOverlappingResourceTag (146.95s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestBasic
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_onCreate (139.39s)
=== CONT  TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_replace (230.51s)
=== CONT  TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (12.25s)
=== CONT  TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_resourceTag (278.38s)
=== CONT  TestAccDynamoDBTable_Tags_null
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_add (225.60s)
=== CONT  TestAccDynamoDBTable_Tags_emptyMap
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeHashKey (397.65s)
=== CONT  TestAccDynamoDBTable_Replica_upgradeV6_2_0
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_providerOnly (327.53s)
=== CONT  TestAccDynamoDBTable_encryption
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_overlapping (314.21s)
=== CONT  TestAccDynamoDBTable_Tags_addOnUpdate
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nonOverlapping (313.19s)
--- PASS: TestAccDynamoDBTable_streamSpecification (177.13s)
--- PASS: TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_DifferentFromTable (184.12s)
--- PASS: TestAccDynamoDBTable_gsiOnDemandThroughput (184.29s)
--- PASS: TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_SameAsTable (187.38s)
--- PASS: TestAccDynamoDBTable_onDemandThroughput (252.64s)
--- PASS: TestAccDynamoDBTable_Tags_emptyMap (122.36s)
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_onCreate (144.13s)
--- PASS: TestAccDynamoDBTable_Tags_null (127.79s)
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_replace (139.48s)
--- PASS: TestAccDynamoDBTable_Tags_addOnUpdate (114.50s)
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_add (171.52s)
--- PASS: TestAccDynamoDBTable_encryption (200.04s)
--- PASS: TestAccDynamoDBTable_streamSpecificationDiffs (354.99s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (300.14s)
--- PASS: TestAccDynamoDBTable_Replica_upgradeV6_2_0 (318.74s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestBasic (364.10s)
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (661.55s)
=== NAME  TestAccDynamoDBTable_Replica_doubleAddCMK
    table_test.go:5334: Step 2/3 error: Error running apply: exit status 1

        Error: updating AWS DynamoDB Table (tf-acc-test-7531351959465990478): updating replicas, while creating: creating replica (us-east-2): operation error DynamoDB: UpdateTable, https response error StatusCode: 400, RequestID: 9GL5GSTS45BSAFNICQI27NPAPVVV4KQNSO5AEMVJF66Q9ASUAAJG, api error ValidationException: Replica specified in the Replica Update or Replica Delete action of the request was not found.

          with aws_dynamodb_table.test,
          on terraform_plugin_test.tf line 68, in resource "aws_dynamodb_table" "test":
          68: resource "aws_dynamodb_table" "test" {

--- FAIL: TestAccDynamoDBTable_Replica_doubleAddCMK (2437.16s)
--- PASS: TestAccDynamoDBTable_TTL_updateDisable (3720.30s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   4319.624s
```

Failures are unrelated to this change.
