### PR TITLE
resource/aws_ecs_express_gateway_service: Fix environment variable ordering causing inconsistent apply

### DIFF
--- a/.changelog/46771.txt
+++ b/.changelog/46771.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_express_gateway_service: Fix `Provider produced inconsistent result after apply` error when `environment` variables are defined in non-alphabetical order
+```

--- a/internal/service/ecs/express_gateway_service.go
+++ b/internal/service/ecs/express_gateway_service.go
@@ -6,9 +6,11 @@
 package ecs
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/YakDriver/smarterr"
@@ -273,6 +275,7 @@ func (r *expressGatewayServiceResource) Create(ctx context.Context, req resource
 
 	// Set values for unknowns.
 	if len(waitOut.ActiveConfigurations) > 0 {
+		orderExpressGatewayContainerEnvironmentVariables(&waitOut.ActiveConfigurations[0])
 		smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, waitOut.ActiveConfigurations[0], &plan))
 		if resp.Diagnostics.HasError() {
 			return
@@ -315,6 +318,7 @@ func (r *expressGatewayServiceResource) Read(ctx context.Context, req resource.R
 	}
 
 	if len(out.ActiveConfigurations) > 0 {
+		orderExpressGatewayContainerEnvironmentVariables(&out.ActiveConfigurations[0])
 		smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, out.ActiveConfigurations[0], &state))
 		if resp.Diagnostics.HasError() {
 			return
@@ -422,6 +426,7 @@ func (r *expressGatewayServiceResource) Update(ctx context.Context, req resource
 
 	// Set values for unknowns.
 	if len(waitOut.ActiveConfigurations) > 0 {
+		orderExpressGatewayContainerEnvironmentVariables(&waitOut.ActiveConfigurations[0])
 		smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, waitOut.ActiveConfigurations[0], &plan))
 		if resp.Diagnostics.HasError() {
 			return
@@ -772,6 +777,21 @@ type expressGatewayScalingTargetModel struct {
 type ingressPathSummaryModel struct {
 	AccessType fwtypes.StringEnum[awstypes.AccessType] `tfsdk:"access_type"`
 	Endpoint   types.String                            `tfsdk:"endpoint"`
+}
+
+// orderExpressGatewayContainerEnvironmentVariables sorts the environment variables and secrets
+// in an ExpressGatewayServiceConfiguration by name. This prevents spurious diffs when the API
+// returns environment variables in a different order than the Terraform configuration.
+func orderExpressGatewayContainerEnvironmentVariables(config *awstypes.ExpressGatewayServiceConfiguration) {
+	if config == nil || config.PrimaryContainer == nil {
+		return
+	}
+	slices.SortFunc(config.PrimaryContainer.Environment, func(a, b awstypes.KeyValuePair) int {
+		return cmp.Compare(aws.ToString(a.Name), aws.ToString(b.Name))
+	})
+	slices.SortFunc(config.PrimaryContainer.Secrets, func(a, b awstypes.Secret) int {
+		return cmp.Compare(aws.ToString(a.Name), aws.ToString(b.Name))
+	})
 }
 
 func retryExpressGatewayServiceCreate(ctx context.Context, conn *ecs.Client, input *ecs.CreateExpressGatewayServiceInput) (*ecs.CreateExpressGatewayServiceOutput, error) {

--- a/internal/service/ecs/express_gateway_service.go
+++ b/internal/service/ecs/express_gateway_service.go
@@ -275,11 +275,15 @@ func (r *expressGatewayServiceResource) Create(ctx context.Context, req resource
 
 	// Set values for unknowns.
 	if len(waitOut.ActiveConfigurations) > 0 {
-		orderExpressGatewayContainerEnvironmentVariables(&waitOut.ActiveConfigurations[0])
+		// Save plan's env/secret ordering before flattening (API may reorder).
+		planEnv, planSecrets := preservePlanContainerOrdering(ctx, plan.PrimaryContainer)
+
 		smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, waitOut.ActiveConfigurations[0], &plan))
 		if resp.Diagnostics.HasError() {
 			return
 		}
+
+		restorePlanContainerOrdering(ctx, &plan.PrimaryContainer, planEnv, planSecrets)
 	}
 
 	plan.Cluster = fwflex.StringValueToFramework(ctx, cluster)
@@ -318,11 +322,19 @@ func (r *expressGatewayServiceResource) Read(ctx context.Context, req resource.R
 	}
 
 	if len(out.ActiveConfigurations) > 0 {
+		// Save state's env/secret ordering before flattening (API may reorder).
+		stateEnv, stateSecrets := preservePlanContainerOrdering(ctx, state.PrimaryContainer)
+
+		// Sort alphabetically as canonical ordering (used as default during import).
 		orderExpressGatewayContainerEnvironmentVariables(&out.ActiveConfigurations[0])
+
 		smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, out.ActiveConfigurations[0], &state))
 		if resp.Diagnostics.HasError() {
 			return
 		}
+
+		// Restore state ordering if env vars are unchanged (no-op during import).
+		restoreContainerOrderingIfUnchanged(ctx, &state.PrimaryContainer, stateEnv, stateSecrets)
 	}
 
 	// Set Optional+Computed attributes from API response
@@ -426,11 +438,16 @@ func (r *expressGatewayServiceResource) Update(ctx context.Context, req resource
 
 	// Set values for unknowns.
 	if len(waitOut.ActiveConfigurations) > 0 {
+		// Save plan's env/secret ordering before flattening (API may reorder).
+		planEnv, planSecrets := preservePlanContainerOrdering(ctx, plan.PrimaryContainer)
+
 		orderExpressGatewayContainerEnvironmentVariables(&waitOut.ActiveConfigurations[0])
 		smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, waitOut.ActiveConfigurations[0], &plan))
 		if resp.Diagnostics.HasError() {
 			return
 		}
+
+		restorePlanContainerOrdering(ctx, &plan.PrimaryContainer, planEnv, planSecrets)
 	}
 
 	// Set Optional+Computed attributes from API response
@@ -444,7 +461,9 @@ func (r *expressGatewayServiceResource) Update(ctx context.Context, req resource
 		}
 	}
 
-	plan.CurrentDeployment = fwflex.StringToFramework(ctx, waitOut.CurrentDeployment)
+	if !plan.CurrentDeployment.IsNull() {
+		plan.CurrentDeployment = fwflex.StringToFramework(ctx, waitOut.CurrentDeployment)
+	}
 
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
 }
@@ -777,6 +796,134 @@ type expressGatewayScalingTargetModel struct {
 type ingressPathSummaryModel struct {
 	AccessType fwtypes.StringEnum[awstypes.AccessType] `tfsdk:"access_type"`
 	Endpoint   types.String                            `tfsdk:"endpoint"`
+}
+
+// preservePlanContainerOrdering extracts the environment and secret lists from the plan's
+// primary container so they can be restored after flattening the API response.
+func preservePlanContainerOrdering(ctx context.Context, primaryContainer fwtypes.ListNestedObjectValueOf[expressGatewayContainerModel]) (
+	fwtypes.ListNestedObjectValueOf[keyValuePairModel],
+	fwtypes.ListNestedObjectValueOf[secretModel],
+) {
+	containers, diags := primaryContainer.ToSlice(ctx)
+	if diags.HasError() || len(containers) == 0 {
+		return fwtypes.NewListNestedObjectValueOfNull[keyValuePairModel](ctx),
+			fwtypes.NewListNestedObjectValueOfNull[secretModel](ctx)
+	}
+	return containers[0].Environment, containers[0].Secrets
+}
+
+// restorePlanContainerOrdering restores the environment and secret lists from the plan
+// into the primary container after flattening the API response. This ensures the state
+// after apply matches the plan's ordering, preventing "Provider produced inconsistent
+// result after apply" errors.
+func restorePlanContainerOrdering(
+	ctx context.Context,
+	primaryContainer *fwtypes.ListNestedObjectValueOf[expressGatewayContainerModel],
+	planEnv fwtypes.ListNestedObjectValueOf[keyValuePairModel],
+	planSecrets fwtypes.ListNestedObjectValueOf[secretModel],
+) {
+	containers, diags := primaryContainer.ToSlice(ctx)
+	if diags.HasError() || len(containers) == 0 {
+		return
+	}
+	containers[0].Environment = planEnv
+	containers[0].Secrets = planSecrets
+
+	updated, diags := fwtypes.NewListNestedObjectValueOfSlice(ctx, containers, nil)
+	if diags.HasError() {
+		return
+	}
+	*primaryContainer = updated
+}
+
+// restoreContainerOrderingIfUnchanged restores the previous state's environment and secret
+// ordering after flattening the API response, but only if the same set of key-value pairs
+// exists. If the environment variables or secrets have actually changed (added/removed/modified),
+// the API response ordering is kept.
+func restoreContainerOrderingIfUnchanged(
+	ctx context.Context,
+	primaryContainer *fwtypes.ListNestedObjectValueOf[expressGatewayContainerModel],
+	prevEnv fwtypes.ListNestedObjectValueOf[keyValuePairModel],
+	prevSecrets fwtypes.ListNestedObjectValueOf[secretModel],
+) {
+	containers, diags := primaryContainer.ToSlice(ctx)
+	if diags.HasError() || len(containers) == 0 {
+		return
+	}
+
+	// Check if environment variables are the same set (just reordered)
+	if envListsEquivalent(ctx, prevEnv, containers[0].Environment) {
+		containers[0].Environment = prevEnv
+	}
+
+	// Check if secrets are the same set (just reordered)
+	if secretListsEquivalent(ctx, prevSecrets, containers[0].Secrets) {
+		containers[0].Secrets = prevSecrets
+	}
+
+	updated, diags := fwtypes.NewListNestedObjectValueOfSlice(ctx, containers, nil)
+	if diags.HasError() {
+		return
+	}
+	*primaryContainer = updated
+}
+
+// envListsEquivalent returns true if two environment variable lists contain the same
+// set of name/value pairs, regardless of ordering.
+func envListsEquivalent(ctx context.Context, a, b fwtypes.ListNestedObjectValueOf[keyValuePairModel]) bool {
+	aSlice, diags := a.ToSlice(ctx)
+	if diags.HasError() {
+		return false
+	}
+	bSlice, diags := b.ToSlice(ctx)
+	if diags.HasError() {
+		return false
+	}
+	if len(aSlice) != len(bSlice) {
+		return false
+	}
+
+	// Build a map from a
+	aMap := make(map[string]string, len(aSlice))
+	for _, item := range aSlice {
+		aMap[item.Name.ValueString()] = item.Value.ValueString()
+	}
+
+	// Check all items in b exist in a with the same value
+	for _, item := range bSlice {
+		if v, ok := aMap[item.Name.ValueString()]; !ok || v != item.Value.ValueString() {
+			return false
+		}
+	}
+	return true
+}
+
+// secretListsEquivalent returns true if two secret lists contain the same
+// set of name/value_from pairs, regardless of ordering.
+func secretListsEquivalent(ctx context.Context, a, b fwtypes.ListNestedObjectValueOf[secretModel]) bool {
+	aSlice, diags := a.ToSlice(ctx)
+	if diags.HasError() {
+		return false
+	}
+	bSlice, diags := b.ToSlice(ctx)
+	if diags.HasError() {
+		return false
+	}
+	if len(aSlice) != len(bSlice) {
+		return false
+	}
+
+	aMap := make(map[string]string, len(aSlice))
+	for _, item := range aSlice {
+		aMap[item.Name.ValueString()] = item.ValueFrom.ValueString()
+	}
+
+	for _, item := range bSlice {
+		if v, ok := aMap[item.Name.ValueString()]; !ok || v != item.ValueFrom.ValueString() {
+			return false
+		}
+	}
+	return true
 }
 
 // orderExpressGatewayContainerEnvironmentVariables sorts the environment variables and secrets

--- a/internal/service/ecs/express_gateway_service_test.go
+++ b/internal/service/ecs/express_gateway_service_test.go
@@ -354,6 +354,72 @@ func TestAccECSExpressGatewayService_checkIdempotency(t *testing.T) {
 	})
 }
 
+// TestAccECSExpressGatewayService_environmentVariableOrdering verifies that
+// environment variables defined in non-alphabetical order do not cause
+// "Provider produced inconsistent result after apply" errors.
+// See: https://github.com/hashicorp/terraform-provider-aws/issues/45792
+func TestAccECSExpressGatewayService_environmentVariableOrdering(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var service awstypes.ECSExpressGatewayService
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ecs_express_gateway_service.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ECSEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExpressGatewayServiceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExpressGatewayServiceConfig_environmentVariableOrdering(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckExpressGatewayServiceExists(ctx, t, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.0.name", "ALPHA"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.0.value", "first"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.1.name", "BETA"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.1.value", "second"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.2.name", "ZULU"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.2.value", "third"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			// Re-apply the same config to verify no diff is detected (the bug caused
+			// "Provider produced inconsistent result after apply" here).
+			{
+				Config: testAccExpressGatewayServiceConfig_environmentVariableOrdering(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportStateVerifyIdentifierAttribute: "service_arn",
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "service_arn"),
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIgnore: []string{
+					"wait_for_steady_state",
+					"current_deployment",
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckExpressGatewayServiceDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).ECSClient(ctx)
@@ -704,6 +770,38 @@ resource "aws_ecs_express_gateway_service" "duplicate" {
   depends_on = [
     aws_ecs_express_gateway_service.test
   ]
+}
+`)
+}
+
+// testAccExpressGatewayServiceConfig_environmentVariableOrdering creates an express
+// gateway service with environment variables intentionally in non-alphabetical order
+// (ZULU, BETA, ALPHA). The API returns them sorted alphabetically, so the provider
+// must sort them before storing in state to avoid spurious diffs.
+func testAccExpressGatewayServiceConfig_environmentVariableOrdering(rName string) string {
+	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName), `
+resource "aws_ecs_express_gateway_service" "test" {
+  execution_role_arn      = aws_iam_role.execution.arn
+  infrastructure_role_arn = aws_iam_role.infrastructure.arn
+
+  primary_container {
+    image = "public.ecr.aws/nginx/nginx:1.28-alpine3.21-slim"
+
+    environment {
+      name  = "ZULU"
+      value = "third"
+    }
+
+    environment {
+      name  = "BETA"
+      value = "second"
+    }
+
+    environment {
+      name  = "ALPHA"
+      value = "first"
+    }
+  }
 }
 `)
 }

--- a/internal/service/ecs/express_gateway_service_test.go
+++ b/internal/service/ecs/express_gateway_service_test.go
@@ -355,8 +355,7 @@ func TestAccECSExpressGatewayService_checkIdempotency(t *testing.T) {
 }
 
 // TestAccECSExpressGatewayService_environmentVariableOrdering verifies that
-// environment variables defined in non-alphabetical order do not cause
-// "Provider produced inconsistent result after apply" errors.
+// non-alphabetical environment variables don't cause inconsistent apply errors.
 // See: https://github.com/hashicorp/terraform-provider-aws/issues/45792
 func TestAccECSExpressGatewayService_environmentVariableOrdering(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -378,16 +377,17 @@ func TestAccECSExpressGatewayService_environmentVariableOrdering(t *testing.T) {
 		CheckDestroy:             testAccCheckExpressGatewayServiceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
+				// Create with env vars in non-alphabetical order.
 				Config: testAccExpressGatewayServiceConfig_environmentVariableOrdering(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckExpressGatewayServiceExists(ctx, t, resourceName, &service),
 					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.#", "3"),
-					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.0.name", "ALPHA"),
-					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.0.value", "first"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.0.name", "ZULU"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.0.value", "third"),
 					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.1.name", "BETA"),
 					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.1.value", "second"),
-					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.2.name", "ZULU"),
-					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.2.value", "third"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.2.name", "ALPHA"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.2.value", "first"),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -395,8 +395,7 @@ func TestAccECSExpressGatewayService_environmentVariableOrdering(t *testing.T) {
 					},
 				},
 			},
-			// Re-apply the same config to verify no diff is detected (the bug caused
-			// "Provider produced inconsistent result after apply" here).
+			// Re-apply same config to verify no diff.
 			{
 				Config: testAccExpressGatewayServiceConfig_environmentVariableOrdering(rName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -405,6 +404,7 @@ func TestAccECSExpressGatewayService_environmentVariableOrdering(t *testing.T) {
 					},
 				},
 			},
+			// Import (env var ordering may differ due to alphabetical default).
 			{
 				ResourceName:                         resourceName,
 				ImportStateVerifyIdentifierAttribute: "service_arn",
@@ -414,6 +414,42 @@ func TestAccECSExpressGatewayService_environmentVariableOrdering(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"wait_for_steady_state",
 					"current_deployment",
+					// Import uses alphabetical ordering (no prior state to preserve).
+					"primary_container.0.environment.0.name",
+					"primary_container.0.environment.0.value",
+					"primary_container.0.environment.1.name",
+					"primary_container.0.environment.1.value",
+					"primary_container.0.environment.2.name",
+					"primary_container.0.environment.2.value",
+					"ingress_paths.0.endpoint",
+					"network_configuration.0.security_groups.#",
+					"network_configuration.0.security_groups.0",
+				},
+			},
+			{
+				// Update env vars.
+				Config: testAccExpressGatewayServiceConfig_environmentVariableUpdated(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckExpressGatewayServiceExists(ctx, t, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.0.name", "ZULU"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.0.value", "third"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.1.name", "GAMMA"),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.environment.1.value", "fourth"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			// Re-apply updated config to verify no diff.
+			{
+				Config: testAccExpressGatewayServiceConfig_environmentVariableUpdated(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
 				},
 			},
 		},
@@ -774,10 +810,8 @@ resource "aws_ecs_express_gateway_service" "duplicate" {
 `)
 }
 
-// testAccExpressGatewayServiceConfig_environmentVariableOrdering creates an express
-// gateway service with environment variables intentionally in non-alphabetical order
-// (ZULU, BETA, ALPHA). The API returns them sorted alphabetically, so the provider
-// must sort them before storing in state to avoid spurious diffs.
+// testAccExpressGatewayServiceConfig_environmentVariableOrdering creates a service
+// with env vars in non-alphabetical order.
 func testAccExpressGatewayServiceConfig_environmentVariableOrdering(rName string) string {
 	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName), `
 resource "aws_ecs_express_gateway_service" "test" {
@@ -800,6 +834,31 @@ resource "aws_ecs_express_gateway_service" "test" {
     environment {
       name  = "ALPHA"
       value = "first"
+    }
+  }
+}
+`)
+}
+
+// testAccExpressGatewayServiceConfig_environmentVariableUpdated creates a service
+// with updated env vars to test ordering after add/remove.
+func testAccExpressGatewayServiceConfig_environmentVariableUpdated(rName string) string {
+	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName), `
+resource "aws_ecs_express_gateway_service" "test" {
+  execution_role_arn      = aws_iam_role.execution.arn
+  infrastructure_role_arn = aws_iam_role.infrastructure.arn
+
+  primary_container {
+    image = "public.ecr.aws/nginx/nginx:1.28-alpine3.21-slim"
+
+    environment {
+      name  = "ZULU"
+      value = "third"
+    }
+
+    environment {
+      name  = "GAMMA"
+      value = "fourth"
     }
   }
 }


### PR DESCRIPTION
### Description

The AWS `DescribeExpressGatewayService` API returns `PrimaryContainer.Environment` and `PrimaryContainer.Secrets` sorted alphabetically by name. When a user defines environment variables in a non-alphabetical order in their Terraform configuration, the provider stored them in the API-returned (alphabetical) order, which differs from the planned order. This caused Terraform to produce a `Provider produced inconsistent result after apply` error.

The original PR (#46771) attempted to fix this by sorting the API response alphabetically before flattening. However, this doesn't work because the Terraform framework compares the **plan** (which preserves the user's config ordering) against the **state** after apply — so alphabetically sorting the state still mismatches the plan when env vars are defined in non-alphabetical order.

### Approach

Instead of sorting, this fix **preserves the plan/state ordering** of environment variables and secrets:

- **Create/Update**: Saves the plan's env var and secret ordering before `fwflex.Flatten`, then restores it afterward so the state matches the plan exactly.
- **Read**: Preserves the prior state's ordering for refresh idempotency. During import (where no prior state exists), alphabetical ordering is used as a stable default.
- **Update**: Also fixes a secondary issue where `current_deployment` transitioned from `null` to a real ARN during the first Update after Create, causing the same "inconsistent result" error.

Closes #46771.
Closes #45792.

### Output from Acceptance Testing
\--- PASS: TestAccECSExpressGatewayService_basic (58.82s) 
\--- PASS: TestAccECSExpressGatewayService_disappears (33.67s) 
\--- PASS: TestAccECSExpressGatewayService_tags (64.65s) 
--- PASS: TestAccECSExpressGatewayService_update (48.15s) 
--- PASS: TestAccECSExpressGatewayService_networkConfiguration (39.07s) 
--- PASS: TestAccECSExpressGatewayService_checkIdempotency (37.36s) 
--- PASS: TestAccECSExpressGatewayService_environmentVariableOrdering (75.46s) 
PASS ok github.com/hashicorp/terraform-provider-aws/internal/service/ecs 82.386s
