### PR TITLE
fix(grafana): allow empty lists in `network_access_control`

### DIFF
--- a/.changelog/47379.txt
+++ b/.changelog/47379.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_grafana_workspace: Fix issue where `network_access_control` requires non-epmpty list in `prefix_list_ids` or `vpce_ids`
+```

--- a/internal/service/grafana/workspace.go
+++ b/internal/service/grafana/workspace.go
@@ -588,11 +588,11 @@ func expandNetworkAccessControl(tfList []any) *awstypes.NetworkAccessConfigurati
 	tfMap := tfList[0].(map[string]any)
 	apiObject := awstypes.NetworkAccessConfiguration{}
 
-	if v, ok := tfMap["prefix_list_ids"].(*schema.Set); ok && v.Len() > 0 {
+	if v, ok := tfMap["prefix_list_ids"].(*schema.Set); ok {
 		apiObject.PrefixListIds = flex.ExpandStringValueSet(v)
 	}
 
-	if v, ok := tfMap["vpce_ids"].(*schema.Set); ok && v.Len() > 0 {
+	if v, ok := tfMap["vpce_ids"].(*schema.Set); ok {
 		apiObject.VpceIds = flex.ExpandStringValueSet(v)
 	}
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
Allow passing empty lists in `network_access_control`, because both arguments are required by the upstream API, but empty list values are valid configurations.

### Relations
Closes https://github.com/hashicorp/terraform-provider-aws/issues/45908
