### PR TITLE
resource/aws_wafv2_web_acl_logging_configuration: Fix redacted_fields removal not detected

### DIFF
--- a/.changelog/47409.txt
+++ b/.changelog/47409.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_wafv2_web_acl_logging_configuration: Fix `redacted_fields` removal not being detected
+```

--- a/internal/service/wafv2/web_acl_logging_configuration.go
+++ b/internal/service/wafv2/web_acl_logging_configuration.go
@@ -589,6 +589,14 @@ func redactedFieldsHash(v any) int {
 }
 
 func suppressRedactedFieldsDiff(k, old, new string, d *schema.ResourceData) bool {
+	// Detect full removal via raw parameters: d.GetChange() can return stale
+	// "new" data for nested TypeList attributes, causing the Set comparison
+	// below to miss the diff.
+	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/41778
+	if k == "redacted_fields.#" && old != "0" && new == "0" {
+		return false
+	}
+
 	o, n := d.GetChange("redacted_fields")
 	oList := o.([]any)
 	nList := n.([]any)

--- a/internal/service/wafv2/web_acl_logging_configuration_test.go
+++ b/internal/service/wafv2/web_acl_logging_configuration_test.go
@@ -492,6 +492,50 @@ func TestAccWAFV2WebACLLoggingConfiguration_updateEmptyRedactedFields(t *testing
 	})
 }
 
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/41778
+func TestAccWAFV2WebACLLoggingConfiguration_removeRedactedFields(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.LoggingConfiguration
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_web_acl_logging_configuration.test"
+	webACLResourceName := "aws_wafv2_web_acl.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWebACLLoggingConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWebACLLoggingConfigurationConfig_updateSingleHeaderRedactedField(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLLoggingConfigurationExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrResourceARN, webACLResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+						"single_header.0.name": "user-agent",
+					}),
+				),
+			},
+			{
+				Config: testAccWebACLLoggingConfigurationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLLoggingConfigurationExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrResourceARN, webACLResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccWAFV2WebACLLoggingConfiguration_Disappears_webACL(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LoggingConfiguration


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls in this pull request.

### Description
When removing all `redacted_fields` blocks from `aws_wafv2_web_acl_logging_configuration`, Terraform did not detect the change and the redacted fields remained on the WAF.

This was caused by `d.GetChange()` returning stale data on the "new" side for nested `TypeList` attributes during `DiffSuppressFunc` evaluation, causing the Set comparison to incorrectly report no diff.

The fix detects full removal using the raw `DiffSuppressFunc` parameters (`k`, `old`, `new`) instead of relying on `d.GetChange()`.

### Relations
Closes #41778

### Output from Acceptance Testing

```console
% make testacc TESTS='TestAccWAFV2WebACLLoggingConfiguration_.*[Rr]edacted' PKG=wafv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-wafv2-web-acl-logging-redacted-fields-removal 🌿...
TF_ACC=1 go1.25.9 test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACLLoggingConfiguration_.*[Rr]edacted'  -timeout 360m -vet=off
2026/04/12 10:50:28 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/12 10:50:28 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_updateSingleHeaderRedactedField
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_updateSingleHeaderRedactedField
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_updateMethodRedactedField
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_updateMethodRedactedField
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_updateQueryStringRedactedField
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_updateQueryStringRedactedField
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_updateURIPathRedactedField
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_updateURIPathRedactedField
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_updateMultipleRedactedFields
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_updateMultipleRedactedFields
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_emptyRedactedFields
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_emptyRedactedFields
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_updateEmptyRedactedFields
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_updateEmptyRedactedFields
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_removeRedactedFields
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_removeRedactedFields
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_updateSingleHeaderRedactedField
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_updateMultipleRedactedFields
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_removeRedactedFields
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_emptyRedactedFields
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_updateURIPathRedactedField
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_updateQueryStringRedactedField
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_updateMethodRedactedField
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_updateEmptyRedactedFields
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_emptyRedactedFields (234.26s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateMethodRedactedField (323.59s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_removeRedactedFields (343.76s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateURIPathRedactedField (343.91s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateEmptyRedactedFields (344.33s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateQueryStringRedactedField (353.12s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateSingleHeaderRedactedField (389.99s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateMultipleRedactedFields (398.08s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      398.430s
```
