### PR TITLE
fix: Correctly pull Latest LaunchTemplate version

### DIFF
--- a/.changelog/47442.txt
+++ b/.changelog/47442.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/ec2_instance: Fix validation of LaunchTemplate when using $Latest
+```

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -4327,6 +4327,31 @@ func TestAccEC2Instance_LaunchTemplate_updateTemplateVersion(t *testing.T) {
 	})
 }
 
+func TestAccEC2Instance_LaunchTemplate_latestVersion(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.Instance
+	resourceName := "aws_instance.test"
+	launchTemplateResourceName := "aws_launch_template.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_templateLatestVersion(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", launchTemplateResourceName, names.AttrID),
+					resource.TestCheckResourceAttr(resourceName, "launch_template.0.version", "$Latest"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEC2Instance_LaunchTemplate_swapIDAndName(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v1, v2 awstypes.Instance
@@ -10785,6 +10810,30 @@ resource "aws_launch_template" "test" {
 resource "aws_instance" "test" {
   launch_template {
     id = aws_launch_template.test.id
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccInstanceConfig_templateLatestVersion(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro", "t1.micro", "m1.small"),
+		fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name          = %[1]q
+  image_id      = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+}
+
+resource "aws_instance" "test" {
+  launch_template {
+    id      = aws_launch_template.test.id
+    version = "$Latest"
   }
 
   tags = {

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -872,29 +872,14 @@ func findLaunchTemplateData(ctx context.Context, conn *ec2.Client, launchTemplat
 		input.LaunchTemplateName = aws.String(v)
 	}
 
-	var latestVersion bool
-
 	if v := aws.ToString(launchTemplateSpecification.Version); v != "" {
-		switch v {
-		case launchTemplateVersionDefault:
-			input.Filters = newAttributeFilterList(map[string]string{
-				"is-default-version": "true",
-			})
-		case launchTemplateVersionLatest:
-			latestVersion = true
-		default:
-			input.Versions = []string{v}
-		}
+		input.Versions = []string{v}
 	}
 
 	output, err := findLaunchTemplateVersions(ctx, conn, &input)
 
 	if err != nil {
 		return nil, fmt.Errorf("reading EC2 Launch Template versions: %w", err)
-	}
-
-	if latestVersion {
-		return output[len(output)-1].LaunchTemplateData, nil
 	}
 
 	return output[0].LaunchTemplateData, nil


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

A new version of the provider would need to be published with a revert.

## Changes to Security Controls

No impact to security controls.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

There is a bug in `findLaunchTemplateData` when using `$Latest` as the version. It is used to validate a launch template before applying it, but when you use latest, it uses `output[len(output)-1].LaunchTemplateData`. As AWS returns the versions in descending order this results in you validating the oldest launch template, not the latest.

Instead of just correcting that, I've changed the function to pass `$Latest` and `$Default` directly in as versions, as that's supported by the API.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

None

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeLaunchTemplateVersions.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
TF_ACC=1 go test ./internal/service/ec2/... \
    -run 'TestAccEC2Instance_LaunchTemplate_latestVersion' \
    -v -count=1 -timeout 30m
2026/04/14 16:35:20 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/14 16:35:20 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEC2Instance_LaunchTemplate_latestVersion
=== PAUSE TestAccEC2Instance_LaunchTemplate_latestVersion
=== CONT  TestAccEC2Instance_LaunchTemplate_latestVersion
--- PASS: TestAccEC2Instance_LaunchTemplate_latestVersion (301.63s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	311.324s
...
```
