### PR TITLE
[Enhancement] aws_msk_cluster: Add `broker_node_group_info.connectivity_info.network_type` to support IPv6 addressing

### DIFF
--- a/.changelog/47279.txt
+++ b/.changelog/47279.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_msk_cluster: Add `broker_node_group_info.connectivity_info.network_type` argument
+```
+
+```release-note:enhancement
+data-source/aws_msk_cluster: Add `broker_node_group_info.connectivity_info.network_type` attribute
+```

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -1370,7 +1370,7 @@ func statusClusterOperation(conn *kafka.Client, arn string) retry.StateRefreshFu
 	}
 }
 
-func waitClusterCreated(ctx context.Context, conn *kafka.Client, arn string, timeout time.Duration) (*types.Cluster, error) {
+func waitClusterCreated(ctx context.Context, conn *kafka.Client, arn string, timeout time.Duration) (*types.Cluster, error) { //nolint:unparam
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(types.ClusterStateCreating),
 		Target:  enum.Slice(types.ClusterStateActive),

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -137,6 +137,12 @@ func resourceCluster() *schema.Resource {
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"network_type": {
+										Type:             schema.TypeString,
+										Optional:         true,
+										Computed:         true,
+										ValidateDiagFunc: enum.Validate[types.NetworkType](),
+									},
 									"vpc_connectivity": {
 										Type:     schema.TypeList,
 										Optional: true,
@@ -575,12 +581,16 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	var vpcConnectivity *types.VpcConnectivity
+	var networkType types.NetworkType
 	if v, ok := d.GetOk("broker_node_group_info"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 		input.BrokerNodeGroupInfo = expandBrokerNodeGroupInfo(v.([]any)[0].(map[string]any))
 		// "BadRequestException: When creating a cluster, all vpcConnectivity auth schemes must be disabled (‘enabled’ : false). You can enable auth schemes after the cluster is created"
 		if input.BrokerNodeGroupInfo != nil && input.BrokerNodeGroupInfo.ConnectivityInfo != nil {
 			vpcConnectivity = input.BrokerNodeGroupInfo.ConnectivityInfo.VpcConnectivity
 			input.BrokerNodeGroupInfo.ConnectivityInfo.VpcConnectivity = nil
+
+			networkType = input.BrokerNodeGroupInfo.ConnectivityInfo.NetworkType
+			input.BrokerNodeGroupInfo.ConnectivityInfo.NetworkType = types.NetworkTypeIpv4
 		}
 	}
 
@@ -624,10 +634,14 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 
 	d.SetId(aws.ToString(output.ClusterArn))
 
-	cluster, err := waitClusterCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate))
+	_, err = waitClusterCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for MSK Cluster (%s) create: %s", d.Id(), err)
+	}
+
+	if err := refreshClusterVersion(ctx, d, meta); err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	if vpcConnectivity != nil {
@@ -636,9 +650,34 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 			ConnectivityInfo: &types.ConnectivityInfo{
 				VpcConnectivity: vpcConnectivity,
 			},
-			CurrentVersion: cluster.CurrentVersion,
+			CurrentVersion: aws.String(d.Get("current_version").(string)),
 		}
 
+		output, err := conn.UpdateConnectivity(ctx, &input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating MSK Cluster (%s) broker connectivity: %s", d.Id(), err)
+		}
+
+		clusterOperationARN := aws.ToString(output.ClusterOperationArn)
+
+		if _, err := waitClusterOperationCompleted(ctx, conn, clusterOperationARN, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for MSK Cluster (%s) operation (%s) complete: %s", d.Id(), clusterOperationARN, err)
+		}
+
+		if err := refreshClusterVersion(ctx, d, meta); err != nil {
+			return sdkdiag.AppendFromErr(diags, err)
+		}
+	}
+
+	if networkType != "" && networkType != types.NetworkTypeIpv4 {
+		input := kafka.UpdateConnectivityInput{
+			ClusterArn: aws.String(d.Id()),
+			ConnectivityInfo: &types.ConnectivityInfo{
+				NetworkType: networkType,
+			},
+			CurrentVersion: aws.String(d.Get("current_version").(string)),
+		}
 		output, err := conn.UpdateConnectivity(ctx, &input)
 
 		if err != nil {
@@ -688,15 +727,77 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KafkaClient(ctx)
 
-	if d.HasChange("broker_node_group_info.0.connectivity_info") {
+	if d.HasChange("broker_node_group_info.0.connectivity_info.0.vpc_connectivity") {
 		input := kafka.UpdateConnectivityInput{
 			ClusterArn:     aws.String(d.Id()),
 			CurrentVersion: aws.String(d.Get("current_version").(string)),
 		}
 
-		if v, ok := d.GetOk("broker_node_group_info.0.connectivity_info"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
-			input.ConnectivityInfo = expandConnectivityInfo(v.([]any)[0].(map[string]any))
+		var connectivityInfo types.ConnectivityInfo
+		if v, ok := d.GetOk("broker_node_group_info.0.connectivity_info.0,vpc_connectivity"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			connectivityInfo.VpcConnectivity = expandVPCConnectivity(v.([]any)[0].(map[string]any))
 		}
+		input.ConnectivityInfo = &connectivityInfo
+
+		output, err := conn.UpdateConnectivity(ctx, &input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating MSK Cluster (%s) broker connectivity: %s", d.Id(), err)
+		}
+
+		clusterOperationARN := aws.ToString(output.ClusterOperationArn)
+
+		if _, err := waitClusterOperationCompleted(ctx, conn, clusterOperationARN, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for MSK Cluster (%s) operation (%s) complete: %s", d.Id(), clusterOperationARN, err)
+		}
+
+		// refresh the current_version attribute after each update
+		if err := refreshClusterVersion(ctx, d, meta); err != nil {
+			return sdkdiag.AppendFromErr(diags, err)
+		}
+	}
+
+	if d.HasChange("broker_node_group_info.0.connectivity_info.0.public_access") {
+		input := kafka.UpdateConnectivityInput{
+			ClusterArn:     aws.String(d.Id()),
+			CurrentVersion: aws.String(d.Get("current_version").(string)),
+		}
+
+		var connectivityInfo types.ConnectivityInfo
+		if v, ok := d.GetOk("broker_node_group_info.0.connectivity_info.0.public_access"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			connectivityInfo.PublicAccess = expandPublicAccess(v.([]any)[0].(map[string]any))
+		}
+		input.ConnectivityInfo = &connectivityInfo
+
+		output, err := conn.UpdateConnectivity(ctx, &input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating MSK Cluster (%s) broker connectivity: %s", d.Id(), err)
+		}
+
+		clusterOperationARN := aws.ToString(output.ClusterOperationArn)
+
+		if _, err := waitClusterOperationCompleted(ctx, conn, clusterOperationARN, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for MSK Cluster (%s) operation (%s) complete: %s", d.Id(), clusterOperationARN, err)
+		}
+
+		// refresh the current_version attribute after each update
+		if err := refreshClusterVersion(ctx, d, meta); err != nil {
+			return sdkdiag.AppendFromErr(diags, err)
+		}
+	}
+
+	if d.HasChange("broker_node_group_info.0.connectivity_info.0.network_type") {
+		input := kafka.UpdateConnectivityInput{
+			ClusterArn:     aws.String(d.Id()),
+			CurrentVersion: aws.String(d.Get("current_version").(string)),
+		}
+
+		var connectivityInfo types.ConnectivityInfo
+		if v, ok := d.GetOk("broker_node_group_info.0.connectivity_info.0.network_type"); ok && v != "" {
+			connectivityInfo.NetworkType = types.NetworkType(v.(string))
+		}
+		input.ConnectivityInfo = &connectivityInfo
 
 		output, err := conn.UpdateConnectivity(ctx, &input)
 
@@ -1400,6 +1501,10 @@ func expandConnectivityInfo(tfMap map[string]any) *types.ConnectivityInfo {
 
 	apiObject := &types.ConnectivityInfo{}
 
+	if v, ok := tfMap["network_type"].(string); ok && v != "" {
+		apiObject.NetworkType = types.NetworkType(v)
+	}
+
 	if v, ok := tfMap["public_access"].([]any); ok && len(v) > 0 && v[0] != nil {
 		apiObject.PublicAccess = expandPublicAccess(v[0].(map[string]any))
 	}
@@ -1856,6 +1961,10 @@ func flattenConnectivityInfo(apiObject *types.ConnectivityInfo) map[string]any {
 	}
 
 	tfMap := map[string]any{}
+
+	if v := apiObject.NetworkType; v != "" {
+		tfMap["network_type"] = v
+	}
 
 	if v := apiObject.PublicAccess; v != nil {
 		tfMap["public_access"] = []any{flattenPublicAccess(v)}

--- a/internal/service/kafka/cluster_data_source.go
+++ b/internal/service/kafka/cluster_data_source.go
@@ -83,6 +83,10 @@ func dataSourceCluster() *schema.Resource {
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"network_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
 									"vpc_connectivity": {
 										Type:     schema.TypeList,
 										Computed: true,

--- a/internal/service/kafka/cluster_data_source_test.go
+++ b/internal/service/kafka/cluster_data_source_test.go
@@ -42,6 +42,7 @@ func TestAccKafkaClusterDataSource_basic(t *testing.T) {
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "broker_node_group_info.0.client_subnets.*", "aws_subnet.test.1", names.AttrID),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "broker_node_group_info.0.client_subnets.*", "aws_subnet.test.2", names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.network_type", string(types.NetworkTypeIpv4)),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.public_access.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.public_access.0.type", "DISABLED"),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.vpc_connectivity.#", "1"),

--- a/internal/service/kafka/cluster_test.go
+++ b/internal/service/kafka/cluster_test.go
@@ -1682,6 +1682,42 @@ func TestAccKafkaCluster_networkTypeUpdateToDual(t *testing.T) {
 	})
 }
 
+func TestAccKafkaCluster_networkTypeWithVPCConnectivity(t *testing.T) {
+	ctx := acctest.Context(t)
+	var cluster1 types.ClusterInfo
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_msk_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KafkaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_brokerNodeGroupInfoVPCConnectivitySASLIAMWithNetworkType(rName, string(types.NetworkTypeDual)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster1),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.network_type", string(types.NetworkTypeDual)),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.public_access.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.public_access.0.type", "DISABLED"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.vpc_connectivity.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.vpc_connectivity.0.client_authentication.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.vpc_connectivity.0.client_authentication.0.sasl.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.vpc_connectivity.0.client_authentication.0.sasl.0.iam", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.vpc_connectivity.0.client_authentication.0.sasl.0.scram", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.vpc_connectivity.0.client_authentication.0.tls", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "client_authentication.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_authentication.0.sasl.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_authentication.0.sasl.0.iam", acctest.CtTrue),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckResourceAttrIsSortedCSV(resourceName, attributeName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		is, err := acctest.PrimaryInstanceState(s, resourceName)
@@ -2935,7 +2971,8 @@ resource "aws_msk_cluster" "test" {
 
 func testAccClusterConfig_networkType(rName, networkType string) string {
 	return acctest.ConfigCompose(
-		acctest.ConfigVPCWithSubnetsIPv6(rName, 3), fmt.Sprintf(`
+		acctest.ConfigVPCWithSubnetsIPv6(rName, 3),
+		fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name   = %[1]q
   vpc_id = aws_vpc.test.id
@@ -2963,6 +3000,61 @@ resource "aws_msk_cluster" "test" {
 
     connectivity_info {
       network_type = %[2]q
+    }
+  }
+}
+`, rName, networkType))
+}
+
+func testAccClusterConfig_brokerNodeGroupInfoVPCConnectivitySASLIAMWithNetworkType(rName, networkType string) string {
+	return acctest.ConfigCompose(
+		testAccClusterConfig_allowEveryoneNoACLFoundFalse(rName),
+		acctest.ConfigVPCWithSubnetsIPv6(rName, 3),
+		fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name   = %[1]q
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  kafka_version          = "3.8.x"
+  number_of_broker_nodes = 3
+
+  broker_node_group_info {
+    client_subnets  = aws_subnet.test[*].id
+    instance_type   = "kafka.m7g.large"
+    security_groups = [aws_security_group.test.id]
+
+    connectivity_info {
+      network_type = %[2]q
+      vpc_connectivity {
+        client_authentication {
+          sasl {
+            iam = true
+          }
+        }
+      }
+    }
+
+    storage_info {
+      ebs_storage_info {
+        volume_size = 10
+      }
+    }
+  }
+
+  configuration_info {
+    arn      = aws_msk_configuration.test.arn
+    revision = aws_msk_configuration.test.latest_revision
+  }
+
+  client_authentication {
+    sasl {
+      iam = true
     }
   }
 }

--- a/internal/service/kafka/cluster_test.go
+++ b/internal/service/kafka/cluster_test.go
@@ -1582,6 +1582,105 @@ func TestAccKafkaCluster_rebalancing(t *testing.T) {
 	})
 }
 
+func TestAccKafkaCluster_networkTypeCreateDual(t *testing.T) {
+	ctx := acctest.Context(t)
+	var cluster types.ClusterInfo
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_msk_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KafkaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_networkType(rName, string(types.NetworkTypeDual)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.network_type", string(types.NetworkTypeDual)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrARN), checkClusterARN),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"current_version",
+				},
+			},
+		},
+	})
+}
+
+func TestAccKafkaCluster_networkTypeUpdateToDual(t *testing.T) {
+	ctx := acctest.Context(t)
+	var cluster types.ClusterInfo
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_msk_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KafkaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_networkType(rName, string(types.NetworkTypeIpv4)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.network_type", string(types.NetworkTypeIpv4)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrARN), checkClusterARN),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"current_version",
+				},
+			},
+			{
+				Config: testAccClusterConfig_networkType(rName, string(types.NetworkTypeDual)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.network_type", string(types.NetworkTypeDual)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrARN), checkClusterARN),
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckResourceAttrIsSortedCSV(resourceName, attributeName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		is, err := acctest.PrimaryInstanceState(s, resourceName)
@@ -2831,4 +2930,40 @@ resource "aws_msk_cluster" "test" {
   }
 }
 `, rName, status))
+}
+
+func testAccClusterConfig_networkType(rName, networkType string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigVPCWithSubnetsIPv6(rName, 3), fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name   = %[1]q
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  kafka_version          = "3.8.x"
+  number_of_broker_nodes = 3
+
+  broker_node_group_info {
+    client_subnets  = aws_subnet.test[*].id
+    instance_type   = "kafka.m7g.large"
+    security_groups = [aws_security_group.test.id]
+
+    storage_info {
+      ebs_storage_info {
+        volume_size = 10
+      }
+    }
+
+    connectivity_info {
+      network_type = %[2]q
+    }
+  }
+}
+`, rName, networkType))
 }

--- a/internal/service/kafka/cluster_test.go
+++ b/internal/service/kafka/cluster_test.go
@@ -148,6 +148,7 @@ func TestAccKafkaCluster_basic(t *testing.T) {
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "broker_node_group_info.0.client_subnets.*", "aws_subnet.test.1", names.AttrID),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "broker_node_group_info.0.client_subnets.*", "aws_subnet.test.2", names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.network_type", string(types.NetworkTypeIpv4)),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.public_access.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.public_access.0.type", "DISABLED"),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.vpc_connectivity.#", "1"),

--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -229,6 +229,7 @@ This resource supports the following arguments:
 
 ### broker_node_group_info connectivity_info Argument Reference
 
+* `network_type` - (Optional) Network type of the cluster. Valid values are: `IPV4` or `DUAL`. Default value: `IPV4`. Only updating from `IPV4` to `DUAL` is allowed.
 * `public_access` - (Optional) Access control settings for brokers. See [connectivity_info public_access Argument Reference](#connectivity_info-public_access-argument-reference) below.
 * `vpc_connectivity` - (Optional) VPC connectivity access control for brokers. See [connectivity_info vpc_connectivity Argument Reference](#connectivity_info-vpc_connectivity-argument-reference) below.
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR adds the `broker_node_group_info.connectivity_info.network_type` argument to the `aws_msk_cluster` resource and data source to support IPv6 addressing.

#### AWS API Behavior and Provider Implementation

* During creation, only `IPV4` is allowed for `network_type`. After creation, it can be updated to `DUAL` using the `UpdateConnectivity` API.

  * Therefore, when `network_type` is set to `DUAL`, the cluster is initially created with `IPV4` and then updated to `DUAL`.
  * Changing from `DUAL` to `IPv4` is not allowed, according to the verification.
* The `UpdateConnectivity` API accepts only one setting per request. If multiple settings are included in a single request, the following error occurs:

> BadRequestException: You can't update multiple connectivity settings in the same request. Modify your request to update only NetworkType, VpcConnectivity, or PublicAccess connectivity setting, and try again.

* When multiple updates are required, they must be performed sequentially using the `UpdateConnectivity` API, updating the `current_version`, which must be included in each request.

### Relations

Closes #47198 

### References
https://docs.aws.amazon.com/msk/1.0/apireference/clusters-clusterarn.html#clusters-clusterarn-prop-connectivityinfo-networktype

### Output from Acceptance Testing


```console
$ MSK_EXPRESS_BROKER_ENABLED=1 make testacc TESTS='TestAccKafkaCluster(DataSource|)_' PKG=kafka
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_msk_cluster-add_network_type 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/kafka/... -v -count 1 -parallel 20 -run='TestAccKafkaCluster(DataSource|)_'  -timeout 360m -vet=off
2026/04/04 00:04:40 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/04 00:04:40 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKafkaClusterDataSource_basic
=== PAUSE TestAccKafkaClusterDataSource_basic
=== RUN   TestAccKafkaCluster_Identity_basic
=== PAUSE TestAccKafkaCluster_Identity_basic
=== RUN   TestAccKafkaCluster_Identity_regionOverride
=== PAUSE TestAccKafkaCluster_Identity_regionOverride
=== RUN   TestAccKafkaCluster_Identity_ExistingResource_basic
=== PAUSE TestAccKafkaCluster_Identity_ExistingResource_basic
=== RUN   TestAccKafkaCluster_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccKafkaCluster_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccKafkaCluster_List_basic
=== PAUSE TestAccKafkaCluster_List_basic
=== RUN   TestAccKafkaCluster_List_includeResource
=== PAUSE TestAccKafkaCluster_List_includeResource
=== RUN   TestAccKafkaCluster_List_regionOverride
=== PAUSE TestAccKafkaCluster_List_regionOverride
=== RUN   TestAccKafkaCluster_basic
=== PAUSE TestAccKafkaCluster_basic
=== RUN   TestAccKafkaCluster_disappears
=== PAUSE TestAccKafkaCluster_disappears
=== RUN   TestAccKafkaCluster_tags
=== PAUSE TestAccKafkaCluster_tags
=== RUN   TestAccKafkaCluster_BrokerNodeGroupInfo_StorageInfo_disabledToEnabled
=== PAUSE TestAccKafkaCluster_BrokerNodeGroupInfo_StorageInfo_disabledToEnabled
=== RUN   TestAccKafkaCluster_BrokerNodeGroupInfo_StorageInfo_enabledToDisabled
=== PAUSE TestAccKafkaCluster_BrokerNodeGroupInfo_StorageInfo_enabledToDisabled
=== RUN   TestAccKafkaCluster_BrokerNodeGroupInfo_StorageInfo_enabledToUnset
=== PAUSE TestAccKafkaCluster_BrokerNodeGroupInfo_StorageInfo_enabledToUnset
=== RUN   TestAccKafkaCluster_BrokerNodeGroupInfo_instanceType
=== PAUSE TestAccKafkaCluster_BrokerNodeGroupInfo_instanceType
=== RUN   TestAccKafkaCluster_BrokerNodeGroupInfo_publicAccessSASLIAM
=== PAUSE TestAccKafkaCluster_BrokerNodeGroupInfo_publicAccessSASLIAM
=== RUN   TestAccKafkaCluster_BrokerNodeGroupInfo_vpcConnectivity
=== PAUSE TestAccKafkaCluster_BrokerNodeGroupInfo_vpcConnectivity
=== RUN   TestAccKafkaCluster_ClientAuthenticationSASL_scram
=== PAUSE TestAccKafkaCluster_ClientAuthenticationSASL_scram
=== RUN   TestAccKafkaCluster_ClientAuthenticationSASL_iam
=== PAUSE TestAccKafkaCluster_ClientAuthenticationSASL_iam
=== RUN   TestAccKafkaCluster_ClientAuthenticationTLS_certificateAuthorityARNs
=== PAUSE TestAccKafkaCluster_ClientAuthenticationTLS_certificateAuthorityARNs
=== RUN   TestAccKafkaCluster_ClientAuthenticationTLS_initiallyNoAuthentication
=== PAUSE TestAccKafkaCluster_ClientAuthenticationTLS_initiallyNoAuthentication
=== RUN   TestAccKafkaCluster_ClientAuthentication_SASL_enabledToUnset
=== PAUSE TestAccKafkaCluster_ClientAuthentication_SASL_enabledToUnset
=== RUN   TestAccKafkaCluster_Info_revision
=== PAUSE TestAccKafkaCluster_Info_revision
=== RUN   TestAccKafkaCluster_EncryptionInfo_encryptionAtRestKMSKeyARN
=== PAUSE TestAccKafkaCluster_EncryptionInfo_encryptionAtRestKMSKeyARN
=== RUN   TestAccKafkaCluster_EncryptionInfoEncryptionInTransit_clientBroker
=== PAUSE TestAccKafkaCluster_EncryptionInfoEncryptionInTransit_clientBroker
=== RUN   TestAccKafkaCluster_EncryptionInfoEncryptionInTransit_inCluster
=== PAUSE TestAccKafkaCluster_EncryptionInfoEncryptionInTransit_inCluster
=== RUN   TestAccKafkaCluster_enhancedMonitoring
=== PAUSE TestAccKafkaCluster_enhancedMonitoring
=== RUN   TestAccKafkaCluster_numberOfBrokerNodes
=== PAUSE TestAccKafkaCluster_numberOfBrokerNodes
=== RUN   TestAccKafkaCluster_openMonitoring
=== PAUSE TestAccKafkaCluster_openMonitoring
=== RUN   TestAccKafkaCluster_storageMode
=== PAUSE TestAccKafkaCluster_storageMode
=== RUN   TestAccKafkaCluster_loggingInfo
=== PAUSE TestAccKafkaCluster_loggingInfo
=== RUN   TestAccKafkaCluster_loggingInfoForExpress
=== PAUSE TestAccKafkaCluster_loggingInfoForExpress
=== RUN   TestAccKafkaCluster_kafkaVersionUpgrade
=== PAUSE TestAccKafkaCluster_kafkaVersionUpgrade
=== RUN   TestAccKafkaCluster_kafkaVersionDowngrade
=== PAUSE TestAccKafkaCluster_kafkaVersionDowngrade
=== RUN   TestAccKafkaCluster_kafkaVersionUpgradeWithInfo
=== PAUSE TestAccKafkaCluster_kafkaVersionUpgradeWithInfo
=== RUN   TestAccKafkaCluster_rebalancing
=== PAUSE TestAccKafkaCluster_rebalancing
=== RUN   TestAccKafkaCluster_networkTypeCreateDual
=== PAUSE TestAccKafkaCluster_networkTypeCreateDual
=== RUN   TestAccKafkaCluster_networkTypeUpdateToDual
=== PAUSE TestAccKafkaCluster_networkTypeUpdateToDual
=== RUN   TestAccKafkaCluster_networkTypeWithVPCConnectivity
=== PAUSE TestAccKafkaCluster_networkTypeWithVPCConnectivity
=== CONT  TestAccKafkaClusterDataSource_basic
=== CONT  TestAccKafkaCluster_ClientAuthenticationTLS_initiallyNoAuthentication
=== CONT  TestAccKafkaCluster_loggingInfo
=== CONT  TestAccKafkaCluster_EncryptionInfoEncryptionInTransit_inCluster
=== CONT  TestAccKafkaCluster_storageMode
=== CONT  TestAccKafkaCluster_openMonitoring
=== CONT  TestAccKafkaCluster_numberOfBrokerNodes
=== CONT  TestAccKafkaCluster_enhancedMonitoring
=== CONT  TestAccKafkaCluster_rebalancing
=== CONT  TestAccKafkaCluster_networkTypeWithVPCConnectivity
=== CONT  TestAccKafkaCluster_networkTypeUpdateToDual
=== CONT  TestAccKafkaCluster_networkTypeCreateDual
=== CONT  TestAccKafkaCluster_EncryptionInfoEncryptionInTransit_clientBroker
=== CONT  TestAccKafkaCluster_kafkaVersionDowngrade
=== CONT  TestAccKafkaCluster_kafkaVersionUpgradeWithInfo
=== CONT  TestAccKafkaCluster_kafkaVersionUpgrade
=== CONT  TestAccKafkaCluster_EncryptionInfo_encryptionAtRestKMSKeyARN
=== CONT  TestAccKafkaCluster_tags
=== CONT  TestAccKafkaCluster_List_basic
=== CONT  TestAccKafkaCluster_ClientAuthenticationTLS_certificateAuthorityARNs
--- PASS: TestAccKafkaClusterDataSource_basic (1600.48s)
=== CONT  TestAccKafkaCluster_disappears
--- PASS: TestAccKafkaCluster_EncryptionInfoEncryptionInTransit_clientBroker (1604.91s)
=== CONT  TestAccKafkaCluster_ClientAuthenticationSASL_iam
--- PASS: TestAccKafkaCluster_List_basic (1606.53s)
=== CONT  TestAccKafkaCluster_basic
--- PASS: TestAccKafkaCluster_EncryptionInfoEncryptionInTransit_inCluster (1657.83s)
=== CONT  TestAccKafkaCluster_ClientAuthenticationSASL_scram
--- PASS: TestAccKafkaCluster_openMonitoring (1787.39s)
=== CONT  TestAccKafkaCluster_List_regionOverride
--- PASS: TestAccKafkaCluster_enhancedMonitoring (1788.40s)
=== CONT  TestAccKafkaCluster_BrokerNodeGroupInfo_vpcConnectivity
--- PASS: TestAccKafkaCluster_loggingInfo (1820.43s)
=== CONT  TestAccKafkaCluster_List_includeResource
--- PASS: TestAccKafkaCluster_EncryptionInfo_encryptionAtRestKMSKeyARN (1822.33s)
=== CONT  TestAccKafkaCluster_BrokerNodeGroupInfo_publicAccessSASLIAM
--- PASS: TestAccKafkaCluster_ClientAuthenticationTLS_certificateAuthorityARNs (1849.41s)
=== CONT  TestAccKafkaCluster_BrokerNodeGroupInfo_StorageInfo_enabledToUnset
--- PASS: TestAccKafkaCluster_tags (2006.14s)
=== CONT  TestAccKafkaCluster_BrokerNodeGroupInfo_StorageInfo_enabledToDisabled
--- PASS: TestAccKafkaCluster_numberOfBrokerNodes (2820.60s)
=== CONT  TestAccKafkaCluster_BrokerNodeGroupInfo_instanceType
--- PASS: TestAccKafkaCluster_rebalancing (2824.03s)
=== CONT  TestAccKafkaCluster_BrokerNodeGroupInfo_StorageInfo_disabledToEnabled
--- PASS: TestAccKafkaCluster_disappears (1564.02s)
=== CONT  TestAccKafkaCluster_loggingInfoForExpress
--- PASS: TestAccKafkaCluster_basic (1557.99s)
=== CONT  TestAccKafkaCluster_Identity_ExistingResource_basic
--- PASS: TestAccKafkaCluster_kafkaVersionDowngrade (3169.20s)
=== CONT  TestAccKafkaCluster_ClientAuthentication_SASL_enabledToUnset
--- PASS: TestAccKafkaCluster_List_includeResource (1358.15s)
=== CONT  TestAccKafkaCluster_Identity_ExistingResource_noRefreshNoChange
--- PASS: TestAccKafkaCluster_List_regionOverride (1468.60s)
=== CONT  TestAccKafkaCluster_Identity_regionOverride
--- PASS: TestAccKafkaCluster_BrokerNodeGroupInfo_StorageInfo_enabledToUnset (1551.74s)
=== CONT  TestAccKafkaCluster_Identity_basic
--- PASS: TestAccKafkaCluster_BrokerNodeGroupInfo_StorageInfo_enabledToDisabled (1412.97s)
=== CONT  TestAccKafkaCluster_Info_revision
--- PASS: TestAccKafkaCluster_networkTypeCreateDual (3515.56s)
--- PASS: TestAccKafkaCluster_networkTypeUpdateToDual (3684.12s)
--- PASS: TestAccKafkaCluster_ClientAuthenticationTLS_initiallyNoAuthentication (3986.28s)
--- PASS: TestAccKafkaCluster_Identity_ExistingResource_basic (1556.71s)
--- PASS: TestAccKafkaCluster_Identity_basic (1324.91s)
--- PASS: TestAccKafkaCluster_Identity_ExistingResource_noRefreshNoChange (1548.76s)
--- PASS: TestAccKafkaCluster_ClientAuthenticationSASL_scram (3132.82s)
--- PASS: TestAccKafkaCluster_BrokerNodeGroupInfo_StorageInfo_disabledToEnabled (2000.17s)
--- PASS: TestAccKafkaCluster_ClientAuthenticationSASL_iam (3346.37s)
--- PASS: TestAccKafkaCluster_Identity_regionOverride (1895.22s)
--- PASS: TestAccKafkaCluster_Info_revision (1982.44s)
--- PASS: TestAccKafkaCluster_storageMode (5654.00s)
--- PASS: TestAccKafkaCluster_loggingInfoForExpress (2570.67s)
--- PASS: TestAccKafkaCluster_ClientAuthentication_SASL_enabledToUnset (3511.88s)
--- PASS: TestAccKafkaCluster_BrokerNodeGroupInfo_vpcConnectivity (5467.12s)
--- PASS: TestAccKafkaCluster_kafkaVersionUpgradeWithInfo (7387.77s)
--- PASS: TestAccKafkaCluster_kafkaVersionUpgrade (7390.54s)
--- PASS: TestAccKafkaCluster_networkTypeWithVPCConnectivity (7424.30s)
--- PASS: TestAccKafkaCluster_BrokerNodeGroupInfo_publicAccessSASLIAM (5614.54s)
--- PASS: TestAccKafkaCluster_BrokerNodeGroupInfo_instanceType (6882.43s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kafka      9708.628s

```
