### PR TITLE
fix: acm certificate export defaults to ENABLED when options block is omitted

### DIFF
--- a/.changelog/46498.txt
+++ b/.changelog/46498.txt
@@ -1,0 +1,2 @@
+release-note:bug
+resource/aws_acm_certificate: Fix options.export defaulting to ENABLED instead of DISABLED when options block is not specified

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -634,6 +634,8 @@ func expandCertificateOptions(tfMap map[string]any) *types.CertificateOptions {
 
 	if v, ok := tfMap["export"].(string); ok && v != "" {
 		apiObject.Export = types.CertificateExport(v)
+	} else {
+		apiObject.Export = types.CertificateExportDisabled
 	}
 
 	return apiObject


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

This fix changes the default value of `export` in `options` from `ENABLED` to `DISABLED`, which reduces the attack surface by preventing unintended certificate exports. No other security controls are affected.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When the options block is omitted from `aws_acm_certificate`, the `export` attribute incorrectly defaults to `ENABLED` instead of `DISABLED`.

The root cause is that `certificate_transparency_logging_preference` has Default: `ENABLED`, which causes the options object to always be sent to the AWS API even when the block is omitted. When AWS receives an `Options` object without an explicit Export value, it sets Export to `ENABLED`. In contrast, when no Options object is sent at all (e.g., via AWS CLI), AWS defaults to `DISABLED`.

This fix explicitly sets Export: `DISABLED` in expandCertificateOptions when no value is provided, matching the behavior of the AWS CLI and Console.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #46498

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- https://docs.aws.amazon.com/acm/latest/APIReference/API_CertificateOptions.html
- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

I was unable to run acceptance tests due to the cost of AWS Private CA. The existing `TestAccACMCertificate_emailValidation test` covers this fix by verifying that options.0.export defaults to DISABLED when the options block is omitted.

```console
% make testacc TESTS=TestAccACMCertificate_emailValidation PKG=acm

...
```
