### PR TITLE
r/aws_sesv2_configuration_set_event_destination: Fix swapped argument descriptions

### DIFF
--- a/website/docs/r/sesv2_configuration_set_event_destination.html.markdown
+++ b/website/docs/r/sesv2_configuration_set_event_destination.html.markdown
@@ -133,8 +133,8 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `configuration_set_name` - (Required) The name of the configuration set.
-* `event_destination` - (Required) A name that identifies the event destination within the configuration set.
-* `event_destination_name` - (Required) An object that defines the event destination. See [`event_destination` Block](#event_destination-block) for details.
+* `event_destination` - (Required) An object that defines the event destination. See [`event_destination` Block](#event_destination-block) for details.
+* `event_destination_name` - (Required) A name that identifies the event destination within the configuration set.
 
 ### `event_destination` Block
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

The argument reference for `aws_sesv2_configuration_set_event_destination` has the descriptions for `event_destination` and `event_destination_name` swapped:

- `event_destination` is incorrectly described as "A name that identifies the event destination within the configuration set."
- `event_destination_name` is incorrectly described as "An object that defines the event destination."

This PR swaps the two descriptions back to correctly reflect the schema:

- `event_destination` is a required list/block that defines the destination (CloudWatch, EventBridge, Kinesis Firehose, Pinpoint, or SNS).
- `event_destination_name` is a required string that names the destination within the configuration set.

The corrected descriptions match the upstream AWS API reference and every example in the same documentation file.

Only `website/docs/r/sesv2_configuration_set_event_destination.html.markdown` is modified. The CDKtf-generated docs under `website/docs/cdktf/` are intentionally left untouched per `docs/documentation-changes.md`, which states that files in the `cdktf/` folder should not be edited directly and are regenerated from the source markdown.

### Relations

Closes #47312

### References

- AWS SESv2 `CreateConfigurationSetEventDestination` API reference: https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_CreateConfigurationSetEventDestination.html

### Output from Acceptance Testing

N/A - documentation-only change.