### PR TITLE
fix: Fix service principals for ec2 and s3 in China

### DIFF
--- a/.changelog/47141.txt
+++ b/.changelog/47141.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-data-source/aws_service_principal: Fix service principals for ec2 and s3 in China
+data-source/aws_service_principal: Fix service principal names for EC2 and S3 in the `aws-cn` partition
 ```

--- a/.changelog/47141.txt
+++ b/.changelog/47141.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_service_principal: Fix service principals for ec2 and s3 in China
+```

--- a/internal/service/meta/service_principal_data_source.go
+++ b/internal/service/meta/service_principal_data_source.go
@@ -108,7 +108,9 @@ func servicePrincipalNameForPartition(service string, partition endpoints.Partit
 			switch service {
 			case "codedeploy",
 				"elasticmapreduce",
-				"logs":
+				"logs",
+				"ec2",
+				"s3":
 				return partition.DNSSuffix()
 			}
 		}

--- a/internal/service/meta/service_principal_data_source_test.go
+++ b/internal/service/meta/service_principal_data_source_test.go
@@ -68,11 +68,11 @@ func TestAccMetaServicePrincipalDataSource_ByRegion(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				Steps: []resource.TestStep{
 					{
-						Config: testAccServicePrincipalDataSourceConfig_withRegion("s3", region),
+						Config: testAccServicePrincipalDataSourceConfig_withRegion("autoscaling", region),
 						Check: resource.ComposeTestCheckFunc(
 							//lintignore:AWSR001
-							resource.TestCheckResourceAttr(dataSourceName, names.AttrID, fmt.Sprintf("s3.%s.amazonaws.com", region)),
-							resource.TestCheckResourceAttr(dataSourceName, names.AttrName, "s3.amazonaws.com"),
+							resource.TestCheckResourceAttr(dataSourceName, names.AttrID, fmt.Sprintf("autoscaling.%s.amazonaws.com", region)),
+							resource.TestCheckResourceAttr(dataSourceName, names.AttrName, "autoscaling.amazonaws.com"),
 							resource.TestCheckResourceAttr(dataSourceName, "suffix", "amazonaws.com"),
 							resource.TestCheckResourceAttr(dataSourceName, names.AttrRegion, region),
 						),

--- a/internal/service/meta/service_principal_data_source_test.go
+++ b/internal/service/meta/service_principal_data_source_test.go
@@ -115,7 +115,7 @@ func TestAccMetaServicePrincipalDataSource_UniqueForServiceInRegion(t *testing.T
 		{
 			Region:   "cn-north-1", //lintignore:AWSAT003
 			Suffix:   "amazonaws.com.cn",
-			Services: []string{"codedeploy", "elasticmapreduce", "logs"},
+			Services: []string{"codedeploy", "elasticmapreduce", "logs", "ec2", "s3"},
 		},
 	}
 

--- a/internal/types/service_principal.go
+++ b/internal/types/service_principal.go
@@ -10,7 +10,7 @@ import (
 // servicePrincipalRegexp matches AWS service principal names.
 // Service principals follow the pattern: service-id.amazonaws.com, service-id.amazon.com, or service-id.amazonaws.com.cn.
 // Examples: ec2.amazonaws.com, s3.amazonaws.com, elasticmapreduce.amazonaws.com, s3.amazonaws.com.cn.
-var servicePrincipalRegexp = regexache.MustCompile(`^([0-9a-z-]+\.){1,4}(amazonaws|amazon)\.(com|com\.cn)$`)
+var servicePrincipalRegexp = regexache.MustCompile(`^(?:[0-9a-z-]+\.){1,4}(?:amazonaws\.com(?:\.cn)?|amazon\.com)$`)
 
 // IsServicePrincipal returns whether or not the specified string is a valid AWS service principal.
 func IsServicePrincipal(s string) bool {

--- a/internal/types/service_principal.go
+++ b/internal/types/service_principal.go
@@ -10,7 +10,7 @@ import (
 // servicePrincipalRegexp matches AWS service principal names.
 // Service principals follow the pattern: service-id.amazonaws.com or service-id.amazon.com
 // Examples: ec2.amazonaws.com, s3.amazonaws.com, elasticmapreduce.amazonaws.com
-var servicePrincipalRegexp = regexache.MustCompile(`^([0-9a-z-]+\.){1,4}(amazonaws|amazon)\.com$`)
+var servicePrincipalRegexp = regexache.MustCompile(`^([0-9a-z-]+\.){1,4}(amazonaws|amazon)\.(com|com\.cn)$`)
 
 // IsServicePrincipal returns whether or not the specified string is a valid AWS service principal.
 func IsServicePrincipal(s string) bool {

--- a/internal/types/service_principal.go
+++ b/internal/types/service_principal.go
@@ -8,8 +8,8 @@ import (
 )
 
 // servicePrincipalRegexp matches AWS service principal names.
-// Service principals follow the pattern: service-id.amazonaws.com or service-id.amazon.com
-// Examples: ec2.amazonaws.com, s3.amazonaws.com, elasticmapreduce.amazonaws.com
+// Service principals follow the pattern: service-id.amazonaws.com, service-id.amazon.com, or service-id.amazonaws.com.cn.
+// Examples: ec2.amazonaws.com, s3.amazonaws.com, elasticmapreduce.amazonaws.com, s3.amazonaws.com.cn.
 var servicePrincipalRegexp = regexache.MustCompile(`^([0-9a-z-]+\.){1,4}(amazonaws|amazon)\.(com|com\.cn)$`)
 
 // IsServicePrincipal returns whether or not the specified string is a valid AWS service principal.

--- a/internal/types/service_principal_test.go
+++ b/internal/types/service_principal_test.go
@@ -14,8 +14,10 @@ func TestIsServicePrincipal(t *testing.T) {
 	}{
 		{"ec2.amazonaws.com", true},
 		{"ec2.amazonaws.com.cn", true},
+		{"ec2.amazon.com.cn", false},
 		{"s3.amazonaws.com", true},
 		{"s3.amazonaws.com.cn", true},
+		{"s3.amazonaws.com.com", false},
 		{"elasticmapreduce.amazonaws.com", true},
 		{"lambda.amazonaws.com", true},
 		{"ecs-tasks.amazonaws.com", true},

--- a/internal/types/service_principal_test.go
+++ b/internal/types/service_principal_test.go
@@ -13,7 +13,9 @@ func TestIsServicePrincipal(t *testing.T) {
 		valid     bool
 	}{
 		{"ec2.amazonaws.com", true},
+		{"ec2.amazonaws.com.cn", true},
 		{"s3.amazonaws.com", true},
+		{"s3.amazonaws.com.cn", true},
 		{"elasticmapreduce.amazonaws.com", true},
 		{"lambda.amazonaws.com", true},
 		{"ecs-tasks.amazonaws.com", true},


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-aws/issues/46209

### Description
aws_service_principal should return s3.amazonaws.com.cn and ec2.amazonaws.com.cn on name for S3 and EC2 services in AWS China regions, but instead it returns s3.amazonaws.com and ec2.amazonaws.com. This PR fixes that issue