### PR TITLE
fix(security hub): allow SELF_MANAGED_SECURITY_HUB

### DIFF
--- a/.changelog/47078.txt
+++ b/.changelog/47078.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_securityhub_configuration_policy_association: Add support for `SELF_MANAGED_SECURITY_HUB` as a `policy_id` value
+```

--- a/internal/service/securityhub/configuration_policy_association.go
+++ b/internal/service/securityhub/configuration_policy_association.go
@@ -46,10 +46,13 @@ func resourceConfigurationPolicyAssociation() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"policy_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				Description:  "The universally unique identifier (UUID) of the configuration policy.",
-				ValidateFunc: validation.IsUUID,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The universally unique identifier (UUID) of the configuration policy, or SELF_MANAGED_SECURITY_HUB for a self-managed configuration.",
+				ValidateFunc: validation.Any(
+					validation.IsUUID,
+					validation.StringInSlice([]string{"SELF_MANAGED_SECURITY_HUB"}, false),
+				),
 			},
 			"target_id": {
 				Type:        schema.TypeString,

--- a/internal/service/securityhub/configuration_policy_association_test.go
+++ b/internal/service/securityhub/configuration_policy_association_test.go
@@ -216,6 +216,61 @@ resource "aws_securityhub_configuration_policy" "test_2" {
 }`, rName)
 }
 
+func testAccConfigurationPolicyAssociation_selfManagedSecurityHub(t *testing.T) {
+	ctx := acctest.Context(t)
+	providers := make(map[string]*schema.Provider)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_securityhub_configuration_policy_association.test"
+	ouTarget := "aws_organizations_organizational_unit.test.id"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+			acctest.PreCheckOrganizationMemberAccount(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecurityHubServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesNamedAlternate(ctx, t, providers),
+		CheckDestroy:             testAccCheckConfigurationPolicyAssociationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Run a simple configuration to initialize the alternate providers
+				Config: testAccOrganizationConfigurationConfig_centralConfigurationInit,
+			},
+			{
+				PreConfig: func() {
+					acctest.PreCheckOrganizationManagementAccountWithProvider(ctx, t, acctest.NamedProviderFunc(acctest.ProviderNameAlternate, providers))
+				},
+				Config: testAccConfigurationPolicyAssociationConfig_selfManaged(rName, ouTarget),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationPolicyAssociationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "policy_id", "SELF_MANAGED_SECURITY_HUB"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_id", "aws_organizations_organizational_unit.test", names.AttrID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccConfigurationPolicyAssociationConfig_selfManaged(rName, targetID string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAlternateAccountProvider(),
+		testAccMemberAccountDelegatedAdminConfig_base,
+		testAccOrganizationalUnitConfig_base(rName),
+		testAccCentralConfigurationEnabledConfig_base,
+		fmt.Sprintf(`
+resource "aws_securityhub_configuration_policy_association" "test" {
+  target_id = %[1]s
+  policy_id = "SELF_MANAGED_SECURITY_HUB"
+}
+`, targetID))
+}
+
 func testAccConfigurationPolicyAssociationConfig_basic(rName, targetID, policyID string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAlternateAccountProvider(),

--- a/internal/service/securityhub/securityhub_test.go
+++ b/internal/service/securityhub/securityhub_test.go
@@ -45,8 +45,9 @@ func TestAccSecurityHub_serial(t *testing.T) {
 			"ControlIdentifiers": testAccConfigurationPolicy_specificControlIdentifiers,
 		},
 		"ConfigurationPolicyAssociation": {
-			acctest.CtBasic:      testAccConfigurationPolicyAssociation_basic,
-			acctest.CtDisappears: testAccConfigurationPolicyAssociation_disappears,
+			acctest.CtBasic:          testAccConfigurationPolicyAssociation_basic,
+			acctest.CtDisappears:     testAccConfigurationPolicyAssociation_disappears,
+			"SelfManagedSecurityHub": testAccConfigurationPolicyAssociation_selfManagedSecurityHub,
 		},
 		"FindingAggregator": {
 			acctest.CtBasic:      testAccFindingAggregator_basic,

--- a/website/docs/r/securityhub_configuration_policy_association.html.markdown
+++ b/website/docs/r/securityhub_configuration_policy_association.html.markdown
@@ -61,6 +61,11 @@ resource "aws_securityhub_configuration_policy_association" "ou_example" {
   target_id = "ou-abcd-12345678"
   policy_id = aws_securityhub_configuration_policy.example.id
 }
+
+resource "aws_securityhub_configuration_policy_association" "self_managed_example" {
+  target_id = "123456789012"
+  policy_id = "SELF_MANAGED_SECURITY_HUB"
+}
 ```
 
 ## Argument Reference
@@ -68,7 +73,7 @@ resource "aws_securityhub_configuration_policy_association" "ou_example" {
 This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `policy_id` - (Required) The universally unique identifier (UUID) of the configuration policy.
+* `policy_id` - (Required) The universally unique identifier (UUID) of the configuration policy, or `SELF_MANAGED_SECURITY_HUB` for a self-managed configuration.
 * `target_id` - (Required, Forces new resource) The identifier of the target account, organizational unit, or the root to associate with the specified configuration.
 
 ## Attribute Reference


### PR DESCRIPTION
# Description

This fixes an issue with the `aws_securityhub_configuration_policy_association` resource, where the `policy_id` validation used to require a UUID, but the AWS API docs states this can be a UUID or the string `SELF_MANAGED_SECURITY_HUB`

### Relations

Partially addresses https://github.com/hashicorp/terraform-provider-aws/issues/39392#issuecomment-2915899576

### References

https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_StartConfigurationPolicyAssociation.html#API_StartConfigurationPolicyAssociation_RequestBody
https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_StartConfigurationPolicyAssociation.html#API_StartConfigurationPolicyAssociation_RequestSyntax

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccSecurityHub_serial/ConfigurationPolicyAssociation PKG=securityhub
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 support-SELF_MANAGED_SECURITY_HUB 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/securityhub/... -v -count 1 -parallel 20 -run='TestAccSecurityHub_serial/ConfigurationPolicyAssociation'  -timeout 360m -vet=off
2026/03/24 09:34:34 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/24 09:34:34 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSecurityHub_serial
=== PAUSE TestAccSecurityHub_serial
=== CONT  TestAccSecurityHub_serial
=== RUN   TestAccSecurityHub_serial/ConfigurationPolicyAssociation
=== RUN   TestAccSecurityHub_serial/ConfigurationPolicyAssociation/disappears
    configuration_policy_association_test.go:101: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
=== RUN   TestAccSecurityHub_serial/ConfigurationPolicyAssociation/SelfManagedSecurityHub
    configuration_policy_association_test.go:229: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
=== RUN   TestAccSecurityHub_serial/ConfigurationPolicyAssociation/basic
    configuration_policy_association_test.go:34: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- PASS: TestAccSecurityHub_serial (1.11s)
    --- PASS: TestAccSecurityHub_serial/ConfigurationPolicyAssociation (1.11s)
        --- SKIP: TestAccSecurityHub_serial/ConfigurationPolicyAssociation/disappears (1.00s)
        --- SKIP: TestAccSecurityHub_serial/ConfigurationPolicyAssociation/SelfManagedSecurityHub (0.06s)
        --- SKIP: TestAccSecurityHub_serial/ConfigurationPolicyAssociation/basic (0.04s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/securityhub	6.564s
```
