### PR TITLE
Fix placeholder FIXME/TODO values in error messages and log statements

### DIFF
--- a/.changelog/47305.txt
+++ b/.changelog/47305.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_paymentcryptography_key: Replace placeholder `FIXME` in error messages with the actual key ARN
+```
+
+```release-note:bug
+resource/aws_ssmcontacts_rotation: Replace placeholder `TODO` in debug log with descriptive resource name
+```

--- a/internal/service/paymentcryptography/key.go
+++ b/internal/service/paymentcryptography/key.go
@@ -273,14 +273,14 @@ func (r *keyResource) Create(ctx context.Context, request resource.CreateRequest
 	out, err := conn.CreateKey(ctx, in)
 	if err != nil {
 		response.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.PaymentCryptography, create.ErrActionCreating, ResNameKey, "FIXME", err),
+			create.ProblemStandardMessage(names.PaymentCryptography, create.ErrActionCreating, ResNameKey, plan.KeyARN.String(), err),
 			err.Error(),
 		)
 		return
 	}
 	if out == nil || out.Key == nil {
 		response.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.PaymentCryptography, create.ErrActionCreating, ResNameKey, "FIXME", nil),
+			create.ProblemStandardMessage(names.PaymentCryptography, create.ErrActionCreating, ResNameKey, plan.KeyARN.String(), nil),
 			errors.New("empty output").Error(),
 		)
 		return

--- a/internal/service/ssmcontacts/rotation.go
+++ b/internal/service/ssmcontacts/rotation.go
@@ -422,7 +422,7 @@ func (r *rotationResource) Delete(ctx context.Context, request resource.DeleteRe
 		return
 	}
 
-	tflog.Debug(ctx, "deleting TODO", map[string]any{
+	tflog.Debug(ctx, "deleting SSMContacts Rotation", map[string]any{
 		names.AttrID: state.ID.ValueString(),
 	})
 


### PR DESCRIPTION
## Description

Fix placeholder values that were left in production code during development.

### Changes

**1. `internal/service/paymentcryptography/key.go` - Replace "FIXME" in error messages**

The `Create` function's error diagnostics contain literal `"FIXME"` strings as the resource identifier:

```go
// Before
create.ProblemStandardMessage(names.PaymentCryptography, create.ErrActionCreating, ResNameKey, "FIXME", err)

// After
create.ProblemStandardMessage(names.PaymentCryptography, create.ErrActionCreating, ResNameKey, plan.KeyARN.String(), err)
```

This matches the pattern used later in the same function (line 296) and across other resources in the package. Without this fix, error messages for key creation failures display the unhelpful text "FIXME" instead of the resource identifier.

**2. `internal/service/ssmcontacts/rotation.go` - Replace "TODO" in log message**

The `Delete` function's debug log message contains a "TODO" placeholder:

```go
// Before
tflog.Debug(ctx, "deleting TODO", map[string]any{...})

// After
tflog.Debug(ctx, "deleting SSMContacts Rotation", map[string]any{...})
```

This matches the naming convention used in `ProblemStandardMessage` calls in the same function (e.g., `create.ErrActionDeleting, ResNameRotation`).

### Testing

These are string-only changes affecting error messages and debug logs. No behavioral changes.