### PR TITLE
fix(ec2): clear regional NAT Gateway attributes for zonal gateways

### DIFF
--- a/.changelog/47297.txt
+++ b/.changelog/47297.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_nat_gateway: Fix perpetual drift for regional NAT Gateway by clearing zonal-only attributes (`regional_nat_gateway_address`, `regional_nat_gateway_auto_mode`, `route_table_id`, `auto_provision_zones`, `auto_scaling_ips`) when the gateway mode is `availability-zone`
+```

--- a/internal/service/ec2/vpc_nat_gateway.go
+++ b/internal/service/ec2/vpc_nat_gateway.go
@@ -384,6 +384,11 @@ func resourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta an
 		d.Set("secondary_private_ip_address_count", len(secondaryPrivateIPAddresses))
 		d.Set("secondary_private_ip_addresses", secondaryPrivateIPAddresses)
 		d.Set(names.AttrSubnetID, natGateway.SubnetId)
+		d.Set("regional_nat_gateway_address", nil)
+		d.Set("regional_nat_gateway_auto_mode", nil)
+		d.Set("route_table_id", nil)
+		d.Set("auto_provision_zones", nil)
+		d.Set("auto_scaling_ips", nil)
 
 	case awstypes.AvailabilityModeRegional:
 		d.Set("auto_provision_zones", natGateway.AutoProvisionZones)


### PR DESCRIPTION
### Description

Fixes phantom plan drift on `regional_nat_gateway_address` for existing zonal NAT gateways after upgrading to a provider version that includes the regional NAT gateway attributes (added in #45240).

### Problem

Users upgrading from provider versions before 6.24 to 6.28+ see unwanted plan changes on every `terraform plan`:

```
~ resource "aws_nat_gateway" "example" {
      id = "nat-xxx"
    + regional_nat_gateway_address = (known after apply)
  }
```

This diff never resolves — applying produces the same plan again because the Read function never sets these attributes for zonal gateways.

### Root Cause

In `resourceNATGatewayRead`, the `AvailabilityModeZonal` code path does not explicitly nil out regional-only attributes (`regional_nat_gateway_address`, `regional_nat_gateway_auto_mode`, `route_table_id`, `auto_provision_zones`, `auto_scaling_ips`). When these Computed attributes exist in the schema but are absent from state, Terraform generates a plan diff.

### Fix

Explicitly set regional-only attributes to `nil` in the zonal Read path, signaling to Terraform that they are intentionally empty.

Fixes #46242

#### Community Note

- [x] Please vote on this pull request with a :+1: or :-1: reaction to help maintainers prioritize
- [x] This PR addresses a previously filed issue: #46242