### PR TITLE
d/aws_iam_role_policy_attachments: new data source

### DIFF
--- a/.changelog/47119.txt
+++ b/.changelog/47119.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_iam_role_policy_attachments
+```

--- a/internal/service/iam/role_policy_attachments_data_source.go
+++ b/internal/service/iam/role_policy_attachments_data_source.go
@@ -1,0 +1,97 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package iam
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+)
+
+// @FrameworkDataSource("aws_iam_role_policy_attachments", name="Role Policy Attachments")
+func newRolePolicyAttachmentsDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &rolePolicyAttachmentsDataSource{}, nil
+}
+
+type rolePolicyAttachmentsDataSource struct {
+	framework.DataSourceWithModel[rolePolicyAttachmentsDataSourceModel]
+}
+
+func (d *rolePolicyAttachmentsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"attached_policies": framework.DataSourceComputedListOfObjectAttribute[attachedPolicyModel](ctx),
+			"path_prefix": schema.StringAttribute{
+				Optional: true,
+			},
+			"role_name": schema.StringAttribute{
+				Required: true,
+			},
+		},
+	}
+}
+
+func (d *rolePolicyAttachmentsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().IAMClient(ctx)
+
+	var data rolePolicyAttachmentsDataSourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Config.Get(ctx, &data))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var input iam.ListAttachedRolePoliciesInput
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Expand(ctx, data, &input))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	roleName := data.RoleName.String()
+	out, err := findRolePolicyAttachments(ctx, conn, &input)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, "role_name", roleName)
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &data.AttachedPolicies), "role_name", roleName)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data), "role_name", roleName)
+}
+
+func findRolePolicyAttachments(ctx context.Context, conn *iam.Client, input *iam.ListAttachedRolePoliciesInput) ([]awstypes.AttachedPolicy, error) {
+	var output []awstypes.AttachedPolicy
+
+	paginator := iam.NewListAttachedRolePoliciesPaginator(conn, input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		output = append(output, page.AttachedPolicies...)
+	}
+
+	return output, nil
+}
+
+type rolePolicyAttachmentsDataSourceModel struct {
+	AttachedPolicies fwtypes.ListNestedObjectValueOf[attachedPolicyModel] `tfsdk:"attached_policies"`
+	PathPrefix       types.String                                         `tfsdk:"path_prefix"`
+	RoleName         types.String                                         `tfsdk:"role_name"`
+}
+
+type attachedPolicyModel struct {
+	PolicyArn  types.String `tfsdk:"policy_arn"`
+	PolicyName types.String `tfsdk:"policy_name"`
+}

--- a/internal/service/iam/role_policy_attachments_data_source_test.go
+++ b/internal/service/iam/role_policy_attachments_data_source_test.go
@@ -1,0 +1,224 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package iam_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccIAMRolePolicyAttachmentsDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_iam_role_policy_attachments.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRolePolicyAttachmentsDataSourceConfig_basic(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("role_name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("attached_policies"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"policy_arn":  tfknownvalue.GlobalARNExact("iam", "policy/"+rName),
+							"policy_name": knownvalue.StringExact(rName),
+						}),
+					})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMRolePolicyAttachmentsDataSource_empty(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_iam_role_policy_attachments.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRolePolicyAttachmentsDataSourceConfig_empty(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("role_name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("attached_policies"), knownvalue.Null()),
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMRolePolicyAttachmentsDataSource_multiple(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_iam_role_policy_attachments.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRolePolicyAttachmentsDataSourceConfig_multiple(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("role_name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("attached_policies"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"policy_arn":  tfknownvalue.GlobalARNExact("iam", "policy/"+rName+"-1"),
+							"policy_name": knownvalue.StringExact(rName + "-1"),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"policy_arn":  tfknownvalue.GlobalARNExact("iam", "policy/"+rName+"-2"),
+							"policy_name": knownvalue.StringExact(rName + "-2"),
+						}),
+					})),
+				},
+			},
+		},
+	})
+}
+
+func testAccRolePolicyAttachmentsDataSourceConfig_Base(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+`, rName)
+}
+
+func testAccRolePolicyAttachmentsDataSourceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccRolePolicyAttachmentsDataSourceConfig_Base(rName),
+		fmt.Sprintf(`
+resource "aws_iam_policy" "test" {
+  name = %[1]q
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = aws_iam_policy.test.arn
+}
+
+data "aws_iam_role_policy_attachments" "test" {
+  role_name = aws_iam_role.test.name
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName))
+}
+
+func testAccRolePolicyAttachmentsDataSourceConfig_empty(rName string) string {
+	return acctest.ConfigCompose(testAccRolePolicyAttachmentsDataSourceConfig_Base(rName),
+		`
+data "aws_iam_role_policy_attachments" "test" {
+  role_name = aws_iam_role.test.name
+}
+`)
+}
+
+func testAccRolePolicyAttachmentsDataSourceConfig_multiple(rName string) string {
+	return acctest.ConfigCompose(testAccRolePolicyAttachmentsDataSourceConfig_Base(rName),
+		fmt.Sprintf(`
+resource "aws_iam_policy" "test1" {
+  name = "%[1]s-1"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "test2" {
+  name = "%[1]s-2"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:Get*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "test1" {
+  role       = aws_iam_role.test.name
+  policy_arn = aws_iam_policy.test1.arn
+}
+
+resource "aws_iam_role_policy_attachment" "test2" {
+  role       = aws_iam_role.test.name
+  policy_arn = aws_iam_policy.test2.arn
+}
+
+data "aws_iam_role_policy_attachments" "test" {
+  role_name = aws_iam_role.test.name
+
+  depends_on = [
+    aws_iam_role_policy_attachment.test1,
+    aws_iam_role_policy_attachment.test2
+  ]
+}
+`, rName))
+}

--- a/internal/service/iam/service_package_gen.go
+++ b/internal/service/iam/service_package_gen.go
@@ -36,6 +36,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 			Name:     "Role Policies",
 			Region:   unique.Make(inttypes.ResourceRegionDisabled()),
 		},
+		{
+			Factory:  newRolePolicyAttachmentsDataSource,
+			TypeName: "aws_iam_role_policy_attachments",
+			Name:     "Role Policy Attachments",
+			Region:   unique.Make(inttypes.ResourceRegionDisabled()),
+		},
 	}
 }
 

--- a/website/docs/d/iam_role_policy_attachments.html.markdown
+++ b/website/docs/d/iam_role_policy_attachments.html.markdown
@@ -1,0 +1,42 @@
+---
+subcategory: "IAM (Identity & Access Management)"
+layout: "aws"
+page_title: "AWS: aws_iam_role_policy_attachments"
+description: |-
+  Provides details about AWS IAM Role Policy Attachments.
+---
+
+# Data Source: aws_iam_role_policy_attachments
+
+Provides details about the managed policies attached to an AWS IAM Role.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_iam_role_policy_attachments" "example" {
+  role_name = "example-role"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `role_name` - (Required) Name of the IAM role.
+
+The following arguments are optional:
+
+* `path_prefix` - (Optional) Path prefix for filtering the results.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `attached_policies` - List of attached managed policies. See [below](#attached_policies-attribute-reference).
+
+### `attached_policies` Attribute Reference
+
+* `policy_arn` - ARN of the attached managed policy.
+* `policy_name` - Name of the attached managed policy.


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This data source returns the managed policies attached to a given IAM role. The `managed_policies` attribute will be null when no policies are attached.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/46579

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListAttachedRolePolicies.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make t K=iam T=TestAccIAMRolePolicyAttachmentsDataSource_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-iam_role_policy_attachments-data 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRolePolicyAttachmentsDataSource_'  -timeout 360m -vet=off
2026/03/26 09:52:49 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/26 09:52:49 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccIAMRolePolicyAttachmentsDataSource_empty (19.72s)
--- PASS: TestAccIAMRolePolicyAttachmentsDataSource_basic (20.23s)
--- PASS: TestAccIAMRolePolicyAttachmentsDataSource_multiple (20.24s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        27.731s
```
