### PR TITLE
Add sort order to s3tables iceberg metadata

### DIFF
--- a/.changelog/47391.txt
+++ b/.changelog/47391.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3tables_table: Add `metadata.iceberg.write_order` attribute
+```

--- a/internal/service/s3tables/table.go
+++ b/internal/service/s3tables/table.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -214,6 +215,76 @@ func (r *tableResource) Schema(ctx context.Context, request resource.SchemaReque
 										Validators: []validator.List{
 											listvalidator.IsRequired(),
 											listvalidator.SizeBetween(1, 1),
+										},
+										PlanModifiers: []planmodifier.List{
+											listplanmodifier.RequiresReplace(),
+										},
+									},
+									"write_order": schema.ListNestedBlock{
+										Description: "Sort order configuration for the Iceberg table.",
+										CustomType:  fwtypes.NewListNestedObjectTypeOf[icebergSortOrderModel](ctx),
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"order_id": schema.Int32Attribute{
+													Optional:    true,
+													Computed:    true,
+													Description: "The unique identifier for this sort order. Defaults to 1.",
+													PlanModifiers: []planmodifier.Int32{
+														int32planmodifier.RequiresReplace(),
+														int32planmodifier.UseStateForUnknown(),
+													},
+												},
+											},
+											Blocks: map[string]schema.Block{
+												names.AttrField: schema.ListNestedBlock{
+													Description: "Sort fields that define how data is ordered within files.",
+													CustomType:  fwtypes.NewListNestedObjectTypeOf[icebergSortFieldModel](ctx),
+													NestedObject: schema.NestedBlockObject{
+														Attributes: map[string]schema.Attribute{
+															"direction": schema.StringAttribute{
+																CustomType:  fwtypes.StringEnumType[awstypes.IcebergSortDirection](),
+																Required:    true,
+																Description: "Sort direction. Valid values: asc, desc.",
+																PlanModifiers: []planmodifier.String{
+																	stringplanmodifier.RequiresReplace(),
+																},
+															},
+															"null_order": schema.StringAttribute{
+																CustomType:  fwtypes.StringEnumType[awstypes.IcebergNullOrder](),
+																Required:    true,
+																Description: "Null value ordering. Valid values: nulls-first, nulls-last.",
+																PlanModifiers: []planmodifier.String{
+																	stringplanmodifier.RequiresReplace(),
+																},
+															},
+															"source_id": schema.Int32Attribute{
+																Required:    true,
+																Description: "The ID of the source schema field to sort by.",
+																PlanModifiers: []planmodifier.Int32{
+																	int32planmodifier.RequiresReplace(),
+																},
+															},
+															"transform": schema.StringAttribute{
+																Required:    true,
+																Description: "The transform to apply to the source field before sorting.",
+																PlanModifiers: []planmodifier.String{
+																	stringplanmodifier.RequiresReplace(),
+																},
+															},
+														},
+													},
+													Validators: []validator.List{
+														listvalidator.IsRequired(),
+														listvalidator.SizeAtLeast(1),
+													},
+													PlanModifiers: []planmodifier.List{
+														listplanmodifier.RequiresReplace(),
+													},
+												},
+											},
+										},
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
 										},
 										PlanModifiers: []planmodifier.List{
 											listplanmodifier.RequiresReplace(),
@@ -1014,7 +1085,8 @@ type tableMetadataModel struct {
 }
 
 type icebergMetadataModel struct {
-	Schema fwtypes.ListNestedObjectValueOf[icebergSchemaModel] `tfsdk:"schema"`
+	Schema     fwtypes.ListNestedObjectValueOf[icebergSchemaModel]    `tfsdk:"schema"`
+	WriteOrder fwtypes.ListNestedObjectValueOf[icebergSortOrderModel] `tfsdk:"write_order"`
 }
 
 type icebergSchemaModel struct {
@@ -1025,6 +1097,18 @@ type icebergSchemaFieldModel struct {
 	Name     types.String `tfsdk:"name"`
 	Required types.Bool   `tfsdk:"required"`
 	Type     types.String `tfsdk:"type"`
+}
+
+type icebergSortOrderModel struct {
+	Fields  fwtypes.ListNestedObjectValueOf[icebergSortFieldModel] `tfsdk:"field"`
+	OrderId types.Int32                                            `tfsdk:"order_id"`
+}
+
+type icebergSortFieldModel struct {
+	Direction fwtypes.StringEnum[awstypes.IcebergSortDirection] `tfsdk:"direction"`
+	NullOrder fwtypes.StringEnum[awstypes.IcebergNullOrder]     `tfsdk:"null_order"`
+	SourceId  types.Int32                                       `tfsdk:"source_id"`
+	Transform types.String                                      `tfsdk:"transform"`
 }
 
 var (

--- a/internal/service/s3tables/table_test.go
+++ b/internal/service/s3tables/table_test.go
@@ -588,6 +588,48 @@ func TestAccS3TablesTable_metadata(t *testing.T) {
 	})
 }
 
+func TestAccS3TablesTable_writeOrder(t *testing.T) {
+	ctx := acctest.Context(t)
+	var table s3tables.GetTableOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	bucketName := rName
+	nsName := strings.ReplaceAll(rName, "-", "_")
+	tableName := strings.ReplaceAll(rName, "-", "_")
+	resourceName := "aws_s3tables_table.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3TablesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_writeOrder(tableName, nsName, bucketName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableExists(ctx, t, resourceName, &table),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.write_order.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.write_order.0.field.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.write_order.0.field.0.direction", "asc"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.write_order.0.field.0.null_order", "nulls-first"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.write_order.0.field.0.source_id", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.0.iceberg.0.write_order.0.field.0.transform", "identity"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    testAccTableImportStateIdFunc(resourceName),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrARN,
+				ImportStateVerifyIgnore:              []string{"metadata"},
+			},
+		},
+	})
+}
+
 func testAccCheckTableDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).S3TablesClient(ctx)
@@ -814,6 +856,42 @@ resource "aws_s3tables_table" "test" {
           name     = "created_at"
           type     = "timestamp"
           required = true
+        }
+      }
+    }
+  }
+}
+`, tableName))
+}
+
+func testAccTableConfig_writeOrder(tableName, nsName, bucketName string) string {
+	return acctest.ConfigCompose(testAccTableConfig_base(nsName, bucketName), fmt.Sprintf(`
+resource "aws_s3tables_table" "test" {
+  name             = %[1]q
+  namespace        = aws_s3tables_namespace.test.namespace
+  table_bucket_arn = aws_s3tables_namespace.test.table_bucket_arn
+  format           = "ICEBERG"
+
+  metadata {
+    iceberg {
+      schema {
+        field {
+          name     = "id"
+          type     = "int"
+          required = true
+        }
+        field {
+          name = "name"
+          type = "string"
+        }
+      }
+
+      write_order {
+        field {
+          direction  = "asc"
+          null_order = "nulls-first"
+          source_id  = 1
+          transform  = "identity"
         }
       }
     }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No

### Description

AWS s3tables allows you to specify a sort order:

    - CLI docs: https://docs.aws.amazon.com/cli/latest/reference/s3tables/create-table.html
    - Golang docs: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3tables@v1.15.0/types#IcebergMetadata

It's helpful to specify this when creating a table.


### Relations

Relates #43167

### References

Linked above

### Output from Acceptance Testing

I tried to run these. I don't have a sandbox AWS acct that I can point these tests at unfortunately.

I did however compile and use the provider to provision a resource:

```terraform
      write_order {
        order_id = 1

        field {
          source_id  = 1
          transform  = "identity"
          direction  = "asc"
          null_order = "nulls-first"
        }
      }
```

```
$ aws s3 cp s3://redacted.metadata.json - | python3 -m json.tool
...
    "sort-orders": [                                                                                                                                           
        {                                                                                                                                                      
            "order-id": 1,                                                                                                                                     
            "fields": [                                                                                                                                        
                {                                                                                                                                              
                    "transform": "identity",                                                                                                                   
                    "source-id": 1,                                                                                                                            
                    "direction": "asc",                                                                                                                        
                    "null-order": "nulls-first"                                                                                                                
                }                                                              
            ]                                                                                                                                                  
        }                                                                                                                                                      
    ], 
...
```