### PR TITLE
Add tests, clean up s3files standalone test config

### DIFF
--- a/internal/service/s3files/access_point_list_test.go
+++ b/internal/service/s3files/access_point_list_test.go
@@ -6,12 +6,16 @@ package s3files_test
 import (
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/querycheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
 	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
 	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
 	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
@@ -112,6 +116,65 @@ func TestAccS3FilesAccessPoint_List_regionOverride(t *testing.T) {
 
 					tfquerycheck.ExpectIdentityFunc("aws_s3files_access_point.test", identity2.Checks()),
 					tfquerycheck.ExpectNoResourceObject("aws_s3files_access_point.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccS3FilesAccessPoint_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_s3files_access_point.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3FilesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAccessPointDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/AccessPoint/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					"resource_count":       config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{acctest.CtKey1: config.StringVariable(acctest.CtValue1)}),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity.GetIdentity(resourceName),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/AccessPoint/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					"resource_count":       config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{acctest.CtKey1: config.StringVariable(acctest.CtValue1)}),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_s3files_access_point.test", identity.Checks()),
+					querycheck.ExpectResourceKnownValues("aws_s3files_access_point.test", tfqueryfilter.ByResourceIdentityFunc(identity.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNRegexp("s3files", regexache.MustCompile(`file-system/.+/access-point/.+`))),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrFileSystemID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrOwnerID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrStatus), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("posix_user"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTagsAll), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+					}),
 				},
 			},
 		},

--- a/internal/service/s3files/file_system_list_test.go
+++ b/internal/service/s3files/file_system_list_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
 	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
 	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
 	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
@@ -123,6 +124,63 @@ func TestAccS3FilesFileSystem_List_regionOverride(t *testing.T) {
 
 					tfquerycheck.ExpectIdentityFunc("aws_s3files_file_system.test", identity2.Checks()),
 					tfquerycheck.ExpectNoResourceObject("aws_s3files_file_system.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccS3FilesFileSystem_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_s3files_file_system.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3FilesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFileSystemDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/FileSystem/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					"resource_count":       config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{acctest.CtKey1: config.StringVariable(acctest.CtValue1)}),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity.GetIdentity(resourceName),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/FileSystem/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					"resource_count":       config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{acctest.CtKey1: config.StringVariable(acctest.CtValue1)}),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_s3files_file_system.test", identity.Checks()),
+					querycheck.ExpectResourceKnownValues("aws_s3files_file_system.test", tfqueryfilter.ByResourceIdentityFunc(identity.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNRegexp("s3files", regexache.MustCompile(`file-system/.+`))),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrOwnerID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrStatus), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTagsAll), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+					}),
 				},
 			},
 		},

--- a/internal/service/s3files/file_system_policy_list_test.go
+++ b/internal/service/s3files/file_system_policy_list_test.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/querycheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
@@ -100,6 +102,53 @@ func TestAccS3FilesFileSystemPolicy_List_regionOverride(t *testing.T) {
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					tfquerycheck.ExpectIdentityFunc("aws_s3files_file_system_policy.test", identity.Checks()),
 					tfquerycheck.ExpectNoResourceObject("aws_s3files_file_system_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccS3FilesFileSystemPolicy_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_s3files_file_system_policy.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3FilesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFileSystemPolicyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/FileSystemPolicy/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity.GetIdentity(resourceName),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/FileSystemPolicy/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_s3files_file_system_policy.test", identity.Checks()),
+					querycheck.ExpectResourceKnownValues("aws_s3files_file_system_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrFileSystemID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrPolicy), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+					}),
 				},
 			},
 		},

--- a/internal/service/s3files/mount_target_list_test.go
+++ b/internal/service/s3files/mount_target_list_test.go
@@ -128,3 +128,51 @@ func TestAccS3FilesMountTarget_List_regionOverride(t *testing.T) {
 		},
 	})
 }
+
+func TestAccS3FilesMountTarget_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_s3files_mount_target.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3FilesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMountTargetDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/MountTarget/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity.GetIdentity(resourceName),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/MountTarget/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_s3files_mount_target.test", identity.Checks()),
+					querycheck.ExpectResourceKnownValues("aws_s3files_mount_target.test", tfqueryfilter.ByResourceIdentityFunc(identity.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrFileSystemID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrSubnetID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+					}),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/s3files/synchronization_configuration_list_test.go
+++ b/internal/service/s3files/synchronization_configuration_list_test.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/querycheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
@@ -96,6 +98,52 @@ func TestAccS3FilesSynchronizationConfiguration_List_regionOverride(t *testing.T
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					tfquerycheck.ExpectIdentityFunc("aws_s3files_synchronization_configuration.test", identity.Checks()),
 					tfquerycheck.ExpectNoResourceObject("aws_s3files_synchronization_configuration.test", tfqueryfilter.ByResourceIdentityFunc(identity.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccS3FilesSynchronizationConfiguration_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_s3files_synchronization_configuration.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3FilesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSynchronizationConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/SynchronizationConfiguration/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity.GetIdentity(resourceName),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/SynchronizationConfiguration/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_s3files_synchronization_configuration.test", identity.Checks()),
+					querycheck.ExpectResourceKnownValues("aws_s3files_synchronization_configuration.test", tfqueryfilter.ByResourceIdentityFunc(identity.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrFileSystemID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("import_data_rule"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("expiration_data_rule"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+					}),
 				},
 			},
 		},

--- a/internal/service/s3files/testdata/AccessPoint/basic/main_gen.tf
+++ b/internal/service/s3files/testdata/AccessPoint/basic/main_gen.tf
@@ -1,6 +1,22 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_access_point" "test" {
+  file_system_id = aws_s3files_file_system.test.id
+
+  posix_user {
+    gid = 1001
+    uid = 1001
+  }
+}
+
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -133,22 +149,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_access_point" "test" {
-  file_system_id = aws_s3files_file_system.test.id
-
-  posix_user {
-    gid = 1001
-    uid = 1001
-  }
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/AccessPoint/list_basic/main.tf
+++ b/internal/service/s3files/testdata/AccessPoint/list_basic/main.tf
@@ -1,6 +1,24 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_access_point" "test" {
+  count = var.resource_count
+
+  file_system_id = aws_s3files_file_system.test.id
+
+  posix_user {
+    gid = 1001 + count.index
+    uid = 1001 + count.index
+  }
+}
+
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {}
@@ -132,24 +150,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_access_point" "test" {
-  count = var.resource_count
-
-  file_system_id = aws_s3files_file_system.test.id
-
-  posix_user {
-    gid = 1001 + count.index
-    uid = 1001 + count.index
-  }
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/AccessPoint/list_include_resource/main.tf
+++ b/internal/service/s3files/testdata/AccessPoint/list_include_resource/main.tf
@@ -1,0 +1,172 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_s3files_access_point" "test" {
+  count = var.resource_count
+
+  file_system_id = aws_s3files_file_system.test.id
+
+  posix_user {
+    gid = 1001
+    uid = 1001
+  }
+
+  tags = var.resource_tags
+}
+
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_s3_bucket" "test" {
+  bucket = var.rName
+}
+
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name = var.rName
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowS3FilesAssumeRole"
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "elasticfilesystem.amazonaws.com"
+        }
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+          ArnLike = {
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:s3files:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:file-system/*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = var.rName
+  role = aws_iam_role.test.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "S3BucketPermissions"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:ListBucketVersions"
+        ]
+        Resource = aws_s3_bucket.test.arn
+        Condition = {
+          StringEquals = {
+            "aws:ResourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      },
+      {
+        Sid    = "S3ObjectPermissions"
+        Effect = "Allow"
+        Action = [
+          "s3:AbortMultipartUpload",
+          "s3:DeleteObject*",
+          "s3:GetObject*",
+          "s3:List*",
+          "s3:PutObject*"
+        ]
+        Resource = "${aws_s3_bucket.test.arn}/*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      },
+      {
+        Sid    = "UseKmsKeyWithS3Files"
+        Effect = "Allow"
+        Action = [
+          "kms:GenerateDataKey",
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncryptFrom",
+          "kms:ReEncryptTo"
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+        Condition = {
+          StringLike = {
+            "kms:ViaService" = "s3.${data.aws_region.current.name}.amazonaws.com"
+            "kms:EncryptionContext:aws:s3:arn" = [
+              aws_s3_bucket.test.arn,
+              "${aws_s3_bucket.test.arn}/*"
+            ]
+          }
+        }
+      },
+      {
+        Sid    = "EventBridgeManage"
+        Effect = "Allow"
+        Action = [
+          "events:DeleteRule",
+          "events:DisableRule",
+          "events:EnableRule",
+          "events:PutRule",
+          "events:PutTargets",
+          "events:RemoveTargets"
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:events:*:*:rule/DO-NOT-DELETE-S3-Files*"
+        Condition = {
+          StringEquals = {
+            "events:ManagedBy" = "elasticfilesystem.amazonaws.com"
+          }
+        }
+      },
+      {
+        Sid    = "EventBridgeRead"
+        Effect = "Allow"
+        Action = [
+          "events:DescribeRule",
+          "events:ListRuleNamesByTarget",
+          "events:ListRules",
+          "events:ListTargetsByRule"
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:events:*:*:rule/*"
+      }
+    ]
+  })
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  type     = number
+  nullable = false
+}
+
+variable "resource_tags" {
+  description = "Tags for resource"
+  type        = map(string)
+  nullable    = false
+}

--- a/internal/service/s3files/testdata/AccessPoint/list_include_resource/query.tfquery.hcl
+++ b/internal/service/s3files/testdata/AccessPoint/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,12 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_s3files_access_point" "test" {
+  provider = aws
+
+  config {
+    file_system_id = aws_s3files_file_system.test.id
+  }
+
+  include_resource = true
+}

--- a/internal/service/s3files/testdata/AccessPoint/list_region_override/main.tf
+++ b/internal/service/s3files/testdata/AccessPoint/list_region_override/main.tf
@@ -1,6 +1,26 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_access_point" "test" {
+  count = var.resource_count
+
+  region         = var.region
+  file_system_id = aws_s3files_file_system.test.id
+
+  posix_user {
+    gid = 1001 + count.index
+    uid = 1001 + count.index
+  }
+}
+
+resource "aws_s3files_file_system" "test" {
+  region   = var.region
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -136,26 +156,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  region   = var.region
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_access_point" "test" {
-  count = var.resource_count
-
-  region         = var.region
-  file_system_id = aws_s3files_file_system.test.id
-
-  posix_user {
-    gid = 1001 + count.index
-    uid = 1001 + count.index
-  }
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/AccessPoint/region_override/main_gen.tf
+++ b/internal/service/s3files/testdata/AccessPoint/region_override/main_gen.tf
@@ -1,6 +1,26 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_access_point" "test" {
+  region = var.region
+
+  file_system_id = aws_s3files_file_system.test.id
+
+  posix_user {
+    gid = 1001
+    uid = 1001
+  }
+}
+
+resource "aws_s3files_file_system" "test" {
+  region = var.region
+
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -139,26 +159,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  region = var.region
-
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_access_point" "test" {
-  region = var.region
-
-  file_system_id = aws_s3files_file_system.test.id
-
-  posix_user {
-    gid = 1001
-    uid = 1001
-  }
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/AccessPoint/tags/main_gen.tf
+++ b/internal/service/s3files/testdata/AccessPoint/tags/main_gen.tf
@@ -1,6 +1,24 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_access_point" "test" {
+  file_system_id = aws_s3files_file_system.test.id
+
+  posix_user {
+    gid = 1001
+    uid = 1001
+  }
+
+  tags = var.resource_tags
+}
+
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -133,24 +151,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_access_point" "test" {
-  file_system_id = aws_s3files_file_system.test.id
-
-  posix_user {
-    gid = 1001
-    uid = 1001
-  }
-
-  tags = var.resource_tags
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/AccessPoint/tagsComputed1/main_gen.tf
+++ b/internal/service/s3files/testdata/AccessPoint/tagsComputed1/main_gen.tf
@@ -3,6 +3,26 @@
 
 provider "null" {}
 
+resource "aws_s3files_access_point" "test" {
+  file_system_id = aws_s3files_file_system.test.id
+
+  posix_user {
+    gid = 1001
+    uid = 1001
+  }
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+  }
+}
+
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -135,26 +155,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_access_point" "test" {
-  file_system_id = aws_s3files_file_system.test.id
-
-  posix_user {
-    gid = 1001
-    uid = 1001
-  }
-
-  tags = {
-    (var.unknownTagKey) = null_resource.test.id
-  }
 }
 
 resource "null_resource" "test" {}

--- a/internal/service/s3files/testdata/AccessPoint/tagsComputed2/main_gen.tf
+++ b/internal/service/s3files/testdata/AccessPoint/tagsComputed2/main_gen.tf
@@ -3,6 +3,27 @@
 
 provider "null" {}
 
+resource "aws_s3files_access_point" "test" {
+  file_system_id = aws_s3files_file_system.test.id
+
+  posix_user {
+    gid = 1001
+    uid = 1001
+  }
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
+  }
+}
+
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -135,27 +156,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_access_point" "test" {
-  file_system_id = aws_s3files_file_system.test.id
-
-  posix_user {
-    gid = 1001
-    uid = 1001
-  }
-
-  tags = {
-    (var.unknownTagKey) = null_resource.test.id
-    (var.knownTagKey)   = var.knownTagValue
-  }
 }
 
 resource "null_resource" "test" {}

--- a/internal/service/s3files/testdata/AccessPoint/tags_defaults/main_gen.tf
+++ b/internal/service/s3files/testdata/AccessPoint/tags_defaults/main_gen.tf
@@ -7,6 +7,24 @@ provider "aws" {
   }
 }
 
+resource "aws_s3files_access_point" "test" {
+  file_system_id = aws_s3files_file_system.test.id
+
+  posix_user {
+    gid = 1001
+    uid = 1001
+  }
+
+  tags = var.resource_tags
+}
+
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -139,24 +157,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_access_point" "test" {
-  file_system_id = aws_s3files_file_system.test.id
-
-  posix_user {
-    gid = 1001
-    uid = 1001
-  }
-
-  tags = var.resource_tags
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/AccessPoint/tags_ignore/main_gen.tf
+++ b/internal/service/s3files/testdata/AccessPoint/tags_ignore/main_gen.tf
@@ -10,6 +10,24 @@ provider "aws" {
   }
 }
 
+resource "aws_s3files_access_point" "test" {
+  file_system_id = aws_s3files_file_system.test.id
+
+  posix_user {
+    gid = 1001
+    uid = 1001
+  }
+
+  tags = var.resource_tags
+}
+
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -142,24 +160,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_access_point" "test" {
-  file_system_id = aws_s3files_file_system.test.id
-
-  posix_user {
-    gid = 1001
-    uid = 1001
-  }
-
-  tags = var.resource_tags
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/FileSystem/basic/main_gen.tf
+++ b/internal/service/s3files/testdata/FileSystem/basic/main_gen.tf
@@ -1,6 +1,13 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -133,13 +140,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/FileSystem/list_basic/main.tf
+++ b/internal/service/s3files/testdata/FileSystem/list_basic/main.tf
@@ -1,6 +1,14 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_file_system" "test" {
+  count    = var.resource_count
+  bucket   = aws_s3_bucket.test[count.index].arn
+  role_arn = aws_iam_role.test[count.index].arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {}
@@ -140,15 +148,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  count = var.resource_count
-
-  bucket   = aws_s3_bucket.test[count.index].arn
-  role_arn = aws_iam_role.test[count.index].arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/FileSystem/list_include_resource/main.tf
+++ b/internal/service/s3files/testdata/FileSystem/list_include_resource/main.tf
@@ -1,0 +1,171 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_s3files_file_system" "test" {
+  count    = var.resource_count
+  bucket   = aws_s3_bucket.test[count.index].arn
+  role_arn = aws_iam_role.test[count.index].arn
+
+  tags = var.resource_tags
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_s3_bucket" "test" {
+  count = var.resource_count
+
+  bucket = "${var.rName}-${count.index}"
+}
+
+resource "aws_s3_bucket_versioning" "test" {
+  count = var.resource_count
+
+  bucket = aws_s3_bucket.test[count.index].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_iam_role" "test" {
+  count = var.resource_count
+
+  name = "${var.rName}-${count.index}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowS3FilesAssumeRole"
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "elasticfilesystem.amazonaws.com"
+        }
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+          ArnLike = {
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:s3files:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:file-system/*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "test" {
+  count = var.resource_count
+
+  name = "${var.rName}-${count.index}"
+  role = aws_iam_role.test[count.index].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "S3BucketPermissions"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:ListBucketVersions"
+        ]
+        Resource = aws_s3_bucket.test[count.index].arn
+        Condition = {
+          StringEquals = {
+            "aws:ResourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      },
+      {
+        Sid    = "S3ObjectPermissions"
+        Effect = "Allow"
+        Action = [
+          "s3:AbortMultipartUpload",
+          "s3:DeleteObject*",
+          "s3:GetObject*",
+          "s3:List*",
+          "s3:PutObject*"
+        ]
+        Resource = "${aws_s3_bucket.test[count.index].arn}/*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      },
+      {
+        Sid    = "UseKmsKeyWithS3Files"
+        Effect = "Allow"
+        Action = [
+          "kms:GenerateDataKey",
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncryptFrom",
+          "kms:ReEncryptTo"
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+        Condition = {
+          StringLike = {
+            "kms:ViaService" = "s3.${data.aws_region.current.name}.amazonaws.com"
+            "kms:EncryptionContext:aws:s3:arn" = [
+              aws_s3_bucket.test[count.index].arn,
+              "${aws_s3_bucket.test[count.index].arn}/*"
+            ]
+          }
+        }
+      },
+      {
+        Sid    = "EventBridgeManage"
+        Effect = "Allow"
+        Action = [
+          "events:DeleteRule",
+          "events:DisableRule",
+          "events:EnableRule",
+          "events:PutRule",
+          "events:PutTargets",
+          "events:RemoveTargets"
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:events:*:*:rule/DO-NOT-DELETE-S3-Files*"
+        Condition = {
+          StringEquals = {
+            "events:ManagedBy" = "elasticfilesystem.amazonaws.com"
+          }
+        }
+      },
+      {
+        Sid    = "EventBridgeRead"
+        Effect = "Allow"
+        Action = [
+          "events:DescribeRule",
+          "events:ListRuleNamesByTarget",
+          "events:ListRules",
+          "events:ListTargetsByRule"
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:events:*:*:rule/*"
+      }
+    ]
+  })
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "resource_tags" {
+  description = "Tags for resource"
+  type        = map(string)
+  nullable    = false
+}

--- a/internal/service/s3files/testdata/FileSystem/list_include_resource/query.tfquery.hcl
+++ b/internal/service/s3files/testdata/FileSystem/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_s3files_file_system" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/s3files/testdata/FileSystem/list_region_override/main.tf
+++ b/internal/service/s3files/testdata/FileSystem/list_region_override/main.tf
@@ -1,6 +1,16 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_file_system" "test" {
+  region = var.region
+  count  = var.resource_count
+
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
@@ -135,16 +145,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  region = var.region
-  count  = var.resource_count
-
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/FileSystem/region_override/main_gen.tf
+++ b/internal/service/s3files/testdata/FileSystem/region_override/main_gen.tf
@@ -1,6 +1,15 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_file_system" "test" {
+  region = var.region
+
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -139,15 +148,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  region = var.region
-
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/FileSystem/tags/main_gen.tf
+++ b/internal/service/s3files/testdata/FileSystem/tags/main_gen.tf
@@ -1,6 +1,15 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+
+  tags = var.resource_tags
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -133,15 +142,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-
-  tags = var.resource_tags
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/FileSystem/tagsComputed1/main_gen.tf
+++ b/internal/service/s3files/testdata/FileSystem/tagsComputed1/main_gen.tf
@@ -3,6 +3,17 @@
 
 provider "null" {}
 
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+  }
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -135,17 +146,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-
-  tags = {
-    (var.unknownTagKey) = null_resource.test.id
-  }
 }
 
 resource "null_resource" "test" {}

--- a/internal/service/s3files/testdata/FileSystem/tagsComputed2/main_gen.tf
+++ b/internal/service/s3files/testdata/FileSystem/tagsComputed2/main_gen.tf
@@ -3,6 +3,18 @@
 
 provider "null" {}
 
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
+  }
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -135,18 +147,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-
-  tags = {
-    (var.unknownTagKey) = null_resource.test.id
-    (var.knownTagKey)   = var.knownTagValue
-  }
 }
 
 resource "null_resource" "test" {}

--- a/internal/service/s3files/testdata/FileSystem/tags_defaults/main_gen.tf
+++ b/internal/service/s3files/testdata/FileSystem/tags_defaults/main_gen.tf
@@ -7,6 +7,15 @@ provider "aws" {
   }
 }
 
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+
+  tags = var.resource_tags
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -139,15 +148,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-
-  tags = var.resource_tags
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/FileSystem/tags_ignore/main_gen.tf
+++ b/internal/service/s3files/testdata/FileSystem/tags_ignore/main_gen.tf
@@ -10,6 +10,15 @@ provider "aws" {
   }
 }
 
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+
+  tags = var.resource_tags
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -142,15 +151,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-
-  tags = var.resource_tags
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/FileSystemPolicy/basic/main_gen.tf
+++ b/internal/service/s3files/testdata/FileSystemPolicy/basic/main_gen.tf
@@ -1,6 +1,31 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_file_system_policy" "test" {
+  file_system_id = aws_s3files_file_system.test.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "s3files:ClientMount"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -130,31 +155,6 @@ resource "aws_iam_role_policy" "test" {
           "events:ListTargetsByRule"
         ]
         Resource = "arn:${data.aws_partition.current.partition}:events:*:*:rule/*"
-      }
-    ]
-  })
-}
-
-resource "aws_s3files_file_system" "test" {
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_file_system_policy" "test" {
-  file_system_id = aws_s3files_file_system.test.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
-        }
-        Action   = "s3files:ClientMount"
-        Resource = "*"
       }
     ]
   })

--- a/internal/service/s3files/testdata/FileSystemPolicy/list_basic/main.tf
+++ b/internal/service/s3files/testdata/FileSystemPolicy/list_basic/main.tf
@@ -1,6 +1,33 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_file_system_policy" "test" {
+  count          = var.resource_count
+  file_system_id = aws_s3files_file_system.test[count.index].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "s3files:ClientMount"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_s3files_file_system" "test" {
+  count    = var.resource_count
+  bucket   = aws_s3_bucket.test[count.index].arn
+  role_arn = aws_iam_role.test[count.index].arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {}
@@ -133,33 +160,6 @@ resource "aws_iam_role_policy" "test" {
           "events:ListTargetsByRule"
         ]
         Resource = "arn:${data.aws_partition.current.partition}:events:*:*:rule/*"
-      }
-    ]
-  })
-}
-
-resource "aws_s3files_file_system" "test" {
-  count    = var.resource_count
-  bucket   = aws_s3_bucket.test[count.index].arn
-  role_arn = aws_iam_role.test[count.index].arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_file_system_policy" "test" {
-  count          = var.resource_count
-  file_system_id = aws_s3files_file_system.test[count.index].id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
-        }
-        Action   = "s3files:ClientMount"
-        Resource = "*"
       }
     ]
   })

--- a/internal/service/s3files/testdata/FileSystemPolicy/list_include_resource/main.tf
+++ b/internal/service/s3files/testdata/FileSystemPolicy/list_include_resource/main.tf
@@ -1,0 +1,180 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_s3files_file_system_policy" "test" {
+  count          = var.resource_count
+  file_system_id = aws_s3files_file_system.test[count.index].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "s3files:ClientMount"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_s3files_file_system" "test" {
+  count    = var.resource_count
+  bucket   = aws_s3_bucket.test[count.index].arn
+  role_arn = aws_iam_role.test[count.index].arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_s3_bucket" "test" {
+  count = var.resource_count
+
+  bucket = "${var.rName}-${count.index}"
+}
+
+resource "aws_s3_bucket_versioning" "test" {
+  count = var.resource_count
+
+  bucket = aws_s3_bucket.test[count.index].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_iam_role" "test" {
+  count = var.resource_count
+
+  name = "${var.rName}-${count.index}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowS3FilesAssumeRole"
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "elasticfilesystem.amazonaws.com"
+        }
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+          ArnLike = {
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:s3files:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:file-system/*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "test" {
+  count = var.resource_count
+
+  name = "${var.rName}-${count.index}"
+  role = aws_iam_role.test[count.index].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "S3BucketPermissions"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:ListBucketVersions"
+        ]
+        Resource = aws_s3_bucket.test[count.index].arn
+        Condition = {
+          StringEquals = {
+            "aws:ResourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      },
+      {
+        Sid    = "S3ObjectPermissions"
+        Effect = "Allow"
+        Action = [
+          "s3:AbortMultipartUpload",
+          "s3:DeleteObject*",
+          "s3:GetObject*",
+          "s3:List*",
+          "s3:PutObject*"
+        ]
+        Resource = "${aws_s3_bucket.test[count.index].arn}/*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      },
+      {
+        Sid    = "UseKmsKeyWithS3Files"
+        Effect = "Allow"
+        Action = [
+          "kms:GenerateDataKey",
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncryptFrom",
+          "kms:ReEncryptTo"
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+        Condition = {
+          StringLike = {
+            "kms:ViaService" = "s3.${data.aws_region.current.name}.amazonaws.com"
+            "kms:EncryptionContext:aws:s3:arn" = [
+              aws_s3_bucket.test[count.index].arn,
+              "${aws_s3_bucket.test[count.index].arn}/*"
+            ]
+          }
+        }
+      },
+      {
+        Sid    = "EventBridgeManage"
+        Effect = "Allow"
+        Action = [
+          "events:DeleteRule",
+          "events:DisableRule",
+          "events:EnableRule",
+          "events:PutRule",
+          "events:PutTargets",
+          "events:RemoveTargets"
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:events:*:*:rule/DO-NOT-DELETE-S3-Files*"
+        Condition = {
+          StringEquals = {
+            "events:ManagedBy" = "elasticfilesystem.amazonaws.com"
+          }
+        }
+      },
+      {
+        Sid    = "EventBridgeRead"
+        Effect = "Allow"
+        Action = [
+          "events:DescribeRule",
+          "events:ListRuleNamesByTarget",
+          "events:ListRules",
+          "events:ListTargetsByRule"
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:events:*:*:rule/*"
+      }
+    ]
+  })
+}
+
+variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "resource_count" {
+  type     = number
+  nullable = false
+}

--- a/internal/service/s3files/testdata/FileSystemPolicy/list_include_resource/query.tfquery.hcl
+++ b/internal/service/s3files/testdata/FileSystemPolicy/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,12 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_s3files_file_system_policy" "test" {
+  provider = aws
+
+  config {
+    file_system_id = aws_s3files_file_system.test[0].id
+  }
+
+  include_resource = true
+}

--- a/internal/service/s3files/testdata/FileSystemPolicy/list_region_override/main.tf
+++ b/internal/service/s3files/testdata/FileSystemPolicy/list_region_override/main.tf
@@ -1,6 +1,35 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_file_system_policy" "test" {
+  count          = var.resource_count
+  region         = var.region
+  file_system_id = aws_s3files_file_system.test[count.index].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "s3files:ClientMount"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_s3files_file_system" "test" {
+  count    = var.resource_count
+  region   = var.region
+  bucket   = aws_s3_bucket.test[count.index].arn
+  role_arn = aws_iam_role.test[count.index].arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -137,35 +166,6 @@ resource "aws_iam_role_policy" "test" {
           "events:ListTargetsByRule"
         ]
         Resource = "arn:${data.aws_partition.current.partition}:events:*:*:rule/*"
-      }
-    ]
-  })
-}
-
-resource "aws_s3files_file_system" "test" {
-  count    = var.resource_count
-  region   = var.region
-  bucket   = aws_s3_bucket.test[count.index].arn
-  role_arn = aws_iam_role.test[count.index].arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_file_system_policy" "test" {
-  count          = var.resource_count
-  region         = var.region
-  file_system_id = aws_s3files_file_system.test[count.index].id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
-        }
-        Action   = "s3files:ClientMount"
-        Resource = "*"
       }
     ]
   })

--- a/internal/service/s3files/testdata/FileSystemPolicy/region_override/main_gen.tf
+++ b/internal/service/s3files/testdata/FileSystemPolicy/region_override/main_gen.tf
@@ -1,6 +1,35 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_file_system_policy" "test" {
+  region = var.region
+
+  file_system_id = aws_s3files_file_system.test.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "s3files:ClientMount"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_s3files_file_system" "test" {
+  region = var.region
+
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -136,35 +165,6 @@ resource "aws_iam_role_policy" "test" {
           "events:ListTargetsByRule"
         ]
         Resource = "arn:${data.aws_partition.current.partition}:events:*:*:rule/*"
-      }
-    ]
-  })
-}
-
-resource "aws_s3files_file_system" "test" {
-  region = var.region
-
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_file_system_policy" "test" {
-  region = var.region
-
-  file_system_id = aws_s3files_file_system.test.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
-        }
-        Action   = "s3files:ClientMount"
-        Resource = "*"
       }
     ]
   })

--- a/internal/service/s3files/testdata/MountTarget/basic/main_gen.tf
+++ b/internal/service/s3files/testdata/MountTarget/basic/main_gen.tf
@@ -1,6 +1,18 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_mount_target" "test" {
+  file_system_id = aws_s3files_file_system.test.id
+  subnet_id      = aws_subnet.test[0].id
+}
+
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -153,18 +165,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_mount_target" "test" {
-  file_system_id = aws_s3files_file_system.test.id
-  subnet_id      = aws_subnet.test[0].id
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/MountTarget/list_basic/main.tf
+++ b/internal/service/s3files/testdata/MountTarget/list_basic/main.tf
@@ -1,6 +1,20 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_mount_target" "test" {
+  count = var.resource_count
+
+  file_system_id = aws_s3files_file_system.test.id
+  subnet_id      = aws_subnet.test[count.index].id
+}
+
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {}
@@ -152,20 +166,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_mount_target" "test" {
-  count = var.resource_count
-
-  file_system_id = aws_s3files_file_system.test.id
-  subnet_id      = aws_subnet.test[count.index].id
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/MountTarget/list_include_resource/main.tf
+++ b/internal/service/s3files/testdata/MountTarget/list_include_resource/main.tf
@@ -1,0 +1,181 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_s3files_mount_target" "test" {
+  count = var.resource_count
+
+  file_system_id = aws_s3files_file_system.test.id
+  subnet_id      = aws_subnet.test[count.index].id
+}
+
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test" {
+  count             = var.resource_count
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = var.rName
+}
+
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name = var.rName
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowS3FilesAssumeRole"
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "elasticfilesystem.amazonaws.com"
+        }
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+          ArnLike = {
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:s3files:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:file-system/*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = var.rName
+  role = aws_iam_role.test.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "S3BucketPermissions"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:ListBucketVersions"
+        ]
+        Resource = aws_s3_bucket.test.arn
+        Condition = {
+          StringEquals = {
+            "aws:ResourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      },
+      {
+        Sid    = "S3ObjectPermissions"
+        Effect = "Allow"
+        Action = [
+          "s3:AbortMultipartUpload",
+          "s3:DeleteObject*",
+          "s3:GetObject*",
+          "s3:List*",
+          "s3:PutObject*"
+        ]
+        Resource = "${aws_s3_bucket.test.arn}/*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      },
+      {
+        Sid    = "UseKmsKeyWithS3Files"
+        Effect = "Allow"
+        Action = [
+          "kms:GenerateDataKey",
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncryptFrom",
+          "kms:ReEncryptTo"
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+        Condition = {
+          StringLike = {
+            "kms:ViaService" = "s3.${data.aws_region.current.name}.amazonaws.com"
+            "kms:EncryptionContext:aws:s3:arn" = [
+              aws_s3_bucket.test.arn,
+              "${aws_s3_bucket.test.arn}/*"
+            ]
+          }
+        }
+      },
+      {
+        Sid    = "EventBridgeManage"
+        Effect = "Allow"
+        Action = [
+          "events:DeleteRule",
+          "events:DisableRule",
+          "events:EnableRule",
+          "events:PutRule",
+          "events:PutTargets",
+          "events:RemoveTargets"
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:events:*:*:rule/DO-NOT-DELETE-S3-Files*"
+        Condition = {
+          StringEquals = {
+            "events:ManagedBy" = "elasticfilesystem.amazonaws.com"
+          }
+        }
+      },
+      {
+        Sid    = "EventBridgeRead"
+        Effect = "Allow"
+        Action = [
+          "events:DescribeRule",
+          "events:ListRuleNamesByTarget",
+          "events:ListRules",
+          "events:ListTargetsByRule"
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:events:*:*:rule/*"
+      }
+    ]
+  })
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/s3files/testdata/MountTarget/list_include_resource/query.tfquery.hcl
+++ b/internal/service/s3files/testdata/MountTarget/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,12 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_s3files_mount_target" "test" {
+  provider = aws
+
+  config {
+    file_system_id = aws_s3files_file_system.test.id
+  }
+
+  include_resource = true
+}

--- a/internal/service/s3files/testdata/MountTarget/list_region_override/main.tf
+++ b/internal/service/s3files/testdata/MountTarget/list_region_override/main.tf
@@ -1,6 +1,22 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_mount_target" "test" {
+  region = var.region
+  count  = var.resource_count
+
+  file_system_id = aws_s3files_file_system.test.id
+  subnet_id      = aws_subnet.test[count.index].id
+}
+
+resource "aws_s3files_file_system" "test" {
+  region   = var.region
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
@@ -156,22 +172,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  region   = var.region
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_mount_target" "test" {
-  region = var.region
-  count  = var.resource_count
-
-  file_system_id = aws_s3files_file_system.test.id
-  subnet_id      = aws_subnet.test[count.index].id
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/MountTarget/region_override/main_gen.tf
+++ b/internal/service/s3files/testdata/MountTarget/region_override/main_gen.tf
@@ -1,6 +1,22 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_mount_target" "test" {
+  region = var.region
+
+  file_system_id = aws_s3files_file_system.test.id
+  subnet_id      = aws_subnet.test[0].id
+}
+
+resource "aws_s3files_file_system" "test" {
+  region = var.region
+
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -165,22 +181,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  region = var.region
-
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_mount_target" "test" {
-  region = var.region
-
-  file_system_id = aws_s3files_file_system.test.id
-  subnet_id      = aws_subnet.test[0].id
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/SynchronizationConfiguration/basic/main_gen.tf
+++ b/internal/service/s3files/testdata/SynchronizationConfiguration/basic/main_gen.tf
@@ -1,6 +1,33 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_synchronization_configuration" "test" {
+  file_system_id = aws_s3files_file_system.test.id
+
+  import_data_rule {
+    prefix         = ""
+    size_less_than = 52673613135872
+    trigger        = "ON_FILE_ACCESS"
+  }
+
+  import_data_rule {
+    prefix         = "data/"
+    size_less_than = 1048576
+    trigger        = "ON_FILE_ACCESS"
+  }
+
+  expiration_data_rule {
+    days_after_last_access = 30
+  }
+}
+
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -133,33 +160,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_synchronization_configuration" "test" {
-  file_system_id = aws_s3files_file_system.test.id
-
-  import_data_rule {
-    prefix         = ""
-    size_less_than = 52673613135872
-    trigger        = "ON_FILE_ACCESS"
-  }
-
-  import_data_rule {
-    prefix         = "data/"
-    size_less_than = 1048576
-    trigger        = "ON_FILE_ACCESS"
-  }
-
-  expiration_data_rule {
-    days_after_last_access = 30
-  }
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/SynchronizationConfiguration/list_basic/main.tf
+++ b/internal/service/s3files/testdata/SynchronizationConfiguration/list_basic/main.tf
@@ -1,6 +1,27 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_synchronization_configuration" "test" {
+  file_system_id = aws_s3files_file_system.test.id
+
+  import_data_rule {
+    prefix         = ""
+    size_less_than = 52673613135872
+    trigger        = "ON_FILE_ACCESS"
+  }
+
+  expiration_data_rule {
+    days_after_last_access = 30
+  }
+}
+
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {}
@@ -132,27 +153,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_synchronization_configuration" "test" {
-  file_system_id = aws_s3files_file_system.test.id
-
-  import_data_rule {
-    prefix         = ""
-    size_less_than = 52673613135872
-    trigger        = "ON_FILE_ACCESS"
-  }
-
-  expiration_data_rule {
-    days_after_last_access = 30
-  }
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/SynchronizationConfiguration/list_include_resource/main.tf
+++ b/internal/service/s3files/testdata/SynchronizationConfiguration/list_include_resource/main.tf
@@ -1,0 +1,162 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_s3files_synchronization_configuration" "test" {
+  file_system_id = aws_s3files_file_system.test.id
+
+  import_data_rule {
+    prefix         = ""
+    size_less_than = 52673613135872
+    trigger        = "ON_FILE_ACCESS"
+  }
+
+  expiration_data_rule {
+    days_after_last_access = 30
+  }
+}
+
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_s3_bucket" "test" {
+  bucket = var.rName
+}
+
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name = var.rName
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowS3FilesAssumeRole"
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "elasticfilesystem.amazonaws.com"
+        }
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+          ArnLike = {
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:s3files:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:file-system/*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = var.rName
+  role = aws_iam_role.test.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "S3BucketPermissions"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:ListBucketVersions"
+        ]
+        Resource = aws_s3_bucket.test.arn
+        Condition = {
+          StringEquals = {
+            "aws:ResourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      },
+      {
+        Sid    = "S3ObjectPermissions"
+        Effect = "Allow"
+        Action = [
+          "s3:AbortMultipartUpload",
+          "s3:DeleteObject*",
+          "s3:GetObject*",
+          "s3:List*",
+          "s3:PutObject*"
+        ]
+        Resource = "${aws_s3_bucket.test.arn}/*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      },
+      {
+        Sid    = "UseKmsKeyWithS3Files"
+        Effect = "Allow"
+        Action = [
+          "kms:GenerateDataKey",
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncryptFrom",
+          "kms:ReEncryptTo"
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+        Condition = {
+          StringLike = {
+            "kms:ViaService" = "s3.${data.aws_region.current.name}.amazonaws.com"
+            "kms:EncryptionContext:aws:s3:arn" = [
+              aws_s3_bucket.test.arn,
+              "${aws_s3_bucket.test.arn}/*"
+            ]
+          }
+        }
+      },
+      {
+        Sid    = "EventBridgeManage"
+        Effect = "Allow"
+        Action = [
+          "events:DeleteRule",
+          "events:DisableRule",
+          "events:EnableRule",
+          "events:PutRule",
+          "events:PutTargets",
+          "events:RemoveTargets"
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:events:*:*:rule/DO-NOT-DELETE-S3-Files*"
+        Condition = {
+          StringEquals = {
+            "events:ManagedBy" = "elasticfilesystem.amazonaws.com"
+          }
+        }
+      },
+      {
+        Sid    = "EventBridgeRead"
+        Effect = "Allow"
+        Action = [
+          "events:DescribeRule",
+          "events:ListRuleNamesByTarget",
+          "events:ListRules",
+          "events:ListTargetsByRule"
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:events:*:*:rule/*"
+      }
+    ]
+  })
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/s3files/testdata/SynchronizationConfiguration/list_include_resource/query.tfquery.hcl
+++ b/internal/service/s3files/testdata/SynchronizationConfiguration/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,12 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_s3files_synchronization_configuration" "test" {
+  provider = aws
+
+  config {
+    file_system_id = aws_s3files_file_system.test.id
+  }
+
+  include_resource = true
+}

--- a/internal/service/s3files/testdata/SynchronizationConfiguration/list_region_override/main.tf
+++ b/internal/service/s3files/testdata/SynchronizationConfiguration/list_region_override/main.tf
@@ -1,6 +1,29 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_synchronization_configuration" "test" {
+  region         = var.region
+  file_system_id = aws_s3files_file_system.test.id
+
+  import_data_rule {
+    prefix         = ""
+    size_less_than = 52673613135872
+    trigger        = "ON_FILE_ACCESS"
+  }
+
+  expiration_data_rule {
+    days_after_last_access = 30
+  }
+}
+
+resource "aws_s3files_file_system" "test" {
+  region   = var.region
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -136,29 +159,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  region   = var.region
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_synchronization_configuration" "test" {
-  region         = var.region
-  file_system_id = aws_s3files_file_system.test.id
-
-  import_data_rule {
-    prefix         = ""
-    size_less_than = 52673613135872
-    trigger        = "ON_FILE_ACCESS"
-  }
-
-  expiration_data_rule {
-    days_after_last_access = 30
-  }
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/SynchronizationConfiguration/region_override/main_gen.tf
+++ b/internal/service/s3files/testdata/SynchronizationConfiguration/region_override/main_gen.tf
@@ -1,6 +1,37 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_s3files_synchronization_configuration" "test" {
+  region = var.region
+
+  file_system_id = aws_s3files_file_system.test.id
+
+  import_data_rule {
+    prefix         = ""
+    size_less_than = 52673613135872
+    trigger        = "ON_FILE_ACCESS"
+  }
+
+  import_data_rule {
+    prefix         = "data/"
+    size_less_than = 1048576
+    trigger        = "ON_FILE_ACCESS"
+  }
+
+  expiration_data_rule {
+    days_after_last_access = 30
+  }
+}
+
+resource "aws_s3files_file_system" "test" {
+  region = var.region
+
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -139,37 +170,6 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-  region = var.region
-
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_synchronization_configuration" "test" {
-  region = var.region
-
-  file_system_id = aws_s3files_file_system.test.id
-
-  import_data_rule {
-    prefix         = ""
-    size_less_than = 52673613135872
-    trigger        = "ON_FILE_ACCESS"
-  }
-
-  import_data_rule {
-    prefix         = "data/"
-    size_less_than = 1048576
-    trigger        = "ON_FILE_ACCESS"
-  }
-
-  expiration_data_rule {
-    days_after_last_access = 30
-  }
 }
 
 variable "rName" {

--- a/internal/service/s3files/testdata/tmpl/access_point_basic.gtpl
+++ b/internal/service/s3files/testdata/tmpl/access_point_basic.gtpl
@@ -1,3 +1,22 @@
+resource "aws_s3files_access_point" "test" {
+{{- template "region" }}
+  file_system_id = aws_s3files_file_system.test.id
+
+  posix_user {
+    gid = 1001
+    uid = 1001
+  }
+{{- template "tags" . }}
+}
+
+resource "aws_s3files_file_system" "test" {
+{{- template "region" }}
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -133,23 +152,4 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-{{- template "region" }}
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_access_point" "test" {
-{{- template "region" }}
-  file_system_id = aws_s3files_file_system.test.id
-
-  posix_user {
-    gid = 1001
-    uid = 1001
-  }
-{{- template "tags" . }}
 }

--- a/internal/service/s3files/testdata/tmpl/file_system_basic.gtpl
+++ b/internal/service/s3files/testdata/tmpl/file_system_basic.gtpl
@@ -1,3 +1,12 @@
+resource "aws_s3files_file_system" "test" {
+{{- template "region" }}
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+{{- template "tags" . }}
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -133,13 +142,4 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-{{- template "region" }}
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-{{- template "tags" . }}
 }

--- a/internal/service/s3files/testdata/tmpl/file_system_policy_basic.gtpl
+++ b/internal/service/s3files/testdata/tmpl/file_system_policy_basic.gtpl
@@ -1,3 +1,31 @@
+resource "aws_s3files_file_system_policy" "test" {
+{{- template "region" }}
+  file_system_id = aws_s3files_file_system.test.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "s3files:ClientMount"
+        Resource = "*"
+      }
+    ]
+  })
+{{- template "tags" . }}
+}
+
+resource "aws_s3files_file_system" "test" {
+{{- template "region" }}
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -133,32 +161,4 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-{{- template "region" }}
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_file_system_policy" "test" {
-{{- template "region" }}
-  file_system_id = aws_s3files_file_system.test.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
-        }
-        Action   = "s3files:ClientMount"
-        Resource = "*"
-      }
-    ]
-  })
-{{- template "tags" . }}
 }

--- a/internal/service/s3files/testdata/tmpl/mount_target_basic.gtpl
+++ b/internal/service/s3files/testdata/tmpl/mount_target_basic.gtpl
@@ -1,3 +1,17 @@
+resource "aws_s3files_mount_target" "test" {
+{{- template "region" }}
+  file_system_id = aws_s3files_file_system.test.id
+  subnet_id      = aws_subnet.test[0].id
+}
+
+resource "aws_s3files_file_system" "test" {
+{{- template "region" }}
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -156,18 +170,4 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-{{- template "region" }}
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_mount_target" "test" {
-{{- template "region" }}
-  file_system_id = aws_s3files_file_system.test.id
-  subnet_id      = aws_subnet.test[0].id
 }

--- a/internal/service/s3files/testdata/tmpl/synchronization_configuration_basic.gtpl
+++ b/internal/service/s3files/testdata/tmpl/synchronization_configuration_basic.gtpl
@@ -1,3 +1,33 @@
+resource "aws_s3files_synchronization_configuration" "test" {
+{{- template "region" }}
+  file_system_id = aws_s3files_file_system.test.id
+
+  import_data_rule {
+    prefix         = ""
+    size_less_than = 52673613135872
+    trigger        = "ON_FILE_ACCESS"
+  }
+
+  import_data_rule {
+    prefix         = "data/"
+    size_less_than = 1048576
+    trigger        = "ON_FILE_ACCESS"
+  }
+
+  expiration_data_rule {
+    days_after_last_access = 30
+  }
+{{- template "tags" . }}
+}
+
+resource "aws_s3files_file_system" "test" {
+{{- template "region" }}
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {
@@ -133,34 +163,4 @@ resource "aws_iam_role_policy" "test" {
       }
     ]
   })
-}
-
-resource "aws_s3files_file_system" "test" {
-{{- template "region" }}
-  bucket   = aws_s3_bucket.test.arn
-  role_arn = aws_iam_role.test.arn
-
-  depends_on = [aws_s3_bucket_versioning.test]
-}
-
-resource "aws_s3files_synchronization_configuration" "test" {
-{{- template "region" }}
-  file_system_id = aws_s3files_file_system.test.id
-
-  import_data_rule {
-    prefix         = ""
-    size_less_than = 52673613135872
-    trigger        = "ON_FILE_ACCESS"
-  }
-
-  import_data_rule {
-    prefix         = "data/"
-    size_less_than = 1048576
-    trigger        = "ON_FILE_ACCESS"
-  }
-
-  expiration_data_rule {
-    days_after_last_access = 30
-  }
-{{- template "tags" . }}
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Follow two additional idioms:
- [x] Config being tested comes first in standalone config files
- [x] Use `_includeResource` tests to ensure list resources have expected attributes set



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #47324 


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAcc K=s3files
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-s3files-cleanup 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/s3files/... -v -count 1 -parallel 20 -run='TestAcc'  -timeout 360m -vet=off
2026/04/08 16:19:10 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/08 16:19:10 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3FilesAccessPointDataSource_basic
=== PAUSE TestAccS3FilesAccessPointDataSource_basic
=== RUN   TestAccS3FilesAccessPoint_Identity_basic
=== PAUSE TestAccS3FilesAccessPoint_Identity_basic
=== RUN   TestAccS3FilesAccessPoint_Identity_regionOverride
=== PAUSE TestAccS3FilesAccessPoint_Identity_regionOverride
=== RUN   TestAccS3FilesAccessPoint_List_basic
=== PAUSE TestAccS3FilesAccessPoint_List_basic
=== RUN   TestAccS3FilesAccessPoint_List_regionOverride
=== PAUSE TestAccS3FilesAccessPoint_List_regionOverride
=== RUN   TestAccS3FilesAccessPoint_List_includeResource
=== PAUSE TestAccS3FilesAccessPoint_List_includeResource
=== RUN   TestAccS3FilesAccessPoint_tags
=== PAUSE TestAccS3FilesAccessPoint_tags
=== RUN   TestAccS3FilesAccessPoint_Tags_null
=== PAUSE TestAccS3FilesAccessPoint_Tags_null
=== RUN   TestAccS3FilesAccessPoint_Tags_emptyMap
=== PAUSE TestAccS3FilesAccessPoint_Tags_emptyMap
=== RUN   TestAccS3FilesAccessPoint_Tags_addOnUpdate
=== PAUSE TestAccS3FilesAccessPoint_Tags_addOnUpdate
=== RUN   TestAccS3FilesAccessPoint_Tags_EmptyTag_onCreate
=== PAUSE TestAccS3FilesAccessPoint_Tags_EmptyTag_onCreate
=== RUN   TestAccS3FilesAccessPoint_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccS3FilesAccessPoint_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccS3FilesAccessPoint_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccS3FilesAccessPoint_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccS3FilesAccessPoint_Tags_DefaultTags_providerOnly
=== PAUSE TestAccS3FilesAccessPoint_Tags_DefaultTags_providerOnly
=== RUN   TestAccS3FilesAccessPoint_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccS3FilesAccessPoint_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccS3FilesAccessPoint_Tags_DefaultTags_overlapping
=== PAUSE TestAccS3FilesAccessPoint_Tags_DefaultTags_overlapping
=== RUN   TestAccS3FilesAccessPoint_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccS3FilesAccessPoint_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccS3FilesAccessPoint_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccS3FilesAccessPoint_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccS3FilesAccessPoint_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccS3FilesAccessPoint_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccS3FilesAccessPoint_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccS3FilesAccessPoint_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccS3FilesAccessPoint_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccS3FilesAccessPoint_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccS3FilesAccessPoint_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccS3FilesAccessPoint_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccS3FilesAccessPoint_Tags_ComputedTag_onCreate
=== PAUSE TestAccS3FilesAccessPoint_Tags_ComputedTag_onCreate
=== RUN   TestAccS3FilesAccessPoint_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccS3FilesAccessPoint_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccS3FilesAccessPoint_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccS3FilesAccessPoint_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccS3FilesAccessPoint_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccS3FilesAccessPoint_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccS3FilesAccessPoint_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccS3FilesAccessPoint_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccS3FilesAccessPoint_basic
=== PAUSE TestAccS3FilesAccessPoint_basic
=== RUN   TestAccS3FilesAccessPoint_rootDirectory
=== PAUSE TestAccS3FilesAccessPoint_rootDirectory
=== RUN   TestAccS3FilesFileSystemDataSource_basic
=== PAUSE TestAccS3FilesFileSystemDataSource_basic
=== RUN   TestAccS3FilesFileSystem_Identity_basic
=== PAUSE TestAccS3FilesFileSystem_Identity_basic
=== RUN   TestAccS3FilesFileSystem_Identity_regionOverride
=== PAUSE TestAccS3FilesFileSystem_Identity_regionOverride
=== RUN   TestAccS3FilesFileSystem_List_basic
=== PAUSE TestAccS3FilesFileSystem_List_basic
=== RUN   TestAccS3FilesFileSystem_List_regionOverride
=== PAUSE TestAccS3FilesFileSystem_List_regionOverride
=== RUN   TestAccS3FilesFileSystem_List_includeResource
=== PAUSE TestAccS3FilesFileSystem_List_includeResource
=== RUN   TestAccS3FilesFileSystemPolicy_Identity_basic
=== PAUSE TestAccS3FilesFileSystemPolicy_Identity_basic
=== RUN   TestAccS3FilesFileSystemPolicy_Identity_regionOverride
=== PAUSE TestAccS3FilesFileSystemPolicy_Identity_regionOverride
=== RUN   TestAccS3FilesFileSystemPolicy_List_basic
=== PAUSE TestAccS3FilesFileSystemPolicy_List_basic
=== RUN   TestAccS3FilesFileSystemPolicy_List_regionOverride
=== PAUSE TestAccS3FilesFileSystemPolicy_List_regionOverride
=== RUN   TestAccS3FilesFileSystemPolicy_List_includeResource
=== PAUSE TestAccS3FilesFileSystemPolicy_List_includeResource
=== RUN   TestAccS3FilesFileSystemPolicy_basic
=== PAUSE TestAccS3FilesFileSystemPolicy_basic
=== RUN   TestAccS3FilesFileSystemPolicy_update
=== PAUSE TestAccS3FilesFileSystemPolicy_update
=== RUN   TestAccS3FilesFileSystem_tags
=== PAUSE TestAccS3FilesFileSystem_tags
=== RUN   TestAccS3FilesFileSystem_Tags_null
=== PAUSE TestAccS3FilesFileSystem_Tags_null
=== RUN   TestAccS3FilesFileSystem_Tags_emptyMap
=== PAUSE TestAccS3FilesFileSystem_Tags_emptyMap
=== RUN   TestAccS3FilesFileSystem_Tags_addOnUpdate
=== PAUSE TestAccS3FilesFileSystem_Tags_addOnUpdate
=== RUN   TestAccS3FilesFileSystem_Tags_EmptyTag_onCreate
=== PAUSE TestAccS3FilesFileSystem_Tags_EmptyTag_onCreate
=== RUN   TestAccS3FilesFileSystem_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccS3FilesFileSystem_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccS3FilesFileSystem_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccS3FilesFileSystem_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccS3FilesFileSystem_Tags_DefaultTags_providerOnly
=== PAUSE TestAccS3FilesFileSystem_Tags_DefaultTags_providerOnly
=== RUN   TestAccS3FilesFileSystem_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccS3FilesFileSystem_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccS3FilesFileSystem_Tags_DefaultTags_overlapping
=== PAUSE TestAccS3FilesFileSystem_Tags_DefaultTags_overlapping
=== RUN   TestAccS3FilesFileSystem_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccS3FilesFileSystem_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccS3FilesFileSystem_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccS3FilesFileSystem_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccS3FilesFileSystem_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccS3FilesFileSystem_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccS3FilesFileSystem_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccS3FilesFileSystem_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccS3FilesFileSystem_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccS3FilesFileSystem_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccS3FilesFileSystem_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccS3FilesFileSystem_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccS3FilesFileSystem_Tags_ComputedTag_onCreate
=== PAUSE TestAccS3FilesFileSystem_Tags_ComputedTag_onCreate
=== RUN   TestAccS3FilesFileSystem_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccS3FilesFileSystem_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccS3FilesFileSystem_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccS3FilesFileSystem_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccS3FilesFileSystem_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccS3FilesFileSystem_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccS3FilesFileSystem_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccS3FilesFileSystem_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccS3FilesFileSystem_basic
=== PAUSE TestAccS3FilesFileSystem_basic
=== RUN   TestAccS3FilesFileSystem_disappears
=== PAUSE TestAccS3FilesFileSystem_disappears
=== RUN   TestAccS3FilesFileSystem_kmsKey
=== PAUSE TestAccS3FilesFileSystem_kmsKey
=== RUN   TestAccS3FilesFileSystemsDataSource_basic
=== PAUSE TestAccS3FilesFileSystemsDataSource_basic
=== RUN   TestAccS3FilesMountTargetDataSource_basic
=== PAUSE TestAccS3FilesMountTargetDataSource_basic
=== RUN   TestAccS3FilesMountTarget_Identity_basic
=== PAUSE TestAccS3FilesMountTarget_Identity_basic
=== RUN   TestAccS3FilesMountTarget_Identity_regionOverride
=== PAUSE TestAccS3FilesMountTarget_Identity_regionOverride
=== RUN   TestAccS3FilesMountTarget_List_basic
=== PAUSE TestAccS3FilesMountTarget_List_basic
=== RUN   TestAccS3FilesMountTarget_List_regionOverride
=== PAUSE TestAccS3FilesMountTarget_List_regionOverride
=== RUN   TestAccS3FilesMountTarget_List_includeResource
=== PAUSE TestAccS3FilesMountTarget_List_includeResource
=== RUN   TestAccS3FilesMountTarget_basic
=== PAUSE TestAccS3FilesMountTarget_basic
=== RUN   TestAccS3FilesMountTarget_securityGroups
=== PAUSE TestAccS3FilesMountTarget_securityGroups
=== RUN   TestAccS3FilesMountTarget_disappears
=== PAUSE TestAccS3FilesMountTarget_disappears
=== RUN   TestAccS3FilesSynchronizationConfiguration_Identity_basic
=== PAUSE TestAccS3FilesSynchronizationConfiguration_Identity_basic
=== RUN   TestAccS3FilesSynchronizationConfiguration_Identity_regionOverride
=== PAUSE TestAccS3FilesSynchronizationConfiguration_Identity_regionOverride
=== RUN   TestAccS3FilesSynchronizationConfiguration_List_basic
=== PAUSE TestAccS3FilesSynchronizationConfiguration_List_basic
=== RUN   TestAccS3FilesSynchronizationConfiguration_List_regionOverride
=== PAUSE TestAccS3FilesSynchronizationConfiguration_List_regionOverride
=== RUN   TestAccS3FilesSynchronizationConfiguration_List_includeResource
=== PAUSE TestAccS3FilesSynchronizationConfiguration_List_includeResource
=== RUN   TestAccS3FilesSynchronizationConfiguration_basic
=== PAUSE TestAccS3FilesSynchronizationConfiguration_basic
=== RUN   TestAccS3FilesSynchronizationConfiguration_update
=== PAUSE TestAccS3FilesSynchronizationConfiguration_update
=== CONT  TestAccS3FilesAccessPointDataSource_basic
=== CONT  TestAccS3FilesFileSystem_tags
=== CONT  TestAccS3FilesFileSystemPolicy_List_regionOverride
=== CONT  TestAccS3FilesFileSystem_basic
=== CONT  TestAccS3FilesAccessPoint_Tags_EmptyTag_OnUpdate_add
=== CONT  TestAccS3FilesAccessPoint_tags
=== CONT  TestAccS3FilesAccessPoint_Tags_DefaultTags_updateToProviderOnly
=== CONT  TestAccS3FilesFileSystemPolicy_update
=== CONT  TestAccS3FilesMountTarget_basic
=== CONT  TestAccS3FilesFileSystemPolicy_basic
=== CONT  TestAccS3FilesFileSystemPolicy_List_includeResource
=== CONT  TestAccS3FilesSynchronizationConfiguration_update
=== CONT  TestAccS3FilesSynchronizationConfiguration_basic
=== CONT  TestAccS3FilesSynchronizationConfiguration_List_includeResource
=== CONT  TestAccS3FilesSynchronizationConfiguration_List_regionOverride
=== CONT  TestAccS3FilesSynchronizationConfiguration_List_basic
=== CONT  TestAccS3FilesSynchronizationConfiguration_Identity_regionOverride
=== CONT  TestAccS3FilesSynchronizationConfiguration_Identity_basic
=== CONT  TestAccS3FilesAccessPoint_Tags_DefaultTags_nonOverlapping
=== CONT  TestAccS3FilesAccessPoint_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccS3FilesSynchronizationConfiguration_List_regionOverride (61.92s)
=== CONT  TestAccS3FilesMountTarget_disappears
--- PASS: TestAccS3FilesFileSystemPolicy_List_regionOverride (67.21s)
=== CONT  TestAccS3FilesMountTarget_securityGroups
--- PASS: TestAccS3FilesFileSystemPolicy_List_includeResource (70.30s)
=== CONT  TestAccS3FilesFileSystem_Identity_basic
--- PASS: TestAccS3FilesAccessPointDataSource_basic (75.30s)
=== CONT  TestAccS3FilesFileSystemPolicy_List_basic
--- PASS: TestAccS3FilesSynchronizationConfiguration_List_includeResource (75.51s)
=== CONT  TestAccS3FilesFileSystemPolicy_Identity_regionOverride
--- PASS: TestAccS3FilesSynchronizationConfiguration_basic (81.07s)
=== CONT  TestAccS3FilesFileSystemPolicy_Identity_basic
--- PASS: TestAccS3FilesSynchronizationConfiguration_Identity_regionOverride (84.72s)
=== CONT  TestAccS3FilesFileSystem_List_includeResource
--- PASS: TestAccS3FilesSynchronizationConfiguration_List_basic (86.91s)
=== CONT  TestAccS3FilesFileSystem_List_regionOverride
--- PASS: TestAccS3FilesFileSystemPolicy_basic (89.21s)
=== CONT  TestAccS3FilesFileSystem_List_basic
--- PASS: TestAccS3FilesFileSystemPolicy_update (91.72s)
=== CONT  TestAccS3FilesFileSystem_Identity_regionOverride
--- PASS: TestAccS3FilesAccessPoint_Tags_DefaultTags_nullNonOverlappingResourceTag (106.74s)
=== CONT  TestAccS3FilesMountTarget_Identity_basic
--- PASS: TestAccS3FilesFileSystem_basic (106.92s)
=== CONT  TestAccS3FilesMountTarget_List_includeResource
--- PASS: TestAccS3FilesAccessPoint_Tags_DefaultTags_updateToProviderOnly (110.37s)
=== CONT  TestAccS3FilesMountTarget_List_regionOverride
--- PASS: TestAccS3FilesSynchronizationConfiguration_update (112.16s)
=== CONT  TestAccS3FilesMountTarget_List_basic
--- PASS: TestAccS3FilesFileSystem_List_regionOverride (56.73s)
=== CONT  TestAccS3FilesMountTarget_Identity_regionOverride
--- PASS: TestAccS3FilesFileSystemPolicy_Identity_regionOverride (68.89s)
=== CONT  TestAccS3FilesAccessPoint_Tags_addOnUpdate
--- PASS: TestAccS3FilesFileSystem_Identity_regionOverride (66.95s)
=== CONT  TestAccS3FilesAccessPoint_Tags_EmptyTag_onCreate
--- PASS: TestAccS3FilesAccessPoint_Tags_DefaultTags_nonOverlapping (188.94s)
=== CONT  TestAccS3FilesAccessPoint_Tags_emptyMap
--- PASS: TestAccS3FilesAccessPoint_tags (190.60s)
=== CONT  TestAccS3FilesAccessPoint_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccS3FilesSynchronizationConfiguration_Identity_basic (197.76s)
=== CONT  TestAccS3FilesFileSystemDataSource_basic
--- PASS: TestAccS3FilesFileSystem_List_includeResource (143.51s)
=== CONT  TestAccS3FilesAccessPoint_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccS3FilesAccessPoint_Tags_addOnUpdate (94.70s)
=== CONT  TestAccS3FilesAccessPoint_rootDirectory
--- PASS: TestAccS3FilesFileSystem_tags (243.52s)
=== CONT  TestAccS3FilesAccessPoint_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccS3FilesAccessPoint_Tags_emptyMap (63.23s)
=== CONT  TestAccS3FilesAccessPoint_basic
--- PASS: TestAccS3FilesFileSystemDataSource_basic (62.66s)
=== CONT  TestAccS3FilesAccessPoint_Tags_DefaultTags_providerOnly
--- PASS: TestAccS3FilesAccessPoint_Tags_EmptyTag_onCreate (103.61s)
=== CONT  TestAccS3FilesFileSystem_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccS3FilesFileSystem_List_basic (178.08s)
=== CONT  TestAccS3FilesAccessPoint_Tags_DefaultTags_overlapping
--- PASS: TestAccS3FilesFileSystem_Identity_basic (206.63s)
=== CONT  TestAccS3FilesFileSystem_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccS3FilesAccessPoint_rootDirectory (56.69s)
=== CONT  TestAccS3FilesFileSystem_Tags_ComputedTag_onCreate
--- PASS: TestAccS3FilesFileSystemPolicy_Identity_basic (216.05s)
=== CONT  TestAccS3FilesFileSystem_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccS3FilesAccessPoint_Tags_ComputedTag_OnUpdate_replace (93.43s)
=== CONT  TestAccS3FilesFileSystem_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccS3FilesAccessPoint_Tags_EmptyTag_OnUpdate_add (327.28s)
=== CONT  TestAccS3FilesFileSystem_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccS3FilesAccessPoint_Tags_IgnoreTags_Overlap_resourceTag (144.68s)
=== CONT  TestAccS3FilesFileSystem_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccS3FilesFileSystemPolicy_List_basic (265.34s)
=== CONT  TestAccS3FilesFileSystem_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccS3FilesAccessPoint_Tags_IgnoreTags_Overlap_defaultTag (117.14s)
=== CONT  TestAccS3FilesFileSystem_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccS3FilesMountTarget_basic (378.42s)
=== CONT  TestAccS3FilesFileSystem_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccS3FilesFileSystem_Tags_DefaultTags_nullNonOverlappingResourceTag (81.90s)
=== CONT  TestAccS3FilesAccessPoint_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccS3FilesFileSystem_Tags_ComputedTag_onCreate (86.48s)
=== CONT  TestAccS3FilesFileSystem_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccS3FilesFileSystem_Tags_DefaultTags_updateToResourceOnly (125.84s)
=== CONT  TestAccS3FilesFileSystem_Tags_addOnUpdate
--- PASS: TestAccS3FilesFileSystem_Tags_IgnoreTags_Overlap_resourceTag (121.68s)
=== CONT  TestAccS3FilesFileSystem_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccS3FilesFileSystem_Tags_DefaultTags_nullOverlappingResourceTag (73.35s)
=== CONT  TestAccS3FilesFileSystem_Tags_EmptyTag_onCreate
--- PASS: TestAccS3FilesAccessPoint_Tags_DefaultTags_overlapping (138.57s)
=== CONT  TestAccS3FilesFileSystemsDataSource_basic
--- PASS: TestAccS3FilesFileSystem_Tags_IgnoreTags_Overlap_defaultTag (116.05s)
=== CONT  TestAccS3FilesMountTargetDataSource_basic
--- PASS: TestAccS3FilesFileSystem_Tags_ComputedTag_OnUpdate_replace (111.36s)
=== CONT  TestAccS3FilesAccessPoint_List_basic
--- PASS: TestAccS3FilesMountTarget_securityGroups (400.48s)
=== CONT  TestAccS3FilesAccessPoint_List_includeResource
--- PASS: TestAccS3FilesMountTarget_List_regionOverride (360.07s)
=== CONT  TestAccS3FilesAccessPoint_List_regionOverride
--- PASS: TestAccS3FilesMountTarget_List_includeResource (371.23s)
=== CONT  TestAccS3FilesAccessPoint_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccS3FilesFileSystem_Tags_EmptyTag_OnUpdate_replace (100.47s)
=== CONT  TestAccS3FilesAccessPoint_Identity_regionOverride
--- PASS: TestAccS3FilesFileSystemsDataSource_basic (83.29s)
=== CONT  TestAccS3FilesAccessPoint_Tags_ComputedTag_onCreate
--- PASS: TestAccS3FilesMountTarget_List_basic (377.68s)
=== CONT  TestAccS3FilesAccessPoint_Tags_null
--- PASS: TestAccS3FilesFileSystem_Tags_EmptyTag_onCreate (96.85s)
=== CONT  TestAccS3FilesFileSystem_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccS3FilesAccessPoint_basic (248.51s)
=== CONT  TestAccS3FilesFileSystem_Tags_DefaultTags_overlapping
--- PASS: TestAccS3FilesMountTarget_Identity_basic (401.91s)
=== CONT  TestAccS3FilesFileSystem_Tags_DefaultTags_providerOnly
--- PASS: TestAccS3FilesAccessPoint_Tags_ComputedTag_OnUpdate_add (131.89s)
=== CONT  TestAccS3FilesAccessPoint_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccS3FilesFileSystem_Tags_DefaultTags_emptyProviderOnlyTag (176.96s)
=== CONT  TestAccS3FilesAccessPoint_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccS3FilesAccessPoint_List_basic (73.92s)
=== CONT  TestAccS3FilesAccessPoint_Identity_basic
--- PASS: TestAccS3FilesMountTarget_Identity_regionOverride (377.17s)
=== CONT  TestAccS3FilesFileSystem_Tags_emptyMap
--- PASS: TestAccS3FilesAccessPoint_List_regionOverride (50.88s)
=== CONT  TestAccS3FilesAccessPoint_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccS3FilesMountTarget_disappears (462.31s)
=== CONT  TestAccS3FilesFileSystem_Tags_null
--- PASS: TestAccS3FilesFileSystem_Tags_DefaultTags_emptyResourceTag (155.08s)
=== CONT  TestAccS3FilesFileSystem_kmsKey
--- PASS: TestAccS3FilesFileSystem_Tags_ComputedTag_OnUpdate_add (186.50s)
=== CONT  TestAccS3FilesFileSystem_disappears
--- PASS: TestAccS3FilesAccessPoint_Identity_regionOverride (71.77s)
=== CONT  TestAccS3FilesAccessPoint_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccS3FilesFileSystem_Tags_EmptyTag_OnUpdate_add (184.27s)
=== CONT  TestAccS3FilesFileSystem_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccS3FilesFileSystem_kmsKey (63.00s)
--- PASS: TestAccS3FilesFileSystem_Tags_emptyMap (80.62s)
--- PASS: TestAccS3FilesAccessPoint_Tags_null (119.84s)
--- PASS: TestAccS3FilesAccessPoint_Identity_basic (93.75s)
--- PASS: TestAccS3FilesFileSystem_disappears (68.99s)
--- PASS: TestAccS3FilesAccessPoint_Tags_DefaultTags_emptyProviderOnlyTag (65.19s)
--- PASS: TestAccS3FilesAccessPoint_Tags_DefaultTags_updateToResourceOnly (113.54s)
--- PASS: TestAccS3FilesAccessPoint_List_includeResource (166.29s)
--- PASS: TestAccS3FilesFileSystem_Tags_null (112.66s)
--- PASS: TestAccS3FilesFileSystem_Tags_DefaultTags_nonOverlapping (157.16s)
--- PASS: TestAccS3FilesAccessPoint_Tags_ComputedTag_onCreate (171.28s)
--- PASS: TestAccS3FilesAccessPoint_Tags_DefaultTags_providerOnly (400.17s)
--- PASS: TestAccS3FilesAccessPoint_Tags_DefaultTags_emptyResourceTag (152.43s)
--- PASS: TestAccS3FilesFileSystem_Tags_DefaultTags_updateToProviderOnly (90.30s)
--- PASS: TestAccS3FilesAccessPoint_Tags_EmptyTag_OnUpdate_replace (200.01s)
--- PASS: TestAccS3FilesFileSystem_Tags_addOnUpdate (301.07s)
--- PASS: TestAccS3FilesFileSystem_Tags_DefaultTags_overlapping (197.99s)
--- PASS: TestAccS3FilesFileSystem_Tags_DefaultTags_providerOnly (196.34s)
--- PASS: TestAccS3FilesAccessPoint_Tags_DefaultTags_nullOverlappingResourceTag (245.09s)
--- PASS: TestAccS3FilesMountTargetDataSource_basic (362.85s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3files	807.474s
```
