### PR TITLE
resource/aws_wafv2_web_acl_rule: Adds schema element caching

### DIFF
--- a/internal/provider/framework/provider_test.go
+++ b/internal/provider/framework/provider_test.go
@@ -1,0 +1,76 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package framework
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2"
+)
+
+// go test -bench=. -benchmem -run=Bench -v ./internal/provider/framework
+
+// This logs Initialization an annoying number of times
+// func BenchmarkFrameworkProviderInitialization(b *testing.B) {
+// 	ctx := b.Context()
+// 	primary, err := sdkv2.NewProvider(ctx)
+// 	if err != nil {
+// 		b.Fatalf("Initializing SDKv2 provider: %s", err)
+// 	}
+
+// 	// Reset memory counters to zero, so that we only measure the Framework provider initialization.
+// 	b.ResetTimer()
+// 	for b.Loop() {
+// 		_, err := NewProvider(ctx, primary)
+// 		if err != nil {
+// 			b.Fatalf("Initializing Framework provider: %s", err)
+// 		}
+// 	}
+// }
+
+func BenchmarkFrameworkProviderDataSourceSchemaInitialization(b *testing.B) {
+	ctx := b.Context()
+	primary, err := sdkv2.NewProvider(ctx)
+	if err != nil {
+		b.Fatalf("Initializing SDKv2 provider: %s", err)
+	}
+	provider, err := NewProvider(ctx, primary)
+	if err != nil {
+		b.Fatalf("Initializing Framework provider: %s", err)
+	}
+
+	// Reset memory counters to zero, so that we only measure the Data Source schema initialization.
+	b.ResetTimer()
+	for b.Loop() {
+		datasources := provider.DataSources(ctx)
+		for _, f := range datasources {
+			ds := f()
+			ds.Schema(ctx, datasource.SchemaRequest{}, &datasource.SchemaResponse{})
+		}
+	}
+}
+
+func BenchmarkFrameworkProviderResourceSchemaInitialization(b *testing.B) {
+	ctx := b.Context()
+	primary, err := sdkv2.NewProvider(ctx)
+	if err != nil {
+		b.Fatalf("Initializing SDKv2 provider: %s", err)
+	}
+	provider, err := NewProvider(ctx, primary)
+	if err != nil {
+		b.Fatalf("Initializing Framework provider: %s", err)
+	}
+
+	// Reset memory counters to zero, so that we only measure the Resource schema initialization.
+	b.ResetTimer()
+	for b.Loop() {
+		resources := provider.Resources(ctx)
+		for _, f := range resources {
+			r := f()
+			r.Schema(ctx, resource.SchemaRequest{}, &resource.SchemaResponse{})
+		}
+	}
+}

--- a/internal/provider/sdkv2/provider_test.go
+++ b/internal/provider/sdkv2/provider_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// go test -bench=BenchmarkSDKProviderInitialization -benchmem -run=Bench -v ./internal/provider
+// go test -bench=BenchmarkSDKProviderInitialization -benchmem -run=Bench -v ./internal/provider/sdkv2
 func BenchmarkSDKProviderInitialization(b *testing.B) {
 	ctx := b.Context()
 	for b.Loop() {

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -1165,7 +1165,7 @@ var fieldToMatchBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Blo
 	}
 })
 
-func textTransformationBlock(ctx context.Context) schema.ListNestedBlock {
+var textTransformationBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleTextTransformModel](ctx),
 		Validators: []validator.List{
@@ -1186,7 +1186,7 @@ func textTransformationBlock(ctx context.Context) schema.ListNestedBlock {
 			},
 		},
 	}
-}
+})
 
 var rateBasedStatementCustomKeysBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -226,7 +226,7 @@ var managedRuleGroupStatementBlock = tfsync.OnceValueCtx(func(ctx context.Contex
 	}
 })
 
-func regexPatternSetReferenceStatementBlock(ctx context.Context) schema.ListNestedBlock {
+var regexPatternSetReferenceStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleRegexPatternSetReferenceStatementModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -247,7 +247,7 @@ func regexPatternSetReferenceStatementBlock(ctx context.Context) schema.ListNest
 		},
 		Description: "Rule statement used to search web request components for matches with regular expressions from a RegexPatternSet.",
 	}
-}
+})
 
 func rateBasedStatementBlock(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -61,7 +61,7 @@ var jaFingerprintBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Bl
 
 // statementBlock and related functions are generated in web_acl_rule_statement_models_gen.go
 
-func ipSetReferenceStatementBlock(ctx context.Context) schema.ListNestedBlock {
+var ipSetReferenceStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleIPSetReferenceStatementModel](ctx),
 		Validators: []validator.List{
@@ -103,7 +103,7 @@ func ipSetReferenceStatementBlock(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "IP set reference statement.",
 	}
-}
+})
 
 func geoMatchStatementBlock(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -451,7 +451,7 @@ var asnMatchStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context) schem
 	}
 })
 
-func managedRuleGroupConfigsBlock(ctx context.Context) schema.ListNestedBlock {
+var managedRuleGroupConfigsBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleManagedRuleGroupConfigModel](ctx),
 		NestedObject: schema.NestedBlockObject{
@@ -481,7 +481,7 @@ func managedRuleGroupConfigsBlock(ctx context.Context) schema.ListNestedBlock {
 			},
 		},
 	}
-}
+})
 
 var identifierFieldBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -249,7 +249,7 @@ var regexPatternSetReferenceStatementBlock = tfsync.OnceValueCtx(func(ctx contex
 	}
 })
 
-func rateBasedStatementBlock(ctx context.Context) schema.ListNestedBlock {
+var rateBasedStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleRateBasedStatementModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -284,9 +284,9 @@ func rateBasedStatementBlock(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Rate-based statement.",
 	}
-}
+})
 
-func byteMatchStatementBlock(ctx context.Context) schema.ListNestedBlock {
+var byteMatchStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleByteMatchStatementModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -314,9 +314,9 @@ func byteMatchStatementBlock(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Byte match statement.",
 	}
-}
+})
 
-func sqliMatchStatementBlock(ctx context.Context) schema.ListNestedBlock {
+var sqliMatchStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleSqliMatchStatementModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -337,9 +337,9 @@ func sqliMatchStatementBlock(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "SQL injection match statement.",
 	}
-}
+})
 
-func xssMatchStatementBlock(ctx context.Context) schema.ListNestedBlock {
+var xssMatchStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleXssMatchStatementModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -351,9 +351,9 @@ func xssMatchStatementBlock(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Cross-site scripting match statement.",
 	}
-}
+})
 
-func sizeConstraintStatementBlock(ctx context.Context) schema.ListNestedBlock {
+var sizeConstraintStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleSizeConstraintStatementModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -377,9 +377,9 @@ func sizeConstraintStatementBlock(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Size constraint statement.",
 	}
-}
+})
 
-func regexMatchStatementBlock(ctx context.Context) schema.ListNestedBlock {
+var regexMatchStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleRegexMatchStatementModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -400,9 +400,9 @@ func regexMatchStatementBlock(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Rule statement used to search web request components for a match against a single regular expression.",
 	}
-}
+})
 
-func labelMatchStatementBlock(ctx context.Context) schema.ListNestedBlock {
+var labelMatchStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleLabelMatchStatementModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -425,9 +425,9 @@ func labelMatchStatementBlock(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Label match statement.",
 	}
-}
+})
 
-func asnMatchStatementBlock(ctx context.Context) schema.ListNestedBlock {
+var asnMatchStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleAsnMatchStatementModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -449,7 +449,7 @@ func asnMatchStatementBlock(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "ASN match statement.",
 	}
-}
+})
 
 func managedRuleGroupConfigsBlock(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -717,7 +717,7 @@ func requestInspectionACFPBlock(ctx context.Context) schema.ListNestedBlock {
 	}
 }
 
-func responseInspectionBlock(ctx context.Context) schema.ListNestedBlock {
+var responseInspectionBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleResponseInspectionModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -810,7 +810,7 @@ func responseInspectionBlock(ctx context.Context) schema.ListNestedBlock {
 			},
 		},
 	}
-}
+})
 
 var ruleActionOverrideBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -29,22 +29,21 @@ var emptyBlock = tfsync.OnceValueCtx(func(ctx context.Context) *schema.ListNeste
 	}
 })
 
-var nameOnlyBlock = sync.OnceValue(func() func(context.Context, string) schema.ListNestedBlock {
-	return func(ctx context.Context, description string) schema.ListNestedBlock {
-		return schema.ListNestedBlock{
-			CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleSingleHeaderModel](ctx),
-			Validators: []validator.List{listvalidator.SizeAtMost(1)},
-			NestedObject: schema.NestedBlockObject{
-				Attributes: map[string]schema.Attribute{
-					names.AttrName: schema.StringAttribute{
-						Required:    true,
-						Description: description,
-					},
+// nameOnlyBlock cannot be cached because of the description parameter
+func nameOnlyBlock(ctx context.Context, description string) schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleSingleHeaderModel](ctx),
+		Validators: []validator.List{listvalidator.SizeAtMost(1)},
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				names.AttrName: schema.StringAttribute{
+					Required:    true,
+					Description: description,
 				},
 			},
-		}
+		},
 	}
-})
+}
 
 var jaFingerprintBlock = sync.OnceValue(func() func(context.Context) schema.ListNestedBlock {
 	return func(ctx context.Context) schema.ListNestedBlock {
@@ -1146,8 +1145,8 @@ func fieldToMatchBlock(ctx context.Context) schema.ListNestedBlock {
 				},
 				"method":                emptyBlock(ctx),
 				"query_string":          emptyBlock(ctx),
-				"single_header":         nameOnlyBlock()(ctx, "Header name"),
-				"single_query_argument": nameOnlyBlock()(ctx, "Query argument name"),
+				"single_header":         nameOnlyBlock(ctx, "Header name"),
+				"single_query_argument": nameOnlyBlock(ctx, "Query argument name"),
 				"uri_fragment": schema.ListNestedBlock{
 					CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleUriFragmentModel](ctx),
 					Validators: []validator.List{listvalidator.SizeAtMost(1)},

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -17,18 +17,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/sync"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// Common reusable block builders using sync.OnceValue pattern
-
-var emptyBlock = sync.OnceValue(func() func(context.Context) schema.ListNestedBlock {
-	return func(ctx context.Context) schema.ListNestedBlock {
-		return schema.ListNestedBlock{
-			CustomType:   fwtypes.NewListNestedObjectTypeOf[webACLRuleTrulyEmptyModel](ctx),
-			Validators:   []validator.List{listvalidator.SizeAtMost(1)},
-			NestedObject: schema.NestedBlockObject{},
-		}
+var emptyBlock = tfsync.OnceValueCtx(func(ctx context.Context) *schema.ListNestedBlock {
+	return &schema.ListNestedBlock{
+		CustomType:   fwtypes.NewListNestedObjectTypeOf[webACLRuleTrulyEmptyModel](ctx),
+		Validators:   []validator.List{listvalidator.SizeAtMost(1)},
+		NestedObject: schema.NestedBlockObject{},
 	}
 })
 
@@ -993,7 +990,7 @@ func fieldToMatchBlock(ctx context.Context) schema.ListNestedBlock {
 		},
 		NestedObject: schema.NestedBlockObject{
 			Blocks: map[string]schema.Block{
-				"all_query_arguments": emptyBlock()(ctx),
+				"all_query_arguments": emptyBlock(ctx),
 				"body": schema.ListNestedBlock{
 					CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleBodyModel](ctx),
 					Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -1040,7 +1037,7 @@ func fieldToMatchBlock(ctx context.Context) schema.ListNestedBlock {
 										},
 									},
 									Blocks: map[string]schema.Block{
-										"all": emptyBlock()(ctx),
+										"all": emptyBlock(ctx),
 									},
 								},
 							},
@@ -1147,8 +1144,8 @@ func fieldToMatchBlock(ctx context.Context) schema.ListNestedBlock {
 						},
 					},
 				},
-				"method":                emptyBlock()(ctx),
-				"query_string":          emptyBlock()(ctx),
+				"method":                emptyBlock(ctx),
+				"query_string":          emptyBlock(ctx),
 				"single_header":         nameOnlyBlock()(ctx, "Header name"),
 				"single_query_argument": nameOnlyBlock()(ctx, "Query argument name"),
 				"uri_fragment": schema.ListNestedBlock{
@@ -1164,7 +1161,7 @@ func fieldToMatchBlock(ctx context.Context) schema.ListNestedBlock {
 						},
 					},
 				},
-				"uri_path": emptyBlock()(ctx),
+				"uri_path": emptyBlock(ctx),
 			},
 		},
 	}
@@ -1198,7 +1195,7 @@ func rateBasedStatementCustomKeysBlock(ctx context.Context) schema.ListNestedBlo
 		Validators: []validator.List{listvalidator.SizeAtMost(5)},
 		NestedObject: schema.NestedBlockObject{
 			Blocks: map[string]schema.Block{
-				"asn": emptyBlock()(ctx),
+				"asn": emptyBlock(ctx),
 				"cookie": schema.ListNestedBlock{
 					CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleRateBasedStatementCustomKeyCookieModel](ctx),
 					Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -1213,7 +1210,7 @@ func rateBasedStatementCustomKeysBlock(ctx context.Context) schema.ListNestedBlo
 						},
 					},
 				},
-				"forwarded_ip": emptyBlock()(ctx),
+				"forwarded_ip": emptyBlock(ctx),
 				names.AttrHeader: schema.ListNestedBlock{
 					CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleRateBasedStatementCustomKeyHeaderModel](ctx),
 					Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -1228,8 +1225,8 @@ func rateBasedStatementCustomKeysBlock(ctx context.Context) schema.ListNestedBlo
 						},
 					},
 				},
-				"http_method":     emptyBlock()(ctx),
-				"ip":              emptyBlock()(ctx),
+				"http_method":     emptyBlock(ctx),
+				"ip":              emptyBlock(ctx),
 				"ja3_fingerprint": jaFingerprintBlock()(ctx),
 				"ja4_fingerprint": jaFingerprintBlock()(ctx),
 				"label_namespace": schema.ListNestedBlock{

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -5,6 +5,7 @@ package wafv2
 
 import (
 	"context"
+	"sync"
 
 	"github.com/YakDriver/regexache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
@@ -50,12 +51,16 @@ var jaFingerprintBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Bl
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
-				"fallback_behavior": schema.StringAttribute{
-					CustomType: fwtypes.StringEnumType[awstypes.FallbackBehavior](),
-					Required:   true,
-				},
+				"fallback_behavior": fallbackBehaviorAttrRequired(),
 			},
 		},
+	}
+})
+
+var fallbackBehaviorAttrRequired = sync.OnceValue(func() schema.Attribute {
+	return schema.StringAttribute{
+		CustomType: fwtypes.StringEnumType[awstypes.FallbackBehavior](),
+		Required:   true,
 	}
 })
 
@@ -81,20 +86,13 @@ var ipSetReferenceStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context)
 					Validators: []validator.List{listvalidator.SizeAtMost(1)},
 					NestedObject: schema.NestedBlockObject{
 						Attributes: map[string]schema.Attribute{
-							"fallback_behavior": schema.StringAttribute{
-								Required: true,
-								Validators: []validator.String{
-									stringvalidator.OneOf("MATCH", "NO_MATCH"),
-								},
-							},
+							"fallback_behavior": fallbackBehaviorAttrRequired(),
 							"header_name": schema.StringAttribute{
 								Required: true,
 							},
 							"position": schema.StringAttribute{
-								Required: true,
-								Validators: []validator.String{
-									stringvalidator.OneOf("FIRST", "LAST", "ANY"),
-								},
+								CustomType: fwtypes.StringEnumType[awstypes.ForwardedIPPosition](),
+								Required:   true,
 							},
 						},
 					},
@@ -126,12 +124,7 @@ var geoMatchStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context) schem
 					Validators: []validator.List{listvalidator.SizeAtMost(1)},
 					NestedObject: schema.NestedBlockObject{
 						Attributes: map[string]schema.Attribute{
-							"fallback_behavior": schema.StringAttribute{
-								Required: true,
-								Validators: []validator.String{
-									stringvalidator.OneOf("MATCH", "NO_MATCH"),
-								},
-							},
+							"fallback_behavior": fallbackBehaviorAttrRequired(),
 							"header_name": schema.StringAttribute{
 								Required: true,
 							},
@@ -300,11 +293,9 @@ var byteMatchStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context) sche
 					},
 				},
 				"positional_constraint": schema.StringAttribute{
+					CustomType:  fwtypes.StringEnumType[awstypes.PositionalConstraint](),
 					Required:    true,
 					Description: "Area within the portion of a web request that you want AWS WAF to search for SearchString.",
-					Validators: []validator.String{
-						stringvalidator.OneOf("EXACTLY", "STARTS_WITH", "ENDS_WITH", "CONTAINS", "CONTAINS_WORD"),
-					},
 				},
 			},
 			Blocks: map[string]schema.Block{
@@ -965,12 +956,7 @@ var forwardedIPConfigBlock = tfsync.OnceValueCtx(func(ctx context.Context) schem
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
-				"fallback_behavior": schema.StringAttribute{
-					Required: true,
-					Validators: []validator.String{
-						stringvalidator.OneOf("MATCH", "NO_MATCH"),
-					},
-				},
+				"fallback_behavior": fallbackBehaviorAttrRequired(),
 				"header_name": schema.StringAttribute{
 					Required: true,
 				},
@@ -1178,10 +1164,8 @@ var textTransformationBlock = tfsync.OnceValueCtx(func(ctx context.Context) sche
 					Required: true,
 				},
 				names.AttrType: schema.StringAttribute{
-					Required: true,
-					Validators: []validator.String{
-						stringvalidator.OneOf("NONE", "COMPRESS_WHITE_SPACE", "HTML_ENTITY_DECODE", "LOWERCASE", "CMD_LINE", "URL_DECODE", "BASE64_DECODE", "HEX_DECODE", "MD5", "REPLACE_COMMENTS", "ESCAPE_SEQ_DECODE", "SQL_HEX_DECODE", "CSS_DECODE", "JS_DECODE", "NORMALIZE_PATH", "NORMALIZE_PATH_WIN", "REMOVE_NULLS", "REPLACE_NULLS", "BASE64_DECODE_EXT", "URL_DECODE_UNI", "UTF8_TO_UNICODE"),
-					},
+					CustomType: fwtypes.StringEnumType[awstypes.TextTransformationType](),
+					Required:   true,
 				},
 			},
 		},

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -5,7 +5,6 @@ package wafv2
 
 import (
 	"context"
-	"sync"
 
 	"github.com/YakDriver/regexache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
@@ -45,20 +44,18 @@ func nameOnlyBlock(ctx context.Context, description string) schema.ListNestedBlo
 	}
 }
 
-var jaFingerprintBlock = sync.OnceValue(func() func(context.Context) schema.ListNestedBlock {
-	return func(ctx context.Context) schema.ListNestedBlock {
-		return schema.ListNestedBlock{
-			CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleJAFingerprintModel](ctx),
-			Validators: []validator.List{listvalidator.SizeAtMost(1)},
-			NestedObject: schema.NestedBlockObject{
-				Attributes: map[string]schema.Attribute{
-					"fallback_behavior": schema.StringAttribute{
-						CustomType: fwtypes.StringEnumType[awstypes.FallbackBehavior](),
-						Required:   true,
-					},
+var jaFingerprintBlock = tfsync.OnceValueCtx(func(ctx context.Context) *schema.ListNestedBlock {
+	return &schema.ListNestedBlock{
+		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleJAFingerprintModel](ctx),
+		Validators: []validator.List{listvalidator.SizeAtMost(1)},
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"fallback_behavior": schema.StringAttribute{
+					CustomType: fwtypes.StringEnumType[awstypes.FallbackBehavior](),
+					Required:   true,
 				},
 			},
-		}
+		},
 	}
 })
 
@@ -1096,8 +1093,8 @@ func fieldToMatchBlock(ctx context.Context) schema.ListNestedBlock {
 						},
 					},
 				},
-				"ja3_fingerprint": jaFingerprintBlock()(ctx),
-				"ja4_fingerprint": jaFingerprintBlock()(ctx),
+				"ja3_fingerprint": jaFingerprintBlock(ctx),
+				"ja4_fingerprint": jaFingerprintBlock(ctx),
 				"json_body": schema.ListNestedBlock{
 					CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleJsonBodyModel](ctx),
 					Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -1226,8 +1223,8 @@ func rateBasedStatementCustomKeysBlock(ctx context.Context) schema.ListNestedBlo
 				},
 				"http_method":     emptyBlock(ctx),
 				"ip":              emptyBlock(ctx),
-				"ja3_fingerprint": jaFingerprintBlock()(ctx),
-				"ja4_fingerprint": jaFingerprintBlock()(ctx),
+				"ja3_fingerprint": jaFingerprintBlock(ctx),
+				"ja4_fingerprint": jaFingerprintBlock(ctx),
 				"label_namespace": schema.ListNestedBlock{
 					CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleRateBasedStatementCustomKeyLabelNamespaceModel](ctx),
 					Validators: []validator.List{listvalidator.SizeAtMost(1)},

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -105,7 +105,7 @@ var ipSetReferenceStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context)
 	}
 })
 
-func geoMatchStatementBlock(ctx context.Context) schema.ListNestedBlock {
+var geoMatchStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleGeoMatchStatementModel](ctx),
 		Validators: []validator.List{
@@ -142,7 +142,7 @@ func geoMatchStatementBlock(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Geo match statement.",
 	}
-}
+})
 
 func ruleGroupReferenceStatementBlock(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -20,8 +20,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-var emptyBlock = tfsync.OnceValueCtx(func(ctx context.Context) *schema.ListNestedBlock {
-	return &schema.ListNestedBlock{
+var emptyBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
+	return schema.ListNestedBlock{
 		CustomType:   fwtypes.NewListNestedObjectTypeOf[webACLRuleTrulyEmptyModel](ctx),
 		Validators:   []validator.List{listvalidator.SizeAtMost(1)},
 		NestedObject: schema.NestedBlockObject{},
@@ -44,8 +44,8 @@ func nameOnlyBlock(ctx context.Context, description string) schema.ListNestedBlo
 	}
 }
 
-var jaFingerprintBlock = tfsync.OnceValueCtx(func(ctx context.Context) *schema.ListNestedBlock {
-	return &schema.ListNestedBlock{
+var jaFingerprintBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
+	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleJAFingerprintModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
 		NestedObject: schema.NestedBlockObject{
@@ -910,7 +910,7 @@ func scopeDownStatementBlock(ctx context.Context) schema.ListNestedBlock {
 	}
 }
 
-func customRequestHandlingBlock(ctx context.Context) schema.ListNestedBlock {
+var customRequestHandlingBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleCustomRequestHandlingModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -929,7 +929,7 @@ func customRequestHandlingBlock(ctx context.Context) schema.ListNestedBlock {
 			},
 		},
 	}
-}
+})
 
 func customResponseBlock(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -187,7 +187,7 @@ var excludedRuleBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Blo
 	}
 })
 
-func managedRuleGroupStatementBlock(ctx context.Context) schema.ListNestedBlock {
+var managedRuleGroupStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleManagedRuleGroupStatementModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -224,7 +224,7 @@ func managedRuleGroupStatementBlock(ctx context.Context) schema.ListNestedBlock 
 		},
 		Description: "Managed rule group statement.",
 	}
-}
+})
 
 func regexPatternSetReferenceStatementBlock(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{
@@ -888,7 +888,7 @@ var ruleActionOverrideBlock = tfsync.OnceValueCtx(func(ctx context.Context) sche
 	}
 })
 
-func scopeDownStatementBlock(ctx context.Context) schema.ListNestedBlock {
+var scopeDownStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleScopeDownStatementModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -908,7 +908,7 @@ func scopeDownStatementBlock(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Scope down statement for managed rule groups.",
 	}
-}
+})
 
 var customRequestHandlingBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -534,7 +534,7 @@ var identifiersFieldBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema
 	}
 })
 
-func awsManagedRulesBotControlRuleSetBlock(ctx context.Context) schema.ListNestedBlock { // nosempgrep:ci.aws-in-func-name
+var awsManagedRulesBotControlRuleSetBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block { // nosempgrep:ci.aws-in-func-name
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleAWSManagedRulesBotControlRuleSetModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -551,9 +551,9 @@ func awsManagedRulesBotControlRuleSetBlock(ctx context.Context) schema.ListNeste
 			},
 		},
 	}
-}
+})
 
-func awsManagedRulesACFPRuleSetBlock(ctx context.Context) schema.ListNestedBlock { // nosempgrep:ci.aws-in-func-name
+var awsManagedRulesACFPRuleSetBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block { // nosempgrep:ci.aws-in-func-name
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleAWSManagedRulesACFPRuleSetModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -582,9 +582,9 @@ func awsManagedRulesACFPRuleSetBlock(ctx context.Context) schema.ListNestedBlock
 			},
 		},
 	}
-}
+})
 
-func awsManagedRulesATPRuleSetBlock(ctx context.Context) schema.ListNestedBlock { // nosempgrep:ci.aws-in-func-name
+var awsManagedRulesATPRuleSetBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block { // nosempgrep:ci.aws-in-func-name
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleAWSManagedRulesATPRuleSetModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -607,9 +607,9 @@ func awsManagedRulesATPRuleSetBlock(ctx context.Context) schema.ListNestedBlock 
 			},
 		},
 	}
-}
+})
 
-func awsManagedRulesAntiDDoSRuleSetBlock(ctx context.Context) schema.ListNestedBlock { // nosempgrep:ci.aws-in-func-name
+var awsManagedRulesAntiDDoSRuleSetBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block { // nosempgrep:ci.aws-in-func-name
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleAWSManagedRulesAntiDDoSRuleSetModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -626,9 +626,9 @@ func awsManagedRulesAntiDDoSRuleSetBlock(ctx context.Context) schema.ListNestedB
 			},
 		},
 	}
-}
+})
 
-func clientSideActionConfigBlock(ctx context.Context) schema.ListNestedBlock {
+var clientSideActionConfigBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleClientSideActionConfigModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -638,9 +638,9 @@ func clientSideActionConfigBlock(ctx context.Context) schema.ListNestedBlock {
 			},
 		},
 	}
-}
+})
 
-func clientSideActionBlock(ctx context.Context) schema.ListNestedBlock {
+var clientSideActionBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleClientSideActionModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -674,7 +674,7 @@ func clientSideActionBlock(ctx context.Context) schema.ListNestedBlock {
 			},
 		},
 	}
-}
+})
 
 var requestInspectionBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -931,7 +931,7 @@ var customRequestHandlingBlock = tfsync.OnceValueCtx(func(ctx context.Context) s
 	}
 })
 
-func customResponseBlock(ctx context.Context) schema.ListNestedBlock {
+var customResponseBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleCustomResponseModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -957,7 +957,8 @@ func customResponseBlock(ctx context.Context) schema.ListNestedBlock {
 			},
 		},
 	}
-}
+})
+
 func forwardedIPConfigBlock(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleForwardedIPConfigModel](ctx),

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -483,7 +483,7 @@ func managedRuleGroupConfigsBlock(ctx context.Context) schema.ListNestedBlock {
 	}
 }
 
-func identifierFieldBlock(ctx context.Context) schema.ListNestedBlock {
+var identifierFieldBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleIdentifierFieldModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -498,7 +498,7 @@ func identifierFieldBlock(ctx context.Context) schema.ListNestedBlock {
 			},
 		},
 	}
-}
+})
 
 func identifierFieldBlockDeprecated(ctx context.Context, deprecationMessage string) schema.ListNestedBlock {
 	return schema.ListNestedBlock{
@@ -518,7 +518,7 @@ func identifierFieldBlockDeprecated(ctx context.Context, deprecationMessage stri
 	}
 }
 
-func identifiersFieldBlock(ctx context.Context) schema.ListNestedBlock {
+var identifiersFieldBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleIdentifiersFieldModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -532,7 +532,7 @@ func identifiersFieldBlock(ctx context.Context) schema.ListNestedBlock {
 			},
 		},
 	}
-}
+})
 
 func awsManagedRulesBotControlRuleSetBlock(ctx context.Context) schema.ListNestedBlock { // nosempgrep:ci.aws-in-func-name
 	return schema.ListNestedBlock{
@@ -676,7 +676,7 @@ func clientSideActionBlock(ctx context.Context) schema.ListNestedBlock {
 	}
 }
 
-func requestInspectionBlock(ctx context.Context) schema.ListNestedBlock {
+var requestInspectionBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleRequestInspectionModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -693,9 +693,9 @@ func requestInspectionBlock(ctx context.Context) schema.ListNestedBlock {
 			},
 		},
 	}
-}
+})
 
-func requestInspectionACFPBlock(ctx context.Context) schema.ListNestedBlock {
+var requestInspectionACFPBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleRequestInspectionACFPModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -715,7 +715,7 @@ func requestInspectionACFPBlock(ctx context.Context) schema.ListNestedBlock {
 			},
 		},
 	}
-}
+})
 
 var responseInspectionBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -144,7 +144,7 @@ var geoMatchStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context) schem
 	}
 })
 
-func ruleGroupReferenceStatementBlock(ctx context.Context) schema.ListNestedBlock {
+var ruleGroupReferenceStatementBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleRuleGroupReferenceStatementModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -165,9 +165,9 @@ func ruleGroupReferenceStatementBlock(ctx context.Context) schema.ListNestedBloc
 		},
 		Description: "Rule statement used to run the rules that are defined in a RuleGroup.",
 	}
-}
+})
 
-func excludedRuleBlock(ctx context.Context) schema.ListNestedBlock {
+var excludedRuleBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleExcludedRuleModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(100)},
@@ -185,7 +185,7 @@ func excludedRuleBlock(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Rules in the referenced rule group whose actions are set to Count. Deprecated: use rule_action_override instead.",
 	}
-}
+})
 
 func managedRuleGroupStatementBlock(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{
@@ -812,7 +812,7 @@ func responseInspectionBlock(ctx context.Context) schema.ListNestedBlock {
 	}
 }
 
-func ruleActionOverrideBlock(ctx context.Context) schema.ListNestedBlock {
+var ruleActionOverrideBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleRuleActionOverrideModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(100)},
@@ -886,7 +886,7 @@ func ruleActionOverrideBlock(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Action settings to use in place of rule actions configured inside the rule group.",
 	}
-}
+})
 
 func scopeDownStatementBlock(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -959,7 +959,7 @@ var customResponseBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.B
 	}
 })
 
-func forwardedIPConfigBlock(ctx context.Context) schema.ListNestedBlock {
+var forwardedIPConfigBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleForwardedIPConfigModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -977,7 +977,8 @@ func forwardedIPConfigBlock(ctx context.Context) schema.ListNestedBlock {
 			},
 		},
 	}
-}
+})
+
 func fieldToMatchBlock(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleFieldToMatchModel](ctx),

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -979,7 +979,7 @@ var forwardedIPConfigBlock = tfsync.OnceValueCtx(func(ctx context.Context) schem
 	}
 })
 
-func fieldToMatchBlock(ctx context.Context) schema.ListNestedBlock {
+var fieldToMatchBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleFieldToMatchModel](ctx),
 		Validators: []validator.List{
@@ -1163,7 +1163,7 @@ func fieldToMatchBlock(ctx context.Context) schema.ListNestedBlock {
 			},
 		},
 	}
-}
+})
 
 func textTransformationBlock(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{
@@ -1187,6 +1187,7 @@ func textTransformationBlock(ctx context.Context) schema.ListNestedBlock {
 		},
 	}
 }
+
 func rateBasedStatementCustomKeysBlock(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleRateBasedStatementCustomKeyModel](ctx),

--- a/internal/service/wafv2/web_acl_rule_blocks.go
+++ b/internal/service/wafv2/web_acl_rule_blocks.go
@@ -1188,7 +1188,7 @@ func textTransformationBlock(ctx context.Context) schema.ListNestedBlock {
 	}
 }
 
-func rateBasedStatementCustomKeysBlock(ctx context.Context) schema.ListNestedBlock {
+var rateBasedStatementCustomKeysBlock = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleRateBasedStatementCustomKeyModel](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(5)},
@@ -1274,6 +1274,6 @@ func rateBasedStatementCustomKeysBlock(ctx context.Context) schema.ListNestedBlo
 			},
 		},
 	}
-}
+})
 
 // andStatementBlock and related functions are generated in web_acl_rule_statement_models_gen.go

--- a/internal/service/wafv2/web_acl_rule_statement_models.gtpl
+++ b/internal/service/wafv2/web_acl_rule_statement_models.gtpl
@@ -179,7 +179,7 @@ var statementBlockLevel{{minus .}}NoMinMax = tfsync.OnceValueCtx(func(ctx contex
 })
 
 // statementBlockLevel{{minus .}}Single is for NOT statement that needs exactly one nested statement.
-func statementBlockLevel{{minus .}}Single(ctx context.Context) schema.ListNestedBlock {
+var statementBlockLevel{{minus .}}Single = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	blocks := map[string]schema.Block{
 		"asn_match_statement":                   asnMatchStatementBlock(ctx),
 		"byte_match_statement":                  byteMatchStatementBlock(ctx),
@@ -212,7 +212,7 @@ func statementBlockLevel{{minus .}}Single(ctx context.Context) schema.ListNested
 		},
 		Description: "Nested statement for NOT operation.",
 	}
-}
+})
 {{- end}}
 {{end}}
 

--- a/internal/service/wafv2/web_acl_rule_statement_models.gtpl
+++ b/internal/service/wafv2/web_acl_rule_statement_models.gtpl
@@ -117,7 +117,7 @@ var andStatementBlockLevel{{minus .}} = tfsync.OnceValueCtx(func(ctx context.Con
 	}
 })
 
-func notStatementBlockLevel{{minus .}}(ctx context.Context) schema.ListNestedBlock {
+var notStatementBlockLevel{{minus .}} = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleNotStatementLevel{{minus .}}Model](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -128,7 +128,7 @@ func notStatementBlockLevel{{minus .}}(ctx context.Context) schema.ListNestedBlo
 		},
 		Description: "Logical NOT statement.",
 	}
-}
+})
 
 func orStatementBlockLevel{{minus .}}(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{

--- a/internal/service/wafv2/web_acl_rule_statement_models.gtpl
+++ b/internal/service/wafv2/web_acl_rule_statement_models.gtpl
@@ -130,7 +130,7 @@ var notStatementBlockLevel{{minus .}} = tfsync.OnceValueCtx(func(ctx context.Con
 	}
 })
 
-func orStatementBlockLevel{{minus .}}(ctx context.Context) schema.ListNestedBlock {
+var orStatementBlockLevel{{minus .}} = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleOrStatementLevel{{minus .}}Model](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -141,7 +141,7 @@ func orStatementBlockLevel{{minus .}}(ctx context.Context) schema.ListNestedBloc
 		},
 		Description: "Logical OR statement.",
 	}
-}
+})
 
 // statementBlockLevel{{minus .}}NoMinMax is for AND/OR statements that need multiple nested statements.
 func statementBlockLevel{{minus .}}NoMinMax(ctx context.Context) schema.ListNestedBlock {

--- a/internal/service/wafv2/web_acl_rule_statement_models.gtpl
+++ b/internal/service/wafv2/web_acl_rule_statement_models.gtpl
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/sync"
 )
 
 // StatementModelMaxLevel is the maximum nesting depth for logical statements.
@@ -103,7 +104,7 @@ func statementBlockLevel{{.}}(ctx context.Context) schema.ListNestedBlock {
 
 {{- if gt . 0}}
 
-func andStatementBlockLevel{{minus .}}(ctx context.Context) schema.ListNestedBlock {
+var andStatementBlockLevel{{minus .}} = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleAndStatementLevel{{minus .}}Model](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -114,7 +115,7 @@ func andStatementBlockLevel{{minus .}}(ctx context.Context) schema.ListNestedBlo
 		},
 		Description: "Logical AND statement.",
 	}
-}
+})
 
 func notStatementBlockLevel{{minus .}}(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{

--- a/internal/service/wafv2/web_acl_rule_statement_models.gtpl
+++ b/internal/service/wafv2/web_acl_rule_statement_models.gtpl
@@ -82,12 +82,12 @@ func statementBlockLevel{{.}}(ctx context.Context) schema.ListNestedBlock {
 		"size_constraint_statement":             sizeConstraintStatementBlock(ctx),
 		"sqli_match_statement":                  sqliMatchStatementBlock(ctx),
 		"xss_match_statement":                   xssMatchStatementBlock(ctx),
-	}
 {{- if gt . 0}}
-	blocks["and_statement"] = andStatementBlockLevel{{minus .}}(ctx)
-	blocks["not_statement"] = notStatementBlockLevel{{minus .}}(ctx)
-	blocks["or_statement"] = orStatementBlockLevel{{minus .}}(ctx)
+		"and_statement":                         andStatementBlockLevel{{minus .}}(ctx),
+		"not_statement":                         notStatementBlockLevel{{minus .}}(ctx),
+		"or_statement":                          orStatementBlockLevel{{minus .}}(ctx),
 {{- end}}
+	}
 
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleStatementLevel{{.}}Model](ctx),
@@ -159,12 +159,12 @@ var statementBlockLevel{{minus .}}NoMinMax = tfsync.OnceValueCtx(func(ctx contex
 		"size_constraint_statement":             sizeConstraintStatementBlock(ctx),
 		"sqli_match_statement":                  sqliMatchStatementBlock(ctx),
 		"xss_match_statement":                   xssMatchStatementBlock(ctx),
-	}
 {{- if gt (minus .) 0}}
-	blocks["and_statement"] = andStatementBlockLevel{{minus (minus .)}}(ctx)
-	blocks["not_statement"] = notStatementBlockLevel{{minus (minus .)}}(ctx)
-	blocks["or_statement"] = orStatementBlockLevel{{minus (minus .)}}(ctx)
+		"and_statement":                         andStatementBlockLevel{{minus (minus .)}}(ctx),
+		"not_statement":                         notStatementBlockLevel{{minus (minus .)}}(ctx),
+		"or_statement":                          orStatementBlockLevel{{minus (minus .)}}(ctx),
 {{- end}}
+	}
 
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleStatementLevel{{minus .}}Model](ctx),
@@ -194,12 +194,12 @@ var statementBlockLevel{{minus .}}Single = tfsync.OnceValueCtx(func(ctx context.
 		"size_constraint_statement":             sizeConstraintStatementBlock(ctx),
 		"sqli_match_statement":                  sqliMatchStatementBlock(ctx),
 		"xss_match_statement":                   xssMatchStatementBlock(ctx),
-	}
 {{- if gt (minus .) 0}}
-	blocks["and_statement"] = andStatementBlockLevel{{minus (minus .)}}(ctx)
-	blocks["not_statement"] = notStatementBlockLevel{{minus (minus .)}}(ctx)
-	blocks["or_statement"] = orStatementBlockLevel{{minus (minus .)}}(ctx)
+		"and_statement":                         andStatementBlockLevel{{minus (minus .)}}(ctx),
+		"not_statement":                         notStatementBlockLevel{{minus (minus .)}}(ctx),
+		"or_statement":                          orStatementBlockLevel{{minus (minus .)}}(ctx),
 {{- end}}
+	}
 
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleStatementLevel{{minus .}}Model](ctx),

--- a/internal/service/wafv2/web_acl_rule_statement_models.gtpl
+++ b/internal/service/wafv2/web_acl_rule_statement_models.gtpl
@@ -144,7 +144,7 @@ var orStatementBlockLevel{{minus .}} = tfsync.OnceValueCtx(func(ctx context.Cont
 })
 
 // statementBlockLevel{{minus .}}NoMinMax is for AND/OR statements that need multiple nested statements.
-func statementBlockLevel{{minus .}}NoMinMax(ctx context.Context) schema.ListNestedBlock {
+var statementBlockLevel{{minus .}}NoMinMax = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	blocks := map[string]schema.Block{
 		"asn_match_statement":                   asnMatchStatementBlock(ctx),
 		"byte_match_statement":                  byteMatchStatementBlock(ctx),
@@ -176,7 +176,7 @@ func statementBlockLevel{{minus .}}NoMinMax(ctx context.Context) schema.ListNest
 		},
 		Description: "Nested statements for logical operations.",
 	}
-}
+})
 
 // statementBlockLevel{{minus .}}Single is for NOT statement that needs exactly one nested statement.
 func statementBlockLevel{{minus .}}Single(ctx context.Context) schema.ListNestedBlock {

--- a/internal/service/wafv2/web_acl_rule_statement_models_gen.go
+++ b/internal/service/wafv2/web_acl_rule_statement_models_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/sync"
 )
 
 // StatementModelMaxLevel is the maximum nesting depth for logical statements.
@@ -209,7 +210,7 @@ func statementBlockLevel1(ctx context.Context) schema.ListNestedBlock {
 	}
 }
 
-func andStatementBlockLevel0(ctx context.Context) schema.ListNestedBlock {
+var andStatementBlockLevel0 = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleAndStatementLevel0Model](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -220,7 +221,7 @@ func andStatementBlockLevel0(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Logical AND statement.",
 	}
-}
+})
 
 func notStatementBlockLevel0(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{
@@ -342,7 +343,7 @@ func statementBlockLevel2(ctx context.Context) schema.ListNestedBlock {
 	}
 }
 
-func andStatementBlockLevel1(ctx context.Context) schema.ListNestedBlock {
+var andStatementBlockLevel1 = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleAndStatementLevel1Model](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -353,7 +354,7 @@ func andStatementBlockLevel1(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Logical AND statement.",
 	}
-}
+})
 
 func notStatementBlockLevel1(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{
@@ -481,7 +482,7 @@ func statementBlockLevel3(ctx context.Context) schema.ListNestedBlock {
 	}
 }
 
-func andStatementBlockLevel2(ctx context.Context) schema.ListNestedBlock {
+var andStatementBlockLevel2 = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleAndStatementLevel2Model](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -492,7 +493,7 @@ func andStatementBlockLevel2(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Logical AND statement.",
 	}
-}
+})
 
 func notStatementBlockLevel2(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{

--- a/internal/service/wafv2/web_acl_rule_statement_models_gen.go
+++ b/internal/service/wafv2/web_acl_rule_statement_models_gen.go
@@ -280,7 +280,7 @@ var statementBlockLevel0NoMinMax = tfsync.OnceValueCtx(func(ctx context.Context)
 })
 
 // statementBlockLevel0Single is for NOT statement that needs exactly one nested statement.
-func statementBlockLevel0Single(ctx context.Context) schema.ListNestedBlock {
+var statementBlockLevel0Single = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	blocks := map[string]schema.Block{
 		"asn_match_statement":                   asnMatchStatementBlock(ctx),
 		"byte_match_statement":                  byteMatchStatementBlock(ctx),
@@ -308,7 +308,7 @@ func statementBlockLevel0Single(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Nested statement for NOT operation.",
 	}
-}
+})
 
 func statementBlockLevel2(ctx context.Context) schema.ListNestedBlock {
 	blocks := map[string]schema.Block{
@@ -416,7 +416,7 @@ var statementBlockLevel1NoMinMax = tfsync.OnceValueCtx(func(ctx context.Context)
 })
 
 // statementBlockLevel1Single is for NOT statement that needs exactly one nested statement.
-func statementBlockLevel1Single(ctx context.Context) schema.ListNestedBlock {
+var statementBlockLevel1Single = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	blocks := map[string]schema.Block{
 		"asn_match_statement":                   asnMatchStatementBlock(ctx),
 		"byte_match_statement":                  byteMatchStatementBlock(ctx),
@@ -447,7 +447,7 @@ func statementBlockLevel1Single(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Nested statement for NOT operation.",
 	}
-}
+})
 
 func statementBlockLevel3(ctx context.Context) schema.ListNestedBlock {
 	blocks := map[string]schema.Block{
@@ -555,7 +555,7 @@ var statementBlockLevel2NoMinMax = tfsync.OnceValueCtx(func(ctx context.Context)
 })
 
 // statementBlockLevel2Single is for NOT statement that needs exactly one nested statement.
-func statementBlockLevel2Single(ctx context.Context) schema.ListNestedBlock {
+var statementBlockLevel2Single = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	blocks := map[string]schema.Block{
 		"asn_match_statement":                   asnMatchStatementBlock(ctx),
 		"byte_match_statement":                  byteMatchStatementBlock(ctx),
@@ -586,7 +586,7 @@ func statementBlockLevel2Single(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Nested statement for NOT operation.",
 	}
-}
+})
 
 // statementBlock returns the top-level statement block schema.
 func statementBlock(ctx context.Context, level int) schema.ListNestedBlock {

--- a/internal/service/wafv2/web_acl_rule_statement_models_gen.go
+++ b/internal/service/wafv2/web_acl_rule_statement_models_gen.go
@@ -250,7 +250,7 @@ var orStatementBlockLevel0 = tfsync.OnceValueCtx(func(ctx context.Context) schem
 })
 
 // statementBlockLevel0NoMinMax is for AND/OR statements that need multiple nested statements.
-func statementBlockLevel0NoMinMax(ctx context.Context) schema.ListNestedBlock {
+var statementBlockLevel0NoMinMax = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	blocks := map[string]schema.Block{
 		"asn_match_statement":                   asnMatchStatementBlock(ctx),
 		"byte_match_statement":                  byteMatchStatementBlock(ctx),
@@ -277,7 +277,7 @@ func statementBlockLevel0NoMinMax(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Nested statements for logical operations.",
 	}
-}
+})
 
 // statementBlockLevel0Single is for NOT statement that needs exactly one nested statement.
 func statementBlockLevel0Single(ctx context.Context) schema.ListNestedBlock {
@@ -383,7 +383,7 @@ var orStatementBlockLevel1 = tfsync.OnceValueCtx(func(ctx context.Context) schem
 })
 
 // statementBlockLevel1NoMinMax is for AND/OR statements that need multiple nested statements.
-func statementBlockLevel1NoMinMax(ctx context.Context) schema.ListNestedBlock {
+var statementBlockLevel1NoMinMax = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	blocks := map[string]schema.Block{
 		"asn_match_statement":                   asnMatchStatementBlock(ctx),
 		"byte_match_statement":                  byteMatchStatementBlock(ctx),
@@ -413,7 +413,7 @@ func statementBlockLevel1NoMinMax(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Nested statements for logical operations.",
 	}
-}
+})
 
 // statementBlockLevel1Single is for NOT statement that needs exactly one nested statement.
 func statementBlockLevel1Single(ctx context.Context) schema.ListNestedBlock {
@@ -522,7 +522,7 @@ var orStatementBlockLevel2 = tfsync.OnceValueCtx(func(ctx context.Context) schem
 })
 
 // statementBlockLevel2NoMinMax is for AND/OR statements that need multiple nested statements.
-func statementBlockLevel2NoMinMax(ctx context.Context) schema.ListNestedBlock {
+var statementBlockLevel2NoMinMax = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	blocks := map[string]schema.Block{
 		"asn_match_statement":                   asnMatchStatementBlock(ctx),
 		"byte_match_statement":                  byteMatchStatementBlock(ctx),
@@ -552,7 +552,7 @@ func statementBlockLevel2NoMinMax(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Nested statements for logical operations.",
 	}
-}
+})
 
 // statementBlockLevel2Single is for NOT statement that needs exactly one nested statement.
 func statementBlockLevel2Single(ctx context.Context) schema.ListNestedBlock {

--- a/internal/service/wafv2/web_acl_rule_statement_models_gen.go
+++ b/internal/service/wafv2/web_acl_rule_statement_models_gen.go
@@ -236,7 +236,7 @@ var notStatementBlockLevel0 = tfsync.OnceValueCtx(func(ctx context.Context) sche
 	}
 })
 
-func orStatementBlockLevel0(ctx context.Context) schema.ListNestedBlock {
+var orStatementBlockLevel0 = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleOrStatementLevel0Model](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -247,7 +247,7 @@ func orStatementBlockLevel0(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Logical OR statement.",
 	}
-}
+})
 
 // statementBlockLevel0NoMinMax is for AND/OR statements that need multiple nested statements.
 func statementBlockLevel0NoMinMax(ctx context.Context) schema.ListNestedBlock {
@@ -369,7 +369,7 @@ var notStatementBlockLevel1 = tfsync.OnceValueCtx(func(ctx context.Context) sche
 	}
 })
 
-func orStatementBlockLevel1(ctx context.Context) schema.ListNestedBlock {
+var orStatementBlockLevel1 = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleOrStatementLevel1Model](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -380,7 +380,7 @@ func orStatementBlockLevel1(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Logical OR statement.",
 	}
-}
+})
 
 // statementBlockLevel1NoMinMax is for AND/OR statements that need multiple nested statements.
 func statementBlockLevel1NoMinMax(ctx context.Context) schema.ListNestedBlock {
@@ -508,7 +508,7 @@ var notStatementBlockLevel2 = tfsync.OnceValueCtx(func(ctx context.Context) sche
 	}
 })
 
-func orStatementBlockLevel2(ctx context.Context) schema.ListNestedBlock {
+var orStatementBlockLevel2 = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleOrStatementLevel2Model](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -519,7 +519,7 @@ func orStatementBlockLevel2(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Logical OR statement.",
 	}
-}
+})
 
 // statementBlockLevel2NoMinMax is for AND/OR statements that need multiple nested statements.
 func statementBlockLevel2NoMinMax(ctx context.Context) schema.ListNestedBlock {

--- a/internal/service/wafv2/web_acl_rule_statement_models_gen.go
+++ b/internal/service/wafv2/web_acl_rule_statement_models_gen.go
@@ -192,10 +192,10 @@ func statementBlockLevel1(ctx context.Context) schema.ListNestedBlock {
 		"size_constraint_statement":             sizeConstraintStatementBlock(ctx),
 		"sqli_match_statement":                  sqliMatchStatementBlock(ctx),
 		"xss_match_statement":                   xssMatchStatementBlock(ctx),
+		"and_statement":                         andStatementBlockLevel0(ctx),
+		"not_statement":                         notStatementBlockLevel0(ctx),
+		"or_statement":                          orStatementBlockLevel0(ctx),
 	}
-	blocks["and_statement"] = andStatementBlockLevel0(ctx)
-	blocks["not_statement"] = notStatementBlockLevel0(ctx)
-	blocks["or_statement"] = orStatementBlockLevel0(ctx)
 
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleStatementLevel1Model](ctx),
@@ -325,10 +325,10 @@ func statementBlockLevel2(ctx context.Context) schema.ListNestedBlock {
 		"size_constraint_statement":             sizeConstraintStatementBlock(ctx),
 		"sqli_match_statement":                  sqliMatchStatementBlock(ctx),
 		"xss_match_statement":                   xssMatchStatementBlock(ctx),
+		"and_statement":                         andStatementBlockLevel1(ctx),
+		"not_statement":                         notStatementBlockLevel1(ctx),
+		"or_statement":                          orStatementBlockLevel1(ctx),
 	}
-	blocks["and_statement"] = andStatementBlockLevel1(ctx)
-	blocks["not_statement"] = notStatementBlockLevel1(ctx)
-	blocks["or_statement"] = orStatementBlockLevel1(ctx)
 
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleStatementLevel2Model](ctx),
@@ -398,10 +398,10 @@ var statementBlockLevel1NoMinMax = tfsync.OnceValueCtx(func(ctx context.Context)
 		"size_constraint_statement":             sizeConstraintStatementBlock(ctx),
 		"sqli_match_statement":                  sqliMatchStatementBlock(ctx),
 		"xss_match_statement":                   xssMatchStatementBlock(ctx),
+		"and_statement":                         andStatementBlockLevel0(ctx),
+		"not_statement":                         notStatementBlockLevel0(ctx),
+		"or_statement":                          orStatementBlockLevel0(ctx),
 	}
-	blocks["and_statement"] = andStatementBlockLevel0(ctx)
-	blocks["not_statement"] = notStatementBlockLevel0(ctx)
-	blocks["or_statement"] = orStatementBlockLevel0(ctx)
 
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleStatementLevel1Model](ctx),
@@ -431,10 +431,10 @@ var statementBlockLevel1Single = tfsync.OnceValueCtx(func(ctx context.Context) s
 		"size_constraint_statement":             sizeConstraintStatementBlock(ctx),
 		"sqli_match_statement":                  sqliMatchStatementBlock(ctx),
 		"xss_match_statement":                   xssMatchStatementBlock(ctx),
+		"and_statement":                         andStatementBlockLevel0(ctx),
+		"not_statement":                         notStatementBlockLevel0(ctx),
+		"or_statement":                          orStatementBlockLevel0(ctx),
 	}
-	blocks["and_statement"] = andStatementBlockLevel0(ctx)
-	blocks["not_statement"] = notStatementBlockLevel0(ctx)
-	blocks["or_statement"] = orStatementBlockLevel0(ctx)
 
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleStatementLevel1Model](ctx),
@@ -464,10 +464,10 @@ func statementBlockLevel3(ctx context.Context) schema.ListNestedBlock {
 		"size_constraint_statement":             sizeConstraintStatementBlock(ctx),
 		"sqli_match_statement":                  sqliMatchStatementBlock(ctx),
 		"xss_match_statement":                   xssMatchStatementBlock(ctx),
+		"and_statement":                         andStatementBlockLevel2(ctx),
+		"not_statement":                         notStatementBlockLevel2(ctx),
+		"or_statement":                          orStatementBlockLevel2(ctx),
 	}
-	blocks["and_statement"] = andStatementBlockLevel2(ctx)
-	blocks["not_statement"] = notStatementBlockLevel2(ctx)
-	blocks["or_statement"] = orStatementBlockLevel2(ctx)
 
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleStatementLevel3Model](ctx),
@@ -537,10 +537,10 @@ var statementBlockLevel2NoMinMax = tfsync.OnceValueCtx(func(ctx context.Context)
 		"size_constraint_statement":             sizeConstraintStatementBlock(ctx),
 		"sqli_match_statement":                  sqliMatchStatementBlock(ctx),
 		"xss_match_statement":                   xssMatchStatementBlock(ctx),
+		"and_statement":                         andStatementBlockLevel1(ctx),
+		"not_statement":                         notStatementBlockLevel1(ctx),
+		"or_statement":                          orStatementBlockLevel1(ctx),
 	}
-	blocks["and_statement"] = andStatementBlockLevel1(ctx)
-	blocks["not_statement"] = notStatementBlockLevel1(ctx)
-	blocks["or_statement"] = orStatementBlockLevel1(ctx)
 
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleStatementLevel2Model](ctx),
@@ -570,10 +570,10 @@ var statementBlockLevel2Single = tfsync.OnceValueCtx(func(ctx context.Context) s
 		"size_constraint_statement":             sizeConstraintStatementBlock(ctx),
 		"sqli_match_statement":                  sqliMatchStatementBlock(ctx),
 		"xss_match_statement":                   xssMatchStatementBlock(ctx),
+		"and_statement":                         andStatementBlockLevel1(ctx),
+		"not_statement":                         notStatementBlockLevel1(ctx),
+		"or_statement":                          orStatementBlockLevel1(ctx),
 	}
-	blocks["and_statement"] = andStatementBlockLevel1(ctx)
-	blocks["not_statement"] = notStatementBlockLevel1(ctx)
-	blocks["or_statement"] = orStatementBlockLevel1(ctx)
 
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleStatementLevel2Model](ctx),

--- a/internal/service/wafv2/web_acl_rule_statement_models_gen.go
+++ b/internal/service/wafv2/web_acl_rule_statement_models_gen.go
@@ -223,7 +223,7 @@ var andStatementBlockLevel0 = tfsync.OnceValueCtx(func(ctx context.Context) sche
 	}
 })
 
-func notStatementBlockLevel0(ctx context.Context) schema.ListNestedBlock {
+var notStatementBlockLevel0 = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleNotStatementLevel0Model](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -234,7 +234,7 @@ func notStatementBlockLevel0(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Logical NOT statement.",
 	}
-}
+})
 
 func orStatementBlockLevel0(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{
@@ -356,7 +356,7 @@ var andStatementBlockLevel1 = tfsync.OnceValueCtx(func(ctx context.Context) sche
 	}
 })
 
-func notStatementBlockLevel1(ctx context.Context) schema.ListNestedBlock {
+var notStatementBlockLevel1 = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleNotStatementLevel1Model](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -367,7 +367,7 @@ func notStatementBlockLevel1(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Logical NOT statement.",
 	}
-}
+})
 
 func orStatementBlockLevel1(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{
@@ -495,7 +495,7 @@ var andStatementBlockLevel2 = tfsync.OnceValueCtx(func(ctx context.Context) sche
 	}
 })
 
-func notStatementBlockLevel2(ctx context.Context) schema.ListNestedBlock {
+var notStatementBlockLevel2 = tfsync.OnceValueCtx(func(ctx context.Context) schema.Block {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[webACLRuleNotStatementLevel2Model](ctx),
 		Validators: []validator.List{listvalidator.SizeAtMost(1)},
@@ -506,7 +506,7 @@ func notStatementBlockLevel2(ctx context.Context) schema.ListNestedBlock {
 		},
 		Description: "Logical NOT statement.",
 	}
-}
+})
 
 func orStatementBlockLevel2(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{

--- a/internal/sync/once.go
+++ b/internal/sync/once.go
@@ -1,0 +1,40 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package sync
+
+import (
+	"context"
+	"sync"
+)
+
+// Adapted from sync.OnceValue in the Go standard library
+
+func OnceValueCtx[T any](f func(context.Context) T) func(context.Context) T {
+	d := struct {
+		f      func(context.Context) T
+		once   sync.Once
+		valid  bool
+		p      any
+		result T
+	}{
+		f: f,
+	}
+	return func(ctx context.Context) T {
+		d.once.Do(func() {
+			defer func() {
+				d.f = nil // release reference to f after first call
+				d.p = recover()
+				if !d.valid {
+					panic(d.p)
+				}
+			}()
+			d.result = d.f(ctx)
+			d.valid = true
+		})
+		if !d.valid {
+			panic(d.p)
+		}
+		return d.result
+	}
+}

--- a/internal/sync/once_test.go
+++ b/internal/sync/once_test.go
@@ -13,6 +13,8 @@ import (
 // Adapted from TestOnceValue in sync/once_test.go in the Go standard library
 
 func TestOnceValueCtx(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 	calls := 0
 	of := func(_ context.Context) int {
@@ -40,6 +42,8 @@ func TestOnceValueCtx(t *testing.T) {
 }
 
 func TestOnceValueCtxPanic(t *testing.T) {
+	t.Parallel()
+
 	calls := 0
 	f := sync.OnceValueCtx(func(_ context.Context) int {
 		calls++

--- a/internal/sync/once_test.go
+++ b/internal/sync/once_test.go
@@ -1,0 +1,80 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package sync_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/sync"
+)
+
+// Adapted from TestOnceValue in sync/once_test.go in the Go standard library
+
+func TestOnceValueCtx(t *testing.T) {
+	ctx := t.Context()
+	calls := 0
+	of := func(_ context.Context) int {
+		calls++
+		return calls
+	}
+	f := sync.OnceValueCtx(of)
+	allocs := testing.AllocsPerRun(10, func() { f(ctx) })
+	value := f(ctx)
+	if calls != 1 {
+		t.Errorf("want calls==1, got %d", calls)
+	}
+	if value != 1 {
+		t.Errorf("want value==1, got %d", value)
+	}
+	if allocs != 0 {
+		t.Errorf("want 0 allocations per call to f, got %v", allocs)
+	}
+	allocs = testing.AllocsPerRun(10, func() {
+		f = sync.OnceValueCtx(of)
+	})
+	if allocs > 2 {
+		t.Errorf("want at most 2 allocations per call to OnceValue, got %v", allocs)
+	}
+}
+
+func TestOnceValueCtxPanic(t *testing.T) {
+	calls := 0
+	f := sync.OnceValueCtx(func(_ context.Context) int {
+		calls++
+		panic("x")
+	})
+	testOncePanicX(t, &calls, func() { f(t.Context()) })
+}
+
+func testOncePanicX(t *testing.T, calls *int, f func()) {
+	testOncePanicWith(t, calls, f, func(label string, p any) {
+		if p != "x" {
+			t.Fatalf("%s: want panic %v, got %v", label, "x", p)
+		}
+	})
+}
+
+func testOncePanicWith(t *testing.T, calls *int, f func(), check func(label string, p any)) {
+	// Check that the each call to f panics with the same value, but the
+	// underlying function is only called once.
+	for _, label := range []string{"first time", "second time"} {
+		var p any
+		panicked := true
+		func() {
+			defer func() {
+				p = recover()
+			}()
+			f()
+			panicked = false
+		}()
+		if !panicked {
+			t.Fatalf("%s: f did not panic", label)
+		}
+		check(label, p)
+	}
+	if *calls != 1 {
+		t.Errorf("want calls==1, got %d", *calls)
+	}
+}

--- a/internal/sync/once_test.go
+++ b/internal/sync/once_test.go
@@ -12,9 +12,7 @@ import (
 
 // Adapted from TestOnceValue in sync/once_test.go in the Go standard library
 
-func TestOnceValueCtx(t *testing.T) {
-	t.Parallel()
-
+func TestOnceValueCtx(t *testing.T) { //nolint:paralleltest // t.Parallel() cannot be used with testing.AllocsPerRun
 	ctx := t.Context()
 	calls := 0
 	of := func(_ context.Context) int {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Caches elements of the `aws_wafv2_web_acl_rule` schema.

Before the change, memory allocation for all Framework resource type schema is

```
BenchmarkFrameworkProviderResourceSchemaInitialization-10      	       3	 386733083 ns/op	420244816 B/op	 6100751 allocs/op
```

After changes in this PR

```
BenchmarkFrameworkProviderResourceSchemaInitialization-10      	       5	 243161533 ns/op	261602288 B/op	 3601241 allocs/op
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/47003.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/46682.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
