### PR TITLE
resource/aws_bcmdataexports_export: Allow setting `table_configurations` value even when empty

### DIFF
--- a/.changelog/47261.txt
+++ b/.changelog/47261.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bcmdataexports_export: Allows empty values in `export.data_query.table_configurations`
+```

--- a/internal/framework/flex/autoflex_flatten.go
+++ b/internal/framework/flex/autoflex_flatten.go
@@ -1005,26 +1005,6 @@ func (flattener autoFlattener) map_(ctx context.Context, sourcePath path.Path, v
 						logAttrKeySourceSize: len(from),
 					})
 
-					// Check for omitempty: if all inner maps are empty, return null
-					if fieldOpts.omitempty {
-						allEmpty := true
-						for _, innerMap := range from {
-							if len(innerMap) > 0 {
-								allEmpty = false
-								break
-							}
-						}
-						if allEmpty {
-							tflog.SubsystemTrace(ctx, subsystemName, "All inner maps empty with omitempty, returning null")
-							to, d := tTo.ValueFromMap(ctx, types.MapNull(types.MapType{ElemType: types.StringType}))
-							diags.Append(d...)
-							if !diags.HasError() {
-								vTo.Set(reflect.ValueOf(to))
-							}
-							return diags
-						}
-					}
-
 					elements := make(map[string]attr.Value, len(from))
 					for k, v := range from {
 						innerElements := make(map[string]attr.Value, len(v))

--- a/internal/framework/flex/autoflex_flatten.go
+++ b/internal/framework/flex/autoflex_flatten.go
@@ -911,7 +911,7 @@ func (flattener autoFlattener) slice(ctx context.Context, sourcePath path.Path, 
 }
 
 // map_ copies an AWS API map value to a compatible Plugin Framework value.
-func (flattener autoFlattener) map_(ctx context.Context, sourcePath path.Path, vFrom reflect.Value, targetPath path.Path, tTo attr.Type, vTo reflect.Value, fieldOpts fieldOpts) diag.Diagnostics {
+func (flattener autoFlattener) map_(ctx context.Context, sourcePath path.Path, vFrom reflect.Value, targetPath path.Path, tTo attr.Type, vTo reflect.Value, _ fieldOpts) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	switch tMapKey := vFrom.Type().Key(); tMapKey.Kind() {

--- a/internal/service/bcmdataexports/export.go
+++ b/internal/service/bcmdataexports/export.go
@@ -120,6 +120,8 @@ func exportDataQuerySchema(ctx context.Context) schema.ListNestedBlock {
 					Required: true,
 				},
 				"table_configurations": schema.MapAttribute{
+					// TODO: Because `Computed` can only be speciied at the top level, default values for specific tables must be specified if any values are specified.
+					// This should be resolved when we can use `schema.MapNestedAttribute` with protov6.
 					CustomType: fwtypes.MapOfMapOfStringType,
 					Optional:   true,
 					Computed:   true,

--- a/internal/service/bcmdataexports/export.go
+++ b/internal/service/bcmdataexports/export.go
@@ -15,6 +15,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/bcmdataexports/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -128,6 +129,9 @@ func exportDataQuerySchema(ctx context.Context) schema.ListNestedBlock {
 					PlanModifiers: []planmodifier.Map{
 						mapplanmodifier.UseStateForUnknown(),
 						mapplanmodifier.RequiresReplace(),
+					},
+					Validators: []validator.Map{
+						mapvalidator.SizeAtMost(1),
 					},
 				},
 			},

--- a/internal/service/bcmdataexports/export.go
+++ b/internal/service/bcmdataexports/export.go
@@ -500,7 +500,7 @@ type exportData struct {
 
 type dataQueryData struct {
 	QueryStatement      types.String             `tfsdk:"query_statement"`
-	TableConfigurations fwtypes.MapOfMapOfString `tfsdk:"table_configurations" autoflex:",omitempty"`
+	TableConfigurations fwtypes.MapOfMapOfString `tfsdk:"table_configurations"`
 }
 
 type s3OutputConfigurations struct {

--- a/internal/service/bcmdataexports/export_test.go
+++ b/internal/service/bcmdataexports/export_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccBCMDataExportsExport_basic(t *testing.T) {
+func TestAccBCMDataExportsExport_CUR_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -76,7 +76,7 @@ func TestAccBCMDataExportsExport_basic(t *testing.T) {
 	})
 }
 
-func TestAccBCMDataExportsExport_carbonEmissions(t *testing.T) {
+func TestAccBCMDataExportsExport_CarbonEmissions_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")

--- a/internal/service/bcmdataexports/export_test.go
+++ b/internal/service/bcmdataexports/export_test.go
@@ -69,9 +69,9 @@ func TestAccBCMDataExportsExport_CUR_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("export").AtSliceIndex(0).AtMapKey("data_query").AtSliceIndex(0).AtMapKey("table_configurations"), knownvalue.MapExact(map[string]knownvalue.Check{
 						"COST_AND_USAGE_REPORT": knownvalue.MapExact(map[string]knownvalue.Check{
 							"TIME_GRANULARITY":                      knownvalue.StringExact("HOURLY"),
-							"INCLUDE_RESOURCES":                     knownvalue.StringExact("FALSE"),
-							"INCLUDE_SPLIT_COST_ALLOCATION_DATA":    knownvalue.StringExact("FALSE"),
-							"INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY": knownvalue.StringExact("FALSE"),
+							"INCLUDE_RESOURCES":                     knownvalue.StringExact(acctest.CtFalseCaps),
+							"INCLUDE_SPLIT_COST_ALLOCATION_DATA":    knownvalue.StringExact(acctest.CtFalseCaps),
+							"INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY": knownvalue.StringExact(acctest.CtFalseCaps),
 							"BILLING_VIEW_ARN":                      tfknownvalue.GlobalARNExact("billing", "billingview/primary"),
 						}),
 					})),
@@ -127,9 +127,9 @@ func TestAccBCMDataExportsExport_CUR_tableConfigurations(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("export").AtSliceIndex(0).AtMapKey("data_query").AtSliceIndex(0).AtMapKey("table_configurations"), knownvalue.MapExact(map[string]knownvalue.Check{
 						"COST_AND_USAGE_REPORT": knownvalue.MapExact(map[string]knownvalue.Check{
 							"TIME_GRANULARITY":                      knownvalue.StringExact("DAILY"),
-							"INCLUDE_RESOURCES":                     knownvalue.StringExact("TRUE"),
-							"INCLUDE_SPLIT_COST_ALLOCATION_DATA":    knownvalue.StringExact("TRUE"),
-							"INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY": knownvalue.StringExact("TRUE"),
+							"INCLUDE_RESOURCES":                     knownvalue.StringExact(acctest.CtTrueCaps),
+							"INCLUDE_SPLIT_COST_ALLOCATION_DATA":    knownvalue.StringExact(acctest.CtTrueCaps),
+							"INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY": knownvalue.StringExact(acctest.CtTrueCaps),
 							"BILLING_VIEW_ARN":                      tfknownvalue.GlobalARNExact("billing", "billingview/primary"),
 						}),
 					})),

--- a/internal/service/bcmdataexports/export_test.go
+++ b/internal/service/bcmdataexports/export_test.go
@@ -15,8 +15,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/bcmdataexports/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tfbcmdataexports "github.com/hashicorp/terraform-provider-aws/internal/service/bcmdataexports"
@@ -44,7 +48,7 @@ func TestAccBCMDataExportsExport_CUR_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckExportDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExportConfig_basic(rName),
+				Config: testAccExportConfig_CUR_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExportExists(ctx, t, resourceName, &export),
 					resource.TestCheckResourceAttr(resourceName, "export.#", "1"),
@@ -52,7 +56,6 @@ func TestAccBCMDataExportsExport_CUR_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "export.0.name", rName),
 					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "export.0.data_query.0.query_statement"),
-					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_output_configurations.0.overwrite", "OVERWRITE_REPORT"),
@@ -61,11 +64,18 @@ func TestAccBCMDataExportsExport_CUR_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_output_configurations.0.output_type", "CUSTOM"),
 					resource.TestCheckResourceAttr(resourceName, "export.0.refresh_cadence.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "export.0.refresh_cadence.0.frequency", "SYNCHRONOUS"),
-					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.COST_AND_USAGE_REPORT.TIME_GRANULARITY", "HOURLY"),
-					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.COST_AND_USAGE_REPORT.INCLUDE_RESOURCES", acctest.CtFalseCaps),
-					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.COST_AND_USAGE_REPORT.INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY", acctest.CtFalseCaps),
-					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.COST_AND_USAGE_REPORT.INCLUDE_SPLIT_COST_ALLOCATION_DATA", acctest.CtFalseCaps),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("export").AtSliceIndex(0).AtMapKey("data_query").AtSliceIndex(0).AtMapKey("table_configurations"), knownvalue.MapExact(map[string]knownvalue.Check{
+						"COST_AND_USAGE_REPORT": knownvalue.MapExact(map[string]knownvalue.Check{
+							"TIME_GRANULARITY":                      knownvalue.StringExact("HOURLY"),
+							"INCLUDE_RESOURCES":                     knownvalue.StringExact("FALSE"),
+							"INCLUDE_SPLIT_COST_ALLOCATION_DATA":    knownvalue.StringExact("FALSE"),
+							"INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY": knownvalue.StringExact("FALSE"),
+							"BILLING_VIEW_ARN":                      tfknownvalue.GlobalARNExact("billing", "billingview/primary"),
+						}),
+					})),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -96,15 +106,19 @@ func TestAccBCMDataExportsExport_CarbonEmissions_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckExportDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExportConfig_carbonEmissions(rName),
+				Config: testAccExportConfig_CarbonEmissions_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExportExists(ctx, t, resourceName, &export),
 					resource.TestCheckResourceAttr(resourceName, "export.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "export.0.name", rName),
 					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.query_statement", "SELECT usage_account_id FROM CARBON_EMISSIONS"),
-					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.%", "0"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("export").AtSliceIndex(0).AtMapKey("data_query").AtSliceIndex(0).AtMapKey("table_configurations"), knownvalue.MapExact(map[string]knownvalue.Check{
+						"CARBON_EMISSIONS": knownvalue.MapExact(map[string]knownvalue.Check{}),
+					})),
+				},
 			},
 		},
 	})
@@ -357,7 +371,7 @@ func TestAccBCMDataExportsExport_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckExportDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExportConfig_basic(rName),
+				Config: testAccExportConfig_CUR_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExportExists(ctx, t, resourceName, &export),
 					acctest.CheckFrameworkResourceDisappears(ctx, t, tfbcmdataexports.ResourceExport, resourceName),
@@ -491,7 +505,7 @@ resource "aws_s3_bucket" "test" {
 `, rName)
 }
 
-func testAccExportConfig_basic(rName string) string {
+func testAccExportConfig_CUR_basic(rName string) string {
 	return acctest.ConfigCompose(
 		testAccExportConfigBase(rName),
 		fmt.Sprintf(`
@@ -503,15 +517,6 @@ resource "aws_bcmdataexports_export" "test" {
     name = %[1]q
     data_query {
       query_statement = "SELECT identity_line_item_id, identity_time_interval, line_item_product_code,line_item_unblended_cost FROM COST_AND_USAGE_REPORT"
-      table_configurations = {
-        "COST_AND_USAGE_REPORT" = {
-          "TIME_GRANULARITY"                      = "HOURLY",
-          "INCLUDE_RESOURCES"                     = "FALSE",
-          "INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY" = "FALSE",
-          "INCLUDE_SPLIT_COST_ALLOCATION_DATA"    = "FALSE",
-          "BILLING_VIEW_ARN"                      = "arn:${data.aws_partition.current.partition}:billing::${data.aws_caller_identity.current.account_id}:billingview/primary"
-        }
-      }
     }
     destination_configurations {
       s3_destination {
@@ -668,7 +673,7 @@ resource "aws_bcmdataexports_export" "test" {
 `, rName, query))
 }
 
-func testAccExportConfig_carbonEmissions(rName string) string {
+func testAccExportConfig_CarbonEmissions_basic(rName string) string {
 	return acctest.ConfigCompose(
 		testAccExportConfigBase(rName),
 		fmt.Sprintf(`

--- a/internal/service/bcmdataexports/export_test.go
+++ b/internal/service/bcmdataexports/export_test.go
@@ -86,6 +86,64 @@ func TestAccBCMDataExportsExport_CUR_basic(t *testing.T) {
 	})
 }
 
+func TestAccBCMDataExportsExport_CUR_tableConfigurations(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var export bcmdataexports.GetExportOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bcmdataexports_export.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionNot(t, endpoints.AwsUsGovPartitionID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExportDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExportConfig_tableConfigurations(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExportExists(ctx, t, resourceName, &export),
+					resource.TestCheckResourceAttr(resourceName, "export.#", "1"),
+					acctest.MatchResourceAttrRegionalARNRegion(ctx, resourceName, "export.0.export_arn", "bcm-data-exports", endpoints.UsEast1RegionID, regexache.MustCompile("export/"+rName+"-"+verify.UUIDRegexPattern)),
+					resource.TestCheckResourceAttr(resourceName, "export.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "export.0.data_query.0.query_statement"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_output_configurations.0.overwrite", "OVERWRITE_REPORT"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_output_configurations.0.format", "TEXT_OR_CSV"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_output_configurations.0.compression", "GZIP"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_output_configurations.0.output_type", "CUSTOM"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.refresh_cadence.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.refresh_cadence.0.frequency", "SYNCHRONOUS"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("export").AtSliceIndex(0).AtMapKey("data_query").AtSliceIndex(0).AtMapKey("table_configurations"), knownvalue.MapExact(map[string]knownvalue.Check{
+						"COST_AND_USAGE_REPORT": knownvalue.MapExact(map[string]knownvalue.Check{
+							"TIME_GRANULARITY":                      knownvalue.StringExact("DAILY"),
+							"INCLUDE_RESOURCES":                     knownvalue.StringExact("TRUE"),
+							"INCLUDE_SPLIT_COST_ALLOCATION_DATA":    knownvalue.StringExact("TRUE"),
+							"INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY": knownvalue.StringExact("TRUE"),
+							"BILLING_VIEW_ARN":                      tfknownvalue.GlobalARNExact("billing", "billingview/primary"),
+						}),
+					})),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccBCMDataExportsExport_CarbonEmissions_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -107,6 +165,44 @@ func TestAccBCMDataExportsExport_CarbonEmissions_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccExportConfig_CarbonEmissions_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExportExists(ctx, t, resourceName, &export),
+					resource.TestCheckResourceAttr(resourceName, "export.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.query_statement", "SELECT usage_account_id FROM CARBON_EMISSIONS"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("export").AtSliceIndex(0).AtMapKey("data_query").AtSliceIndex(0).AtMapKey("table_configurations"), knownvalue.MapExact(map[string]knownvalue.Check{
+						"CARBON_EMISSIONS": knownvalue.MapExact(map[string]knownvalue.Check{}),
+					})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccBCMDataExportsExport_CarbonEmissions_tableConfigurations(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var export bcmdataexports.GetExportOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bcmdataexports_export.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionNot(t, endpoints.AwsUsGovPartitionID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExportDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExportConfig_CarbonEmissions_tableConfigurations(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExportExists(ctx, t, resourceName, &export),
 					resource.TestCheckResourceAttr(resourceName, "export.#", "1"),
@@ -540,6 +636,50 @@ resource "aws_bcmdataexports_export" "test" {
 `, rName))
 }
 
+func testAccExportConfig_tableConfigurations(rName string) string {
+	return acctest.ConfigCompose(
+		testAccExportConfigBase(rName),
+		fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_bcmdataexports_export" "test" {
+  export {
+    name = %[1]q
+    data_query {
+      query_statement = "SELECT identity_line_item_id, identity_time_interval, line_item_product_code,line_item_unblended_cost FROM COST_AND_USAGE_REPORT"
+      table_configurations = {
+        "COST_AND_USAGE_REPORT" = {
+          "TIME_GRANULARITY"                      = "DAILY",
+          "INCLUDE_RESOURCES"                     = "TRUE",
+          "INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY" = "TRUE",
+          "INCLUDE_SPLIT_COST_ALLOCATION_DATA"    = "TRUE",
+          "BILLING_VIEW_ARN"                      = "arn:${data.aws_partition.current.partition}:billing::${data.aws_caller_identity.current.account_id}:billingview/primary"
+        }
+      }
+    }
+    destination_configurations {
+      s3_destination {
+        s3_bucket = aws_s3_bucket.test.bucket
+        s3_prefix = aws_s3_bucket.test.bucket_prefix
+        s3_region = aws_s3_bucket.test.region
+        s3_output_configurations {
+          overwrite   = "OVERWRITE_REPORT"
+          format      = "TEXT_OR_CSV"
+          compression = "GZIP"
+          output_type = "CUSTOM"
+        }
+      }
+    }
+
+    refresh_cadence {
+      frequency = "SYNCHRONOUS"
+    }
+  }
+}
+`, rName))
+}
+
 func testAccExportConfig_update(rName, overwrite string) string {
 	return acctest.ConfigCompose(
 		testAccExportConfigBase(rName),
@@ -682,6 +822,41 @@ resource "aws_bcmdataexports_export" "test" {
     name = %[1]q
     data_query {
       query_statement = "SELECT usage_account_id FROM CARBON_EMISSIONS"
+    }
+    destination_configurations {
+      s3_destination {
+        s3_bucket = aws_s3_bucket.test.bucket
+        s3_prefix = aws_s3_bucket.test.bucket_prefix
+        s3_region = aws_s3_bucket.test.region
+        s3_output_configurations {
+          overwrite   = "OVERWRITE_REPORT"
+          format      = "PARQUET"
+          compression = "GZIP"
+          output_type = "CUSTOM"
+        }
+      }
+    }
+
+    refresh_cadence {
+      frequency = "SYNCHRONOUS"
+    }
+  }
+}
+`, rName))
+}
+
+func testAccExportConfig_CarbonEmissions_tableConfigurations(rName string) string {
+	return acctest.ConfigCompose(
+		testAccExportConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_bcmdataexports_export" "test" {
+  export {
+    name = %[1]q
+    data_query {
+      query_statement = "SELECT usage_account_id FROM CARBON_EMISSIONS"
+      table_configurations = {
+        "CARBON_EMISSIONS" = {}
+      }
     }
     destination_configurations {
       s3_destination {

--- a/website/docs/r/bcmdataexports_export.html.markdown
+++ b/website/docs/r/bcmdataexports_export.html.markdown
@@ -71,8 +71,12 @@ This resource supports the following arguments:
 
 ### `data_query` Argument Reference
 
-* `query_statement` - (Required) Query statement. The SQL table name for CUR 2.0 is `COST_AND_USAGE_REPORT`. See the [AWS documentation](https://docs.aws.amazon.com/cur/latest/userguide/table-dictionary-cur2.html) for a list of available columns.
-* `table_configurations` - (Optional) Table configuration. See the [AWS documentation](https://docs.aws.amazon.com/cur/latest/userguide/table-dictionary-cur2.html#cur2-table-configurations) for the available configurations. In addition to those listed in the documentation, `BILLING_VIEW_ARN` must also be included, as shown in the example above.
+* `query_statement` - (Required) Query statement.
+  See the [AWS documentation](https://docs.aws.amazon.com/cur/latest/userguide/dataexports-table-dictionary.html) for a list of available tables.
+* `table_configurations` - (Optional) Table configuration.
+  See the [AWS documentation](https://docs.aws.amazon.com/cur/latest/userguide/dataexports-table-dictionary.html) for a list of available tables.
+  If a value is set for `table_configurations`, all configuration values must be set.
+  For the Cost and Usage Report, `BILLING_VIEW_ARN` must also be set, in addition to the documented settings.
 
 ### `destination_configurations` Argument Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

The `export.data_query.table_configurations` value in the resource type `aws_bcmdataexports_export` is modelled as a map of maps. The top level key is the name of the SQL table used for the report query. Some report types have configuration parameters, while others don't.

The `CARBON_EMISSIONS` report, for example, does not have any configuration parameters. This change allows explicitly setting the `table_configurations` to

```terraform
table_configurations = {
"CARBON_EMISSIONS" = {}
}
```

Previously, this would cause `terraform apply` to fail with an "inconsistent result" error.

This PR also removes special handling for `omitempty` on a map of maps, as this was the only use and the behaviour was not specified in tests or documentation.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #46230

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bcmdataexports TESTS=TestAccBCMDataExportsExport_ ACCTEST_PARALLELISM=5

--- PASS: TestAccBCMDataExportsExport_curSubset (39.67s)
--- PASS: TestAccBCMDataExportsExport_disappears (41.14s)
--- PASS: TestAccBCMDataExportsExport_update (60.66s)
--- PASS: TestAccBCMDataExportsExport_updateTable (66.04s)
--- PASS: TestAccBCMDataExportsExport_Identity_basic (66.21s)
--- PASS: TestAccBCMDataExportsExport_CarbonEmissions_tableConfigurations (28.15s)
--- PASS: TestAccBCMDataExportsExport_CarbonEmissions_basic (28.16s)
--- PASS: TestAccBCMDataExportsExport_CUR_tableConfigurations (36.64s)
--- PASS: TestAccBCMDataExportsExport_CUR_basic (36.19s)
--- PASS: TestAccBCMDataExportsExport_Tags_ComputedTag_OnUpdate_replace (67.24s)
--- PASS: TestAccBCMDataExportsExport_Tags_ComputedTag_onCreate (40.63s)
--- PASS: TestAccBCMDataExportsExport_Tags_IgnoreTags_Overlap_defaultTag (78.37s)
--- PASS: TestAccBCMDataExportsExport_Tags_IgnoreTags_Overlap_resourceTag (87.21s)
--- PASS: TestAccBCMDataExportsExport_Tags_ComputedTag_OnUpdate_add (66.50s)
--- PASS: TestAccBCMDataExportsExport_Tags_DefaultTags_updateToResourceOnly (68.61s)
--- PASS: TestAccBCMDataExportsExport_Tags_DefaultTags_updateToProviderOnly (68.86s)
--- PASS: TestAccBCMDataExportsExport_Tags_emptyMap (37.96s)
--- PASS: TestAccBCMDataExportsExport_Tags_DefaultTags_overlapping (107.49s)
--- PASS: TestAccBCMDataExportsExport_Tags_DefaultTags_nonOverlapping (105.76s)
--- PASS: TestAccBCMDataExportsExport_Tags_addOnUpdate (59.39s)
--- PASS: TestAccBCMDataExportsExport_Tags_DefaultTags_providerOnly (133.99s)
--- PASS: TestAccBCMDataExportsExport_Identity_ExistingResource_fromV6 (63.47s)
--- PASS: TestAccBCMDataExportsExport_Identity_ExistingResource_fromV5 (58.67s)
--- PASS: TestAccBCMDataExportsExport_tags (105.43s)
```
