### PR TITLE
docs: update aws_mq_configuration example to supported engine_version

### DIFF
--- a/website/docs/r/mq_configuration.html.markdown
+++ b/website/docs/r/mq_configuration.html.markdown
@@ -18,7 +18,7 @@ resource "aws_mq_configuration" "example" {
   description    = "Example Configuration"
   name           = "example"
   engine_type    = "ActiveMQ"
-  engine_version = "5.17.6"
+  engine_version = "5.19"
 
   data = <<DATA
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -40,7 +40,7 @@ resource "aws_mq_configuration" "example" {
   description    = "Example Configuration"
   name           = "example"
   engine_type    = "RabbitMQ"
-  engine_version = "3.11.20"
+  engine_version = "4.2"
 
   data = <<DATA
 # Default RabbitMQ delivery acknowledgement timeout is 30 minutes in milliseconds


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

The examples in the documentation for resource [`aws_mq_configuration`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/mq_configuration) use no longer supported engine versions.  Applying the example code ends up in below errors for ActiveMQ and RabbitMQ:

```shell
aws_mq_configuration.example: Creating...
aws_mq_configuration.example2: Creating...
╷
│ Error: creating MQ Configuration (example): operation error mq: CreateConfiguration, https response error StatusCode: 400, RequestID: cac85b08-0cb5-4fde-893a-3cd4165aab01, BadRequestException: Broker engine version [5.17.6] is invalid for broker engine type [ACTIVEMQ]. Valid values: [5.19, 5.18].
│ 
│   with aws_mq_configuration.example,
│   on main.tf line 15, in resource "aws_mq_configuration" "example":
│   15: resource "aws_mq_configuration" "example" {
│ 
╵
╷
│ Error: creating MQ Configuration (example): operation error mq: CreateConfiguration, https response error StatusCode: 400, RequestID: 2cbb6634-0903-43da-ad64-9177fa98622f, BadRequestException: Broker engine version [3.11.20] is invalid for broker engine type [RABBITMQ]. Valid values: [4.2, 3.13].
│ 
│   with aws_mq_configuration.example2,
│   on main.tf line 33, in resource "aws_mq_configuration" "example2":
│   33: resource "aws_mq_configuration" "example2" {
│ 
╵
```

This PR replaces the unsupported engine versions.

### Relations

Relates #47273 

### References


### Output from Acceptance Testing

Not applicable. Only documentation is updated.