### PR TITLE
Support optional `period` argument for policies that use custom metri…

### DIFF
--- a/.changelog/47136.txt
+++ b/.changelog/47136.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_autoscaling_policy: Add support for using the `period` property with `metric` expressions
+```

--- a/internal/service/autoscaling/policy.go
+++ b/internal/service/autoscaling/policy.go
@@ -115,6 +115,11 @@ func resourcePolicy() *schema.Resource {
 									},
 								},
 							},
+							"period": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								ValidateFunc: validation.IntInSlice([]int{10, 30, 60}),
+							},
 							"return_data": {
 								Type:     schema.TypeBool,
 								Optional: true,
@@ -445,6 +450,11 @@ func resourcePolicy() *schema.Resource {
 																},
 															},
 														},
+													},
+													"period": {
+														Type:         schema.TypeInt,
+														Optional:     true,
+														ValidateFunc: validation.IntInSlice([]int{10, 30, 60}),
 													},
 													"return_data": {
 														Type:     schema.TypeBool,
@@ -868,6 +878,9 @@ func expandTargetTrackingMetricDataQueries(tfList []any) []awstypes.TargetTracki
 			}
 			apiObject.MetricStat = targetTrackingMetricStat
 		}
+		if v, ok := tfMap["period"].(int); ok && v != 0 {
+			apiObject.Period = aws.Int32(int32(v))
+		}
 		if v, ok := tfMap["return_data"]; ok {
 			apiObject.ReturnData = aws.Bool(v.(bool))
 		}
@@ -1182,6 +1195,9 @@ func flattenTargetTrackingMetricDataQueries(apiObjects []awstypes.TargetTracking
 				tfMapMetricStat[names.AttrUnit] = aws.ToString(v)
 			}
 			tfMap["metric_stat"] = []map[string]any{tfMapMetricStat}
+		}
+		if v := apiObject.Period; v != nil {
+			tfMap["period"] = aws.ToInt32(v)
 		}
 		if v := apiObject.ReturnData; v != nil {
 			tfMap["return_data"] = aws.ToBool(v)

--- a/internal/service/autoscaling/policy_test.go
+++ b/internal/service/autoscaling/policy_test.go
@@ -1029,6 +1029,12 @@ resource "aws_autoscaling_policy" "test" {
   target_tracking_configuration {
     customized_metric_specification {
       metrics {
+        id          = "m1"
+        expression  = "TIME_SERIES(20)"
+		period      = 10
+        return_data = false
+      }
+      metrics {
         id = "m2"
         metric_stat {
           metric {
@@ -1037,7 +1043,7 @@ resource "aws_autoscaling_policy" "test" {
           }
           unit   = "Percent"
           stat   = "Sum"
-          period = 10
+		  period = 10
         }
         return_data = false
       }
@@ -1058,13 +1064,20 @@ resource "aws_autoscaling_policy" "test" {
           }
           unit   = "Percent"
           stat   = "Sum"
-          period = 10
+		  period = 10
         }
+        return_data = false
+      }
+      metrics {
+        id          = "e1"
+        expression  = "m1 + m2 + m3"
+		period      = 10
         return_data = true
       }
     }
 
     target_value = 12.3
+
   }
 }
 `, rName))

--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -89,6 +89,7 @@ resource "aws_autoscaling_policy" "example" {
         label       = "Calculate the backlog per instance"
         id          = "e1"
         expression  = "m1 / m2"
+        period      = 10
         return_data = true
       }
     }
@@ -294,6 +295,7 @@ This configuration block supports the following arguments:
 * `id` - (Required) Short name for the metric used in target tracking scaling policy.
 * `label` - (Optional) Human-readable label for this metric or expression.
 * `metric_stat` - (Optional) Structure that defines CloudWatch metric to be used in target tracking scaling policy. You must specify either `expression` or `metric_stat`, but not both.
+* `period` - (Optional) The period of the metric in seconds.
 * `return_data` - (Optional) Boolean that indicates whether to return the timestamps and raw data values of this metric, the default is true
 
 ##### metric_stat


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When using high-resolution metrics with a final expression, you cannot set the period on the final `metrics` block. 
This PR allows adding the `period` property to a final `metrics` block that uses an expression.

Here is an example of the bug:

```terraform
resource "aws_autoscaling_policy" "memory" {
  name                      = "memory"
  autoscaling_group_name    = aws_autoscaling_group.foo.name
  policy_type               = "TargetTrackingScaling"
  enabled                   = true
  estimated_instance_warmup = aws_autoscaling_group.foo.default_cooldown

  target_tracking_configuration {
    target_value = 80

    customized_metric_specification {
      metrics {
        label = "MemAvailable from /proc/meminfo"
        id    = "m1"
        metric_stat {
          metric {
            namespace   = "CWAgent"
            metric_name = "mem_available_percent"
            dimensions {
              name  = "AutoScalingGroupName"
              value = aws_autoscaling_group.foo.name
            }

          }

          stat = "Average"
		  period = 10
        }

        return_data = false
      }

      metrics {
        label       = "Memory used calculated from MemAvailable"
        id          = "e1"
        expression  = "100 - m1"
        return_data = true
      }
    }
  }
}
```

Running Terraform yields this error:

```
Error: updating Auto Scaling Policy (connections): operation error Auto Scaling: PutScalingPolicy, https response error StatusCode: 400, RequestID: bc086640-7a25-4a8e-8636-a68354dc4184, api error ValidationError: Unable to create alarms in CloudWatch: All metrics in the alarm should have the same period
```

Adding the `period` property to the final expression is not allowed.

```terraform
resource "aws_autoscaling_policy" "memory" {

	// --->8----

    customized_metric_specification {
      metrics {
        label       = "Memory used calculated from MemAvailable"
        id          = "e1"
        expression  = "100 - m1"
		period      = 10
        return_data = true
      }
    }
  }
}
```

Error:

```
Error: Unsupported argument
  on ../../modules/foo/asg.tf line 279, in resource "aws_autoscaling_policy" "memory":
 279: period = 10
 
An argument named "period" is not expected here.
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

N/A

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_TargetTrackingMetricDataQuery.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccAutoScalingPolicy_TargetTrack_custom PKG=autoscaling
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-add-period-to-aws_autoscaling_policy-resources-with-expressions 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/autoscaling/... -v -count 1 -parallel 20 -run='TestAccAutoScalingPolicy_TargetTrack_custom'  -timeout 360m -vet=off
2026/03/28 19:15:52 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/28 19:15:52 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAutoScalingPolicy_TargetTrack_custom
=== PAUSE TestAccAutoScalingPolicy_TargetTrack_custom
=== CONT  TestAccAutoScalingPolicy_TargetTrack_custom
    acctest.go:1723: skipping test for aws/us-west-2: Error running apply: exit status 1

        Error: creating Auto Scaling Launch Configuration (tf-acc-test-4258354255506794111): operation error Auto Scaling: CreateLaunchConfiguration, https response error StatusCode: 400, RequestID: 45eaeed3-bb59-44b8-8582-1613a931d14b, api error UnsupportedOperation: The Launch Configuration creation operation is not available in your account. Use launch templates to create configuration templates for your Auto Scaling groups.

          with aws_launch_configuration.test,
          on terraform_plugin_test.tf line 41, in resource "aws_launch_configuration" "test":
          41: resource "aws_launch_configuration" "test" {

--- SKIP: TestAccAutoScalingPolicy_TargetTrack_custom (11.37s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling        16.609s

...
```
