### PR TITLE
Support bucket metrics for directory buckets

### DIFF
--- a/.changelog/47184.txt
+++ b/.changelog/47184.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket_metrics: Support bucket metrics for directory buckets
+```

--- a/.changelog/47184.txt
+++ b/.changelog/47184.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_s3_bucket_metrics: Support bucket metrics for directory buckets
+resource/aws_s3_bucket_metric: Support bucket metrics for directory buckets
 ```

--- a/internal/service/s3/bucket_metric_test.go
+++ b/internal/service/s3/bucket_metric_test.go
@@ -607,7 +607,145 @@ func TestAccS3BucketMetric_withFilterSingleTag(t *testing.T) {
 	})
 }
 
-func TestAccS3BucketMetric_directoryBucket(t *testing.T) {
+unc TestAccS3BucketMetric_directoryBucket(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf types.MetricsConfiguration
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_metric.test"
+	metricName := t.Name()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBucketMetricDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketMetricConfig_directoryBucket(rName, metricName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketMetricsExistsConfig(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, metricName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketMetric_directoryBucket_filterPrefix(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf types.MetricsConfiguration
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_metric.test"
+	metricName := t.Name()
+	prefix := "prefix-1/"
+	prefixUpdate := "prefix-2/"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBucketMetricDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketMetricConfig_directoryBucketFilterPrefix(rName, metricName, prefix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketMetricsExistsConfig(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.prefix", prefix),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.%", "0"),
+				),
+			},
+			{
+				Config: testAccBucketMetricConfig_directoryBucketFilterPrefix(rName, metricName, prefixUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketMetricsExistsConfig(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.prefix", prefixUpdate),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketMetric_directoryBucket_filterAccessPoint(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf types.MetricsConfiguration
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_metric.test"
+	accessPointResourceName := "aws_s3_access_point.test"
+	metricName := t.Name()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBucketMetricDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketMetricConfig_directoryBucketFilterAccessPoint(rName, metricName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketMetricsExistsConfig(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "filter.0.access_point", accessPointResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketMetric_directoryBucket_filterAccessPointAndPrefix(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf types.MetricsConfiguration
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_metric.test"
+	accessPointResourceName := "aws_s3_access_point.test"
+	metricName := t.Name()
+	prefix := "prefix-1/"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBucketMetricDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketMetricConfig_directoryBucketFilterAccessPointAndPrefix(rName, metricName, prefix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketMetricsExistsConfig(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "filter.0.access_point", accessPointResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.prefix", prefix),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketMetric_directoryBucket_filterTagsNotSupported(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	metricName := t.Name()
@@ -621,9 +759,96 @@ func TestAccS3BucketMetric_directoryBucket(t *testing.T) {
 			{
 				Config:      testAccBucketMetricConfig_directoryBucket(rName, metricName),
 				ExpectError: regexache.MustCompile(`directory buckets are not supported`),
+				Config:      testAccBucketMetricConfig_directoryBucketFilterTags(rName, metricName),
+				ExpectError: regexache.MustCompile(`MalformedXML`),
 			},
 		},
 	})
+}
+
+func testAccBucketMetricConfig_directoryBucketBase(bucketName string) string {
+	return acctest.ConfigCompose(testAccDirectoryBucketConfig_baseAZ(bucketName), `
+resource "aws_s3_directory_bucket" "test" {
+  bucket = local.bucket
+
+  location {
+    name = local.location_name
+  }
+}
+`)
+}
+
+func testAccBucketMetricConfig_directoryBucket(bucketName, metricName string) string {
+	return acctest.ConfigCompose(testAccBucketMetricConfig_directoryBucketBase(bucketName), fmt.Sprintf(`
+resource "aws_s3_bucket_metric" "test" {
+  bucket = aws_s3_directory_bucket.test.bucket
+  name   = %[1]q
+}
+`, metricName))
+}
+
+func testAccBucketMetricConfig_directoryBucketFilterPrefix(bucketName, metricName, prefix string) string {
+	return acctest.ConfigCompose(testAccBucketMetricConfig_directoryBucketBase(bucketName), fmt.Sprintf(`
+resource "aws_s3_bucket_metric" "test" {
+  bucket = aws_s3_directory_bucket.test.bucket
+  name   = %[1]q
+
+  filter {
+    prefix = %[2]q
+  }
+}
+`, metricName, prefix))
+}
+
+func testAccBucketMetricConfig_directoryBucketAccessPointBase(bucketName string) string {
+	return acctest.ConfigCompose(testAccBucketMetricConfig_directoryBucketBase(bucketName), fmt.Sprintf(`
+resource "aws_s3_access_point" "test" {
+  bucket = aws_s3_directory_bucket.test.bucket
+  name   = "%[1]s--${local.location_name}--xa-s3"
+}
+`, bucketName))
+}
+
+func testAccBucketMetricConfig_directoryBucketFilterAccessPoint(bucketName, metricName string) string {
+	return acctest.ConfigCompose(testAccBucketMetricConfig_directoryBucketAccessPointBase(bucketName), fmt.Sprintf(`
+resource "aws_s3_bucket_metric" "test" {
+  bucket = aws_s3_directory_bucket.test.bucket
+  name   = %[1]q
+
+  filter {
+    access_point = aws_s3_access_point.test.arn
+  }
+}
+`, metricName))
+}
+
+func testAccBucketMetricConfig_directoryBucketFilterAccessPointAndPrefix(bucketName, metricName, prefix string) string {
+	return acctest.ConfigCompose(testAccBucketMetricConfig_directoryBucketAccessPointBase(bucketName), fmt.Sprintf(`
+resource "aws_s3_bucket_metric" "test" {
+  bucket = aws_s3_directory_bucket.test.bucket
+  name   = %[1]q
+
+  filter {
+    access_point = aws_s3_access_point.test.arn
+    prefix       = %[2]q
+  }
+}
+`, metricName, prefix))
+}
+
+func testAccBucketMetricConfig_directoryBucketFilterTags(bucketName, metricName string) string {
+	return acctest.ConfigCompose(testAccBucketMetricConfig_directoryBucketBase(bucketName), fmt.Sprintf(`
+resource "aws_s3_bucket_metric" "test" {
+  bucket = aws_s3_directory_bucket.test.bucket
+  name   = %[1]q
+
+  filter {
+    tags = {
+      "tag1" = "value1"
+    }
+  }
+}
+`, metricName))
 }
 
 func testAccCheckBucketMetricDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
@@ -896,23 +1121,6 @@ func testAccBucketMetricConfig_noFilter(bucketName, metricName string) string {
 	return acctest.ConfigCompose(testAccBucketMetricConfig_base(bucketName), fmt.Sprintf(`
 resource "aws_s3_bucket_metric" "test" {
   bucket = aws_s3_bucket.bucket.id
-  name   = %[1]q
-}
-`, metricName))
-}
-
-func testAccBucketMetricConfig_directoryBucket(bucketName, metricName string) string {
-	return acctest.ConfigCompose(testAccDirectoryBucketConfig_baseAZ(bucketName), fmt.Sprintf(`
-resource "aws_s3_directory_bucket" "test" {
-  bucket = local.bucket
-
-  location {
-    name = local.location_name
-  }
-}
-
-resource "aws_s3_bucket_metric" "test" {
-  bucket = aws_s3_directory_bucket.test.bucket
   name   = %[1]q
 }
 `, metricName))

--- a/internal/service/s3/bucket_metric_test.go
+++ b/internal/service/s3/bucket_metric_test.go
@@ -607,7 +607,7 @@ func TestAccS3BucketMetric_withFilterSingleTag(t *testing.T) {
 	})
 }
 
-unc TestAccS3BucketMetric_directoryBucket(t *testing.T) {
+func TestAccS3BucketMetric_directoryBucket(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf types.MetricsConfiguration
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -757,8 +757,6 @@ func TestAccS3BucketMetric_directoryBucket_filterTagsNotSupported(t *testing.T) 
 		CheckDestroy:             testAccCheckBucketMetricDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccBucketMetricConfig_directoryBucket(rName, metricName),
-				ExpectError: regexache.MustCompile(`directory buckets are not supported`),
 				Config:      testAccBucketMetricConfig_directoryBucketFilterTags(rName, metricName),
 				ExpectError: regexache.MustCompile(`MalformedXML`),
 			},

--- a/website/docs/r/s3_bucket_metric.html.markdown
+++ b/website/docs/r/s3_bucket_metric.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Provides a S3 bucket [metrics configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/metrics-configurations.html) resource.
 
--> This resource cannot be used with S3 directory buckets.
-
 ## Example Usage
 
 ### Add metrics configuration for entire S3 bucket
@@ -76,6 +74,36 @@ resource "aws_s3_bucket_metric" "example-filtered" {
 }
 ```
 
+### Add metrics configuration for S3 directory bucket
+
+```
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+ 
+resource "aws_s3_directory_bucket" "example" {
+  bucket = "example--zoneId--x-s3"
+  location {
+    name = data.aws_availability_zones.available.zone_ids[0]
+  }
+}
+ 
+resource "aws_s3_access_point" "example-access-point" {
+  bucket = aws_s3_directory_bucket.example.id
+  name   = "example--zoneId--xa-s3"
+}
+ 
+resource "aws_s3_bucket_metric" "example-bucket-metric" {
+  bucket = aws_s3_directory_bucket.example.id
+  name   = "ExampleBucketMetricForDirectoryBuckets"
+ 
+  filter {
+    access_point = aws_s3_access_point.example-access-point.arn
+    prefix       = "documents/"
+  }
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
@@ -91,7 +119,7 @@ The `filter` metric configuration supports the following:
 
 * `access_point` - (Optional) S3 Access Point ARN for filtering (singular).
 * `prefix` - (Optional) Object prefix for filtering (singular).
-* `tags` - (Optional) Object tags for filtering (up to 10).
+* `tags` - (Optional) Object tags for filtering (up to 10). Unsupported for S3 directory buckets.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description
Amazon S3 has added support for bucket metric configurations for directory buckets. The existing code forwards the metric configuration requests correctly for directory buckets. This commit updates the docs and acceptance tests to ensure that the new feature works as expected with Terraform. 

### References
- https://aws.amazon.com/about-aws/whats-new/2026/03/s3-express-one-zone-cloudwatch-request-metrics/
- https://docs.aws.amazon.com/AmazonS3/latest/userguide/metrics-configurations.html

### Output from Acceptance Testing

```console
shreedub@bcd074a8f7b2 terraform-provider-aws % make testacc TESTS=TestAccS3BucketMetric_directoryBucket PKG=s3                           
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketMetric_directoryBucket'  -timeout 360m -vet=off
2026/03/18 14:52:13 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/18 14:52:13 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3BucketMetric_directoryBucket
=== PAUSE TestAccS3BucketMetric_directoryBucket
=== RUN   TestAccS3BucketMetric_directoryBucket_filterPrefix
=== PAUSE TestAccS3BucketMetric_directoryBucket_filterPrefix
=== RUN   TestAccS3BucketMetric_directoryBucket_filterAccessPoint
=== PAUSE TestAccS3BucketMetric_directoryBucket_filterAccessPoint
=== RUN   TestAccS3BucketMetric_directoryBucket_filterAccessPointAndPrefix
=== PAUSE TestAccS3BucketMetric_directoryBucket_filterAccessPointAndPrefix
=== RUN   TestAccS3BucketMetric_directoryBucket_filterTagsNotSupported
=== PAUSE TestAccS3BucketMetric_directoryBucket_filterTagsNotSupported
=== CONT  TestAccS3BucketMetric_directoryBucket
=== CONT  TestAccS3BucketMetric_directoryBucket_filterAccessPointAndPrefix
=== CONT  TestAccS3BucketMetric_directoryBucket_filterAccessPoint
=== CONT  TestAccS3BucketMetric_directoryBucket_filterTagsNotSupported
=== CONT  TestAccS3BucketMetric_directoryBucket_filterPrefix
--- PASS: TestAccS3BucketMetric_directoryBucket_filterTagsNotSupported (14.36s)
--- PASS: TestAccS3BucketMetric_directoryBucket (32.15s)
--- PASS: TestAccS3BucketMetric_directoryBucket_filterAccessPointAndPrefix (32.35s)
--- PASS: TestAccS3BucketMetric_directoryBucket_filterAccessPoint (32.45s)
--- PASS: TestAccS3BucketMetric_directoryBucket_filterPrefix (46.90s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 54.998s
```