### PR TITLE
resource/aws_timestreaminfluxdb_db_cluster: Add maintenance_schedule

### DIFF
--- a/.changelog/47354.txt
+++ b/.changelog/47354.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_timestreaminfluxdb_db_cluster: Add `maintenance_schedule` configuration block
+```

--- a/internal/service/timestreaminfluxdb/db_cluster.go
+++ b/internal/service/timestreaminfluxdb/db_cluster.go
@@ -360,6 +360,40 @@ func (r *dbClusterResource) Schema(ctx context.Context, req resource.SchemaReque
 					},
 				},
 			},
+			"maintenance_schedule": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[dbClusterMaintenanceScheduleData](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				Description: `Specifies the maintenance schedule for the DB cluster, including the preferred
+					maintenance window and timezone. This field is only supported for InfluxDB V3 clusters
+					(when using an InfluxDB V3 db parameter group).`,
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrPreferredMaintenanceWindow: schema.StringAttribute{
+							Required: true,
+							Validators: []validator.String{
+								stringvalidator.LengthAtMost(19),
+								stringvalidator.RegexMatches(
+									regexache.MustCompile(`^$|^(Mon|Tue|Wed|Thu|Fri|Sat|Sun):([01]\d|2[0-3]):[0-5]\d-(Mon|Tue|Wed|Thu|Fri|Sat|Sun):([01]\d|2[0-3]):[0-5]\d$`),
+									"must be in the format ddd:HH:MM-ddd:HH:MM or an empty string",
+								),
+							},
+							Description: `The preferred maintenance window in the format ddd:HH:MM-ddd:HH:MM.
+								Day must be one of Mon, Tue, Wed, Thu, Fri, Sat, or Sun. Provide an empty
+								string to let the system choose a window.`,
+						},
+						"timezone": schema.StringAttribute{
+							Required: true,
+							Validators: []validator.String{
+								stringvalidator.LengthAtLeast(1),
+							},
+							Description: `The IANA timezone identifier for the maintenance window. For
+								example, America/New_York or UTC.`,
+						},
+					},
+				},
+			},
 			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
 				Create: true,
 				Update: true,
@@ -695,6 +729,14 @@ func (r *dbClusterResource) ValidateConfig(ctx context.Context, req resource.Val
 				)
 			}
 		}
+
+		if !isNullOrUnknown(data.MaintenanceSchedule) {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("maintenance_schedule"),
+				"Invalid Configuration for InfluxDB V2",
+				"maintenance_schedule is only supported for InfluxDB V3 clusters (when using an InfluxDB V3 db parameter group)",
+			)
+		}
 	}
 }
 
@@ -858,6 +900,7 @@ type dbClusterResourceModel struct {
 	ID                            types.String                                                           `tfsdk:"id"`
 	InfluxAuthParametersSecretARN types.String                                                           `tfsdk:"influx_auth_parameters_secret_arn"`
 	LogDeliveryConfiguration      fwtypes.ListNestedObjectValueOf[dbClusterLogDeliveryConfigurationData] `tfsdk:"log_delivery_configuration"`
+	MaintenanceSchedule           fwtypes.ListNestedObjectValueOf[dbClusterMaintenanceScheduleData]      `tfsdk:"maintenance_schedule"`
 	Name                          types.String                                                           `tfsdk:"name"`
 	NetworkType                   fwtypes.StringEnum[awstypes.NetworkType]                               `tfsdk:"network_type"`
 	Organization                  types.String                                                           `tfsdk:"organization"`
@@ -875,6 +918,11 @@ type dbClusterResourceModel struct {
 
 type dbClusterLogDeliveryConfigurationData struct {
 	S3Configuration fwtypes.ListNestedObjectValueOf[dbClusterS3ConfigurationData] `tfsdk:"s3_configuration"`
+}
+
+type dbClusterMaintenanceScheduleData struct {
+	PreferredMaintenanceWindow types.String `tfsdk:"preferred_maintenance_window"`
+	Timezone                   types.String `tfsdk:"timezone"`
 }
 
 type dbClusterS3ConfigurationData struct {

--- a/internal/service/timestreaminfluxdb/db_cluster_test.go
+++ b/internal/service/timestreaminfluxdb/db_cluster_test.go
@@ -560,6 +560,66 @@ func TestAccTimestreamInfluxDBDBCluster_dbParameterGroupV3(t *testing.T) {
 	})
 }
 
+func TestAccTimestreamInfluxDBDBCluster_maintenanceSchedule(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var dbCluster1, dbCluster2 timestreaminfluxdb.GetDbClusterOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_timestreaminfluxdb_db_cluster.test"
+	preferredMaintenanceWindow1 := "Sun:02:00-Sun:06:00"
+	preferredMaintenanceWindow2 := "Mon:01:00-Mon:05:00"
+	timezone1 := "UTC"
+	timezone2 := "America/New_York"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckDBClusters(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDBClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDBClusterConfig_maintenanceScheduleV3(rName, preferredMaintenanceWindow1, timezone1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBClusterExists(ctx, t, resourceName, &dbCluster1),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_schedule.0.preferred_maintenance_window", preferredMaintenanceWindow1),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_schedule.0.timezone", timezone1),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrBucket, names.AttrUsername, names.AttrPassword, "organization", names.AttrAllocatedStorage},
+			},
+			{
+				Config: testAccDBClusterConfig_maintenanceScheduleV3(rName, preferredMaintenanceWindow2, timezone2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBClusterExists(ctx, t, resourceName, &dbCluster2),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_schedule.0.preferred_maintenance_window", preferredMaintenanceWindow2),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_schedule.0.timezone", timezone2),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrBucket, names.AttrUsername, names.AttrPassword, "organization", names.AttrAllocatedStorage},
+			},
+		},
+	})
+}
+
 func TestAccTimestreamInfluxDBDBCluster_validateConfig(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -624,6 +684,10 @@ func TestAccTimestreamInfluxDBDBCluster_validateConfig(t *testing.T) {
 			{
 				Config:      testAccDBClusterConfig_v3WithUsername(rName),
 				ExpectError: regexache.MustCompile(`(?s)username must not be set when using an InfluxDB V3 db parameter.*group`),
+			},
+			{
+				Config:      testAccDBClusterConfig_maintenanceScheduleV2(rName, "Sun:02:00-Sun:06:00", "UTC"),
+				ExpectError: regexache.MustCompile(`(?s)maintenance_schedule is only supported for InfluxDB V3 clusters`),
 			},
 		},
 	})
@@ -1000,6 +1064,52 @@ resource "aws_timestreaminfluxdb_db_cluster" "test" {
   ]
 }
 `, rName))
+}
+
+func testAccDBClusterConfig_maintenanceScheduleV2(rName, preferredMaintenanceWindow, timezone string) string {
+	return acctest.ConfigCompose(testAccDBClusterConfig_base(rName, 2), fmt.Sprintf(`
+resource "aws_timestreaminfluxdb_db_cluster" "test" {
+  name                   = %[1]q
+  allocated_storage      = 20
+  username               = "admin"
+  password               = "testpassword"
+  vpc_subnet_ids         = aws_subnet.test[*].id
+  vpc_security_group_ids = [aws_security_group.test.id]
+  db_instance_type       = "db.influx.medium"
+  bucket                 = "initial"
+  organization           = "organization"
+
+  maintenance_schedule {
+    preferred_maintenance_window = %[2]q
+    timezone                     = %[3]q
+  }
+}
+`, rName, preferredMaintenanceWindow, timezone))
+}
+
+func testAccDBClusterConfig_maintenanceScheduleV3(rName, preferredMaintenanceWindow, timezone string) string {
+	return acctest.ConfigCompose(
+		testAccDBClusterConfig_base(rName, 2),
+		testAccDBClusterConfig_v3Base(rName),
+		fmt.Sprintf(`
+resource "aws_timestreaminfluxdb_db_cluster" "test" {
+  name                          = %[1]q
+  vpc_subnet_ids                = aws_subnet.test[*].id
+  vpc_security_group_ids        = [aws_security_group.test.id]
+  db_instance_type              = "db.influx.medium"
+  db_parameter_group_identifier = "InfluxDBV3Core"
+
+  maintenance_schedule {
+    preferred_maintenance_window = %[2]q
+    timezone                     = %[3]q
+  }
+
+  depends_on = [
+    aws_vpc_endpoint_route_table_association.test,
+    aws_security_group_rule.test,
+  ]
+}
+`, rName, preferredMaintenanceWindow, timezone))
 }
 
 func testAccDBClusterConfig_v2MissingAllocatedStorage(rName string) string {

--- a/website/docs/r/timestreaminfluxdb_db_cluster.html.markdown
+++ b/website/docs/r/timestreaminfluxdb_db_cluster.html.markdown
@@ -190,7 +190,7 @@ resource "aws_timestreaminfluxdb_db_cluster" "example" {
 
 ### Usage with InfluxDB V3
 
-For InfluxDB V3 clusters, you can create a cluster without providing `allocated_storage`, `bucket`, `organization`, `username`, `password`, or `deployment_type` by specifying a `db_parameter_group_identifier` such as `"InfluxDBV3Core"`. The following example shows how to create an InfluxDB V3 cluster:
+For InfluxDB V3 clusters, you can create a cluster without providing `allocated_storage`, `bucket`, `organization`, `username`, `password`, or `deployment_type` by specifying a `db_parameter_group_identifier` such as `"InfluxDBV3Core"`. You can also optionally configure a maintenance schedule.
 
 ```terraform
 resource "aws_timestreaminfluxdb_db_cluster" "example" {
@@ -199,6 +199,11 @@ resource "aws_timestreaminfluxdb_db_cluster" "example" {
   db_parameter_group_identifier = "InfluxDBV3Core"
   vpc_subnet_ids                = [aws_subnet.example_1.id, aws_subnet.example_2.id]
   vpc_security_group_ids        = [aws_security_group.example.id]
+
+  maintenance_schedule {
+    preferred_maintenance_window = "Sun:02:00-Sun:06:00"
+    timezone                     = "America/New_York"
+  }
 }
 ```
 
@@ -246,6 +251,7 @@ The following arguments are optional:
 * `deployment_type` - (Default `"MULTI_NODE_READ_REPLICAS"` for InfluxDB V2 clusters) Specifies the type of cluster to create. Valid options are: `"MULTI_NODE_READ_REPLICAS"`. This field is forbidden for InfluxDB V3 clusters (when using an InfluxDB V3 db parameter group).
 * `failover_mode` - (Default `"AUTOMATIC"`) Specifies the behavior of failure recovery when the primary node of the cluster fails. Valid options are: `"AUTOMATIC"` and `"NO_FAILOVER"`.
 * `log_delivery_configuration` - (Optional) Configuration for sending InfluxDB engine logs to a specified S3 bucket. This argument is updatable.
+* `maintenance_schedule` - (Optional) Maintenance schedule for the DB cluster, including the preferred maintenance window and timezone. This argument is updatable. This field is only supported for InfluxDB V3 clusters (when using an InfluxDB V3 db parameter group).
 * `network_type` - (Optional) Specifies whether the network type of the Timestream for InfluxDB cluster is IPV4, which can communicate over IPv4 protocol only, or DUAL, which can communicate over both IPv4 and IPv6 protocols.
 * `organization` - (Optional) Name of the initial organization for the initial admin user in InfluxDB. An InfluxDB organization is a workspace for a group of users. Along with `bucket`, `username`, and `password`, this argument will be stored in the secret referred to by the `influx_auth_parameters_secret_arn` attribute. This field is forbidden for InfluxDB V3 clusters (when using an InfluxDB V3 db parameter group).
 * `password` - (Optional) Password of the initial admin user created in InfluxDB. This password will allow you to access the InfluxDB UI to perform various administrative tasks and also use the InfluxDB CLI to create an operator token. Along with `bucket`, `username`, and `organization`, this argument will be stored in the secret referred to by the `influx_auth_parameters_secret_arn` attribute. This field is forbidden for InfluxDB V3 clusters (when using an InfluxDB V3 db parameter group) as the AWS API rejects it.
@@ -261,12 +267,17 @@ The following arguments are optional:
 
 * `s3_configuration` - (Required) Configuration for S3 bucket log delivery.
 
+#### `maintenance_schedule`
+
+* `preferred_maintenance_window` - (Required) Preferred maintenance window in the format `ddd:HH:MM-ddd:HH:MM`. Day must be one of `Mon`, `Tue`, `Wed`, `Thu`, `Fri`, `Sat`, or `Sun`. Provide an empty string to let the system choose a window.
+* `timezone` - (Required) IANA timezone identifier for the maintenance window. For example, `America/New_York` or `UTC`.
+
 #### `s3_configuration`
 
 * `bucket_name` - (Required) Name of the S3 bucket to deliver logs to.
 * `enabled` - (Required) Indicates whether log delivery to the S3 bucket is enabled.
 
-**Note**: The following arguments do updates in-place: `db_parameter_group_identifier`, `log_delivery_configuration`, `port`, `db_instance_type`, `failover_mode`, and `tags`. Changes to any other argument after a cluster has been deployed will cause destruction and re-creation of the cluster. Additionally, when `db_parameter_group_identifier` is added to a cluster or modified, the cluster will be updated in-place but if `db_parameter_group_identifier` is removed from a cluster, the cluster will be destroyed and re-created.
+**Note**: The following arguments do updates in-place: `db_parameter_group_identifier`, `log_delivery_configuration`, `maintenance_schedule`, `port`, `db_instance_type`, `failover_mode`, and `tags`. Changes to any other argument after a cluster has been deployed will cause destruction and re-creation of the cluster. Additionally, when `db_parameter_group_identifier` is added to a cluster or modified, the cluster will be updated in-place but if `db_parameter_group_identifier` is removed from a cluster, the cluster will be destroyed and re-created.
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Add `maintenance_schedule` support to `aws_timestreaminfluxdb_db_cluster`.

This adds support for:
- `preferred_maintenance_window`
- `timezone`

The block is restricted to InfluxDB V3 clusters. The PR also adds acceptance coverage for create, update, and import, and updates the resource documentation.

### Relations

Closes #47431

### References

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/timestreaminfluxdb_db_cluster
- https://docs.aws.amazon.com/timestream/latest/developerguide/influxdb3-maintenance-windows.html
- https://docs.aws.amazon.com/cli/latest/reference/timestream-influxdb/update-db-cluster.html

### Output from Acceptance Testing

```console
% TF_ACC=1 GOCACHE=/tmp/gocache GOTMPDIR=$PWD/.gotmp go1.25.8 test ./internal/service/timestreaminfluxdb -v -count=1 -parallel=1 -p=1 -run "^TestAccTimestreamInfluxDBDBCluster_maintenanceSchedule$" -timeout=360m -vet=off

--- PASS: TestAccTimestreamInfluxDBDBCluster_maintenanceSchedule (896.26s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/timestreaminfluxdb  902.803s
```