### PR TITLE
resource/aws_dynamodb_table: fix premature timeout during creation

### DIFF
--- a/.changelog/46530.txt
+++ b/.changelog/46530.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Fix premature "couldn't find resource (21 retries)" error during creation [GH-46530]
+```

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -8747,6 +8747,29 @@ func TestAccDynamoDBTable_GSI_keySchema_unknown(t *testing.T) {
 	})
 }
 
+func TestAccDynamoDBTable_creationTimeout(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf awstypes.TableDescription
+	resourceName := "aws_dynamodb_table.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_creationTimeout(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckTableDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).DynamoDBClient(ctx)
@@ -13182,6 +13205,26 @@ variable "key_schemas" {
     attribute_name = %[1]q
     key_type       = "HASH"
   }]
+}
+`, rName)
+}
+
+func testAccTableConfig_creationTimeout(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = %[1]q
+  hash_key       = "TestTableHashKey"
+  read_capacity  = 1
+  write_capacity = 1
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  timeouts {
+    create = "30m"
+  }
 }
 `, rName)
 }

--- a/internal/service/dynamodb/wait.go
+++ b/internal/service/dynamodb/wait.go
@@ -33,6 +33,7 @@ func waitTableActive(ctx context.Context, conn *dynamodb.Client, tableName strin
 		Refresh:                   statusTable(conn, tableName),
 		Timeout:                   max(createTableTimeout, timeout),
 		MinTimeout:                1 * time.Second,
+		NotFoundChecks:            1000,
 		ContinuousTargetOccurence: 2,
 	}
 


### PR DESCRIPTION
This PR fixes a regression introduced in v6.28.0 where DynamoDB table creation fails after only ~3 minutes, creating a significant deviation from the [documented 30-minute default timeout](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table#timeouts).

### The Problem
Although `createTableTimeout` is correctly set to 30 minutes in the code and documentation, the migration to the internal `retry` package introduced a hardcoded default `NotFoundChecks: 20` limit. 

For DynamoDB table creation, `waitTableActive` uses a 1s `MinTimeout` and exponential backoff (capped at 10s). The 21st retry is reached in approximately **185 seconds (~3 minutes)**. In environments where tables take longer than 3 minutes to appear in the API, Terraform fails prematurely with a `couldn't find resource (21 retries)` error, ignoring the remaining 27 minutes of the intended timeout.

### The Fix
Sets `NotFoundChecks: 1000` for `waitTableActive`. This restores the documented behavior by ensuring the waiter is bound by its **30-minute `Timeout`** rather than an arbitrary retry count. This aligns with the established pattern used in other services (like EC2) to handle eventual consistency.

### Testing
Added a regression acceptance test `TestAccDynamoDBTable_creationTimeout` that exercises the creation path with a custom timeout block.

Fixes #46530

### AI Disclosure
Gemini CLI was used for the root cause analysis. The fix follows the provider's idiomatic patterns for handling eventual consistency timeouts.