### PR TITLE
resource/aws_route: Fix update failure when only timeouts change

### DIFF
--- a/.changelog/47413.txt
+++ b/.changelog/47413.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route: Fix `route target attribute not specified` error when only `timeouts` block is changed
+```

--- a/internal/service/ec2/vpc_route.go
+++ b/internal/service/ec2/vpc_route.go
@@ -354,6 +354,12 @@ func resourceRouteRead(ctx context.Context, d *schema.ResourceData, meta any) di
 
 func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
+
+	// If no route target attributes changed, there is nothing to update via the API.
+	if !d.HasChanges(routeValidTargets...) {
+		return diags
+	}
+
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	destinationAttributeKey, destination, err := routeDestinationAttribute(d)

--- a/internal/service/ec2/vpc_route_test.go
+++ b/internal/service/ec2/vpc_route_test.go
@@ -1515,6 +1515,37 @@ func TestAccVPCRoute_IPv6Update_target(t *testing.T) {
 	})
 }
 
+func TestAccVPCRoute_timeoutsOnlyChange(t *testing.T) {
+	ctx := acctest.Context(t)
+	var route awstypes.Route
+	resourceName := "aws_route.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	destinationCidr := "10.3.0.0/16"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRouteDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCRouteConfig_ipv4InternetGateway(rName, destinationCidr),
+				Check:  testAccCheckRouteExists(ctx, t, resourceName, &route),
+			},
+			{
+				Config: testAccVPCRouteConfig_ipv4InternetGatewayWithTimeouts(rName, destinationCidr),
+				Check:  testAccCheckRouteExists(ctx, t, resourceName, &route),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccVPCRoute_ipv4ToVPCEndpoint(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -2707,6 +2738,45 @@ resource "aws_route" "test" {
   route_table_id         = aws_route_table.test.id
   destination_cidr_block = %[2]q
   gateway_id             = aws_internet_gateway.test.id
+}
+`, rName, destinationCidr)
+}
+
+func testAccVPCRouteConfig_ipv4InternetGatewayWithTimeouts(rName, destinationCidr string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id         = aws_route_table.test.id
+  destination_cidr_block = %[2]q
+  gateway_id             = aws_internet_gateway.test.id
+
+  timeouts {
+    create = "5m"
+    delete = "5m"
+  }
 }
 `, rName, destinationCidr)
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls in this pull request.

### Description
Fixes `aws_route` failing with `route target attribute not specified` when only the `timeouts` block is changed (or when a provider upgrade causes a timeouts-only diff).

The `resourceRouteUpdate` function calls `routeTargetAttribute`, which requires at least one target attribute to have `HasChange` return `true`. When only timeouts change, no target attribute has changed, causing the error.

This adds an early return in `resourceRouteUpdate` when no route target attributes have changed, skipping the unnecessary `ReplaceRoute` API call.

### Relations
Closes #45228

### Output from Acceptance Testing

```console
% make testacc TESTS='TestAccVPCRoute_timeoutsOnlyChange|TestAccVPCRoute_basic' PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-ec2-vpc-route-timeouts-only-update 🌿...
TF_ACC=1 go1.25.9 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCRoute_timeoutsOnlyChange|TestAccVPCRoute_basic'  -timeout 360m -vet=off
2026/04/12 16:15:01 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/12 16:15:01 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCRoute_basic
=== PAUSE TestAccVPCRoute_basic
=== RUN   TestAccVPCRoute_timeoutsOnlyChange
=== PAUSE TestAccVPCRoute_timeoutsOnlyChange
=== CONT  TestAccVPCRoute_basic
=== CONT  TestAccVPCRoute_timeoutsOnlyChange
--- PASS: TestAccVPCRoute_basic (57.05s)
--- PASS: TestAccVPCRoute_timeoutsOnlyChange (83.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        83.972s
```