### PR TITLE
[bugfix] aws_cloudwatch_log_metric_filter: Fix validation to count `pattern` length in UTF-8 characters

### DIFF
--- a/.changelog/47287.txt
+++ b/.changelog/47287.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_log_metric_filter: Fix validation to count `pattern` length in UTF-8 characters
+```

--- a/.ci/.golangci3.yml
+++ b/.ci/.golangci3.yml
@@ -56,6 +56,7 @@ linters:
         - nullable.*
         - tfresource.Retry*
         - tfresource.With*
+        - verify.StringUTF8LenBetween
         # Terraform Plugin SDK
         - retry.RetryContext
         - schema.DefaultTimeout

--- a/internal/service/logs/metric_filter.go
+++ b/internal/service/logs/metric_filter.go
@@ -10,10 +10,12 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -100,9 +102,9 @@ func resourceMetricFilter() *schema.Resource {
 				ValidateFunc: validLogMetricFilterName,
 			},
 			"pattern": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(0, 1024),
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validatePatternLength(),
 				StateFunc: func(v any) string {
 					s, ok := v.(string)
 					if !ok {
@@ -112,6 +114,25 @@ func resourceMetricFilter() *schema.Resource {
 				},
 			},
 		},
+	}
+}
+
+func validatePatternLength() schema.SchemaValidateDiagFunc {
+	return func(v any, path cty.Path) diag.Diagnostics {
+		var diags diag.Diagnostics
+		value := v.(string)
+		const maxLength = 1024
+
+		utf8Length := utf8.RuneCountInString(value)
+		if utf8Length > maxLength {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Invalid character length",
+				Detail:   fmt.Sprintf("expected length of pattern to be between 0 and %d UTF-8 characters, got %d", maxLength, utf8Length),
+			})
+		}
+
+		return diags
 	}
 }
 

--- a/internal/service/logs/metric_filter.go
+++ b/internal/service/logs/metric_filter.go
@@ -10,12 +10,10 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -28,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2/types/nullable"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -104,7 +103,7 @@ func resourceMetricFilter() *schema.Resource {
 			"pattern": {
 				Type:             schema.TypeString,
 				Required:         true,
-				ValidateDiagFunc: validatePatternLength(),
+				ValidateDiagFunc: verify.StringUTF8LenBetween(0, 1024),
 				StateFunc: func(v any) string {
 					s, ok := v.(string)
 					if !ok {
@@ -114,25 +113,6 @@ func resourceMetricFilter() *schema.Resource {
 				},
 			},
 		},
-	}
-}
-
-func validatePatternLength() schema.SchemaValidateDiagFunc {
-	return func(v any, path cty.Path) diag.Diagnostics {
-		var diags diag.Diagnostics
-		value := v.(string)
-		const maxLength = 1024
-
-		utf8Length := utf8.RuneCountInString(value)
-		if utf8Length > maxLength {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Invalid character length",
-				Detail:   fmt.Sprintf("expected length of pattern to be between 0 and %d UTF-8 characters, got %d", maxLength, utf8Length),
-			})
-		}
-
-		return diags
 	}
 }
 

--- a/internal/service/logs/metric_filter_test.go
+++ b/internal/service/logs/metric_filter_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -184,6 +185,44 @@ func TestAccLogsMetricFilter_update(t *testing.T) {
 	})
 }
 
+func TestAccLogsMetricFilter_longPatternInUTF8(t *testing.T) {
+	ctx := acctest.Context(t)
+	var mf types.MetricFilter
+	resourceName := "aws_cloudwatch_log_metric_filter.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	// 1027 characters in UTF-8, which exceeds 1024-character limit
+	pattern1 := "[(msg = \"*ERROR*\") && (msg != \"*テスト除外パターン０１*\") && (msg != \"*テスト除外パターン０２*\") && (msg != \"*テスト除外パターン０３*\") && (msg != \"*テスト除外パターン０４*\") && (msg != \"*テスト除外パターン０５*\") && (msg != \"*テスト除外パターン０６*\") && (msg != \"*テスト除外パターン０７*\") && (msg != \"*テスト除外パターン０８*\") && (msg != \"*テスト除外パターン０９*\") && (msg != \"*テスト除外パターン１０*\") && (msg != \"*テスト除外パターン１１*\") && (msg != \"*テスト除外パターン１２*\") && (msg != \"*テスト除外パターン１３*\") && (msg != \"*テスト除外パターン１４*\") && (msg != \"*テスト除外パターン１５*\") && (msg != \"*テスト除外パターン１６*\") && (msg != \"*テスト除外パターン１７*\") && (msg != \"*テスト除外パターン１８*\") && (msg != \"*テスト除外パターン１９*\") && (msg != \"*テスト除外パターン２０*\") && (msg != \"*テスト除外パターン２１*\") && (msg != \"*テスト除外パターン２２*\") && (msg != \"*テスト除外パターン２３*\") && (msg != \"*テスト除外パターン２４*\") && (msg != \"*テスト除外パターン２５*\") && (msg != \"*テスト除外パターン２６*\") && (msg != \"*テスト除外パターン２７*\") && (msg != \"*テスト除外パターン２８*\") && (msg != \"*テスト除外パターン２９*\") && (msg != \"*テスト除外パターン３０*\") && (msg != \"*テスト除外パターン３１*\") && (msg != \"*テスト除外パターン３２*\") && (msg != \"*テスト除外パターン３３*\") && (msg != \"*テスト除外パターン３４*\") && (msg != \"*テスト除外パターン３５*\") && (msg != \"*テスト除外パターン３６*\")]"
+	// 806 characters in UTF-8, but exceeds 1024 in bytes
+	pattern2 := "[(msg = \"*ERROR*\") && (msg != \"*テスト除外パターン０１*\") && (msg != \"*テスト除外パターン０２*\") && (msg != \"*テスト除外パターン０３*\") && (msg != \"*テスト除外パターン０４*\") && (msg != \"*テスト除外パターン０５*\") && (msg != \"*テスト除外パターン０６*\") && (msg != \"*テスト除外パターン０７*\") && (msg != \"*テスト除外パターン０８*\") && (msg != \"*テスト除外パターン０９*\") && (msg != \"*テスト除外パターン１０*\") && (msg != \"*テスト除外パターン１１*\") && (msg != \"*テスト除外パターン１２*\") && (msg != \"*テスト除外パターン１３*\") && (msg != \"*テスト除外パターン１４*\") && (msg != \"*テスト除外パターン１５*\") && (msg != \"*テスト除外パターン１６*\") && (msg != \"*テスト除外パターン１７*\") && (msg != \"*テスト除外パターン１８*\") && (msg != \"*テスト除外パターン１９*\") && (msg != \"*テスト除外パターン２０*\") && (msg != \"*テスト除外パターン２１*\") && (msg != \"*テスト除外パターン２２*\") && (msg != \"*テスト除外パターン２３*\") && (msg != \"*テスト除外パターン２４*\") && (msg != \"*テスト除外パターン２５*\") && (msg != \"*テスト除外パターン２６*\") && (msg != \"*テスト除外パターン２７*\") && (msg != \"*テスト除外パターン２８*\")]"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMetricFilterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccMetricFilterConfig_pattern(rName, pattern1),
+				ExpectError: regexache.MustCompile(`Error: Invalid character length`),
+			},
+			{
+				Config: testAccMetricFilterConfig_pattern(rName, pattern2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMetricFilterExists(ctx, t, resourceName, &mf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "pattern", pattern2),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccMetricFilterImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccMetricFilterImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -352,4 +391,24 @@ EOS
   }
 }
 `, rName)
+}
+
+func testAccMetricFilterConfig_pattern(rName, pattern string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_log_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_cloudwatch_log_metric_filter" "test" {
+  name           = %[1]q
+  pattern        = %[2]q
+  log_group_name = aws_cloudwatch_log_group.test.name
+
+  metric_transformation {
+    name      = "metric1"
+    namespace = "ns1"
+    value     = "1"
+  }
+}
+`, rName, pattern)
 }

--- a/internal/verify/utf8_length_between.go
+++ b/internal/verify/utf8_length_between.go
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package verify
+
+import (
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func StringUTF8LenBetween(minVal, maxVal int) schema.SchemaValidateDiagFunc {
+	return func(v any, path cty.Path) diag.Diagnostics {
+		var diags diag.Diagnostics
+		value, ok := v.(string)
+		if !ok {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("expected a string, got %T", v),
+				Detail:   fmt.Sprintf("expected a string, got %T", v),
+			})
+			return diags
+		}
+
+		utf8Length := utf8.RuneCountInString(value)
+		if utf8Length < minVal || utf8Length > maxVal {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Invalid character length",
+				Detail:   fmt.Sprintf("expected length of pattern to be between %d and %d UTF-8 characters, got %d", minVal, maxVal, utf8Length),
+			})
+		}
+
+		return diags
+	}
+}

--- a/internal/verify/utf8_length_between_test.go
+++ b/internal/verify/utf8_length_between_test.go
@@ -1,0 +1,92 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package verify
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+func TestStringUTF8LenBetween(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid ASCII length", func(t *testing.T) {
+		t.Parallel()
+
+		diags := StringUTF8LenBetween(2, 4)("test", cty.Path{})
+
+		if len(diags) != 0 {
+			t.Fatalf("expected no diagnostics, got %#v", diags)
+		}
+	})
+
+	t.Run("valid multibyte UTF-8 length", func(t *testing.T) {
+		t.Parallel()
+
+		diags := StringUTF8LenBetween(2, 4)("あい", cty.Path{})
+
+		if len(diags) != 0 {
+			t.Fatalf("expected no diagnostics, got %#v", diags)
+		}
+	})
+
+	t.Run("too short", func(t *testing.T) {
+		t.Parallel()
+
+		diags := StringUTF8LenBetween(2, 4)("a", cty.Path{})
+
+		if len(diags) != 1 {
+			t.Fatalf("expected 1 diagnostic, got %#v", diags)
+		}
+		if diags[0].Severity != diag.Error {
+			t.Fatalf("expected severity %q, got %q", diag.Error, diags[0].Severity)
+		}
+		if got, want := diags[0].Summary, "Invalid character length"; got != want {
+			t.Fatalf("expected summary %q, got %q", want, got)
+		}
+		if got, want := diags[0].Detail, "expected length of pattern to be between 2 and 4 UTF-8 characters, got 1"; got != want {
+			t.Fatalf("expected detail %q, got %q", want, got)
+		}
+	})
+
+	t.Run("too long with multibyte UTF-8 characters", func(t *testing.T) {
+		t.Parallel()
+
+		diags := StringUTF8LenBetween(1, 2)("あいう", cty.Path{})
+
+		if len(diags) != 1 {
+			t.Fatalf("expected 1 diagnostic, got %#v", diags)
+		}
+		if diags[0].Severity != diag.Error {
+			t.Fatalf("expected severity %q, got %q", diag.Error, diags[0].Severity)
+		}
+		if got, want := diags[0].Summary, "Invalid character length"; got != want {
+			t.Fatalf("expected summary %q, got %q", want, got)
+		}
+		if got, want := diags[0].Detail, "expected length of pattern to be between 1 and 2 UTF-8 characters, got 3"; got != want {
+			t.Fatalf("expected detail %q, got %q", want, got)
+		}
+	})
+
+	t.Run("invalid type", func(t *testing.T) {
+		t.Parallel()
+
+		diags := StringUTF8LenBetween(1, 2)(123, cty.Path{})
+
+		if len(diags) != 1 {
+			t.Fatalf("expected 1 diagnostic, got %#v", diags)
+		}
+		if diags[0].Severity != diag.Error {
+			t.Fatalf("expected severity %q, got %q", diag.Error, diags[0].Severity)
+		}
+		if got, want := diags[0].Summary, "expected a string, got int"; got != want {
+			t.Fatalf("expected summary %q, got %q", want, got)
+		}
+		if got, want := diags[0].Detail, "expected a string, got int"; got != want {
+			t.Fatalf("expected detail %q, got %q", want, got)
+		}
+	})
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR fixes the validation for the `pattern` length to count UTF-8 characters instead of bytes.

* Although the AWS documentation does not explicitly state this, the "1024 character limit" appears to be based on the number of UTF-8 characters rather than bytes.

* A custom validator is implemented to count the length in UTF-8 characters.

* Without this fix, the newly added acceptance test fails when `pattern2` (which exceeds 1024 bytes but is fewer than 1024 UTF-8 characters) is used, reproducing the reported issue.

* When `pattern1` (which exceeds 1024 UTF-8 characters) is used and the validation is removed, the AWS API raises an error due to the string being too long. This indicates that the validation is consistent with the AWS API behavior.

### Relations
Closes #47274 

### References
https://docs.aws.amazon.com/ja_jp/AmazonCloudWatchLogs/latest/APIReference/API_PutMetricFilter.html#CWL-PutMetricFilter-request-filterPattern

### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccLogsMetricFilter_' PKG=logs 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws_cloudwatch_log_metric_filter_validate_char_length_in_utf8 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/logs/... -v -count 1 -parallel 20 -run='TestAccLogsMetricFilter_'  -timeout 360m -vet=off
2026/04/04 09:32:13 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/04 09:32:13 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLogsMetricFilter_basic
=== PAUSE TestAccLogsMetricFilter_basic
=== RUN   TestAccLogsMetricFilter_disappears
=== PAUSE TestAccLogsMetricFilter_disappears
=== RUN   TestAccLogsMetricFilter_Disappears_logGroup
=== PAUSE TestAccLogsMetricFilter_Disappears_logGroup
=== RUN   TestAccLogsMetricFilter_many
=== PAUSE TestAccLogsMetricFilter_many
=== RUN   TestAccLogsMetricFilter_update
=== PAUSE TestAccLogsMetricFilter_update
=== RUN   TestAccLogsMetricFilter_longPatternInUTF8
=== PAUSE TestAccLogsMetricFilter_longPatternInUTF8
=== CONT  TestAccLogsMetricFilter_basic
=== CONT  TestAccLogsMetricFilter_many
=== CONT  TestAccLogsMetricFilter_Disappears_logGroup
=== CONT  TestAccLogsMetricFilter_longPatternInUTF8
=== CONT  TestAccLogsMetricFilter_disappears
=== CONT  TestAccLogsMetricFilter_update
--- PASS: TestAccLogsMetricFilter_Disappears_logGroup (34.78s)
--- PASS: TestAccLogsMetricFilter_disappears (35.58s)
--- PASS: TestAccLogsMetricFilter_basic (38.09s)
--- PASS: TestAccLogsMetricFilter_longPatternInUTF8 (39.64s)
--- PASS: TestAccLogsMetricFilter_update (57.35s)
--- PASS: TestAccLogsMetricFilter_many (60.84s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       66.813s
```
