### PR TITLE
resource/aws_ecs_service: clear lifecycle hooks on removal

### DIFF
--- a/.changelog/47096.txt
+++ b/.changelog/47096.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_service: Fix `deployment_configuration.lifecycle_hook` not being removed from the ECS service when removed from configuration
+```

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -1640,6 +1640,8 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta any
 				input.DeploymentConfiguration = &awstypes.DeploymentConfiguration{}
 			}
 
+			input.DeploymentConfiguration.LifecycleHooks = []awstypes.DeploymentLifecycleHook{}
+
 			if v, ok := d.GetOk("deployment_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 				config := v.([]any)[0].(map[string]any)
 

--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -1135,6 +1135,39 @@ func TestAccECSService_BlueGreenDeployment_outOfBandRemoval(t *testing.T) {
 	})
 }
 
+func TestAccECSService_BlueGreenDeployment_removeLifecycleHook(t *testing.T) {
+	ctx := acctest.Context(t)
+	var service awstypes.Service
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)[:16] // Use shorter name to avoid target group name length issues
+	resourceName := "aws_ecs_service.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckServiceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceConfig_blueGreenDeployment_switchToRolling(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, t, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "deployment_configuration.0.strategy", "ROLLING"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_configuration.0.lifecycle_hook.#", "1"),
+				),
+			},
+			{
+				Config: testAccServiceConfig_blueGreenDeployment_switchToRollingWithoutLifecycleHook(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, t, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "deployment_configuration.0.strategy", "ROLLING"),
+					resource.TestCheckNoResourceAttr(resourceName, "deployment_configuration.0.lifecycle_hook.#"),
+					testAccCheckServiceNoLifecycleHooks(&service),
+				),
+			},
+		},
+	})
+}
+
 func TestAccECSService_BlueGreenDeployment_sigintRollback(t *testing.T) {
 	acctest.Skip(t, "SIGINT handling can't reliably be tested in CI")
 
@@ -3332,6 +3365,16 @@ func testAccCheckServiceExists(ctx context.Context, t *testing.T, name string, s
 	}
 }
 
+func testAccCheckServiceNoLifecycleHooks(service *awstypes.Service) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if service.DeploymentConfiguration != nil && len(service.DeploymentConfiguration.LifecycleHooks) > 0 {
+			return fmt.Errorf("expected ECS service %s to have no lifecycle hooks, found %d", aws.ToString(service.ServiceName), len(service.DeploymentConfiguration.LifecycleHooks))
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckServiceDisableServiceConnect(ctx context.Context, t *testing.T, service *awstypes.Service) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).ECSClient(ctx)
@@ -4378,6 +4421,65 @@ resource "aws_ecs_service" "test" {
       role_arn         = aws_iam_role.global.arn
       lifecycle_stages = ["PRE_SCALE_UP"]
     }
+  }
+
+  service_connect_configuration {
+    enabled   = true
+    namespace = aws_service_discovery_http_namespace.test.arn
+
+    service {
+      client_alias {
+        dns_name = "test-service.local"
+        port     = 8080
+
+        test_traffic_rules {
+          header {
+            name = "x-test-header"
+            value {
+              exact = "test-value"
+            }
+          }
+        }
+      }
+      discovery_name = "test-service"
+      port_name      = "http"
+    }
+  }
+
+  network_configuration {
+    security_groups  = [aws_security_group.test.id]
+    subnets          = aws_subnet.test[*].id
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.alternate.arn
+    container_name   = "test"
+    container_port   = 80
+  }
+
+  wait_for_steady_state = true
+
+  depends_on = [
+    aws_iam_role_policy_attachment.global_admin_attach,
+    aws_iam_role_policy.ecs_elb_permissions,
+    aws_iam_role_policy_attachment.ecs_service_role
+  ]
+}
+`, rName))
+}
+
+func testAccServiceConfig_blueGreenDeployment_switchToRollingWithoutLifecycleHook(rName string) string {
+	return acctest.ConfigCompose(testAccServiceConfig_blueGreenDeploymentBase(rName), fmt.Sprintf(`
+resource "aws_ecs_service" "test" {
+  name            = %[1]q
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.test.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  deployment_configuration {
+    strategy = "ROLLING"
   }
 
   service_connect_configuration {


### PR DESCRIPTION
## Rollback Plan

If this change needs to be reverted, we can ship a follow-up provider release that restores the previous `aws_ecs_service` update behavior.

## Changes to Security Controls

No changes to security controls.

### Description

This fixes `aws_ecs_service` so removing the final `deployment_configuration.lifecycle_hook` from configuration also removes it from the ECS service in AWS.

Previously, when `deployment_configuration` changed and no `lifecycle_hook` values remained configured, the provider omitted `DeploymentConfiguration.LifecycleHooks` from the ECS `UpdateService` request. ECS requires an explicit empty lifecycle hook list to clear existing hooks, so the remote service could retain the old hook after Terraform removed it from configuration.

This change initializes `DeploymentConfiguration.LifecycleHooks` to an explicit empty slice during update and overwrites it only if hooks are still configured.

This PR also adds an acceptance regression test covering a transition from one lifecycle hook to zero lifecycle hooks and verifies that the remote ECS service no longer has lifecycle hooks.

### Relations

N/A

### References

N/A

### Output from Acceptance Testing

Acceptance tests not run locally; requires AWS acceptance test environment.

Local validation run:

```console
% go test ./internal/service/ecs -run '^$' -timeout 90s
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        [no tests to run]