### PR TITLE
r/aws_batch_compute_environment: add scaling_policy support

### DIFF
--- a/.changelog/47383.txt
+++ b/.changelog/47383.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_batch_compute_environment: Add `scaling_policy` configuration block to `compute_resources`
+```

--- a/internal/service/batch/compute_environment.go
+++ b/internal/service/batch/compute_environment.go
@@ -202,6 +202,23 @@ func resourceComputeEnvironment() *schema.Resource {
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"scaling_policy": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"min_scale_down_delay_minutes": {
+										Type:     schema.TypeInt,
+										Required: true,
+										ValidateFunc: validation.Any(
+											validation.IntInSlice([]int{0}),
+											validation.IntBetween(20, 10080),
+										),
+									},
+								},
+							},
+						},
 						names.AttrTags: tftags.TagsSchema(),
 						names.AttrType: {
 							Type:             schema.TypeString,
@@ -514,6 +531,15 @@ func resourceComputeEnvironmentUpdate(ctx context.Context, d *schema.ResourceDat
 				if d.HasChange("compute_resources.0.launch_template") {
 					launchTemplate := d.Get("compute_resources.0.launch_template").([]any)
 					computeResourceUpdate.LaunchTemplate = expandLaunchTemplateSpecificationUpdate(launchTemplate)
+				}
+
+				if d.HasChange("compute_resources.0.scaling_policy") {
+					if v, ok := d.GetOk("compute_resources.0.scaling_policy"); ok {
+						scalingPolicy := v.([]any)
+						if len(scalingPolicy) > 0 && scalingPolicy[0] != nil {
+							computeResourceUpdate.ScalingPolicy = expandComputeScalingPolicy(scalingPolicy[0].(map[string]any))
+						}
+					}
 				}
 
 				if d.HasChange("compute_resources.0.tags") {
@@ -964,6 +990,10 @@ func expandComputeResource(ctx context.Context, tfMap map[string]any) *awstypes.
 		apiObject.PlacementGroup = aws.String(v)
 	}
 
+	if v, ok := tfMap["scaling_policy"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.ScalingPolicy = expandComputeScalingPolicy(v[0].(map[string]any))
+	}
+
 	if v, ok := tfMap[names.AttrSecurityGroupIDs].(*schema.Set); ok && v.Len() > 0 {
 		apiObject.SecurityGroupIds = flex.ExpandStringValueSet(v)
 	}
@@ -1185,6 +1215,10 @@ func flattenComputeResource(ctx context.Context, apiObject *awstypes.ComputeReso
 		tfMap["placement_group"] = aws.ToString(v)
 	}
 
+	if v := apiObject.ScalingPolicy; v != nil {
+		tfMap["scaling_policy"] = flattenComputeScalingPolicy(v)
+	}
+
 	if v := apiObject.SecurityGroupIds; v != nil {
 		tfMap[names.AttrSecurityGroupIDs] = v
 	}
@@ -1303,6 +1337,34 @@ func flattenComputeEnvironmentUpdatePolicy(apiObject *awstypes.UpdatePolicy) []a
 	m := map[string]any{
 		"job_execution_timeout_minutes": aws.ToInt64(apiObject.JobExecutionTimeoutMinutes),
 		"terminate_jobs_on_update":      aws.ToBool(apiObject.TerminateJobsOnUpdate),
+	}
+
+	return []any{m}
+}
+
+func expandComputeScalingPolicy(tfMap map[string]any) *awstypes.ComputeScalingPolicy {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &awstypes.ComputeScalingPolicy{}
+
+	if v, ok := tfMap["min_scale_down_delay_minutes"].(int); ok {
+		apiObject.MinScaleDownDelayMinutes = aws.Int32(int32(v))
+	}
+
+	return apiObject
+}
+
+func flattenComputeScalingPolicy(apiObject *awstypes.ComputeScalingPolicy) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	m := map[string]any{}
+
+	if v := apiObject.MinScaleDownDelayMinutes; v != nil {
+		m["min_scale_down_delay_minutes"] = aws.ToInt32(v)
 	}
 
 	return []any{m}

--- a/internal/service/batch/compute_environment_test.go
+++ b/internal/service/batch/compute_environment_test.go
@@ -3429,3 +3429,130 @@ resource "aws_batch_compute_environment" "test" {
 }
 `, rName, instanceType))
 }
+
+func TestAccBatchComputeEnvironment_ComputeResources_scalingPolicy(t *testing.T) {
+	ctx := acctest.Context(t)
+	var ce awstypes.ComputeEnvironmentDetail
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_batch_compute_environment.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeEnvironmentConfig_ec2ScalingPolicy(rName, 20),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, t, resourceName, &ce),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.scaling_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.scaling_policy.0.min_scale_down_delay_minutes", "20"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeEnvironmentConfig_ec2ScalingPolicy(rName, 60),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, t, resourceName, &ce),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.scaling_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.scaling_policy.0.min_scale_down_delay_minutes", "60"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBatchComputeEnvironment_ComputeResources_scalingPolicyUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var ce awstypes.ComputeEnvironmentDetail
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_batch_compute_environment.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeEnvironmentConfig_ec2ScalingPolicyOmitted(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, t, resourceName, &ce),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.scaling_policy.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeEnvironmentConfig_ec2ScalingPolicy(rName, 30),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, t, resourceName, &ce),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.scaling_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.scaling_policy.0.min_scale_down_delay_minutes", "30"),
+				),
+			},
+		},
+	})
+}
+
+func testAccComputeEnvironmentConfig_ec2ScalingPolicy(rName string, minScaleDownDelayMinutes int) string {
+	return acctest.ConfigCompose(testAccComputeEnvironmentConfig_baseDefaultSLR(rName), fmt.Sprintf(`
+resource "aws_batch_compute_environment" "test" {
+  name = %[1]q
+
+  compute_resources {
+    allocation_strategy = "BEST_FIT_PROGRESSIVE"
+    instance_role       = aws_iam_instance_profile.ecs_instance.arn
+    instance_type       = ["optimal"]
+    max_vcpus           = 4
+    min_vcpus           = 0
+    security_group_ids = [
+      aws_security_group.test.id
+    ]
+    subnets = [
+      aws_subnet.test.id
+    ]
+    type = "EC2"
+
+    scaling_policy {
+      min_scale_down_delay_minutes = %[2]d
+    }
+  }
+
+  type = "MANAGED"
+}
+`, rName, minScaleDownDelayMinutes))
+}
+
+func testAccComputeEnvironmentConfig_ec2ScalingPolicyOmitted(rName string) string {
+	return acctest.ConfigCompose(testAccComputeEnvironmentConfig_baseDefaultSLR(rName), fmt.Sprintf(`
+resource "aws_batch_compute_environment" "test" {
+  name = %[1]q
+
+  compute_resources {
+    allocation_strategy = "BEST_FIT_PROGRESSIVE"
+    instance_role       = aws_iam_instance_profile.ecs_instance.arn
+    instance_type       = ["optimal"]
+    max_vcpus           = 4
+    min_vcpus           = 0
+    security_group_ids = [
+      aws_security_group.test.id
+    ]
+    subnets = [
+      aws_subnet.test.id
+    ]
+    type = "EC2"
+  }
+
+  type = "MANAGED"
+}
+`, rName))
+}

--- a/website/docs/r/batch_compute_environment.html.markdown
+++ b/website/docs/r/batch_compute_environment.html.markdown
@@ -214,6 +214,7 @@ This resource supports the following arguments:
 * `max_vcpus` - (Required) The maximum number of EC2 vCPUs that an environment can reach.
 * `min_vcpus` - (Optional) The minimum number of EC2 vCPUs that an environment should maintain. For `EC2` or `SPOT` compute environments, if the parameter is not explicitly defined, a `0` default value will be set. This parameter isn't applicable to jobs running on Fargate resources, and shouldn't be specified.
 * `placement_group` - (Optional) The Amazon EC2 placement group to associate with your compute resources.
+* `scaling_policy` - (Optional) The scaling policy for the compute environment. See details below. This parameter isn't applicable to jobs running on Fargate resources, and shouldn't be specified.
 * `security_group_ids` - (Optional) A list of EC2 security group that are associated with instances launched in the compute environment. This parameter is required for Fargate compute environments.
 * `spot_iam_fleet_role` - (Optional) The Amazon Resource Name (ARN) of the Amazon EC2 Spot Fleet IAM role applied to a SPOT compute environment. This parameter is required for SPOT compute environments. This parameter isn't applicable to jobs running on Fargate resources, and shouldn't be specified.
 * `subnets` - (Required) A list of VPC subnets into which the compute resources are launched.
@@ -235,6 +236,12 @@ This resource supports the following arguments:
 * `launch_template_id` - (Optional) ID of the launch template. You must specify either the launch template ID or launch template name in the request, but not both.
 * `launch_template_name` - (Optional) Name of the launch template.
 * `version` - (Optional) The version number of the launch template. Default: The default version of the launch template.
+
+### scaling_policy
+
+`scaling_policy` supports the following:
+
+* `min_scale_down_delay_minutes` - (Required) The minimum time (in minutes) that AWS Batch keeps instances running in the compute environment after their jobs complete. For each instance, the delay period begins when the last job finishes. If no new jobs are placed on the instance during this delay, AWS Batch terminates the instance once the delay expires. Valid values are between `20` and `10080`. Use `0` to disable the scale down delay.
 
 ### eks_configuration
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Adds support for the `scaling_policy` configuration block within `compute_resources` on `aws_batch_compute_environment`. This exposes the `MinScaleDownDelayMinutes` field added to the AWS Batch API, which keeps instances running after their last job completes to avoid re-provisioning for back-to-back workloads.

- Added `scaling_policy` block to `compute_resources` schema
- Added expand/flatten functions for `ComputeScalingPolicy`
- Wired into Create, Read, and Update paths
- Added acceptance tests
- Added documentation

### Relations

Closes #47380

### References

- [ComputeScalingPolicy API reference](https://docs.aws.amazon.com/batch/latest/APIReference/API_ComputeScalingPolicy.html)
- [AWS Go SDK v2 - ComputeScalingPolicy](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/batch/types#ComputeScalingPolicy)

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccBatchComputeEnvironment_ComputeResources_scalingPolicy PKG=batch

...
```