### PR TITLE
Tech debt: Replace use of deprecated `parser.ParseDir` in generators

### DIFF
--- a/internal/generate/common/ast.go
+++ b/internal/generate/common/ast.go
@@ -6,12 +6,44 @@ package common
 import (
 	"fmt"
 	"go/ast"
+	"go/parser"
+	"go/token"
+	"iter"
+	"os"
+	"strings"
 
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"golang.org/x/tools/go/packages"
 )
 
+type PackageFile struct {
+	name string
+	file *ast.File
+}
+
+func (file *PackageFile) Name() string {
+	return file.name
+}
+
+func (file *PackageFile) File() *ast.File {
+	return file.file
+}
+
+func (file *PackageFile) PackageName() string {
+	return file.file.Name.Name
+}
+
 type Package struct {
-	files []*ast.File
+	name  string
+	files []*PackageFile
+}
+
+func (pkg *Package) Name() string {
+	return pkg.name
+}
+
+func (pkg *Package) Files() []*PackageFile {
+	return pkg.files
 }
 
 func LoadPackage(sourcePackage string) (*Package, error) {
@@ -28,17 +60,22 @@ func LoadPackage(sourcePackage string) (*Package, error) {
 	pkg := pkgs[0]
 
 	return &Package{
-		files: pkg.Syntax,
+		name: pkg.Name,
+		files: tfslices.ApplyToAll(pkg.Syntax, func(file *ast.File) *PackageFile {
+			return &PackageFile{
+				file: file,
+			}
+		}),
 	}, nil
 }
 
-func (pkg *Package) FindFunction(functionName string) *Function {
-	for _, file := range pkg.files {
+func (pkg *Package) FindFunction(functionName string) *PackageFunction {
+	for _, file := range pkg.Files() {
 		if file != nil {
-			for _, decl := range file.Decls {
+			for _, decl := range file.File().Decls {
 				if funcDecl, ok := decl.(*ast.FuncDecl); ok {
 					if funcDecl.Name.Name == functionName {
-						return &Function{
+						return &PackageFunction{
 							funcDecl: funcDecl,
 						}
 					}
@@ -50,18 +87,50 @@ func (pkg *Package) FindFunction(functionName string) *Function {
 	return nil
 }
 
-type Function struct {
+type PackageFunction struct {
 	funcDecl *ast.FuncDecl
 }
 
-func (function *Function) Name() string {
+func (function *PackageFunction) Name() string {
 	return function.funcDecl.Name.Name
 }
 
-func (function *Function) Params() []*ast.Field {
+func (function *PackageFunction) Params() []*ast.Field {
 	return function.funcDecl.Type.Params.List
 }
 
-func (function *Function) Results() []*ast.Field {
+func (function *PackageFunction) Results() []*ast.Field {
 	return function.funcDecl.Type.Results.List
+}
+
+// ScanDirectory scans a single directory and returns an iterator of Go sources files.
+func ScanDirectory(path string) iter.Seq2[*PackageFile, error] {
+	return func(yield func(*PackageFile, error) bool) {
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		fileSet := token.NewFileSet()
+
+		for _, entry := range entries {
+			// Skip directories and test files.
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+				continue
+			}
+
+			name := path + "/" + entry.Name()
+
+			file, err := parser.ParseFile(fileSet, name, nil, parser.ParseComments)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			if !yield(&PackageFile{name: name, file: file}, nil) {
+				return
+			}
+		}
+	}
 }

--- a/internal/generate/identitytests/main.go
+++ b/internal/generate/identitytests/main.go
@@ -497,29 +497,36 @@ type visitor struct {
 
 // processDir scans a single service package directory and processes contained Go sources files.
 func (v *visitor) processDir(path string) {
-	fileSet := token.NewFileSet()
-	packageMap, err := parser.ParseDir(fileSet, path, func(fi os.FileInfo) bool {
-		// Skip tests.
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, parser.ParseComments)
-
+	entries, err := os.ReadDir(path)
 	if err != nil {
-		v.errs = append(v.errs, fmt.Errorf("parsing (%s): %w", path, err))
+		v.errs = append(v.errs, fmt.Errorf("reading directory (%s): %w", path, err))
 
 		return
 	}
 
-	for name, pkg := range packageMap {
-		v.packageName = name
+	fileSet := token.NewFileSet()
 
-		for name, file := range pkg.Files {
-			v.fileName = name
-
-			v.processFile(file)
-
-			v.fileName = ""
+	for _, entry := range entries {
+		// Skip directories and test files.
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
 		}
 
+		name := path + "/" + entry.Name()
+
+		file, err := parser.ParseFile(fileSet, name, nil, parser.ParseComments)
+		if err != nil {
+			v.errs = append(v.errs, fmt.Errorf("parsing (%s): %w", name, err))
+
+			continue
+		}
+
+		v.packageName = file.Name.Name
+		v.fileName = name
+
+		v.processFile(file)
+
+		v.fileName = ""
 		v.packageName = ""
 	}
 }

--- a/internal/generate/identitytests/main.go
+++ b/internal/generate/identitytests/main.go
@@ -10,8 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
-	"go/parser"
-	"go/token"
 	"maps"
 	"os"
 	"path"
@@ -89,7 +87,19 @@ func main() {
 		g: g,
 	}
 
-	v.processDir(".")
+	for file, err := range common.ScanDirectory(".") {
+		if err != nil {
+			g.Fatalf("%s", err.Error())
+		}
+
+		v.packageName = file.PackageName()
+		v.fileName = file.Name()
+
+		v.processFile(file.File())
+
+		v.fileName = ""
+		v.packageName = ""
+	}
 
 	if err := errors.Join(v.errs...); err != nil {
 		g.Fatalf("%s", err.Error())
@@ -493,42 +503,6 @@ type visitor struct {
 	packageName  string
 
 	identityResources []ResourceDatum
-}
-
-// processDir scans a single service package directory and processes contained Go sources files.
-func (v *visitor) processDir(path string) {
-	entries, err := os.ReadDir(path)
-	if err != nil {
-		v.errs = append(v.errs, fmt.Errorf("reading directory (%s): %w", path, err))
-
-		return
-	}
-
-	fileSet := token.NewFileSet()
-
-	for _, entry := range entries {
-		// Skip directories and test files.
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
-			continue
-		}
-
-		name := path + "/" + entry.Name()
-
-		file, err := parser.ParseFile(fileSet, name, nil, parser.ParseComments)
-		if err != nil {
-			v.errs = append(v.errs, fmt.Errorf("parsing (%s): %w", name, err))
-
-			continue
-		}
-
-		v.packageName = file.Name.Name
-		v.fileName = name
-
-		v.processFile(file)
-
-		v.fileName = ""
-		v.packageName = ""
-	}
 }
 
 // processFile processes a single Go source file.

--- a/internal/generate/servicepackage/main.go
+++ b/internal/generate/servicepackage/main.go
@@ -11,8 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
-	"go/parser"
-	"go/token"
 	"maps"
 	"os"
 	"slices"
@@ -73,7 +71,19 @@ func main() {
 			sdkListResources:       make(map[string]ResourceDatum, 0),
 		}
 
-		v.processDir(".")
+		for file, err := range common.ScanDirectory(".") {
+			if err != nil {
+				g.Fatalf("%s", err.Error())
+			}
+
+			v.packageName = file.PackageName()
+			v.fileName = file.Name()
+
+			v.processFile(file.File())
+
+			v.fileName = ""
+			v.packageName = ""
+		}
 
 		if err := errors.Join(v.errs...); err != nil {
 			g.Fatalf("%s", err.Error())
@@ -294,42 +304,6 @@ type visitor struct {
 	sdkDataSources         map[string]ResourceDatum
 	sdkResources           map[string]ResourceDatum
 	sdkListResources       map[string]ResourceDatum
-}
-
-// processDir scans a single service package directory and processes contained Go sources files.
-func (v *visitor) processDir(path string) {
-	entries, err := os.ReadDir(path)
-	if err != nil {
-		v.errs = append(v.errs, fmt.Errorf("reading directory (%s): %w", path, err))
-
-		return
-	}
-
-	fileSet := token.NewFileSet()
-
-	for _, entry := range entries {
-		// Skip directories and test files.
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
-			continue
-		}
-
-		name := path + "/" + entry.Name()
-
-		file, err := parser.ParseFile(fileSet, name, nil, parser.ParseComments)
-		if err != nil {
-			v.errs = append(v.errs, fmt.Errorf("parsing (%s): %w", name, err))
-
-			continue
-		}
-
-		v.packageName = file.Name.Name
-		v.fileName = name
-
-		v.processFile(file)
-
-		v.fileName = ""
-		v.packageName = ""
-	}
 }
 
 // processFile processes a single Go source file.

--- a/internal/generate/servicepackage/main.go
+++ b/internal/generate/servicepackage/main.go
@@ -298,29 +298,36 @@ type visitor struct {
 
 // processDir scans a single service package directory and processes contained Go sources files.
 func (v *visitor) processDir(path string) {
-	fileSet := token.NewFileSet()
-	packageMap, err := parser.ParseDir(fileSet, path, func(fi os.FileInfo) bool {
-		// Skip tests.
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, parser.ParseComments)
-
+	entries, err := os.ReadDir(path)
 	if err != nil {
-		v.errs = append(v.errs, fmt.Errorf("parsing (%s): %w", path, err))
+		v.errs = append(v.errs, fmt.Errorf("reading directory (%s): %w", path, err))
 
 		return
 	}
 
-	for name, pkg := range packageMap {
-		v.packageName = name
+	fileSet := token.NewFileSet()
 
-		for name, file := range pkg.Files {
-			v.fileName = name
-
-			v.processFile(file)
-
-			v.fileName = ""
+	for _, entry := range entries {
+		// Skip directories and test files.
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
 		}
 
+		name := path + "/" + entry.Name()
+
+		file, err := parser.ParseFile(fileSet, name, nil, parser.ParseComments)
+		if err != nil {
+			v.errs = append(v.errs, fmt.Errorf("parsing (%s): %w", name, err))
+
+			continue
+		}
+
+		v.packageName = file.Name.Name
+		v.fileName = name
+
+		v.processFile(file)
+
+		v.fileName = ""
 		v.packageName = ""
 	}
 }

--- a/internal/generate/tagstests/main.go
+++ b/internal/generate/tagstests/main.go
@@ -475,29 +475,36 @@ type visitor struct {
 
 // processDir scans a single service package directory and processes contained Go sources files.
 func (v *visitor) processDir(path string) {
-	fileSet := token.NewFileSet()
-	packageMap, err := parser.ParseDir(fileSet, path, func(fi os.FileInfo) bool {
-		// Skip tests.
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, parser.ParseComments)
-
+	entries, err := os.ReadDir(path)
 	if err != nil {
-		v.errs = append(v.errs, fmt.Errorf("parsing (%s): %w", path, err))
+		v.errs = append(v.errs, fmt.Errorf("reading directory (%s): %w", path, err))
 
 		return
 	}
 
-	for name, pkg := range packageMap {
-		v.packageName = name
+	fileSet := token.NewFileSet()
 
-		for name, file := range pkg.Files {
-			v.fileName = name
-
-			v.processFile(file)
-
-			v.fileName = ""
+	for _, entry := range entries {
+		// Skip directories and test files.
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
 		}
 
+		name := path + "/" + entry.Name()
+
+		file, err := parser.ParseFile(fileSet, name, nil, parser.ParseComments)
+		if err != nil {
+			v.errs = append(v.errs, fmt.Errorf("parsing (%s): %w", name, err))
+
+			continue
+		}
+
+		v.packageName = file.Name.Name
+		v.fileName = name
+
+		v.processFile(file)
+
+		v.fileName = ""
 		v.packageName = ""
 	}
 }

--- a/internal/generate/tagstests/main.go
+++ b/internal/generate/tagstests/main.go
@@ -10,8 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
-	"go/parser"
-	"go/token"
 	"iter"
 	"os"
 	"path"
@@ -85,7 +83,19 @@ func main() {
 		g: g,
 	}
 
-	v.processDir(".")
+	for file, err := range common.ScanDirectory(".") {
+		if err != nil {
+			g.Fatalf("%s", err.Error())
+		}
+
+		v.packageName = file.PackageName()
+		v.fileName = file.Name()
+
+		v.processFile(file.File())
+
+		v.fileName = ""
+		v.packageName = ""
+	}
 
 	if err := errors.Join(v.errs...); err != nil {
 		g.Fatalf("%s", err.Error())
@@ -471,42 +481,6 @@ type visitor struct {
 	packageName  string
 
 	taggedResources []ResourceDatum
-}
-
-// processDir scans a single service package directory and processes contained Go sources files.
-func (v *visitor) processDir(path string) {
-	entries, err := os.ReadDir(path)
-	if err != nil {
-		v.errs = append(v.errs, fmt.Errorf("reading directory (%s): %w", path, err))
-
-		return
-	}
-
-	fileSet := token.NewFileSet()
-
-	for _, entry := range entries {
-		// Skip directories and test files.
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
-			continue
-		}
-
-		name := path + "/" + entry.Name()
-
-		file, err := parser.ParseFile(fileSet, name, nil, parser.ParseComments)
-		if err != nil {
-			v.errs = append(v.errs, fmt.Errorf("parsing (%s): %w", name, err))
-
-			continue
-		}
-
-		v.packageName = file.Name.Name
-		v.fileName = name
-
-		v.processFile(file)
-
-		v.fileName = ""
-		v.packageName = ""
-	}
 }
 
 // processFile processes a single Go source file.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

* Replaces use of the deprecated [`parser.ParseDir`](https://pkg.go.dev/go/parser#ParseDir) call in generators
* Moves the duplicated package scanning code into `generator/common`

AI assisted by Kiro.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/47328.