### PR TITLE
resource/aws_ecs_express_gateway_service: Add RequiresReplace to cluster attribute

### DIFF
--- a/.changelog/47277.txt
+++ b/.changelog/47277.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_express_gateway_service: Changing `cluster` now correctly triggers resource replacement instead of an in-place update that fails with "Provider produced inconsistent result after apply"
+```

--- a/internal/service/ecs/express_gateway_service.go
+++ b/internal/service/ecs/express_gateway_service.go
@@ -68,6 +68,7 @@ func (r *expressGatewayServiceResource) Schema(ctx context.Context, req resource
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"cpu": schema.StringAttribute{

--- a/internal/service/ecs/express_gateway_service_test.go
+++ b/internal/service/ecs/express_gateway_service_test.go
@@ -354,6 +354,51 @@ func TestAccECSExpressGatewayService_checkIdempotency(t *testing.T) {
 	})
 }
 
+// TestAccECSExpressGatewayService_clusterForceNew verifies that changing
+// the cluster attribute triggers a destroy + create (ForceNew).
+// See: https://github.com/hashicorp/terraform-provider-aws/issues/47277
+func TestAccECSExpressGatewayService_clusterForceNew(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var service1, service2 awstypes.ECSExpressGatewayService
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ecs_express_gateway_service.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ECSEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExpressGatewayServiceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExpressGatewayServiceConfig_cluster(rName, rName+"-cluster-1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExpressGatewayServiceExists(ctx, t, resourceName, &service1),
+					resource.TestCheckResourceAttr(resourceName, "cluster", rName+"-cluster-1"),
+				),
+			},
+			{
+				Config: testAccExpressGatewayServiceConfig_cluster(rName, rName+"-cluster-2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExpressGatewayServiceExists(ctx, t, resourceName, &service2),
+					resource.TestCheckResourceAttr(resourceName, "cluster", rName+"-cluster-2"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
 // TestAccECSExpressGatewayService_environmentVariableOrdering verifies that
 // non-alphabetical environment variables don't cause inconsistent apply errors.
 // See: https://github.com/hashicorp/terraform-provider-aws/issues/45792
@@ -863,4 +908,22 @@ resource "aws_ecs_express_gateway_service" "test" {
   }
 }
 `)
+}
+
+func testAccExpressGatewayServiceConfig_cluster(rName, clusterName string) string {
+	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName), fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+  name = %[2]q
+}
+
+resource "aws_ecs_express_gateway_service" "test" {
+  cluster                 = aws_ecs_cluster.test.name
+  execution_role_arn      = aws_iam_role.execution.arn
+  infrastructure_role_arn = aws_iam_role.infrastructure.arn
+
+  primary_container {
+    image = "public.ecr.aws/nginx/nginx:1.28-alpine3.21-slim"
+  }
+}
+`, rName, clusterName))
 }

--- a/website/docs/r/ecs_express_gateway_service.html.markdown
+++ b/website/docs/r/ecs_express_gateway_service.html.markdown
@@ -46,7 +46,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `cluster` - (Optional) Name or ARN of the ECS cluster. Defaults to `default`.
+* `cluster` - (Optional, Forces new resource) Name or ARN of the ECS cluster. Defaults to `default`. Changing this value will recreate the resource.
 * `cpu` - (Optional) Number of CPU units used by the task. Valid values are powers of 2 between 256 and 4096.
 * `health_check_path` - (Optional) Path for health check requests. Defaults to `/ping`.
 * `memory` - (Optional) Amount of memory (in MiB) used by the task. Valid values are between 512 and 8192.


### PR DESCRIPTION
## Summary

Adds `stringplanmodifier.RequiresReplace()` to the `cluster` attribute of `aws_ecs_express_gateway_service`.

The `UpdateExpressGatewayService` API does not accept a `cluster` parameter ([API docs](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_UpdateExpressGatewayService.html)), meaning the cluster is immutable after service creation. Without `RequiresReplace()`, changing `cluster` attempts an in-place update, which fails with:

```
Error: Provider produced inconsistent result after apply
.cluster: was cty.StringVal("my-app"), but now cty.StringVal("default").
```

This is consistent with how `infrastructure_role_arn` (another immutable attribute) already uses `RequiresReplace()`.

## Changes

- `internal/service/ecs/express_gateway_service.go`: Added `stringplanmodifier.RequiresReplace()` to `cluster` attribute's `PlanModifiers`

## Root Cause (from TRACE logs)

1. Provider sends `UpdateExpressGatewayService` request **without** `cluster` in the body
2. API response returns the original cluster (`default`)
3. Provider compares planned value (`my-app`) with API response (`default`) → inconsistent result error

## Verification

- Confirmed via AWS CLI that `CreateExpressGatewayService --cluster <custom>` works correctly
- Confirmed via AWS API docs that `UpdateExpressGatewayService` does not accept `cluster`

Fixes #47277

---

> [!NOTE]
> This PR was created to address a bug discovered during an App Runner → ECS Express Mode migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
