### PR TITLE
[Docs] aws_cloudfront_distribution_tenant: Fix incorrect valid values for `validation_token_host` 

### DIFF
--- a/website/docs/r/cloudfront_distribution_tenant.html.markdown
+++ b/website/docs/r/cloudfront_distribution_tenant.html.markdown
@@ -108,7 +108,7 @@ This resource supports the following arguments:
 
 * `certificate_transparency_logging_preference` (Optional) - Certificate transparency logging preference. Valid values: `enabled`, `disabled`.
 * `primary_domain_name` (Optional) - Primary domain name for the certificate.
-* `validation_token_host` (Optional) - Host for validation token. Valid values: `cloudfront`, `domain`.
+* `validation_token_host` (Optional) - Host for validation token. Valid values: `cloudfront`, `self-hosted`.
 
 #### Parameter Arguments
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

The documentation for `aws_cloudfront_distribution_tenant` lists the valid values for `managed_certificate_request.validation_token_host` as `cloudfront`, `domain`. However, `domain` is not a valid value — the correct values are `cloudfront` and `self-hosted`.

This PR fixes the documented valid values from `cloudfront`, `domain` to `cloudfront`, `self-hosted`.

### Relations

Closes #47283

### References

- AWS SDK Go v2 enum definition: [`ValidationTokenHost`](https://github.com/aws/aws-sdk-go-v2/blob/main/service/cloudfront/types/enums.go#L992) defines `cloudfront` and `self-hosted`
- AWS API Reference: [ManagedCertificateRequest](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ManagedCertificateRequest.html)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.