### PR TITLE
[Docs] Replace deprecated data.aws_region .name attribute with .region in example configurations

### DIFF
--- a/website/docs/r/appsync_api.html.markdown
+++ b/website/docs/r/appsync_api.html.markdown
@@ -53,7 +53,7 @@ resource "aws_appsync_api" "example" {
       auth_type = "AMAZON_COGNITO_USER_POOLS"
       cognito_config {
         user_pool_id = aws_cognito_user_pool.example.id
-        aws_region   = data.aws_region.current.name
+        aws_region   = data.aws_region.current.region
       }
     }
 

--- a/website/docs/r/datazone_environment_profile.html.markdown
+++ b/website/docs/r/datazone_environment_profile.html.markdown
@@ -87,12 +87,12 @@ resource "aws_datazone_environment_blueprint_configuration" "test" {
   domain_id                = aws_datazone_domain.test.id
   environment_blueprint_id = data.aws_datazone_environment_blueprint.test.id
   provisioning_role_arn    = aws_iam_role.domain_execution_role.arn
-  enabled_regions          = [data.aws_region.test.name]
+  enabled_regions          = [data.aws_region.test.region]
 }
 
 resource "aws_datazone_environment_profile" "test" {
   aws_account_id                   = data.aws_caller_identity.test.account_id
-  aws_account_region               = data.aws_region.test.name
+  aws_account_region               = data.aws_region.test.region
   description                      = "description"
   environment_blueprint_identifier = data.aws_datazone_environment_blueprint.test.id
   name                             = "example-name"

--- a/website/docs/r/directory_service_region.html.markdown
+++ b/website/docs/r/directory_service_region.html.markdown
@@ -104,7 +104,7 @@ resource "aws_subnet" "example-secondary" {
 
 resource "aws_directory_service_region" "example" {
   directory_id = aws_directory_service_directory.example.id
-  region_name  = data.aws_region.example.name
+  region_name  = data.aws_region.example.region
 
   vpc_settings {
     vpc_id     = aws_vpc.example-secondary.id

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -320,11 +320,11 @@ resource "aws_dynamodb_table" "example" {
   }
 
   replica {
-    region_name = data.aws_region.alternate.name
+    region_name = data.aws_region.alternate.region
   }
 
   replica {
-    region_name    = data.aws_region.third.name
+    region_name    = data.aws_region.third.region
     propagate_tags = true
   }
 
@@ -335,7 +335,7 @@ resource "aws_dynamodb_table" "example" {
 }
 
 resource "aws_dynamodb_tag" "example" {
-  resource_arn = replace(aws_dynamodb_table.example.arn, data.aws_region.current.region, data.aws_region.alternate.name)
+  resource_arn = replace(aws_dynamodb_table.example.arn, data.aws_region.current.region, data.aws_region.alternate.region)
   key          = "Architect"
   value        = "Gigi"
 }

--- a/website/docs/r/dynamodb_tag.html.markdown
+++ b/website/docs/r/dynamodb_tag.html.markdown
@@ -36,14 +36,14 @@ resource "aws_dynamodb_table" "example" {
   # ... other configuration ...
 
   replica {
-    region_name = data.aws_region.replica.name
+    region_name = data.aws_region.replica.region
   }
 }
 
 resource "aws_dynamodb_tag" "test" {
   provider = aws.replica
 
-  resource_arn = replace(aws_dynamodb_table.example.arn, data.aws_region.current.region, data.aws_region.replica.name)
+  resource_arn = replace(aws_dynamodb_table.example.arn, data.aws_region.current.region, data.aws_region.replica.region)
   key          = "testkey"
   value        = "testvalue"
 }

--- a/website/docs/r/ec2_transit_gateway_peering_attachment.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_peering_attachment.html.markdown
@@ -46,7 +46,7 @@ resource "aws_ec2_transit_gateway" "peer" {
 
 resource "aws_ec2_transit_gateway_peering_attachment" "example" {
   peer_account_id         = aws_ec2_transit_gateway.peer.owner_id
-  peer_region             = data.aws_region.peer.name
+  peer_region             = data.aws_region.peer.region
   peer_transit_gateway_id = aws_ec2_transit_gateway.peer.id
   transit_gateway_id      = aws_ec2_transit_gateway.local.id
 

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -195,7 +195,7 @@ resource "aws_ecs_service" "example" {
       log_driver = "awslogs"
       options = {
         "awslogs-group"         = aws_cloudwatch_log_group.example.name
-        "awslogs-region"        = data.aws_region.current.name
+        "awslogs-region"        = data.aws_region.current.region
         "awslogs-stream-prefix" = "service-connect"
       }
     }

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -38,7 +38,7 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 resource "aws_s3_bucket" "example" {
-  bucket           = format("my-tf-test-bucket-%s-%s-an", data.aws_caller_identity.current.account_id, data.aws_region.current.name)
+  bucket           = format("my-tf-test-bucket-%s-%s-an", data.aws_caller_identity.current.account_id, data.aws_region.current.region)
   bucket_namespace = "account-regional"
 }
 ```

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -58,7 +58,7 @@ resource "aws_vpc_ipam" "test" {
 resource "aws_vpc_ipam_pool" "test" {
   address_family = "ipv4"
   ipam_scope_id  = aws_vpc_ipam.test.private_default_scope_id
-  locale         = data.aws_region.current.name
+  locale         = data.aws_region.current.region
 }
 
 resource "aws_vpc_ipam_pool_cidr" "test" {
@@ -76,13 +76,13 @@ resource "aws_vpc" "test" {
 resource "aws_vpc_ipam_pool" "vpc" {
   address_family      = "ipv4"
   ipam_scope_id       = aws_vpc_ipam.test.private_default_scope_id
-  locale              = data.aws_region.current.name
+  locale              = data.aws_region.current.region
   source_ipam_pool_id = aws_vpc_ipam_pool.test.id
 
   source_resource {
     resource_id     = aws_vpc.test.id
     resource_owner  = data.aws_caller_identity.current.account_id
-    resource_region = data.aws_region.current.name
+    resource_region = data.aws_region.current.region
     resource_type   = "vpc"
   }
 }

--- a/website/docs/r/transfer_web_app.html.markdown
+++ b/website/docs/r/transfer_web_app.html.markdown
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "example" {
       "s3:ListCallerAccessGrants",
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:s3:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:access-grants/*"
+      "arn:${data.aws_partition.current.partition}:s3:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:access-grants/*"
     ]
     condition {
       test     = "StringEquals"

--- a/website/docs/r/vpc_ipam_pool.html.markdown
+++ b/website/docs/r/vpc_ipam_pool.html.markdown
@@ -98,13 +98,13 @@ resource "aws_vpc" "test" {
 resource "aws_vpc_ipam_pool" "vpc" {
   address_family      = "ipv4"
   ipam_scope_id       = aws_vpc_ipam.test.private_default_scope_id
-  locale              = data.aws_region.current.name
+  locale              = data.aws_region.current.region
   source_ipam_pool_id = aws_vpc_ipam_pool.test.id
 
   source_resource {
     resource_id     = aws_vpc.test.id
     resource_owner  = data.aws_caller_identity.current.account_id
-    resource_region = data.aws_region.current.name
+    resource_region = data.aws_region.current.region
     resource_type   = "vpc"
   }
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description
The `data.aws_region` data source's `name` attribute is deprecated in favor of `region` (see [aws_region arguments reference](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region)). Multiple resource documentation examples still reference `.name`, which produces deprecation warnings.

This PR replaces all occurrences of `data.aws_region.<name>.name` with `data.aws_region.<name>.region` across the following resource documentation:

- `aws_appsync_api`
- `aws_datazone_environment_profile`
- `aws_directory_service_region`
- `aws_dynamodb_table`
- `aws_dynamodb_tag`
- `aws_ec2_transit_gateway_peering_attachment`
- `aws_ecs_service`
- `aws_s3_bucket`
- `aws_subnet`
- `aws_transfer_web_app`
- `aws_vpc_ipam_pool`


### Relations

Closes #47002


### References

- [`aws_region` data source documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) — `name` is listed as **Deprecated**
- Provider source: [`internal/service/meta/region_data_source.go#L56`](https://github.com/hashicorp/terraform-provider-aws/blob/80b998197362c27a5485943e0d6f26b9ee865023/internal/service/meta/region_data_source.go#L56) — `DeprecationMessage: "name is deprecated. Use region instead."`

### Output from Acceptance Testing

Not applicable. Only documentation is updated.
