### PR TITLE
resource/aws_dynamodb_table: Prevents error when `global_secondary_index[*].range_key` is explicitly set to empty string

### DIFF
--- a/.changelog/47427.txt
+++ b/.changelog/47427.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Prevents validation error when global secondary index `range_key` is set to empty string
+```

--- a/internal/errs/diag.go
+++ b/internal/errs/diag.go
@@ -184,6 +184,15 @@ func NewAttributeConflictsWhenWillBeError(path, otherPath cty.Path, otherValue s
 	)
 }
 
+// NewInvalidValueAttributeWillBeError returns a warning diagnostic indicating that the attribute at the given path
+// has an invalid value.
+// This is intended to be used for situations where the invalid value will become an error in a future release.
+func NewInvalidValueAttributeWillBeError(path cty.Path, detail string) diag.Diagnostic {
+	return willBeError(
+		NewInvalidValueAttributeError(path, detail),
+	)
+}
+
 func PathString(path cty.Path) string {
 	var buf strings.Builder
 	for i, step := range path {

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -190,10 +190,11 @@ func resourceTable() *schema.Resource {
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"hash_key": {
-								Type:       schema.TypeString,
-								Optional:   true,
-								Computed:   true,
-								Deprecated: "hash_key is deprecated. Use key_schema instead.",
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								Deprecated:   "hash_key is deprecated. Use key_schema instead.",
+								ValidateFunc: validation.StringIsNotEmpty,
 							},
 							"key_schema": {
 								Type:     schema.TypeList,
@@ -202,8 +203,9 @@ func resourceTable() *schema.Resource {
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
 										"attribute_name": {
-											Type:     schema.TypeString,
-											Required: true,
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringIsNotEmpty,
 										},
 										"key_type": {
 											Type:             schema.TypeString,
@@ -229,9 +231,10 @@ func resourceTable() *schema.Resource {
 								ValidateDiagFunc: enum.Validate[awstypes.ProjectionType](),
 							},
 							"range_key": {
-								Type:       schema.TypeString,
-								Optional:   true,
-								Deprecated: "range_key is deprecated. Use key_schema instead.",
+								Type:             schema.TypeString,
+								Optional:         true,
+								Deprecated:       "range_key is deprecated. Use key_schema instead.",
+								ValidateDiagFunc: verify.WarnStringIsNotEmpty,
 							},
 							"read_capacity": {
 								Type:     schema.TypeInt,

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -3276,7 +3276,7 @@ func validateTableAttributes(ctx context.Context, d *schema.ResourceDiff, meta a
 					indexedAttributes[hashKey.AsString()] = true
 				}
 				rangeKey := v.GetAttr("range_key")
-				if rangeKey.IsKnown() && !rangeKey.IsNull() {
+				if rangeKey.IsKnown() && !rangeKey.IsNull() && rangeKey.AsString() != "" {
 					indexedAttributes[rangeKey.AsString()] = true
 				}
 				keySchema := v.GetAttr("key_schema")

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -3253,6 +3253,63 @@ func TestAccDynamoDBTable_GSI_keySchema_removeGSI(t *testing.T) {
 	})
 }
 
+func TestAccDynamoDBTable_GSI_rangeKeyExplicitEmptyString(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var table awstypes.TableDescription
+	resourceName := "aws_dynamodb_table.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		CheckDestroy: testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "6.28.0",
+					},
+				},
+				Config: testAccTableConfig_GSI_rangeKeyExplicitEmptyString(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(ctx, t, resourceName, &table),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("global_secondary_index"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"hash_key":     knownvalue.StringExact(rName + "-hash"),
+							names.AttrName: knownvalue.StringExact(rName + "-index"),
+							"range_key":    knownvalue.StringExact(""),
+						}),
+					})),
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccTableConfig_GSI_rangeKeyExplicitEmptyString(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(ctx, t, resourceName, &table),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema(t *testing.T) {
 	ctx := acctest.Context(t)
 
@@ -13181,6 +13238,47 @@ variable "key_schemas" {
   default = [{
     attribute_name = %[1]q
     key_type       = "HASH"
+  }]
+}
+`, rName)
+}
+
+func testAccTableConfig_GSI_rangeKeyExplicitEmptyString(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = %[1]q
+  read_capacity  = 1
+  write_capacity = 1
+  hash_key       = "%[1]s-hash"
+
+  attribute {
+    name = "%[1]s-hash"
+    type = "S"
+  }
+
+  dynamic "global_secondary_index" {
+    for_each = var.global_secondary_index
+	content {
+      name               = global_secondary_index.value.name
+      hash_key           = global_secondary_index.value.hash_key
+      non_key_attributes = lookup(global_secondary_index.value, "non_key_attributes", null)
+      projection_type    = global_secondary_index.value.projection_type
+      range_key          = lookup(global_secondary_index.value, "range_key", null)
+      read_capacity      = global_secondary_index.value.read_capacity
+      write_capacity     = global_secondary_index.value.write_capacity
+    }
+  }
+}
+
+variable "global_secondary_index" {
+  default = [{
+    name               = "%[1]s-index"
+    hash_key           = "%[1]s-hash"
+    range_key          = ""
+    projection_type    = "ALL"
+    non_key_attributes = []
+    read_capacity      = 1
+    write_capacity     = 1
   }]
 }
 `, rName)

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -13258,7 +13258,7 @@ resource "aws_dynamodb_table" "test" {
 
   dynamic "global_secondary_index" {
     for_each = var.global_secondary_index
-	content {
+    content {
       name               = global_secondary_index.value.name
       hash_key           = global_secondary_index.value.hash_key
       non_key_attributes = lookup(global_secondary_index.value, "non_key_attributes", null)

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -569,3 +569,19 @@ func CaseInsensitiveMatchDeprecation(valid []string) schema.SchemaValidateDiagFu
 		return diags
 	}
 }
+
+func WarnStringIsNotEmpty(v any, path cty.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+	s := v.(string)
+
+	if s == "" {
+		diags = append(diags, diag.Diagnostic{
+			Severity:      diag.Warning,
+			Summary:       "Empty String",
+			Detail:        "Value must not be an empty string.\n\nThis will be an error in a future release of the provider.",
+			AttributePath: path,
+		})
+	}
+
+	return diags
+}

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -572,15 +572,14 @@ func CaseInsensitiveMatchDeprecation(valid []string) schema.SchemaValidateDiagFu
 
 func WarnStringIsNotEmpty(v any, path cty.Path) diag.Diagnostics {
 	var diags diag.Diagnostics
-	s := v.(string)
 
-	if s == "" {
-		diags = append(diags, diag.Diagnostic{
-			Severity:      diag.Warning,
-			Summary:       "Empty String",
-			Detail:        "Value must not be an empty string.\n\nThis will be an error in a future release of the provider.",
-			AttributePath: path,
-		})
+	switch s := v.(type) {
+	case string:
+		if s == "" {
+			diags = append(diags, errs.NewInvalidValueAttributeWillBeError(path, "Value must not be an empty string"))
+		}
+	default:
+		diags = append(diags, errs.NewIncorrectValueTypeAttributeError(path, "string"))
 	}
 
 	return diags

--- a/internal/verify/validate_test.go
+++ b/internal/verify/validate_test.go
@@ -900,3 +900,31 @@ func TestCaseInsensitiveMatchDeprecation(t *testing.T) {
 		})
 	}
 }
+
+func TestWarnStringIsNotEmpty(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		value    any
+		wantDiag bool
+	}{
+		"empty string": {
+			value:    "",
+			wantDiag: true,
+		},
+		"non-empty string": {
+			value: "value",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := WarnStringIsNotEmpty(tt.value, cty.Path{})
+			if got, want := len(diags) > 0, tt.wantDiag; got != want {
+				t.Errorf("got = %v, want = %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Before the introduction of multi-attribute keys in DynamoDB Global Secondary Indexes, the `range_key` was ignored if it was explicitly set to an empty string. This was missed when adding multi-attribute key support.

Also adds validation for `hash_key`, `range_key`, and `key_schema[*].attribute_name`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #46322

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=dynamodb TESTS=TestAccDynamoDBTable_

--- PASS: TestAccDynamoDBTable_GSI_unknown (265.28s)
--- PASS: TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed_onUpdate (265.63s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_unknown (273.25s)
--- PASS: TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed (24.15s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_MixedConsistencyModes (345.64s)
--- FAIL: TestAccDynamoDBTable_Replica_MRSC_TooManyReplicas (383.98s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_NotEnoughReplicas (392.50s)
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (421.74s)
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_add (421.74s)
--- PASS: TestAccDynamoDBTable_TTL_updateEnable (422.14s)
--- PASS: TestAccDynamoDBTable_nameKnownAfterApply (148.97s)
--- PASS: TestAccDynamoDBTable_Replica_upgradeV6_2_0 (536.29s)
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_onCreate (132.26s)
--- PASS: TestAccDynamoDBTable_warmThroughputDefault (132.45s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeHashKey (636.18s)
--- PASS: TestAccDynamoDBTable_tags (674.46s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nullNonOverlappingResourceTag (151.05s)
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_switchBilling (400.67s)
--- PASS: TestAccDynamoDBTable_importTable (197.70s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_overlapping (353.11s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_nonPropagatedTagsAreUnmanaged (776.79s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nullOverlappingResourceTag (113.40s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_emptyProviderOnlyTag (79.05s)
--- PASS: TestAccDynamoDBTable_tableClass_migrate (77.42s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_twoOfTwo (831.28s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_notPropagatedToAddedReplica (676.94s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_nonPropagatedTagsAreUnmanaged (832.93s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_emptyResourceTag (77.63s)
--- PASS: TestAccDynamoDBTable_warmThroughput (316.38s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica (601.90s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_propagateToAddedReplica (598.82s)
--- PASS: TestAccDynamoDBTable_tableClass_ConcurrentModification (116.98s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_CreateEventuallyConsistent (904.24s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_updateToResourceOnly (126.23s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_twoOfTwo (535.77s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleHashKeys (107.64s)
--- PASS: TestAccDynamoDBTable_tableClassExplicitDefault (113.64s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_updateToProviderOnly (114.88s)
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_billingPayPerRequest (605.52s)
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_billingProvisioned (627.74s)
--- PASS: TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_noChange (153.80s)
--- PASS: TestAccDynamoDBTable_backupEncryption (374.92s)
--- PASS: TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_noChange (156.36s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tagsUpdate (1106.11s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tagsUpdate (1122.83s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create_witness_too_many_replicas (120.92s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleHashKey (158.71s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleRangeKey (198.14s)
--- PASS: TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_removeKey (446.00s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_addHashKey (452.91s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_oneOfTwo (510.87s)
--- PASS: TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_addHashKey (445.65s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_pitr (533.21s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_oneOfTwo (599.52s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_pitr (539.24s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create_witness (395.49s)
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (906.03s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create (382.17s)
--- PASS: TestAccDynamoDBTable_deletion_protection (142.51s)
--- PASS: TestAccDynamoDBTable_disappears (100.91s)
--- PASS: TestAccDynamoDBTable_Replica_tags_updateIsPropagated_oneOfTwo (924.97s)
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (288.54s)
--- PASS: TestAccDynamoDBTable_Replica_singleCMK (505.35s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_pitrKMS (1029.92s)
--- PASS: TestAccDynamoDBTable_basic (141.13s)
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (10.78s)
--- PASS: TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_resourceTag (266.30s)
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted (622.34s)
--- PASS: TestAccDynamoDBTable_Replica_tags_nonPropagatedTagsAreUnmanaged (860.47s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_pitrKMS (1079.18s)
--- PASS: TestAccDynamoDBTable_Replica_deletionProtection (1981.91s)
--- PASS: TestAccDynamoDBTable_Replica_tags_notPropagatedToAddedReplica (866.81s)
--- PASS: TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_defaultTag (168.23s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_doubleAddCMK (1146.10s)
--- PASS: TestAccDynamoDBTable_Replica_tags_propagateToAddedReplica (862.41s)
--- PASS: TestAccDynamoDBTable_TTL_validate (30.50s)
--- PASS: TestAccDynamoDBTable_extended (522.36s)
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_add (268.37s)
--- PASS: TestAccDynamoDBTable_Replica_tags_updateIsPropagated_twoOfTwo (876.52s)
--- PASS: TestAccDynamoDBTable_Replica_pitr (761.03s)
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_replace (246.87s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nonOverlapping (326.43s)
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_replace (250.51s)
--- PASS: TestAccDynamoDBTable_encryption (336.40s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_doubleAddCMK (1333.85s)
--- PASS: TestAccDynamoDBTable_lsiUpdate (203.10s)
--- PASS: TestAccDynamoDBTable_Replica_singleStreamSpecification (514.22s)
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (12.50s)
--- PASS: TestAccDynamoDBTable_Tags_emptyMap (179.49s)
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncryptedAmazonOwned (907.35s)
--- PASS: TestAccDynamoDBTable_TTL_disabled (146.72s)
--- PASS: TestAccDynamoDBTable_Tags_addOnUpdate (205.01s)
--- PASS: TestAccDynamoDBTable_TTL_enabled (153.60s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_providerOnly (431.34s)
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_onCreate (189.25s)
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (318.48s)
--- PASS: TestAccDynamoDBTable_Tags_null (375.35s)
--- PASS: TestAccDynamoDBTable_GSI_validate_keySchema_tooManyHashKeys (44.21s)
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (479.83s)
--- PASS: TestAccDynamoDBTable_GSI_validate_exactlyOneOfKeySchemaHashKey (5.12s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (666.26s)
--- PASS: TestAccDynamoDBTable_streamSpecification (466.93s)
--- PASS: TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema (9.01s)
--- PASS: TestAccDynamoDBTable_gsiOnDemandThroughput (512.65s)
--- PASS: TestAccDynamoDBTable_onDemandThroughput (560.56s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeGSI (256.85s)
--- PASS: TestAccDynamoDBTable_restoreCrossRegion (973.06s)
--- PASS: TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_DifferentFromTable (206.79s)
--- PASS: TestAccDynamoDBTable_GSI_rangeKeyExplicitEmptyString (120.00s)
--- PASS: TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_SameAsTable (159.64s)
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (640.03s)
--- PASS: TestAccDynamoDBTable_GSIvalidate_keySchema_tooManyRangeKeys (3.49s)
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (1805.35s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (237.24s)
--- PASS: TestAccDynamoDBTable_streamSpecificationDiffs (702.83s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestBasic (668.41s)
--- PASS: TestAccDynamoDBTable_enablePITR (122.37s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleRangeKeys (82.18s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (665.98s)
--- PASS: TestAccDynamoDBTable_attributeUpdate (1062.47s)
--- PASS: TestAccDynamoDBTable_enablePITRWithCustomRecoveryPeriod (144.60s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (195.78s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_maxSet (63.08s)
--- PASS: TestAccDynamoDBTable_Replica_pitrKMS (1770.78s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (138.59s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (291.01s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_addRangeKey (362.16s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeRangeKey (337.37s)
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (934.18s)
--- PASS: TestAccDynamoDBTable_Replica_single (1398.50s)
--- PASS: TestAccDynamoDBTable_Replica_multiple (1546.53s)
--- FAIL: TestAccDynamoDBTable_Replica_doubleAddCMK (2570.76s)
--- PASS: TestAccDynamoDBTable_TTL_updateDisable (3736.20s)
```

`TestAccDynamoDBTable_Replica_MRSC_TooManyReplicas` and `TestAccDynamoDBTable_Replica_doubleAddCMK` are pre-existing failures