### PR TITLE
🤖🤖🤖  r/aws_redshift_cluster: Add VPC endpoint attributes

### DIFF
--- a/.changelog/47435.txt
+++ b/.changelog/47435.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+resource/aws_redshift_cluster: Add `vpc_endpoints` attribute
+data-source/aws_redshift_cluster: Add `vpc_endpoints` attribute
+```

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -201,6 +201,7 @@ func resourceCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"vpc_endpoints": redshiftVPCEndpointSchema(),
 			"enhanced_vpc_routing": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -683,6 +684,9 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	d.Set(names.AttrDNSName, nil)
 	d.Set(names.AttrEndpoint, nil)
 	d.Set(names.AttrPort, nil)
+	if err := d.Set("vpc_endpoints", nil); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting vpc_endpoints: %s", err)
+	}
 	if endpoint := rsc.Endpoint; endpoint != nil {
 		if address := aws.ToString(endpoint.Address); address != "" {
 			d.Set(names.AttrDNSName, address)
@@ -692,6 +696,9 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) 
 			} else {
 				d.Set(names.AttrEndpoint, address)
 			}
+		}
+		if err := d.Set("vpc_endpoints", flattenVPCEndpoints(endpoint.VpcEndpoints)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting vpc_endpoints: %s", err)
 		}
 	}
 

--- a/internal/service/redshift/cluster_data_source.go
+++ b/internal/service/redshift/cluster_data_source.go
@@ -132,6 +132,7 @@ func dataSourceCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"vpc_endpoints": redshiftVPCEndpointSchema(),
 			"enhanced_vpc_routing": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -256,9 +257,15 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any
 		d.Set("elastic_ip", rsc.ElasticIpStatus.ElasticIp)
 	}
 	d.Set(names.AttrEncrypted, rsc.Encrypted)
+	if err := d.Set("vpc_endpoints", nil); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting vpc_endpoints: %s", err)
+	}
 	if rsc.Endpoint != nil {
 		d.Set(names.AttrEndpoint, rsc.Endpoint.Address)
 		d.Set(names.AttrPort, rsc.Endpoint.Port)
+		if err := d.Set("vpc_endpoints", flattenVPCEndpoints(rsc.Endpoint.VpcEndpoints)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting vpc_endpoints: %s", err)
+		}
 	}
 	d.Set("enhanced_vpc_routing", rsc.EnhancedVpcRouting)
 	d.Set("iam_roles", tfslices.ApplyToAll(rsc.IamRoles, func(v awstypes.ClusterIamRole) string {

--- a/internal/service/redshift/cluster_data_source_test.go
+++ b/internal/service/redshift/cluster_data_source_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -62,6 +63,7 @@ func TestAccRedshiftClusterDataSource_basic(t *testing.T) {
 func TestAccRedshiftClusterDataSource_vpc(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_redshift_cluster.test"
+	resourceName := "aws_redshift_cluster.test"
 	subnetGroupResourceName := "aws_redshift_subnet_group.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
@@ -77,6 +79,16 @@ func TestAccRedshiftClusterDataSource_vpc(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "vpc_security_group_ids.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "cluster_type", "multi-node"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_subnet_group_name", subnetGroupResourceName, names.AttrName),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoints.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vpc_endpoints.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "vpc_endpoints.0.network_interface.#", regexache.MustCompile(`^[1-9][0-9]*$`)),
+					resource.TestMatchResourceAttr(dataSourceName, "vpc_endpoints.0.network_interface.#", regexache.MustCompile(`^[1-9][0-9]*$`)),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_endpoints.0.vpc_endpoint_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "vpc_endpoints.0.vpc_endpoint_id", resourceName, "vpc_endpoints.0.vpc_endpoint_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "vpc_endpoints.0.vpc_id", resourceName, "vpc_endpoints.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_endpoints.0.network_interface.0.network_interface_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_endpoints.0.network_interface.0.private_ip_address"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "vpc_endpoints.0.network_interface.0.private_ip_address"),
 				),
 			},
 		},

--- a/internal/service/redshift/endpoint_access.go
+++ b/internal/service/redshift/endpoint_access.go
@@ -70,46 +70,7 @@ func resourceEndpointAccess() *schema.Resource {
 				ForceNew: true,
 				Required: true,
 			},
-			"vpc_endpoint": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"network_interface": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrAvailabilityZone: {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									names.AttrNetworkInterfaceID: {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"private_ip_address": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									names.AttrSubnetID: {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-								},
-							},
-						},
-						names.AttrVPCEndpointID: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrVPCID: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
+			"vpc_endpoint": redshiftVPCEndpointSchema(),
 			names.AttrVPCSecurityGroupIDs: {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -250,11 +211,72 @@ func vpcSgsIdsToSlice(vpsSgsIds []awstypes.VpcSecurityGroupMembership) []string 
 	return VpcSgsSlice
 }
 
+func redshiftVPCEndpointSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"network_interface": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrAvailabilityZone: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrNetworkInterfaceID: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"private_ip_address": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrSubnetID: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+				names.AttrVPCEndpointID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrVPCID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
 func flattenVPCEndpoint(apiObject *awstypes.VpcEndpoint) []any {
 	if apiObject == nil {
 		return nil
 	}
 
+	return []any{flattenVPCEndpointMap(*apiObject)}
+}
+
+func flattenVPCEndpoints(apiObjects []awstypes.VpcEndpoint) []any {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	tfList := make([]any, 0, len(apiObjects))
+
+	for _, apiObject := range apiObjects {
+		tfList = append(tfList, flattenVPCEndpointMap(apiObject))
+	}
+
+	return tfList
+}
+
+func flattenVPCEndpointMap(apiObject awstypes.VpcEndpoint) map[string]any {
 	tfMap := map[string]any{}
 
 	if v := apiObject.NetworkInterfaces; v != nil {
@@ -269,7 +291,7 @@ func flattenVPCEndpoint(apiObject *awstypes.VpcEndpoint) []any {
 		tfMap[names.AttrVPCID] = aws.ToString(v)
 	}
 
-	return []any{tfMap}
+	return tfMap
 }
 
 func flattenNetworkInterface(apiObject awstypes.NetworkInterface) map[string]any {

--- a/website/docs/d/redshift_cluster.html.markdown
+++ b/website/docs/d/redshift_cluster.html.markdown
@@ -73,6 +73,7 @@ This data source exports the following attributes in addition to the arguments a
 * `enable_logging` - Whether cluster logging is enabled
 * `encrypted` - Whether the cluster data is encrypted
 * `endpoint` - Cluster endpoint
+* `vpc_endpoints` - Redshift-managed VPC endpoints for the cluster. See details below.
 * `enhanced_vpc_routing` - Whether enhanced VPC routing is enabled
 * `iam_roles` - IAM roles associated to the cluster
 * `kms_key_id` - KMS encryption key associated to the cluster
@@ -97,3 +98,16 @@ Cluster nodes (for `cluster_nodes`) support the following attributes:
 * `node_role` - Whether the node is a leader node or a compute node
 * `private_ip_address` - Private IP address of a node within a cluster
 * `public_ip_address` - Public IP address of a node within a cluster
+
+### VPC Endpoint
+
+* `network_interface` - One or more network interfaces of the endpoint. See details below.
+* `vpc_endpoint_id` - The Redshift-managed VPC endpoint ID.
+* `vpc_id` - The VPC identifier that the endpoint is associated with.
+
+### Network Interface
+
+* `availability_zone` - The Availability Zone.
+* `network_interface_id` - The network interface identifier.
+* `private_ip_address` - The IPv4 address of the network interface within the subnet.
+* `subnet_id` - The subnet identifier.

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -128,6 +128,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `automated_snapshot_retention_period` - The backup retention period
 * `preferred_maintenance_window` - The backup window
 * `endpoint` - The connection endpoint
+* `vpc_endpoints` - Redshift-managed VPC endpoints for the cluster. See details below.
 * `encrypted` - Whether the data in the cluster is encrypted
 * `vpc_security_group_ids` - The VPC security group Ids associated with the cluster
 * `dns_name` - The DNS name of the cluster
@@ -147,6 +148,19 @@ Cluster nodes (for `cluster_nodes`) support the following attributes:
 * `node_role` - Whether the node is a leader node or a compute node
 * `private_ip_address` - The private IP address of a node within a cluster
 * `public_ip_address` - The public IP address of a node within a cluster
+
+### VPC Endpoint
+
+* `network_interface` - One or more network interfaces of the endpoint. See details below.
+* `vpc_endpoint_id` - The Redshift-managed VPC endpoint ID.
+* `vpc_id` - The VPC identifier that the endpoint is associated with.
+
+### Network Interface
+
+* `availability_zone` - The Availability Zone.
+* `network_interface_id` - The network interface identifier.
+* `private_ip_address` - The IPv4 address of the network interface within the subnet.
+* `subnet_id` - The subnet identifier.
 
 ## Timeouts
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No.

### Description

Adds computed `vpc_endpoints` attributes to `aws_redshift_cluster` and `data.aws_redshift_cluster`, populated from `Cluster.Endpoint.VpcEndpoints`.

The nested shape mirrors `aws_redshift_endpoint_access` `vpc_endpoint`, including `network_interface` entries with `private_ip_address` for use cases such as registering Redshift endpoint IPs as Network Load Balancer targets.

Updated resource/data source documentation and added a changelog entry.

AI usage: Used an LLM coding agent to help implement the feature. I did it with Codex GPT 5.4 on xplus with AWS knowledge MCP so it can lookup the APIs.

I also tested it manually by importing existing clusters with different VPC endpoints(somehow one cluster has 3 network interfaces another only 1) and also using the data.aws_redshift_cluster on them and verified the output. 

### Relations

Closes #46079

### References

The AWS Redshift API response for the `DescribeClusters` operation contains a list of VPC Endpoints at `Clusters[*].Endpoint.VpcEndpoints[*]` [^1]. Each VPC Endpoint then describes its own network interface IPs at `NetworkInterfaces[*].PrivateIpAddress` [^2].

<details><summary>Truncated response example.</summary>

```json
{
  "Clusters": [
    {
      "ClusterIdentifier": "my-redshift-provisioned-cluster",
      "Endpoint": {
        "Address": "my-redshift-provisioned-cluster.abcdefghi.eu-west-1.redshift.amazonaws.com",
        "Port": 5439,
        "VpcEndpoints": [
          {
            "VpcEndpointId": "vpce-0123456789",
            "VpcId": "vpc-0123456789",
            "NetworkInterfaces": [
              {
                "NetworkInterfaceId": "eni-0123456789",
                "SubnetId": "subnet-0123456789",
                "PrivateIpAddress": "10.0.0.123",
                "AvailabilityZone": "eu-west-1b"
              }
            ]
          }
        ]
      },
      [...]
    }
  ]
}
```
</details>

The same information is available in the output of the AWS Go SDK v2 [^3][^4] equivalent of the DescribeClusters API request.

The information about the VPC endpoints is also available in the response of the CreateCluster API request.


[^1]: https://docs.aws.amazon.com/redshift/latest/APIReference/API_DescribeClusters.html#API_DescribeClusters_ResponseElements
[^2]: https://docs.aws.amazon.com/redshift/latest/APIReference/API_VpcEndpoint.html
[^3]: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/redshift#DescribeClustersOutput
[^4]: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/redshift@v1.62.0/types#Endpoint



### Output from Acceptance Testing

Note that some tests failed due to Terraform attempting to operations when cluster has invalid state. These are other bugs in the tests or code and should be fixed outside of this PR, I'll make separate issues for them and see if they can be fixed or not.

<details><summary>Acceptance test output</summary>

```console
$ make testacc PKG=redshift TESTS='^(TestAccRedshiftCluster|TestAccRedshiftEndpoint)' P=2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-redshift-cluster-vpc-endpoints 🌿...
TF_ACC=1 go1.25.9 test ./internal/service/redshift/... -v -count 1 -parallel 2 -run='^(TestAccRedshiftCluster|TestAccRedshiftEndpoint)'  -timeout 360m -vet=off
2026/04/13 21:14:46 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/13 21:14:46 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRedshiftClusterCredentialsDataSource_basic
=== PAUSE TestAccRedshiftClusterCredentialsDataSource_basic
=== RUN   TestAccRedshiftClusterDataSource_tags
=== PAUSE TestAccRedshiftClusterDataSource_tags
=== RUN   TestAccRedshiftClusterDataSource_Tags_nullMap
=== PAUSE TestAccRedshiftClusterDataSource_Tags_nullMap
=== RUN   TestAccRedshiftClusterDataSource_Tags_emptyMap
=== PAUSE TestAccRedshiftClusterDataSource_Tags_emptyMap
=== RUN   TestAccRedshiftClusterDataSource_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccRedshiftClusterDataSource_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccRedshiftClusterDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccRedshiftClusterDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccRedshiftClusterDataSource_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccRedshiftClusterDataSource_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccRedshiftClusterDataSource_basic
=== PAUSE TestAccRedshiftClusterDataSource_basic
=== RUN   TestAccRedshiftClusterDataSource_vpc
=== PAUSE TestAccRedshiftClusterDataSource_vpc
=== RUN   TestAccRedshiftClusterDataSource_logging
=== PAUSE TestAccRedshiftClusterDataSource_logging
=== RUN   TestAccRedshiftClusterDataSource_availabilityZoneRelocationEnabled
=== PAUSE TestAccRedshiftClusterDataSource_availabilityZoneRelocationEnabled
=== RUN   TestAccRedshiftClusterDataSource_multiAZEnabled
=== PAUSE TestAccRedshiftClusterDataSource_multiAZEnabled
=== RUN   TestAccRedshiftClusterIAMRoles_basic
=== PAUSE TestAccRedshiftClusterIAMRoles_basic
=== RUN   TestAccRedshiftClusterIAMRoles_disappears
=== PAUSE TestAccRedshiftClusterIAMRoles_disappears
=== RUN   TestAccRedshiftClusterSnapshot_tags
=== PAUSE TestAccRedshiftClusterSnapshot_tags
=== RUN   TestAccRedshiftClusterSnapshot_Tags_null
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_null
=== RUN   TestAccRedshiftClusterSnapshot_Tags_emptyMap
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_emptyMap
=== RUN   TestAccRedshiftClusterSnapshot_Tags_addOnUpdate
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_addOnUpdate
=== RUN   TestAccRedshiftClusterSnapshot_Tags_EmptyTag_onCreate
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_EmptyTag_onCreate
=== RUN   TestAccRedshiftClusterSnapshot_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccRedshiftClusterSnapshot_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccRedshiftClusterSnapshot_Tags_DefaultTags_providerOnly
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_DefaultTags_providerOnly
=== RUN   TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccRedshiftClusterSnapshot_Tags_DefaultTags_overlapping
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_DefaultTags_overlapping
=== RUN   TestAccRedshiftClusterSnapshot_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccRedshiftClusterSnapshot_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccRedshiftClusterSnapshot_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccRedshiftClusterSnapshot_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccRedshiftClusterSnapshot_Tags_ComputedTag_onCreate
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_ComputedTag_onCreate
=== RUN   TestAccRedshiftClusterSnapshot_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccRedshiftClusterSnapshot_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccRedshiftClusterSnapshot_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccRedshiftClusterSnapshot_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccRedshiftClusterSnapshot_basic
=== PAUSE TestAccRedshiftClusterSnapshot_basic
=== RUN   TestAccRedshiftClusterSnapshot_disappears
=== PAUSE TestAccRedshiftClusterSnapshot_disappears
=== RUN   TestAccRedshiftCluster_tags
=== PAUSE TestAccRedshiftCluster_tags
=== RUN   TestAccRedshiftCluster_Tags_null
=== PAUSE TestAccRedshiftCluster_Tags_null
=== RUN   TestAccRedshiftCluster_Tags_emptyMap
=== PAUSE TestAccRedshiftCluster_Tags_emptyMap
=== RUN   TestAccRedshiftCluster_Tags_addOnUpdate
=== PAUSE TestAccRedshiftCluster_Tags_addOnUpdate
=== RUN   TestAccRedshiftCluster_Tags_EmptyTag_onCreate
=== PAUSE TestAccRedshiftCluster_Tags_EmptyTag_onCreate
=== RUN   TestAccRedshiftCluster_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccRedshiftCluster_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccRedshiftCluster_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccRedshiftCluster_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccRedshiftCluster_Tags_DefaultTags_providerOnly
=== PAUSE TestAccRedshiftCluster_Tags_DefaultTags_providerOnly
=== RUN   TestAccRedshiftCluster_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccRedshiftCluster_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccRedshiftCluster_Tags_DefaultTags_overlapping
=== PAUSE TestAccRedshiftCluster_Tags_DefaultTags_overlapping
=== RUN   TestAccRedshiftCluster_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccRedshiftCluster_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccRedshiftCluster_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccRedshiftCluster_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccRedshiftCluster_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccRedshiftCluster_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccRedshiftCluster_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccRedshiftCluster_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccRedshiftCluster_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccRedshiftCluster_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccRedshiftCluster_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccRedshiftCluster_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccRedshiftCluster_Tags_ComputedTag_onCreate
=== PAUSE TestAccRedshiftCluster_Tags_ComputedTag_onCreate
=== RUN   TestAccRedshiftCluster_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccRedshiftCluster_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccRedshiftCluster_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccRedshiftCluster_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccRedshiftCluster_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccRedshiftCluster_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccRedshiftCluster_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccRedshiftCluster_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccRedshiftCluster_basic
=== PAUSE TestAccRedshiftCluster_basic
=== RUN   TestAccRedshiftCluster_aqua
=== PAUSE TestAccRedshiftCluster_aqua
=== RUN   TestAccRedshiftCluster_disappears
=== PAUSE TestAccRedshiftCluster_disappears
=== RUN   TestAccRedshiftCluster_withFinalSnapshot
=== PAUSE TestAccRedshiftCluster_withFinalSnapshot
=== RUN   TestAccRedshiftCluster_kmsKey
=== PAUSE TestAccRedshiftCluster_kmsKey
=== RUN   TestAccRedshiftCluster_enhancedVPCRoutingEnabled
=== PAUSE TestAccRedshiftCluster_enhancedVPCRoutingEnabled
=== RUN   TestAccRedshiftCluster_iamRoles
=== PAUSE TestAccRedshiftCluster_iamRoles
=== RUN   TestAccRedshiftCluster_publiclyAccessible
=== PAUSE TestAccRedshiftCluster_publiclyAccessible
=== RUN   TestAccRedshiftCluster_publiclyAccessible_default
=== PAUSE TestAccRedshiftCluster_publiclyAccessible_default
=== RUN   TestAccRedshiftCluster_updateNodeCount
=== PAUSE TestAccRedshiftCluster_updateNodeCount
=== RUN   TestAccRedshiftCluster_updateNodeType
=== PAUSE TestAccRedshiftCluster_updateNodeType
=== RUN   TestAccRedshiftCluster_masterUsername
=== PAUSE TestAccRedshiftCluster_masterUsername
=== RUN   TestAccRedshiftCluster_masterUsername_invalid
=== PAUSE TestAccRedshiftCluster_masterUsername_invalid
=== RUN   TestAccRedshiftCluster_changeAvailabilityZone
=== PAUSE TestAccRedshiftCluster_changeAvailabilityZone
=== RUN   TestAccRedshiftCluster_changeAvailabilityZoneAndSetAvailabilityZoneRelocation
=== PAUSE TestAccRedshiftCluster_changeAvailabilityZoneAndSetAvailabilityZoneRelocation
=== RUN   TestAccRedshiftCluster_changeAvailabilityZone_availabilityZoneRelocationNotSet
=== PAUSE TestAccRedshiftCluster_changeAvailabilityZone_availabilityZoneRelocationNotSet
=== RUN   TestAccRedshiftCluster_changeEncryption_unsetToFalse
=== PAUSE TestAccRedshiftCluster_changeEncryption_unsetToFalse
=== RUN   TestAccRedshiftCluster_changeEncryption_unsetToTrue
=== PAUSE TestAccRedshiftCluster_changeEncryption_unsetToTrue
=== RUN   TestAccRedshiftCluster_changeEncryption_trueToFalse
=== PAUSE TestAccRedshiftCluster_changeEncryption_trueToFalse
=== RUN   TestAccRedshiftCluster_changeEncryption_falseToTrue
=== PAUSE TestAccRedshiftCluster_changeEncryption_falseToTrue
=== RUN   TestAccRedshiftCluster_changeEncryption_falseToUnset
=== PAUSE TestAccRedshiftCluster_changeEncryption_falseToUnset
=== RUN   TestAccRedshiftCluster_changeEncryption_trueToUnset
=== PAUSE TestAccRedshiftCluster_changeEncryption_trueToUnset
=== RUN   TestAccRedshiftCluster_availabilityZoneRelocation
=== PAUSE TestAccRedshiftCluster_availabilityZoneRelocation
=== RUN   TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible
=== PAUSE TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible
=== RUN   TestAccRedshiftCluster_restoreFromSnapshot_Identifier
=== PAUSE TestAccRedshiftCluster_restoreFromSnapshot_Identifier
=== RUN   TestAccRedshiftCluster_restoreFromSnapshot_ARN
=== PAUSE TestAccRedshiftCluster_restoreFromSnapshot_ARN
=== RUN   TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_trueToFalse
=== PAUSE TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_trueToFalse
=== RUN   TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_falseToTrue
=== PAUSE TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_falseToTrue
=== RUN   TestAccRedshiftCluster_manageMasterPassword
=== PAUSE TestAccRedshiftCluster_manageMasterPassword
=== RUN   TestAccRedshiftCluster_multiAZ
=== PAUSE TestAccRedshiftCluster_multiAZ
=== RUN   TestAccRedshiftCluster_passwordWriteOnly
=== PAUSE TestAccRedshiftCluster_passwordWriteOnly
=== RUN   TestAccRedshiftCluster_port
=== PAUSE TestAccRedshiftCluster_port
=== RUN   TestAccRedshiftEndpointAccess_basic
=== PAUSE TestAccRedshiftEndpointAccess_basic
=== RUN   TestAccRedshiftEndpointAccess_sgs
=== PAUSE TestAccRedshiftEndpointAccess_sgs
=== RUN   TestAccRedshiftEndpointAccess_disappears
=== PAUSE TestAccRedshiftEndpointAccess_disappears
=== RUN   TestAccRedshiftEndpointAccess_disappears_cluster
=== PAUSE TestAccRedshiftEndpointAccess_disappears_cluster
=== RUN   TestAccRedshiftEndpointAuthorization_basic
=== PAUSE TestAccRedshiftEndpointAuthorization_basic
=== RUN   TestAccRedshiftEndpointAuthorization_vpcs
=== PAUSE TestAccRedshiftEndpointAuthorization_vpcs
=== RUN   TestAccRedshiftEndpointAuthorization_disappears
=== PAUSE TestAccRedshiftEndpointAuthorization_disappears
=== RUN   TestAccRedshiftEndpointAuthorization_disappears_cluster
=== PAUSE TestAccRedshiftEndpointAuthorization_disappears_cluster
=== CONT  TestAccRedshiftClusterCredentialsDataSource_basic
=== CONT  TestAccRedshiftCluster_iamRoles
--- PASS: TestAccRedshiftClusterCredentialsDataSource_basic (253.50s)
=== CONT  TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible
--- PASS: TestAccRedshiftCluster_iamRoles (305.66s)
=== CONT  TestAccRedshiftEndpointAuthorization_disappears_cluster
    endpoint_authorization_test.go:141: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRedshiftEndpointAuthorization_disappears_cluster (0.00s)
=== CONT  TestAccRedshiftEndpointAuthorization_disappears
    endpoint_authorization_test.go:114: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRedshiftEndpointAuthorization_disappears (0.00s)
=== CONT  TestAccRedshiftEndpointAuthorization_vpcs
    endpoint_authorization_test.go:65: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRedshiftEndpointAuthorization_vpcs (0.00s)
=== CONT  TestAccRedshiftEndpointAuthorization_basic
    endpoint_authorization_test.go:29: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRedshiftEndpointAuthorization_basic (0.00s)
=== CONT  TestAccRedshiftEndpointAccess_disappears_cluster
--- PASS: TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible (265.86s)
=== CONT  TestAccRedshiftEndpointAccess_disappears
--- PASS: TestAccRedshiftEndpointAccess_disappears_cluster (336.27s)
=== CONT  TestAccRedshiftEndpointAccess_sgs
--- PASS: TestAccRedshiftEndpointAccess_disappears (416.07s)
=== CONT  TestAccRedshiftEndpointAccess_basic
--- PASS: TestAccRedshiftEndpointAccess_sgs (531.28s)
=== CONT  TestAccRedshiftCluster_port
--- PASS: TestAccRedshiftEndpointAccess_basic (442.54s)
=== CONT  TestAccRedshiftCluster_passwordWriteOnly
--- PASS: TestAccRedshiftCluster_port (298.70s)
=== CONT  TestAccRedshiftCluster_multiAZ
--- PASS: TestAccRedshiftCluster_passwordWriteOnly (556.95s)
=== CONT  TestAccRedshiftCluster_manageMasterPassword
--- PASS: TestAccRedshiftCluster_multiAZ (737.68s)
=== CONT  TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_falseToTrue
--- PASS: TestAccRedshiftCluster_manageMasterPassword (296.94s)
=== CONT  TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_trueToFalse
    cluster_test.go:1034: Step 1/2 error: Error running apply: exit status 1

        Error: creating Redshift Cluster (tf-acc-test-6094138600498459717-restored): modifying Encrypted(false): operation error Redshift: ModifyCluster, https response error StatusCode: 400, RequestID: a5279c83-495b-41ed-a81f-63ae58559a26, InvalidClusterState: Cluster cannot be resized when streaming restore is in progress

          with aws_redshift_cluster.restored,
          on terraform_plugin_test.tf line 33, in resource "aws_redshift_cluster" "restored":
          33: resource "aws_redshift_cluster" "restored" {

--- FAIL: TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_trueToFalse (667.06s)
=== CONT  TestAccRedshiftCluster_restoreFromSnapshot_ARN
=== NAME  TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_falseToTrue
    cluster_test.go:1078: Step 1/2 error: Error running apply: exit status 1

        Error: creating Redshift Cluster (tf-acc-test-4942833006773359766-restored): modifying Encrypted(true): operation error Redshift: ModifyCluster, https response error StatusCode: 400, RequestID: fc8f85d5-517b-407a-b087-24a4c8645899, InvalidClusterState: Cluster cannot be resized when streaming restore is in progress

          with aws_redshift_cluster.restored,
          on terraform_plugin_test.tf line 33, in resource "aws_redshift_cluster" "restored":
          33: resource "aws_redshift_cluster" "restored" {

--- PASS: TestAccRedshiftCluster_restoreFromSnapshot_ARN (680.78s)
=== CONT  TestAccRedshiftCluster_restoreFromSnapshot_Identifier
--- FAIL: TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_falseToTrue (1865.27s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccRedshiftCluster_restoreFromSnapshot_Identifier (656.16s)
=== CONT  TestAccRedshiftCluster_enhancedVPCRoutingEnabled
--- PASS: TestAccRedshiftClusterSnapshot_Tags_ComputedTag_OnUpdate_replace (413.20s)
=== CONT  TestAccRedshiftCluster_kmsKey
--- PASS: TestAccRedshiftCluster_kmsKey (264.62s)
=== CONT  TestAccRedshiftCluster_withFinalSnapshot
--- PASS: TestAccRedshiftCluster_enhancedVPCRoutingEnabled (656.65s)
=== CONT  TestAccRedshiftCluster_disappears
--- PASS: TestAccRedshiftCluster_withFinalSnapshot (316.96s)
=== CONT  TestAccRedshiftCluster_aqua
--- PASS: TestAccRedshiftCluster_disappears (283.93s)
=== CONT  TestAccRedshiftCluster_basic
--- PASS: TestAccRedshiftCluster_aqua (295.82s)
=== CONT  TestAccRedshiftCluster_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccRedshiftCluster_basic (277.24s)
=== CONT  TestAccRedshiftCluster_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccRedshiftCluster_Tags_IgnoreTags_Overlap_resourceTag (324.22s)
=== CONT  TestAccRedshiftCluster_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccRedshiftCluster_Tags_IgnoreTags_Overlap_defaultTag (332.72s)
=== CONT  TestAccRedshiftCluster_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccRedshiftCluster_Tags_ComputedTag_OnUpdate_replace (303.34s)
=== CONT  TestAccRedshiftCluster_Tags_ComputedTag_onCreate
--- PASS: TestAccRedshiftCluster_Tags_ComputedTag_OnUpdate_add (333.81s)
=== CONT  TestAccRedshiftCluster_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccRedshiftCluster_Tags_ComputedTag_onCreate (303.46s)
=== CONT  TestAccRedshiftCluster_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccRedshiftCluster_Tags_DefaultTags_nullNonOverlappingResourceTag (310.75s)
=== CONT  TestAccRedshiftCluster_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccRedshiftCluster_Tags_DefaultTags_nullOverlappingResourceTag (280.36s)
=== CONT  TestAccRedshiftCluster_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccRedshiftCluster_Tags_DefaultTags_emptyProviderOnlyTag (250.52s)
=== CONT  TestAccRedshiftCluster_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccRedshiftCluster_Tags_DefaultTags_emptyResourceTag (292.28s)
=== CONT  TestAccRedshiftCluster_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccRedshiftCluster_Tags_DefaultTags_updateToResourceOnly (278.88s)
=== CONT  TestAccRedshiftCluster_Tags_DefaultTags_overlapping
--- PASS: TestAccRedshiftCluster_Tags_DefaultTags_updateToProviderOnly (342.40s)
=== CONT  TestAccRedshiftCluster_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccRedshiftCluster_Tags_DefaultTags_overlapping (311.30s)
=== CONT  TestAccRedshiftCluster_Tags_DefaultTags_providerOnly
--- PASS: TestAccRedshiftCluster_Tags_DefaultTags_nonOverlapping (377.81s)
=== CONT  TestAccRedshiftCluster_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccRedshiftCluster_Tags_DefaultTags_providerOnly (339.60s)
=== CONT  TestAccRedshiftCluster_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccRedshiftCluster_Tags_EmptyTag_OnUpdate_replace (326.81s)
=== CONT  TestAccRedshiftCluster_Tags_EmptyTag_onCreate
--- PASS: TestAccRedshiftCluster_Tags_EmptyTag_OnUpdate_add (330.78s)
=== CONT  TestAccRedshiftCluster_Tags_addOnUpdate
--- PASS: TestAccRedshiftCluster_Tags_EmptyTag_onCreate (318.49s)
=== CONT  TestAccRedshiftCluster_Tags_emptyMap
--- PASS: TestAccRedshiftCluster_Tags_addOnUpdate (436.92s)
=== CONT  TestAccRedshiftCluster_Tags_null
--- PASS: TestAccRedshiftCluster_Tags_emptyMap (295.53s)
=== CONT  TestAccRedshiftCluster_tags
--- PASS: TestAccRedshiftCluster_Tags_null (305.28s)
=== CONT  TestAccRedshiftClusterSnapshot_disappears
--- PASS: TestAccRedshiftCluster_tags (355.27s)
=== CONT  TestAccRedshiftClusterSnapshot_basic
--- PASS: TestAccRedshiftClusterSnapshot_disappears (371.55s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccRedshiftClusterSnapshot_basic (409.35s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccRedshiftClusterSnapshot_Tags_IgnoreTags_Overlap_resourceTag (406.43s)
=== CONT  TestAccRedshiftCluster_changeAvailabilityZone_availabilityZoneRelocationNotSet
--- PASS: TestAccRedshiftClusterSnapshot_Tags_IgnoreTags_Overlap_defaultTag (367.73s)
=== CONT  TestAccRedshiftCluster_availabilityZoneRelocation
--- PASS: TestAccRedshiftCluster_changeAvailabilityZone_availabilityZoneRelocationNotSet (274.21s)
=== CONT  TestAccRedshiftCluster_changeEncryption_trueToUnset
--- PASS: TestAccRedshiftCluster_availabilityZoneRelocation (242.21s)
=== CONT  TestAccRedshiftCluster_changeEncryption_falseToUnset
--- PASS: TestAccRedshiftCluster_changeEncryption_trueToUnset (259.04s)
=== CONT  TestAccRedshiftCluster_changeEncryption_falseToTrue
--- PASS: TestAccRedshiftCluster_changeEncryption_falseToUnset (1780.74s)
=== CONT  TestAccRedshiftCluster_changeEncryption_trueToFalse
--- PASS: TestAccRedshiftCluster_changeEncryption_falseToTrue (2056.57s)
=== CONT  TestAccRedshiftCluster_changeEncryption_unsetToTrue
--- PASS: TestAccRedshiftCluster_changeEncryption_unsetToTrue (310.46s)
=== CONT  TestAccRedshiftCluster_changeEncryption_unsetToFalse
--- PASS: TestAccRedshiftCluster_changeEncryption_trueToFalse (1624.31s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_emptyMap
--- PASS: TestAccRedshiftCluster_changeEncryption_unsetToFalse (1263.74s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_ComputedTag_OnUpdate_add
    cluster_snapshot_tags_gen_test.go:1803: Step 1/3 error: Error running apply: exit status 1

        Error: creating Redshift Cluster (tf-acc-test-8275424384619408802): waiting for completion: unexpected state 'Maintenance', wanted target 'Available'. last error: creating

          with aws_redshift_cluster.test,
          on main_gen.tf line 13, in resource "aws_redshift_cluster" "test":
          13: resource "aws_redshift_cluster" "test" {

--- PASS: TestAccRedshiftClusterSnapshot_Tags_emptyMap (380.06s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_ComputedTag_onCreate
--- FAIL: TestAccRedshiftClusterSnapshot_Tags_ComputedTag_OnUpdate_add (258.44s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccRedshiftClusterSnapshot_Tags_ComputedTag_onCreate (486.20s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nullNonOverlappingResourceTag (349.48s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nullOverlappingResourceTag (359.08s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccRedshiftClusterSnapshot_Tags_DefaultTags_emptyProviderOnlyTag (410.26s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccRedshiftClusterSnapshot_Tags_DefaultTags_emptyResourceTag (428.59s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccRedshiftClusterSnapshot_Tags_DefaultTags_updateToResourceOnly (396.60s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_DefaultTags_overlapping
--- PASS: TestAccRedshiftClusterSnapshot_Tags_DefaultTags_updateToProviderOnly (408.59s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccRedshiftClusterSnapshot_Tags_DefaultTags_overlapping (393.59s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_DefaultTags_providerOnly
--- PASS: TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nonOverlapping (416.06s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccRedshiftClusterSnapshot_Tags_DefaultTags_providerOnly (410.73s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccRedshiftClusterSnapshot_Tags_EmptyTag_OnUpdate_replace (420.21s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_EmptyTag_onCreate
--- PASS: TestAccRedshiftClusterSnapshot_Tags_EmptyTag_OnUpdate_add (375.14s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_addOnUpdate
--- PASS: TestAccRedshiftClusterSnapshot_Tags_EmptyTag_onCreate (383.74s)
=== CONT  TestAccRedshiftCluster_masterUsername
--- PASS: TestAccRedshiftClusterSnapshot_Tags_addOnUpdate (562.29s)
=== CONT  TestAccRedshiftCluster_changeAvailabilityZoneAndSetAvailabilityZoneRelocation
--- PASS: TestAccRedshiftCluster_changeAvailabilityZoneAndSetAvailabilityZoneRelocation (346.68s)
=== CONT  TestAccRedshiftCluster_changeAvailabilityZone
--- PASS: TestAccRedshiftCluster_masterUsername (592.82s)
=== CONT  TestAccRedshiftCluster_masterUsername_invalid
--- PASS: TestAccRedshiftCluster_masterUsername_invalid (5.48s)
=== CONT  TestAccRedshiftClusterDataSource_vpc
--- PASS: TestAccRedshiftCluster_changeAvailabilityZone (377.94s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_null
--- PASS: TestAccRedshiftClusterDataSource_vpc (433.62s)
=== CONT  TestAccRedshiftClusterSnapshot_tags
--- PASS: TestAccRedshiftClusterSnapshot_Tags_null (362.31s)
=== CONT  TestAccRedshiftClusterIAMRoles_disappears
--- PASS: TestAccRedshiftClusterSnapshot_tags (478.72s)
=== CONT  TestAccRedshiftClusterIAMRoles_basic
--- PASS: TestAccRedshiftClusterIAMRoles_disappears (287.91s)
=== CONT  TestAccRedshiftClusterDataSource_multiAZEnabled
--- PASS: TestAccRedshiftClusterDataSource_multiAZEnabled (302.08s)
=== CONT  TestAccRedshiftClusterDataSource_availabilityZoneRelocationEnabled
--- PASS: TestAccRedshiftClusterIAMRoles_basic (361.55s)
=== CONT  TestAccRedshiftClusterDataSource_logging
--- PASS: TestAccRedshiftClusterDataSource_availabilityZoneRelocationEnabled (241.06s)
=== CONT  TestAccRedshiftCluster_updateNodeCount
--- PASS: TestAccRedshiftClusterDataSource_logging (300.71s)
=== CONT  TestAccRedshiftCluster_updateNodeType
--- PASS: TestAccRedshiftCluster_updateNodeCount (980.72s)
=== CONT  TestAccRedshiftClusterDataSource_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccRedshiftCluster_updateNodeType (1060.33s)
=== CONT  TestAccRedshiftClusterDataSource_basic
--- PASS: TestAccRedshiftClusterDataSource_Tags_DefaultTags_nonOverlapping (281.87s)
=== CONT  TestAccRedshiftClusterDataSource_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccRedshiftClusterDataSource_basic (301.84s)
=== CONT  TestAccRedshiftClusterDataSource_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccRedshiftClusterDataSource_Tags_IgnoreTags_Overlap_resourceTag (254.16s)
=== CONT  TestAccRedshiftClusterDataSource_Tags_nullMap
--- PASS: TestAccRedshiftClusterDataSource_Tags_nullMap (283.50s)
=== CONT  TestAccRedshiftClusterDataSource_Tags_emptyMap
--- PASS: TestAccRedshiftClusterDataSource_Tags_IgnoreTags_Overlap_defaultTag (396.64s)
=== CONT  TestAccRedshiftCluster_publiclyAccessible_default
--- PASS: TestAccRedshiftCluster_publiclyAccessible_default (350.50s)
=== CONT  TestAccRedshiftClusterDataSource_tags
--- PASS: TestAccRedshiftClusterDataSource_Tags_emptyMap (539.50s)
=== CONT  TestAccRedshiftCluster_publiclyAccessible
--- PASS: TestAccRedshiftClusterDataSource_tags (272.24s)
--- PASS: TestAccRedshiftCluster_publiclyAccessible (350.35s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	21400.318s
FAIL
make: *** [testacc] Error 1
```

</details>