### PR TITLE
resource/aws_cloudfront_public_key: Fix encoded_key whitespace diff causing unnecessary replacement

### DIFF
--- a/.changelog/47201.txt
+++ b/.changelog/47201.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudfront_public_key: Fix `encoded_key` forcing replacement when value differs only in trailing whitespace
+```

--- a/internal/service/cloudfront/public_key.go
+++ b/internal/service/cloudfront/public_key.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -52,6 +53,9 @@ func resourcePublicKey() *schema.Resource {
 					Type:     schema.TypeString,
 					Required: true,
 					ForceNew: true,
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						return strings.TrimSpace(old) == strings.TrimSpace(new)
+					},
 				},
 				"etag": {
 					Type:     schema.TypeString,


### PR DESCRIPTION
Description:

Closes #47204 (re-opened from #20081 — the previous fix #29491 was docs-only, the underlying bug still exists)


### Problem

The encoded_key attribute on aws_cloudfront_public_key forces replacement even when the PEM content is identical. This happens because the CloudFront API returns the key with a trailing newline, but users may provide the value without one
(e.g., via trimspace() or string variables). Since encoded_key is marked ForceNew, any whitespace difference triggers a destroy and recreate of the public key, which:

- Changes the key pair ID, breaking existing signed URLs
- Cascades to key group updates
- Causes unnecessary downtime

### Fix

Added a DiffSuppressFunc that normalizes whitespace using strings.TrimSpace() before comparing old and new values. If the PEM content is the same but differs only in leading/trailing whitespace, the diff is suppressed.

### Impact

- No behavioural change when the key content actually differs — replacement still happens correctly
- Prevents unnecessary replacement when only whitespace differs