### PR TITLE
New List Resource: `aws_api_gateway_method_response`

### DIFF
--- a/.changelog/47387.txt
+++ b/.changelog/47387.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_api_gateway_method_response
+```

--- a/internal/service/apigateway/method_response.go
+++ b/internal/service/apigateway/method_response.go
@@ -135,14 +135,14 @@ func resourceMethodResponseRead(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "reading API Gateway Method Response (%s): %s", d.Id(), err)
 	}
 
-	if err := d.Set("response_models", methodResponse.ResponseModels); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting response_models: %s", err)
-	}
-	if err := d.Set("response_parameters", methodResponse.ResponseParameters); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting response_parameters: %s", err)
-	}
+	resourceMethodResponseFlatten(d, methodResponse)
 
 	return diags
+}
+
+func resourceMethodResponseFlatten(d *schema.ResourceData, methodResponse *apigateway.GetMethodResponseOutput) {
+	d.Set("response_models", methodResponse.ResponseModels)
+	d.Set("response_parameters", methodResponse.ResponseParameters)
 }
 
 func resourceMethodResponseUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/service/apigateway/method_response_list.go
+++ b/internal/service/apigateway/method_response_list.go
@@ -1,0 +1,126 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package apigateway
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for list resource registration to the Provider. DO NOT EDIT.
+// @SDKListResource("aws_api_gateway_method_response")
+func newMethodResponseResourceAsListResource() inttypes.ListResourceForSDK {
+	l := methodResponseListResource{}
+	l.SetResourceSchema(resourceMethodResponse())
+	return &l
+}
+
+var _ list.ListResource = &methodResponseListResource{}
+var _ list.ListResourceWithRawV5Schemas = &methodResponseListResource{}
+
+type methodResponseListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+func (l *methodResponseListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = listschema.Schema{
+		Attributes: map[string]listschema.Attribute{
+			"rest_api_id": listschema.StringAttribute{
+				Required:    true,
+				Description: "ID of the associated REST API.",
+			},
+			names.AttrResourceID: listschema.StringAttribute{
+				Required:    true,
+				Description: "ID of the API Gateway Resource.",
+			},
+			"http_method": listschema.StringAttribute{
+				Required:    true,
+				Description: "HTTP method of the API Gateway Method.",
+			},
+		},
+	}
+}
+
+func (l *methodResponseListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	conn := l.Meta().APIGatewayClient(ctx)
+
+	var query listMethodResponseModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	restAPIID := query.RestAPIID.ValueString()
+	resourceID := query.ResourceID.ValueString()
+	httpMethod := query.HTTPMethod.ValueString()
+
+	tflog.Info(ctx, "Listing API Gateway Method Responses", map[string]any{
+		logging.ResourceAttributeKey("rest_api_id"):        restAPIID,
+		logging.ResourceAttributeKey(names.AttrResourceID): resourceID,
+		logging.ResourceAttributeKey("http_method"):        httpMethod,
+	})
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		method, err := findMethodByThreePartKey(ctx, conn, httpMethod, resourceID, restAPIID)
+		if err != nil {
+			result := fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("reading API Gateway Method (%s/%s/%s): %w", restAPIID, resourceID, httpMethod, err))
+			yield(result)
+			return
+		}
+
+		for statusCode := range method.MethodResponses {
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrStatusCode), statusCode)
+
+			result := request.NewListResult(ctx)
+			rd := l.ResourceData()
+			rd.SetId(resourceMethodResponseIDAttr(restAPIID, resourceID, httpMethod, statusCode))
+			rd.Set("rest_api_id", restAPIID)
+			rd.Set(names.AttrResourceID, resourceID)
+			rd.Set("http_method", httpMethod)
+			rd.Set(names.AttrStatusCode, statusCode)
+
+			if request.IncludeResource {
+				methodResponse, err := findMethodResponseByFourPartKey(ctx, conn, httpMethod, resourceID, restAPIID, statusCode)
+				if err != nil {
+					tflog.Error(ctx, "Reading API Gateway Method Response", map[string]any{
+						"error": err.Error(),
+					})
+					continue
+				}
+				resourceMethodResponseFlatten(rd, methodResponse)
+			}
+
+			result.DisplayName = fmt.Sprintf("%s %s", httpMethod, statusCode)
+
+			l.SetResult(ctx, l.Meta(), request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+type listMethodResponseModel struct {
+	framework.WithRegionModel
+	RestAPIID  types.String `tfsdk:"rest_api_id"`
+	ResourceID types.String `tfsdk:"resource_id"`
+	HTTPMethod types.String `tfsdk:"http_method"`
+}

--- a/internal/service/apigateway/method_response_list_test.go
+++ b/internal/service/apigateway/method_response_list_test.go
@@ -1,0 +1,177 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package apigateway_test
+
+import (
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccAPIGatewayMethodResponse_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_api_gateway_method_response.test[0]"
+	resourceName2 := "aws_api_gateway_method_response.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		CheckDestroy:             testAccCheckMethodResponseDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/MethodResponse/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"status_codes":  config.ListVariable(config.StringVariable("200"), config.StringVariable("400")),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/MethodResponse/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"status_codes":  config.ListVariable(config.StringVariable("200"), config.StringVariable("400")),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_method_response.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_api_gateway_method_response.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringRegexp(regexache.MustCompile(`^GET (200|400)$`))),
+					tfquerycheck.ExpectNoResourceObject("aws_api_gateway_method_response.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_method_response.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_api_gateway_method_response.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringRegexp(regexache.MustCompile(`^GET (200|400)$`))),
+					tfquerycheck.ExpectNoResourceObject("aws_api_gateway_method_response.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayMethodResponse_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_api_gateway_method_response.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		CheckDestroy:             testAccCheckMethodResponseDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/MethodResponse/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"status_codes":  config.ListVariable(config.StringVariable("200")),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/MethodResponse/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"status_codes":  config.ListVariable(config.StringVariable("200")),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_method_response.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_api_gateway_method_response.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact("GET 200")),
+					querycheck.ExpectResourceKnownValues("aws_api_gateway_method_response.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("http_method"), knownvalue.StringExact("GET")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrResourceID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("response_models"), knownvalue.MapExact(map[string]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("response_parameters"), knownvalue.MapExact(map[string]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("rest_api_id"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrStatusCode), knownvalue.StringExact("200")),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayMethodResponse_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_api_gateway_method_response.test[0]"
+	resourceName2 := "aws_api_gateway_method_response.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+			acctest.PreCheckAPIGatewayTypeEDGE(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		CheckDestroy:             testAccCheckMethodResponseDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/MethodResponse/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"status_codes":  config.ListVariable(config.StringVariable("200"), config.StringVariable("400")),
+					"region":        config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/MethodResponse/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"status_codes":  config.ListVariable(config.StringVariable("200"), config.StringVariable("400")),
+					"region":        config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_method_response.test", identity1.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_method_response.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/apigateway/service_package_gen.go
+++ b/internal/service/apigateway/service_package_gen.go
@@ -365,6 +365,18 @@ func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttype
 			}),
 		},
 		{
+			Factory:  newMethodResponseResourceAsListResource,
+			TypeName: "aws_api_gateway_method_response",
+			Name:     "Method Response",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+			Identity: inttypes.RegionalParameterizedIdentity([]inttypes.IdentityAttribute{
+				inttypes.StringIdentityAttribute("rest_api_id", true),
+				inttypes.StringIdentityAttribute(names.AttrResourceID, true),
+				inttypes.StringIdentityAttribute("http_method", true),
+				inttypes.StringIdentityAttribute(names.AttrStatusCode, true),
+			}),
+		},
+		{
 			Factory:  newResourceResourceAsListResource,
 			TypeName: "aws_api_gateway_resource",
 			Name:     "Resource",

--- a/internal/service/apigateway/testdata/MethodResponse/list_basic/main.tf
+++ b/internal/service/apigateway/testdata/MethodResponse/list_basic/main.tf
@@ -1,0 +1,40 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_api_gateway_method_response" "test" {
+  count = length(var.status_codes)
+
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
+  status_code = var.status_codes[count.index]
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  name = var.rName
+}
+
+resource "aws_api_gateway_resource" "test" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
+}
+
+resource "aws_api_gateway_method" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "status_codes" {
+  description = "Status codes to create"
+  type        = list(string)
+  nullable    = false
+}

--- a/internal/service/apigateway/testdata/MethodResponse/list_basic/query.tfquery.hcl
+++ b/internal/service/apigateway/testdata/MethodResponse/list_basic/query.tfquery.hcl
@@ -1,0 +1,12 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_api_gateway_method_response" "test" {
+  provider = aws
+
+  config {
+    rest_api_id = aws_api_gateway_rest_api.test.id
+    resource_id = aws_api_gateway_resource.test.id
+    http_method = aws_api_gateway_method.test.http_method
+  }
+}

--- a/internal/service/apigateway/testdata/MethodResponse/list_include_resource/main.tf
+++ b/internal/service/apigateway/testdata/MethodResponse/list_include_resource/main.tf
@@ -1,0 +1,40 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_api_gateway_method_response" "test" {
+  count = length(var.status_codes)
+
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
+  status_code = var.status_codes[count.index]
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  name = var.rName
+}
+
+resource "aws_api_gateway_resource" "test" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
+}
+
+resource "aws_api_gateway_method" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "status_codes" {
+  description = "Status codes to create"
+  type        = list(string)
+  nullable    = false
+}

--- a/internal/service/apigateway/testdata/MethodResponse/list_include_resource/query.tfquery.hcl
+++ b/internal/service/apigateway/testdata/MethodResponse/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,14 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_api_gateway_method_response" "test" {
+  provider = aws
+
+  include_resource = true
+
+  config {
+    rest_api_id = aws_api_gateway_rest_api.test.id
+    resource_id = aws_api_gateway_resource.test.id
+    http_method = aws_api_gateway_method.test.http_method
+  }
+}

--- a/internal/service/apigateway/testdata/MethodResponse/list_region_override/main.tf
+++ b/internal/service/apigateway/testdata/MethodResponse/list_region_override/main.tf
@@ -1,0 +1,53 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_api_gateway_method_response" "test" {
+  count  = length(var.status_codes)
+  region = var.region
+
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
+  status_code = var.status_codes[count.index]
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  region = var.region
+
+  name = var.rName
+}
+
+resource "aws_api_gateway_resource" "test" {
+  region = var.region
+
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
+}
+
+resource "aws_api_gateway_method" "test" {
+  region = var.region
+
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "status_codes" {
+  description = "Status codes to create"
+  type        = list(string)
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/apigateway/testdata/MethodResponse/list_region_override/query.tfquery.hcl
+++ b/internal/service/apigateway/testdata/MethodResponse/list_region_override/query.tfquery.hcl
@@ -1,0 +1,13 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_api_gateway_method_response" "test" {
+  provider = aws
+
+  config {
+    region      = var.region
+    rest_api_id = aws_api_gateway_rest_api.test.id
+    resource_id = aws_api_gateway_resource.test.id
+    http_method = aws_api_gateway_method.test.http_method
+  }
+}

--- a/website/docs/list-resources/api_gateway_method_response.html.markdown
+++ b/website/docs/list-resources/api_gateway_method_response.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "API Gateway"
+layout: "aws"
+page_title: "AWS: aws_api_gateway_method_response"
+description: |-
+  Lists API Gateway Method Response resources.
+---
+
+# List Resource: aws_api_gateway_method_response
+
+Lists API Gateway Method Response resources for a specific API Gateway Method.
+
+## Example Usage
+
+```terraform
+list "aws_api_gateway_method_response" "example" {
+  provider = aws
+
+  config {
+    rest_api_id = aws_api_gateway_rest_api.example.id
+    resource_id = aws_api_gateway_resource.example.id
+    http_method = aws_api_gateway_method.example.http_method
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `http_method` - (Required) HTTP method of the API Gateway Method.
+* `region` - (Optional) Region to query. Defaults to provider region.
+* `resource_id` - (Required) ID of the API Gateway Resource.
+* `rest_api_id` - (Required) ID of the associated REST API.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

New List Resource: `aws_api_gateway_method_response`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Based on #47360
Closes #47231

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=apigateway TESTS=TestAccAPIGatewayMethodResponse_

--- PASS: TestAccAPIGatewayMethodResponse_List_includeResource (45.42s)
--- PASS: TestAccAPIGatewayMethodResponse_List_basic (45.96s)
--- PASS: TestAccAPIGatewayMethodResponse_List_regionOverride (49.40s)
--- PASS: TestAccAPIGatewayMethodResponse_Identity_regionOverride (80.51s)
--- PASS: TestAccAPIGatewayMethodResponse_Identity_ExistingResource_basic (115.64s)
--- PASS: TestAccAPIGatewayMethodResponse_basic (138.94s)
--- PASS: TestAccAPIGatewayMethodResponse_Identity_basic (179.34s)
--- PASS: TestAccAPIGatewayMethodResponse_disappears (238.12s)
--- PASS: TestAccAPIGatewayMethodResponse_Identity_ExistingResource_noRefreshNoChange (250.42s)
```
