### PR TITLE
r/aws_observabilityadmin_centralization_rule_for_organization: Add `data_source_selection_criteria` attribute

### DIFF
--- a/.changelog/47154.txt
+++ b/.changelog/47154.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_observabilityadmin_centralization_rule_for_organization: Add `data_source_selection_criteria` attribute to `source_logs_configuration` block
+```

--- a/.changelog/47154.txt
+++ b/.changelog/47154.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_observabilityadmin_centralization_rule_for_organization: Add `data_source_selection_criteria` attribute to `source_logs_configuration` block
+resource/aws_observabilityadmin_centralization_rule_for_organization: Add `source.source_logs_configuration.data_source_selection_criteria` argument. Change `source.source_logs_configuration.log_group_selection_criteria` to Optional
 ```

--- a/internal/service/observabilityadmin/centralization_rule_for_organization.go
+++ b/internal/service/observabilityadmin/centralization_rule_for_organization.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -212,15 +213,34 @@ func (r *centralizationRuleForOrganizationResource) Schema(ctx context.Context, 
 										},
 										NestedObject: schema.NestedBlockObject{
 											Attributes: map[string]schema.Attribute{
+												"data_source_selection_criteria": schema.StringAttribute{
+													Optional: true,
+													Computed: true,
+													Default:  stringdefault.StaticString("*"),
+													Validators: []validator.String{
+														stringvalidator.LengthAtLeast(1),
+														stringvalidator.LengthAtMost(2000),
+														stringvalidator.AtLeastOneOf(
+															path.MatchRelative().AtParent().AtName("data_source_selection_criteria"),
+															path.MatchRelative().AtParent().AtName("log_group_selection_criteria"),
+														),
+													},
+												},
 												"encrypted_log_group_strategy": schema.StringAttribute{
 													CustomType: fwtypes.StringEnumType[awstypes.EncryptedLogGroupStrategy](),
 													Required:   true,
 												},
 												"log_group_selection_criteria": schema.StringAttribute{
-													Required: true,
+													Optional: true,
+													Computed: true,
+													Default:  stringdefault.StaticString("*"),
 													Validators: []validator.String{
 														stringvalidator.LengthAtLeast(1),
 														stringvalidator.LengthAtMost(2000),
+														stringvalidator.AtLeastOneOf(
+															path.MatchRelative().AtParent().AtName("data_source_selection_criteria"),
+															path.MatchRelative().AtParent().AtName("log_group_selection_criteria"),
+														),
 													},
 												},
 											},
@@ -477,8 +497,9 @@ type destinationLogsConfigurationModel struct {
 }
 
 type sourceLogsConfigurationModel struct {
-	EncryptedLogGroupStrategy fwtypes.StringEnum[awstypes.EncryptedLogGroupStrategy] `tfsdk:"encrypted_log_group_strategy"`
-	LogGroupSelectionCriteria types.String                                           `tfsdk:"log_group_selection_criteria"`
+	DataSourceSelectionCriteria types.String                                           `tfsdk:"data_source_selection_criteria"`
+	EncryptedLogGroupStrategy   fwtypes.StringEnum[awstypes.EncryptedLogGroupStrategy] `tfsdk:"encrypted_log_group_strategy"`
+	LogGroupSelectionCriteria   types.String                                           `tfsdk:"log_group_selection_criteria"`
 }
 
 type logsBackupConfigurationModel struct {

--- a/internal/service/observabilityadmin/centralization_rule_for_organization_test.go
+++ b/internal/service/observabilityadmin/centralization_rule_for_organization_test.go
@@ -657,3 +657,118 @@ resource "aws_observabilityadmin_centralization_rule_for_organization" "test" {
 }
 `, rName, tag1Key, tag1Value, tag2Key, tag2Value, endpoints.EuWest1RegionID, endpoints.ApSoutheast1RegionID)
 }
+
+func TestAccObservabilityAdminCentralizationRuleForOrganization_dataSourceSelectionCriteria(t *testing.T) {
+	ctx := acctest.Context(t)
+	var rule observabilityadmin.GetCentralizationRuleForOrganizationOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_observabilityadmin_centralization_rule_for_organization.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+			acctest.PreCheckIAMServiceLinkedRole(ctx, t, "/aws-service-role/observabilityadmin.amazonaws.com")
+			acctest.PreCheckOrganizationsEnabledServicePrincipal(ctx, t, "observabilityadmin.amazonaws.com")
+			acctest.PreCheckIAMServiceLinkedRole(ctx, t, "/aws-service-role/logs-centralization.observabilityadmin.amazonaws.com")
+			acctest.PreCheckPartition(t, endpoints.AwsPartitionID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ObservabilityAdminServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCentralizationRuleForOrganizationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCentralizationRuleForOrganizationConfig_dataSourceSelectionCriteria(rName, "DataSourceName = 'amazon_eks' AND DataSourceType = 'api_server'", endpoints.EuWest1RegionID, endpoints.ApSoutheast1RegionID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCentralizationRuleForOrganizationExists(ctx, t, resourceName, &rule),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rule_arn"), tfknownvalue.RegionalARNExact("observabilityadmin", `organization-centralization-rule/`+rName)),
+					statecheck.ExpectKnownValue(resourceName,
+						tfjsonpath.New(names.AttrRule).AtSliceIndex(0).
+							AtMapKey(names.AttrSource).AtSliceIndex(0).
+							AtMapKey("source_logs_configuration").AtSliceIndex(0).
+							AtMapKey("data_source_selection_criteria"),
+						knownvalue.StringExact("DataSourceName = 'amazon_eks' AND DataSourceType = 'api_server'")),
+					statecheck.ExpectKnownValue(resourceName,
+						tfjsonpath.New(names.AttrRule).AtSliceIndex(0).
+							AtMapKey(names.AttrSource).AtSliceIndex(0).
+							AtMapKey("source_logs_configuration").AtSliceIndex(0).
+							AtMapKey("log_group_selection_criteria"),
+						knownvalue.StringExact("*")),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "rule_name"),
+				ImportStateVerifyIdentifierAttribute: "rule_name",
+			},
+			{
+				Config: testAccCentralizationRuleForOrganizationConfig_dataSourceSelectionCriteria(rName, "DataSourceName = 'amazon_eks'", endpoints.EuWest1RegionID, endpoints.ApSoutheast1RegionID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCentralizationRuleForOrganizationExists(ctx, t, resourceName, &rule),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName,
+						tfjsonpath.New(names.AttrRule).AtSliceIndex(0).
+							AtMapKey(names.AttrSource).AtSliceIndex(0).
+							AtMapKey("source_logs_configuration").AtSliceIndex(0).
+							AtMapKey("data_source_selection_criteria"),
+						knownvalue.StringExact("DataSourceName = 'amazon_eks'")),
+				},
+			},
+			{
+				Config: testAccCentralizationRuleForOrganizationConfig_basic(rName, endpoints.EuWest1RegionID, endpoints.ApSoutheast1RegionID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCentralizationRuleForOrganizationExists(ctx, t, resourceName, &rule),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccCentralizationRuleForOrganizationConfig_dataSourceSelectionCriteria(rName, dataSourceSelectionCriteria, dstRegion string, srcRegions ...string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_organizations_organization" "current" {}
+
+resource "aws_observabilityadmin_centralization_rule_for_organization" "test" {
+  rule_name = %[1]q
+
+  rule {
+    destination {
+      region  = %[2]q
+      account = data.aws_caller_identity.current.account_id
+    }
+
+    source {
+      regions = [%[4]s]
+      scope   = "OrganizationId = '${data.aws_organizations_organization.current.id}'"
+
+      source_logs_configuration {
+        encrypted_log_group_strategy    = "SKIP"
+        data_source_selection_criteria = %[3]q
+      }
+    }
+  }
+}
+`, rName, dstRegion, dataSourceSelectionCriteria, acctest.ListOfStrings(srcRegions...))
+}

--- a/internal/service/observabilityadmin/centralization_rule_for_organization_test.go
+++ b/internal/service/observabilityadmin/centralization_rule_for_organization_test.go
@@ -740,6 +740,20 @@ func TestAccObservabilityAdminCentralizationRuleForOrganization_dataSourceSelect
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName,
+						tfjsonpath.New(names.AttrRule).AtSliceIndex(0).
+							AtMapKey(names.AttrSource).AtSliceIndex(0).
+							AtMapKey("source_logs_configuration").AtSliceIndex(0).
+							AtMapKey("data_source_selection_criteria"),
+						knownvalue.StringExact("*")),
+					statecheck.ExpectKnownValue(resourceName,
+						tfjsonpath.New(names.AttrRule).AtSliceIndex(0).
+							AtMapKey(names.AttrSource).AtSliceIndex(0).
+							AtMapKey("source_logs_configuration").AtSliceIndex(0).
+							AtMapKey("log_group_selection_criteria"),
+						knownvalue.StringExact("*")),
+				},
 			},
 		},
 	})

--- a/internal/service/observabilityadmin/centralization_rule_for_organization_test.go
+++ b/internal/service/observabilityadmin/centralization_rule_for_organization_test.go
@@ -778,7 +778,7 @@ resource "aws_observabilityadmin_centralization_rule_for_organization" "test" {
       scope   = "OrganizationId = '${data.aws_organizations_organization.current.id}'"
 
       source_logs_configuration {
-        encrypted_log_group_strategy    = "SKIP"
+        encrypted_log_group_strategy   = "SKIP"
         data_source_selection_criteria = %[3]q
       }
     }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Output from Acceptance Testing

```console
% make testacc TESTS='TestAccObservabilityAdminCentralizationRuleForOrganization_' PKG=observabilityadmin
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_observabilityadmin_centralization_rule_for_organization-data_source_selection_criteria 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/observabilityadmin/... -v -count 1 -parallel 20 -run='TestAccObservabilityAdminCentralizationRuleForOrganization_'  -timeout 360m -vet=off
2026/03/31 14:32:15 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/31 14:32:15 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccObservabilityAdminCentralizationRuleForOrganization_basic
=== PAUSE TestAccObservabilityAdminCentralizationRuleForOrganization_basic
=== RUN   TestAccObservabilityAdminCentralizationRuleForOrganization_disappears
=== PAUSE TestAccObservabilityAdminCentralizationRuleForOrganization_disappears
=== RUN   TestAccObservabilityAdminCentralizationRuleForOrganization_update
=== PAUSE TestAccObservabilityAdminCentralizationRuleForOrganization_update
=== RUN   TestAccObservabilityAdminCentralizationRuleForOrganization_destinationLogGroupNameConfiguration
=== PAUSE TestAccObservabilityAdminCentralizationRuleForOrganization_destinationLogGroupNameConfiguration
=== RUN   TestAccObservabilityAdminCentralizationRuleForOrganization_tags
=== PAUSE TestAccObservabilityAdminCentralizationRuleForOrganization_tags
=== RUN   TestAccObservabilityAdminCentralizationRuleForOrganization_dataSourceSelectionCriteria
=== PAUSE TestAccObservabilityAdminCentralizationRuleForOrganization_dataSourceSelectionCriteria
=== CONT  TestAccObservabilityAdminCentralizationRuleForOrganization_basic
=== CONT  TestAccObservabilityAdminCentralizationRuleForOrganization_destinationLogGroupNameConfiguration
=== CONT  TestAccObservabilityAdminCentralizationRuleForOrganization_dataSourceSelectionCriteria
=== CONT  TestAccObservabilityAdminCentralizationRuleForOrganization_tags
=== CONT  TestAccObservabilityAdminCentralizationRuleForOrganization_update
=== CONT  TestAccObservabilityAdminCentralizationRuleForOrganization_disappears
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_disappears (42.72s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_basic (51.71s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_update (105.11s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_destinationLogGroupNameConfiguration (113.86s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_tags (114.63s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_dataSourceSelectionCriteria (114.82s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/observabilityadmin	120.305s
```
