### PR TITLE
[Docs] aws_ecs_capacity_provider:  Fix incorrect value for `managed_instances_provider.instance_launch_template.monitoring` in an example

### DIFF
--- a/internal/service/ecs/capacity_provider_test.go
+++ b/internal/service/ecs/capacity_provider_test.go
@@ -500,6 +500,57 @@ func TestAccECSCapacityProvider_managedInstancesProvider_capacityOptionTypeRepla
 	})
 }
 
+func TestAccECSCapacityProvider_createManagedInstancesProvider_monitoring(t *testing.T) {
+	ctx := acctest.Context(t)
+	var provider awstypes.CapacityProvider
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ecs_capacity_provider.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCapacityProviderDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCapacityProviderConfig_managedInstancesProvider_monitoring(rName, string(awstypes.ManagedInstancesMonitoringOptionsDetailed)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCapacityProviderExists(ctx, t, resourceName, &provider),
+					resource.TestCheckResourceAttr(resourceName, "managed_instances_provider.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "managed_instances_provider.0.infrastructure_role_arn", "aws_iam_role.test", names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "managed_instances_provider.0.instance_launch_template.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "managed_instances_provider.0.instance_launch_template.0.monitoring", string(awstypes.ManagedInstancesMonitoringOptionsDetailed)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCapacityProviderConfig_managedInstancesProvider_monitoring(rName, string(awstypes.ManagedInstancesMonitoringOptionsBasic)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCapacityProviderExists(ctx, t, resourceName, &provider),
+					resource.TestCheckResourceAttr(resourceName, "managed_instances_provider.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "managed_instances_provider.0.infrastructure_role_arn", "aws_iam_role.test", names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "managed_instances_provider.0.instance_launch_template.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "managed_instances_provider.0.instance_launch_template.0.monitoring", string(awstypes.ManagedInstancesMonitoringOptionsBasic)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckCapacityProviderDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).ECSClient(ctx)
@@ -1062,4 +1113,28 @@ resource "aws_ecs_capacity_provider" "test" {
   }
 }
 `, rName, capacityOptionType))
+}
+
+func testAccCapacityProviderConfig_managedInstancesProvider_monitoring(rName, monitoring string) string {
+	return acctest.ConfigCompose(testAccCapacityProviderConfig_managedInstancesProvider_base(rName), fmt.Sprintf(`
+resource "aws_ecs_capacity_provider" "test" {
+  name    = %[1]q
+  cluster = aws_ecs_cluster.test.name
+
+  managed_instances_provider {
+    infrastructure_role_arn = aws_iam_role.test.arn
+    propagate_tags          = "NONE"
+
+    instance_launch_template {
+      ec2_instance_profile_arn = aws_iam_instance_profile.test.arn
+      monitoring               = %[2]q
+
+      network_configuration {
+        subnets         = aws_subnet.test[*].id
+        security_groups = [aws_security_group.test.id]
+      }
+    }
+  }
+}
+`, rName, monitoring))
 }

--- a/website/docs/r/ecs_capacity_provider.html.markdown
+++ b/website/docs/r/ecs_capacity_provider.html.markdown
@@ -59,7 +59,7 @@ resource "aws_ecs_capacity_provider" "example" {
 
     instance_launch_template {
       ec2_instance_profile_arn = aws_iam_instance_profile.ecs_instance.arn
-      monitoring               = "ENABLED"
+      monitoring               = "DETAILED"
 
       network_configuration {
         subnets         = [aws_subnet.example.id]


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR fixes an incorrect value for the `managed_instances_provider.instance_launch_template.monitoring` argument. The valid values are `BASIC` and `DETAILED`, but `ENABLED` is currently specified.

This PR also adds an acceptance test to verify the `monitoring` argument and its update behavior.

### Relations

Closes #47180

### References
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_capacity_provider#monitoring-1

### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccECSCapacityProvider_createManagedInstancesProvider_monitoring' PKG=ecs
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 d-aws_ecs_capacity_provider-fix_monitoring_in_example 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSCapacityProvider_createManagedInstancesProvider_monitoring'  -timeout 360m -vet=off
2026/04/01 23:59:11 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/01 23:59:11 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSCapacityProvider_createManagedInstancesProvider_monitoring
=== PAUSE TestAccECSCapacityProvider_createManagedInstancesProvider_monitoring
=== CONT  TestAccECSCapacityProvider_createManagedInstancesProvider_monitoring
--- PASS: TestAccECSCapacityProvider_createManagedInstancesProvider_monitoring (82.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        88.492s
?       github.com/hashicorp/terraform-provider-aws/internal/service/ecs/test-fixtures  [no test files]
```
