### PR TITLE
[Enhancement] feat: add bedrock agentcore observability support

### DIFF
--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -321,6 +321,10 @@ func (r *agentRuntimeResource) Schema(ctx context.Context, request resource.Sche
 										Computed: true,
 										Validators: []validator.String{
 											stringvalidator.LengthBetween(1, 512),
+											stringvalidator.RegexMatches(
+												regexache.MustCompile(`^[a-zA-Z0-9._/\-#]+$`),
+												"must contain only alphanumeric characters, periods, hyphens, underscores, forward slashes, and hash signs",
+											),
 										},
 									},
 									"retention_in_days": schema.Int32Attribute{

--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -1423,13 +1423,13 @@ func configureObservability(ctx context.Context, conn *bedrockagentcorecontrol.C
 	}
 
 	obsEnvVars := map[string]string{
-		"AGENT_OBSERVABILITY_ENABLED":          "true",
-		"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT":     fmt.Sprintf("https://logs.%s.amazonaws.com/v1/logs", region),
-		"OTEL_EXPORTER_OTLP_LOGS_HEADERS":      fmt.Sprintf("x-aws-log-group=%s,x-aws-log-stream=runtime-logs,x-aws-metric-namespace=bedrock-agentcore", logGroup),
-		"OTEL_EXPORTER_OTLP_PROTOCOL":          "http/protobuf",
-		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT":   fmt.Sprintf("https://xray.%s.amazonaws.com/v1/traces", region),
-		"OTEL_RESOURCE_ATTRIBUTES":             fmt.Sprintf("service.name=%s,aws.log.group.names=%s", runtimeName, logGroup),
-		"OTEL_TRACES_EXPORTER":                 "otlp",
+		"AGENT_OBSERVABILITY_ENABLED":        "true",
+		"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT":   fmt.Sprintf("https://logs.%s.amazonaws.com/v1/logs", region),
+		"OTEL_EXPORTER_OTLP_LOGS_HEADERS":    fmt.Sprintf("x-aws-log-group=%s,x-aws-log-stream=runtime-logs,x-aws-metric-namespace=bedrock-agentcore", logGroup),
+		"OTEL_EXPORTER_OTLP_PROTOCOL":        "http/protobuf",
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": fmt.Sprintf("https://xray.%s.amazonaws.com/v1/traces", region),
+		"OTEL_RESOURCE_ATTRIBUTES":           fmt.Sprintf("service.name=%s,aws.log.group.names=%s", runtimeName, logGroup),
+		"OTEL_TRACES_EXPORTER":               "otlp",
 	}
 
 	// Inject language-specific OTEL env vars.
@@ -1647,8 +1647,8 @@ func readLogGroupRetention(ctx context.Context, logsConn *cloudwatchlogs.Client,
 }
 
 const (
-	xraySamplingRulePrefix  = "bedrock-agentcore-"
-	xraySamplingRuleMaxLen  = 32
+	xraySamplingRulePrefix = "bedrock-agentcore-"
+	xraySamplingRuleMaxLen = 32
 )
 
 func xraySamplingRuleName(runtimeID string) string {

--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -8,6 +8,7 @@ package bedrockagentcore
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/YakDriver/regexache"
@@ -26,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -691,9 +693,79 @@ func (r *agentRuntimeResource) Read(ctx context.Context, request resource.ReadRe
 				}
 			}
 		}
+	} else if out.EnvironmentVariables["AGENT_OBSERVABILITY_ENABLED"] == "true" {
+		// Import path: observability was enabled but no prior Terraform state exists.
+		// Reconstruct the observability block from OTEL environment variables injected
+		// by configureObservability.
+		obsConfig, err := reconstructObservabilityFromEnvVars(ctx, r.Meta().LogsClient(ctx), r.Meta().XRayClient(ctx), out.EnvironmentVariables, agentRuntimeID)
+		if err != nil {
+			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+			return
+		}
+		data.Observability = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, obsConfig)
+
+		// Strip OTEL env vars so environment_variables reflects the user-managed set only.
+		filteredAttrs := make(map[string]attr.Value)
+		for k, v := range data.EnvironmentVariables.Elements() {
+			if !isOtelEnvVar(k) {
+				filteredAttrs[k] = v
+			}
+		}
+		data.EnvironmentVariables = fwtypes.NewMapValueOfMust[types.String](ctx, filteredAttrs)
 	}
 
 	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, &data))
+}
+
+func reconstructObservabilityFromEnvVars(ctx context.Context, logsConn *cloudwatchlogs.Client, xrayConn *xray.Client, apiEnvVars map[string]string, runtimeID string) (*observabilityConfigurationModel, error) {
+	// Detect runtime language from language-specific env vars.
+	runtimeLanguage := ""
+	if _, ok := apiEnvVars["OTEL_PYTHON_DISTRO"]; ok {
+		runtimeLanguage = "python"
+	}
+
+	// Extract log group from OTEL_EXPORTER_OTLP_LOGS_HEADERS.
+	logGroup := ""
+	if headers, ok := apiEnvVars["OTEL_EXPORTER_OTLP_LOGS_HEADERS"]; ok {
+		for _, part := range strings.Split(headers, ",") {
+			if strings.HasPrefix(part, "x-aws-log-group=") {
+				logGroup = strings.TrimPrefix(part, "x-aws-log-group=")
+				break
+			}
+		}
+	}
+
+	// Build cloudwatch_logs config, reading retention from the API.
+	cwConfig := &cloudwatchLogsConfigurationModel{
+		LogGroupName:    types.StringValue(logGroup),
+		RetentionInDays: types.Int32Null(),
+	}
+	if logGroup != "" {
+		retention, err := readLogGroupRetention(ctx, logsConn, logGroup)
+		if err != nil {
+			return nil, fmt.Errorf("reading log group retention during import: %w", err)
+		}
+		if retention > 0 {
+			cwConfig.RetentionInDays = types.Int32Value(retention)
+		}
+	}
+
+	// Build xray config, reading sampling percentage from the API.
+	xrayConfig := &xrayConfigurationModel{SamplingPercentage: types.Int32Null()}
+	percentage, found, err := readXRaySamplingPercentage(ctx, xrayConn, runtimeID)
+	if err != nil {
+		return nil, fmt.Errorf("reading X-Ray sampling percentage during import: %w", err)
+	}
+	if found {
+		xrayConfig.SamplingPercentage = types.Int32Value(percentage)
+	}
+
+	return &observabilityConfigurationModel{
+		Enabled:         types.BoolValue(true),
+		RuntimeLanguage: types.StringValue(runtimeLanguage),
+		CloudwatchLogs:  fwtypes.NewListNestedObjectValueOfPtrMust(ctx, cwConfig),
+		Xray:            fwtypes.NewListNestedObjectValueOfPtrMust(ctx, xrayConfig),
+	}, nil
 }
 
 func (r *agentRuntimeResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
@@ -791,6 +863,27 @@ func (r *agentRuntimeResource) Update(ctx context.Context, request resource.Upda
 					if _, err := waitAgentRuntimeUpdated(ctx, conn, agentRuntimeID, r.UpdateTimeout(ctx, new.Timeouts)); err != nil {
 						smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
 						return
+					}
+				}
+				// Resolve computed log_group_name: preserve from old state or derive from runtime ID.
+				if !obsConfig.CloudwatchLogs.IsNull() {
+					cwConfig, d := obsConfig.CloudwatchLogs.ToPtr(ctx)
+					smerr.AddEnrich(ctx, &response.Diagnostics, d)
+					if response.Diagnostics.HasError() {
+						return
+					}
+					if cwConfig != nil && (cwConfig.LogGroupName.IsNull() || cwConfig.LogGroupName.IsUnknown()) {
+						resolvedName := fmt.Sprintf("/aws/bedrock-agentcore/runtimes/%s", agentRuntimeID)
+						if oldObsConfig != nil && !oldObsConfig.CloudwatchLogs.IsNull() {
+							oldCwConfig, d := oldObsConfig.CloudwatchLogs.ToPtr(ctx)
+							smerr.AddEnrich(ctx, &response.Diagnostics, d)
+							if !response.Diagnostics.HasError() && oldCwConfig != nil && !oldCwConfig.LogGroupName.IsNull() && !oldCwConfig.LogGroupName.IsUnknown() {
+								resolvedName = oldCwConfig.LogGroupName.ValueString()
+							}
+						}
+						cwConfig.LogGroupName = types.StringValue(resolvedName)
+						obsConfig.CloudwatchLogs = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, cwConfig)
+						new.Observability = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, obsConfig)
 					}
 				}
 			}

--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -299,6 +299,12 @@ func (r *agentRuntimeResource) Schema(ctx context.Context, request resource.Sche
 						"enabled": schema.BoolAttribute{
 							Required: true,
 						},
+						"runtime_language": schema.StringAttribute{
+							Optional: true,
+							Validators: []validator.String{
+								stringvalidator.OneOf("python"),
+							},
+						},
 					},
 					Blocks: map[string]schema.Block{
 						"cloudwatch_logs": schema.ListNestedBlock{
@@ -1241,9 +1247,10 @@ type workloadIdentityDetailsModel struct {
 }
 
 type observabilityConfigurationModel struct {
-	CloudwatchLogs fwtypes.ListNestedObjectValueOf[cloudwatchLogsConfigurationModel] `tfsdk:"cloudwatch_logs"`
-	Enabled        types.Bool                                                         `tfsdk:"enabled"`
-	Xray           fwtypes.ListNestedObjectValueOf[xrayConfigurationModel]            `tfsdk:"xray"`
+	CloudwatchLogs  fwtypes.ListNestedObjectValueOf[cloudwatchLogsConfigurationModel] `tfsdk:"cloudwatch_logs"`
+	Enabled         types.Bool                                                         `tfsdk:"enabled"`
+	RuntimeLanguage types.String                                                      `tfsdk:"runtime_language"`
+	Xray            fwtypes.ListNestedObjectValueOf[xrayConfigurationModel]            `tfsdk:"xray"`
 }
 
 type xrayConfigurationModel struct {
@@ -1290,6 +1297,13 @@ func configureObservability(ctx context.Context, conn *bedrockagentcorecontrol.C
 		"OTEL_EXPORTER_OTLP_PROTOCOL":     "http/protobuf",
 		"OTEL_RESOURCE_ATTRIBUTES":        fmt.Sprintf("service.name=%s,aws.log.group.names=%s", runtimeName, logGroup),
 		"OTEL_TRACES_EXPORTER":            "otlp",
+	}
+
+	// Inject language-specific OTEL env vars.
+	switch obsConfig.RuntimeLanguage.ValueString() {
+	case "python":
+		obsEnvVars["OTEL_PYTHON_DISTRO"] = "aws_distro"
+		obsEnvVars["OTEL_PYTHON_CONFIGURATOR"] = "aws_configurator"
 	}
 
 	mergedEnvVars := make(map[string]string)

--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -528,6 +528,22 @@ func (r *agentRuntimeResource) Create(ctx context.Context, request resource.Crea
 		return
 	}
 
+	// Persist the created runtime to state immediately so that a subsequent destroy
+	// can remove it even if post-create observability configuration fails.
+	// Save with null observability to avoid unknown computed values (e.g. log_group_name).
+	userEnvVars := data.EnvironmentVariables
+	configObservability := data.Observability
+	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, runtime, &data, fwflex.WithFieldNamePrefix("AgentRuntime")))
+	if response.Diagnostics.HasError() {
+		return
+	}
+	data.Observability = fwtypes.NewListNestedObjectValueOfNull[observabilityConfigurationModel](ctx)
+	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, data))
+	if response.Diagnostics.HasError() {
+		return
+	}
+	data.Observability = configObservability
+
 	if !data.Observability.IsNull() {
 		obsConfig, d := data.Observability.ToPtr(ctx)
 		smerr.AddEnrich(ctx, &response.Diagnostics, d)
@@ -543,7 +559,7 @@ func (r *agentRuntimeResource) Create(ctx context.Context, request resource.Crea
 				smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("waiting for X-Ray resource policy: %w", err), smerr.ID, agentRuntimeID)
 				return
 			}
-			resolvedLogGroup, err := configureObservability(ctx, conn, r.Meta().LogsClient(ctx), r.Meta().XRayClient(ctx), runtime, obsConfig, data.EnvironmentVariables)
+			resolvedLogGroup, err := configureObservability(ctx, conn, r.Meta().LogsClient(ctx), r.Meta().XRayClient(ctx), r.Meta().Region(ctx), runtime, obsConfig, data.EnvironmentVariables)
 			if err != nil {
 				smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
 				return
@@ -569,15 +585,16 @@ func (r *agentRuntimeResource) Create(ctx context.Context, request resource.Crea
 		}
 	}
 
-	// Set values for unknowns.
-	savedObservability := data.Observability
-	userEnvVars := data.EnvironmentVariables
+	// resolvedObservability holds the fully resolved observability block (known log_group_name).
+	resolvedObservability := data.Observability
+
+	// Re-flatten after observability to pick up any updated API fields.
 	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, runtime, &data, fwflex.WithFieldNamePrefix("AgentRuntime")))
 	if response.Diagnostics.HasError() {
 		return
 	}
 	// fwflex.Flatten operates on API fields only; restore Terraform-managed fields.
-	data.Observability = savedObservability
+	data.Observability = resolvedObservability
 	if !data.Observability.IsNull() {
 		obsConfig, d := data.Observability.ToPtr(ctx)
 		smerr.AddEnrich(ctx, &response.Diagnostics, d)
@@ -733,7 +750,7 @@ func (r *agentRuntimeResource) Update(ctx context.Context, request resource.Upda
 					smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
 					return
 				}
-				resolvedLogGroup, err := configureObservability(ctx, conn, r.Meta().LogsClient(ctx), r.Meta().XRayClient(ctx), runtime, obsConfig, new.EnvironmentVariables)
+				resolvedLogGroup, err := configureObservability(ctx, conn, r.Meta().LogsClient(ctx), r.Meta().XRayClient(ctx), r.Meta().Region(ctx), runtime, obsConfig, new.EnvironmentVariables)
 				if err != nil {
 					smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
 					return
@@ -1288,7 +1305,7 @@ const xrayResourcePolicyName = "BedrockAgentCoreXRayPolicy"
 // configureObservability injects OTEL environment variables, configures X-Ray, and applies
 // any CloudWatch Logs settings. It returns the resolved log group name so callers can
 // persist it as a computed value in state.
-func configureObservability(ctx context.Context, conn *bedrockagentcorecontrol.Client, logsConn *cloudwatchlogs.Client, xrayConn *xray.Client, runtime *bedrockagentcorecontrol.GetAgentRuntimeOutput, obsConfig *observabilityConfigurationModel, existingEnvVars fwtypes.MapOfString) (string, error) {
+func configureObservability(ctx context.Context, conn *bedrockagentcorecontrol.Client, logsConn *cloudwatchlogs.Client, xrayConn *xray.Client, region string, runtime *bedrockagentcorecontrol.GetAgentRuntimeOutput, obsConfig *observabilityConfigurationModel, existingEnvVars fwtypes.MapOfString) (string, error) {
 	runtimeID := aws.ToString(runtime.AgentRuntimeId)
 	runtimeName := aws.ToString(runtime.AgentRuntimeName)
 
@@ -1313,11 +1330,13 @@ func configureObservability(ctx context.Context, conn *bedrockagentcorecontrol.C
 	}
 
 	obsEnvVars := map[string]string{
-		"AGENT_OBSERVABILITY_ENABLED":     "true",
-		"OTEL_EXPORTER_OTLP_LOGS_HEADERS": fmt.Sprintf("x-aws-log-group=%s,x-aws-log-stream=runtime-logs,x-aws-metric-namespace=bedrock-agentcore", logGroup),
-		"OTEL_EXPORTER_OTLP_PROTOCOL":     "http/protobuf",
-		"OTEL_RESOURCE_ATTRIBUTES":        fmt.Sprintf("service.name=%s,aws.log.group.names=%s", runtimeName, logGroup),
-		"OTEL_TRACES_EXPORTER":            "otlp",
+		"AGENT_OBSERVABILITY_ENABLED":          "true",
+		"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT":     fmt.Sprintf("https://logs.%s.amazonaws.com/v1/logs", region),
+		"OTEL_EXPORTER_OTLP_LOGS_HEADERS":      fmt.Sprintf("x-aws-log-group=%s,x-aws-log-stream=runtime-logs,x-aws-metric-namespace=bedrock-agentcore", logGroup),
+		"OTEL_EXPORTER_OTLP_PROTOCOL":          "http/protobuf",
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT":   fmt.Sprintf("https://xray.%s.amazonaws.com/v1/traces", region),
+		"OTEL_RESOURCE_ATTRIBUTES":             fmt.Sprintf("service.name=%s,aws.log.group.names=%s", runtimeName, logGroup),
+		"OTEL_TRACES_EXPORTER":                 "otlp",
 	}
 
 	// Inject language-specific OTEL env vars.
@@ -1325,6 +1344,7 @@ func configureObservability(ctx context.Context, conn *bedrockagentcorecontrol.C
 	case "python":
 		obsEnvVars["OTEL_PYTHON_DISTRO"] = "aws_distro"
 		obsEnvVars["OTEL_PYTHON_CONFIGURATOR"] = "aws_configurator"
+		obsEnvVars["OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED"] = "true"
 	}
 
 	mergedEnvVars := make(map[string]string)
@@ -1476,15 +1496,28 @@ func (r *agentRuntimeResource) waitForXRayResourcePolicy(ctx context.Context, ti
 }
 
 // applyLogGroupRetention sets the retention policy on a CloudWatch Logs log group.
-// The log group is created automatically by CloudWatch when the first log event arrives,
-// so this call may fail if the group does not yet exist; callers should decide whether
-// to treat that as a hard error or to retry later.
+// If the log group does not yet exist it is created first, then the retention policy is applied.
 func applyLogGroupRetention(ctx context.Context, logsConn *cloudwatchlogs.Client, logGroupName string, retentionInDays int32) error {
 	_, err := logsConn.PutRetentionPolicy(ctx, &cloudwatchlogs.PutRetentionPolicyInput{
 		LogGroupName:    aws.String(logGroupName),
 		RetentionInDays: aws.Int32(retentionInDays),
 	})
-	if err != nil {
+	if err == nil {
+		return nil
+	}
+	if !errs.IsA[*logstypes.ResourceNotFoundException](err) {
+		return fmt.Errorf("setting retention policy on log group %q: %w", logGroupName, err)
+	}
+	// Log group does not exist yet — create it, then apply the retention policy.
+	if _, cerr := logsConn.CreateLogGroup(ctx, &cloudwatchlogs.CreateLogGroupInput{
+		LogGroupName: aws.String(logGroupName),
+	}); cerr != nil && !errs.IsA[*logstypes.ResourceAlreadyExistsException](cerr) {
+		return fmt.Errorf("creating log group %q: %w", logGroupName, cerr)
+	}
+	if _, err := logsConn.PutRetentionPolicy(ctx, &cloudwatchlogs.PutRetentionPolicyInput{
+		LogGroupName:    aws.String(logGroupName),
+		RetentionInDays: aws.Int32(retentionInDays),
+	}); err != nil {
 		return fmt.Errorf("setting retention policy on log group %q: %w", logGroupName, err)
 	}
 	return nil
@@ -1520,10 +1553,17 @@ func readLogGroupRetention(ctx context.Context, logsConn *cloudwatchlogs.Client,
 	return 0, nil
 }
 
-const xraySamplingRulePrefix = "bedrock-agentcore-"
+const (
+	xraySamplingRulePrefix  = "bedrock-agentcore-"
+	xraySamplingRuleMaxLen  = 32
+)
 
 func xraySamplingRuleName(runtimeID string) string {
-	return xraySamplingRulePrefix + runtimeID
+	name := xraySamplingRulePrefix + runtimeID
+	if len(name) > xraySamplingRuleMaxLen {
+		name = name[:xraySamplingRuleMaxLen]
+	}
+	return name
 }
 
 // applyXRaySamplingRule creates or updates an X-Ray sampling rule for the given runtime,
@@ -1655,12 +1695,15 @@ func disableObservability(ctx context.Context, conn *bedrockagentcorecontrol.Cli
 func isOtelEnvVar(key string) bool {
 	switch key {
 	case "AGENT_OBSERVABILITY_ENABLED",
+		"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
 		"OTEL_EXPORTER_OTLP_LOGS_HEADERS",
 		"OTEL_EXPORTER_OTLP_PROTOCOL",
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
 		"OTEL_RESOURCE_ATTRIBUTES",
 		"OTEL_TRACES_EXPORTER",
 		"OTEL_PYTHON_DISTRO",
-		"OTEL_PYTHON_CONFIGURATOR":
+		"OTEL_PYTHON_CONFIGURATOR",
+		"OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED":
 		return true
 	}
 	return false

--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -755,6 +755,27 @@ func (r *agentRuntimeResource) Update(ctx context.Context, request resource.Upda
 					smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
 					return
 				}
+			} else if obsConfig != nil && !obsConfig.Enabled.ValueBool() {
+				oldObsConfig, d := old.Observability.ToPtr(ctx)
+				smerr.AddEnrich(ctx, &response.Diagnostics, d)
+				if response.Diagnostics.HasError() {
+					return
+				}
+				if oldObsConfig != nil && oldObsConfig.Enabled.ValueBool() {
+					runtime, err := findAgentRuntimeByID(ctx, conn, agentRuntimeID)
+					if err != nil {
+						smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+						return
+					}
+					if err := disableObservability(ctx, conn, r.Meta().XRayClient(ctx), runtime, agentRuntimeID); err != nil {
+						smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+						return
+					}
+					if _, err := waitAgentRuntimeUpdated(ctx, conn, agentRuntimeID, r.UpdateTimeout(ctx, new.Timeouts)); err != nil {
+						smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+						return
+					}
+				}
 			}
 		}
 
@@ -926,24 +947,24 @@ func findAgentRuntime(ctx context.Context, conn *bedrockagentcorecontrol.Client,
 
 type agentRuntimeResourceModel struct {
 	framework.WithRegionModel
-	AgentRuntimeARN            types.String                                                       `tfsdk:"agent_runtime_arn"`
-	AgentRuntimeArtifact       fwtypes.ListNestedObjectValueOf[agentRuntimeArtifactModel]         `tfsdk:"agent_runtime_artifact"`
-	AgentRuntimeID             types.String                                                       `tfsdk:"agent_runtime_id"`
-	AgentRuntimeName           types.String                                                       `tfsdk:"agent_runtime_name"`
-	AgentRuntimeVersion        types.String                                                       `tfsdk:"agent_runtime_version"`
-	AuthorizerConfiguration    fwtypes.ListNestedObjectValueOf[authorizerConfigurationModel]      `tfsdk:"authorizer_configuration"`
-	Description                types.String                                                       `tfsdk:"description"`
-	EnvironmentVariables       fwtypes.MapOfString                                                `tfsdk:"environment_variables"`
-	LifecycleConfiguration     fwtypes.ListNestedObjectValueOf[lifecycleConfigurationModel]       `tfsdk:"lifecycle_configuration"`
-	NetworkConfiguration       fwtypes.ListNestedObjectValueOf[networkConfigurationModel]         `tfsdk:"network_configuration"`
-	Observability              fwtypes.ListNestedObjectValueOf[observabilityConfigurationModel]   `tfsdk:"observability"`
-	ProtocolConfiguration      fwtypes.ListNestedObjectValueOf[protocolConfigurationModel]        `tfsdk:"protocol_configuration"`
-	RequestHeaderConfiguration fwtypes.ListNestedObjectValueOf[requestHeaderConfigurationModel]   `tfsdk:"request_header_configuration"`
-	RoleARN                    fwtypes.ARN                                                        `tfsdk:"role_arn"`
-	Tags                       tftags.Map                                                         `tfsdk:"tags"`
-	TagsAll                    tftags.Map                                                         `tfsdk:"tags_all"`
-	Timeouts                   timeouts.Value                                                     `tfsdk:"timeouts"`
-	WorkloadIdentityDetails    fwtypes.ListNestedObjectValueOf[workloadIdentityDetailsModel]      `tfsdk:"workload_identity_details"`
+	AgentRuntimeARN            types.String                                                     `tfsdk:"agent_runtime_arn"`
+	AgentRuntimeArtifact       fwtypes.ListNestedObjectValueOf[agentRuntimeArtifactModel]       `tfsdk:"agent_runtime_artifact"`
+	AgentRuntimeID             types.String                                                     `tfsdk:"agent_runtime_id"`
+	AgentRuntimeName           types.String                                                     `tfsdk:"agent_runtime_name"`
+	AgentRuntimeVersion        types.String                                                     `tfsdk:"agent_runtime_version"`
+	AuthorizerConfiguration    fwtypes.ListNestedObjectValueOf[authorizerConfigurationModel]    `tfsdk:"authorizer_configuration"`
+	Description                types.String                                                     `tfsdk:"description"`
+	EnvironmentVariables       fwtypes.MapOfString                                              `tfsdk:"environment_variables"`
+	LifecycleConfiguration     fwtypes.ListNestedObjectValueOf[lifecycleConfigurationModel]     `tfsdk:"lifecycle_configuration"`
+	NetworkConfiguration       fwtypes.ListNestedObjectValueOf[networkConfigurationModel]       `tfsdk:"network_configuration"`
+	Observability              fwtypes.ListNestedObjectValueOf[observabilityConfigurationModel] `tfsdk:"observability"`
+	ProtocolConfiguration      fwtypes.ListNestedObjectValueOf[protocolConfigurationModel]      `tfsdk:"protocol_configuration"`
+	RequestHeaderConfiguration fwtypes.ListNestedObjectValueOf[requestHeaderConfigurationModel] `tfsdk:"request_header_configuration"`
+	RoleARN                    fwtypes.ARN                                                      `tfsdk:"role_arn"`
+	Tags                       tftags.Map                                                       `tfsdk:"tags"`
+	TagsAll                    tftags.Map                                                       `tfsdk:"tags_all"`
+	Timeouts                   timeouts.Value                                                   `tfsdk:"timeouts"`
+	WorkloadIdentityDetails    fwtypes.ListNestedObjectValueOf[workloadIdentityDetailsModel]    `tfsdk:"workload_identity_details"`
 }
 
 type agentRuntimeArtifactModel struct {
@@ -1248,9 +1269,9 @@ type workloadIdentityDetailsModel struct {
 
 type observabilityConfigurationModel struct {
 	CloudwatchLogs  fwtypes.ListNestedObjectValueOf[cloudwatchLogsConfigurationModel] `tfsdk:"cloudwatch_logs"`
-	Enabled         types.Bool                                                         `tfsdk:"enabled"`
+	Enabled         types.Bool                                                        `tfsdk:"enabled"`
 	RuntimeLanguage types.String                                                      `tfsdk:"runtime_language"`
-	Xray            fwtypes.ListNestedObjectValueOf[xrayConfigurationModel]            `tfsdk:"xray"`
+	Xray            fwtypes.ListNestedObjectValueOf[xrayConfigurationModel]           `tfsdk:"xray"`
 }
 
 type xrayConfigurationModel struct {
@@ -1292,7 +1313,7 @@ func configureObservability(ctx context.Context, conn *bedrockagentcorecontrol.C
 	}
 
 	obsEnvVars := map[string]string{
-		"AGENT_OBSERVABILITY_ENABLED":      "true",
+		"AGENT_OBSERVABILITY_ENABLED":     "true",
 		"OTEL_EXPORTER_OTLP_LOGS_HEADERS": fmt.Sprintf("x-aws-log-group=%s,x-aws-log-stream=runtime-logs,x-aws-metric-namespace=bedrock-agentcore", logGroup),
 		"OTEL_EXPORTER_OTLP_PROTOCOL":     "http/protobuf",
 		"OTEL_RESOURCE_ATTRIBUTES":        fmt.Sprintf("service.name=%s,aws.log.group.names=%s", runtimeName, logGroup),
@@ -1473,20 +1494,27 @@ func applyLogGroupRetention(ctx context.Context, logsConn *cloudwatchlogs.Client
 // or 0 if no retention policy is set (never expire).
 // Returns an error only for API failures; a missing log group is treated as 0, no error.
 func readLogGroupRetention(ctx context.Context, logsConn *cloudwatchlogs.Client, logGroupName string) (int32, error) {
-	out, err := logsConn.DescribeLogGroups(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
-		LogGroupNamePrefix: aws.String(logGroupName),
-		Limit:              aws.Int32(1),
-	})
-	if err != nil {
-		return 0, fmt.Errorf("describing log group %q: %w", logGroupName, err)
-	}
-	for _, lg := range out.LogGroups {
-		if aws.ToString(lg.LogGroupName) == logGroupName {
-			if lg.RetentionInDays != nil {
-				return *lg.RetentionInDays, nil
-			}
-			return 0, nil
+	var nextToken *string
+	for {
+		out, err := logsConn.DescribeLogGroups(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
+			LogGroupNamePrefix: aws.String(logGroupName),
+			NextToken:          nextToken,
+		})
+		if err != nil {
+			return 0, fmt.Errorf("describing log group %q: %w", logGroupName, err)
 		}
+		for _, lg := range out.LogGroups {
+			if aws.ToString(lg.LogGroupName) == logGroupName {
+				if lg.RetentionInDays != nil {
+					return *lg.RetentionInDays, nil
+				}
+				return 0, nil
+			}
+		}
+		if out.NextToken == nil {
+			break
+		}
+		nextToken = out.NextToken
 	}
 	// Log group does not exist yet (first log event hasn't arrived).
 	return 0, nil
@@ -1594,4 +1622,46 @@ func deleteXRaySamplingRule(ctx context.Context, xrayConn *xray.Client, runtimeI
 		return fmt.Errorf("deleting X-Ray sampling rule %q: %w", ruleName, err)
 	}
 	return nil
+}
+
+// disableObservability removes OTEL environment variables injected during observability
+// configuration and deletes the per-runtime X-Ray sampling rule.
+func disableObservability(ctx context.Context, conn *bedrockagentcorecontrol.Client, xrayConn *xray.Client, runtime *bedrockagentcorecontrol.GetAgentRuntimeOutput, runtimeID string) error {
+	cleaned := make(map[string]string, len(runtime.EnvironmentVariables))
+	for k, v := range runtime.EnvironmentVariables {
+		if !isOtelEnvVar(k) {
+			cleaned[k] = v
+		}
+	}
+
+	updateInput := &bedrockagentcorecontrol.UpdateAgentRuntimeInput{
+		AgentRuntimeId:          aws.String(runtimeID),
+		AgentRuntimeArtifact:    runtime.AgentRuntimeArtifact,
+		AuthorizerConfiguration: runtime.AuthorizerConfiguration,
+		Description:             runtime.Description,
+		EnvironmentVariables:    cleaned,
+		NetworkConfiguration:    runtime.NetworkConfiguration,
+		ProtocolConfiguration:   runtime.ProtocolConfiguration,
+		RoleArn:                 runtime.RoleArn,
+	}
+	if _, err := conn.UpdateAgentRuntime(ctx, updateInput); err != nil {
+		return fmt.Errorf("removing observability environment variables from agent runtime: %w", err)
+	}
+
+	return deleteXRaySamplingRule(ctx, xrayConn, runtimeID)
+}
+
+// isOtelEnvVar reports whether key is an OTEL env var injected by configureObservability.
+func isOtelEnvVar(key string) bool {
+	switch key {
+	case "AGENT_OBSERVABILITY_ENABLED",
+		"OTEL_EXPORTER_OTLP_LOGS_HEADERS",
+		"OTEL_EXPORTER_OTLP_PROTOCOL",
+		"OTEL_RESOURCE_ATTRIBUTES",
+		"OTEL_TRACES_EXPORTER",
+		"OTEL_PYTHON_DISTRO",
+		"OTEL_PYTHON_CONFIGURATOR":
+		return true
+	}
+	return false
 }

--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -21,6 +21,7 @@ import (
 	xraytypes "github.com/aws/aws-sdk-go-v2/service/xray/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -299,6 +300,31 @@ func (r *agentRuntimeResource) Schema(ctx context.Context, request resource.Sche
 							Required: true,
 						},
 					},
+					Blocks: map[string]schema.Block{
+						"cloudwatch_logs": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[cloudwatchLogsConfigurationModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"log_group_name": schema.StringAttribute{
+										Optional: true,
+										Computed: true,
+										Validators: []validator.String{
+											stringvalidator.LengthBetween(1, 512),
+										},
+									},
+									"retention_in_days": schema.Int32Attribute{
+										Optional: true,
+										Validators: []validator.Int32{
+											int32validator.OneOf(1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653),
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
@@ -495,10 +521,24 @@ func (r *agentRuntimeResource) Create(ctx context.Context, request resource.Crea
 				smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("waiting for X-Ray resource policy: %w", err), smerr.ID, agentRuntimeID)
 				return
 			}
-			if err := configureObservability(ctx, conn, r.Meta().XRayClient(ctx), runtime, data.EnvironmentVariables); err != nil {
+			resolvedLogGroup, err := configureObservability(ctx, conn, r.Meta().LogsClient(ctx), r.Meta().XRayClient(ctx), runtime, obsConfig, data.EnvironmentVariables)
+			if err != nil {
 				smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
 				return
 			}
+			// Persist computed log_group_name when the user did not explicitly set one.
+			if !obsConfig.CloudwatchLogs.IsNull() {
+				cwConfig, d := obsConfig.CloudwatchLogs.ToPtr(ctx)
+				smerr.AddEnrich(ctx, &response.Diagnostics, d)
+				if response.Diagnostics.HasError() {
+					return
+				}
+				if cwConfig != nil && (cwConfig.LogGroupName.IsNull() || cwConfig.LogGroupName.IsUnknown()) {
+					cwConfig.LogGroupName = types.StringValue(resolvedLogGroup)
+					obsConfig.CloudwatchLogs = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, cwConfig)
+				}
+			}
+			data.Observability = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, obsConfig)
 			runtime, err = findAgentRuntimeByID(ctx, conn, agentRuntimeID)
 			if err != nil {
 				smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
@@ -508,11 +548,14 @@ func (r *agentRuntimeResource) Create(ctx context.Context, request resource.Crea
 	}
 
 	// Set values for unknowns.
+	savedObservability := data.Observability
 	userEnvVars := data.EnvironmentVariables
 	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, runtime, &data, fwflex.WithFieldNamePrefix("AgentRuntime")))
 	if response.Diagnostics.HasError() {
 		return
 	}
+	// fwflex.Flatten operates on API fields only; restore Terraform-managed fields.
+	data.Observability = savedObservability
 	if !data.Observability.IsNull() {
 		obsConfig, d := data.Observability.ToPtr(ctx)
 		smerr.AddEnrich(ctx, &response.Diagnostics, d)
@@ -545,17 +588,46 @@ func (r *agentRuntimeResource) Read(ctx context.Context, request resource.ReadRe
 		return
 	}
 
+	savedObservability := data.Observability
 	userEnvVars := data.EnvironmentVariables
 	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, out, &data, fwflex.WithFieldNamePrefix("AgentRuntime")))
 	if response.Diagnostics.HasError() {
 		return
 	}
+	// fwflex.Flatten operates on API fields only; restore Terraform-managed fields.
+	data.Observability = savedObservability
 
 	if !data.Observability.IsNull() {
 		obsConfig, d := data.Observability.ToPtr(ctx)
 		smerr.AddEnrich(ctx, &response.Diagnostics, d)
-		if !response.Diagnostics.HasError() && obsConfig != nil && obsConfig.Enabled.ValueBool() {
+		if response.Diagnostics.HasError() {
+			return
+		}
+		if obsConfig != nil && obsConfig.Enabled.ValueBool() {
 			data.EnvironmentVariables = userEnvVars
+
+			// Drift detection: sync retention_in_days from CloudWatch Logs.
+			if !obsConfig.CloudwatchLogs.IsNull() {
+				cwConfig, d := obsConfig.CloudwatchLogs.ToPtr(ctx)
+				smerr.AddEnrich(ctx, &response.Diagnostics, d)
+				if response.Diagnostics.HasError() {
+					return
+				}
+				if cwConfig != nil && !cwConfig.LogGroupName.IsNull() && !cwConfig.RetentionInDays.IsNull() {
+					retention, err := readLogGroupRetention(ctx, r.Meta().LogsClient(ctx), cwConfig.LogGroupName.ValueString())
+					if err != nil {
+						smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+						return
+					}
+					if retention > 0 {
+						cwConfig.RetentionInDays = types.Int32Value(retention)
+					} else {
+						cwConfig.RetentionInDays = types.Int32Null()
+					}
+					obsConfig.CloudwatchLogs = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, cwConfig)
+					data.Observability = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, obsConfig)
+				}
+			}
 		}
 	}
 
@@ -616,10 +688,24 @@ func (r *agentRuntimeResource) Update(ctx context.Context, request resource.Upda
 					smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
 					return
 				}
-				if err := configureObservability(ctx, conn, r.Meta().XRayClient(ctx), runtime, new.EnvironmentVariables); err != nil {
+				resolvedLogGroup, err := configureObservability(ctx, conn, r.Meta().LogsClient(ctx), r.Meta().XRayClient(ctx), runtime, obsConfig, new.EnvironmentVariables)
+				if err != nil {
 					smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
 					return
 				}
+				// Persist computed log_group_name when the user did not explicitly set one.
+				if !obsConfig.CloudwatchLogs.IsNull() {
+					cwConfig, d := obsConfig.CloudwatchLogs.ToPtr(ctx)
+					smerr.AddEnrich(ctx, &response.Diagnostics, d)
+					if response.Diagnostics.HasError() {
+						return
+					}
+					if cwConfig != nil && (cwConfig.LogGroupName.IsNull() || cwConfig.LogGroupName.IsUnknown()) {
+						cwConfig.LogGroupName = types.StringValue(resolvedLogGroup)
+						obsConfig.CloudwatchLogs = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, cwConfig)
+					}
+				}
+				new.Observability = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, obsConfig)
 				if _, err := waitAgentRuntimeUpdated(ctx, conn, agentRuntimeID, r.UpdateTimeout(ctx, new.Timeouts)); err != nil {
 					smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
 					return
@@ -633,11 +719,14 @@ func (r *agentRuntimeResource) Update(ctx context.Context, request resource.Upda
 			return
 		}
 
+		savedObservability := new.Observability
 		userEnvVars := new.EnvironmentVariables
 		smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, runtime, &new, fwflex.WithFieldNamePrefix("AgentRuntime")))
 		if response.Diagnostics.HasError() {
 			return
 		}
+		// fwflex.Flatten operates on API fields only; restore Terraform-managed fields.
+		new.Observability = savedObservability
 		if !new.Observability.IsNull() {
 			obsConfig, d := new.Observability.ToPtr(ctx)
 			smerr.AddEnrich(ctx, &response.Diagnostics, d)
@@ -1101,18 +1190,46 @@ type workloadIdentityDetailsModel struct {
 }
 
 type observabilityConfigurationModel struct {
-	Enabled types.Bool `tfsdk:"enabled"`
+	CloudwatchLogs fwtypes.ListNestedObjectValueOf[cloudwatchLogsConfigurationModel] `tfsdk:"cloudwatch_logs"`
+	Enabled        types.Bool                                                         `tfsdk:"enabled"`
+}
+
+type cloudwatchLogsConfigurationModel struct {
+	LogGroupName    types.String `tfsdk:"log_group_name"`
+	RetentionInDays types.Int32  `tfsdk:"retention_in_days"`
 }
 
 const xrayResourcePolicyName = "BedrockAgentCoreXRayPolicy"
 
-func configureObservability(ctx context.Context, conn *bedrockagentcorecontrol.Client, xrayConn *xray.Client, runtime *bedrockagentcorecontrol.GetAgentRuntimeOutput, existingEnvVars fwtypes.MapOfString) error {
+// configureObservability injects OTEL environment variables, configures X-Ray, and applies
+// any CloudWatch Logs settings. It returns the resolved log group name so callers can
+// persist it as a computed value in state.
+func configureObservability(ctx context.Context, conn *bedrockagentcorecontrol.Client, logsConn *cloudwatchlogs.Client, xrayConn *xray.Client, runtime *bedrockagentcorecontrol.GetAgentRuntimeOutput, obsConfig *observabilityConfigurationModel, existingEnvVars fwtypes.MapOfString) (string, error) {
 	runtimeID := aws.ToString(runtime.AgentRuntimeId)
 	runtimeName := aws.ToString(runtime.AgentRuntimeName)
+
+	// Resolve log group name: use user-provided value if set, otherwise derive from runtime ID.
 	logGroup := fmt.Sprintf("/aws/bedrock-agentcore/runtimes/%s", runtimeID)
+	var retentionInDays *int32
+
+	if !obsConfig.CloudwatchLogs.IsNull() {
+		cwConfig, d := obsConfig.CloudwatchLogs.ToPtr(ctx)
+		if d.HasError() {
+			return "", fmt.Errorf("reading cloudwatch_logs configuration: %s", d)
+		}
+		if cwConfig != nil {
+			if !cwConfig.LogGroupName.IsNull() && !cwConfig.LogGroupName.IsUnknown() {
+				logGroup = cwConfig.LogGroupName.ValueString()
+			}
+			if !cwConfig.RetentionInDays.IsNull() {
+				v := cwConfig.RetentionInDays.ValueInt32()
+				retentionInDays = &v
+			}
+		}
+	}
 
 	obsEnvVars := map[string]string{
-		"AGENT_OBSERVABILITY_ENABLED":     "true",
+		"AGENT_OBSERVABILITY_ENABLED":      "true",
 		"OTEL_EXPORTER_OTLP_LOGS_HEADERS": fmt.Sprintf("x-aws-log-group=%s,x-aws-log-stream=runtime-logs,x-aws-metric-namespace=bedrock-agentcore", logGroup),
 		"OTEL_EXPORTER_OTLP_PROTOCOL":     "http/protobuf",
 		"OTEL_RESOURCE_ATTRIBUTES":        fmt.Sprintf("service.name=%s,aws.log.group.names=%s", runtimeName, logGroup),
@@ -1143,14 +1260,20 @@ func configureObservability(ctx context.Context, conn *bedrockagentcorecontrol.C
 	}
 
 	if _, err := conn.UpdateAgentRuntime(ctx, updateInput); err != nil {
-		return fmt.Errorf("updating agent runtime with observability environment variables: %w", err)
+		return "", fmt.Errorf("updating agent runtime with observability environment variables: %w", err)
 	}
 
 	if err := configureXRayForObservability(ctx, xrayConn); err != nil {
-		return fmt.Errorf("configuring X-Ray for observability: %w", err)
+		return "", fmt.Errorf("configuring X-Ray for observability: %w", err)
 	}
 
-	return nil
+	if retentionInDays != nil {
+		if err := applyLogGroupRetention(ctx, logsConn, logGroup, *retentionInDays); err != nil {
+			return "", err
+		}
+	}
+
+	return logGroup, nil
 }
 
 func configureXRayForObservability(ctx context.Context, xrayConn *xray.Client) error {
@@ -1247,4 +1370,42 @@ func (r *agentRuntimeResource) waitForXRayResourcePolicy(ctx context.Context, ti
 	}
 	_, err := stateConf.WaitForStateContext(ctx)
 	return err
+}
+
+// applyLogGroupRetention sets the retention policy on a CloudWatch Logs log group.
+// The log group is created automatically by CloudWatch when the first log event arrives,
+// so this call may fail if the group does not yet exist; callers should decide whether
+// to treat that as a hard error or to retry later.
+func applyLogGroupRetention(ctx context.Context, logsConn *cloudwatchlogs.Client, logGroupName string, retentionInDays int32) error {
+	_, err := logsConn.PutRetentionPolicy(ctx, &cloudwatchlogs.PutRetentionPolicyInput{
+		LogGroupName:    aws.String(logGroupName),
+		RetentionInDays: aws.Int32(retentionInDays),
+	})
+	if err != nil {
+		return fmt.Errorf("setting retention policy on log group %q: %w", logGroupName, err)
+	}
+	return nil
+}
+
+// readLogGroupRetention returns the current retention-in-days for the given log group,
+// or 0 if no retention policy is set (never expire).
+// Returns an error only for API failures; a missing log group is treated as 0, no error.
+func readLogGroupRetention(ctx context.Context, logsConn *cloudwatchlogs.Client, logGroupName string) (int32, error) {
+	out, err := logsConn.DescribeLogGroups(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
+		LogGroupNamePrefix: aws.String(logGroupName),
+		Limit:              aws.Int32(1),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("describing log group %q: %w", logGroupName, err)
+	}
+	for _, lg := range out.LogGroups {
+		if aws.ToString(lg.LogGroupName) == logGroupName {
+			if lg.RetentionInDays != nil {
+				return *lg.RetentionInDays, nil
+			}
+			return 0, nil
+		}
+	}
+	// Log group does not exist yet (first log event hasn't arrived).
+	return 0, nil
 }

--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -324,6 +324,22 @@ func (r *agentRuntimeResource) Schema(ctx context.Context, request resource.Sche
 								},
 							},
 						},
+						"xray": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[xrayConfigurationModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"sampling_percentage": schema.Int32Attribute{
+										Optional: true,
+										Validators: []validator.Int32{
+											int32validator.Between(0, 100),
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -628,6 +644,29 @@ func (r *agentRuntimeResource) Read(ctx context.Context, request resource.ReadRe
 					data.Observability = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, obsConfig)
 				}
 			}
+
+			// Drift detection: sync sampling_percentage from X-Ray.
+			if !obsConfig.Xray.IsNull() {
+				xrayConfig, d := obsConfig.Xray.ToPtr(ctx)
+				smerr.AddEnrich(ctx, &response.Diagnostics, d)
+				if response.Diagnostics.HasError() {
+					return
+				}
+				if xrayConfig != nil && !xrayConfig.SamplingPercentage.IsNull() {
+					percentage, found, err := readXRaySamplingPercentage(ctx, r.Meta().XRayClient(ctx), agentRuntimeID)
+					if err != nil {
+						smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+						return
+					}
+					if found {
+						xrayConfig.SamplingPercentage = types.Int32Value(percentage)
+					} else {
+						xrayConfig.SamplingPercentage = types.Int32Null()
+					}
+					obsConfig.Xray = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, xrayConfig)
+					data.Observability = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, obsConfig)
+				}
+			}
 		}
 	}
 
@@ -767,6 +806,18 @@ func (r *agentRuntimeResource) Delete(ctx context.Context, request resource.Dele
 	if _, err := waitAgentRuntimeDeleted(ctx, conn, agentRuntimeID, r.DeleteTimeout(ctx, data.Timeouts)); err != nil {
 		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
 		return
+	}
+
+	// Clean up X-Ray sampling rule if observability was configured with xray.
+	if !data.Observability.IsNull() {
+		obsConfig, d := data.Observability.ToPtr(ctx)
+		smerr.AddEnrich(ctx, &response.Diagnostics, d)
+		if !response.Diagnostics.HasError() && obsConfig != nil && !obsConfig.Xray.IsNull() {
+			if err := deleteXRaySamplingRule(ctx, r.Meta().XRayClient(ctx), agentRuntimeID); err != nil {
+				smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+				return
+			}
+		}
 	}
 }
 
@@ -1192,6 +1243,11 @@ type workloadIdentityDetailsModel struct {
 type observabilityConfigurationModel struct {
 	CloudwatchLogs fwtypes.ListNestedObjectValueOf[cloudwatchLogsConfigurationModel] `tfsdk:"cloudwatch_logs"`
 	Enabled        types.Bool                                                         `tfsdk:"enabled"`
+	Xray           fwtypes.ListNestedObjectValueOf[xrayConfigurationModel]            `tfsdk:"xray"`
+}
+
+type xrayConfigurationModel struct {
+	SamplingPercentage types.Int32 `tfsdk:"sampling_percentage"`
 }
 
 type cloudwatchLogsConfigurationModel struct {
@@ -1265,6 +1321,18 @@ func configureObservability(ctx context.Context, conn *bedrockagentcorecontrol.C
 
 	if err := configureXRayForObservability(ctx, xrayConn); err != nil {
 		return "", fmt.Errorf("configuring X-Ray for observability: %w", err)
+	}
+
+	if !obsConfig.Xray.IsNull() {
+		xrayConfig, d := obsConfig.Xray.ToPtr(ctx)
+		if d.HasError() {
+			return "", fmt.Errorf("reading xray configuration: %s", d)
+		}
+		if xrayConfig != nil && !xrayConfig.SamplingPercentage.IsNull() {
+			if err := applyXRaySamplingRule(ctx, xrayConn, runtimeID, xrayConfig.SamplingPercentage.ValueInt32()); err != nil {
+				return "", fmt.Errorf("configuring X-Ray sampling rule: %w", err)
+			}
+		}
 	}
 
 	if retentionInDays != nil {
@@ -1408,4 +1476,108 @@ func readLogGroupRetention(ctx context.Context, logsConn *cloudwatchlogs.Client,
 	}
 	// Log group does not exist yet (first log event hasn't arrived).
 	return 0, nil
+}
+
+const xraySamplingRulePrefix = "bedrock-agentcore-"
+
+func xraySamplingRuleName(runtimeID string) string {
+	return xraySamplingRulePrefix + runtimeID
+}
+
+// applyXRaySamplingRule creates or updates an X-Ray sampling rule for the given runtime,
+// setting the fixed sampling rate to samplingPercentage/100.
+func applyXRaySamplingRule(ctx context.Context, xrayConn *xray.Client, runtimeID string, samplingPercentage int32) error {
+	ruleName := xraySamplingRuleName(runtimeID)
+	fixedRate := float64(samplingPercentage) / 100.0
+
+	// Check whether the rule already exists.
+	var nextToken *string
+	for {
+		out, err := xrayConn.GetSamplingRules(ctx, &xray.GetSamplingRulesInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return fmt.Errorf("getting X-Ray sampling rules: %w", err)
+		}
+		for _, record := range out.SamplingRuleRecords {
+			if record.SamplingRule != nil && aws.ToString(record.SamplingRule.RuleName) == ruleName {
+				// Rule exists — update the fixed rate.
+				if _, err := xrayConn.UpdateSamplingRule(ctx, &xray.UpdateSamplingRuleInput{
+					SamplingRuleUpdate: &xraytypes.SamplingRuleUpdate{
+						RuleName:  aws.String(ruleName),
+						FixedRate: aws.Float64(fixedRate),
+					},
+				}); err != nil {
+					return fmt.Errorf("updating X-Ray sampling rule %q: %w", ruleName, err)
+				}
+				return nil
+			}
+		}
+		if out.NextToken == nil {
+			break
+		}
+		nextToken = out.NextToken
+	}
+
+	// Rule does not exist — create it.
+	if _, err := xrayConn.CreateSamplingRule(ctx, &xray.CreateSamplingRuleInput{
+		SamplingRule: &xraytypes.SamplingRule{
+			RuleName:      aws.String(ruleName),
+			FixedRate:     fixedRate,
+			HTTPMethod:    aws.String("*"),
+			Host:          aws.String("*"),
+			Priority:      aws.Int32(9000),
+			ReservoirSize: 5,
+			ResourceARN:   aws.String("*"),
+			ServiceName:   aws.String("*"),
+			ServiceType:   aws.String("*"),
+			URLPath:       aws.String("*"),
+			Version:       aws.Int32(1),
+		},
+	}); err != nil {
+		return fmt.Errorf("creating X-Ray sampling rule %q: %w", ruleName, err)
+	}
+	return nil
+}
+
+// readXRaySamplingPercentage returns the current sampling percentage (0–100) for the
+// per-runtime sampling rule, and whether the rule was found. Returns an error only for
+// API failures; a missing rule is treated as (0, false, nil).
+func readXRaySamplingPercentage(ctx context.Context, xrayConn *xray.Client, runtimeID string) (int32, bool, error) {
+	ruleName := xraySamplingRuleName(runtimeID)
+	var nextToken *string
+	for {
+		out, err := xrayConn.GetSamplingRules(ctx, &xray.GetSamplingRulesInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return 0, false, fmt.Errorf("getting X-Ray sampling rules: %w", err)
+		}
+		for _, record := range out.SamplingRuleRecords {
+			if record.SamplingRule != nil && aws.ToString(record.SamplingRule.RuleName) == ruleName {
+				percentage := int32(record.SamplingRule.FixedRate * 100)
+				return percentage, true, nil
+			}
+		}
+		if out.NextToken == nil {
+			break
+		}
+		nextToken = out.NextToken
+	}
+	return 0, false, nil
+}
+
+// deleteXRaySamplingRule removes the per-runtime X-Ray sampling rule. A missing rule is
+// treated as a no-op so that deletes remain idempotent.
+func deleteXRaySamplingRule(ctx context.Context, xrayConn *xray.Client, runtimeID string) error {
+	ruleName := xraySamplingRuleName(runtimeID)
+	if _, err := xrayConn.DeleteSamplingRule(ctx, &xray.DeleteSamplingRuleInput{
+		RuleName: aws.String(ruleName),
+	}); err != nil {
+		if tfawserr.ErrCodeEquals(err, "InvalidRequestException") {
+			return nil // rule does not exist
+		}
+		return fmt.Errorf("deleting X-Ray sampling rule %q: %w", ruleName, err)
+	}
+	return nil
 }

--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -15,6 +15,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	logstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/aws/aws-sdk-go-v2/service/xray"
+	xraytypes "github.com/aws/aws-sdk-go-v2/service/xray/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -284,6 +288,19 @@ func (r *agentRuntimeResource) Schema(ctx context.Context, request resource.Sche
 					},
 				},
 			},
+			"observability": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[observabilityConfigurationModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"enabled": schema.BoolAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
 			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
 				Create: true,
 				Update: true,
@@ -463,10 +480,45 @@ func (r *agentRuntimeResource) Create(ctx context.Context, request resource.Crea
 		return
 	}
 
+	if !data.Observability.IsNull() {
+		obsConfig, d := data.Observability.ToPtr(ctx)
+		smerr.AddEnrich(ctx, &response.Diagnostics, d)
+		if response.Diagnostics.HasError() {
+			return
+		}
+		if obsConfig != nil && obsConfig.Enabled.ValueBool() {
+			if err := r.ensureXRayResourcePolicy(ctx); err != nil {
+				smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+				return
+			}
+			if err := r.waitForXRayResourcePolicy(ctx, propagationTimeout); err != nil {
+				smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("waiting for X-Ray resource policy: %w", err), smerr.ID, agentRuntimeID)
+				return
+			}
+			if err := configureObservability(ctx, conn, r.Meta().XRayClient(ctx), runtime, data.EnvironmentVariables); err != nil {
+				smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+				return
+			}
+			runtime, err = findAgentRuntimeByID(ctx, conn, agentRuntimeID)
+			if err != nil {
+				smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+				return
+			}
+		}
+	}
+
 	// Set values for unknowns.
+	userEnvVars := data.EnvironmentVariables
 	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, runtime, &data, fwflex.WithFieldNamePrefix("AgentRuntime")))
 	if response.Diagnostics.HasError() {
 		return
+	}
+	if !data.Observability.IsNull() {
+		obsConfig, d := data.Observability.ToPtr(ctx)
+		smerr.AddEnrich(ctx, &response.Diagnostics, d)
+		if !response.Diagnostics.HasError() && obsConfig != nil && obsConfig.Enabled.ValueBool() {
+			data.EnvironmentVariables = userEnvVars
+		}
 	}
 
 	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, data))
@@ -493,9 +545,18 @@ func (r *agentRuntimeResource) Read(ctx context.Context, request resource.ReadRe
 		return
 	}
 
+	userEnvVars := data.EnvironmentVariables
 	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, out, &data, fwflex.WithFieldNamePrefix("AgentRuntime")))
 	if response.Diagnostics.HasError() {
 		return
+	}
+
+	if !data.Observability.IsNull() {
+		obsConfig, d := data.Observability.ToPtr(ctx)
+		smerr.AddEnrich(ctx, &response.Diagnostics, d)
+		if !response.Diagnostics.HasError() && obsConfig != nil && obsConfig.Enabled.ValueBool() {
+			data.EnvironmentVariables = userEnvVars
+		}
 	}
 
 	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, &data))
@@ -528,20 +589,61 @@ func (r *agentRuntimeResource) Update(ctx context.Context, request resource.Upda
 		// Additional fields.
 		input.ClientToken = aws.String(create.UniqueId(ctx))
 
-		out, err := conn.UpdateAgentRuntime(ctx, &input)
+		_, err := conn.UpdateAgentRuntime(ctx, &input)
 		if err != nil {
 			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
-			return
-		}
-
-		smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, out, &new, fwflex.WithFieldNamePrefix("AgentRuntime")))
-		if response.Diagnostics.HasError() {
 			return
 		}
 
 		if _, err := waitAgentRuntimeUpdated(ctx, conn, agentRuntimeID, r.UpdateTimeout(ctx, new.Timeouts)); err != nil {
 			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
 			return
+		}
+
+		if !new.Observability.IsNull() {
+			obsConfig, d := new.Observability.ToPtr(ctx)
+			smerr.AddEnrich(ctx, &response.Diagnostics, d)
+			if response.Diagnostics.HasError() {
+				return
+			}
+			if obsConfig != nil && obsConfig.Enabled.ValueBool() {
+				runtime, err := findAgentRuntimeByID(ctx, conn, agentRuntimeID)
+				if err != nil {
+					smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+					return
+				}
+				if err := r.ensureXRayResourcePolicy(ctx); err != nil {
+					smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+					return
+				}
+				if err := configureObservability(ctx, conn, r.Meta().XRayClient(ctx), runtime, new.EnvironmentVariables); err != nil {
+					smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+					return
+				}
+				if _, err := waitAgentRuntimeUpdated(ctx, conn, agentRuntimeID, r.UpdateTimeout(ctx, new.Timeouts)); err != nil {
+					smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+					return
+				}
+			}
+		}
+
+		runtime, err := findAgentRuntimeByID(ctx, conn, agentRuntimeID)
+		if err != nil {
+			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+			return
+		}
+
+		userEnvVars := new.EnvironmentVariables
+		smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, runtime, &new, fwflex.WithFieldNamePrefix("AgentRuntime")))
+		if response.Diagnostics.HasError() {
+			return
+		}
+		if !new.Observability.IsNull() {
+			obsConfig, d := new.Observability.ToPtr(ctx)
+			smerr.AddEnrich(ctx, &response.Diagnostics, d)
+			if !response.Diagnostics.HasError() && obsConfig != nil && obsConfig.Enabled.ValueBool() {
+				new.EnvironmentVariables = userEnvVars
+			}
 		}
 	} else {
 		new.AgentRuntimeVersion = old.AgentRuntimeVersion
@@ -678,23 +780,24 @@ func findAgentRuntime(ctx context.Context, conn *bedrockagentcorecontrol.Client,
 
 type agentRuntimeResourceModel struct {
 	framework.WithRegionModel
-	AgentRuntimeARN            types.String                                                     `tfsdk:"agent_runtime_arn"`
-	AgentRuntimeArtifact       fwtypes.ListNestedObjectValueOf[agentRuntimeArtifactModel]       `tfsdk:"agent_runtime_artifact"`
-	AgentRuntimeID             types.String                                                     `tfsdk:"agent_runtime_id"`
-	AgentRuntimeName           types.String                                                     `tfsdk:"agent_runtime_name"`
-	AgentRuntimeVersion        types.String                                                     `tfsdk:"agent_runtime_version"`
-	AuthorizerConfiguration    fwtypes.ListNestedObjectValueOf[authorizerConfigurationModel]    `tfsdk:"authorizer_configuration"`
-	Description                types.String                                                     `tfsdk:"description"`
-	EnvironmentVariables       fwtypes.MapOfString                                              `tfsdk:"environment_variables"`
-	LifecycleConfiguration     fwtypes.ListNestedObjectValueOf[lifecycleConfigurationModel]     `tfsdk:"lifecycle_configuration"`
-	NetworkConfiguration       fwtypes.ListNestedObjectValueOf[networkConfigurationModel]       `tfsdk:"network_configuration"`
-	ProtocolConfiguration      fwtypes.ListNestedObjectValueOf[protocolConfigurationModel]      `tfsdk:"protocol_configuration"`
-	RequestHeaderConfiguration fwtypes.ListNestedObjectValueOf[requestHeaderConfigurationModel] `tfsdk:"request_header_configuration"`
-	RoleARN                    fwtypes.ARN                                                      `tfsdk:"role_arn"`
-	Tags                       tftags.Map                                                       `tfsdk:"tags"`
-	TagsAll                    tftags.Map                                                       `tfsdk:"tags_all"`
-	Timeouts                   timeouts.Value                                                   `tfsdk:"timeouts"`
-	WorkloadIdentityDetails    fwtypes.ListNestedObjectValueOf[workloadIdentityDetailsModel]    `tfsdk:"workload_identity_details"`
+	AgentRuntimeARN            types.String                                                       `tfsdk:"agent_runtime_arn"`
+	AgentRuntimeArtifact       fwtypes.ListNestedObjectValueOf[agentRuntimeArtifactModel]         `tfsdk:"agent_runtime_artifact"`
+	AgentRuntimeID             types.String                                                       `tfsdk:"agent_runtime_id"`
+	AgentRuntimeName           types.String                                                       `tfsdk:"agent_runtime_name"`
+	AgentRuntimeVersion        types.String                                                       `tfsdk:"agent_runtime_version"`
+	AuthorizerConfiguration    fwtypes.ListNestedObjectValueOf[authorizerConfigurationModel]      `tfsdk:"authorizer_configuration"`
+	Description                types.String                                                       `tfsdk:"description"`
+	EnvironmentVariables       fwtypes.MapOfString                                                `tfsdk:"environment_variables"`
+	LifecycleConfiguration     fwtypes.ListNestedObjectValueOf[lifecycleConfigurationModel]       `tfsdk:"lifecycle_configuration"`
+	NetworkConfiguration       fwtypes.ListNestedObjectValueOf[networkConfigurationModel]         `tfsdk:"network_configuration"`
+	Observability              fwtypes.ListNestedObjectValueOf[observabilityConfigurationModel]   `tfsdk:"observability"`
+	ProtocolConfiguration      fwtypes.ListNestedObjectValueOf[protocolConfigurationModel]        `tfsdk:"protocol_configuration"`
+	RequestHeaderConfiguration fwtypes.ListNestedObjectValueOf[requestHeaderConfigurationModel]   `tfsdk:"request_header_configuration"`
+	RoleARN                    fwtypes.ARN                                                        `tfsdk:"role_arn"`
+	Tags                       tftags.Map                                                         `tfsdk:"tags"`
+	TagsAll                    tftags.Map                                                         `tfsdk:"tags_all"`
+	Timeouts                   timeouts.Value                                                     `tfsdk:"timeouts"`
+	WorkloadIdentityDetails    fwtypes.ListNestedObjectValueOf[workloadIdentityDetailsModel]      `tfsdk:"workload_identity_details"`
 }
 
 type agentRuntimeArtifactModel struct {
@@ -995,4 +1098,153 @@ func (m requestHeaderConfigurationModel) Expand(ctx context.Context) (any, diag.
 
 type workloadIdentityDetailsModel struct {
 	WorkloadIdentityARN types.String `tfsdk:"workload_identity_arn"`
+}
+
+type observabilityConfigurationModel struct {
+	Enabled types.Bool `tfsdk:"enabled"`
+}
+
+const xrayResourcePolicyName = "BedrockAgentCoreXRayPolicy"
+
+func configureObservability(ctx context.Context, conn *bedrockagentcorecontrol.Client, xrayConn *xray.Client, runtime *bedrockagentcorecontrol.GetAgentRuntimeOutput, existingEnvVars fwtypes.MapOfString) error {
+	runtimeID := aws.ToString(runtime.AgentRuntimeId)
+	runtimeName := aws.ToString(runtime.AgentRuntimeName)
+	logGroup := fmt.Sprintf("/aws/bedrock-agentcore/runtimes/%s", runtimeID)
+
+	obsEnvVars := map[string]string{
+		"AGENT_OBSERVABILITY_ENABLED":     "true",
+		"OTEL_EXPORTER_OTLP_LOGS_HEADERS": fmt.Sprintf("x-aws-log-group=%s,x-aws-log-stream=runtime-logs,x-aws-metric-namespace=bedrock-agentcore", logGroup),
+		"OTEL_EXPORTER_OTLP_PROTOCOL":     "http/protobuf",
+		"OTEL_RESOURCE_ATTRIBUTES":        fmt.Sprintf("service.name=%s,aws.log.group.names=%s", runtimeName, logGroup),
+		"OTEL_TRACES_EXPORTER":            "otlp",
+	}
+
+	mergedEnvVars := make(map[string]string)
+	if !existingEnvVars.IsNull() {
+		for k, v := range existingEnvVars.Elements() {
+			if strVal, ok := v.(types.String); ok {
+				mergedEnvVars[k] = strVal.ValueString()
+			}
+		}
+	}
+	for k, v := range obsEnvVars {
+		mergedEnvVars[k] = v
+	}
+
+	updateInput := &bedrockagentcorecontrol.UpdateAgentRuntimeInput{
+		AgentRuntimeId:          aws.String(runtimeID),
+		AgentRuntimeArtifact:    runtime.AgentRuntimeArtifact,
+		AuthorizerConfiguration: runtime.AuthorizerConfiguration,
+		Description:             runtime.Description,
+		EnvironmentVariables:    mergedEnvVars,
+		NetworkConfiguration:    runtime.NetworkConfiguration,
+		ProtocolConfiguration:   runtime.ProtocolConfiguration,
+		RoleArn:                 runtime.RoleArn,
+	}
+
+	if _, err := conn.UpdateAgentRuntime(ctx, updateInput); err != nil {
+		return fmt.Errorf("updating agent runtime with observability environment variables: %w", err)
+	}
+
+	if err := configureXRayForObservability(ctx, xrayConn); err != nil {
+		return fmt.Errorf("configuring X-Ray for observability: %w", err)
+	}
+
+	return nil
+}
+
+func configureXRayForObservability(ctx context.Context, xrayConn *xray.Client) error {
+	out, err := xrayConn.GetTraceSegmentDestination(ctx, &xray.GetTraceSegmentDestinationInput{})
+	if err != nil {
+		return fmt.Errorf("getting X-Ray trace segment destination: %w", err)
+	}
+
+	if out.Destination != xraytypes.TraceSegmentDestinationCloudWatchLogs {
+		if _, err := xrayConn.UpdateTraceSegmentDestination(ctx, &xray.UpdateTraceSegmentDestinationInput{
+			Destination: xraytypes.TraceSegmentDestinationCloudWatchLogs,
+		}); err != nil {
+			return fmt.Errorf("updating X-Ray trace segment destination: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *agentRuntimeResource) ensureXRayResourcePolicy(ctx context.Context) error {
+	meta := r.Meta()
+	logsConn := meta.LogsClient(ctx)
+	region := meta.Region(ctx)
+	accountID := meta.AccountID(ctx)
+
+	policyDocument := fmt.Sprintf(`{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "TransactionSearchXRayAccess",
+				"Effect": "Allow",
+				"Principal": {
+					"Service": "xray.amazonaws.com"
+				},
+				"Action": "logs:PutLogEvents",
+				"Resource": [
+					"arn:aws:logs:%[1]s:%[2]s:log-group:aws/spans:*",
+					"arn:aws:logs:%[1]s:%[2]s:log-group:/aws/application-signals/data:*"
+				],
+				"Condition": {
+					"ArnLike": {
+						"aws:SourceArn": "arn:aws:xray:%[1]s:%[2]s:*"
+					},
+					"StringEquals": {
+						"aws:SourceAccount": "%[2]s"
+					}
+				}
+			}
+		]
+	}`, region, accountID)
+
+	_, err := logsConn.PutResourcePolicy(ctx, &cloudwatchlogs.PutResourcePolicyInput{
+		PolicyName:     aws.String(xrayResourcePolicyName),
+		PolicyDocument: aws.String(policyDocument),
+	})
+	if errs.IsA[*logstypes.ResourceAlreadyExistsException](err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("putting CloudWatch Logs resource policy for X-Ray: %w", err)
+	}
+
+	return nil
+}
+
+func (r *agentRuntimeResource) waitForXRayResourcePolicy(ctx context.Context, timeout time.Duration) error {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{"notfound"},
+		Target:  []string{"found"},
+		Timeout: timeout,
+		Refresh: func(ctx context.Context) (any, string, error) {
+			logsConn := r.Meta().LogsClient(ctx)
+			var nextToken *string
+			for {
+				out, err := logsConn.DescribeResourcePolicies(ctx, &cloudwatchlogs.DescribeResourcePoliciesInput{
+					Limit:     aws.Int32(50),
+					NextToken: nextToken,
+				})
+				if err != nil {
+					return nil, "", err
+				}
+				for _, policy := range out.ResourcePolicies {
+					if aws.ToString(policy.PolicyName) == xrayResourcePolicyName {
+						return policy, "found", nil
+					}
+				}
+				if out.NextToken == nil {
+					break
+				}
+				nextToken = out.NextToken
+			}
+			return nil, "notfound", nil
+		},
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
 }

--- a/internal/service/bedrockagentcore/agent_runtime_observability_test.go
+++ b/internal/service/bedrockagentcore/agent_runtime_observability_test.go
@@ -1,0 +1,70 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// Unit tests for observability helper functions. These tests do not require AWS
+// credentials and can be run with `go test ./internal/service/bedrockagentcore/ -run Unit`.
+
+package bedrockagentcore
+
+import (
+	"testing"
+)
+
+func TestUnitIsOtelEnvVar(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		{"AGENT_OBSERVABILITY_ENABLED", true},
+		{"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", true},
+		{"OTEL_EXPORTER_OTLP_LOGS_HEADERS", true},
+		{"OTEL_EXPORTER_OTLP_PROTOCOL", true},
+		{"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", true},
+		{"OTEL_RESOURCE_ATTRIBUTES", true},
+		{"OTEL_TRACES_EXPORTER", true},
+		{"OTEL_PYTHON_CONFIGURATOR", true},
+		{"OTEL_PYTHON_DISTRO", true},
+		{"OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED", true},
+		// Non-OTEL keys must not be removed.
+		{"MY_APP_SECRET", false},
+		{"LOG_LEVEL", false},
+		{"OTEL_CUSTOM_VAR", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			t.Parallel()
+			if got := isOtelEnvVar(tt.key); got != tt.want {
+				t.Errorf("isOtelEnvVar(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnitXraySamplingRuleName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		runtimeID string
+		want      string
+	}{
+		{"abc123", "bedrock-agentcore-abc123"},
+		// "bedrock-agentcore-runtime-xyz-456" = 33 chars → truncated to 32
+		{"runtime-xyz-456", "bedrock-agentcore-runtime-xyz-45"},
+		{"my_runtime_01", "bedrock-agentcore-my_runtime_01"},
+		// Long IDs are truncated to 32 chars total
+		{"thisIsAVeryLongRuntimeIDThatExceedsLimit", "bedrock-agentcore-thisIsAVeryLon"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.runtimeID, func(t *testing.T) {
+			t.Parallel()
+			if got := xraySamplingRuleName(tt.runtimeID); got != tt.want {
+				t.Errorf("xraySamplingRuleName(%q) = %q, want %q", tt.runtimeID, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/service/bedrockagentcore/agent_runtime_test.go
+++ b/internal/service/bedrockagentcore/agent_runtime_test.go
@@ -1347,3 +1347,150 @@ resource "aws_bedrockagentcore_agent_runtime" "test" {
 }
 `, rName, s3Bucket, s3Key))
 }
+
+func TestAccBedrockAgentCoreAgentRuntime_observability(t *testing.T) {
+	ctx := acctest.Context(t)
+	var agentRuntime bedrockagentcorecontrol.GetAgentRuntimeOutput
+	rName := strings.ReplaceAll(acctest.RandomWithPrefix(t, acctest.ResourcePrefix), "-", "_")
+	resourceName := "aws_bedrockagentcore_agent_runtime.test"
+	rImageUri := acctest.SkipIfEnvVarNotSet(t, "AWS_BEDROCK_AGENTCORE_RUNTIME_IMAGE_V1_URI")
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckAgentRuntimes(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAgentRuntimeDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgentRuntimeConfig_observability(rName, rImageUri, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAgentRuntimeExists(ctx, t, resourceName, &agentRuntime),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("observability").AtSliceIndex(0).AtMapKey("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("observability").AtSliceIndex(0).AtMapKey("runtime_language"), knownvalue.StringExact("python")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("observability").AtSliceIndex(0).AtMapKey("cloudwatch_logs").AtSliceIndex(0).AtMapKey("log_group_name"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("observability").AtSliceIndex(0).AtMapKey("cloudwatch_logs").AtSliceIndex(0).AtMapKey("retention_in_days"), knownvalue.Int32Exact(7)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("observability").AtSliceIndex(0).AtMapKey("xray").AtSliceIndex(0).AtMapKey("sampling_percentage"), knownvalue.Int32Exact(10)),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "agent_runtime_id"),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "agent_runtime_id",
+			},
+			// Disable observability — verifies OTEL env var cleanup.
+			{
+				Config: testAccAgentRuntimeConfig_observability(rName, rImageUri, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAgentRuntimeExists(ctx, t, resourceName, &agentRuntime),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("observability").AtSliceIndex(0).AtMapKey("enabled"), knownvalue.Bool(false)),
+				},
+			},
+		},
+	})
+}
+
+func testAccAgentRuntimeConfig_observability(rName, imageUri string, enabled bool) string {
+	return acctest.ConfigCompose(testAccAgentRuntimeConfig_observabilityIAMRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_agent_runtime" "test" {
+  agent_runtime_name = %[1]q
+  role_arn           = aws_iam_role.test_observability.arn
+
+  agent_runtime_artifact {
+    container_configuration {
+      container_uri = %[2]q
+    }
+  }
+
+  network_configuration {
+    network_mode = "PUBLIC"
+  }
+
+  observability {
+    enabled          = %[3]t
+    runtime_language = "python"
+
+    cloudwatch_logs {
+      retention_in_days = 7
+    }
+
+    xray {
+      sampling_percentage = 10
+    }
+  }
+}
+`, rName, imageUri, enabled))
+}
+
+// testAccAgentRuntimeConfig_observabilityIAMRole creates an IAM role with permissions
+// required by the runtime container to emit logs and traces when observability is enabled.
+func testAccAgentRuntimeConfig_observabilityIAMRole(rName string) string {
+	return fmt.Sprintf(`
+data "aws_iam_policy_document" "test_obs_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["bedrock-agentcore.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "test_obs" {
+  # Container image access.
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+    effect    = "Allow"
+    resources = ["*"]
+  }
+
+  # CloudWatch Logs: runtime emits logs via OTEL.
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+    ]
+    effect    = "Allow"
+    resources = ["*"]
+  }
+
+  # X-Ray: runtime sends traces via OTEL.
+  statement {
+    actions = [
+      "xray:PutTraceSegments",
+      "xray:PutTelemetryRecords",
+      "xray:GetSamplingRules",
+      "xray:GetSamplingTargets",
+    ]
+    effect    = "Allow"
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "test_observability" {
+  name               = %[1]q
+  assume_role_policy = data.aws_iam_policy_document.test_obs_assume.json
+}
+
+resource "aws_iam_role_policy" "test_observability" {
+  role   = aws_iam_role.test_observability.id
+  policy = data.aws_iam_policy_document.test_obs.json
+}
+`, rName)
+}

--- a/website/docs/r/bedrockagentcore_agent_runtime.html.markdown
+++ b/website/docs/r/bedrockagentcore_agent_runtime.html.markdown
@@ -340,12 +340,14 @@ The `workload_identity_details` block contains the following:
 
 ## Observability IAM Permissions
 
-When `observability` is enabled, the IAM role must have the following permissions:
+### Runtime Execution Role (`role_arn`)
+
+When `observability` is enabled, the IAM role specified in `role_arn` must have the following permissions to allow the runtime container to export traces and logs via OpenTelemetry:
 
 * `logs:CreateLogGroup` - Create CloudWatch Logs log groups
 * `logs:CreateLogStream` - Create CloudWatch Logs log streams
 * `logs:PutLogEvents` - Put log events to CloudWatch Logs
-* `logs:PutResourcePolicy` - Put resource policy for X-Ray integration
+* `logs:DescribeLogGroups` - Describe CloudWatch Logs log groups
 * `xray:PutTraceSegments` - Put X-Ray trace segments
 * `xray:PutTelemetryRecords` - Put X-Ray telemetry records
 * `xray:GetSamplingRules` - Get X-Ray sampling rules

--- a/website/docs/r/bedrockagentcore_agent_runtime.html.markdown
+++ b/website/docs/r/bedrockagentcore_agent_runtime.html.markdown
@@ -133,6 +133,46 @@ resource "aws_bedrockagentcore_agent_runtime" "example" {
 }
 ```
 
+### Agent runtime with Observability
+
+```terraform
+resource "aws_bedrockagentcore_agent_runtime" "example_with_observability" {
+  agent_runtime_name = "example_agent_runtime_with_observability"
+  role_arn           = aws_iam_role.example.arn
+
+  agent_runtime_artifact {
+    code_configuration {
+      entry_point = ["main.py"]
+      runtime     = "PYTHON_3_13"
+      code {
+        s3 {
+          bucket = "example-bucket"
+          prefix = "example-agent-runtime-code.zip"
+        }
+      }
+    }
+  }
+
+  network_configuration {
+    network_mode = "PUBLIC"
+  }
+
+  observability {
+    enabled            = true
+    runtime_language   = "python"
+
+    cloudwatch_logs {
+      log_group_name     = "/aws/bedrock-agentcore/example-runtime"
+      retention_in_days  = 30
+    }
+
+    xray {
+      sampling_percentage = 10
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -149,6 +189,7 @@ The following arguments are optional:
 * `environment_variables` - (Optional) Map of environment variables to pass to the container.
 * `authorizer_configuration` - (Optional) Authorization configuration for authenticating incoming requests. See [`authorizer_configuration`](#authorizer_configuration) below.
 * `lifecycle_configuration` - (Optional) Runtime session and resource lifecycle configuration for the agent runtime. See [`lifecycle_configuration`](#lifecycle_configuration) below.
+* `observability` - (Optional) Observability configuration for the agent runtime. See [`observability`](#observability) below.
 * `protocol_configuration` - (Optional) Protocol configuration for the agent runtime. See [`protocol_configuration`](#protocol_configuration) below.
 * `request_header_configuration` - (Optional) Configuration for HTTP request headers that will be passed through to the runtime. See [`request_header_configuration`](#request_header_configuration) below.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
@@ -233,6 +274,28 @@ The `lifecycle_configuration` block supports the following:
 * `idle_runtime_session_timeout` - (Optional) Timeout in seconds for idle runtime sessions.
 * `max_lifetime` - (Optional) Maximum lifetime for the instance in seconds.
 
+### `observability`
+
+The `observability` block supports the following:
+
+* `enabled` - (Required) Whether observability is enabled for the agent runtime.
+* `runtime_language` - (Optional) Programming language of the agent runtime. Used to inject language-specific OpenTelemetry configuration. Currently only `"python"` is supported. When set to `"python"`, injects `OTEL_PYTHON_DISTRO=aws_distro` and `OTEL_PYTHON_CONFIGURATOR=aws_configurator`.
+* `cloudwatch_logs` - (Optional) CloudWatch Logs configuration. See [`cloudwatch_logs`](#cloudwatch_logs) below.
+* `xray` - (Optional) X-Ray tracing configuration. See [`xray`](#xray) below.
+
+### `cloudwatch_logs`
+
+The `cloudwatch_logs` block supports the following:
+
+* `log_group_name` - (Optional, Computed) Name of the CloudWatch Logs log group. If not specified, defaults to `/aws/bedrock-agentcore/runtimes/<runtime_id>`.
+* `retention_in_days` - (Optional) Number of days to retain log events. Valid values: `1`, `3`, `5`, `7`, `14`, `30`, `60`, `90`, `120`, `150`, `180`, `365`, `400`, `545`, `731`, `1096`, `1827`, `2192`, `2557`, `2922`, `3288`, `3653`.
+
+### `xray`
+
+The `xray` block supports the following:
+
+* `sampling_percentage` - (Optional) Percentage of requests to sample with X-Ray. Valid values: `0` to `100`. Creates or updates an X-Ray sampling rule named `bedrock-agentcore-<runtime_id>`.
+
 ### `network_configuration`
 
 The `network_configuration` block supports the following:
@@ -274,6 +337,27 @@ This resource exports the following attributes in addition to the arguments abov
 The `workload_identity_details` block contains the following:
 
 * `workload_identity_arn` - ARN of the workload identity.
+
+## Observability IAM Permissions
+
+When `observability` is enabled, the IAM role must have the following permissions:
+
+* `logs:CreateLogGroup` - Create CloudWatch Logs log groups
+* `logs:CreateLogStream` - Create CloudWatch Logs log streams
+* `logs:PutLogEvents` - Put log events to CloudWatch Logs
+* `logs:PutResourcePolicy` - Put resource policy for X-Ray integration
+* `xray:PutTraceSegments` - Put X-Ray trace segments
+* `xray:PutTelemetryRecords` - Put X-Ray telemetry records
+* `xray:GetSamplingRules` - Get X-Ray sampling rules
+* `xray:GetSamplingTargets` - Get X-Ray sampling targets
+
+Ensure these permissions are scoped to the appropriate log group and resources.
+
+## Observability Behavior Notes
+
+* When `enabled` changes from `true` to `false`, the provider removes the injected OpenTelemetry environment variables and deletes the X-Ray sampling rule.
+* The X-Ray trace segment destination is set to CloudWatch Logs account-wide when observability is first enabled.
+* `log_group_name` is computed and persisted in state when not explicitly specified. The computed value defaults to `/aws/bedrock-agentcore/runtimes/<runtime_id>`.
 
 ## Timeouts
 

--- a/website/docs/r/bedrockagentcore_agent_runtime.html.markdown
+++ b/website/docs/r/bedrockagentcore_agent_runtime.html.markdown
@@ -279,7 +279,7 @@ The `lifecycle_configuration` block supports the following:
 The `observability` block supports the following:
 
 * `enabled` - (Required) Whether observability is enabled for the agent runtime.
-* `runtime_language` - (Optional) Programming language of the agent runtime. Used to inject language-specific OpenTelemetry configuration. Currently only `"python"` is supported. When set to `"python"`, injects `OTEL_PYTHON_DISTRO=aws_distro` and `OTEL_PYTHON_CONFIGURATOR=aws_configurator`.
+* `runtime_language` - (Optional) Programming language of the agent runtime. Used to inject language-specific OpenTelemetry configuration. Currently only `"python"` is supported. When set to `"python"`, injects `OTEL_PYTHON_DISTRO=aws_distro`, `OTEL_PYTHON_CONFIGURATOR=aws_configurator`, and `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true`.
 * `cloudwatch_logs` - (Optional) CloudWatch Logs configuration. See [`cloudwatch_logs`](#cloudwatch_logs) below.
 * `xray` - (Optional) X-Ray tracing configuration. See [`xray`](#xray) below.
 
@@ -355,9 +355,16 @@ Ensure these permissions are scoped to the appropriate log group and resources.
 
 ## Observability Behavior Notes
 
+* When `enabled` is `true`, the provider automatically injects the following OpenTelemetry environment variables into the runtime:
+  * `AGENT_OBSERVABILITY_ENABLED=true`
+  * `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` — regional X-Ray OTLP endpoint (`https://xray.<region>.amazonaws.com/v1/traces`)
+  * `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` — regional CloudWatch Logs OTLP endpoint (`https://logs.<region>.amazonaws.com/v1/logs`)
+  * `OTEL_EXPORTER_OTLP_LOGS_HEADERS`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_TRACES_EXPORTER`
+  * Language-specific variables when `runtime_language` is set (see above)
 * When `enabled` changes from `true` to `false`, the provider removes the injected OpenTelemetry environment variables and deletes the X-Ray sampling rule.
 * The X-Ray trace segment destination is set to CloudWatch Logs account-wide when observability is first enabled.
 * `log_group_name` is computed and persisted in state when not explicitly specified. The computed value defaults to `/aws/bedrock-agentcore/runtimes/<runtime_id>`.
+* When importing a runtime that has observability enabled, the provider reconstructs the `observability` block automatically from the injected environment variables.
 
 ## Timeouts
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

When `observability` is enabled, the provider grants the runtime IAM role additional permissions to write to CloudWatch Logs and X-Ray. This is achieved by injecting environment variables that configure the OpenTelemetry SDK - no new IAM policies are created by the provider itself; the permissions must be granted by the user on the execution role.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Follow up PR of #44779 , resolves #44742.

Adds a full `observability` block to `aws_bedrockagentcore_agent_runtime`, enabling declarative management of tracing and logging for AgentCore runtimes via OpenTelemetry (ADOT).

### What the provider does automatically

When `observability { enabled = true }` is declared, the provider:

1. Injects OpenTelemetry environment variables into the runtime, including regional OTLP endpoints for X-Ray and CloudWatch Logs - no manual env var configuration needed
2. Sets the X-Ray trace segment destination to CloudWatch Logs (account-wide, once)
3. Creates an X-Ray sampling rule with the configured `sampling_percentage`
4. Creates the CloudWatch log group (if it does not yet exist) and applies the configured `retention_in_days`
5. Cleans up all injected env vars and the X-Ray sampling rule when `enabled` is set back to `false`

### What the agent application must do

The agent container must initialize the AWS OpenTelemetry SDK before framework imports.
For Python (using [aws-opentelemetry-distro](https://github.com/aws-observability/aws-otel-python-instrumentation)):

```python
from amazon.opentelemetry.distro.aws_opentelemetry_configurator import AwsOpenTelemetryConfigurator

AwsOpenTelemetryConfigurator().configure()
```

The provider sets `AGENT_OBSERVABILITY_ENABLED=true` in the runtime environment.
The application can guard intiializaion with:

```python
import os

if os.environ.set("AGENT_OBSERVABILITY_ENABLED") == "true":
    AwsOpenTelemetryConfigurator().configure()
```

See the https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html for the full list of supported runtimes and SDK versions.

### `observability`

The `observability` block supports the following:

* `enabled` - (Required) Whether observability is enabled for the agent runtime.
* `runtime_language` - (Optional) Programming language of the agent runtime. Used to inject language-specific OpenTelemetry configuration. Currently only `"python"` is supported. When set to `"python"`, injects `OTEL_PYTHON_DISTRO=aws_distro`, `OTEL_PYTHON_CONFIGURATOR=aws_configurator`, and `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true`.
* `cloudwatch_logs` - (Optional) CloudWatch Logs configuration. See [`cloudwatch_logs`](#cloudwatch_logs) below.
* `xray` - (Optional) X-Ray tracing configuration. See [`xray`](#xray) below.

### `cloudwatch_logs`

The `cloudwatch_logs` block supports the following:

* `log_group_name` - (Optional, Computed) Name of the CloudWatch Logs log group. If not specified, defaults to `/aws/bedrock-agentcore/runtimes/<runtime_id>`.
* `retention_in_days` - (Optional) Number of days to retain log events. Valid values: `1`, `3`, `5`, `7`, `14`, `30`, `60`, `90`, `120`, `150`, `180`, `365`, `400`, `545`, `731`, `1096`, `1827`, `2192`, `2557`, `2922`, `3288`, `3653`.

### `xray`

The `xray` block supports the following:

* `sampling_percentage` - (Optional) Percentage of requests to sample with X-Ray. Valid values: `0` to `100`. Creates or updates an X-Ray sampling rule named `bedrock-agentcore-<runtime_id>`.

**IAM Permissions**

When observability is enabled, the IAM role specified in role_arn
must have the following permissions to allow the runtime container to
 export traces and logs via OpenTelemetry:

CloudWatch Logs
  - `logs:CreateLogGroup`
  - `logs:CreateLogStream`
  - `logs:PutLogEvents`
  - `logs:DescribeLogGroups`

X-Ray
  - `xray:PutTraceSegments`
  - `xray:PutTelemetryRecords`
  - `xray:GetSamplingRules`
  - `xray:GetSamplingTargets`

**Terraform Example**

```terraform
resource "aws_bedrockagentcore_agent_runtime" "example" {
  agent_runtime_name = "example-agent"
  role_arn           = aws_iam_role.example.arn

  agent_runtime_artifact {
    container_configuration {
      container_uri = "${aws_ecr_repository.example.repository_url}:latest"
    }
  }

  network_configuration {
    network_mode = "PUBLIC"
  }

  observability {
    enabled          = true
    runtime_language = "python"

    cloudwatch_logs {
      retention_in_days = 7
    }

    xray {
      sampling_percentage = 10
    }
  }
}
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

Follow up PR of #44779 , resolves #44742.
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html
- https://github.com/aws-observability/aws-otel-python-instrumentation

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bedrockagentcore TESTS='^TestAccBedrockAgentCoreAgentRuntime_observability'
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-bedrock_agentcore_observability_v2 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/bedrockagentcore/... -v -count 1 -parallel 20 -run='^TestAccBedrockAgentCoreAgentRuntime_observability'  -timeout 360m -vet=off
2026/04/06 15:14:14 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/06 15:14:14 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockAgentCoreAgentRuntime_observability
=== PAUSE TestAccBedrockAgentCoreAgentRuntime_observability
=== CONT  TestAccBedrockAgentCoreAgentRuntime_observability
--- PASS: TestAccBedrockAgentCoreAgentRuntime_observability (64.71s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore	69.679s
```

Also tested AgentCore runtime generation and deletion on my own.
