### PR TITLE
[Enhancement] aws_opensearch_domain: Add `deployment_strategy_options` configuration block

### DIFF
--- a/.changelog/47401.txt
+++ b/.changelog/47401.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_opensearch_domain: Add `deployment_strategy_options` configuration block
+```
+
+```release-note:enhancement
+data-source/aws_opensearch_domain: Add `deployment_strategy_options` block
+```

--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -492,6 +492,21 @@ func resourceDomain() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"deployment_strategy_options": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"deployment_strategy": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: enum.Validate[awstypes.DeploymentStrategy](),
+						},
+					},
+				},
+			},
 			"domain_endpoint_options": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -872,6 +887,10 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		input.CognitoOptions = expandCognitoOptions(v.([]any))
 	}
 
+	if v, ok := d.GetOk("deployment_strategy_options"); ok {
+		input.DeploymentStrategyOptions = expandDeploymentStrategyOptions(v.([]any))
+	}
+
 	if v, ok := d.GetOk("domain_endpoint_options"); ok {
 		input.DomainEndpointOptions = expandDomainEndpointOptions(v.([]any))
 	}
@@ -1090,6 +1109,9 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta any) d
 	if err := d.Set("cognito_options", flattenCognitoOptions(ds.CognitoOptions)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting cognito_options: %s", err)
 	}
+	if err := d.Set("deployment_strategy_options", flattenDeploymentStrategyOptions(ds.DeploymentStrategyOptions)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting deployment_strategy_options: %s", err)
+	}
 	if err := d.Set("domain_endpoint_options", flattenDomainEndpointOptions(ds.DomainEndpointOptions)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting domain_endpoint_options: %s", err)
 	}
@@ -1235,6 +1257,10 @@ func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 
 		if d.HasChange("cognito_options") {
 			input.CognitoOptions = expandCognitoOptions(d.Get("cognito_options").([]any))
+		}
+
+		if d.HasChange("deployment_strategy_options") {
+			input.DeploymentStrategyOptions = expandDeploymentStrategyOptions(d.Get("deployment_strategy_options").([]any))
 		}
 
 		if d.HasChange("domain_endpoint_options") {

--- a/internal/service/opensearch/domain_data_source.go
+++ b/internal/service/opensearch/domain_data_source.go
@@ -255,6 +255,18 @@ func dataSourceDomain() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"deployment_strategy_options": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"deployment_strategy": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"domain_endpoint_v2_hosted_zone_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -606,6 +618,9 @@ func dataSourceDomainRead(ctx context.Context, d *schema.ResourceData, meta any)
 
 	if err := d.Set("cognito_options", flattenCognitoOptions(ds.CognitoOptions)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting cognito_options: %s", err)
+	}
+	if err := d.Set("deployment_strategy_options", flattenDeploymentStrategyOptions(ds.DeploymentStrategyOptions)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting deployment_strategy_options: %s", err)
 	}
 
 	if ds.OffPeakWindowOptions != nil {

--- a/internal/service/opensearch/domain_data_source_test.go
+++ b/internal/service/opensearch/domain_data_source_test.go
@@ -31,6 +31,8 @@ func TestAccOpenSearchDomainDataSource_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "auto_tune_options.#", resourceName, "auto_tune_options.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "cluster_config.#", resourceName, "cluster_config.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "deployment_strategy_options.#", resourceName, "deployment_strategy_options.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "deployment_strategy_options.0.deployment_strategy", resourceName, "deployment_strategy_options.0.deployment_strategy"),
 					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.#", resourceName, "ebs_options.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, names.AttrEngineVersion, resourceName, names.AttrEngineVersion),
 					resource.TestCheckResourceAttrPair(datasourceName, "log_publishing_options.#", resourceName, "log_publishing_options.#"),
@@ -68,6 +70,8 @@ func TestAccOpenSearchDomainDataSource_complex(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "cluster_config.0.instance_count", resourceName, "cluster_config.0.instance_count"),
 					resource.TestCheckResourceAttrPair(datasourceName, "cluster_config.0.dedicated_master_enabled", resourceName, "cluster_config.0.dedicated_master_enabled"),
 					resource.TestCheckResourceAttrPair(datasourceName, "cluster_config.0.zone_awareness_enabled", resourceName, "cluster_config.0.zone_awareness_enabled"),
+					resource.TestCheckResourceAttrPair(datasourceName, "deployment_strategy_options.#", resourceName, "deployment_strategy_options.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "deployment_strategy_options.0.deployment_strategy", resourceName, "deployment_strategy_options.0.deployment_strategy"),
 					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.#", resourceName, "ebs_options.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.0.ebs_enabled", resourceName, "ebs_options.0.ebs_enabled"),
 					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.0.volume_size", resourceName, "ebs_options.0.volume_size"),

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -268,6 +268,8 @@ func TestAccOpenSearchDomain_basic(t *testing.T) {
 					testAccCheckDomainExists(ctx, t, resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "aiml_options.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "dashboard_endpoint", regexache.MustCompile(`.*(opensearch|es)\..*/_dashboards`)),
+					resource.TestCheckResourceAttr(resourceName, "deployment_strategy_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_strategy_options.0.deployment_strategy", string(awstypes.DeploymentStrategyDefault)),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrEngineVersion),
 					resource.TestCheckResourceAttr(resourceName, "identity_center_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "off_peak_window_options.#", "1"),
@@ -2725,6 +2727,64 @@ func TestAccOpenSearchDomain_identityCenterOptions(t *testing.T) {
 	})
 }
 
+func TestAccOpenSearchDomain_deploymentStrategyOptions(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var domain awstypes.DomainStatus
+	rName := testAccRandomDomainName(t)
+	resourceName := "aws_opensearch_domain.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_deploymentStrategyOptions(rName, string(awstypes.DeploymentStrategyCapacityOptimized)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, t, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "aiml_options.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "dashboard_endpoint", regexache.MustCompile(`.*(opensearch|es)\..*/_dashboards`)),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrEngineVersion),
+					resource.TestCheckResourceAttr(resourceName, "deployment_strategy_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_strategy_options.0.deployment_strategy", string(awstypes.DeploymentStrategyCapacityOptimized)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     rName,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDomainConfig_deploymentStrategyOptions(rName, string(awstypes.DeploymentStrategyDefault)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, t, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "aiml_options.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "dashboard_endpoint", regexache.MustCompile(`.*(opensearch|es)\..*/_dashboards`)),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrEngineVersion),
+					resource.TestCheckResourceAttr(resourceName, "deployment_strategy_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_strategy_options.0.deployment_strategy", string(awstypes.DeploymentStrategyDefault)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccOpenSearchDomain_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -4986,4 +5046,21 @@ resource "aws_opensearch_domain" "test" {
   }
 }
 `, rName)
+}
+
+func testAccDomainConfig_deploymentStrategyOptions(rName, deploymentStrategy string) string {
+	return fmt.Sprintf(`
+resource "aws_opensearch_domain" "test" {
+  domain_name = %[1]q
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+  }
+
+  deployment_strategy_options {
+    deployment_strategy = %[2]q
+  }
+}
+`, rName, deploymentStrategy)
 }

--- a/internal/service/opensearch/flex.go
+++ b/internal/service/opensearch/flex.go
@@ -40,6 +40,17 @@ func expandCognitoOptions(c []any) *awstypes.CognitoOptions {
 	return options
 }
 
+func expandDeploymentStrategyOptions(l []any) *awstypes.DeploymentStrategyOptions {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+	m := l[0].(map[string]any)
+	deploymentStrategyOptions := &awstypes.DeploymentStrategyOptions{
+		DeploymentStrategy: awstypes.DeploymentStrategy(m["deployment_strategy"].(string)),
+	}
+
+	return deploymentStrategyOptions
+}
 func expandDomainEndpointOptions(l []any) *awstypes.DomainEndpointOptions {
 	if len(l) == 0 || l[0] == nil {
 		return nil
@@ -112,6 +123,18 @@ func expandEncryptAtRestOptions(m map[string]any) *awstypes.EncryptionAtRestOpti
 	}
 
 	return &options
+}
+
+func flattenDeploymentStrategyOptions(deploymentStrategyOptions *awstypes.DeploymentStrategyOptions) []any {
+	if deploymentStrategyOptions == nil {
+		return nil
+	}
+
+	m := map[string]any{
+		"deployment_strategy": string(deploymentStrategyOptions.DeploymentStrategy),
+	}
+
+	return []any{m}
 }
 
 func flattenCognitoOptions(c *awstypes.CognitoOptions) []map[string]any {

--- a/website/docs/d/opensearch_domain.html.markdown
+++ b/website/docs/d/opensearch_domain.html.markdown
@@ -75,6 +75,8 @@ This data source exports the following attributes in addition to the arguments a
 * `dashboard_endpoint` - Domain-specific endpoint used to access the [Dashboard application](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/dashboards.html).
 * `dashboard_endpoint_v2` - V2 domain-specific endpoint used to access the [Dashboard application](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/dashboards.html)
 * `deleted` - Status of the deletion of the domain.
+* `deployment_strategy_options` - Deployment strategy options for the domain.
+    * `deployment_strategy` - Deployment strategy for the domain.
 * `domain_endpoint_v2_hosted_zone_id` -  Dual stack hosted zone ID for the domain.
 * `domain_id` - Unique identifier for the domain.
 * `ebs_options` - EBS Options for the instances in the domain.

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -328,6 +328,7 @@ The following arguments are optional:
 * `auto_tune_options` - (Optional) Configuration block for the Auto-Tune options of the domain. Detailed below.
 * `cluster_config` - (Optional) Configuration block for the cluster of the domain. Detailed below.
 * `cognito_options` - (Optional) Configuration block for authenticating dashboard with Cognito. Detailed below.
+* `deployment_strategy_options` - (Optional) Configuration block for the deployment strategy options of the domain. Detailed below.
 * `domain_endpoint_options` - (Optional) Configuration block for domain endpoint HTTP(S) related options. Detailed below.
 * `ebs_options` - (Optional) Configuration block for EBS related options, may be required based on chosen [instance size](https://aws.amazon.com/opensearch-service/pricing/). Detailed below.
 * `engine_version` - (Optional) Either `Elasticsearch_X.Y` or `OpenSearch_X.Y` to specify the engine version for the Amazon OpenSearch Service domain. For example, `OpenSearch_1.0` or `Elasticsearch_7.9`.
@@ -448,6 +449,10 @@ AWS documentation: [Amazon Cognito Authentication for Dashboard](https://docs.aw
 * `identity_pool_id` - (Required) ID of the Cognito Identity Pool to use.
 * `role_arn` - (Required) ARN of the IAM role that has the AmazonOpenSearchServiceCognitoAccess policy attached.
 * `user_pool_id` - (Required) ID of the Cognito User Pool to use.
+
+### deployment_strategy_options
+
+* `deployment_strategy` - (Optional) Deployment strategy for the domain. Valid values: `Default` and `CapacityOptimized`.
 
 ### domain_endpoint_options
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
This PR adds `deployment_strategy_options` configuration block to `aws_opensearch_domain` resource and data source.

### Relations
Closes #47372

### References
https://docs.aws.amazon.com/opensearch-service/latest/APIReference/API_CreateDomain.html#opensearchservice-CreateDomain-request-DeploymentStrategyOptions

### Output from Acceptance Testing

#### Resource
```console
$ make testacc TESTS='TestAccOpenSearchDomain_(basic|deploymentStrategyOptions)' PKG=opensearch
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_opensearch_domain-add_deployment_strategy_options 🌿...
TF_ACC=1 go1.25.8 test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchDomain_(basic|deploymentStrategyOptions)'  -timeout 360m -vet=off
2026/04/10 21:13:46 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/10 21:13:46 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccOpenSearchDomain_basic
=== PAUSE TestAccOpenSearchDomain_basic
=== RUN   TestAccOpenSearchDomain_deploymentStrategyOptions
=== PAUSE TestAccOpenSearchDomain_deploymentStrategyOptions
=== CONT  TestAccOpenSearchDomain_basic
=== CONT  TestAccOpenSearchDomain_deploymentStrategyOptions
--- PASS: TestAccOpenSearchDomain_basic (1604.95s)
--- PASS: TestAccOpenSearchDomain_deploymentStrategyOptions (1611.90s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 1617.696s

```

#### Data Source
```console
$ make testacc TESTS='TestAccOpenSearchDomainDataSource_' PKG=opensearch 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_opensearch_domain-add_deployment_strategy_options🌿...
TF_ACC=1 go1.25.8 test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchDomainDataSource_'  -timeout 360m -vet=off
2026/04/10 21:47:52 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/10 21:47:52 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccOpenSearchDomainDataSource_basic
=== PAUSE TestAccOpenSearchDomainDataSource_basic
=== RUN   TestAccOpenSearchDomainDataSource_complex
=== PAUSE TestAccOpenSearchDomainDataSource_complex
=== CONT  TestAccOpenSearchDomainDataSource_basic
=== CONT  TestAccOpenSearchDomainDataSource_complex
--- PASS: TestAccOpenSearchDomainDataSource_basic (1553.89s)
--- PASS: TestAccOpenSearchDomainDataSource_complex (1817.77s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 1823.455s

```