### PR TITLE
internal/acctest: prepare context in `_disappears` test helpers

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1591,6 +1591,11 @@ func NamedProvider(name string, providers map[string]*schema.Provider) *schema.P
 	return p
 }
 
+// NewTestResourceContext bootstaps the testing context for a given resource type
+func NewTestResourceContext(ctx context.Context, rType, region string) context.Context {
+	return conns.NewResourceContext(ctx, "", "", rType, region)
+}
+
 func DeleteResource(ctx context.Context, resource *schema.Resource, d *schema.ResourceData, meta any) error {
 	if resource.DeleteContext != nil || resource.DeleteWithoutTimeout != nil {
 		var diags diag.Diagnostics
@@ -1639,6 +1644,9 @@ func checkSDKResourceDisappears(ctx context.Context, providerMetaF providerMetaF
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("resource ID missing: %s", n)
 		}
+
+		// Bootstrap context for resource type
+		ctx = NewTestResourceContext(ctx, rs.Type, rs.Primary.Attributes[names.AttrRegion])
 
 		var state terraformsdk.InstanceState
 		err := mapstructure.Decode(rs.Primary, &state)

--- a/internal/acctest/framework.go
+++ b/internal/acctest/framework.go
@@ -69,6 +69,9 @@ func deleteFrameworkResource(
 			return fmt.Errorf("resource ID missing: %s", n)
 		}
 
+		// Bootstrap context for resource type
+		ctx = NewTestResourceContext(ctx, rs.Type, rs.Primary.Attributes[names.AttrRegion])
+
 		resource, err := factory(ctx)
 		if err != nil {
 			return err


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
As these test helpers operate on a resource which is composed outside the usual resource wrapping workflow, the lack of an initialized resource context prevented the `Delete` operation from determining when go-vcr testing was enabled. With this change `conns.NewResourceContext` is now called within the disappears workflow.

See below for test execution time differences. `aws_elasticache_serverless_cache` uses Terraform Plugin Framework. `aws_db_instance` uses Terraform Plugin SDK V2.

Before:

```console
% VCR_MODE=REPLAY_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/  make t K=elasticache T=TestAccElastiCacheServerlessCache_disappears
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-cache-usage-serverless-cache 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheServerlessCache_disappears'  -timeout 360m -vet=off
2026/03/31 14:50:02 Creating Terraform AWS Provider (SDKv2-style)...
2026/03/31 14:50:02 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccElastiCacheServerlessCache_disappears (173.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        180.287s```
```

```console
% VCR_MODE=REPLAY_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/  make t K=rds T=TestAccRDSInstance_disappears
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstance_disappears'  -timeout 360m -vet=off
2026/04/01 13:57:33 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/01 13:57:34 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccRDSInstance_disappears (123.71s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        131.137s
```

After:

```console
% VCR_MODE=REPLAY_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/  make t K=elasticache T=TestAccElastiCacheServerlessCache_disappears
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 tmp3 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheServerlessCache_disappears'  -timeout 360m -vet=off
2026/04/01 10:39:50 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/01 10:39:50 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccElastiCacheServerlessCache_disappears (14.15s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        21.281s
```

```console
% VCR_MODE=REPLAY_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/  make t K=rds T=TestAccRDSInstance_disappears
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-go-vcr-disappears-tests 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstance_disappears'  -timeout 360m -vet=off
2026/04/01 13:55:13 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/01 13:55:13 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccRDSInstance_disappears (13.39s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        20.449s
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47160
Relates #25602

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

See above.