### PR TITLE
resource/aws_wafv2_rule_group: Compute `capacity` automatically

### DIFF
--- a/.changelog/47211.txt
+++ b/.changelog/47211.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_wafv2_rule_group: Compute `capacity` automatically if not set explicitly
+```

--- a/internal/service/wafv2/rule_group.go
+++ b/internal/service/wafv2/rule_group.go
@@ -66,7 +66,8 @@ func resourceRuleGroup() *schema.Resource {
 				},
 				"capacity": {
 					Type:         schema.TypeInt,
-					Required:     true,
+					Optional:     true,
+					Computed:     true,
 					ForceNew:     true,
 					ValidateFunc: validation.IntAtLeast(1),
 				},
@@ -169,7 +170,6 @@ func resourceRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta a
 
 	name := create.Name(ctx, d.Get(names.AttrName).(string), d.Get(names.AttrNamePrefix).(string))
 	input := &wafv2.CreateRuleGroupInput{
-		Capacity:         aws.Int64(int64(d.Get("capacity").(int))),
 		Name:             aws.String(name),
 		Scope:            awstypes.Scope(d.Get(names.AttrScope).(string)),
 		Tags:             getTagsIn(ctx),
@@ -194,6 +194,19 @@ func resourceRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta a
 
 	if v, ok := d.GetOk(names.AttrDescription); ok {
 		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("capacity"); ok {
+		input.Capacity = aws.Int64((int64(v.(int))))
+	} else {
+		capacityOutput, err := conn.CheckCapacity(ctx, &wafv2.CheckCapacityInput{
+			Scope: input.Scope,
+			Rules: input.Rules,
+		})
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "checking capacity: %s", err)
+		}
+		input.Capacity = &capacityOutput.Capacity
 	}
 
 	const (

--- a/internal/service/wafv2/rule_group_test.go
+++ b/internal/service/wafv2/rule_group_test.go
@@ -2622,6 +2622,58 @@ func TestAccWAFV2RuleGroup_rateBasedStatement_ASNMatchStatement(t *testing.T) {
 	})
 }
 
+func TestAccWAFV2RuleGroup_computedCapacity(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.RuleGroup
+	ruleGroupName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_rule_group.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckScopeRegional(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRuleGroupDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuleGroupConfig_computedCapacity(ruleGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuleGroupExists(ctx, t, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "wafv2", regexache.MustCompile(`regional/rulegroup/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, ruleGroupName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ruleGroupName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrScope, string(awstypes.ScopeRegional)),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.cloudwatch_metrics_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.metric_name", "friendly-metric-name"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtRulePound, "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						names.AttrName:                      "rule-1",
+						names.AttrPriority:                  "1",
+						"action.#":                          "1",
+						"action.0.allow.#":                  "0",
+						"action.0.block.#":                  "0",
+						"action.0.count.#":                  "1",
+						"action.0.captcha.#":                "0",
+						"action.0.challenge.#":              "0",
+						"statement.#":                       "1",
+						"statement.0.geo_match_statement.#": "1",
+						"statement.0.geo_match_statement.0.country_codes.#": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccRuleGroupImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func testAccPreCheckScopeRegional(ctx context.Context, t *testing.T) {
 	conn := acctest.ProviderMeta(ctx, t).WAFV2Client(ctx)
 
@@ -5771,6 +5823,43 @@ resource "aws_wafv2_rule_group" "test" {
       SampledRequestsEnabled   = false
     }
   }])
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, rName)
+}
+
+func testAccRuleGroupConfig_computedCapacity(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_rule_group" "test" {
+  name     = %[1]q
+  description = %[1]q
+  scope    = "REGIONAL"
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      count {}
+    }
+
+    statement {
+      geo_match_statement {
+        country_codes = ["US"]
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
 
   visibility_config {
     cloudwatch_metrics_enabled = false

--- a/website/docs/r/wafv2_rule_group.html.markdown
+++ b/website/docs/r/wafv2_rule_group.html.markdown
@@ -359,7 +359,7 @@ resource "aws_wafv2_rule_group" "example" {
 This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `capacity` - (Required, Forces new resource) The web ACL capacity units (WCUs) required for this rule group. See [here](https://docs.aws.amazon.com/waf/latest/APIReference/API_CreateRuleGroup.html#API_CreateRuleGroup_RequestSyntax) for general information and [here](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statements-list.html) for capacity specific information.
+* `capacity` - (Optional, Forces new resource) The web ACL capacity units (WCUs) required for this rule group. See [here](https://docs.aws.amazon.com/waf/latest/APIReference/API_CreateRuleGroup.html#API_CreateRuleGroup_RequestSyntax) for general information and [here](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statements-list.html) for capacity specific information.
 * `custom_response_body` - (Optional) Defines custom response bodies that can be referenced by `custom_response` actions. See [Custom Response Body](#custom-response-body) below for details.
 * `description` - (Optional) A friendly description of the rule group.
 * `name` - (Required, Forces new resource) A friendly name of the rule group.


### PR DESCRIPTION
If `capacity` is left unset, calculate it automatically by passing the rules to the CheckCapacity API.

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

No relevant changes to security controls.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #23921

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/waf/latest/APIReference/API_CheckCapacity.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccWAFV2RuleGroup_computedCapacity PKG=wafv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-calculate-capacity 🌿...
TF_ACC=1 go test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2RuleGroup_computedCapacity'  -timeout 360m -vet=off
2026/04/02 17:30:39 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/02 17:30:39 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccWAFV2RuleGroup_computedCapacity
=== PAUSE TestAccWAFV2RuleGroup_computedCapacity
=== CONT  TestAccWAFV2RuleGroup_computedCapacity
--- PASS: TestAccWAFV2RuleGroup_computedCapacity (36.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafv2	37.019s
```
