### PR TITLE
d/aws_iam_custom_policy_simulation: new data source

### DIFF
--- a/.changelog/47120.txt
+++ b/.changelog/47120.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_iam_custom_policy_simulation
+```

--- a/internal/service/iam/custom_policy_simulation_data_source.go
+++ b/internal/service/iam/custom_policy_simulation_data_source.go
@@ -1,0 +1,253 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package iam
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_iam_custom_policy_simulation", name="Custom Policy Simulation")
+func newCustomPolicySimulationDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &customPolicySimulationDataSource{}, nil
+}
+
+type customPolicySimulationDataSource struct {
+	framework.DataSourceWithModel[customPolicySimulationDataSourceModel]
+}
+
+func (d *customPolicySimulationDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"action_names": schema.SetAttribute{
+				CustomType:  fwtypes.SetOfStringType,
+				ElementType: types.StringType,
+				Required:    true,
+			},
+			"all_allowed": schema.BoolAttribute{
+				Computed: true,
+			},
+			"caller_arn": schema.StringAttribute{
+				Optional: true,
+				Validators: []validator.String{
+					fwvalidators.ARN(),
+				},
+			},
+			"permissions_boundary_policies_json": schema.SetAttribute{
+				CustomType:  fwtypes.SetOfStringType,
+				ElementType: types.StringType,
+				Optional:    true,
+				Validators: []validator.Set{
+					setvalidator.ValueStringsAre(fwvalidators.JSON()),
+				},
+			},
+			"policies_json": schema.SetAttribute{
+				CustomType:  fwtypes.SetOfStringType,
+				ElementType: types.StringType,
+				Required:    true,
+				Validators: []validator.Set{
+					setvalidator.ValueStringsAre(fwvalidators.JSON()),
+				},
+			},
+			"resource_arns": schema.SetAttribute{
+				CustomType:  fwtypes.SetOfStringType,
+				ElementType: types.StringType,
+				Optional:    true,
+				Validators: []validator.Set{
+					setvalidator.ValueStringsAre(fwvalidators.ARN()),
+				},
+			},
+			"resource_handling_option": schema.StringAttribute{
+				Optional: true,
+			},
+			"resource_owner_account_id": schema.StringAttribute{
+				Optional: true,
+			},
+			"resource_policy_json": schema.StringAttribute{
+				Optional: true,
+				Validators: []validator.String{
+					fwvalidators.JSON(),
+				},
+			},
+			"results": framework.DataSourceComputedListOfObjectAttribute[evaluationResultModel](ctx),
+		},
+		Blocks: map[string]schema.Block{
+			"context": schema.SetNestedBlock{
+				CustomType: fwtypes.NewSetNestedObjectTypeOf[contextEntryModel](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrKey: schema.StringAttribute{
+							Required: true,
+						},
+						names.AttrType: schema.StringAttribute{
+							Required: true,
+						},
+						names.AttrValues: schema.SetAttribute{
+							CustomType:  fwtypes.SetOfStringType,
+							ElementType: types.StringType,
+							Required:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *customPolicySimulationDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().IAMClient(ctx)
+
+	var data customPolicySimulationDataSourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Config.Get(ctx, &data))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := iam.SimulateCustomPolicyInput{
+		ActionNames:                        fwflex.ExpandFrameworkStringValueSet(ctx, data.ActionNames),
+		PolicyInputList:                    fwflex.ExpandFrameworkStringValueSet(ctx, data.PoliciesJSON),
+		PermissionsBoundaryPolicyInputList: fwflex.ExpandFrameworkStringValueSet(ctx, data.PermissionsBoundaryPoliciesJSON),
+		ResourceArns:                       fwflex.ExpandFrameworkStringValueSet(ctx, data.ResourceARNs),
+	}
+
+	input.CallerArn = data.CallerARN.ValueStringPointer()
+	input.ResourceHandlingOption = data.ResourceHandlingOption.ValueStringPointer()
+	input.ResourceOwner = data.ResourceOwnerAccountID.ValueStringPointer()
+	input.ResourcePolicy = data.ResourcePolicyJSON.ValueStringPointer()
+
+	contextEntries, diags := data.Context.ToSlice(ctx)
+	smerr.AddEnrich(ctx, &resp.Diagnostics, diags)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	for _, entry := range contextEntries {
+		input.ContextEntries = append(input.ContextEntries, awstypes.ContextEntry{
+			ContextKeyName:   entry.Key.ValueStringPointer(),
+			ContextKeyType:   awstypes.ContextKeyTypeEnum(entry.Type.ValueString()),
+			ContextKeyValues: fwflex.ExpandFrameworkStringValueSet(ctx, entry.Values),
+		})
+	}
+
+	apiResults, err := findCustomPolicySimulationResults(ctx, conn, &input)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err)
+		return
+	}
+
+	allowedCount := 0
+	deniedCount := 0
+
+	results := make([]evaluationResultModel, len(apiResults))
+	for i, result := range apiResults {
+		allowed := string(result.EvalDecision) == "allowed"
+		if allowed {
+			allowedCount++
+		} else {
+			deniedCount++
+		}
+
+		var decisionDetails map[string]string
+		for k, v := range result.EvalDecisionDetails {
+			if v != "" {
+				if decisionDetails == nil {
+					decisionDetails = make(map[string]string)
+				}
+				decisionDetails[k] = string(v)
+			}
+		}
+
+		var matchedStmts []matchedStatementModel
+		for _, stmt := range result.MatchedStatements {
+			matchedStmts = append(matchedStmts, matchedStatementModel{
+				SourcePolicyID:   fwflex.StringToFramework(ctx, stmt.SourcePolicyId),
+				SourcePolicyType: fwflex.StringValueToFramework(ctx, stmt.SourcePolicyType),
+			})
+		}
+
+		var missingContextKeys []string
+		for _, v := range result.MissingContextValues {
+			if v != "" {
+				missingContextKeys = append(missingContextKeys, v)
+			}
+		}
+
+		results[i] = evaluationResultModel{
+			ActionName:         fwflex.StringToFramework(ctx, result.EvalActionName),
+			Allowed:            types.BoolValue(allowed),
+			Decision:           types.StringValue(string(result.EvalDecision)),
+			DecisionDetails:    fwtypes.MapOfString{MapValue: fwflex.FlattenFrameworkStringValueMapLegacy(ctx, decisionDetails)},
+			ResourceARN:        fwflex.StringToFramework(ctx, result.EvalResourceName),
+			MatchedStatements:  fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, matchedStmts),
+			MissingContextKeys: fwflex.FlattenFrameworkStringValueSetOfStringLegacy(ctx, missingContextKeys),
+		}
+	}
+
+	data.AllAllowed = types.BoolValue(allowedCount > 0 && deniedCount == 0)
+	data.Results = fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, results)
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
+}
+
+func findCustomPolicySimulationResults(ctx context.Context, conn *iam.Client, input *iam.SimulateCustomPolicyInput) ([]awstypes.EvaluationResult, error) {
+	var output []awstypes.EvaluationResult
+
+	paginator := iam.NewSimulateCustomPolicyPaginator(conn, input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		output = append(output, page.EvaluationResults...)
+	}
+
+	return output, nil
+}
+
+type customPolicySimulationDataSourceModel struct {
+	ActionNames                     fwtypes.SetOfString                                    `tfsdk:"action_names"`
+	AllAllowed                      types.Bool                                             `tfsdk:"all_allowed"`
+	CallerARN                       types.String                                           `tfsdk:"caller_arn"`
+	Context                         fwtypes.SetNestedObjectValueOf[contextEntryModel]      `tfsdk:"context"`
+	PermissionsBoundaryPoliciesJSON fwtypes.SetOfString                                    `tfsdk:"permissions_boundary_policies_json"`
+	PoliciesJSON                    fwtypes.SetOfString                                    `tfsdk:"policies_json"`
+	ResourceARNs                    fwtypes.SetOfString                                    `tfsdk:"resource_arns"`
+	ResourceHandlingOption          types.String                                           `tfsdk:"resource_handling_option"`
+	ResourceOwnerAccountID          types.String                                           `tfsdk:"resource_owner_account_id"`
+	ResourcePolicyJSON              types.String                                           `tfsdk:"resource_policy_json"`
+	Results                         fwtypes.ListNestedObjectValueOf[evaluationResultModel] `tfsdk:"results"`
+}
+
+type contextEntryModel struct {
+	Key    types.String        `tfsdk:"key"`
+	Type   types.String        `tfsdk:"type"`
+	Values fwtypes.SetOfString `tfsdk:"values"`
+}
+
+type evaluationResultModel struct {
+	ActionName         types.String                                           `tfsdk:"action_name"`
+	Allowed            types.Bool                                             `tfsdk:"allowed"`
+	Decision           types.String                                           `tfsdk:"decision"`
+	DecisionDetails    fwtypes.MapOfString                                    `tfsdk:"decision_details"`
+	ResourceARN        types.String                                           `tfsdk:"resource_arn"`
+	MatchedStatements  fwtypes.ListNestedObjectValueOf[matchedStatementModel] `tfsdk:"matched_statements"`
+	MissingContextKeys fwtypes.SetOfString                                    `tfsdk:"missing_context_keys"`
+}
+
+type matchedStatementModel struct {
+	SourcePolicyID   types.String `tfsdk:"source_policy_id"`
+	SourcePolicyType types.String `tfsdk:"source_policy_type"`
+}

--- a/internal/service/iam/custom_policy_simulation_data_source_test.go
+++ b/internal/service/iam/custom_policy_simulation_data_source_test.go
@@ -1,0 +1,325 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package iam_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccIAMCustomPolicySimulationDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_iam_custom_policy_simulation.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomPolicySimulationDataSourceConfig_basic,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("all_allowed"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("results"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"action_name":         knownvalue.StringExact("s3:GetObject"),
+							"allowed":             knownvalue.Bool(true),
+							"decision":            knownvalue.StringExact("allowed"),
+							names.AttrResourceARN: knownvalue.StringExact("*"),
+						}),
+					})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMCustomPolicySimulationDataSource_implicitDeny(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_iam_custom_policy_simulation.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomPolicySimulationDataSourceConfig_implicitDeny,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("all_allowed"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("results"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"action_name": knownvalue.StringExact("s3:DeleteBucket"),
+							"allowed":     knownvalue.Bool(false),
+							"decision":    knownvalue.StringExact("implicitDeny"),
+						}),
+					})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMCustomPolicySimulationDataSource_explicitDeny(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_iam_custom_policy_simulation.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomPolicySimulationDataSourceConfig_explicitDeny,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("all_allowed"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("results"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"action_name": knownvalue.StringExact("s3:GetObject"),
+							"allowed":     knownvalue.Bool(false),
+							"decision":    knownvalue.StringExact("explicitDeny"),
+						}),
+					})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMCustomPolicySimulationDataSource_multipleActions(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_iam_custom_policy_simulation.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomPolicySimulationDataSourceConfig_multipleActions,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("all_allowed"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("results"), knownvalue.ListSizeExact(2)),
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMCustomPolicySimulationDataSource_withContext(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomPolicySimulationDataSourceConfig_withContext,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("data.aws_iam_custom_policy_simulation.match", tfjsonpath.New("all_allowed"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue("data.aws_iam_custom_policy_simulation.no_match", tfjsonpath.New("all_allowed"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue("data.aws_iam_custom_policy_simulation.no_context", tfjsonpath.New("all_allowed"), knownvalue.Bool(false)),
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMCustomPolicySimulationDataSource_permissionsBoundary(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomPolicySimulationDataSourceConfig_permissionsBoundary,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("data.aws_iam_custom_policy_simulation.without_boundary", tfjsonpath.New("all_allowed"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue("data.aws_iam_custom_policy_simulation.with_boundary", tfjsonpath.New("all_allowed"), knownvalue.Bool(false)),
+				},
+			},
+		},
+	})
+}
+
+const testAccCustomPolicySimulationDataSourceConfig_basic = `
+data "aws_iam_custom_policy_simulation" "test" {
+  action_names = ["s3:GetObject"]
+
+  policies_json = [jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "s3:GetObject"
+      Resource = "*"
+    }]
+  })]
+}
+`
+
+const testAccCustomPolicySimulationDataSourceConfig_implicitDeny = `
+data "aws_iam_custom_policy_simulation" "test" {
+  action_names = ["s3:DeleteBucket"]
+
+  policies_json = [jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "s3:GetObject"
+      Resource = "*"
+    }]
+  })]
+}
+`
+
+const testAccCustomPolicySimulationDataSourceConfig_explicitDeny = `
+data "aws_iam_custom_policy_simulation" "test" {
+  action_names = ["s3:GetObject"]
+
+  policies_json = [jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "s3:*"
+        Resource = "*"
+      },
+      {
+        Effect   = "Deny"
+        Action   = "s3:GetObject"
+        Resource = "*"
+      },
+    ]
+  })]
+}
+`
+
+const testAccCustomPolicySimulationDataSourceConfig_multipleActions = `
+data "aws_iam_custom_policy_simulation" "test" {
+  action_names = ["s3:GetObject", "s3:DeleteBucket"]
+
+  policies_json = [jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "s3:GetObject"
+      Resource = "*"
+    }]
+  })]
+}
+`
+
+const testAccCustomPolicySimulationDataSourceConfig_withContext = `
+data "aws_iam_custom_policy_simulation" "match" {
+  action_names = ["s3:GetObject"]
+
+  policies_json = [jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "s3:GetObject"
+      Resource = "*"
+      Condition = {
+        StringEquals = {
+          "s3:prefix" = "test"
+        }
+      }
+    }]
+  })]
+
+  context {
+    key    = "s3:prefix"
+    type   = "string"
+    values = ["test"]
+  }
+}
+
+data "aws_iam_custom_policy_simulation" "no_match" {
+  action_names = ["s3:GetObject"]
+
+  policies_json = [jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "s3:GetObject"
+      Resource = "*"
+      Condition = {
+        StringEquals = {
+          "s3:prefix" = "test"
+        }
+      }
+    }]
+  })]
+
+  context {
+    key    = "s3:prefix"
+    type   = "string"
+    values = ["wrong"]
+  }
+}
+
+data "aws_iam_custom_policy_simulation" "no_context" {
+  action_names = ["s3:GetObject"]
+
+  policies_json = [jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "s3:GetObject"
+      Resource = "*"
+      Condition = {
+        StringEquals = {
+          "s3:prefix" = "test"
+        }
+      }
+    }]
+  })]
+}
+`
+
+const testAccCustomPolicySimulationDataSourceConfig_permissionsBoundary = `
+data "aws_iam_custom_policy_simulation" "without_boundary" {
+  action_names = ["s3:GetObject"]
+
+  policies_json = [jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "s3:*"
+      Resource = "*"
+    }]
+  })]
+}
+
+data "aws_iam_custom_policy_simulation" "with_boundary" {
+  action_names = ["s3:GetObject"]
+
+  policies_json = [jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "s3:*"
+      Resource = "*"
+    }]
+  })]
+
+  permissions_boundary_policies_json = [jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "ec2:*"
+      Resource = "*"
+    }]
+  })]
+}
+`

--- a/internal/service/iam/service_package_gen.go
+++ b/internal/service/iam/service_package_gen.go
@@ -25,6 +25,12 @@ type servicePackage struct{}
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
 	return []*inttypes.ServicePackageFrameworkDataSource{
 		{
+			Factory:  newCustomPolicySimulationDataSource,
+			TypeName: "aws_iam_custom_policy_simulation",
+			Name:     "Custom Policy Simulation",
+			Region:   unique.Make(inttypes.ResourceRegionDisabled()),
+		},
+		{
 			Factory:  newOutboundWebIdentityFederationDataSource,
 			TypeName: "aws_iam_outbound_web_identity_federation",
 			Name:     "Outbound Web Identity Federation",

--- a/website/docs/d/iam_custom_policy_simulation.html.markdown
+++ b/website/docs/d/iam_custom_policy_simulation.html.markdown
@@ -1,0 +1,103 @@
+---
+subcategory: "IAM (Identity & Access Management)"
+layout: "aws"
+page_title: "AWS: aws_iam_custom_policy_simulation"
+description: |-
+  Simulates the effect of custom IAM policies.
+---
+
+# Data Source: aws_iam_custom_policy_simulation
+
+Runs a simulation of the IAM policies provided as input against a set of API operations and optionally resource ARNs, using the [SimulateCustomPolicy](https://docs.aws.amazon.com/IAM/latest/APIReference/API_SimulateCustomPolicy.html) API.
+
+Unlike [`aws_iam_principal_policy_simulation`](/docs/providers/aws/d/iam_principal_policy_simulation.html.markdown), this data source evaluates arbitrary inline policy documents without requiring an existing IAM principal.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_iam_custom_policy_simulation" "example" {
+  action_names  = ["s3:GetObject"]
+  resource_arns = ["arn:aws:s3:::my-bucket/*"]
+
+  policies_json = [jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "s3:GetObject"
+      Resource = "arn:aws:s3:::my-bucket/*"
+    }]
+  })]
+}
+```
+
+### Using as a Postcondition
+
+```terraform
+data "aws_iam_custom_policy_simulation" "check" {
+  action_names  = ["s3:GetObject"]
+  resource_arns = ["arn:aws:s3:::my-bucket/*"]
+
+  policies_json = [jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "s3:GetObject"
+      Resource = "arn:aws:s3:::my-bucket/*"
+    }]
+  })]
+
+  lifecycle {
+    postcondition {
+      condition     = self.all_allowed
+      error_message = "Policy does not allow the required access."
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `action_names` - (Required) Set of IAM action names to simulate, e.g. `s3:GetObject`.
+* `policies_json` - (Required) Set of IAM policy documents (as JSON strings) to use as the policies for the simulation.
+
+The following arguments are optional:
+
+* `caller_arn` - (Optional) ARN of an IAM user to use as the caller of the simulated requests. Required if `resource_policy_json` is specified.
+* `context` - (Optional) Each block specifies one context entry for condition evaluation. See [`context` Block](#context-block) below.
+* `permissions_boundary_policies_json` - (Optional) Set of IAM permissions boundary policy documents (as JSON strings) to use in the simulation.
+* `resource_arns` - (Optional) Set of ARNs of resources to include in the simulation. If not specified, the simulator assumes `*`.
+* `resource_handling_option` - (Optional) Specifies the type of simulation to run for resource-level scenarios.
+* `resource_owner_account_id` - (Optional) AWS account ID to use as the simulated owner for any resource whose ARN does not include a specific owner account ID.
+* `resource_policy_json` - (Optional) Resource-based policy (as a JSON string) to associate with all target resources for simulation purposes.
+
+### `context` Block
+
+* `key` - (Required) Context key name, such as `aws:CurrentTime`.
+* `type` - (Required) Type for the simulator to interpret the context values, such as `string`, `numeric`, `boolean`, `ip`, `date`, or their list variants.
+* `values` - (Required) Set of values to assign to the context key.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `all_allowed` - `true` if every result in `results` has a decision of `allowed`.
+* `results` - List of result objects, one per action-resource pair evaluated. See [`results` Attribute Reference](#results-attribute-reference) below.
+
+### `results` Attribute Reference
+
+* `action_name` - The action name that was tested.
+* `allowed` - `true` if the `decision` is `allowed`.
+* `decision` - The raw decision: `allowed`, `explicitDeny`, or `implicitDeny`.
+* `decision_details` - Map of additional details about the decision.
+* `matched_statements` - List of statements that contributed to the decision. See [`matched_statements` Attribute Reference](#matched_statements-attribute-reference) below.
+* `missing_context_keys` - Set of context keys that were needed by the policies but not provided.
+* `resource_arn` - ARN of the resource that the action was tested against.
+
+### `matched_statements` Attribute Reference
+
+* `source_policy_id` - Identifier of the policy that contained the matched statement.
+* `source_policy_type` - Type of the policy that contained the matched statement.


### PR DESCRIPTION
## Community Note

* Please vote on this pull request by adding a :+1: reaction to the original pull request to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for pull request followers and do not help prioritize for review

## Description

Adds a new data source `aws_iam_custom_policy_simulation` that simulates the effect of custom IAM policies using the [SimulateCustomPolicy](https://docs.aws.amazon.com/IAM/latest/APIReference/API_SimulateCustomPolicy.html) API.

Unlike `aws_iam_principal_policy_simulation`, this data source evaluates arbitrary inline policy documents without requiring an existing IAM principal. This is useful for validating policies before they are attached to any entity.

- close #46579

## PR Checklist

- [x] Acceptance tests covering the new data source
- [x] Documentation (`website/docs/d/iam_custom_policy_simulation.html.markdown`)
- [x] Code generation (`service_package_gen.go` updated)

## New Data Source

- `aws_iam_custom_policy_simulation`

### Example Usage

```hcl
data "aws_iam_custom_policy_simulation" "example" {
  action_names  = ["s3:GetObject"]
  resource_arns = ["arn:aws:s3:::my-bucket/*"]

  policies_json = [jsonencode({
    Version = "2012-10-17"
    Statement = [{
      Effect   = "Allow"
      Action   = "s3:GetObject"
      Resource = "arn:aws:s3:::my-bucket/*"
    }]
  })]
}
```

### Arguments

- `action_names` (Required) - Set of IAM action names to simulate.
- `policies_json` (Required) - Set of IAM policy documents as JSON strings.
- `caller_arn` (Optional) - ARN of the simulated caller.
- `context` (Optional) - Context entries for condition evaluation.
- `permissions_boundary_policies_json` (Optional) - Permissions boundary policies.
- `resource_arns` (Optional) - Resource ARNs to test against.
- `resource_handling_option` (Optional) - Simulation scenario type.
- `resource_owner_account_id` (Optional) - Owner account ID for resources.
- `resource_policy_json` (Optional) - Resource-based policy.

### Attributes

- `all_allowed` - `true` if all results have decision `allowed`.
- `results` - List of evaluation results per action-resource pair.

## Testing

New acceptance tests:

- `TestAccIAMCustomPolicySimulationDataSource_basic`
- `TestAccIAMCustomPolicySimulationDataSource_denied`
- `TestAccIAMCustomPolicySimulationDataSource_withContext`