### PR TITLE
r/aws_dynamodb_table: restore `5s` delay to `waitTableActive`

### DIFF
--- a/.changelog/47143.txt
+++ b/.changelog/47143.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Fix `Error: waiting for creation AWS DynamoDB Table (xxxxx): couldn't find resource` in highly active accounts by restoring `5s` delay before polling for table status. This fixes a regression introduced in [v6.28.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#6280-january-7-2026).
+```

--- a/internal/service/dynamodb/wait.go
+++ b/internal/service/dynamodb/wait.go
@@ -32,6 +32,7 @@ func waitTableActive(ctx context.Context, conn *dynamodb.Client, tableName strin
 		Target:                    enum.Slice(awstypes.TableStatusActive),
 		Refresh:                   statusTable(conn, tableName),
 		Timeout:                   max(createTableTimeout, timeout),
+		Delay:                     5 * time.Second,
 		MinTimeout:                1 * time.Second,
 		ContinuousTargetOccurence: 2,
 	}


### PR DESCRIPTION



<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
In `v6.28.0` the initial `5s` delay was removed from the `waitTableActive` helper function and replaced with a `MinTimeout` of `1s`. In accounts with large numbers of tables, users have reported an increase in errors waiting for table creation (`Error: waiting for creation AWS DynamoDB Table (xxxxx): couldn't find resource (21 retries)`) following this change.

At this time it is believed the removal of the delay may be causing the initial `NotFound` status to be cached in environments with high load, resulting in the provider exhausting the configured number of "NotFound" retry attempts before the cached value expires and is replaced with the correct, existing table status. We going to restore the initial `5s` delay as a first attempt at resolving this without increasing the number of `NotFoundChecks` which were already in place before `v6.28.0`.

See https://github.com/hashicorp/terraform-provider-aws/issues/46530#issuecomment-4145972809 for additional research.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Relates #46530
Relates #44999

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=dynamodb T=TestAccDynamoDBTable_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-dynamodb_table-create-delay 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_'  -timeout 360m -vet=off
2026/03/30 10:43:39 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/30 10:43:39 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed (9.10s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_doubleAddCMK
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (21.08s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_Create_witness_too_many_replicas
--- PASS: TestAccDynamoDBTable_nameKnownAfterApply (58.46s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_Create_witness
--- PASS: TestAccDynamoDBTable_GSI_unknown (61.07s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_Create
--- PASS: TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed_onUpdate (63.09s)
=== CONT  TestAccDynamoDBTable_Replica_tagsUpdate
--- PASS: TestAccDynamoDBTable_warmThroughputDefault (67.24s)
=== CONT  TestAccDynamoDBTable_Replica_tags_nonPropagatedTagsAreUnmanaged
--- PASS: TestAccDynamoDBTable_tableClass_migrate (70.20s)
=== CONT  TestAccDynamoDBTable_Replica_tags_notPropagatedToAddedReplica
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create_witness_too_many_replicas (57.27s)
=== CONT  TestAccDynamoDBTable_Replica_tags_propagateToAddedReplica
--- PASS: TestAccDynamoDBTable_GSI_keySchema_unknown (86.20s)
=== CONT  TestAccDynamoDBTable_Replica_tags_updateIsPropagated_twoOfTwo
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (151.66s)
=== CONT  TestAccDynamoDBTable_Replica_tags_updateIsPropagated_oneOfTwo
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (160.90s)
=== CONT  TestAccDynamoDBTable_Replica_pitrKMS
--- PASS: TestAccDynamoDBTable_importTable (161.40s)
=== CONT  TestAccDynamoDBTable_Replica_pitr
--- PASS: TestAccDynamoDBTable_warmThroughput (186.20s)
=== CONT  TestAccDynamoDBTable_Replica_doubleAddCMK
--- PASS: TestAccDynamoDBTable_tags (188.56s)
=== CONT  TestAccDynamoDBTable_Replica_singleCMK
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_switchBilling (270.18s)
=== CONT  TestAccDynamoDBTable_Replica_singleDefaultKeyEncryptedAmazonOwned
--- PASS: TestAccDynamoDBTable_Replica_MRSC_pitr (294.00s)
=== CONT  TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_notPropagatedToAddedReplica (299.41s)
=== CONT  TestAccDynamoDBTable_Replica_singleStreamSpecification
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create_witness (241.68s)
=== CONT  TestAccDynamoDBTable_Replica_single
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create (255.56s)
=== CONT  TestAccDynamoDBTable_Replica_multiple
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_billingProvisioned (418.51s)
=== CONT  TestAccDynamoDBTable_restoreCrossRegion
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_billingPayPerRequest (423.71s)
=== CONT  TestAccDynamoDBTable_encryption
--- PASS: TestAccDynamoDBTable_Replica_singleCMK (301.97s)
=== CONT  TestAccDynamoDBTable_backup_overrideEncryption
--- PASS: TestAccDynamoDBTable_Replica_singleStreamSpecification (307.14s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_TooManyReplicas
--- PASS: TestAccDynamoDBTable_encryption (191.01s)
=== CONT  TestAccDynamoDBTable_Replica_upgradeV6_2_0
=== NAME  TestAccDynamoDBTable_Replica_MRSC_TooManyReplicas
    table_test.go:7756: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: deleting AWS DynamoDB Table (tf-acc-test-5753384086458950938): deleting replica(s): operation error DynamoDB: UpdateTable, https response error StatusCode: 400, RequestID: 0TUR56ADTUCO62K82H817FOVAFVV4KQNSO5AEMVJF66Q9ASUAAJG, api error ValidationException: Cannot add or delete the local region through ReplicaUpdates. Use CreateTable, DeleteTable, or UpdateTable as required.

--- FAIL: TestAccDynamoDBTable_Replica_MRSC_TooManyReplicas (43.56s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_CreateEventuallyConsistent
--- PASS: TestAccDynamoDBTable_Replica_tags_nonPropagatedTagsAreUnmanaged (597.14s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_MixedConsistencyModes
--- PASS: TestAccDynamoDBTable_Replica_tags_updateIsPropagated_twoOfTwo (582.10s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_NotEnoughReplicas
--- PASS: TestAccDynamoDBTable_Replica_tags_notPropagatedToAddedReplica (598.82s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_oneOfTwo
--- PASS: TestAccDynamoDBTable_Replica_MRSC_MixedConsistencyModes (40.68s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica
--- PASS: TestAccDynamoDBTable_Replica_MRSC_NotEnoughReplicas (49.80s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_tags_propagateToAddedReplica
--- PASS: TestAccDynamoDBTable_Replica_tags_updateIsPropagated_oneOfTwo (577.24s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_twoOfTwo
--- PASS: TestAccDynamoDBTable_Replica_tags_propagateToAddedReplica (650.69s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_twoOfTwo
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncryptedAmazonOwned (463.30s)
=== CONT  TestAccDynamoDBTable_backupEncryption
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted (440.48s)
=== CONT  TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_DifferentFromTable
--- PASS: TestAccDynamoDBTable_Replica_pitr (630.44s)
=== CONT  TestAccDynamoDBTable_lsiUpdate
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_doubleAddCMK (804.42s)
=== CONT  TestAccDynamoDBTable_attributeUpdate
--- PASS: TestAccDynamoDBTable_Replica_MRSC_doubleAddCMK (825.87s)
=== CONT  TestAccDynamoDBTable_TTL_validate
--- PASS: TestAccDynamoDBTable_TTL_validate (4.51s)
=== CONT  TestAccDynamoDBTable_TTL_updateDisable
--- PASS: TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_DifferentFromTable (105.16s)
=== CONT  TestAccDynamoDBTable_TTL_updateEnable
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (791.37s)
=== CONT  TestAccDynamoDBTable_TTL_disabled
--- PASS: TestAccDynamoDBTable_lsiUpdate (101.78s)
=== CONT  TestAccDynamoDBTable_TTL_enabled
--- PASS: TestAccDynamoDBTable_Replica_pitrKMS (745.07s)
=== CONT  TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
--- PASS: TestAccDynamoDBTable_Replica_upgradeV6_2_0 (296.34s)
=== CONT  TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
--- PASS: TestAccDynamoDBTable_TTL_updateEnable (82.09s)
=== CONT  TestAccDynamoDBTable_lsiNonKeyAttributes
--- PASS: TestAccDynamoDBTable_TTL_disabled (72.85s)
=== CONT  TestAccDynamoDBTable_gsiUpdateOtherAttributes
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_oneOfTwo (266.80s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleRangeKeys
--- PASS: TestAccDynamoDBTable_TTL_enabled (69.56s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (49.35s)
=== CONT  TestAccDynamoDBTable_enablePITRWithCustomRecoveryPeriod
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica (287.51s)
=== CONT  TestAccDynamoDBTable_enablePITR
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (87.05s)
=== CONT  TestAccDynamoDBTable_GSIvalidate_keySchema_tooManyRangeKeys
--- PASS: TestAccDynamoDBTable_GSIvalidate_keySchema_tooManyRangeKeys (1.66s)
=== CONT  TestAccDynamoDBTable_GSI_validate_keySchema_tooManyHashKeys
--- PASS: TestAccDynamoDBTable_GSI_validate_keySchema_tooManyHashKeys (1.77s)
=== CONT  TestAccDynamoDBTable_GSI_validate_exactlyOneOfKeySchemaHashKey
--- PASS: TestAccDynamoDBTable_GSI_validate_exactlyOneOfKeySchemaHashKey (1.72s)
=== CONT  TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema
--- PASS: TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema (1.43s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_removeGSI
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleRangeKeys (64.87s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_removeRangeKey
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_twoOfTwo (310.15s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_addRangeKey
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_propagateToAddedReplica (330.20s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_pitrKMS
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_twoOfTwo (322.61s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_oneOfTwo
--- PASS: TestAccDynamoDBTable_enablePITRWithCustomRecoveryPeriod (109.83s)
=== CONT  TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_noChange
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (118.50s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_maxSet
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeGSI (83.65s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_removeHashKey
--- PASS: TestAccDynamoDBTable_enablePITR (92.88s)
=== CONT  TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_removeKey
--- PASS: TestAccDynamoDBTable_Replica_single (787.30s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_addHashKey
--- PASS: TestAccDynamoDBTable_GSI_keySchema_maxSet (65.00s)
=== CONT  TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_addHashKey
--- PASS: TestAccDynamoDBTable_Replica_MRSC_CreateEventuallyConsistent (503.70s)
=== CONT  TestAccDynamoDBTable_tableClassExplicitDefault
--- PASS: TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_noChange (84.81s)
=== CONT  TestAccDynamoDBTable_tableClass_ConcurrentModification
--- PASS: TestAccDynamoDBTable_tableClassExplicitDefault (60.00s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccDynamoDBTable_Replica_deletionProtection (1217.66s)
=== CONT  TestAccDynamoDBTable_disappears
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (337.33s)
=== CONT  TestAccDynamoDBTable_deletion_protection
--- PASS: TestAccDynamoDBTable_tableClass_ConcurrentModification (82.77s)
=== CONT  TestAccDynamoDBTable_basic
--- PASS: TestAccDynamoDBTable_disappears (35.51s)
=== CONT  TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_emptyResourceTag (48.62s)
=== CONT  TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccDynamoDBTable_restoreCrossRegion (867.59s)
=== CONT  TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccDynamoDBTable_basic (44.68s)
=== CONT  TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccDynamoDBTable_deletion_protection (72.89s)
=== CONT  TestAccDynamoDBTable_Tags_ComputedTag_onCreate
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_oneOfTwo (278.01s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (847.37s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeRangeKey (345.69s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_resourceTag (100.93s)
=== CONT  TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_defaultTag (91.80s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_replace (82.05s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_add (86.98s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_overlapping
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_onCreate (59.27s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nullNonOverlappingResourceTag (54.97s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_providerOnly
--- PASS: TestAccDynamoDBTable_Replica_multiple (1068.55s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleHashKey
--- PASS: TestAccDynamoDBTable_GSI_keySchema_addRangeKey (350.10s)
=== CONT  TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_noChange
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nullOverlappingResourceTag (54.43s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleRangeKey
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_emptyProviderOnlyTag (59.09s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_tagsUpdate
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeHashKey (349.53s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tagsUpdate
--- PASS: TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_removeKey (351.86s)
=== CONT  TestAccDynamoDBTable_Tags_addOnUpdate
--- PASS: TestAccDynamoDBTable_GSI_keySchema_addHashKey (350.27s)
=== CONT  TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_updateToResourceOnly (90.02s)
=== CONT  TestAccDynamoDBTable_Tags_EmptyTag_onCreate
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_replace (103.13s)
=== CONT  TestAccDynamoDBTable_onDemandThroughput
--- PASS: TestAccDynamoDBTable_attributeUpdate (647.01s)
=== CONT  TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_SameAsTable
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_updateToProviderOnly (95.34s)
=== CONT  TestAccDynamoDBTable_streamSpecificationValidation
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (6.92s)
=== CONT  TestAccDynamoDBTable_streamSpecificationDiffs
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleHashKey (89.74s)
=== CONT  TestAccDynamoDBTable_streamSpecification
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_pitrKMS (441.43s)
=== CONT  TestAccDynamoDBTable_gsiOnDemandThroughput
--- PASS: TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_addHashKey (351.05s)
=== CONT  TestAccDynamoDBTable_Tags_emptyMap
--- PASS: TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_noChange (125.49s)
=== CONT  TestAccDynamoDBTable_Tags_null
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleRangeKey (122.35s)
=== CONT  TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestBasic
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (608.51s)
--- PASS: TestAccDynamoDBTable_Tags_addOnUpdate (125.61s)
=== CONT  TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nonOverlapping (193.91s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_overlapping (198.21s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tags_nonPropagatedTagsAreUnmanaged
--- PASS: TestAccDynamoDBTable_backupEncryption (848.86s)
=== CONT  TestAccDynamoDBTable_tableClassInfrequentAccess
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_onCreate (143.87s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_tags_nonPropagatedTagsAreUnmanaged
--- PASS: TestAccDynamoDBTable_streamSpecification (138.76s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleHashKeys
--- PASS: TestAccDynamoDBTable_Tags_emptyMap (123.46s)
=== CONT  TestAccDynamoDBTable_restoreBackupARN
--- PASS: TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_SameAsTable (174.22s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_pitrKMS
--- PASS: TestAccDynamoDBTable_Tags_null (120.64s)
=== CONT  TestAccDynamoDBTable_extended
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_add (201.97s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_pitr
=== NAME  TestAccDynamoDBTable_restoreBackupARN
    table_test.go:7988: Step 1/2 error: Error running apply: exit status 1

        Error: Attempt to index null value

          on terraform_plugin_test.tf line 50, in resource "aws_dynamodb_table" "test_restore":
          50:   restore_backup_arn = data.aws_dynamodb_backups.test.backup_summaries[0].backup_arn
            ├────────────────
            │ data.aws_dynamodb_backups.test.backup_summaries is null

        This value is null, so it does not have any indices.
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_providerOnly (265.35s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
--- FAIL: TestAccDynamoDBTable_restoreBackupARN (39.21s)
--- PASS: TestAccDynamoDBTable_onDemandThroughput (203.19s)
--- PASS: TestAccDynamoDBTable_gsiOnDemandThroughput (173.56s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleHashKeys (78.57s)
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (111.35s)
--- PASS: TestAccDynamoDBTable_streamSpecificationDiffs (293.04s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (251.39s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (212.49s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (186.96s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (315.30s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_nonPropagatedTagsAreUnmanaged (312.02s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestBasic (363.22s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_pitr (281.41s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tagsUpdate (522.56s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_nonPropagatedTagsAreUnmanaged (356.66s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tagsUpdate (520.68s)
--- PASS: TestAccDynamoDBTable_extended (346.03s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_pitrKMS (431.33s)
=== NAME  TestAccDynamoDBTable_Replica_doubleAddCMK
    table_test.go:5334: Step 3/3 error: Error running apply: exit status 1

        Error: updating AWS DynamoDB Table (tf-acc-test-7644445080160258683): updating replicas, while creating: creating replica (us-east-1): operation error DynamoDB: UpdateTable, https response error StatusCode: 400, RequestID: C1PMVQLQ0RHT5O0NQOOQ6FE5EFVV4KQNSO5AEMVJF66Q9ASUAAJG, api error ValidationException: Replica specified in the Replica Update or Replica Delete action of the request was not found.

          with aws_dynamodb_table.test,
          on terraform_plugin_test.tf line 68, in resource "aws_dynamodb_table" "test":
          68: resource "aws_dynamodb_table" "test" {

--- FAIL: TestAccDynamoDBTable_Replica_doubleAddCMK (2979.96s)
--- PASS: TestAccDynamoDBTable_TTL_updateDisable (3687.93s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   4525.490s
```

Failures are unrelated to this change.