### PR TITLE
resource/aws_db_instance: fix perpetual drift on parameter_group_name during pending major version upgrade

### DIFF
--- a/.changelog/00000.txt
+++ b/.changelog/00000.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_db_instance: Add `parameter_group_name_actual` attribute to track the currently active parameter group, mirroring `engine_version_actual`
+```
+
+```release-note:bug
+resource/aws_db_instance: Fix perpetual drift on `parameter_group_name` when a major engine version upgrade is pending in the maintenance window
+```

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -492,6 +492,10 @@ func resourceInstance() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"parameter_group_name_actual": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			names.AttrPassword: {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -2041,7 +2045,8 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta any)
 		d.Set("option_group_name", v.OptionGroupMemberships[0].OptionGroupName)
 	}
 	if len(v.DBParameterGroups) > 0 {
-		d.Set(names.AttrParameterGroupName, v.DBParameterGroups[0].DBParameterGroupName)
+		hasPendingEngineVersionUpgrade := v.PendingModifiedValues != nil && v.PendingModifiedValues.EngineVersion != nil
+		setParameterGroupName(d, aws.ToString(v.DBParameterGroups[0].DBParameterGroupName), hasPendingEngineVersionUpgrade)
 	}
 	d.Set("performance_insights_enabled", v.PerformanceInsightsEnabled)
 	d.Set("performance_insights_kms_key_id", v.PerformanceInsightsKMSKeyId)

--- a/internal/service/rds/parameter_group_name_test.go
+++ b/internal/service/rds/parameter_group_name_test.go
@@ -1,0 +1,63 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package rds
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestSetParameterGroupName(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		configuredPG                      string
+		currentPG                         string
+		hasPendingEngineVersionUpgrade    bool
+		expectedParameterGroupName        string
+		expectedParameterGroupNameActual  string
+	}
+	tests := map[string]testCase{
+		"no pending upgrade": {
+			configuredPG:                     "my-db-pg16",
+			currentPG:                        "my-db-pg16",
+			hasPendingEngineVersionUpgrade:   false,
+			expectedParameterGroupName:       "my-db-pg16",
+			expectedParameterGroupNameActual: "my-db-pg16",
+		},
+		"pending major version upgrade": {
+			configuredPG:                     "my-db-pg17",
+			currentPG:                        "my-db-pg16",
+			hasPendingEngineVersionUpgrade:   true,
+			expectedParameterGroupName:       "my-db-pg17",
+			expectedParameterGroupNameActual: "my-db-pg16",
+		},
+		"no pending upgrade with different groups": {
+			configuredPG:                     "my-db-pg16-old",
+			currentPG:                        "my-db-pg16-new",
+			hasPendingEngineVersionUpgrade:   false,
+			expectedParameterGroupName:       "my-db-pg16-new",
+			expectedParameterGroupNameActual: "my-db-pg16-new",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			r := resourceInstance()
+			d := r.Data(nil)
+			d.Set(names.AttrParameterGroupName, test.configuredPG)
+			setParameterGroupName(d, test.currentPG, test.hasPendingEngineVersionUpgrade)
+
+			if want, got := test.expectedParameterGroupName, d.Get(names.AttrParameterGroupName); got != want {
+				t.Errorf("unexpected parameter_group_name; want: %q, got: %q", want, got)
+			}
+			if want, got := test.expectedParameterGroupNameActual, d.Get("parameter_group_name_actual"); got != want {
+				t.Errorf("unexpected parameter_group_name_actual; want: %q, got: %q", want, got)
+			}
+		})
+	}
+}

--- a/internal/service/rds/verify.go
+++ b/internal/service/rds/verify.go
@@ -35,3 +35,19 @@ func compareActualEngineVersion(d *schema.ResourceData, oldVersion, newVersion, 
 
 	d.Set(names.AttrEngineVersion, newVersion)
 }
+
+// setParameterGroupName sets parameter group related attributes
+//
+// `parameter_group_name_actual` is always set to currentPG
+//
+// `parameter_group_name` is set to currentPG unless there is a pending engine
+// version upgrade (e.g. major version upgrade deferred to maintenance window).
+// In that case, the parameter group in the configuration may belong to the new
+// engine family and differ from the currently active parameter group.
+func setParameterGroupName(d *schema.ResourceData, currentPG string, hasPendingEngineVersionUpgrade bool) {
+	d.Set("parameter_group_name_actual", currentPG)
+
+	if !hasPendingEngineVersionUpgrade {
+		d.Set(names.AttrParameterGroupName, currentPG)
+	}
+}


### PR DESCRIPTION
### Description

When performing a major PostgreSQL version upgrade (e.g., 16 → 17) with `apply_immediately = false`, the engine version change is correctly deferred to the maintenance window. However, the parameter group — which must also change family (e.g., `postgres16` → `postgres17`) — causes perpetual drift and failed applies.

**Root cause:** During refresh, the provider reads `parameter_group_name` directly from `DBParameterGroups[0].DBParameterGroupName`, which still reflects the current (pre-upgrade) parameter group. Unlike `engine_version`, which has the `engine_version_actual` companion attribute and checks `PendingModifiedValues.EngineVersion` to avoid drift, there is no equivalent mechanism for `parameter_group_name`.

The cycle is:
1. State has the new parameter group (postgres17 family) after initial apply
2. Refresh reads the current parameter group from AWS (still postgres16 family, since the upgrade hasn't happened yet)
3. Terraform plans an update: old pg16 group → new pg17 group
4. Apply fails: `InvalidParameterCombination: The parameter group ... with DBParameterGroupFamily postgres17 can't be used for this instance`
5. Repeat on every plan/apply until the maintenance window

The AWS Console handles this correctly — it accepts both engine version and parameter group changes together, deferred to the maintenance window.

**This PR:**
- Skips overwriting `parameter_group_name` during refresh when `PendingModifiedValues.EngineVersion` is set, preventing the drift loop
- Adds a new `parameter_group_name_actual` computed attribute that always reflects the currently active parameter group, mirroring the existing `engine_version` / `engine_version_actual` pattern

### Relations

Relates #28219
Relates #28339
Relates #35385
Relates #38984