### PR TITLE
r/aws_instance: Fix perpetual `source_dest_check` drift with `primary_network_interface`

### DIFF
--- a/.changelog/44768.txt
+++ b/.changelog/44768.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_instance: Fix perpetual `source_dest_check` drift when using `primary_network_interface` with an ENI that has `source_dest_check` set to `false`
+```

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -890,9 +890,10 @@ func resourceInstance() *schema.Resource {
 				Optional: true,
 				Default:  true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// Suppress diff if network_interface is set
-					_, ok := d.GetOk("network_interface")
-					return ok
+					// Suppress diff if network_interface or primary_network_interface is set
+					_, niOk := d.GetOk("network_interface")
+					_, pniOk := d.GetOk("primary_network_interface")
+					return niOk || pniOk
 				},
 			},
 			"spot_instance_request_id": {
@@ -1414,9 +1415,11 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta an
 		}
 	}
 
-	// SourceDestCheck can only be modified on an instance without manually specified network interfaces.
-	// SourceDestCheck, in that case, is configured at the network interface level
-	if _, ok := d.GetOk("network_interface"); !ok {
+	// SourceDestCheck should only be modified at the instance level when no explicit network interface
+	// is attached via network_interface or primary_network_interface. Otherwise it is managed on the ENI.
+	_, niOk := d.GetOk("network_interface")
+	_, pniOk := d.GetOk("primary_network_interface")
+	if !niOk && !pniOk {
 		// If we have a new resource and source_dest_check is still true, don't modify
 		sourceDestCheck := d.Get("source_dest_check").(bool)
 

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -3436,6 +3436,39 @@ func TestAccEC2Instance_NetworkInterface_primaryNetworkInterfaceSourceDestCheck(
 	})
 }
 
+func TestAccEC2Instance_PrimaryNetworkInterface_sourceDestCheckNoDrift(t *testing.T) {
+	ctx := acctest.Context(t)
+	var instance awstypes.Instance
+	var eni awstypes.NetworkInterface
+	resourceName := "aws_instance.test"
+	eniResourceName := "aws_network_interface.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_primaryNetworkInterface_sourceDestCheck(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, t, resourceName, &instance),
+					testAccCheckENIExists(ctx, t, eniResourceName, &eni),
+					resource.TestCheckResourceAttr(eniResourceName, "source_dest_check", acctest.CtFalse),
+				),
+			},
+			// Re-plan same config — must produce no diff.
+			// Before the fix for #44768, this step fails because
+			// source_dest_check drifts from false to true on the instance.
+			{
+				Config:   testAccInstanceConfig_primaryNetworkInterface_sourceDestCheck(rName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccEC2Instance_NetworkInterface_attachSecondaryInterface_inlineAttachment(t *testing.T) {
 	ctx := acctest.Context(t)
 	var before, after awstypes.Instance
@@ -9357,6 +9390,36 @@ resource "aws_instance" "test" {
   network_interface {
     network_interface_id = aws_network_interface.test.id
     device_index         = 0
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccInstanceConfig_primaryNetworkInterface_sourceDestCheck(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		testAccInstanceConfig_vpcBase(rName, false, 0),
+		fmt.Sprintf(`
+resource "aws_network_interface" "test" {
+  subnet_id         = aws_subnet.test.id
+  private_ips       = ["10.1.1.42"]
+  source_dest_check = false
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type = "t2.micro"
+
+  primary_network_interface {
+    network_interface_id = aws_network_interface.test.id
   }
 
   tags = {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The `DiffSuppressFunc` and update guard for `source_dest_check` only checked for the deprecated `network_interface` block, not the newer `primary_network_interface` block. This caused an infinite plan/apply loop when an ENI with `source_dest_check = false` was attached via `primary_network_interface`, because the provider would repeatedly call `ModifyInstanceAttribute` to reset it to the default of `true`.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #44768

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS="TestAccEC2Instance_PrimaryNetworkInterface_sourceDestCheckNoDrift|TestAccEC2Instance_NetworkInterface_primaryNetworkInterfaceSourceDestCheck" PKG=ec2 GO_VER=go                                                  
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 44768 🌿...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Instance_PrimaryNetworkInterface_sourceDestCheckNoDrift|TestAccEC2Instance_NetworkInterface_primaryNetworkInterfaceSourceDestCheck'  -timeout 360m -vet=off
2026/03/24 14:12:08 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/24 14:12:08 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEC2Instance_NetworkInterface_primaryNetworkInterfaceSourceDestCheck
=== PAUSE TestAccEC2Instance_NetworkInterface_primaryNetworkInterfaceSourceDestCheck
=== RUN   TestAccEC2Instance_PrimaryNetworkInterface_sourceDestCheckNoDrift
=== PAUSE TestAccEC2Instance_PrimaryNetworkInterface_sourceDestCheckNoDrift
=== CONT  TestAccEC2Instance_NetworkInterface_primaryNetworkInterfaceSourceDestCheck
=== CONT  TestAccEC2Instance_PrimaryNetworkInterface_sourceDestCheckNoDrift
--- PASS: TestAccEC2Instance_NetworkInterface_primaryNetworkInterfaceSourceDestCheck (318.95s)
--- PASS: TestAccEC2Instance_PrimaryNetworkInterface_sourceDestCheckNoDrift (342.57s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        347.514s

...
```
