### PR TITLE
r/route53_record: validate TXT/SPF record string part lengths

### DIFF
--- a/.changelog/47292.txt
+++ b/.changelog/47292.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_route53_record: Add validation that each quoted string part in TXT and SPF records does not exceed the DNS 255-character limit
+```

--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -336,6 +336,11 @@ func resourceRecord() *schema.Resource {
 
 func resourceRecordCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
+
+	if err := validateTXTRecordStringLengths(d); err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating Route53 Record: %s", err)
+	}
+
 	conn := meta.(*conns.AWSClient).Route53Client(ctx)
 
 	zoneID := cleanZoneID(d.Get("zone_id").(string))
@@ -498,6 +503,11 @@ func resourceRecordRead(ctx context.Context, d *schema.ResourceData, meta any) d
 
 func resourceRecordUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
+
+	if err := validateTXTRecordStringLengths(d); err != nil {
+		return sdkdiag.AppendErrorf(diags, "updating Route53 Record (%s): %s", d.Id(), err)
+	}
+
 	conn := meta.(*conns.AWSClient).Route53Client(ctx)
 
 	// Route 53 supports CREATE, DELETE, and UPSERT actions. We use UPSERT, and
@@ -880,6 +890,41 @@ func nilString(s string) *string {
 		return nil
 	}
 	return aws.String(s)
+}
+
+// validateTXTRecordStringLengths checks that each quoted string part in TXT and
+// SPF records does not exceed the DNS 255-character limit. Users split long
+// values using \"\" notation, and each resulting part must be ≤ 255 characters.
+func validateTXTRecordStringLengths(d *schema.ResourceData) error {
+	rrType := awstypes.RRType(d.Get(names.AttrType).(string))
+	if rrType != awstypes.RRTypeTxt && rrType != awstypes.RRTypeSpf {
+		return nil
+	}
+
+	v, ok := d.GetOk("records")
+	if !ok {
+		return nil
+	}
+
+	return validateTXTStringParts(flex.ExpandStringValueSet(v.(*schema.Set)))
+}
+
+// validateTXTStringParts checks that each quoted string part in a set of TXT
+// record values does not exceed the DNS 255-character limit per RFC 1035.
+func validateTXTStringParts(records []string) error {
+	for _, record := range records {
+		// Split on escaped quote pairs that represent multi-string TXT entries.
+		parts := strings.Split(record, "\"\"")
+		for _, part := range parts {
+			if len(part) > 255 {
+				return fmt.Errorf("a TXT record contains a string part longer than 255 characters (%d characters). "+
+					"DNS TXT records require each quoted string to be at most 255 characters. "+
+					"Split long values using \\\"\\\" notation, e.g. \"first255chars\\\"\\\"remaining\"", len(part))
+			}
+		}
+	}
+
+	return nil
 }
 
 func expandResourceRecordSet(d *schema.ResourceData, zoneName string) *awstypes.ResourceRecordSet {

--- a/internal/service/route53/record_validation_test.go
+++ b/internal/service/route53/record_validation_test.go
@@ -1,0 +1,86 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package route53
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateTXTStringParts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		records []string
+		wantErr bool
+	}{
+		{
+			name:    "valid short record",
+			records: []string{"v=spf1 include:example.com ~all"},
+			wantErr: false,
+		},
+		{
+			name:    "valid record at 255 characters",
+			records: []string{strings.Repeat("a", 255)},
+			wantErr: false,
+		},
+		{
+			name:    "invalid record at 256 characters",
+			records: []string{strings.Repeat("a", 256)},
+			wantErr: true,
+		},
+		{
+			name:    "valid split record",
+			records: []string{strings.Repeat("a", 255) + "\"\"" + strings.Repeat("b", 255)},
+			wantErr: false,
+		},
+		{
+			name:    "invalid first part of split record",
+			records: []string{strings.Repeat("a", 256) + "\"\"" + strings.Repeat("b", 100)},
+			wantErr: true,
+		},
+		{
+			name:    "invalid second part of split record",
+			records: []string{strings.Repeat("a", 100) + "\"\"" + strings.Repeat("b", 256)},
+			wantErr: true,
+		},
+		{
+			name:    "multiple valid records",
+			records: []string{"short record", strings.Repeat("x", 255)},
+			wantErr: false,
+		},
+		{
+			name:    "one valid one invalid record",
+			records: []string{"short record", strings.Repeat("x", 300)},
+			wantErr: true,
+		},
+		{
+			name:    "empty records",
+			records: []string{},
+			wantErr: false,
+		},
+		{
+			name:    "DKIM-like long record without split",
+			records: []string{"v=DKIM1; k=rsa; p=" + strings.Repeat("A", 300)},
+			wantErr: true,
+		},
+		{
+			name:    "DKIM-like record properly split",
+			records: []string{"v=DKIM1; k=rsa; p=" + strings.Repeat("A", 237) + "\"\"" + strings.Repeat("A", 63)},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateTXTStringParts(tt.records)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateTXTStringParts() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 reaction to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or "me too" comments, they generate extra noise for pull request followers and do not help prioritize the request.

### Description

Adds plan-time validation for TXT and SPF record string part lengths in `aws_route53_record`.

DNS TXT records have a 255-character limit per quoted string (RFC 1035 §3.3). When users provide values longer than 255 characters without properly splitting them using `""` notation, `terraform plan` succeeds but `terraform apply` fails with a cryptic `CharacterStringTooLong` error from the Route 53 API.

This change adds a validation check during Create and Update that:
1. Detects when the record type is TXT or SPF
2. Splits each record value on `""` (the Terraform notation for multi-string TXT entries)
3. Checks that each resulting string part is ≤ 255 characters
4. Returns a clear error message explaining the 255-character limit and how to use `""` notation to split long values

### Affected Resource(s)

* `aws_route53_record`

### How Has This Been Tested?

* Added 11 unit tests covering:
  - Valid short records
  - Records at exactly 255 characters (boundary)
  - Records exceeding 255 characters (should error)
  - Properly split records using `""` notation
  - Invalid first/second parts of split records
  - Multiple records (mix of valid/invalid)
  - Empty record sets
  - DKIM-like long records (common real-world case)

```
$ go test -run TestValidateTXTStringParts -v ./internal/service/route53/
=== RUN   TestValidateTXTStringParts
--- PASS: TestValidateTXTStringParts (0.00s)
    --- PASS: TestValidateTXTStringParts/valid_short_record (0.00s)
    --- PASS: TestValidateTXTStringParts/valid_record_at_255_characters (0.00s)
    --- PASS: TestValidateTXTStringParts/invalid_record_at_256_characters (0.00s)
    --- PASS: TestValidateTXTStringParts/valid_split_record (0.00s)
    --- PASS: TestValidateTXTStringParts/invalid_first_part_of_split_record (0.00s)
    --- PASS: TestValidateTXTStringParts/invalid_second_part_of_split_record (0.00s)
    --- PASS: TestValidateTXTStringParts/multiple_valid_records (0.00s)
    --- PASS: TestValidateTXTStringParts/one_valid_one_invalid_record (0.00s)
    --- PASS: TestValidateTXTStringParts/empty_records (0.00s)
    --- PASS: TestValidateTXTStringParts/DKIM-like_long_record_without_split (0.00s)
    --- PASS: TestValidateTXTStringParts/DKIM-like_record_properly_split (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53   5.220s
```

### New or Affected Resource(s)

N/A - No new resources. Adds validation to existing `aws_route53_record` resource.

Fixes #14941