### PR TITLE
fix: preserve service_password in aws_iam_service_specific_credential Read

### DIFF
--- a/.changelog/47424.txt
+++ b/.changelog/47424.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iam_service_specific_credential: Fix `service_password` always being empty in state after resource creation
+```

--- a/internal/service/iam/service_specific_credential.go
+++ b/internal/service/iam/service_specific_credential.go
@@ -175,6 +175,7 @@ func resourceServiceSpecificCredentialRead(ctx context.Context, d *schema.Resour
 	d.Set("service_user_name", cred.ServiceUserName)
 	d.Set(names.AttrStatus, cred.Status)
 	d.Set(names.AttrUserName, cred.UserName)
+	d.Set("service_password", d.Get("service_password"))
 
 	return diags
 }

--- a/internal/service/iam/service_specific_credential_test.go
+++ b/internal/service/iam/service_specific_credential_test.go
@@ -39,6 +39,7 @@ func TestAccIAMServiceSpecificCredential_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "Active"),
 					resource.TestCheckResourceAttrSet(resourceName, "service_user_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "service_specific_credential_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "service_password"),
 				),
 			},
 			{


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No.

### Description

`service_password` is always `""` in state after `aws_iam_service_specific_credential` is created. `Read` uses `ListServiceSpecificCredentials` which returns no password, so the value set by `Create` is cleared before state is finalised. Preserve the existing state value in `Read`.

### Relations

Closes #47421

### Output from Acceptance Testing

Unable to run acceptance tests (no funded AWS environment). Requesting maintainer run.