### PR TITLE
Fix aws_organizations_account delete when account already closed

### DIFF
--- a/.changelog/46627.txt
+++ b/.changelog/46627.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_organizations_account: Fix `AccountAlreadyClosedException` error when deleting an account that has already been closed with `close_on_deletion` set to `true`
+```

--- a/internal/service/organizations/account.go
+++ b/internal/service/organizations/account.go
@@ -329,7 +329,7 @@ func resourceAccountDelete(ctx context.Context, d *schema.ResourceData, meta any
 		})
 	}
 
-	if errs.IsA[*awstypes.AccountNotFoundException](err) {
+	if errs.IsA[*awstypes.AccountNotFoundException](err) || errs.IsA[*awstypes.AccountAlreadyClosedException](err) {
 		return diags
 	}
 


### PR DESCRIPTION

### Description

Fixes #46627.

When destroying an `aws_organizations_account` resource with `close_on_deletion = true`, the delete fails with `AccountAlreadyClosedException` if the account was already closed outside of Terraform.

This PR handles `AccountAlreadyClosedException` as a no-op during deletion, matching the existing handling of `AccountNotFoundException` on the same code path. The desired state (account closed) is already achieved, so the error can be safely ignored.

### Changes

- Handle `AccountAlreadyClosedException` alongside `AccountNotFoundException` in `resourceAccountDelete`
- Added changelog entry

### Output from acceptance testing

Difficult to feasibly test, it would require a real AWS Organizations accounts with close cooldowns. The change follows the identical established pattern used for AccountNotFoundException on the same line.