### PR TITLE
r/aws_route53_record: fix the `type` attribute to no longer force resource replacement on change

### DIFF
--- a/.changelog/47105.txt
+++ b/.changelog/47105.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53_record: Fix the `type` attribute to no longer force resource replacement on change
+```

--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -294,7 +294,6 @@ func resourceRecord() *schema.Resource {
 				names.AttrType: {
 					Type:             schema.TypeString,
 					Required:         true,
-					ForceNew:         true,
 					ValidateDiagFunc: enum.Validate[awstypes.RRType](),
 				},
 				"weighted_routing_policy": {

--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -652,6 +652,11 @@ func resourceRecordUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 		oldRec.SetIdentifier = aws.String(v.(string))
 	}
 
+	newRecAction := awstypes.ChangeActionCreate
+	if d.Get("allow_overwrite").(bool) {
+		newRecAction = awstypes.ChangeActionUpsert
+	}
+
 	// Delete the old and create the new records in a single batch.
 	input := &route53.ChangeResourceRecordSetsInput{
 		ChangeBatch: &awstypes.ChangeBatch{
@@ -661,7 +666,7 @@ func resourceRecordUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 					ResourceRecordSet: oldRec,
 				},
 				{
-					Action:            awstypes.ChangeActionCreate,
+					Action:            newRecAction,
 					ResourceRecordSet: expandResourceRecordSet(d, aws.ToString(zoneRecord.HostedZone.Name)),
 				},
 			},

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -1100,7 +1100,7 @@ func TestAccRoute53Record_typeChange(t *testing.T) {
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
 			},

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -3060,56 +3060,56 @@ resource "aws_route53_record" "sample" {
 
 const testAccRecordConfig_typeChangeAllowOverwritePre = `
 resource "aws_route53_zone" "main" {
-	name = "domain.test"
+  name = "domain.test"
 }
 
 resource "aws_route53_record" "managed" {
-	allow_overwrite = true
-	zone_id         = aws_route53_zone.main.zone_id
-	name            = "sample"
-	type            = "TXT"
-	ttl             = 30
-	records         = ["phase1-txt"]
+  allow_overwrite = true
+  zone_id         = aws_route53_zone.main.zone_id
+  name            = "sample"
+  type            = "TXT"
+  ttl             = 30
+  records         = ["phase1-txt"]
 
-	set_identifier = "primary"
-	weighted_routing_policy {
-		weight = 1
-	}
+  set_identifier = "primary"
+  weighted_routing_policy {
+    weight = 1
+  }
 }
 `
 
 const testAccRecordConfig_typeChangeAllowOverwritePost = `
 resource "aws_route53_zone" "main" {
-	name = "domain.test"
+  name = "domain.test"
 }
 
 resource "aws_route53_record" "conflict" {
-	zone_id = aws_route53_zone.main.zone_id
-	name    = "sample"
-	type    = "A"
-	ttl     = 30
-	records = ["192.0.2.10"]
+  zone_id = aws_route53_zone.main.zone_id
+  name    = "sample"
+  type    = "A"
+  ttl     = 30
+  records = ["192.0.2.10"]
 
-	set_identifier = "primary"
-	weighted_routing_policy {
-		weight = 1
-	}
+  set_identifier = "primary"
+  weighted_routing_policy {
+    weight = 1
+  }
 }
 
 resource "aws_route53_record" "managed" {
-	depends_on = [aws_route53_record.conflict]
+  depends_on = [aws_route53_record.conflict]
 
-	allow_overwrite = true
-	zone_id         = aws_route53_zone.main.zone_id
-	name            = "sample"
-	type            = "A"
-	ttl             = 30
-	records         = ["192.0.2.10"]
+  allow_overwrite = true
+  zone_id         = aws_route53_zone.main.zone_id
+  name            = "sample"
+  type            = "A"
+  ttl             = 30
+  records         = ["192.0.2.10"]
 
-	set_identifier = "primary"
-	weighted_routing_policy {
-		weight = 1
-	}
+  set_identifier = "primary"
+  weighted_routing_policy {
+    weight = 1
+  }
 }
 `
 

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -1108,6 +1108,50 @@ func TestAccRoute53Record_typeChange(t *testing.T) {
 	})
 }
 
+func TestAccRoute53Record_typeChange_allowOverwrite(t *testing.T) {
+	ctx := acctest.Context(t)
+	var record1, record2 awstypes.ResourceRecordSet
+	resourceName := "aws_route53_record.managed"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecordConfig_typeChangeAllowOverwritePre,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordExists(ctx, t, resourceName, &record1),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), knownvalue.StringExact("TXT")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("records"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact("phase1-txt"),
+					})),
+				},
+			},
+			{
+				Config: testAccRecordConfig_typeChangeAllowOverwritePost,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordExists(ctx, t, resourceName, &record2),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), knownvalue.StringExact("A")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("records"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact("192.0.2.10"),
+					})),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccRoute53Record_nameChange(t *testing.T) {
 	ctx := acctest.Context(t)
 	var record1, record2 awstypes.ResourceRecordSet
@@ -3011,6 +3055,61 @@ resource "aws_route53_record" "sample" {
   type    = "A"
   ttl     = "30"
   records = ["127.0.0.1", "8.8.8.8"]
+}
+`
+
+const testAccRecordConfig_typeChangeAllowOverwritePre = `
+resource "aws_route53_zone" "main" {
+	name = "domain.test"
+}
+
+resource "aws_route53_record" "managed" {
+	allow_overwrite = true
+	zone_id         = aws_route53_zone.main.zone_id
+	name            = "sample"
+	type            = "TXT"
+	ttl             = 30
+	records         = ["phase1-txt"]
+
+	set_identifier = "primary"
+	weighted_routing_policy {
+		weight = 1
+	}
+}
+`
+
+const testAccRecordConfig_typeChangeAllowOverwritePost = `
+resource "aws_route53_zone" "main" {
+	name = "domain.test"
+}
+
+resource "aws_route53_record" "conflict" {
+	zone_id = aws_route53_zone.main.zone_id
+	name    = "sample"
+	type    = "A"
+	ttl     = 30
+	records = ["192.0.2.10"]
+
+	set_identifier = "primary"
+	weighted_routing_policy {
+		weight = 1
+	}
+}
+
+resource "aws_route53_record" "managed" {
+	depends_on = [aws_route53_record.conflict]
+
+	allow_overwrite = true
+	zone_id         = aws_route53_zone.main.zone_id
+	name            = "sample"
+	type            = "A"
+	ttl             = 30
+	records         = ["192.0.2.10"]
+
+	set_identifier = "primary"
+	weighted_routing_policy {
+		weight = 1
+	}
 }
 `
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Changes the attribute "type" to no longer ForceNew


### Relations

Closes #43500

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
