### PR TITLE
Upgrade `google.golang.org/grpc`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -391,6 +391,6 @@ require (
 	golang.org/x/sys v0.42.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
-	google.golang.org/grpc v1.79.2 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -892,8 +892,8 @@ google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAs
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 h1:gRkg/vSppuSQoDjxyiGfN4Upv/h/DQmIR10ZU8dh4Ww=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
-google.golang.org/grpc v1.79.2 h1:fRMD94s2tITpyJGtBBn7MkMseNpOZU8ZxgC3MMBaXRU=
-google.golang.org/grpc v1.79.2/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
+google.golang.org/grpc v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Upgrades to the latest version of `google.golang.org/grpc`, which usually occurs via `terraform-plugin-framework`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Addresses https://github.com/hashicorp/terraform-provider-aws/security/dependabot/137.

```console
% make sane
make: Sane Smoke Tests (x tests of Top y resources)
make: Like 'sanity' except full output and stops soon after 1st error
make: NOTE: NOT an exhaustive set of tests! Finds big problems only.
2026/03/24 08:07:22 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/24 08:07:22 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIAMInstanceProfile_tags
=== PAUSE TestAccIAMInstanceProfile_tags
=== RUN   TestAccIAMInstanceProfile_basic
=== PAUSE TestAccIAMInstanceProfile_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_basic
=== PAUSE TestAccIAMPolicyDocumentDataSource_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== RUN   TestAccIAMPolicy_tags
=== PAUSE TestAccIAMPolicy_tags
=== RUN   TestAccIAMPolicy_basic
=== PAUSE TestAccIAMPolicy_basic
=== RUN   TestAccIAMPolicy_policy
=== PAUSE TestAccIAMPolicy_policy
=== RUN   TestAccIAMRolePolicyAttachment_basic
=== PAUSE TestAccIAMRolePolicyAttachment_basic
=== RUN   TestAccIAMRolePolicyAttachment_disappears
=== PAUSE TestAccIAMRolePolicyAttachment_disappears
=== RUN   TestAccIAMRolePolicyAttachment_Disappears_role
=== PAUSE TestAccIAMRolePolicyAttachment_Disappears_role
=== RUN   TestAccIAMRolePolicy_basic
=== PAUSE TestAccIAMRolePolicy_basic
=== RUN   TestAccIAMRolePolicy_unknownsInPolicy
=== PAUSE TestAccIAMRolePolicy_unknownsInPolicy
=== RUN   TestAccIAMRole_basic
=== PAUSE TestAccIAMRole_basic
=== RUN   TestAccIAMRole_namePrefix
=== PAUSE TestAccIAMRole_namePrefix
=== RUN   TestAccIAMRole_disappears
=== PAUSE TestAccIAMRole_disappears
=== RUN   TestAccIAMRole_InlinePolicy_basic
=== PAUSE TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMInstanceProfile_tags
=== CONT  TestAccIAMRolePolicyAttachment_disappears
=== CONT  TestAccIAMRole_basic
=== CONT  TestAccIAMRolePolicy_basic
=== CONT  TestAccIAMRole_disappears
=== CONT  TestAccIAMPolicyDocumentDataSource_basic
=== CONT  TestAccIAMInstanceProfile_basic
=== CONT  TestAccIAMRolePolicy_unknownsInPolicy
=== CONT  TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMRole_namePrefix
=== CONT  TestAccIAMRolePolicyAttachment_basic
=== CONT  TestAccIAMRolePolicyAttachment_Disappears_role
=== CONT  TestAccIAMPolicy_basic
=== CONT  TestAccIAMPolicy_tags
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== CONT  TestAccIAMPolicy_policy
--- PASS: TestAccIAMPolicyDocumentDataSource_basic (25.46s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceConflicting (25.96s)
--- PASS: TestAccIAMRole_disappears (32.96s)
--- PASS: TestAccIAMRolePolicyAttachment_Disappears_role (33.24s)
--- PASS: TestAccIAMRolePolicyAttachment_disappears (33.36s)
--- PASS: TestAccIAMRolePolicy_unknownsInPolicy (35.66s)
--- PASS: TestAccIAMPolicy_basic (36.58s)
--- PASS: TestAccIAMRole_basic (36.91s)
--- PASS: TestAccIAMRole_namePrefix (36.92s)
--- PASS: TestAccIAMRolePolicy_basic (36.94s)
--- PASS: TestAccIAMInstanceProfile_basic (40.82s)
--- PASS: TestAccIAMRolePolicyAttachment_basic (49.41s)
--- PASS: TestAccIAMPolicy_policy (50.31s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (60.88s)
--- PASS: TestAccIAMPolicy_tags (92.34s)
--- PASS: TestAccIAMInstanceProfile_tags (110.79s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        116.779s
2026/03/24 08:09:55 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/24 08:09:55 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLogsLogGroup_basic
=== PAUSE TestAccLogsLogGroup_basic
=== RUN   TestAccLogsLogGroup_multiple
=== PAUSE TestAccLogsLogGroup_multiple
=== CONT  TestAccLogsLogGroup_basic
=== CONT  TestAccLogsLogGroup_multiple
--- PASS: TestAccLogsLogGroup_multiple (22.43s)
--- PASS: TestAccLogsLogGroup_basic (26.39s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       32.385s
2026/03/24 08:10:03 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/24 08:10:03 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCDataSource_basic
=== PAUSE TestAccVPCDataSource_basic
=== RUN   TestAccVPCRouteTableAssociation_Subnet_basic
=== PAUSE TestAccVPCRouteTableAssociation_Subnet_basic
=== RUN   TestAccVPCRouteTable_basic
=== PAUSE TestAccVPCRouteTable_basic
=== RUN   TestAccVPCSecurityGroupRule_race
=== PAUSE TestAccVPCSecurityGroupRule_race
=== RUN   TestAccVPCSecurityGroupRule_protocolChange
=== PAUSE TestAccVPCSecurityGroupRule_protocolChange
=== RUN   TestAccVPCSecurityGroup_basic
=== PAUSE TestAccVPCSecurityGroup_basic
=== RUN   TestAccVPCSecurityGroup_egressMode
=== PAUSE TestAccVPCSecurityGroup_egressMode
=== RUN   TestAccVPCSecurityGroup_vpcAllEgress
=== PAUSE TestAccVPCSecurityGroup_vpcAllEgress
=== RUN   TestAccVPCSubnet_basic
=== PAUSE TestAccVPCSubnet_basic
=== RUN   TestAccVPC_tenancy
=== PAUSE TestAccVPC_tenancy
=== CONT  TestAccVPCDataSource_basic
=== CONT  TestAccVPCSecurityGroup_basic
=== CONT  TestAccVPCSecurityGroup_egressMode
=== CONT  TestAccVPCSubnet_basic
=== CONT  TestAccVPC_tenancy
=== CONT  TestAccVPCSecurityGroupRule_race
=== CONT  TestAccVPCSecurityGroupRule_protocolChange
=== CONT  TestAccVPCRouteTableAssociation_Subnet_basic
=== CONT  TestAccVPCSecurityGroup_vpcAllEgress
=== CONT  TestAccVPCRouteTable_basic
--- PASS: TestAccVPCSubnet_basic (36.30s)
--- PASS: TestAccVPCRouteTable_basic (36.93s)
--- PASS: TestAccVPCSecurityGroup_basic (38.23s)
--- PASS: TestAccVPCSecurityGroup_vpcAllEgress (38.24s)
--- PASS: TestAccVPCDataSource_basic (39.12s)
--- PASS: TestAccVPCRouteTableAssociation_Subnet_basic (39.26s)
--- PASS: TestAccVPCSecurityGroup_egressMode (66.07s)
--- PASS: TestAccVPCSecurityGroupRule_protocolChange (70.43s)
--- PASS: TestAccVPC_tenancy (74.27s)
--- PASS: TestAccVPCSecurityGroupRule_race (170.39s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        185.236s
2026/03/24 08:09:59 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/24 08:09:59 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== CONT  TestAccECSService_basic
=== CONT  TestAccECSTaskDefinition_basic
--- PASS: TestAccECSTaskDefinition_basic (39.37s)
--- PASS: TestAccECSService_basic (87.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        97.751s
?       github.com/hashicorp/terraform-provider-aws/internal/service/ecs/test-fixtures  [no test files]
2026/03/24 08:10:08 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/24 08:10:08 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccELBV2TargetGroup_basic
=== PAUSE TestAccELBV2TargetGroup_basic
=== CONT  TestAccELBV2TargetGroup_basic
--- PASS: TestAccELBV2TargetGroup_basic (30.38s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      49.456s
2026/03/24 08:10:12 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/24 08:10:12 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEventsPutEventsAction_basic
=== PAUSE TestAccEventsPutEventsAction_basic
=== CONT  TestAccEventsPutEventsAction_basic
--- PASS: TestAccEventsPutEventsAction_basic (224.88s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/events     247.263s
2026/03/24 08:10:16 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/24 08:10:16 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKMSKey_basic
=== PAUSE TestAccKMSKey_basic
=== CONT  TestAccKMSKey_basic
--- PASS: TestAccKMSKey_basic (40.05s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kms        66.566s
2026/03/24 08:14:30 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/24 08:14:30 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== RUN   TestAccLambdaPermission_basic
=== PAUSE TestAccLambdaPermission_basic
=== CONT  TestAccLambdaFunction_basic
=== CONT  TestAccLambdaPermission_basic
--- PASS: TestAccLambdaPermission_basic (43.37s)
--- PASS: TestAccLambdaFunction_basic (52.73s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     67.297s
2026/03/24 08:14:22 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/24 08:14:22 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccMetaPartitionDataSource_basic
=== PAUSE TestAccMetaPartitionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_basic
=== PAUSE TestAccMetaRegionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_endpoint
=== PAUSE TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaPartitionDataSource_basic
=== CONT  TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaRegionDataSource_basic
--- PASS: TestAccMetaPartitionDataSource_basic (14.11s)
--- PASS: TestAccMetaRegionDataSource_endpoint (15.12s)
--- PASS: TestAccMetaRegionDataSource_basic (15.13s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/meta       21.191s
2026/03/24 08:14:26 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/24 08:14:26 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRoute53Record_basic
=== PAUSE TestAccRoute53Record_basic
=== RUN   TestAccRoute53Record_Latency_basic
=== PAUSE TestAccRoute53Record_Latency_basic
=== RUN   TestAccRoute53ZoneDataSource_name
=== PAUSE TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_basic
=== CONT  TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_Latency_basic
--- PASS: TestAccRoute53ZoneDataSource_name (77.75s)
--- PASS: TestAccRoute53Record_Latency_basic (141.86s)
--- PASS: TestAccRoute53Record_basic (142.49s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    152.748s
2026/03/24 08:14:39 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/24 08:14:39 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3BucketACL_updateACL
=== PAUSE TestAccS3BucketACL_updateACL
=== RUN   TestAccS3BucketPolicy_basic
=== PAUSE TestAccS3BucketPolicy_basic
=== RUN   TestAccS3BucketPublicAccessBlock_basic
=== PAUSE TestAccS3BucketPublicAccessBlock_basic
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Security_corsUpdate
=== PAUSE TestAccS3Bucket_Security_corsUpdate
=== RUN   TestAccS3Object_basic
=== PAUSE TestAccS3Object_basic
=== CONT  TestAccS3BucketACL_updateACL
=== CONT  TestAccS3BucketPublicAccessBlock_basic
=== CONT  TestAccS3BucketPolicy_basic
=== CONT  TestAccS3Object_basic
=== CONT  TestAccS3Bucket_Security_corsUpdate
=== CONT  TestAccS3Bucket_Basic_basic
--- PASS: TestAccS3BucketPublicAccessBlock_basic (31.85s)
--- PASS: TestAccS3BucketPolicy_basic (32.04s)
--- PASS: TestAccS3Bucket_Basic_basic (32.69s)
--- PASS: TestAccS3Object_basic (35.78s)
--- PASS: TestAccS3BucketACL_updateACL (48.09s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (50.25s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 69.953s
2026/03/24 08:14:43 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/24 08:14:43 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSSMParameterEphemeral_basic
=== PAUSE TestAccSSMParameterEphemeral_basic
=== CONT  TestAccSSMParameterEphemeral_basic
--- PASS: TestAccSSMParameterEphemeral_basic (20.17s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        43.973s
2026/03/24 08:14:52 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/24 08:14:52 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSecretsManagerSecret_basic
=== PAUSE TestAccSecretsManagerSecret_basic
=== CONT  TestAccSecretsManagerSecret_basic
--- PASS: TestAccSecretsManagerSecret_basic (22.07s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager     54.497s
2026/03/24 08:14:48 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/24 08:14:48 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSTSCallerIdentityDataSource_basic
=== PAUSE TestAccSTSCallerIdentityDataSource_basic
=== CONT  TestAccSTSCallerIdentityDataSource_basic
--- PASS: TestAccSTSCallerIdentityDataSource_basic (13.24s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sts        41.405s
2026/03/24 08:14:35 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/24 08:14:35 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestARNParseFunction_known
=== PAUSE TestARNParseFunction_known
=== CONT  TestARNParseFunction_known
--- PASS: TestARNParseFunction_known (11.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/function   26.877s
```
