### PR TITLE
Update auto_scaling_metric valid values

### DIFF
--- a/website/docs/r/ecs_express_gateway_service.html.markdown
+++ b/website/docs/r/ecs_express_gateway_service.html.markdown
@@ -160,7 +160,7 @@ resource "aws_ecs_express_gateway_service" "example" {
 
 The `scaling_target` configuration block supports the following:
 
-* `auto_scaling_metric` - (Optional) Metric to use for auto-scaling. Valid values are `CPU` and `MEMORY`.
+* `auto_scaling_metric` - (Optional) Metric to use for auto-scaling. Valid values are `AVERAGE_CPU`, `AVERAGE_MEMORY` and `REQUEST_COUNT_PER_TARGET`.
 * `auto_scaling_target_value` - (Optional) Target value for the auto-scaling metric (as a percentage). Defaults to `60`.
 * `max_task_count` - (Optional) Maximum number of tasks to run.
 * `min_task_count` - (Optional) Minimum number of tasks to run.


### PR DESCRIPTION
I had an issue with setting up the CPU value for the `auto_scaling_metric` the given error message suggested those 3 values

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

Revert the PR, it's a documentation change only

## Changes to Security Controls

N/A

### Description
I've setup the value for `auto_scaling_metric` to be `CPU` [according to the documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_express_gateway_service#scaling_target) but it didn't work and the provided error message suggested those 3 values


### Relations

I've searched the issues, but there are no mentions of this

### References
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_express_gateway_service#scaling_target


### Output from Acceptance Testing

N/A
