### PR TITLE
Feature: Add support in S3 Lens for advanced performance metrics

### DIFF
--- a/.changelog/47144.txt
+++ b/.changelog/47144.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3control_storage_lens_configuration: Add support for Advanced Performance Metrics
+```

--- a/internal/service/s3control/storage_lens_configuration.go
+++ b/internal/service/s3control/storage_lens_configuration.go
@@ -111,6 +111,19 @@ func resourceStorageLensConfiguration() *schema.Resource {
 											},
 										},
 									},
+									"advanced_performance_metrics": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												names.AttrEnabled: {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+											},
+										},
+									},
 									"bucket_level": {
 										Type:     schema.TypeList,
 										Required: true,
@@ -144,6 +157,19 @@ func resourceStorageLensConfiguration() *schema.Resource {
 													},
 												},
 												"advanced_data_protection_metrics": {
+													Type:     schema.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															names.AttrEnabled: {
+																Type:     schema.TypeBool,
+																Optional: true,
+															},
+														},
+													},
+												},
+												"advanced_performance_metrics": {
 													Type:     schema.TypeList,
 													Optional: true,
 													MaxItems: 1,
@@ -707,6 +733,10 @@ func expandAccountLevel(tfMap map[string]any) *types.AccountLevel {
 		apiObject.AdvancedDataProtectionMetrics = expandAdvancedDataProtectionMetrics(v[0].(map[string]any))
 	}
 
+	if v, ok := tfMap["advanced_performance_metrics"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.AdvancedPerformanceMetrics = expandAdvancedPerformanceMetrics(v[0].(map[string]any))
+	}
+
 	if v, ok := tfMap["bucket_level"].([]any); ok && len(v) > 0 && v[0] != nil {
 		apiObject.BucketLevel = expandBucketLevel(v[0].(map[string]any))
 	} else {
@@ -753,12 +783,30 @@ func expandBucketLevel(tfMap map[string]any) *types.BucketLevel {
 		apiObject.AdvancedDataProtectionMetrics = expandAdvancedDataProtectionMetrics(v[0].(map[string]any))
 	}
 
+	if v, ok := tfMap["advanced_performance_metrics"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.AdvancedPerformanceMetrics = expandAdvancedPerformanceMetrics(v[0].(map[string]any))
+	}
+
 	if v, ok := tfMap["detailed_status_code_metrics"].([]any); ok && len(v) > 0 && v[0] != nil {
 		apiObject.DetailedStatusCodesMetrics = expandDetailedStatusCodesMetrics(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["prefix_level"].([]any); ok && len(v) > 0 && v[0] != nil {
 		apiObject.PrefixLevel = expandPrefixLevel(v[0].(map[string]any))
+	}
+
+	return apiObject
+}
+
+func expandAdvancedPerformanceMetrics(tfMap map[string]any) *types.AdvancedPerformanceMetrics {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &types.AdvancedPerformanceMetrics{}
+
+	if v, ok := tfMap[names.AttrEnabled].(bool); ok {
+		apiObject.IsEnabled = v
 	}
 
 	return apiObject
@@ -1059,6 +1107,10 @@ func flattenAccountLevel(apiObject *types.AccountLevel) map[string]any {
 		tfMap["advanced_data_protection_metrics"] = []any{flattenAdvancedDataProtectionMetrics(v)}
 	}
 
+	if v := apiObject.AdvancedPerformanceMetrics; v != nil {
+		tfMap["advanced_performance_metrics"] = []any{flattenAdvancedPerformanceMetrics(v)}
+	}
+
 	if v := apiObject.BucketLevel; v != nil {
 		tfMap["bucket_level"] = []any{flattenBucketLevel(v)}
 	}
@@ -1101,6 +1153,10 @@ func flattenBucketLevel(apiObject *types.BucketLevel) map[string]any {
 		tfMap["advanced_data_protection_metrics"] = []any{flattenAdvancedDataProtectionMetrics(v)}
 	}
 
+	if v := apiObject.AdvancedPerformanceMetrics; v != nil {
+		tfMap["advanced_performance_metrics"] = []any{flattenAdvancedPerformanceMetrics(v)}
+	}
+
 	if v := apiObject.DetailedStatusCodesMetrics; v != nil {
 		tfMap["detailed_status_code_metrics"] = []any{flattenDetailedStatusCodesMetrics(v)}
 	}
@@ -1125,6 +1181,18 @@ func flattenAdvancedCostOptimizationMetrics(apiObject *types.AdvancedCostOptimiz
 }
 
 func flattenAdvancedDataProtectionMetrics(apiObject *types.AdvancedDataProtectionMetrics) map[string]any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	tfMap[names.AttrEnabled] = apiObject.IsEnabled
+
+	return tfMap
+}
+
+func flattenAdvancedPerformanceMetrics(apiObject *types.AdvancedPerformanceMetrics) map[string]any {
 	if apiObject == nil {
 		return nil
 	}

--- a/internal/service/s3control/storage_lens_configuration_test.go
+++ b/internal/service/s3control/storage_lens_configuration_test.go
@@ -38,10 +38,12 @@ func TestAccS3ControlStorageLensConfiguration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.activity_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.advanced_cost_optimization_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.advanced_data_protection_metrics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.advanced_performance_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.activity_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.advanced_cost_optimization_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.advanced_data_protection_metrics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.advanced_performance_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.detailed_status_code_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.prefix_level.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.detailed_status_code_metrics.#", "0"),
@@ -153,11 +155,13 @@ func TestAccS3ControlStorageLensConfiguration_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.activity_metrics.0.enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.advanced_cost_optimization_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.advanced_data_protection_metrics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.advanced_performance_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.activity_metrics.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.activity_metrics.0.enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.advanced_cost_optimization_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.advanced_data_protection_metrics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.advanced_performance_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.detailed_status_code_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.prefix_level.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.prefix_level.0.storage_metrics.#", "1"),
@@ -203,11 +207,13 @@ func TestAccS3ControlStorageLensConfiguration_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.activity_metrics.0.enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.advanced_cost_optimization_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.advanced_data_protection_metrics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.advanced_performance_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.activity_metrics.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.activity_metrics.0.enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.advanced_cost_optimization_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.advanced_data_protection_metrics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.advanced_performance_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.detailed_status_code_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.prefix_level.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.detailed_status_code_metrics.#", "0"),
@@ -261,6 +267,8 @@ func TestAccS3ControlStorageLensConfiguration_advancedMetrics(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.advanced_cost_optimization_metrics.0.enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.advanced_data_protection_metrics.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.advanced_data_protection_metrics.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.advanced_performance_metrics.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.advanced_performance_metrics.0.enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.activity_metrics.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.activity_metrics.0.enabled", acctest.CtTrue),
@@ -268,6 +276,8 @@ func TestAccS3ControlStorageLensConfiguration_advancedMetrics(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.advanced_cost_optimization_metrics.0.enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.advanced_data_protection_metrics.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.advanced_data_protection_metrics.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.advanced_performance_metrics.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.advanced_performance_metrics.0.enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.detailed_status_code_metrics.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.detailed_status_code_metrics.0.enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.prefix_level.#", "0"),
@@ -300,10 +310,12 @@ func TestAccS3ControlStorageLensConfiguration_advancedMetrics(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.activity_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.advanced_cost_optimization_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.advanced_data_protection_metrics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.advanced_performance_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.activity_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.advanced_cost_optimization_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.advanced_data_protection_metrics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.advanced_performance_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.detailed_status_code_metrics.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.bucket_level.0.prefix_level.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_lens_configuration.0.account_level.0.detailed_status_code_metrics.#", "0"),
@@ -564,6 +576,10 @@ resource "aws_s3control_storage_lens_configuration" "test" {
         enabled = true
       }
 
+	  advanced_performance_metrics {
+        enabled = true
+      }	
+
       detailed_status_code_metrics {
         enabled = true
       }
@@ -580,6 +596,10 @@ resource "aws_s3control_storage_lens_configuration" "test" {
         advanced_data_protection_metrics {
           enabled = true
         }
+
+		advanced_performance_metrics {
+		  enabled = true
+	    }
 
         detailed_status_code_metrics {
           enabled = true

--- a/website/docs/cdktf/python/r/s3control_storage_lens_configuration.html.markdown
+++ b/website/docs/cdktf/python/r/s3control_storage_lens_configuration.html.markdown
@@ -92,6 +92,7 @@ The `account_level` block supports the following:
 * `activity_metrics` (Optional) S3 Storage Lens activity metrics. See [Activity Metrics](#activity-metrics) below for more details.
 * `advanced_cost_optimization_metrics` (Optional) Advanced cost-optimization metrics for S3 Storage Lens. See [Advanced Cost-Optimization Metrics](#advanced-cost-optimization-metrics) below for more details.
 * `advanced_data_protection_metrics` (Optional) Advanced data-protection metrics for S3 Storage Lens. See [Advanced Data-Protection Metrics](#advanced-data-protection-metrics) below for more details.
+* `advanced_performance_metrics` (Optional) Advanced performance metrics for S3 Storage Lens. See [Advanced Performance Metrics](#advanced-performance-metrics) below for more details.
 * `bucket_level` (Required) S3 Storage Lens bucket-level configuration. See [Bucket Level](#bucket-level) below for more details.
 * `detailed_status_code_metrics` (Optional) Detailed status code metrics for S3 Storage Lens. See [Detailed Status Code Metrics](#detailed-status-code-metrics) below for more details.
 
@@ -113,6 +114,12 @@ The `advanced_data_protection_metrics` block supports the following:
 
 * `enabled` (Optional) Whether advanced data-protection metrics are enabled.
 
+### Advanced Performance Metrics
+
+The `advanced_performance_metrics` block supports the following:
+
+* `enabled` (Optional) Whether advanced performance metrics are enabled.
+
 ### Detailed Status Code Metrics
 
 The `detailed_status_code_metrics` block supports the following:
@@ -126,6 +133,7 @@ The `bucket_level` block supports the following:
 * `activity_metrics` (Optional) S3 Storage Lens activity metrics. See [Activity Metrics](#activity-metrics) above for more details.
 * `advanced_cost_optimization_metrics` (Optional) Advanced cost-optimization metrics for S3 Storage Lens. See [Advanced Cost-Optimization Metrics](#advanced-cost-optimization-metrics) above for more details.
 * `advanced_data_protection_metrics` (Optional) Advanced data-protection metrics for S3 Storage Lens. See [Advanced Data-Protection Metrics](#advanced-data-protection-metrics) above for more details.
+* `advanced_performance_metrics` (Optional) Advanced performance metrics for S3 Storage Lens. See [Advanced Performance Metrics](#advanced-performance-metrics) above for more details.
 * `detailed_status_code_metrics` (Optional) Detailed status code metrics for S3 Storage Lens. See [Detailed Status Code Metrics](#detailed-status-code-metrics) above for more details.
 * `prefix_level` (Optional) Prefix-level metrics for S3 Storage Lens. See [Prefix Level](#prefix-level) below for more details.
 


### PR DESCRIPTION
## Description

In Dec 2025, S3 Lens has added a new feature to support advanced performance metrics: https://aws.amazon.com/blogs/aws/amazon-s3-storage-lens-adds-performance-metrics-support-for-billions-of-prefixes-and-export-to-s3-tables/. This PR adds support in Terraform for it.

We are adding the following property in `aws_s3control_storage_lens_configuration` resource:
- `advanced_performance_metrics` on bucket and account levels

To get the property details, you can take a look at the CFN: https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_s3/CfnStorageLens.html (search for `advanced_performance_metrics`).

## References

advanced_performance_metrics
* Account level properties (with optional AdvancedPerformanceMetrics): https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.CfnStorageLens.AccountLevelProperty.html#advancedperformancemetrics
* Bucket level properties (with optional AdvancedPerformanceMetrics): https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.CfnStorageLens.BucketLevelProperty.html#advancedperformancemetrics
* AdvancedPerformanceMetrics properties: https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.CfnStorageLens.AdvancedPerformanceMetricsProperty.html#properties

## Output from Acceptance Testing

Added new tests and ran `make testacc TESTARGS='-run=TestAccS3ControlStorageLensConfiguration_' PKG=s3control ACCTEST_PARALLELISM=3` against an AWS account:

Output:

```
make: Running acceptance tests on branch: 🌿 f-s3-lens-advanced-performance-metrics 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/s3control/... -v -count 1 -parallel 3  -run=TestAccS3ControlStorageLensConfiguration_ -timeout 360m -vet=off
2026/03/31 11:02:29 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/31 11:02:29 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3ControlStorageLensConfiguration_basic
=== PAUSE TestAccS3ControlStorageLensConfiguration_basic
=== RUN   TestAccS3ControlStorageLensConfiguration_disappears
=== PAUSE TestAccS3ControlStorageLensConfiguration_disappears
=== RUN   TestAccS3ControlStorageLensConfiguration_tags
=== PAUSE TestAccS3ControlStorageLensConfiguration_tags
=== RUN   TestAccS3ControlStorageLensConfiguration_update
=== PAUSE TestAccS3ControlStorageLensConfiguration_update
=== RUN   TestAccS3ControlStorageLensConfiguration_advancedMetrics
=== PAUSE TestAccS3ControlStorageLensConfiguration_advancedMetrics
=== CONT  TestAccS3ControlStorageLensConfiguration_basic
=== CONT  TestAccS3ControlStorageLensConfiguration_update
=== CONT  TestAccS3ControlStorageLensConfiguration_advancedMetrics
--- PASS: TestAccS3ControlStorageLensConfiguration_basic (43.98s)
=== CONT  TestAccS3ControlStorageLensConfiguration_tags
--- PASS: TestAccS3ControlStorageLensConfiguration_advancedMetrics (70.53s)
=== CONT  TestAccS3ControlStorageLensConfiguration_disappears
--- PASS: TestAccS3ControlStorageLensConfiguration_update (86.08s)
--- PASS: TestAccS3ControlStorageLensConfiguration_disappears (34.32s)
--- PASS: TestAccS3ControlStorageLensConfiguration_tags (89.55s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3control  142.064s
```
