### PR TITLE
New List Resource: `aws_api_gateway_resource`

### DIFF
--- a/.changelog/47382.txt
+++ b/.changelog/47382.txt
@@ -1,4 +1,3 @@
-
 ```release-note:new-list-resource
 aws_api_gateway_resource
 ```

--- a/.changelog/47382.txt
+++ b/.changelog/47382.txt
@@ -1,0 +1,4 @@
+
+```release-note:new-list-resource
+aws_api_gateway_resource
+```

--- a/internal/service/apigateway/resource.go
+++ b/internal/service/apigateway/resource.go
@@ -106,11 +106,15 @@ func resourceResourceRead(ctx context.Context, d *schema.ResourceData, meta any)
 		return sdkdiag.AppendErrorf(diags, "reading API Gateway Resource (%s): %s", d.Id(), err)
 	}
 
+	resourceResourceFlatten(d, resource)
+
+	return diags
+}
+
+func resourceResourceFlatten(d *schema.ResourceData, resource *apigateway.GetResourceOutput) {
 	d.Set("parent_id", resource.ParentId)
 	d.Set("path_part", resource.PathPart)
 	d.Set(names.AttrPath, resource.Path)
-
-	return diags
 }
 
 func resourceResourceUpdateOperations(d *schema.ResourceData) []types.PatchOperation {

--- a/internal/service/apigateway/resource_list.go
+++ b/internal/service/apigateway/resource_list.go
@@ -1,0 +1,128 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package apigateway
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/apigateway"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/apigateway/types"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for list resource registration to the Provider. DO NOT EDIT.
+// @SDKListResource("aws_api_gateway_resource")
+func newResourceResourceAsListResource() inttypes.ListResourceForSDK {
+	l := resourceListResource{}
+	l.SetResourceSchema(resourceResource())
+	return &l
+}
+
+var _ list.ListResource = &resourceListResource{}
+var _ list.ListResourceWithRawV5Schemas = &resourceListResource{}
+
+type resourceListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+func (l *resourceListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = listschema.Schema{
+		Attributes: map[string]listschema.Attribute{
+			"rest_api_id": listschema.StringAttribute{
+				Required:    true,
+				Description: "ID of the associated REST API.",
+			},
+		},
+	}
+}
+
+func (l *resourceListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	conn := l.Meta().APIGatewayClient(ctx)
+
+	var query listResourceModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	restAPIID := query.RestAPIID.ValueString()
+
+	tflog.Info(ctx, "Listing API Gateway Resources", map[string]any{
+		logging.ResourceAttributeKey("rest_api_id"): restAPIID,
+	})
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		input := apigateway.GetResourcesInput{
+			RestApiId: aws.String(restAPIID),
+		}
+
+		pages := apigateway.NewGetResourcesPaginator(conn, &input)
+		for pages.HasMorePages() {
+			page, err := pages.NextPage(ctx)
+
+			if errs.IsA[*awstypes.NotFoundException](err) {
+				result := fwdiag.NewListResultErrorDiagnostic(&retry.NotFoundError{LastError: err})
+				yield(result)
+				return
+			}
+
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+
+			for _, item := range page.Items {
+				resourceID := aws.ToString(item.Id)
+				ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrID), resourceID)
+
+				result := request.NewListResult(ctx)
+				rd := l.ResourceData()
+				rd.SetId(resourceID)
+				rd.Set("rest_api_id", restAPIID)
+
+				if request.IncludeResource {
+					output, err := findResourceByTwoPartKey(ctx, conn, resourceID, restAPIID)
+					if err != nil {
+						tflog.Error(ctx, "Reading API Gateway Resource", map[string]any{
+							"error": err.Error(),
+						})
+						continue
+					}
+					resourceResourceFlatten(rd, output)
+				}
+
+				result.DisplayName = aws.ToString(item.Path)
+
+				l.SetResult(ctx, l.Meta(), request.IncludeResource, rd, &result)
+				if result.Diagnostics.HasError() {
+					yield(result)
+					return
+				}
+
+				if !yield(result) {
+					return
+				}
+			}
+		}
+	}
+}
+
+type listResourceModel struct {
+	framework.WithRegionModel
+	RestAPIID types.String `tfsdk:"rest_api_id"`
+}

--- a/internal/service/apigateway/resource_list_test.go
+++ b/internal/service/apigateway/resource_list_test.go
@@ -1,0 +1,174 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package apigateway_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccAPIGatewayResource_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_api_gateway_resource.test[0]"
+	resourceName2 := "aws_api_gateway_resource.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		CheckDestroy:             testAccCheckResourceDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Resource/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"path_parts":    config.ListVariable(config.StringVariable("test1"), config.StringVariable("test2")),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Resource/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"path_parts":    config.ListVariable(config.StringVariable("test1"), config.StringVariable("test2")),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_resource.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_api_gateway_resource.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact("/test1")),
+					tfquerycheck.ExpectNoResourceObject("aws_api_gateway_resource.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_resource.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_api_gateway_resource.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringExact("/test2")),
+					tfquerycheck.ExpectNoResourceObject("aws_api_gateway_resource.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayResource_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_api_gateway_resource.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		CheckDestroy:             testAccCheckResourceDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Resource/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"path_parts":    config.ListVariable(config.StringVariable("test")),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Resource/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"path_parts":    config.ListVariable(config.StringVariable("test")),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_resource.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_api_gateway_resource.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact("/test")),
+					querycheck.ExpectResourceKnownValues("aws_api_gateway_resource.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("parent_id"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrPath), knownvalue.StringExact("/test")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("path_part"), knownvalue.StringExact("test")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("rest_api_id"), knownvalue.NotNull()),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayResource_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_api_gateway_resource.test[0]"
+	resourceName2 := "aws_api_gateway_resource.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+			acctest.PreCheckAPIGatewayTypeEDGE(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		CheckDestroy:             testAccCheckResourceDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Resource/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"path_parts":    config.ListVariable(config.StringVariable("test1"), config.StringVariable("test2")),
+					"region":        config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Resource/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"path_parts":    config.ListVariable(config.StringVariable("test1"), config.StringVariable("test2")),
+					"region":        config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_resource.test", identity1.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_resource.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/apigateway/service_package_gen.go
+++ b/internal/service/apigateway/service_package_gen.go
@@ -365,6 +365,16 @@ func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttype
 			}),
 		},
 		{
+			Factory:  newResourceResourceAsListResource,
+			TypeName: "aws_api_gateway_resource",
+			Name:     "Resource",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+			Identity: inttypes.RegionalParameterizedIdentity([]inttypes.IdentityAttribute{
+				inttypes.StringIdentityAttribute("rest_api_id", true),
+				inttypes.StringIdentityAttribute(names.AttrID, true),
+			}),
+		},
+		{
 			Factory:  newRestAPIResourceAsListResource,
 			TypeName: "aws_api_gateway_rest_api",
 			Name:     "REST API",

--- a/internal/service/apigateway/testdata/Resource/list_basic/main.tf
+++ b/internal/service/apigateway/testdata/Resource/list_basic/main.tf
@@ -1,0 +1,26 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_api_gateway_resource" "test" {
+  count = length(var.path_parts)
+
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = var.path_parts[count.index]
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  name = var.rName
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "path_parts" {
+  description = "Path parts to create"
+  type        = list(string)
+  nullable    = false
+}

--- a/internal/service/apigateway/testdata/Resource/list_basic/query.tfquery.hcl
+++ b/internal/service/apigateway/testdata/Resource/list_basic/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_api_gateway_resource" "test" {
+  provider = aws
+
+  config {
+    rest_api_id = aws_api_gateway_rest_api.test.id
+  }
+}

--- a/internal/service/apigateway/testdata/Resource/list_include_resource/main.tf
+++ b/internal/service/apigateway/testdata/Resource/list_include_resource/main.tf
@@ -1,0 +1,26 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_api_gateway_resource" "test" {
+  count = length(var.path_parts)
+
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = var.path_parts[count.index]
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  name = var.rName
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "path_parts" {
+  description = "Path parts to create"
+  type        = list(string)
+  nullable    = false
+}

--- a/internal/service/apigateway/testdata/Resource/list_include_resource/query.tfquery.hcl
+++ b/internal/service/apigateway/testdata/Resource/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,12 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_api_gateway_resource" "test" {
+  provider = aws
+
+  include_resource = true
+
+  config {
+    rest_api_id = aws_api_gateway_rest_api.test.id
+  }
+}

--- a/internal/service/apigateway/testdata/Resource/list_region_override/main.tf
+++ b/internal/service/apigateway/testdata/Resource/list_region_override/main.tf
@@ -1,0 +1,35 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_api_gateway_resource" "test" {
+  count  = length(var.path_parts)
+  region = var.region
+
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = var.path_parts[count.index]
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  region = var.region
+
+  name = var.rName
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "path_parts" {
+  description = "Path parts to create"
+  type        = list(string)
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/apigateway/testdata/Resource/list_region_override/query.tfquery.hcl
+++ b/internal/service/apigateway/testdata/Resource/list_region_override/query.tfquery.hcl
@@ -1,0 +1,11 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_api_gateway_resource" "test" {
+  provider = aws
+
+  config {
+    region      = var.region
+    rest_api_id = aws_api_gateway_rest_api.test.id
+  }
+}

--- a/website/docs/list-resources/api_gateway_resource.html.markdown
+++ b/website/docs/list-resources/api_gateway_resource.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "API Gateway"
+layout: "aws"
+page_title: "AWS: aws_api_gateway_resource"
+description: |-
+  Lists API Gateway Resource resources.
+---
+
+# List Resource: aws_api_gateway_resource
+
+Lists API Gateway Resource resources for a specific REST API.
+
+## Example Usage
+
+```terraform
+list "aws_api_gateway_resource" "example" {
+  provider = aws
+
+  config {
+    rest_api_id = aws_api_gateway_rest_api.example.id
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.
+* `rest_api_id` - (Required) ID of the associated REST API.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

New List Resource: `aws_api_gateway_resource`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Based on #47358
Closes #47226

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=apigateway TESTS=TestAccAPIGatewayResource_

--- PASS: TestAccAPIGatewayResource_List_regionOverride (40.74s)
--- PASS: TestAccAPIGatewayResource_basic (44.91s)
--- PASS: TestAccAPIGatewayResource_List_includeResource (61.35s)
--- PASS: TestAccAPIGatewayResource_Identity_regionOverride (74.39s)
--- PASS: TestAccAPIGatewayResource_Identity_ExistingResource_noRefreshNoChange (109.16s)
--- PASS: TestAccAPIGatewayResource_List_basic (169.61s)
--- PASS: TestAccAPIGatewayResource_recomputePath (477.54s)
--- PASS: TestAccAPIGatewayResource_withSleep (723.34s)
--- PASS: TestAccAPIGatewayResource_Identity_basic (824.72s)
--- PASS: TestAccAPIGatewayResource_disappears (938.38s)
--- PASS: TestAccAPIGatewayResource_update (1030.09s)
--- PASS: TestAccAPIGatewayResource_Identity_ExistingResource_basic (1258.41s)
```
