### PR TITLE
d/aws_outposts_asset: Add `instance_families` attribute

### DIFF
--- a/.changelog/47153.txt
+++ b/.changelog/47153.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_outposts_asset: Add `instance_families` attribute
+```

--- a/internal/service/outposts/outpost_asset_data_source.go
+++ b/internal/service/outposts/outpost_asset_data_source.go
@@ -42,6 +42,11 @@ func dataSourceOutpostAsset() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"instance_families": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"rack_elevation": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -91,6 +96,7 @@ func DataSourceOutpostAssetRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("asset_id", asset.AssetId)
 	d.Set("asset_type", asset.AssetType)
 	d.Set("host_id", asset.ComputeAttributes.HostId)
+	d.Set("instance_families", asset.ComputeAttributes.InstanceFamilies)
 	d.Set("rack_elevation", asset.AssetLocation.RackElevation)
 	d.Set("rack_id", asset.RackId)
 	return diags

--- a/internal/service/outposts/outpost_asset_data_source_test.go
+++ b/internal/service/outposts/outpost_asset_data_source_test.go
@@ -27,6 +27,7 @@ func TestAccOutpostsAssetDataSource_basic(t *testing.T) {
 					acctest.MatchResourceAttrRegionalARN(ctx, dataSourceName, names.AttrARN, "outposts", regexache.MustCompile(`outpost/.+`)),
 					resource.TestMatchResourceAttr(dataSourceName, "asset_id", regexache.MustCompile(`^(\w+)$`)),
 					resource.TestCheckResourceAttrSet(dataSourceName, "asset_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instance_families.#"),
 					resource.TestMatchResourceAttr(dataSourceName, "rack_elevation", regexache.MustCompile(`^[\S \n]+$`)),
 					resource.TestMatchResourceAttr(dataSourceName, "rack_id", regexache.MustCompile(`^[\S \n]+$`)),
 				),

--- a/website/docs/d/outposts_asset.html.markdown
+++ b/website/docs/d/outposts_asset.html.markdown
@@ -39,5 +39,6 @@ This data source exports the following attributes in addition to the arguments a
 
 * `asset_type` - Type of the asset.
 * `host_id` - Host ID of the Dedicated Hosts on the asset, if a Dedicated Host is provisioned.
+* `instance_families` - Instance families supported by the asset.
 * `rack_elevation` - Position of an asset in a rack measured in rack units.
 * `rack_id` - Rack ID of the asset.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Add `instance_families` attribute to the `aws_outposts_asset` data source. This exposes the instance families supported by the asset, sourced from `ComputeAttributes.InstanceFamilies` in the AWS API response.

### Relations

Closes #47069

### References

- [AWS Outposts `GetOutpostInstanceTypes` API](https://docs.aws.amazon.com/outposts/latest/APIReference/API_GetOutpostInstanceTypes.html)

### Output from Acceptance Testing

Test was skipped as no Outpost is available in the test environment. Test code has been added and can be verified by maintainers with Outpost access.

```console
% make testacc TESTS=TestAccOutpostsAssetDataSource_basic PKG=outposts

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_outposts_asset-instance_families 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/outposts/... -v -count 1 -parallel 20 -run='TestAccOutpostsAssetDataSource_basic'  -timeout 360m -vet=off
2026/03/31 06:23:30 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/31 06:23:30 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccOutpostsAssetDataSource_basic
=== PAUSE TestAccOutpostsAssetDataSource_basic
=== CONT  TestAccOutpostsAssetDataSource_basic
    outpost_asset_data_source_test.go:20: skipping since no Outposts found
--- SKIP: TestAccOutpostsAssetDataSource_basic (2.05s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/outposts   2.349s
```
