### PR TITLE
resource/aws_dynamodb_table: Fix premature "couldn't find resource (21 retries)" error during creation

### DIFF
--- a/.changelog/46530.txt
+++ b/.changelog/46530.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Fix premature "couldn't find resource (21 retries)" error during creation [GH-46530]
+```

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -13185,3 +13185,46 @@ variable "key_schemas" {
 }
 `, rName)
 }
+
+func TestAccDynamoDBTable_Issue46530(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf awstypes.TableDescription
+	resourceName := "aws_dynamodb_table.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_Issue46530(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInitialTableExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+				),
+			},
+		},
+	})
+}
+
+func testAccTableConfig_Issue46530(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = %[1]q
+  hash_key       = "TestTableHashKey"
+  read_capacity  = 1
+  write_capacity = 1
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  timeouts {
+    create = "30m"
+  }
+}
+`, rName)
+}

--- a/internal/service/dynamodb/wait.go
+++ b/internal/service/dynamodb/wait.go
@@ -33,6 +33,7 @@ func waitTableActive(ctx context.Context, conn *dynamodb.Client, tableName strin
 		Refresh:                   statusTable(conn, tableName),
 		Timeout:                   max(createTableTimeout, timeout),
 		MinTimeout:                1 * time.Second,
+		NotFoundChecks:            1000, // Should exceed any reasonable custom timeout value.
 		ContinuousTargetOccurence: 2,
 	}
 


### PR DESCRIPTION
This PR fixes a regression introduced in v6.28.0 where DynamoDB table creation would fail prematurely with a `couldn't find resource (21 retries)` error, even though the timeout is set to 30 minutes.

### Root Cause
The migration to the internal `retry` package introduced a default `NotFoundChecks: 20` limit. In environments where DynamoDB tables take several minutes to appear in the API, this limit is exhausted in ~3 minutes (due to the 1s `MinTimeout` and exponential backoff).

### Fix
Sets `NotFoundChecks: 1000` for `waitTableActive`, matching the established pattern in other services (like EC2) to ensure the waiter is bound by its `Timeout` rather than an arbitrary retry count.

### AI Disclosure
Root cause analysis and fix generation performed by Gemini CLI. The fix follows established patterns in `internal/service/ec2/wait.go`.

Fixes #46530