### PR TITLE
r/aws_ssm_patch_group: add list support

### DIFF
--- a/.changelog/47329.txt
+++ b/.changelog/47329.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_ssm_patch_group
+```

--- a/internal/service/ssm/patch_group_list.go
+++ b/internal/service/ssm/patch_group_list.go
@@ -1,0 +1,117 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ssm
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+)
+
+// @SDKListResource("aws_ssm_patch_group")
+func newPatchGroupResourceAsListResource() inttypes.ListResourceForSDK {
+	l := patchGroupListResource{}
+	l.SetResourceSchema(resourcePatchGroup())
+	return &l
+}
+
+var _ list.ListResource = &patchGroupListResource{}
+
+type patchGroupListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+func (l *patchGroupListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	conn := l.Meta().SSMClient(ctx)
+
+	var query listPatchGroupModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		input := ssm.DescribePatchGroupsInput{}
+		for item, err := range listPatchGroups(ctx, conn, &input) {
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+
+			var groupBaselineID string
+			if item.BaselineIdentity != nil {
+				groupBaselineID = aws.ToString(item.BaselineIdentity.BaselineId)
+			}
+			patchGroupName := aws.ToString(item.PatchGroup)
+
+			id, err := flex.FlattenResourceId([]string{patchGroupName, groupBaselineID}, patchGroupResourceIDPartCount, false)
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("generating id: %w", err))
+				yield(result)
+				return
+			}
+
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey("patch_group"), patchGroupName)
+
+			result := request.NewListResult(ctx)
+			rd := l.ResourceData()
+			rd.SetId(id)
+			rd.Set("patch_group", patchGroupName)
+			rd.Set("baseline_id", groupBaselineID)
+
+			if request.IncludeResource { //nolint:revive,staticcheck // Be explicit about IncludeResource handling
+				// No-op, all attributes already set
+			}
+
+			result.DisplayName = patchGroupName
+
+			l.SetResult(ctx, l.Meta(), request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+type listPatchGroupModel struct {
+	framework.WithRegionModel
+}
+
+func listPatchGroups(ctx context.Context, conn *ssm.Client, input *ssm.DescribePatchGroupsInput) iter.Seq2[awstypes.PatchGroupPatchBaselineMapping, error] {
+	return func(yield func(awstypes.PatchGroupPatchBaselineMapping, error) bool) {
+		pages := ssm.NewDescribePatchGroupsPaginator(conn, input)
+		for pages.HasMorePages() {
+			page, err := pages.NextPage(ctx)
+			if err != nil {
+				yield(awstypes.PatchGroupPatchBaselineMapping{}, fmt.Errorf("listing SSM (Systems Manager) Patch Group resources: %w", err))
+				return
+			}
+
+			for _, item := range page.Mappings {
+				if !yield(item, nil) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/service/ssm/patch_group_list_test.go
+++ b/internal/service/ssm/patch_group_list_test.go
@@ -1,0 +1,183 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ssm_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSSMPatchGroup_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_ssm_patch_group.test[0]"
+	resourceName2 := "aws_ssm_patch_group.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy:             testAccCheckPatchGroupDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/PatchGroup/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/PatchGroup/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_patch_group.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_ssm_patch_group.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					tfquerycheck.ExpectNoResourceObject("aws_ssm_patch_group.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_patch_group.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_ssm_patch_group.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringExact(rName+"-1")),
+					tfquerycheck.ExpectNoResourceObject("aws_ssm_patch_group.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSSMPatchGroup_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_ssm_patch_group.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy:             testAccCheckPatchGroupDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/PatchGroup/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/PatchGroup/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_patch_group.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_ssm_patch_group.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					querycheck.ExpectResourceKnownValues("aws_ssm_patch_group.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("patch_group"), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("baseline_id"), knownvalue.NotNull()),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSSMPatchGroup_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_ssm_patch_group.test[0]"
+	resourceName2 := "aws_ssm_patch_group.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy:             testAccCheckPatchGroupDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/PatchGroup/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/PatchGroup/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_patch_group.test", identity1.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_patch_group.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/ssm/service_package_gen.go
+++ b/internal/service/ssm/service_package_gen.go
@@ -255,6 +255,16 @@ func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttype
 			}),
 			Identity: inttypes.RegionalSingleParameterIdentity(names.AttrName),
 		},
+		{
+			Factory:  newPatchGroupResourceAsListResource,
+			TypeName: "aws_ssm_patch_group",
+			Name:     "Patch Group",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+			Identity: inttypes.RegionalParameterizedIdentity([]inttypes.IdentityAttribute{
+				inttypes.StringIdentityAttribute("patch_group", true),
+				inttypes.StringIdentityAttribute("baseline_id", true),
+			}),
+		},
 	})
 }
 

--- a/internal/service/ssm/testdata/PatchGroup/basic_v6.39.0/main_gen.tf
+++ b/internal/service/ssm/testdata/PatchGroup/basic_v6.39.0/main_gen.tf
@@ -1,15 +1,16 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_ssm_patch_group" "test" {
+  baseline_id = aws_ssm_patch_baseline.test.id
+  patch_group = var.rName
+}
+
 resource "aws_ssm_patch_baseline" "test" {
   name             = var.rName
   approved_patches = ["KB123456"]
 }
 
-resource "aws_ssm_patch_group" "test" {
-  baseline_id = aws_ssm_patch_baseline.test.id
-  patch_group = var.rName
-}
 variable "rName" {
   description = "Name for resource"
   type        = string

--- a/internal/service/ssm/testdata/PatchGroup/list_basic/main.tf
+++ b/internal/service/ssm/testdata/PatchGroup/list_basic/main.tf
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resource "aws_ssm_patch_group" "test" {
+  count       = var.resource_count
   baseline_id = aws_ssm_patch_baseline.test.id
-  patch_group = var.rName
+  patch_group = "${var.rName}-${count.index}"
 }
 
 resource "aws_ssm_patch_baseline" "test" {
@@ -12,7 +13,9 @@ resource "aws_ssm_patch_baseline" "test" {
 }
 
 variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
+  type = string
+}
+
+variable "resource_count" {
+  type = number
 }

--- a/internal/service/ssm/testdata/PatchGroup/list_basic/query.tfquery.hcl
+++ b/internal/service/ssm/testdata/PatchGroup/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ssm_patch_group" "test" {
+  provider = aws
+}

--- a/internal/service/ssm/testdata/PatchGroup/list_include_resource/main.tf
+++ b/internal/service/ssm/testdata/PatchGroup/list_include_resource/main.tf
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resource "aws_ssm_patch_group" "test" {
+  count       = var.resource_count
   baseline_id = aws_ssm_patch_baseline.test.id
-  patch_group = var.rName
+  patch_group = "${var.rName}-${count.index}"
 }
 
 resource "aws_ssm_patch_baseline" "test" {
@@ -12,7 +13,9 @@ resource "aws_ssm_patch_baseline" "test" {
 }
 
 variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
+  type = string
+}
+
+variable "resource_count" {
+  type = number
 }

--- a/internal/service/ssm/testdata/PatchGroup/list_include_resource/query.tfquery.hcl
+++ b/internal/service/ssm/testdata/PatchGroup/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,7 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ssm_patch_group" "test" {
+  provider         = aws
+  include_resource = true
+}

--- a/internal/service/ssm/testdata/PatchGroup/list_region_override/main.tf
+++ b/internal/service/ssm/testdata/PatchGroup/list_region_override/main.tf
@@ -2,17 +2,26 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resource "aws_ssm_patch_group" "test" {
+  count       = var.resource_count
+  region      = var.region
   baseline_id = aws_ssm_patch_baseline.test.id
-  patch_group = var.rName
+  patch_group = "${var.rName}-${count.index}"
 }
 
 resource "aws_ssm_patch_baseline" "test" {
+  region           = var.region
   name             = var.rName
   approved_patches = ["KB123456"]
 }
 
 variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
+  type = string
+}
+
+variable "resource_count" {
+  type = number
+}
+
+variable "region" {
+  type = string
 }

--- a/internal/service/ssm/testdata/PatchGroup/list_region_override/query.tfquery.hcl
+++ b/internal/service/ssm/testdata/PatchGroup/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ssm_patch_group" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}

--- a/internal/service/ssm/testdata/PatchGroup/region_override/main_gen.tf
+++ b/internal/service/ssm/testdata/PatchGroup/region_override/main_gen.tf
@@ -1,6 +1,13 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_ssm_patch_group" "test" {
+  region = var.region
+
+  baseline_id = aws_ssm_patch_baseline.test.id
+  patch_group = var.rName
+}
+
 resource "aws_ssm_patch_baseline" "test" {
   region = var.region
 
@@ -8,12 +15,6 @@ resource "aws_ssm_patch_baseline" "test" {
   approved_patches = ["KB123456"]
 }
 
-resource "aws_ssm_patch_group" "test" {
-  region = var.region
-
-  baseline_id = aws_ssm_patch_baseline.test.id
-  patch_group = var.rName
-}
 variable "rName" {
   description = "Name for resource"
   type        = string

--- a/internal/service/ssm/testdata/tmpl/patch_group_basic.gtpl
+++ b/internal/service/ssm/testdata/tmpl/patch_group_basic.gtpl
@@ -1,11 +1,11 @@
-resource "aws_ssm_patch_baseline" "test" {
-{{- template "region" }}
-  name             = var.rName
-  approved_patches = ["KB123456"]
-}
-
 resource "aws_ssm_patch_group" "test" {
 {{- template "region" }}
   baseline_id = aws_ssm_patch_baseline.test.id
   patch_group = var.rName
+}
+
+resource "aws_ssm_patch_baseline" "test" {
+{{- template "region" }}
+  name             = var.rName
+  approved_patches = ["KB123456"]
 }

--- a/website/docs/list-resources/ssm_patch_group.html.markdown
+++ b/website/docs/list-resources/ssm_patch_group.html.markdown
@@ -1,0 +1,25 @@
+---
+subcategory: "SSM (Systems Manager)"
+layout: "aws"
+page_title: "AWS: aws_ssm_patch_group"
+description: |-
+  Lists SSM (Systems Manager) Patch Group resources.
+---
+
+# List Resource: aws_ssm_patch_group
+
+Lists SSM (Systems Manager) Patch Group resources.
+
+## Example Usage
+
+```terraform
+list "aws_ssm_patch_group" "example" {
+  provider = aws
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.


### PR DESCRIPTION




<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds list support for the `aws_ssm_patch_group` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/47005
Relates https://github.com/hashicorp/terraform-provider-aws/issues/47318
Closes https://github.com/hashicorp/terraform-provider-aws/issues/47215

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=ssm T=TestAccSSMPatchGroup_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-ssm_patch_group-list 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMPatchGroup_'  -timeout 360m -vet=off
2026/04/07 16:56:48 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/07 16:56:48 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccSSMPatchGroup_basic (34.48s)
--- PASS: TestAccSSMPatchGroup_disappears (34.61s)
--- PASS: TestAccSSMPatchGroup_multipleBaselines (34.93s)
--- PASS: TestAccSSMPatchGroup_List_regionOverride (36.90s)
--- PASS: TestAccSSMPatchGroup_List_includeResource (36.97s)
--- PASS: TestAccSSMPatchGroup_List_basic (37.26s)
--- PASS: TestAccSSMPatchGroup_Identity_regionOverride (51.86s)
--- PASS: TestAccSSMPatchGroup_Identity_basic (54.56s)
--- PASS: TestAccSSMPatchGroup_defaultPatchBaselines (59.42s)
--- PASS: TestAccSSMPatchGroup_Identity_ExistingResource_noRefreshNoChange (69.40s)
--- PASS: TestAccSSMPatchGroup_Identity_ExistingResource_basic (75.28s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        82.336s
```