### PR TITLE
docs: fix code block formatting in aws_quicksight_custom_permissions

### DIFF
--- a/website/docs/r/quicksight_custom_permissions.html.markdown
+++ b/website/docs/r/quicksight_custom_permissions.html.markdown
@@ -12,6 +12,7 @@ Manages a QuickSight custom permissions profile.
 
 ## Example Usage
 
+```terraform
 resource "aws_quicksight_custom_permissions" "example" {
   custom_permissions_name = "example-permissions"
 
@@ -20,6 +21,7 @@ resource "aws_quicksight_custom_permissions" "example" {
     share_dashboards = "DENY"
   }
 }
+```
 
 ## Argument Reference
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes implemented.

### Description

Add missing backticks to the code block in section "Example Usage" of resource [aws_quicksight_custom_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_custom_permissions).

### Relations

### References

### Output from Acceptance Testing

Not applicable. Only documentation is updated.