### PR TITLE
Expose `user_status` in `aws_identitystore_user` and `aws_identitystore_users`

### DIFF
--- a/.changelog/47323.txt
+++ b/.changelog/47323.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_identitystore_user: Add `user_status` attribute
+```
+
+```release-note:enhancement
+data-source/aws_identitystore_user: Add `user_status` attribute
+```
+
+```release-note:enhancement
+data-source/aws_identitystore_users: Add `user_status` attribute
+```

--- a/internal/service/identitystore/user.go
+++ b/internal/service/identitystore/user.go
@@ -235,6 +235,10 @@ func resourceUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"user_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			names.AttrUserName: {
 				Type:             schema.TypeString,
 				Required:         true,
@@ -363,6 +367,7 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta any) dia
 	d.Set("title", out.Title)
 	d.Set("user_id", out.UserId)
 	d.Set(names.AttrUserName, out.UserName)
+	d.Set("user_status", out.UserStatus)
 	d.Set("user_type", out.UserType)
 
 	return diags

--- a/internal/service/identitystore/user_data_source.go
+++ b/internal/service/identitystore/user_data_source.go
@@ -250,6 +250,10 @@ func dataSourceUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"user_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"user_type": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -322,6 +326,7 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta any) d
 	d.Set("title", user.Title)
 	d.Set("user_id", user.UserId)
 	d.Set(names.AttrUserName, user.UserName)
+	d.Set("user_status", user.UserStatus)
 	d.Set("user_type", user.UserType)
 
 	return diags

--- a/internal/service/identitystore/user_data_source_test.go
+++ b/internal/service/identitystore/user_data_source_test.go
@@ -46,6 +46,7 @@ func TestAccIdentityStoreUserDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "user_id", resourceName, "user_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrUserName, resourceName, names.AttrUserName),
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrUserName, name),
+					resource.TestCheckResourceAttrPair(dataSourceName, "user_status", resourceName, "user_status"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "user_type", resourceName, "user_type"),
 				),
 			},

--- a/internal/service/identitystore/user_test.go
+++ b/internal/service/identitystore/user_test.go
@@ -57,7 +57,7 @@ func TestAccIdentityStoreUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "title", ""),
 					resource.TestCheckResourceAttrSet(resourceName, "user_id"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrUserName, rName),
-					resource.TestCheckResourceAttrSet(resourceName, "user_status"),
+					resource.TestCheckResourceAttr(resourceName, "user_status", "ENABLED"),
 					resource.TestCheckResourceAttr(resourceName, "user_type", ""),
 				),
 			},

--- a/internal/service/identitystore/user_test.go
+++ b/internal/service/identitystore/user_test.go
@@ -57,6 +57,7 @@ func TestAccIdentityStoreUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "title", ""),
 					resource.TestCheckResourceAttrSet(resourceName, "user_id"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrUserName, rName),
+					resource.TestCheckResourceAttrSet(resourceName, "user_status"),
 					resource.TestCheckResourceAttr(resourceName, "user_type", ""),
 				),
 			},

--- a/internal/service/identitystore/users_data_source.go
+++ b/internal/service/identitystore/users_data_source.go
@@ -110,6 +110,7 @@ type userModel struct {
 	Title             types.String                                       `tfsdk:"title"`
 	UserID            types.String                                       `tfsdk:"user_id"`
 	UserName          types.String                                       `tfsdk:"user_name"`
+	UserStatus        types.String                                       `tfsdk:"user_status"`
 	UserType          types.String                                       `tfsdk:"user_type"`
 }
 

--- a/internal/service/identitystore/users_data_source_test.go
+++ b/internal/service/identitystore/users_data_source_test.go
@@ -37,6 +37,7 @@ func TestAccIdentityStoreUsersDataSource_basic(t *testing.T) {
 					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "users.*.name.0.family_name", userResourceName, "name.0.family_name"),
 					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "users.*.name.0.given_name", userResourceName, "name.0.given_name"),
 					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "users.*.emails.0.value", userResourceName, "emails.0.value"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "users.*.user_status", userResourceName, "user_status"),
 				),
 			},
 		},

--- a/website/docs/d/identitystore_user.html.markdown
+++ b/website/docs/d/identitystore_user.html.markdown
@@ -108,4 +108,5 @@ This data source exports the following attributes in addition to the arguments a
 * `timezone` - The user's time zone.
 * `title` - The user's title.
 * `user_name` - User's user name value.
+* `user_status` - The current status of the user account.
 * `user_type` - The user type.

--- a/website/docs/d/identitystore_users.html.markdown
+++ b/website/docs/d/identitystore_users.html.markdown
@@ -70,4 +70,5 @@ This data source exports the following attributes in addition to the arguments a
     * `title` - User's title.
     * `user_id` - Identifier of the user in the Identity Store.
     * `user_name` - User's user name value.
+    * `user_status` - Current status of the user account.
     * `user_type` - User type.

--- a/website/docs/r/identitystore_user.html.markdown
+++ b/website/docs/r/identitystore_user.html.markdown
@@ -108,6 +108,7 @@ This resource exports the following attributes in addition to the arguments abov
     * `id` - The identifier issued to this resource by an external identity provider.
     * `issuer` - The issuer for an external identifier.
 * `user_id` - The identifier for this user in the identity store.
+* `user_status` - The current status of the user account.
 
 ## Import
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None

### Description

I've exposed the `UserStatus` field from the `DescribeUser` Identity Store API as a new `user_status` field on the resource and data source.

### Relations

Closes #47322

### References

API docs: https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_DescribeUser.html

### Output from Acceptance Testing

I was unable to run the acceptance tests locally 😞 I tried but we've configured our Identity Store to lock out all manual creation of users.