### PR TITLE
New List Resource: `aws_api_gateway_method`

### DIFF
--- a/.changelog/47365.txt
+++ b/.changelog/47365.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_api_gateway_method
+```

--- a/internal/service/apigateway/method.go
+++ b/internal/service/apigateway/method.go
@@ -165,14 +165,7 @@ func resourceMethodRead(ctx context.Context, d *schema.ResourceData, meta any) d
 		return sdkdiag.AppendErrorf(diags, "reading API Gateway Method (%s): %s", d.Id(), err)
 	}
 
-	d.Set("api_key_required", method.ApiKeyRequired)
-	d.Set("authorization", method.AuthorizationType)
-	d.Set("authorization_scopes", method.AuthorizationScopes)
-	d.Set("authorizer_id", method.AuthorizerId)
-	d.Set("operation_name", method.OperationName)
-	d.Set("request_models", method.RequestModels)
-	d.Set("request_parameters", method.RequestParameters)
-	d.Set("request_validator_id", method.RequestValidatorId)
+	resourceMethodFlatten(d, method)
 
 	return diags
 }
@@ -377,6 +370,17 @@ func updateIntegration(ctx context.Context, d *schema.ResourceData, conn *apigat
 	}
 
 	return nil
+}
+
+func resourceMethodFlatten(d *schema.ResourceData, method *apigateway.GetMethodOutput) {
+	d.Set("api_key_required", method.ApiKeyRequired)
+	d.Set("authorization", method.AuthorizationType)
+	d.Set("authorization_scopes", method.AuthorizationScopes)
+	d.Set("authorizer_id", method.AuthorizerId)
+	d.Set("operation_name", method.OperationName)
+	d.Set("request_models", method.RequestModels)
+	d.Set("request_parameters", method.RequestParameters)
+	d.Set("request_validator_id", method.RequestValidatorId)
 }
 
 func findMethodByThreePartKey(ctx context.Context, conn *apigateway.Client, httpMethod, resourceID, apiID string) (*apigateway.GetMethodOutput, error) {

--- a/internal/service/apigateway/method.go
+++ b/internal/service/apigateway/method.go
@@ -31,6 +31,7 @@ import (
 // @IdentityAttribute("rest_api_id")
 // @IdentityAttribute("resource_id")
 // @IdentityAttribute("http_method")
+// @IdAttrFormat("agm-{rest_api_id}-{resource_id}-{http_method}")
 // @ImportIDHandler("methodImportID")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigateway;apigateway.GetMethodOutput")
 // @Testing(preIdentityVersion="v6.39.0")
@@ -143,7 +144,7 @@ func resourceMethodCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		return sdkdiag.AppendErrorf(diags, "creating API Gateway Method: %s", err)
 	}
 
-	d.SetId(fmt.Sprintf("agm-%s-%s-%s", d.Get("rest_api_id").(string), d.Get(names.AttrResourceID).(string), d.Get("http_method").(string)))
+	d.SetId(resourceMethodIDAttr(d.Get("rest_api_id").(string), d.Get(names.AttrResourceID).(string), d.Get("http_method").(string)))
 
 	return diags
 }
@@ -408,6 +409,10 @@ var _ inttypes.SDKv2ImportID = methodImportID{}
 
 type methodImportID struct{}
 
+func resourceMethodIDAttr(restApiID, resourceID, httpMethod string) string {
+	return fmt.Sprintf("agm-%s-%s-%s", restApiID, resourceID, httpMethod)
+}
+
 func methodCreateImportID(restApiID, resourceID, httpMethod string) string {
 	return restApiID + "/" + resourceID + "/" + httpMethod
 }
@@ -428,5 +433,5 @@ func (methodImportID) Parse(id string) (string, map[string]any, error) {
 		"http_method":        parts[2],
 	}
 
-	return fmt.Sprintf("agm-%s-%s-%s", parts[0], parts[1], parts[2]), result, nil
+	return resourceMethodIDAttr(parts[0], parts[1], parts[2]), result, nil
 }

--- a/internal/service/apigateway/method_identity_gen_test.go
+++ b/internal/service/apigateway/method_identity_gen_test.go
@@ -48,6 +48,7 @@ func TestAccAPIGatewayMethod_Identity_basic(t *testing.T) {
 					testAccCheckMethodExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectAttributeFormat(resourceName, tfjsonpath.New(names.AttrID), "agm-{rest_api_id}-{resource_id}-{http_method}"),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
 					statecheck.ExpectIdentity(resourceName, map[string]knownvalue.Check{
 						names.AttrAccountID:  tfknownvalue.AccountID(),
@@ -143,6 +144,7 @@ func TestAccAPIGatewayMethod_Identity_regionOverride(t *testing.T) {
 					"region":        config.StringVariable(acctest.AlternateRegion()),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectAttributeFormat(resourceName, tfjsonpath.New(names.AttrID), "agm-{rest_api_id}-{resource_id}-{http_method}"),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.AlternateRegion())),
 					statecheck.ExpectIdentity(resourceName, map[string]knownvalue.Check{
 						names.AttrAccountID:  tfknownvalue.AccountID(),

--- a/internal/service/apigateway/method_list.go
+++ b/internal/service/apigateway/method_list.go
@@ -1,0 +1,119 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package apigateway
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for list resource registration to the Provider. DO NOT EDIT.
+// @SDKListResource("aws_api_gateway_method")
+func newMethodResourceAsListResource() inttypes.ListResourceForSDK {
+	l := methodListResource{}
+	l.SetResourceSchema(resourceMethod())
+	return &l
+}
+
+var _ list.ListResource = &methodListResource{}
+var _ list.ListResourceWithRawV5Schemas = &methodListResource{}
+
+type methodListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+func (l *methodListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = listschema.Schema{
+		Attributes: map[string]listschema.Attribute{
+			"rest_api_id": listschema.StringAttribute{
+				Required:    true,
+				Description: "ID of the associated REST API.",
+			},
+			names.AttrResourceID: listschema.StringAttribute{
+				Required:    true,
+				Description: "ID of the API Gateway Resource to list methods from.",
+			},
+		},
+	}
+}
+
+func (l *methodListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	conn := l.Meta().APIGatewayClient(ctx)
+
+	var query listMethodModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	restAPIID := query.RestAPIID.ValueString()
+	resourceID := query.ResourceID.ValueString()
+
+	tflog.Info(ctx, "Listing API Gateway Methods", map[string]any{
+		"rest_api_id": restAPIID,
+		"resource_id": resourceID,
+	})
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		resource, err := findResourceByTwoPartKey(ctx, conn, resourceID, restAPIID)
+		if err != nil {
+			result := fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("reading API Gateway Resource (%s): %w", resourceID, err))
+			yield(result)
+			return
+		}
+
+		for httpMethod := range resource.ResourceMethods {
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey("http_method"), httpMethod)
+
+			result := request.NewListResult(ctx)
+			rd := l.ResourceData()
+			rd.SetId(resourceMethodIDAttr(restAPIID, resourceID, httpMethod))
+			rd.Set("rest_api_id", restAPIID)
+			rd.Set(names.AttrResourceID, resourceID)
+			rd.Set("http_method", httpMethod)
+
+			if request.IncludeResource {
+				method, err := findMethodByThreePartKey(ctx, conn, httpMethod, resourceID, restAPIID)
+				if err != nil {
+					tflog.Error(ctx, "Reading API Gateway Method", map[string]any{
+						"error": err.Error(),
+					})
+					continue
+				}
+				resourceMethodFlatten(rd, method)
+			}
+
+			result.DisplayName = fmt.Sprintf("%s %s", httpMethod, aws.ToString(resource.Path))
+
+			l.SetResult(ctx, l.Meta(), request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+type listMethodModel struct {
+	framework.WithRegionModel
+	RestAPIID  types.String `tfsdk:"rest_api_id"`
+	ResourceID types.String `tfsdk:"resource_id"`
+}

--- a/internal/service/apigateway/method_list.go
+++ b/internal/service/apigateway/method_list.go
@@ -64,8 +64,8 @@ func (l *methodListResource) List(ctx context.Context, request list.ListRequest,
 	resourceID := query.ResourceID.ValueString()
 
 	tflog.Info(ctx, "Listing API Gateway Methods", map[string]any{
-		"rest_api_id": restAPIID,
-		"resource_id": resourceID,
+		"rest_api_id":        restAPIID,
+		names.AttrResourceID: resourceID,
 	})
 
 	stream.Results = func(yield func(list.ListResult) bool) {

--- a/internal/service/apigateway/method_list_test.go
+++ b/internal/service/apigateway/method_list_test.go
@@ -4,9 +4,9 @@
 package apigateway_test
 
 import (
-	"regexp"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -61,11 +61,11 @@ func TestAccAPIGatewayMethod_List_basic(t *testing.T) {
 				},
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_method.test", identity1.Checks()),
-					querycheck.ExpectResourceDisplayName("aws_api_gateway_method.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringRegexp(regexp.MustCompile(`^(GET|POST) /test$`))),
+					querycheck.ExpectResourceDisplayName("aws_api_gateway_method.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringRegexp(regexache.MustCompile(`^(GET|POST) /test$`))),
 					tfquerycheck.ExpectNoResourceObject("aws_api_gateway_method.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
 
 					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_method.test", identity2.Checks()),
-					querycheck.ExpectResourceDisplayName("aws_api_gateway_method.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringRegexp(regexp.MustCompile(`^(GET|POST) /test$`))),
+					querycheck.ExpectResourceDisplayName("aws_api_gateway_method.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringRegexp(regexache.MustCompile(`^(GET|POST) /test$`))),
 					tfquerycheck.ExpectNoResourceObject("aws_api_gateway_method.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
 				},
 			},

--- a/internal/service/apigateway/method_list_test.go
+++ b/internal/service/apigateway/method_list_test.go
@@ -1,0 +1,184 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package apigateway_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccAPIGatewayMethod_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_api_gateway_method.test[0]"
+	resourceName2 := "aws_api_gateway_method.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		CheckDestroy:             testAccCheckMethodDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Method/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"http_methods":  config.ListVariable(config.StringVariable("GET"), config.StringVariable("POST")),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Method/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"http_methods":  config.ListVariable(config.StringVariable("GET"), config.StringVariable("POST")),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_method.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_api_gateway_method.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringRegexp(regexp.MustCompile(`^(GET|POST) /test$`))),
+					tfquerycheck.ExpectNoResourceObject("aws_api_gateway_method.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_method.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_api_gateway_method.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringRegexp(regexp.MustCompile(`^(GET|POST) /test$`))),
+					tfquerycheck.ExpectNoResourceObject("aws_api_gateway_method.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayMethod_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_api_gateway_method.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		CheckDestroy:             testAccCheckMethodDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Method/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"http_methods":  config.ListVariable(config.StringVariable("GET")),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Method/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"http_methods":  config.ListVariable(config.StringVariable("GET")),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_method.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_api_gateway_method.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact("GET /test")),
+					querycheck.ExpectResourceKnownValues("aws_api_gateway_method.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("api_key_required"), knownvalue.Bool(false)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("authorization"), knownvalue.StringExact("NONE")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("authorization_scopes"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("authorizer_id"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("http_method"), knownvalue.StringExact("GET")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("operation_name"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("request_models"), knownvalue.MapExact(map[string]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("request_parameters"), knownvalue.MapExact(map[string]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("request_validator_id"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrResourceID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("rest_api_id"), knownvalue.NotNull()),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayMethod_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_api_gateway_method.test[0]"
+	resourceName2 := "aws_api_gateway_method.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+			acctest.PreCheckAPIGatewayTypeEDGE(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		CheckDestroy:             testAccCheckMethodDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Method/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"http_methods":  config.ListVariable(config.StringVariable("GET"), config.StringVariable("POST")),
+					"region":        config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Method/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"http_methods":  config.ListVariable(config.StringVariable("GET"), config.StringVariable("POST")),
+					"region":        config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_method.test", identity1.Checks()),
+
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_method.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/apigateway/service_package_gen.go
+++ b/internal/service/apigateway/service_package_gen.go
@@ -7,6 +7,8 @@ package apigateway
 
 import (
 	"context"
+	"iter"
+	"slices"
 	"unique"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -295,6 +297,22 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			Region: unique.Make(inttypes.ResourceRegionDefault()),
 		},
 	}
+}
+
+func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttypes.ServicePackageSDKListResource] {
+	return slices.Values([]*inttypes.ServicePackageSDKListResource{
+		{
+			Factory:  newMethodResourceAsListResource,
+			TypeName: "aws_api_gateway_method",
+			Name:     "Method",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+			Identity: inttypes.RegionalParameterizedIdentity([]inttypes.IdentityAttribute{
+				inttypes.StringIdentityAttribute("rest_api_id", true),
+				inttypes.StringIdentityAttribute(names.AttrResourceID, true),
+				inttypes.StringIdentityAttribute("http_method", true),
+			}),
+		},
+	})
 }
 
 func (p *servicePackage) ServicePackageName() string {

--- a/internal/service/apigateway/testdata/Method/list_basic/main.tf
+++ b/internal/service/apigateway/testdata/Method/list_basic/main.tf
@@ -1,0 +1,33 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_api_gateway_method" "test" {
+  count = length(var.http_methods)
+
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = var.http_methods[count.index]
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  name = var.rName
+}
+
+resource "aws_api_gateway_resource" "test" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "http_methods" {
+  description = "HTTP methods to create"
+  type        = list(string)
+  nullable    = false
+}

--- a/internal/service/apigateway/testdata/Method/list_basic/query.tfquery.hcl
+++ b/internal/service/apigateway/testdata/Method/list_basic/query.tfquery.hcl
@@ -1,0 +1,11 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_api_gateway_method" "test" {
+  provider = aws
+
+  config {
+    rest_api_id = aws_api_gateway_rest_api.test.id
+    resource_id = aws_api_gateway_resource.test.id
+  }
+}

--- a/internal/service/apigateway/testdata/Method/list_include_resource/main.tf
+++ b/internal/service/apigateway/testdata/Method/list_include_resource/main.tf
@@ -1,0 +1,33 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_api_gateway_method" "test" {
+  count = length(var.http_methods)
+
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = var.http_methods[count.index]
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  name = var.rName
+}
+
+resource "aws_api_gateway_resource" "test" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "http_methods" {
+  description = "HTTP methods to create"
+  type        = list(string)
+  nullable    = false
+}

--- a/internal/service/apigateway/testdata/Method/list_include_resource/query.tfquery.hcl
+++ b/internal/service/apigateway/testdata/Method/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,13 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_api_gateway_method" "test" {
+  provider = aws
+
+  include_resource = true
+
+  config {
+    rest_api_id = aws_api_gateway_rest_api.test.id
+    resource_id = aws_api_gateway_resource.test.id
+  }
+}

--- a/internal/service/apigateway/testdata/Method/list_region_override/main.tf
+++ b/internal/service/apigateway/testdata/Method/list_region_override/main.tf
@@ -1,0 +1,44 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_api_gateway_method" "test" {
+  count  = length(var.http_methods)
+  region = var.region
+
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = var.http_methods[count.index]
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  region = var.region
+
+  name = var.rName
+}
+
+resource "aws_api_gateway_resource" "test" {
+  region = var.region
+
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "http_methods" {
+  description = "HTTP methods to create"
+  type        = list(string)
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/apigateway/testdata/Method/list_region_override/query.tfquery.hcl
+++ b/internal/service/apigateway/testdata/Method/list_region_override/query.tfquery.hcl
@@ -1,0 +1,12 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_api_gateway_method" "test" {
+  provider = aws
+
+  config {
+    region      = var.region
+    rest_api_id = aws_api_gateway_rest_api.test.id
+    resource_id = aws_api_gateway_resource.test.id
+  }
+}

--- a/website/docs/list-resources/api_gateway_method.html.markdown
+++ b/website/docs/list-resources/api_gateway_method.html.markdown
@@ -27,6 +27,6 @@ list "aws_api_gateway_method" "example" {
 
 This list resource supports the following arguments:
 
-* `rest_api_id` - (Required) ID of the associated REST API.
-* `resource_id` - (Required) ID of the API Gateway Resource to list methods from.
 * `region` - (Optional) Region to query. Defaults to provider region.
+* `resource_id` - (Required) ID of the API Gateway Resource to list methods from.
+* `rest_api_id` - (Required) ID of the associated REST API.

--- a/website/docs/list-resources/apigateway_method.html.markdown
+++ b/website/docs/list-resources/apigateway_method.html.markdown
@@ -1,0 +1,32 @@
+---
+subcategory: "API Gateway"
+layout: "aws"
+page_title: "AWS: aws_api_gateway_method"
+description: |-
+  Lists API Gateway Method resources.
+---
+
+# List Resource: aws_api_gateway_method
+
+Lists API Gateway Method resources for a specific API Gateway Resource.
+
+## Example Usage
+
+```terraform
+list "aws_api_gateway_method" "example" {
+  provider = aws
+
+  config {
+    rest_api_id = aws_api_gateway_rest_api.example.id
+    resource_id = aws_api_gateway_resource.example.id
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `rest_api_id` - (Required) ID of the associated REST API.
+* `resource_id` - (Required) ID of the API Gateway Resource to list methods from.
+* `region` - (Optional) Region to query. Defaults to provider region.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

New List Resource: `aws_api_gateway_method`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47221
Based on #47310

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=apigateway TESTS=TestAccAPIGatewayMethod_

--- PASS: TestAccAPIGatewayMethod_disappears (37.47s)
--- PASS: TestAccAPIGatewayMethod_List_regionOverride (44.67s)
--- PASS: TestAccAPIGatewayMethod_List_includeResource (72.61s)
--- PASS: TestAccAPIGatewayMethod_Identity_regionOverride (84.89s)
--- PASS: TestAccAPIGatewayMethod_customRequestValidator (92.25s)
--- PASS: TestAccAPIGatewayMethod_Identity_ExistingResource_noRefreshNoChange (92.52s)
--- PASS: TestAccAPIGatewayMethod_basic (92.97s)
--- PASS: TestAccAPIGatewayMethod_operationName (95.76s)
--- PASS: TestAccAPIGatewayMethod_Identity_ExistingResource_basic (148.50s)
--- PASS: TestAccAPIGatewayMethod_customAuthorizer (218.16s)
--- PASS: TestAccAPIGatewayMethod_List_basic (269.02s)
--- PASS: TestAccAPIGatewayMethod_Identity_basic (401.92s)
--- PASS: TestAccAPIGatewayMethod_cognitoAuthorizer (506.77s)
```
