### PR TITLE
New List Resource: `aws_api_gateway_integration_response`

### DIFF
--- a/.changelog/47388.txt
+++ b/.changelog/47388.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_api_gateway_integration_response
+```

--- a/internal/service/apigateway/integration_response.go
+++ b/internal/service/apigateway/integration_response.go
@@ -145,6 +145,12 @@ func resourceIntegrationResponseRead(ctx context.Context, d *schema.ResourceData
 		return sdkdiag.AppendErrorf(diags, "reading API Gateway Integration Response (%s): %s", d.Id(), err)
 	}
 
+	resourceIntegrationResponseFlatten(d, integrationResponse)
+
+	return diags
+}
+
+func resourceIntegrationResponseFlatten(d *schema.ResourceData, integrationResponse *apigateway.GetIntegrationResponseOutput) {
 	d.Set("content_handling", integrationResponse.ContentHandling)
 	d.Set("response_parameters", integrationResponse.ResponseParameters)
 	// We need to explicitly convert key = nil values into key = "", which aws.StringValueMap() removes.
@@ -152,8 +158,6 @@ func resourceIntegrationResponseRead(ctx context.Context, d *schema.ResourceData
 	maps.Copy(responseTemplates, integrationResponse.ResponseTemplates)
 	d.Set("response_templates", responseTemplates)
 	d.Set("selection_pattern", integrationResponse.SelectionPattern)
-
-	return diags
 }
 
 func resourceIntegrationResponseDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/service/apigateway/integration_response_list.go
+++ b/internal/service/apigateway/integration_response_list.go
@@ -1,0 +1,126 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package apigateway
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for list resource registration to the Provider. DO NOT EDIT.
+// @SDKListResource("aws_api_gateway_integration_response")
+func newIntegrationResponseResourceAsListResource() inttypes.ListResourceForSDK {
+	l := integrationResponseListResource{}
+	l.SetResourceSchema(resourceIntegrationResponse())
+	return &l
+}
+
+var _ list.ListResource = &integrationResponseListResource{}
+var _ list.ListResourceWithRawV5Schemas = &integrationResponseListResource{}
+
+type integrationResponseListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+func (l *integrationResponseListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = listschema.Schema{
+		Attributes: map[string]listschema.Attribute{
+			"rest_api_id": listschema.StringAttribute{
+				Required:    true,
+				Description: "ID of the associated REST API.",
+			},
+			names.AttrResourceID: listschema.StringAttribute{
+				Required:    true,
+				Description: "ID of the API Gateway Resource.",
+			},
+			"http_method": listschema.StringAttribute{
+				Required:    true,
+				Description: "HTTP method of the API Gateway Method.",
+			},
+		},
+	}
+}
+
+func (l *integrationResponseListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	conn := l.Meta().APIGatewayClient(ctx)
+
+	var query listIntegrationResponseModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	restAPIID := query.RestAPIID.ValueString()
+	resourceID := query.ResourceID.ValueString()
+	httpMethod := query.HTTPMethod.ValueString()
+
+	tflog.Info(ctx, "Listing API Gateway Integration Responses", map[string]any{
+		logging.ResourceAttributeKey("rest_api_id"):        restAPIID,
+		logging.ResourceAttributeKey(names.AttrResourceID): resourceID,
+		logging.ResourceAttributeKey("http_method"):        httpMethod,
+	})
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		integration, err := findIntegrationByThreePartKey(ctx, conn, httpMethod, resourceID, restAPIID)
+		if err != nil {
+			result := fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("reading API Gateway Integration (%s/%s/%s): %w", restAPIID, resourceID, httpMethod, err))
+			yield(result)
+			return
+		}
+
+		for statusCode := range integration.IntegrationResponses {
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrStatusCode), statusCode)
+
+			result := request.NewListResult(ctx)
+			rd := l.ResourceData()
+			rd.SetId(resourceIntegrationResponseIDAttr(restAPIID, resourceID, httpMethod, statusCode))
+			rd.Set("rest_api_id", restAPIID)
+			rd.Set(names.AttrResourceID, resourceID)
+			rd.Set("http_method", httpMethod)
+			rd.Set(names.AttrStatusCode, statusCode)
+
+			if request.IncludeResource {
+				integrationResponse, err := findIntegrationResponseByFourPartKey(ctx, conn, httpMethod, resourceID, restAPIID, statusCode)
+				if err != nil {
+					tflog.Error(ctx, "Reading API Gateway Integration Response", map[string]any{
+						"error": err.Error(),
+					})
+					continue
+				}
+				resourceIntegrationResponseFlatten(rd, integrationResponse)
+			}
+
+			result.DisplayName = fmt.Sprintf("%s %s", httpMethod, statusCode)
+
+			l.SetResult(ctx, l.Meta(), request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+type listIntegrationResponseModel struct {
+	framework.WithRegionModel
+	RestAPIID  types.String `tfsdk:"rest_api_id"`
+	ResourceID types.String `tfsdk:"resource_id"`
+	HTTPMethod types.String `tfsdk:"http_method"`
+}

--- a/internal/service/apigateway/integration_response_list_test.go
+++ b/internal/service/apigateway/integration_response_list_test.go
@@ -1,0 +1,185 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package apigateway_test
+
+import (
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccAPIGatewayIntegrationResponse_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_api_gateway_integration_response.test[0]"
+	resourceName2 := "aws_api_gateway_integration_response.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		CheckDestroy:             testAccCheckIntegrationResponseDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/IntegrationResponse/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"status_codes":  config.ListVariable(config.StringVariable("200"), config.StringVariable("400")),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/IntegrationResponse/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"status_codes":  config.ListVariable(config.StringVariable("200"), config.StringVariable("400")),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_integration_response.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_api_gateway_integration_response.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringRegexp(regexache.MustCompile(`^GET (200|400)$`))),
+					tfquerycheck.ExpectNoResourceObject("aws_api_gateway_integration_response.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_integration_response.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_api_gateway_integration_response.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringRegexp(regexache.MustCompile(`^GET (200|400)$`))),
+					tfquerycheck.ExpectNoResourceObject("aws_api_gateway_integration_response.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayIntegrationResponse_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_api_gateway_integration_response.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		CheckDestroy:             testAccCheckIntegrationResponseDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/IntegrationResponse/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"status_codes":  config.ListVariable(config.StringVariable("200")),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+				},
+			},
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/IntegrationResponse/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"status_codes":  config.ListVariable(config.StringVariable("200")),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_integration_response.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_api_gateway_integration_response.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact("GET 200")),
+					querycheck.ExpectResourceKnownValues("aws_api_gateway_integration_response.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("content_handling"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("http_method"), knownvalue.StringExact("GET")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrResourceID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("response_parameters"), knownvalue.MapExact(map[string]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("response_templates"), knownvalue.MapExact(map[string]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("rest_api_id"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("selection_pattern"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrStatusCode), knownvalue.StringExact("200")),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayIntegrationResponse_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_api_gateway_integration_response.test[0]"
+	resourceName2 := "aws_api_gateway_integration_response.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+			acctest.PreCheckAPIGatewayTypeEDGE(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		CheckDestroy:             testAccCheckIntegrationResponseDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/IntegrationResponse/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"status_codes":  config.ListVariable(config.StringVariable("200"), config.StringVariable("400")),
+					"region":        config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/IntegrationResponse/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"status_codes":  config.ListVariable(config.StringVariable("200"), config.StringVariable("400")),
+					"region":        config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_integration_response.test", identity1.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_api_gateway_integration_response.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/apigateway/service_package_gen.go
+++ b/internal/service/apigateway/service_package_gen.go
@@ -354,6 +354,18 @@ func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttype
 			}),
 		},
 		{
+			Factory:  newIntegrationResponseResourceAsListResource,
+			TypeName: "aws_api_gateway_integration_response",
+			Name:     "Integration Response",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+			Identity: inttypes.RegionalParameterizedIdentity([]inttypes.IdentityAttribute{
+				inttypes.StringIdentityAttribute("rest_api_id", true),
+				inttypes.StringIdentityAttribute(names.AttrResourceID, true),
+				inttypes.StringIdentityAttribute("http_method", true),
+				inttypes.StringIdentityAttribute(names.AttrStatusCode, true),
+			}),
+		},
+		{
 			Factory:  newMethodResourceAsListResource,
 			TypeName: "aws_api_gateway_method",
 			Name:     "Method",

--- a/internal/service/apigateway/testdata/IntegrationResponse/list_basic/main.tf
+++ b/internal/service/apigateway/testdata/IntegrationResponse/list_basic/main.tf
@@ -1,0 +1,51 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_api_gateway_integration_response" "test" {
+  count = length(var.status_codes)
+
+  rest_api_id       = aws_api_gateway_rest_api.test.id
+  resource_id       = aws_api_gateway_resource.test.id
+  http_method       = aws_api_gateway_method.test.http_method
+  status_code       = var.status_codes[count.index]
+  selection_pattern = var.status_codes[count.index]
+
+  depends_on = [aws_api_gateway_integration.test]
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  name = var.rName
+}
+
+resource "aws_api_gateway_resource" "test" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
+}
+
+resource "aws_api_gateway_method" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "test" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
+
+  type = "MOCK"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "status_codes" {
+  description = "Status codes to create"
+  type        = list(string)
+  nullable    = false
+}

--- a/internal/service/apigateway/testdata/IntegrationResponse/list_basic/query.tfquery.hcl
+++ b/internal/service/apigateway/testdata/IntegrationResponse/list_basic/query.tfquery.hcl
@@ -1,0 +1,12 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_api_gateway_integration_response" "test" {
+  provider = aws
+
+  config {
+    rest_api_id = aws_api_gateway_rest_api.test.id
+    resource_id = aws_api_gateway_resource.test.id
+    http_method = aws_api_gateway_method.test.http_method
+  }
+}

--- a/internal/service/apigateway/testdata/IntegrationResponse/list_include_resource/main.tf
+++ b/internal/service/apigateway/testdata/IntegrationResponse/list_include_resource/main.tf
@@ -1,0 +1,50 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_api_gateway_integration_response" "test" {
+  count = length(var.status_codes)
+
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
+  status_code = var.status_codes[count.index]
+
+  depends_on = [aws_api_gateway_integration.test]
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  name = var.rName
+}
+
+resource "aws_api_gateway_resource" "test" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
+}
+
+resource "aws_api_gateway_method" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "test" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
+
+  type = "MOCK"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "status_codes" {
+  description = "Status codes to create"
+  type        = list(string)
+  nullable    = false
+}

--- a/internal/service/apigateway/testdata/IntegrationResponse/list_include_resource/query.tfquery.hcl
+++ b/internal/service/apigateway/testdata/IntegrationResponse/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,14 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_api_gateway_integration_response" "test" {
+  provider = aws
+
+  include_resource = true
+
+  config {
+    rest_api_id = aws_api_gateway_rest_api.test.id
+    resource_id = aws_api_gateway_resource.test.id
+    http_method = aws_api_gateway_method.test.http_method
+  }
+}

--- a/internal/service/apigateway/testdata/IntegrationResponse/list_region_override/main.tf
+++ b/internal/service/apigateway/testdata/IntegrationResponse/list_region_override/main.tf
@@ -1,0 +1,66 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_api_gateway_integration_response" "test" {
+  count  = length(var.status_codes)
+  region = var.region
+
+  rest_api_id       = aws_api_gateway_rest_api.test.id
+  resource_id       = aws_api_gateway_resource.test.id
+  http_method       = aws_api_gateway_method.test.http_method
+  status_code       = var.status_codes[count.index]
+  selection_pattern = var.status_codes[count.index]
+
+  depends_on = [aws_api_gateway_integration.test]
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  region = var.region
+
+  name = var.rName
+}
+
+resource "aws_api_gateway_resource" "test" {
+  region = var.region
+
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
+}
+
+resource "aws_api_gateway_method" "test" {
+  region = var.region
+
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "test" {
+  region = var.region
+
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
+
+  type = "MOCK"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "status_codes" {
+  description = "Status codes to create"
+  type        = list(string)
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/apigateway/testdata/IntegrationResponse/list_region_override/query.tfquery.hcl
+++ b/internal/service/apigateway/testdata/IntegrationResponse/list_region_override/query.tfquery.hcl
@@ -1,0 +1,13 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_api_gateway_integration_response" "test" {
+  provider = aws
+
+  config {
+    region      = var.region
+    rest_api_id = aws_api_gateway_rest_api.test.id
+    resource_id = aws_api_gateway_resource.test.id
+    http_method = aws_api_gateway_method.test.http_method
+  }
+}

--- a/website/docs/list-resources/api_gateway_integration_response.html.markdown
+++ b/website/docs/list-resources/api_gateway_integration_response.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "API Gateway"
+layout: "aws"
+page_title: "AWS: aws_api_gateway_integration_response"
+description: |-
+  Lists API Gateway Integration Response resources.
+---
+
+# List Resource: aws_api_gateway_integration_response
+
+Lists API Gateway Integration Response resources for a specific API Gateway Method.
+
+## Example Usage
+
+```terraform
+list "aws_api_gateway_integration_response" "example" {
+  provider = aws
+
+  config {
+    rest_api_id = aws_api_gateway_rest_api.example.id
+    resource_id = aws_api_gateway_resource.example.id
+    http_method = aws_api_gateway_method.example.http_method
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `http_method` - (Required) HTTP method of the API Gateway Method.
+* `region` - (Optional) Region to query. Defaults to provider region.
+* `resource_id` - (Required) ID of the API Gateway Resource.
+* `rest_api_id` - (Required) ID of the associated REST API.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

New List Resource: `aws_api_gateway_integration_response`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Based on #47366
Closes #47245

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=apigateway TESTS=TestAccAPIGatewayIntegrationResponse_

--- PASS: TestAccAPIGatewayIntegrationResponse_disappears (167.87s)
--- PASS: TestAccAPIGatewayIntegrationResponse_List_includeResource (168.09s)
--- PASS: TestAccAPIGatewayIntegrationResponse_List_regionOverride (168.55s)
--- PASS: TestAccAPIGatewayIntegrationResponse_Identity_regionOverride (240.21s)
--- PASS: TestAccAPIGatewayIntegrationResponse_Identity_basic (260.45s)
--- PASS: TestAccAPIGatewayIntegrationResponse_Identity_ExistingResource_noRefreshNoChange (268.07s)
--- PASS: TestAccAPIGatewayIntegrationResponse_Identity_ExistingResource_basic (299.39s)
--- PASS: TestAccAPIGatewayIntegrationResponse_basic (365.32s)
--- PASS: TestAccAPIGatewayIntegrationResponse_List_basic (372.81s)
```
