### PR TITLE
resource/aws_iam_user: Wait until `arn` value is actually an ARN

### DIFF
--- a/internal/service/iam/consts.go
+++ b/internal/service/iam/consts.go
@@ -14,4 +14,8 @@ const (
 	// have incorrect references or permissions.
 	// Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency
 	propagationTimeout = 2 * time.Minute
+
+	arnStateIsUniqueID = "uniqueid"
+	arnStateIsARN      = "isarn"
+	arnStateNotFound   = "notfound"
 )

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -648,17 +648,12 @@ func findRole(ctx context.Context, conn *iam.Client, input *iam.GetRoleInput) (*
 	return output.Role, nil
 }
 
-const (
-	roleARNIsUniqueIDState = "uniqueid"
-	roleNotFoundState      = "notfound"
-)
-
 func statusRoleARNValue(conn *iam.Client, id string) retry.StateRefreshFunc {
 	return func(ctx context.Context) (any, string, error) {
 		role, err := findRoleByName(ctx, conn, id)
 
 		if retry.NotFound(err) {
-			return nil, roleNotFoundState, nil
+			return nil, arnStateNotFound, nil
 		}
 
 		if err != nil {
@@ -666,10 +661,10 @@ func statusRoleARNValue(conn *iam.Client, id string) retry.StateRefreshFunc {
 		}
 
 		if arn.IsARN(aws.ToString(role.Arn)) {
-			return role, names.AttrARN, nil
+			return role, arnStateIsARN, nil
 		}
 
-		return role, roleARNIsUniqueIDState, nil
+		return role, arnStateIsUniqueID, nil
 	}
 }
 
@@ -679,8 +674,8 @@ func waitRoleARNIsNotUniqueID(ctx context.Context, conn *iam.Client, id string, 
 	}
 
 	stateConf := &retry.StateChangeConf{
-		Pending:                   []string{roleARNIsUniqueIDState, roleNotFoundState},
-		Target:                    []string{names.AttrARN},
+		Pending:                   []string{arnStateIsUniqueID, arnStateNotFound},
+		Target:                    []string{arnStateIsARN},
 		Refresh:                   statusRoleARNValue(conn, id),
 		Timeout:                   propagationTimeout,
 		NotFoundChecks:            5,

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -653,7 +653,7 @@ const (
 	roleNotFoundState      = "notfound"
 )
 
-func statusRoleCreate(conn *iam.Client, id string) retry.StateRefreshFunc {
+func statusRoleARNValue(conn *iam.Client, id string) retry.StateRefreshFunc {
 	return func(ctx context.Context) (any, string, error) {
 		role, err := findRoleByName(ctx, conn, id)
 
@@ -681,7 +681,7 @@ func waitRoleARNIsNotUniqueID(ctx context.Context, conn *iam.Client, id string, 
 	stateConf := &retry.StateChangeConf{
 		Pending:                   []string{roleARNIsUniqueIDState, roleNotFoundState},
 		Target:                    []string{names.AttrARN},
-		Refresh:                   statusRoleCreate(conn, id),
+		Refresh:                   statusRoleARNValue(conn, id),
 		Timeout:                   propagationTimeout,
 		NotFoundChecks:            10,
 		ContinuousTargetOccurence: 5,

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -683,9 +683,10 @@ func waitRoleARNIsNotUniqueID(ctx context.Context, conn *iam.Client, id string, 
 		Target:                    []string{names.AttrARN},
 		Refresh:                   statusRoleARNValue(conn, id),
 		Timeout:                   propagationTimeout,
-		NotFoundChecks:            10,
+		NotFoundChecks:            5,
 		ContinuousTargetOccurence: 5,
-		Delay:                     10 * time.Second,
+		Delay:                     5 * time.Second,
+		PollInterval:              1 * time.Second,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)

--- a/internal/service/iam/role_test.go
+++ b/internal/service/iam/role_test.go
@@ -39,9 +39,19 @@ func TestAccIAMRole_basic(t *testing.T) {
 				Config: testAccRoleConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRoleExists(ctx, t, resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/"),
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "iam", "role{path}{name}"),
+					resource.TestCheckResourceAttrSet(resourceName, "assume_role_policy"),
 					resource.TestCheckResourceAttrSet(resourceName, "create_date"),
-					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "iam", "role/{name}"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
+					resource.TestCheckResourceAttr(resourceName, "force_detach_policies", "false"),
+					resource.TestCheckResourceAttr(resourceName, "inline_policy.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "managed_policy_arns.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "max_session_duration", "3600"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, ""),
+					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/"),
+					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "unique_id"),
 				),
 			},
 			{
@@ -1304,13 +1314,8 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_basic(rName string) string {
 	return fmt.Sprintf(`
-data "aws_service_principal" "ec2" {
-  service_name = "ec2"
-}
-
 resource "aws_iam_role" "test" {
   name = %[1]q
-  path = "/"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -1323,6 +1328,10 @@ resource "aws_iam_role" "test" {
       Sid    = ""
     }]
   })
+}
+
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
 }
 `, rName)
 }

--- a/internal/service/iam/role_test.go
+++ b/internal/service/iam/role_test.go
@@ -43,7 +43,7 @@ func TestAccIAMRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "assume_role_policy"),
 					resource.TestCheckResourceAttrSet(resourceName, "create_date"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
-					resource.TestCheckResourceAttr(resourceName, "force_detach_policies", "false"),
+					resource.TestCheckResourceAttr(resourceName, "force_detach_policies", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "inline_policy.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "managed_policy_arns.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "max_session_duration", "3600"),
@@ -218,7 +218,7 @@ func TestAccIAMRole_path(t *testing.T) {
 	path2 := "/" + acctest.RandomWithPrefix(t, acctest.ResourcePrefix) + "/"
 	resourceName := "aws_iam_role.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/iam/role_test.go
+++ b/internal/service/iam/role_test.go
@@ -208,6 +208,57 @@ func TestAccIAMRole_testNameChange(t *testing.T) {
 	})
 }
 
+func TestAccIAMRole_path(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf awstypes.Role
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	path1 := "/" + acctest.RandomWithPrefix(t, acctest.ResourcePrefix) + "/"
+	path2 := "/" + acctest.RandomWithPrefix(t, acctest.ResourcePrefix) + "/"
+	resourceName := "aws_iam_role.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoleConfig_path(path1, rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRoleExists(ctx, t, resourceName, &conf),
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "iam", "role{path}{name}"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrPath, path1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRoleConfig_path(path2, rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRoleExists(ctx, t, resourceName, &conf),
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "iam", "role{path}{name}"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrPath, path2),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 // https://github.com/hashicorp/terraform-provider-aws/issues/23288
 // https://github.com/hashicorp/terraform-provider-aws/issues/28833
 func TestAccIAMRole_diffs(t *testing.T) {
@@ -1557,6 +1608,31 @@ resource "aws_iam_role" "test" {
   })
 }
 `, rName)
+}
+
+func testAccRoleConfig_path(path, rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[2]q
+  path = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole",
+      Principal = {
+        Service = data.aws_service_principal.ec2.name,
+      }
+      Effect = "Allow"
+      Sid    = ""
+    }]
+  })
+}
+
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
+`, path, rName)
 }
 
 func testAccRoleConfig_badJSON(rName string) string {

--- a/internal/service/iam/role_test.go
+++ b/internal/service/iam/role_test.go
@@ -181,6 +181,7 @@ func TestAccIAMRole_testNameChange(t *testing.T) {
 				Config: testAccRoleConfig_basic(rName1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRoleExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName1),
 				),
 			},
 			{
@@ -192,6 +193,7 @@ func TestAccIAMRole_testNameChange(t *testing.T) {
 				Config: testAccRoleConfig_basic(rName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRoleExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName2),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/service/iam/role_test.go
+++ b/internal/service/iam/role_test.go
@@ -167,7 +167,8 @@ func TestAccIAMRole_namePrefix(t *testing.T) {
 func TestAccIAMRole_testNameChange(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Role
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -177,22 +178,31 @@ func TestAccIAMRole_testNameChange(t *testing.T) {
 		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoleConfig_pre(rName),
+				Config: testAccRoleConfig_basic(rName1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRoleExists(ctx, t, resourceName, &conf),
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"inline_policy"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
-				Config: testAccRoleConfig_post(rName),
+				Config: testAccRoleConfig_basic(rName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRoleExists(ctx, t, resourceName, &conf),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -1545,112 +1555,6 @@ resource "aws_iam_role" "test" {
       Sid    = ""
     }]
   })
-}
-`, rName)
-}
-
-func testAccRoleConfig_pre(rName string) string {
-	return fmt.Sprintf(`
-data "aws_partition" "current" {}
-data "aws_service_principal" "ec2" {
-  service_name = "ec2"
-}
-
-resource "aws_iam_role" "test" {
-  name = %[1]q
-  path = "/test/"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Action = "sts:AssumeRole",
-      Principal = {
-        Service = data.aws_service_principal.ec2.name,
-      }
-      Effect = "Allow"
-      Sid    = ""
-    }]
-  })
-}
-
-resource "aws_iam_role_policy" "role_update_test" {
-  name = "%[1]s-2"
-  role = aws_iam_role.test.id
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetBucketLocation",
-        "s3:ListAllMyBuckets"
-      ],
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::*"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_instance_profile" "role_update_test" {
-  name = "%[1]s-2"
-  path = "/test/"
-  role = aws_iam_role.test.name
-}
-`, rName)
-}
-
-func testAccRoleConfig_post(rName string) string {
-	return fmt.Sprintf(`
-data "aws_partition" "current" {}
-data "aws_service_principal" "ec2" {
-  service_name = "ec2"
-}
-
-resource "aws_iam_role" "test" {
-  name = %[1]q
-  path = "/test/"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Action = "sts:AssumeRole",
-      Principal = {
-        Service = data.aws_service_principal.ec2.name,
-      }
-      Effect = "Allow"
-      Sid    = ""
-    }]
-  })
-}
-
-resource "aws_iam_role_policy" "role_update_test" {
-  name = "%[1]s-2"
-  role = aws_iam_role.test.id
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetBucketLocation",
-        "s3:ListAllMyBuckets"
-      ],
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::*"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_instance_profile" "role_update_test" {
-  name = "%[1]s-2"
-  path = "/test/"
-  role = aws_iam_role.test.name
 }
 `, rName)
 }

--- a/internal/service/iam/testdata/Role/list_basic/main.tfquery.hcl
+++ b/internal/service/iam/testdata/Role/list_basic/main.tfquery.hcl
@@ -3,4 +3,6 @@
 
 list "aws_iam_role" "test" {
   provider = aws
+
+  limit = 250
 }

--- a/internal/service/iam/testdata/Role/list_include_resource/main.tfquery.hcl
+++ b/internal/service/iam/testdata/Role/list_include_resource/main.tfquery.hcl
@@ -4,5 +4,7 @@
 list "aws_iam_role" "test" {
   provider = aws
 
+  limit = 250
+
   include_resource = true
 }

--- a/internal/service/iam/user.go
+++ b/internal/service/iam/user.go
@@ -10,9 +10,11 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
@@ -157,6 +159,11 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta any) dia
 		return sdkdiag.AppendErrorf(diags, "reading IAM User (%s): %s", d.Id(), err)
 	}
 
+	// occasionally, immediately after a user is created, AWS will give an ARN like AIDAQ7SSZBKHREXAMPLE (unique ID)
+	if user, err = waitUserARNIsNotUniqueID(ctx, conn, user); err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading IAM User (%s): waiting for valid ARN: %s", d.Id(), err)
+	}
+
 	resourceUserFlatten(user, d)
 	setTagsOut(ctx, user.Tags)
 
@@ -289,6 +296,51 @@ func findUser(ctx context.Context, conn *iam.Client, input *iam.GetUserInput) (*
 	}
 
 	return output.User, nil
+}
+
+func waitUserARNIsNotUniqueID(ctx context.Context, conn *iam.Client, user *awstypes.User) (*awstypes.User, error) {
+	if arn.IsARN(aws.ToString(user.Arn)) {
+		return user, nil
+	}
+
+	stateConf := &retry.StateChangeConf{
+		Pending:                   []string{arnStateIsUniqueID, arnStateNotFound},
+		Target:                    []string{arnStateIsARN},
+		Refresh:                   statusUserARNValue(conn, aws.ToString(user.UserName)),
+		Timeout:                   propagationTimeout,
+		NotFoundChecks:            5,
+		ContinuousTargetOccurence: 5,
+		Delay:                     5 * time.Second,
+		PollInterval:              1 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*awstypes.User); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func statusUserARNValue(conn *iam.Client, name string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
+		user, err := findUserByName(ctx, conn, name)
+
+		if retry.NotFound(err) {
+			return nil, arnStateNotFound, nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if arn.IsARN(aws.ToString(user.Arn)) {
+			return user, arnStateIsARN, nil
+		}
+
+		return user, arnStateIsUniqueID, nil
+	}
 }
 
 func deleteUserGroupMemberships(ctx context.Context, conn *iam.Client, user string) error {

--- a/internal/service/iam/user_test.go
+++ b/internal/service/iam/user_test.go
@@ -31,9 +31,6 @@ func TestAccIAMUser_basic(t *testing.T) {
 	var conf awstypes.User
 
 	name1 := fmt.Sprintf("test-user-%d", acctest.RandInt(t))
-	name2 := fmt.Sprintf("test-user-%d", acctest.RandInt(t))
-	path1 := "/"
-	path2 := "/path2/"
 	resourceName := "aws_iam_user.user"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -43,10 +40,15 @@ func TestAccIAMUser_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserConfig_basic(name1, path1),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, t, "aws_iam_user.user", &conf),
-					testAccCheckUserAttributes(&conf, name1, "/"),
+				Config: testAccUserConfig_basic(name1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserExists(ctx, t, resourceName, &conf),
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "iam", "user{path}{name}"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrForceDestroy, "false"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, name1),
+					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/"),
+					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "unique_id"),
 				),
 			},
 			{
@@ -54,14 +56,8 @@ func TestAccIAMUser_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy},
-			},
-			{
-				Config: testAccUserConfig_basic(name2, path2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, t, "aws_iam_user.user", &conf),
-					testAccCheckUserAttributes(&conf, name2, "/path2/"),
-				),
+					names.AttrForceDestroy,
+				},
 			},
 		},
 	})
@@ -81,7 +77,7 @@ func TestAccIAMUser_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserConfig_basic(rName, "/"),
+				Config: testAccUserConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &user),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfiam.ResourceUser(), resourceName),
@@ -355,7 +351,6 @@ func TestAccIAMUser_nameChange(t *testing.T) {
 
 	name1 := fmt.Sprintf("test-user-%d", acctest.RandInt(t))
 	name2 := fmt.Sprintf("test-user-%d", acctest.RandInt(t))
-	path := "/"
 	resourceName := "aws_iam_user.user"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -365,7 +360,7 @@ func TestAccIAMUser_nameChange(t *testing.T) {
 		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserConfig_basic(name1, path),
+				Config: testAccUserConfig_basic(name1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, "aws_iam_user.user", &conf),
 				),
@@ -378,7 +373,7 @@ func TestAccIAMUser_nameChange(t *testing.T) {
 					names.AttrForceDestroy},
 			},
 			{
-				Config: testAccUserConfig_basic(name2, path),
+				Config: testAccUserConfig_basic(name2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, "aws_iam_user.user", &conf),
 				),
@@ -403,7 +398,7 @@ func TestAccIAMUser_pathChange(t *testing.T) {
 		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserConfig_basic(name, path1),
+				Config: testAccUserConfig_path(name, path1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, "aws_iam_user.user", &conf),
 				),
@@ -416,7 +411,7 @@ func TestAccIAMUser_pathChange(t *testing.T) {
 					names.AttrForceDestroy},
 			},
 			{
-				Config: testAccUserConfig_basic(name, path2),
+				Config: testAccUserConfig_path(name, path2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, "aws_iam_user.user", &conf),
 				),
@@ -475,7 +470,7 @@ func TestAccIAMUser_permissionsBoundary(t *testing.T) {
 			},
 			// Test removal
 			{
-				Config: testAccUserConfig_basic(rName, "/"),
+				Config: testAccUserConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", ""),
@@ -632,20 +627,6 @@ func testAccCheckUserExists(ctx context.Context, t *testing.T, n string, v *awst
 		}
 
 		*v = *output
-
-		return nil
-	}
-}
-
-func testAccCheckUserAttributes(user *awstypes.User, name string, path string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if *user.UserName != name {
-			return fmt.Errorf("Bad name: %s", *user.UserName)
-		}
-
-		if *user.Path != path {
-			return fmt.Errorf("Bad path: %s", *user.Path)
-		}
 
 		return nil
 	}
@@ -864,11 +845,19 @@ func testAccCheckUserInlinePolicy(ctx context.Context, t *testing.T, user *awsty
 	}
 }
 
-func testAccUserConfig_basic(rName, path string) string {
+func testAccUserConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_user" "user" {
-  name = %q
-  path = %q
+  name = %[1]q
+}
+`, rName)
+}
+
+func testAccUserConfig_path(rName, path string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_user" "user" {
+  name = %[1]q
+  path = %[2]q
 }
 `, rName, path)
 }
@@ -876,8 +865,8 @@ resource "aws_iam_user" "user" {
 func testAccUserConfig_permissionsBoundary(rName, permissionsBoundary string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_user" "user" {
-  name                 = %q
-  permissions_boundary = %q
+  name                 = %[1]q
+  permissions_boundary = %[2]q
 }
 `, rName, permissionsBoundary)
 }
@@ -886,7 +875,7 @@ func testAccUserConfig_forceDestroy(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_user" "test" {
   force_destroy = true
-  name          = %q
+  name          = %[1]q
 }
 `, rName)
 }

--- a/internal/service/iam/user_test.go
+++ b/internal/service/iam/user_test.go
@@ -362,7 +362,8 @@ func TestAccIAMUser_nameChange(t *testing.T) {
 			{
 				Config: testAccUserConfig_basic(name1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, t, "aws_iam_user.user", &conf),
+					testAccCheckUserExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, name1),
 				),
 			},
 			{
@@ -370,13 +371,28 @@ func TestAccIAMUser_nameChange(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy},
+					names.AttrForceDestroy,
+				},
 			},
 			{
 				Config: testAccUserConfig_basic(name2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, t, "aws_iam_user.user", &conf),
+					testAccCheckUserExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, name2),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					names.AttrForceDestroy,
+				},
 			},
 		},
 	})
@@ -400,7 +416,7 @@ func TestAccIAMUser_pathChange(t *testing.T) {
 			{
 				Config: testAccUserConfig_path(name, path1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, t, "aws_iam_user.user", &conf),
+					testAccCheckUserExists(ctx, t, resourceName, &conf),
 				),
 			},
 			{
@@ -413,7 +429,7 @@ func TestAccIAMUser_pathChange(t *testing.T) {
 			{
 				Config: testAccUserConfig_path(name, path2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, t, "aws_iam_user.user", &conf),
+					testAccCheckUserExists(ctx, t, resourceName, &conf),
 				),
 			},
 		},

--- a/internal/service/iam/user_test.go
+++ b/internal/service/iam/user_test.go
@@ -44,7 +44,7 @@ func TestAccIAMUser_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &conf),
 					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "iam", "user{path}{name}"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrForceDestroy, "false"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrForceDestroy, acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, name1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/"),
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", ""),

--- a/internal/service/iam/user_test.go
+++ b/internal/service/iam/user_test.go
@@ -363,6 +363,7 @@ func TestAccIAMUser_nameChange(t *testing.T) {
 				Config: testAccUserConfig_basic(name1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &conf),
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "iam", "user{path}{name}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, name1),
 				),
 			},
@@ -378,6 +379,7 @@ func TestAccIAMUser_nameChange(t *testing.T) {
 				Config: testAccUserConfig_basic(name2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &conf),
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "iam", "user{path}{name}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, name2),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -417,6 +419,8 @@ func TestAccIAMUser_pathChange(t *testing.T) {
 				Config: testAccUserConfig_path(name, path1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &conf),
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "iam", "user{path}{name}"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrPath, path1),
 				),
 			},
 			{
@@ -431,6 +435,8 @@ func TestAccIAMUser_pathChange(t *testing.T) {
 				Config: testAccUserConfig_path(name, path2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &conf),
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "iam", "user{path}{name}"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrPath, path2),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/service/iam/user_test.go
+++ b/internal/service/iam/user_test.go
@@ -424,13 +424,27 @@ func TestAccIAMUser_pathChange(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy},
+					names.AttrForceDestroy,
+				},
 			},
 			{
 				Config: testAccUserConfig_path(name, path2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &conf),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					names.AttrForceDestroy,
+				},
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

In some cases during creation, the AWS IAM API returns an IAM Unique ID value in the ARN value of a User. Wait until the ARN is actually returned.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=iam TESTS=TestAccIAMUser_

--- PASS: TestAccIAMUser_List_basic (155.54s)
--- PASS: TestAccIAMUser_disappears (159.46s)
--- PASS: TestAccIAMUser_ForceDestroy_loginProfile (180.78s)
--- PASS: TestAccIAMUser_basic (183.94s)
--- PASS: TestAccIAMUser_ForceDestroy_mfaDevice (184.98s)
--- PASS: TestAccIAMUser_ForceDestroy_sshKey (185.66s)
--- PASS: TestAccIAMUser_ForceDestroy_accessKey (185.86s)
--- PASS: TestAccIAMUser_Tags_DefaultTags_emptyResourceTag (195.13s)
--- PASS: TestAccIAMUser_Identity_ExistingResource_noRefreshNoChange (195.90s)
--- PASS: TestAccIAMUser_Tags_DefaultTags_emptyProviderOnlyTag (208.29s)
--- PASS: TestAccIAMUser_Tags_DefaultTags_nullOverlappingResourceTag (209.01s)
--- PASS: TestAccIAMUser_Tags_DefaultTags_nullNonOverlappingResourceTag (209.36s)
--- PASS: TestAccIAMUser_Identity_basic (294.76s)
--- PASS: TestAccIAMUser_Tags_DefaultTags_updateToResourceOnly (318.61s)
--- PASS: TestAccIAMUser_Tags_addOnUpdate (334.38s)
--- PASS: TestAccIAMUser_List_pathPrefix (138.70s)
--- PASS: TestAccIAMUser_Tags_DefaultTags_updateToProviderOnly (334.62s)
--- PASS: TestAccIAMUser_Tags_EmptyTag_onCreate (346.04s)
--- PASS: TestAccIAMUser_Tags_ComputedTag_onCreate (194.69s)
--- PASS: TestAccIAMUser_Identity_ExistingResource_basic (193.69s)
--- PASS: TestAccIAMUser_Tags_null (262.15s)
--- PASS: TestAccIAMUser_ForceDestroy_policyInlineAttached (129.30s)
--- PASS: TestAccIAMUser_Tags_emptyMap (278.99s)
--- PASS: TestAccIAMUser_ForceDestroy_policyAttached (115.10s)
--- PASS: TestAccIAMUser_Tags_ComputedTag_OnUpdate_replace (287.59s)
--- PASS: TestAccIAMUser_Tags_EmptyTag_OnUpdate_add (476.29s)
--- PASS: TestAccIAMUser_Tags_ComputedTag_OnUpdate_add (291.14s)
--- PASS: TestAccIAMUser_ForceDestroy_policyInline (91.95s)
--- PASS: TestAccIAMUser_Tags_DefaultTags_overlapping (500.70s)
--- PASS: TestAccIAMUser_ForceDestroy_signingCertificate (110.36s)
--- PASS: TestAccIAMUser_Tags_IgnoreTags_Overlap_defaultTag (333.11s)
--- PASS: TestAccIAMUser_ForceDestroy_serviceSpecificCred (103.10s)
--- PASS: TestAccIAMUser_nameAndTags (208.85s)
--- PASS: TestAccIAMUser_nameChange (208.85s)
--- PASS: TestAccIAMUser_pathChange (209.25s)
--- PASS: TestAccIAMUser_Tags_IgnoreTags_Overlap_resourceTag (360.66s)
--- PASS: TestAccIAMUser_Tags_EmptyTag_OnUpdate_replace (201.46s)
--- PASS: TestAccIAMUser_tags (548.97s)
--- PASS: TestAccIAMUser_Tags_DefaultTags_nonOverlapping (360.79s)
--- PASS: TestAccIAMUser_Tags_DefaultTags_providerOnly (403.13s)
--- PASS: TestAccIAMUser_permissionsBoundary (285.96s)
```

```console
% make testacc PKG=iam TESTS=TestAccIAMRole_

--- PASS: TestAccIAMRole_Identity_ExistingResource_OnError (297.02s)
--- PASS: TestAccIAMRole_Identity_ExistingResource_NoRefresh_OnError (297.07s)
--- PASS: TestAccIAMRole_InlinePolicy_empty (297.34s)
--- PASS: TestAccIAMRole_List_includeResource (342.38s)
--- PASS: TestAccIAMRole_List_basic (344.37s)
--- PASS: TestAccIAMRole_badJSON (60.32s)
--- PASS: TestAccIAMRole_Identity_ExistingResource_noRefreshNoChange (466.55s)
--- PASS: TestAccIAMRole_InlinePolicy_malformed (203.03s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored (566.37s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty (619.15s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack (619.28s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved (619.36s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack (619.77s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty (620.01s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved (621.12s)
--- PASS: TestAccIAMRole_Identity_basic (718.04s)
--- PASS: TestAccIAMRole_Tags_emptyMap (718.60s)
--- PASS: TestAccIAMRole_Tags_null (719.19s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored (769.74s)
--- PASS: TestAccIAMRole_Identity_ExistingResource_basic (561.40s)
--- PASS: TestAccIAMRole_disappears (320.63s)
--- PASS: TestAccIAMRole_policiesForceDetach (390.42s)
--- PASS: TestAccIAMRole_description (922.71s)
--- PASS: TestAccIAMRole_ManagedPolicy_basic (923.25s)
--- PASS: TestAccIAMRole_namePrefix (415.26s)
--- PASS: TestAccIAMRole_diffsCondition (566.78s)
--- PASS: TestAccIAMRole_maxSessionDuration (829.01s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (951.35s)
--- PASS: TestAccIAMRole_Tags_DefaultTags_overlapping (1317.24s)
--- PASS: TestAccIAMRole_basic (412.47s)
--- PASS: TestAccIAMRole_Tags_ComputedTag_onCreate (463.35s)
--- PASS: TestAccIAMRole_InlinePolicy_ignoreOrder (1023.17s)
--- PASS: TestAccIAMRole_Tags_EmptyTag_OnUpdate_replace (746.68s)
--- PASS: TestAccIAMRole_path (756.06s)
--- PASS: TestAccIAMRole_diffs (714.72s)
--- PASS: TestAccIAMRole_Tags_EmptyTag_onCreate (729.08s)
--- PASS: TestAccIAMRole_Tags_addOnUpdate (590.70s)
--- PASS: TestAccIAMRole_testNameChange (626.08s)
--- PASS: TestAccIAMRole_nameGenerated (190.09s)
--- PASS: TestAccIAMRole_Tags_DefaultTags_emptyProviderOnlyTag (195.83s)
--- PASS: TestAccIAMRole_Tags_DefaultTags_nullNonOverlappingResourceTag (183.95s)
--- PASS: TestAccIAMRole_Tags_DefaultTags_emptyResourceTag (159.44s)
--- PASS: TestAccIAMRole_Tags_DefaultTags_nullOverlappingResourceTag (171.88s)
--- PASS: TestAccIAMRole_Tags_DefaultTags_nonOverlapping (929.67s)
--- PASS: TestAccIAMRole_Tags_EmptyTag_OnUpdate_add (835.28s)
--- PASS: TestAccIAMRole_Tags_ComputedTag_OnUpdate_replace (371.28s)
--- PASS: TestAccIAMRole_permissionsBoundary (1209.68s)
--- PASS: TestAccIAMRole_Tags_ComputedTag_OnUpdate_add (276.71s)
--- PASS: TestAccIAMRole_Tags_IgnoreTags_Overlap_resourceTag (650.01s)
--- PASS: TestAccIAMRole_Tags_DefaultTags_updateToResourceOnly (213.34s)
--- PASS: TestAccIAMRole_Tags_IgnoreTags_Overlap_defaultTag (398.57s)
--- PASS: TestAccIAMRole_Tags_DefaultTags_updateToProviderOnly (210.20s)
--- PASS: TestAccIAMRole_Tags_DefaultTags_providerOnly (973.75s)
--- PASS: TestAccIAMRole_tags (974.46s)
```
