### PR TITLE
resource/aws_cloudfront_distribution: fix inconsistent final plan for cache_policy_id and origin_request_policy_id

### DIFF
--- a/.changelog/47118.txt
+++ b/.changelog/47118.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudfront_distribution: Fix `cache_policy_id` and `origin_request_policy_id` in `default_cache_behavior` and `ordered_cache_behavior` producing inconsistent final plan
+```

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -145,6 +145,7 @@ func resourceDistribution() *schema.Resource {
 						"cache_policy_id": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"cached_methods": {
 							Type:     schema.TypeSet,
@@ -281,6 +282,7 @@ func resourceDistribution() *schema.Resource {
 						"origin_request_policy_id": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"realtime_log_config_arn": {
 							Type:         schema.TypeString,
@@ -403,6 +405,7 @@ func resourceDistribution() *schema.Resource {
 						"cache_policy_id": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"compress": {
 							Type:     schema.TypeBool,
@@ -533,6 +536,7 @@ func resourceDistribution() *schema.Resource {
 						"origin_request_policy_id": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"path_pattern": {
 							Type:     schema.TypeString,

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -361,6 +361,42 @@ func TestAccCloudFrontDistribution_originPolicyOrdered(t *testing.T) {
 	})
 }
 
+func TestAccCloudFrontDistribution_DefaultCacheBehavior_cachePolicyAndOriginRequestPolicy(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var distribution awstypes.Distribution
+	resourceName := "aws_cloudfront_distribution.main"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDistributionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistributionConfig_defaultCacheBehaviorCachePolicyAndOriginRequestPolicy(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionExists(ctx, t, resourceName, &distribution),
+					resource.TestMatchResourceAttr(resourceName, "default_cache_behavior.0.cache_policy_id", regexache.MustCompile(`^[0-9a-z-]+`)),
+					resource.TestMatchResourceAttr(resourceName, "default_cache_behavior.0.origin_request_policy_id", regexache.MustCompile(`^[0-9a-z-]+`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
+			},
+		},
+	})
+}
+
 // TestAccCloudFrontDistribution_multiOrigin runs an
 // aws_cloudfront_distribution acceptance test with multiple origins.
 //
@@ -3332,6 +3368,60 @@ resource "aws_cloudfront_distribution" "main" {
     max_ttl                = 51
     viewer_protocol_policy = "allow-all"
     path_pattern           = "images2/*.jpg"
+  }
+
+  price_class = "PriceClass_All"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  %[1]s
+}
+`, testAccDistributionRetainConfig())
+}
+
+func testAccDistributionConfig_defaultCacheBehaviorCachePolicyAndOriginRequestPolicy() string {
+	return fmt.Sprintf(`
+data "aws_cloudfront_cache_policy" "test" {
+  name = "Managed-CachingOptimized"
+}
+
+data "aws_cloudfront_origin_request_policy" "test" {
+  name = "Managed-CORS-S3Origin"
+}
+
+resource "aws_cloudfront_distribution" "main" {
+  origin {
+    domain_name = "www.example.com"
+    origin_id   = "myCustomOrigin"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["SSLv3", "TLSv1"]
+    }
+  }
+
+  enabled = true
+  comment = "Some comment"
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "myCustomOrigin"
+
+    cache_policy_id          = data.aws_cloudfront_cache_policy.test.id
+    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.test.id
+
+    viewer_protocol_policy = "allow-all"
   }
 
   price_class = "PriceClass_All"


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Mark `cache_policy_id` and `origin_request_policy_id` as `Computed` in both `default_cache_behavior` and `ordered_cache_behavior` to fix "Provider produced inconsistent final plan" error.

When these fields are set via data sources (e.g., `data.aws_cloudfront_cache_policy`), the plan may record the value as `null` while the apply produces an actual UUID. Without `Computed: true`, Terraform rejects this as an inconsistent plan.

### Relations

Closes #29234
Closes #42095

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccCloudFrontDistribution_DefaultCacheBehavior_cachePolicyAndOriginRequestPolicy PKG=cloudfront
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws_cloudfront_distribution-inconsistent_plan 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontDistribution_DefaultCacheBehavior_cachePolicyAndOriginRequestPolicy'  -timeout 360m -vet=off
2026/03/26 21:19:00 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/26 21:19:00 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_cachePolicyAndOriginRequestPolicy
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_cachePolicyAndOriginRequestPolicy
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_cachePolicyAndOriginRequestPolicy
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_cachePolicyAndOriginRequestPolicy (477.46s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 477.804s
```