### PR TITLE
Implement refresh token rotation handling in Cognito User Pool Client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,10 @@ module github.com/hashicorp/terraform-provider-aws
 
 go 1.23.10
 
+// Disable experimental post-quantum key exchange mechanism X25519Kyber768Draft00
+// This was causing errors with AWS Network Firewall
+godebug tlskyber=0
+
 require (
 	github.com/ProtonMail/go-crypto v1.2.0
 	github.com/YakDriver/go-version v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,6 @@ module github.com/hashicorp/terraform-provider-aws
 
 go 1.23.10
 
-// Disable experimental post-quantum key exchange mechanism X25519Kyber768Draft00
-// This was causing errors with AWS Network Firewall
-godebug tlskyber=0
-
 require (
 	github.com/ProtonMail/go-crypto v1.2.0
 	github.com/YakDriver/go-version v0.1.0

--- a/internal/service/cognitoidp/managed_user_pool_client.go
+++ b/internal/service/cognitoidp/managed_user_pool_client.go
@@ -390,6 +390,11 @@ func (r *managedUserPoolClientResource) Create(ctx context.Context, request reso
 	}
 
 	response.Diagnostics.Append(fwflex.Flatten(ctx, poolClient, &config, fwflex.WithFieldNamePrefix("Client"))...)
+	if config.RefreshTokenRotation.IsNull() && isDefaultRefreshTokenRotation(poolClient.RefreshTokenRotation) {
+		config.RefreshTokenRotation = fwtypes.NewListNestedObjectValueOfNull[refreshTokenRotationModel](ctx)
+	} else {
+		config.RefreshTokenRotation = flattenRefreshTokenRotation(ctx, poolClient.RefreshTokenRotation, &response.Diagnostics)
+	}
 	config.TokenValidityUnits = flattenTokenValidityUnits(ctx, poolClient.TokenValidityUnits, &response.Diagnostics)
 	if response.Diagnostics.HasError() {
 		return
@@ -532,8 +537,14 @@ func (r *managedUserPoolClientResource) Read(ctx context.Context, request resour
 	}
 
 	tokenValidityUnitsNull := state.TokenValidityUnits.IsNull()
+	refreshTokenRotationNull := state.RefreshTokenRotation.IsNull()
 
 	response.Diagnostics.Append(fwflex.Flatten(ctx, poolClient, &state, fwflex.WithFieldNamePrefix("Client"))...)
+	if refreshTokenRotationNull && isDefaultRefreshTokenRotation(poolClient.RefreshTokenRotation) {
+		state.RefreshTokenRotation = fwtypes.NewListNestedObjectValueOfNull[refreshTokenRotationModel](ctx)
+	} else {
+		state.RefreshTokenRotation = flattenRefreshTokenRotation(ctx, poolClient.RefreshTokenRotation, &response.Diagnostics)
+	}
 	if tokenValidityUnitsNull && isDefaultTokenValidityUnits(poolClient.TokenValidityUnits) {
 		state.TokenValidityUnits = fwtypes.NewListNestedObjectValueOfNull[tokenValidityUnitsModel](ctx)
 	} else {
@@ -583,6 +594,13 @@ func (r *managedUserPoolClientResource) Update(ctx context.Context, request reso
 		}
 	}
 
+	// If removing `refresh_token_rotation`, reset to the API default.
+	if !state.RefreshTokenRotation.IsNull() && plan.RefreshTokenRotation.IsNull() {
+		input.RefreshTokenRotation = &awstypes.RefreshTokenRotationType{
+			Feature: awstypes.FeatureTypeDisabled,
+		}
+	}
+
 	const (
 		timeout = 2 * time.Minute
 	)
@@ -600,6 +618,11 @@ func (r *managedUserPoolClientResource) Update(ctx context.Context, request reso
 	poolClient := output.(*cognitoidentityprovider.UpdateUserPoolClientOutput).UserPoolClient
 
 	response.Diagnostics.Append(fwflex.Flatten(ctx, poolClient, &config, fwflex.WithFieldNamePrefix("Client"))...)
+	if plan.RefreshTokenRotation.IsNull() && isDefaultRefreshTokenRotation(poolClient.RefreshTokenRotation) {
+		config.RefreshTokenRotation = fwtypes.NewListNestedObjectValueOfNull[refreshTokenRotationModel](ctx)
+	} else {
+		config.RefreshTokenRotation = flattenRefreshTokenRotation(ctx, poolClient.RefreshTokenRotation, &response.Diagnostics)
+	}
 	if !state.TokenValidityUnits.IsNull() && plan.TokenValidityUnits.IsNull() && isDefaultTokenValidityUnits(poolClient.TokenValidityUnits) {
 		config.TokenValidityUnits = fwtypes.NewListNestedObjectValueOfNull[tokenValidityUnitsModel](ctx)
 	} else {

--- a/internal/service/cognitoidp/user_pool_client.go
+++ b/internal/service/cognitoidp/user_pool_client.go
@@ -381,6 +381,11 @@ func (r *userPoolClientResource) Create(ctx context.Context, request resource.Cr
 	poolClient := resp.UserPoolClient
 
 	response.Diagnostics.Append(fwflex.Flatten(ctx, poolClient, &config, fwflex.WithFieldNamePrefix("Client"))...)
+	if config.RefreshTokenRotation.IsNull() && isDefaultRefreshTokenRotation(poolClient.RefreshTokenRotation) {
+		config.RefreshTokenRotation = fwtypes.NewListNestedObjectValueOfNull[refreshTokenRotationModel](ctx)
+	} else {
+		config.RefreshTokenRotation = flattenRefreshTokenRotation(ctx, poolClient.RefreshTokenRotation, &response.Diagnostics)
+	}
 	config.TokenValidityUnits = flattenTokenValidityUnits(ctx, poolClient.TokenValidityUnits, &response.Diagnostics)
 	if response.Diagnostics.HasError() {
 		return
@@ -412,8 +417,14 @@ func (r *userPoolClientResource) Read(ctx context.Context, request resource.Read
 	}
 
 	tokenValidityUnitsNull := state.TokenValidityUnits.IsNull()
+	refreshTokenRotationNull := state.RefreshTokenRotation.IsNull()
 
 	response.Diagnostics.Append(fwflex.Flatten(ctx, poolClient, &state, fwflex.WithFieldNamePrefix("Client"))...)
+	if refreshTokenRotationNull && isDefaultRefreshTokenRotation(poolClient.RefreshTokenRotation) {
+		state.RefreshTokenRotation = fwtypes.NewListNestedObjectValueOfNull[refreshTokenRotationModel](ctx)
+	} else {
+		state.RefreshTokenRotation = flattenRefreshTokenRotation(ctx, poolClient.RefreshTokenRotation, &response.Diagnostics)
+	}
 	if tokenValidityUnitsNull && isDefaultTokenValidityUnits(poolClient.TokenValidityUnits) {
 		state.TokenValidityUnits = fwtypes.NewListNestedObjectValueOfNull[tokenValidityUnitsModel](ctx)
 	} else {
@@ -462,6 +473,13 @@ func (r *userPoolClientResource) Update(ctx context.Context, request resource.Up
 		}
 	}
 
+	// If removing `refresh_token_rotation`, reset to the API default.
+	if !state.RefreshTokenRotation.IsNull() && plan.RefreshTokenRotation.IsNull() {
+		input.RefreshTokenRotation = &awstypes.RefreshTokenRotationType{
+			Feature: awstypes.FeatureTypeDisabled,
+		}
+	}
+
 	const (
 		timeout = 2 * time.Minute
 	)
@@ -479,6 +497,11 @@ func (r *userPoolClientResource) Update(ctx context.Context, request resource.Up
 	poolClient := output.(*cognitoidentityprovider.UpdateUserPoolClientOutput).UserPoolClient
 
 	response.Diagnostics.Append(fwflex.Flatten(ctx, poolClient, &config, fwflex.WithFieldNamePrefix("Client"))...)
+	if plan.RefreshTokenRotation.IsNull() && isDefaultRefreshTokenRotation(poolClient.RefreshTokenRotation) {
+		config.RefreshTokenRotation = fwtypes.NewListNestedObjectValueOfNull[refreshTokenRotationModel](ctx)
+	} else {
+		config.RefreshTokenRotation = flattenRefreshTokenRotation(ctx, poolClient.RefreshTokenRotation, &response.Diagnostics)
+	}
 	if !state.TokenValidityUnits.IsNull() && plan.TokenValidityUnits.IsNull() && isDefaultTokenValidityUnits(poolClient.TokenValidityUnits) {
 		config.TokenValidityUnits = fwtypes.NewListNestedObjectValueOfNull[tokenValidityUnitsModel](ctx)
 	} else {
@@ -651,6 +674,14 @@ func isDefaultTokenValidityUnits(tvu *awstypes.TokenValidityUnitsType) bool {
 		tvu.RefreshToken == awstypes.TimeUnitsTypeDays
 }
 
+func isDefaultRefreshTokenRotation(rtr *awstypes.RefreshTokenRotationType) bool {
+	if rtr == nil {
+		return false
+	}
+
+	return (rtr.Feature == "" || rtr.Feature == awstypes.FeatureTypeDisabled) && aws.ToInt32(rtr.RetryGracePeriodSeconds) == 0
+}
+
 func resolveTokenValidityUnits(ctx context.Context, list fwtypes.ListNestedObjectValueOf[tokenValidityUnitsModel], diags *diag.Diagnostics) *tokenValidityUnitsModel {
 	var units []tokenValidityUnitsModel
 	diags.Append(list.ElementsAs(ctx, &units, false)...)
@@ -671,6 +702,17 @@ func flattenTokenValidityUnits(ctx context.Context, tvu *awstypes.TokenValidityU
 
 	var result tokenValidityUnitsModel
 	diags.Append(fwflex.Flatten(ctx, tvu, &result)...)
+
+	return fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &result)
+}
+
+func flattenRefreshTokenRotation(ctx context.Context, rtr *awstypes.RefreshTokenRotationType, diags *diag.Diagnostics) fwtypes.ListNestedObjectValueOf[refreshTokenRotationModel] {
+	if rtr == nil || (rtr.Feature == "" && rtr.RetryGracePeriodSeconds == nil) {
+		return fwtypes.NewListNestedObjectValueOfNull[refreshTokenRotationModel](ctx)
+	}
+
+	var result refreshTokenRotationModel
+	diags.Append(fwflex.Flatten(ctx, rtr, &result)...)
 
 	return fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &result)
 }

--- a/internal/service/cognitoidp/user_pool_client_test.go
+++ b/internal/service/cognitoidp/user_pool_client_test.go
@@ -107,6 +107,7 @@ func TestAccCognitoIDPUserPoolClient_enableRevocation(t *testing.T) {
 					testAccCheckUserPoolClientExists(ctx, resourceName, &client),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "enable_token_revocation", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "refresh_token_rotation.#", "0"),
 				),
 			},
 			{
@@ -121,6 +122,7 @@ func TestAccCognitoIDPUserPoolClient_enableRevocation(t *testing.T) {
 					testAccCheckUserPoolClientExists(ctx, resourceName, &client),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "enable_token_revocation", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "refresh_token_rotation.#", "0"),
 				),
 			},
 			{


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. This change only adjusts Cognito user pool client state handling and update behavior in the provider.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This change fixes inconsistent handling of `refresh_token_rotation` for Cognito user pool clients when the block is removed from configuration.

The provider currently allows AWS to return the default disabled `refresh_token_rotation` object during create, read, or update, which can cause Terraform to see an unexpected transition from no block to one block in state. This results in errors such as:

- `Provider produced inconsistent result after apply`
- `.refresh_token_rotation: block count changed from 0 to 1`

This PR updates the Cognito IDP framework resources to:

- preserve `refresh_token_rotation` as null in state when the configuration omits the block and AWS returns the default disabled value
- explicitly reset `refresh_token_rotation` to the API default when the block is removed during update
- align the same normalization behavior for both `aws_cognito_user_pool_client` and `aws_cognito_managed_user_pool_client`
- add regression coverage to verify that an update does not reintroduce an omitted `refresh_token_rotation` block into state

This addresses the provider inconsistency when refresh token rotation is removed and prevents the unexpected `0 -> 1` block count drift after apply.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47196
Closes #47554

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- Cognito user pool client update behavior discussed in issue #47196
- Existing `token_validity_units` null-preservation pattern in the Cognito IDP framework resources was used as the model for this fix

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS='TestAccCognitoIDP(UserPoolClient|ManagedUserPoolClient)' PKG=cognitoidp
...
```