### PR TITLE
r/aws_dynamodb_table: skip find during `CustomizeDiff` for new resources

### DIFF
--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -3293,7 +3293,7 @@ func validateTableAttributes(ctx context.Context, d *schema.ResourceDiff, meta a
 	// validate against remote as well, because we're using the remote state as a bridge between the table and gsi resources
 	remoteGSIAttributes := map[string]bool{}
 	name := planRaw.GetAttr(names.AttrName)
-	if name.IsKnown() {
+	if name.IsKnown() && d.Id() != "" {
 		table, err := findTableByName(ctx, conn, name.AsString())
 		if err != nil && !retry.NotFound(err) {
 			return err


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Prevents calls to `findTableByName` via the `validateTableAttributes` function when the resource does not yet exist.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #46530
Relates https://github.com/hashicorp/terraform-provider-aws/issues/46530#issuecomment-4179198977
Relates #47143 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

GSI tests only (replayed):

```console
% VCR_MODE=REPLAY_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/  make t K=dynamodb T=TestAccDynamoDBTable_GSI
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-dynamodb_table-gsi-validation 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_GSI'  -timeout 360m -vet=off
2026/04/06 16:35:29 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/06 16:35:29 Initializing Terraform AWS Provider (SDKv2-style)...

=== NAME  TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema
    table_test.go:3261: provider meta not found for test TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema
--- PASS: TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema (6.65s)
=== NAME  TestAccDynamoDBTable_GSI_validate_exactlyOneOfKeySchemaHashKey
    table_test.go:3280: provider meta not found for test TestAccDynamoDBTable_GSI_validate_exactlyOneOfKeySchemaHashKey
--- PASS: TestAccDynamoDBTable_GSI_validate_exactlyOneOfKeySchemaHashKey (7.58s)
=== NAME  TestAccDynamoDBTable_GSIvalidate_keySchema_tooManyRangeKeys
    table_test.go:3318: provider meta not found for test TestAccDynamoDBTable_GSIvalidate_keySchema_tooManyRangeKeys
--- PASS: TestAccDynamoDBTable_GSIvalidate_keySchema_tooManyRangeKeys (7.89s)
=== NAME  TestAccDynamoDBTable_GSI_validate_keySchema_tooManyHashKeys
    table_test.go:3299: provider meta not found for test TestAccDynamoDBTable_GSI_validate_keySchema_tooManyHashKeys
--- PASS: TestAccDynamoDBTable_GSI_validate_keySchema_tooManyHashKeys (8.15s)
--- PASS: TestAccDynamoDBTable_GSI_unknown (57.67s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_unknown (57.98s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_maxSet (67.00s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleHashKeys (70.83s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleRangeKeys (71.10s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleHashKey (71.17s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleRangeKey (96.64s)
--- PASS: TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_addHashKey (98.51s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeHashKey (98.57s)
--- PASS: TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_noChange (98.62s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeGSI (98.77s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeRangeKey (98.86s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_addRangeKey (98.98s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_addHashKey (99.00s)
--- PASS: TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_removeKey (99.16s)
--- PASS: TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_noChange (99.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   106.343s
```

Full suite:


```console
% VCR_MODE=RECORD_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/  make t K=dynamodb T=TestAccDynamoDBTable_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-dynamodb_table-gsi-validation 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_'  -timeout 360m -vet=off
2026/04/06 13:21:09 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/06 13:21:09 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (15.73s)
=== CONT  TestAccDynamoDBTable_Replica_singleCMK
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create_witness_too_many_replicas (80.04s)
=== CONT  TestAccDynamoDBTable_Replica_singleDefaultKeyEncryptedAmazonOwned
--- PASS: TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_DifferentFromTable (101.67s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_MixedConsistencyModes
=== NAME  TestAccDynamoDBTable_Replica_MRSC_witness_doubleAddCMK
    table_test.go:6237: Step 1/3 error: Check failed: Check 1/3 error: couldn't find resource
--- PASS: TestAccDynamoDBTable_Replica_MRSC_MixedConsistencyModes (39.05s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_unknown
--- PASS: TestAccDynamoDBTable_tags (153.44s)
=== CONT  TestAccDynamoDBTable_GSI_unknown
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (190.04s)
=== CONT  TestAccDynamoDBTable_gsiWarmThroughput_switchBilling
--- PASS: TestAccDynamoDBTable_GSI_unknown (37.04s)
=== CONT  TestAccDynamoDBTable_tableClass_ConcurrentModification
--- PASS: TestAccDynamoDBTable_GSI_keySchema_unknown (58.69s)
=== CONT  TestAccDynamoDBTable_tableClassExplicitDefault
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create (253.11s)
=== CONT  TestAccDynamoDBTable_tableClassInfrequentAccess
--- FAIL: TestAccDynamoDBTable_Replica_MRSC_witness_doubleAddCMK (255.95s)
=== CONT  TestAccDynamoDBTable_restoreBackupARN
--- PASS: TestAccDynamoDBTable_tableClassExplicitDefault (71.65s)
=== CONT  TestAccDynamoDBTable_Replica_deletionProtection
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create_witness (271.38s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_CreateEventuallyConsistent
--- PASS: TestAccDynamoDBTable_tableClass_ConcurrentModification (89.26s)
=== CONT  TestAccDynamoDBTable_backupEncryption
--- PASS: TestAccDynamoDBTable_Replica_MRSC_pitr (314.58s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (73.97s)
=== CONT  TestAccDynamoDBTable_gsiWarmThroughput_billingPayPerRequest
--- PASS: TestAccDynamoDBTable_Replica_singleCMK (318.19s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_NotEnoughReplicas
--- PASS: TestAccDynamoDBTable_Replica_MRSC_NotEnoughReplicas (78.57s)
=== CONT  TestAccDynamoDBTable_gsiWarmThroughput_billingProvisioned
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted (451.58s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_TooManyReplicas
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_switchBilling (264.37s)
=== CONT  TestAccDynamoDBTable_warmThroughputDefault
--- PASS: TestAccDynamoDBTable_warmThroughputDefault (77.13s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tagsUpdate
--- PASS: TestAccDynamoDBTable_restoreBackupARN (278.58s)
=== CONT  TestAccDynamoDBTable_warmThroughput
=== NAME  TestAccDynamoDBTable_Replica_MRSC_TooManyReplicas
    table_test.go:7756: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: deleting AWS DynamoDB Table (tf-acc-test-829067568348108350): deleting replica(s): operation error DynamoDB: UpdateTable, https response error StatusCode: 400, RequestID: 1C35A1NGSOTLKCS2UKT640VJNJVV4KQNSO5AEMVJF66Q9ASUAAJG, api error ValidationException: Cannot add or delete the local region through ReplicaUpdates. Use CreateTable, DeleteTable, or UpdateTable as required.

--- FAIL: TestAccDynamoDBTable_Replica_MRSC_TooManyReplicas (86.72s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_tagsUpdate
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncryptedAmazonOwned (498.83s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tags_nonPropagatedTagsAreUnmanaged
--- PASS: TestAccDynamoDBTable_Replica_pitr (692.72s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_tags_nonPropagatedTagsAreUnmanaged
--- PASS: TestAccDynamoDBTable_Replica_tags_nonPropagatedTagsAreUnmanaged (693.42s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tags_notPropagatedToAddedReplica
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica (381.67s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_oneOfTwo
--- PASS: TestAccDynamoDBTable_Replica_tags_updateIsPropagated_oneOfTwo (696.32s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_tags_propagateToAddedReplica
--- PASS: TestAccDynamoDBTable_Replica_tags_updateIsPropagated_twoOfTwo (696.71s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_twoOfTwo
--- PASS: TestAccDynamoDBTable_Replica_tags_propagateToAddedReplica (698.26s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_twoOfTwo
--- PASS: TestAccDynamoDBTable_Replica_tags_notPropagatedToAddedReplica (705.59s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_pitrKMS
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_billingPayPerRequest (457.30s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_oneOfTwo
--- PASS: TestAccDynamoDBTable_warmThroughput (257.98s)
=== CONT  TestAccDynamoDBTable_Replica_multiple
--- PASS: TestAccDynamoDBTable_Replica_MRSC_CreateEventuallyConsistent (541.15s)
=== CONT  TestAccDynamoDBTable_Replica_singleStreamSpecification
--- PASS: TestAccDynamoDBTable_Replica_MRSC_doubleAddCMK (889.17s)
=== CONT  TestAccDynamoDBTable_Replica_single
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (930.23s)
=== CONT  TestAccDynamoDBTable_restoreCrossRegion
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_nonPropagatedTagsAreUnmanaged (412.97s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_pitrKMS
--- PASS: TestAccDynamoDBTable_Replica_pitrKMS (1038.37s)
=== CONT  TestAccDynamoDBTable_backup_overrideEncryption
--- PASS: TestAccDynamoDBTable_backupEncryption (834.44s)
=== CONT  TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_notPropagatedToAddedReplica (478.71s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_twoOfTwo (488.34s)
=== CONT  TestAccDynamoDBTable_enablePITRWithCustomRecoveryPeriod
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_oneOfTwo (499.24s)
=== CONT  TestAccDynamoDBTable_enablePITR
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_nonPropagatedTagsAreUnmanaged (537.55s)
=== CONT  TestAccDynamoDBTable_GSIvalidate_keySchema_tooManyRangeKeys
    table_test.go:3318: provider meta not found for test TestAccDynamoDBTable_GSIvalidate_keySchema_tooManyRangeKeys
--- PASS: TestAccDynamoDBTable_GSIvalidate_keySchema_tooManyRangeKeys (2.46s)
=== CONT  TestAccDynamoDBTable_GSI_validate_keySchema_tooManyHashKeys
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_twoOfTwo (534.64s)
=== CONT  TestAccDynamoDBTable_GSI_validate_exactlyOneOfKeySchemaHashKey
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_propagateToAddedReplica (537.12s)
=== CONT  TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema
=== NAME  TestAccDynamoDBTable_GSI_validate_keySchema_tooManyHashKeys
    table_test.go:3299: provider meta not found for test TestAccDynamoDBTable_GSI_validate_keySchema_tooManyHashKeys
=== CONT  TestAccDynamoDBTable_GSI_keySchema_removeGSI
--- PASS: TestAccDynamoDBTable_GSI_validate_keySchema_tooManyHashKeys (3.23s)
=== NAME  TestAccDynamoDBTable_GSI_validate_exactlyOneOfKeySchemaHashKey
    table_test.go:3280: provider meta not found for test TestAccDynamoDBTable_GSI_validate_exactlyOneOfKeySchemaHashKey
--- PASS: TestAccDynamoDBTable_GSI_validate_exactlyOneOfKeySchemaHashKey (3.20s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_removeRangeKey
=== NAME  TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema
    table_test.go:3261: provider meta not found for test TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema
--- PASS: TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema (3.21s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_addRangeKey
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_oneOfTwo (452.95s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleRangeKeys
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tagsUpdate (719.04s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_maxSet
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tagsUpdate (716.34s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_removeHashKey
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (156.77s)
=== CONT  TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_removeKey
--- PASS: TestAccDynamoDBTable_Replica_singleStreamSpecification (485.41s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_addHashKey
--- PASS: TestAccDynamoDBTable_enablePITR (107.48s)
=== CONT  TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_addHashKey
--- PASS: TestAccDynamoDBTable_enablePITRWithCustomRecoveryPeriod (139.16s)
=== CONT  TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_noChange
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleRangeKeys (90.84s)
=== CONT  TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_noChange
--- PASS: TestAccDynamoDBTable_GSI_keySchema_maxSet (78.88s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleRangeKey
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (167.53s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleHashKey
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (306.90s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleHashKeys
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeGSI (122.33s)
=== CONT  TestAccDynamoDBTable_extended
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_pitrKMS (665.90s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleHashKey (66.59s)
=== CONT  TestAccDynamoDBTable_disappears
--- PASS: TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_noChange (86.75s)
=== CONT  TestAccDynamoDBTable_deletion_protection
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleHashKeys (67.94s)
=== CONT  TestAccDynamoDBTable_basic
--- PASS: TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_noChange (87.27s)
=== CONT  TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleRangeKey (86.01s)
=== CONT  TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_emptyResourceTag (51.08s)
=== CONT  TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccDynamoDBTable_disappears (36.06s)
=== CONT  TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccDynamoDBTable_basic (46.35s)
=== CONT  TestAccDynamoDBTable_Tags_ComputedTag_onCreate
--- PASS: TestAccDynamoDBTable_deletion_protection (60.11s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccDynamoDBTable_Replica_MRSC_pitrKMS (491.46s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_replace (78.66s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_defaultTag (86.76s)
=== CONT  TestAccDynamoDBTable_encryption
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_onCreate (51.55s)
=== CONT  TestAccDynamoDBTable_TTL_disabled
--- PASS: TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_resourceTag (97.58s)
=== CONT  TestAccDynamoDBTable_lsiUpdate
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_add (77.59s)
=== CONT  TestAccDynamoDBTable_attributeUpdate
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nullNonOverlappingResourceTag (53.92s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_pitr
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nullOverlappingResourceTag (48.98s)
=== CONT  TestAccDynamoDBTable_TTL_validate
    table_test.go:4701: provider meta not found for test TestAccDynamoDBTable_TTL_validate
--- PASS: TestAccDynamoDBTable_TTL_validate (4.67s)
=== CONT  TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_emptyProviderOnlyTag (52.11s)
=== CONT  TestAccDynamoDBTable_TTL_updateDisable
--- PASS: TestAccDynamoDBTable_TTL_disabled (61.48s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccDynamoDBTable_GSI_keySchema_addRangeKey (352.47s)
=== CONT  TestAccDynamoDBTable_TTL_updateEnable
--- PASS: TestAccDynamoDBTable_lsiUpdate (86.55s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeRangeKey (363.82s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_overlapping
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_replace (75.06s)
=== CONT  TestAccDynamoDBTable_lsiNonKeyAttributes
--- PASS: TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_removeKey (353.82s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_updateToResourceOnly (73.11s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_providerOnly
--- PASS: TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_addHashKey (351.64s)
=== CONT  TestAccDynamoDBTable_onDemandThroughput
--- PASS: TestAccDynamoDBTable_Replica_deletionProtection (1384.35s)
=== CONT  TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_SameAsTable
--- PASS: TestAccDynamoDBTable_GSI_keySchema_addHashKey (362.44s)
=== CONT  TestAccDynamoDBTable_streamSpecificationValidation
--- PASS: TestAccDynamoDBTable_Replica_single (771.52s)
=== CONT  TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
--- PASS: TestAccDynamoDBTable_encryption (163.75s)
=== CONT  TestAccDynamoDBTable_streamSpecificationDiffs
--- PASS: TestAccDynamoDBTable_TTL_updateEnable (77.47s)
=== CONT  TestAccDynamoDBTable_streamSpecification
=== NAME  TestAccDynamoDBTable_streamSpecificationValidation
    table_test.go:4003: provider meta not found for test TestAccDynamoDBTable_streamSpecificationValidation
    table_test.go:4003: randomness source not found for test TestAccDynamoDBTable_streamSpecificationValidation
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (6.37s)
=== CONT  TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (65.69s)
=== CONT  TestAccDynamoDBTable_gsiOnDemandThroughput
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_updateToProviderOnly (100.50s)
=== CONT  TestAccDynamoDBTable_Tags_addOnUpdate
=== NAME  TestAccDynamoDBTable_Replica_MRSC_witness_pitr
    table_test.go:6485: Step 2/2 error: Check failed: Check 1/5 error: couldn't find resource
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (150.26s)
=== CONT  TestAccDynamoDBTable_Tags_emptyMap
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_billingProvisioned (1405.41s)
=== CONT  TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_overlapping (218.35s)
=== CONT  TestAccDynamoDBTable_Tags_null
--- PASS: TestAccDynamoDBTable_streamSpecification (155.12s)
=== CONT  TestAccDynamoDBTable_Tags_EmptyTag_onCreate
--- PASS: TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_SameAsTable (182.25s)
=== CONT  TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
--- PASS: TestAccDynamoDBTable_Tags_addOnUpdate (151.91s)
=== CONT  TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nonOverlapping (227.52s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestBasic
--- PASS: TestAccDynamoDBTable_gsiOnDemandThroughput (177.87s)
=== CONT  TestAccDynamoDBTable_gsiUpdateOtherAttributes
--- FAIL: TestAccDynamoDBTable_Replica_MRSC_witness_pitr (337.35s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
--- PASS: TestAccDynamoDBTable_Replica_multiple (1102.09s)
=== CONT  TestAccDynamoDBTable_importTable
--- PASS: TestAccDynamoDBTable_onDemandThroughput (252.01s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
--- PASS: TestAccDynamoDBTable_restoreCrossRegion (995.28s)
=== CONT  TestAccDynamoDBTable_TTL_enabled
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeHashKey (700.17s)
--- PASS: TestAccDynamoDBTable_Tags_null (147.56s)
--- PASS: TestAccDynamoDBTable_extended (608.08s)
--- PASS: TestAccDynamoDBTable_Tags_emptyMap (153.29s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_providerOnly (331.27s)
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_onCreate (163.08s)
--- PASS: TestAccDynamoDBTable_TTL_enabled (81.78s)
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_add (191.18s)
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (377.69s)
--- PASS: TestAccDynamoDBTable_streamSpecificationDiffs (380.31s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (240.70s)
--- PASS: TestAccDynamoDBTable_importTable (190.48s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (212.29s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (259.20s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (326.50s)
--- PASS: TestAccDynamoDBTable_attributeUpdate (661.31s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestBasic (373.01s)
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (640.33s)
=== NAME  TestAccDynamoDBTable_Replica_doubleAddCMK
    table_test.go:5334: Step 3/3 error: Error running apply: exit status 1

        Error: updating AWS DynamoDB Table (tf-acc-test-7247565849291977439): updating replicas, while creating: creating replica (us-east-1): operation error DynamoDB: UpdateTable, https response error StatusCode: 400, RequestID: D3M7F9OOPCQNCV4B4F3TMT0JE3VV4KQNSO5AEMVJF66Q9ASUAAJG, api error ValidationException: Replica specified in the Replica Update or Replica Delete action of the request was not found.

          with aws_dynamodb_table.test,
          on terraform_plugin_test.tf line 68, in resource "aws_dynamodb_table" "test":
          68: resource "aws_dynamodb_table" "test" {

--- FAIL: TestAccDynamoDBTable_Replica_doubleAddCMK (3122.62s)
--- PASS: TestAccDynamoDBTable_TTL_updateDisable (3683.63s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   5244.203s
```

Failures are unrelated to this change.