### PR TITLE
r/aws_ssm_association: add list support

### DIFF
--- a/.changelog/47321.txt
+++ b/.changelog/47321.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_ssm_association
+```

--- a/internal/service/ssm/association.go
+++ b/internal/service/ssm/association.go
@@ -8,13 +8,13 @@ package ssm
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"strings"
 	"time"
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -261,9 +261,10 @@ func resourceAssociationCreate(ctx context.Context, d *schema.ResourceData, meta
 
 func resourceAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).SSMClient(ctx)
+	awsClient := meta.(*conns.AWSClient)
+	conn := awsClient.SSMClient(ctx)
 
-	association, err := findAssociationByID(ctx, conn, d.Id())
+	out, err := findAssociationByID(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] SSM Association %s not found, removing from state", d.Id())
@@ -275,34 +276,8 @@ func resourceAssociationRead(ctx context.Context, d *schema.ResourceData, meta a
 		return sdkdiag.AppendErrorf(diags, "reading SSM Association (%s): %s", d.Id(), err)
 	}
 
-	d.Set("apply_only_at_cron_interval", association.ApplyOnlyAtCronInterval)
-	arn := arn.ARN{
-		Partition: meta.(*conns.AWSClient).Partition(ctx),
-		Service:   "ssm",
-		Region:    meta.(*conns.AWSClient).Region(ctx),
-		AccountID: meta.(*conns.AWSClient).AccountID(ctx),
-		Resource:  "association/" + aws.ToString(association.AssociationId),
-	}.String()
-	d.Set(names.AttrARN, arn)
-	d.Set(names.AttrAssociationID, association.AssociationId)
-	d.Set("association_name", association.AssociationName)
-	d.Set("automation_target_parameter_name", association.AutomationTargetParameterName)
-	d.Set("calendar_names", association.CalendarNames)
-	d.Set("compliance_severity", association.ComplianceSeverity)
-	d.Set("document_version", association.DocumentVersion)
-	d.Set("max_concurrency", association.MaxConcurrency)
-	d.Set("max_errors", association.MaxErrors)
-	d.Set(names.AttrName, association.Name)
-	if err := d.Set("output_location", flattenAssociationOutputLocation(association.OutputLocation)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting output_location: %s", err)
-	}
-	if err := d.Set(names.AttrParameters, flattenParameters(association.Parameters)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting parameters: %s", err)
-	}
-	d.Set(names.AttrScheduleExpression, association.ScheduleExpression)
-	d.Set("sync_compliance", association.SyncCompliance)
-	if err := d.Set("targets", flattenTargets(association.Targets)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting targets: %s", err)
+	if err := resourceAssociationFlatten(ctx, awsClient, out, d); err != nil {
+		return sdkdiag.AppendErrorf(diags, "flattening SSM Association (%s): %s", d.Id(), err)
 	}
 
 	return diags
@@ -521,4 +496,31 @@ func flattenAssociationOutputLocation(apiObject *awstypes.InstanceAssociationOut
 	tfList = append(tfList, tfMap)
 
 	return tfList
+}
+
+func resourceAssociationFlatten(ctx context.Context, awsClient *conns.AWSClient, out *awstypes.AssociationDescription, d *schema.ResourceData) error {
+	d.Set("apply_only_at_cron_interval", out.ApplyOnlyAtCronInterval)
+	d.Set(names.AttrARN, awsClient.RegionalARN(ctx, "ssm", "association/"+d.Id()))
+	d.Set(names.AttrAssociationID, out.AssociationId)
+	d.Set("association_name", out.AssociationName)
+	d.Set("automation_target_parameter_name", out.AutomationTargetParameterName)
+	d.Set("calendar_names", out.CalendarNames)
+	d.Set("compliance_severity", out.ComplianceSeverity)
+	d.Set("document_version", out.DocumentVersion)
+	d.Set("max_concurrency", out.MaxConcurrency)
+	d.Set("max_errors", out.MaxErrors)
+	d.Set(names.AttrName, out.Name)
+	if err := d.Set("output_location", flattenAssociationOutputLocation(out.OutputLocation)); err != nil {
+		return fmt.Errorf("setting output_location: %w", err)
+	}
+	if err := d.Set(names.AttrParameters, flattenParameters(out.Parameters)); err != nil {
+		return fmt.Errorf("setting parameters: %w", err)
+	}
+	d.Set(names.AttrScheduleExpression, out.ScheduleExpression)
+	d.Set("sync_compliance", out.SyncCompliance)
+	if err := d.Set("targets", flattenTargets(out.Targets)); err != nil {
+		return fmt.Errorf("setting targets: %w", err)
+	}
+
+	return nil
 }

--- a/internal/service/ssm/association_list.go
+++ b/internal/service/ssm/association_list.go
@@ -1,0 +1,123 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ssm
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKListResource("aws_ssm_association", name="Association")
+func newAssociationResourceAsListResource() inttypes.ListResourceForSDK {
+	l := associationListResource{}
+	l.SetResourceSchema(resourceAssociation())
+	return &l
+}
+
+var _ list.ListResource = &associationListResource{}
+
+type associationListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+func (l *associationListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	conn := l.Meta().SSMClient(ctx)
+
+	var query listAssociationModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	tflog.Info(ctx, "Listing Resources", map[string]any{})
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		input := ssm.ListAssociationsInput{}
+		for item, err := range listAssociations(ctx, conn, &input) {
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+			id := aws.ToString(item.AssociationId)
+			name := aws.ToString(item.Name)
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrID), id)
+
+			result := request.NewListResult(ctx)
+
+			rd := l.ResourceData()
+			rd.SetId(id)
+			rd.Set(names.AttrAssociationID, id)
+			rd.Set(names.AttrName, name)
+
+			if request.IncludeResource {
+				out, err := findAssociationByID(ctx, conn, id)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					result = fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("reading SSM Association (%s): %w", name, err))
+					yield(result)
+					return
+				}
+
+				if err := resourceAssociationFlatten(ctx, l.Meta(), out, rd); err != nil {
+					tflog.Error(ctx, "Flatten SSM Association", map[string]any{
+						"error": err.Error(),
+					})
+					continue
+				}
+			}
+
+			result.DisplayName = name
+			l.SetResult(ctx, l.Meta(), request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+type listAssociationModel struct {
+	framework.WithRegionModel
+}
+
+func listAssociations(ctx context.Context, conn *ssm.Client, input *ssm.ListAssociationsInput) iter.Seq2[awstypes.Association, error] {
+	return func(yield func(awstypes.Association, error) bool) {
+		pages := ssm.NewListAssociationsPaginator(conn, input)
+		for pages.HasMorePages() {
+			page, err := pages.NextPage(ctx)
+			if err != nil {
+				yield(awstypes.Association{}, fmt.Errorf("listing SSM (Systems Manager) Association resources: %w", err))
+				return
+			}
+
+			for _, item := range page.Associations {
+				if !yield(item, nil) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/service/ssm/association_list_test.go
+++ b/internal/service/ssm/association_list_test.go
@@ -1,0 +1,224 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ssm_test
+
+import (
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSSMAssociation_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_ssm_association.test[0]"
+	resourceName2 := "aws_ssm_association.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy:             testAccCheckAssociationDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Association/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Association/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_association.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_ssm_association.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					tfquerycheck.ExpectNoResourceObject("aws_ssm_association.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_association.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_ssm_association.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringExact(rName+"-1")),
+					tfquerycheck.ExpectNoResourceObject("aws_ssm_association.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSSMAssociation_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_ssm_association.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy:             testAccCheckAssociationDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Association/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Association/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_association.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_ssm_association.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					querycheck.ExpectResourceKnownValues("aws_ssm_association.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNRegexp("ssm", regexache.MustCompile(`association/.+`))),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrAssociationID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("association_name"), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("apply_only_at_cron_interval"), knownvalue.Bool(false)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("automation_target_parameter_name"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("calendar_names"), knownvalue.SetExact([]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("compliance_severity"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("document_version"), knownvalue.StringExact("$DEFAULT")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("max_concurrency"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("max_errors"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("output_location"), knownvalue.ListExact([]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrParameters), knownvalue.MapExact(map[string]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrScheduleExpression), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("sync_compliance"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("wait_for_success_timeout_seconds"), knownvalue.Null()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("targets"), knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrKey: knownvalue.StringExact("tag:Name"),
+								names.AttrValues: knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.StringExact("acceptanceTest"),
+								}),
+							}),
+						})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTagsAll), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSSMAssociation_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_ssm_association.test[0]"
+	resourceName2 := "aws_ssm_association.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy:             testAccCheckAssociationDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Association/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Association/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_association.test", identity1.Checks()),
+
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_association.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/ssm/service_package_gen.go
+++ b/internal/service/ssm/service_package_gen.go
@@ -234,6 +234,17 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttypes.ServicePackageSDKListResource] {
 	return slices.Values([]*inttypes.ServicePackageSDKListResource{
 		{
+			Factory:  newAssociationResourceAsListResource,
+			TypeName: "aws_ssm_association",
+			Name:     "Association",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrID,
+				ResourceType:        "Association",
+			}),
+			Identity: inttypes.RegionalSingleParameterIdentity(names.AttrAssociationID),
+		},
+		{
 			Factory:  newDocumentResourceAsListResource,
 			TypeName: "aws_ssm_document",
 			Name:     "Document",

--- a/internal/service/ssm/testdata/Association/list_basic/main.tf
+++ b/internal/service/ssm/testdata/Association/list_basic/main.tf
@@ -1,0 +1,51 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ssm_association" "test" {
+  count            = var.resource_count
+  name             = aws_ssm_document.test[count.index].name
+  association_name = "${var.rName}-${count.index}"
+
+  targets {
+    key    = "tag:Name"
+    values = ["acceptanceTest"]
+  }
+}
+
+resource "aws_ssm_document" "test" {
+  count         = var.resource_count
+  name          = "${var.rName}-${count.index}"
+  document_type = "Command"
+
+  content = <<DOC
+{
+  "schemaVersion": "1.2",
+  "description": "Test doc",
+  "parameters": {},
+  "runtimeConfig": {
+    "aws:runShellScript": {
+      "properties": [
+        {
+          "id": "0.aws:runShellScript",
+          "runCommand": [
+            "ifconfig"
+          ]
+        }
+      ]
+    }
+  }
+}
+DOC
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/ssm/testdata/Association/list_basic/query.tfquery.hcl
+++ b/internal/service/ssm/testdata/Association/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ssm_association" "test" {
+  provider = aws
+}

--- a/internal/service/ssm/testdata/Association/list_include_resource/main.tf
+++ b/internal/service/ssm/testdata/Association/list_include_resource/main.tf
@@ -1,0 +1,59 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ssm_association" "test" {
+  count            = var.resource_count
+  name             = aws_ssm_document.test[count.index].name
+  association_name = "${var.rName}-${count.index}"
+
+  targets {
+    key    = "tag:Name"
+    values = ["acceptanceTest"]
+  }
+
+  tags = var.resource_tags
+}
+
+resource "aws_ssm_document" "test" {
+  count         = var.resource_count
+  name          = "${var.rName}-${count.index}"
+  document_type = "Command"
+
+  content = <<DOC
+{
+  "schemaVersion": "1.2",
+  "description": "Test doc",
+  "parameters": {},
+  "runtimeConfig": {
+    "aws:runShellScript": {
+      "properties": [
+        {
+          "id": "0.aws:runShellScript",
+          "runCommand": [
+            "ifconfig"
+          ]
+        }
+      ]
+    }
+  }
+}
+DOC
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "resource_tags" {
+  description = "Tags for resource"
+  type        = map(string)
+  nullable    = false
+}

--- a/internal/service/ssm/testdata/Association/list_include_resource/query.tfquery.hcl
+++ b/internal/service/ssm/testdata/Association/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ssm_association" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/ssm/testdata/Association/list_region_override/main.tf
+++ b/internal/service/ssm/testdata/Association/list_region_override/main.tf
@@ -1,0 +1,59 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ssm_association" "test" {
+  count            = var.resource_count
+  region           = var.region
+  name             = aws_ssm_document.test[count.index].name
+  association_name = "${var.rName}-${count.index}"
+
+  targets {
+    key    = "tag:Name"
+    values = ["acceptanceTest"]
+  }
+}
+
+resource "aws_ssm_document" "test" {
+  count         = var.resource_count
+  region        = var.region
+  name          = "${var.rName}-${count.index}"
+  document_type = "Command"
+
+  content = <<DOC
+{
+  "schemaVersion": "1.2",
+  "description": "Test doc",
+  "parameters": {},
+  "runtimeConfig": {
+    "aws:runShellScript": {
+      "properties": [
+        {
+          "id": "0.aws:runShellScript",
+          "runCommand": [
+            "ifconfig"
+          ]
+        }
+      ]
+    }
+  }
+}
+DOC
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/ssm/testdata/Association/list_region_override/query.tfquery.hcl
+++ b/internal/service/ssm/testdata/Association/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ssm_association" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}

--- a/website/docs/list-resources/ssm_association.html.markdown
+++ b/website/docs/list-resources/ssm_association.html.markdown
@@ -1,0 +1,26 @@
+---
+subcategory: "SSM (Systems Manager)"
+layout: "aws"
+page_title: "AWS: aws_ssm_association"
+description: |-
+  Lists SSM (Systems Manager) Association resources.
+---
+
+# List Resource: aws_ssm_association
+
+Lists SSM (Systems Manager) Association resources..
+
+## Example Usage
+
+```terraform
+list "aws_ssm_association" "example" {
+  provider = aws
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) [Region](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints) to query.
+  Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds list support for the `aws_ssm_association` resource.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/47005
Closes https://github.com/hashicorp/terraform-provider-aws/issues/47228


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make t K=ssm T=TestAccSSMAssociation_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-ssm_assocation-list 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMAssociation_'  -timeout 360m -vet=off
2026/04/07 11:16:55 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/07 11:16:55 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccSSMAssociation_List_regionOverride (57.67s)
=== CONT  TestAccSSMAssociation_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccSSMAssociation_List_basic (57.74s)
=== CONT  TestAccSSMAssociation_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccSSMAssociation_Tags_ComputedTag_onCreate (86.52s)
=== CONT  TestAccSSMAssociation_basic
--- PASS: TestAccSSMAssociation_List_includeResource (92.14s)
=== CONT  TestAccSSMAssociation_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccSSMAssociation_syncCompliance (98.70s)
=== CONT  TestAccSSMAssociation_withOutputLocation_waitForSuccessTimeout
--- PASS: TestAccSSMAssociation_Identity_regionOverride (116.73s)
=== CONT  TestAccSSMAssociation_withComplianceSeverity
--- PASS: TestAccSSMAssociation_Identity_ExistingResource_basic (116.89s)
=== CONT  TestAccSSMAssociation_withScheduleExpression
--- PASS: TestAccSSMAssociation_Identity_ExistingResource_noRefreshNoChange (124.05s)
=== CONT  TestAccSSMAssociation_withAutomationTargetParamName
--- PASS: TestAccSSMAssociation_Tags_DefaultTags_nullOverlappingResourceTag (124.38s)
=== CONT  TestAccSSMAssociation_withTargets
--- PASS: TestAccSSMAssociation_Identity_basic (130.61s)
=== CONT  TestAccSSMAssociation_withParameters
--- PASS: TestAccSSMAssociation_Tags_null (137.30s)
=== CONT  TestAccSSMAssociation_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccSSMAssociation_withAssociationName (142.86s)
=== CONT  TestAccSSMAssociation_applyOnlyAtCronInterval
--- PASS: TestAccSSMAssociation_Tags_DefaultTags_updateToProviderOnly (143.02s)
=== CONT  TestAccSSMAssociation_tags
--- PASS: TestAccSSMAssociation_Tags_DefaultTags_updateToResourceOnly (155.36s)
=== CONT  TestAccSSMAssociation_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccSSMAssociation_rateControl (156.02s)
=== CONT  TestAccSSMAssociation_Tags_EmptyTag_onCreate
--- PASS: TestAccSSMAssociation_Tags_emptyMap (161.32s)
=== CONT  TestAccSSMAssociation_Tags_addOnUpdate
--- PASS: TestAccSSMAssociation_Tags_DefaultTags_nullNonOverlappingResourceTag (103.95s)
=== CONT  TestAccSSMAssociation_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccSSMAssociation_withOutputLocation_waitForSuccessTimeout (96.05s)
=== CONT  TestAccSSMAssociation_disappears_document
--- PASS: TestAccSSMAssociation_withComplianceSeverity (131.38s)
=== CONT  TestAccSSMAssociation_withOutputLocation
--- PASS: TestAccSSMAssociation_withScheduleExpression (131.28s)
=== CONT  TestAccSSMAssociation_withOutputLocation_s3Region
--- PASS: TestAccSSMAssociation_basic (165.00s)
=== CONT  TestAccSSMAssociation_withDocumentVersion
--- PASS: TestAccSSMAssociation_Tags_IgnoreTags_Overlap_defaultTag (201.78s)
=== CONT  TestAccSSMAssociation_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccSSMAssociation_withParameters (135.65s)
=== CONT  TestAccSSMAssociation_withAssociationNameAndScheduleExpression
--- PASS: TestAccSSMAssociation_withAutomationTargetParamName (142.24s)
=== CONT  TestAccSSMAssociation_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccSSMAssociation_applyOnlyAtCronInterval (128.59s)
=== CONT  TestAccSSMAssociation_disappears
--- PASS: TestAccSSMAssociation_Tags_DefaultTags_nonOverlapping (272.68s)
--- PASS: TestAccSSMAssociation_Tags_DefaultTags_overlapping (284.01s)
--- PASS: TestAccSSMAssociation_withTargets (174.97s)
--- PASS: TestAccSSMAssociation_Tags_EmptyTag_OnUpdate_add (299.57s)
--- PASS: TestAccSSMAssociation_Tags_EmptyTag_OnUpdate_replace (162.76s)
--- PASS: TestAccSSMAssociation_Tags_ComputedTag_OnUpdate_replace (148.15s)
--- PASS: TestAccSSMAssociation_Tags_addOnUpdate (146.20s)
--- PASS: TestAccSSMAssociation_Tags_EmptyTag_onCreate (158.24s)
--- PASS: TestAccSSMAssociation_Tags_ComputedTag_OnUpdate_add (152.63s)
--- PASS: TestAccSSMAssociation_withDocumentVersion (65.28s)
--- PASS: TestAccSSMAssociation_Tags_IgnoreTags_Overlap_resourceTag (226.71s)
--- PASS: TestAccSSMAssociation_Tags_DefaultTags_emptyProviderOnlyTag (64.66s)
--- PASS: TestAccSSMAssociation_Tags_DefaultTags_emptyResourceTag (61.77s)
--- PASS: TestAccSSMAssociation_disappears_document (140.53s)
--- PASS: TestAccSSMAssociation_Tags_DefaultTags_providerOnly (336.33s)
--- PASS: TestAccSSMAssociation_withAssociationNameAndScheduleExpression (76.51s)
--- PASS: TestAccSSMAssociation_withOutputLocation (111.61s)
--- PASS: TestAccSSMAssociation_tags (218.60s)
--- PASS: TestAccSSMAssociation_withOutputLocation_s3Region (114.91s)
--- PASS: TestAccSSMAssociation_disappears (117.08s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        395.691s
```