### PR TITLE
[Enhancement] aws_imagebuilder_lifecycle_policy: Support wildcard for `resource_selection.recipe.semantic_version`

### DIFF
--- a/.changelog/47443.txt
+++ b/.changelog/47443.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_aws_imagebuilder_lifecycle_policy: Support wildcard semantic version for `resource_selection.recipe.semantic_version`
+resource/aws_imagebuilder_lifecycle_policy: Support wildcard semantic version for `resource_selection.recipe.semantic_version`
 ```

--- a/.changelog/47443.txt
+++ b/.changelog/47443.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_aws_imagebuilder_lifecycle_policy: Support wildcard semantic version for `resource_selection.recipe.semantic_version`
+```

--- a/internal/service/imagebuilder/lifecycle_policy.go
+++ b/internal/service/imagebuilder/lifecycle_policy.go
@@ -285,7 +285,7 @@ func (r *lifecyclePolicyResource) Schema(ctx context.Context, request resource.S
 									"semantic_version": schema.StringAttribute{
 										Required: true,
 										Validators: []validator.String{
-											stringvalidator.RegexMatches(regexache.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`), ""),
+											stringvalidator.RegexMatches(regexache.MustCompile(`^(?:[0-9]+|x)\.(?:[0-9]+|x)\.(?:[0-9]+|x)$`), ""),
 										},
 									},
 								},

--- a/internal/service/imagebuilder/lifecycle_policy_test.go
+++ b/internal/service/imagebuilder/lifecycle_policy_test.go
@@ -205,6 +205,16 @@ func TestAccImageBuilderLifecyclePolicy_resourceSelection(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "resource_selection.0.recipe.0.semantic_version", "2.0.0"),
 				),
 			},
+			{
+				Config: testAccLifecyclePolicyConfig_resourceSelectionWithWildCardSemanticVersion(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLifecyclePolicyExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "resource_selection.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "resource_selection.0.recipe.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "resource_selection.0.recipe.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "resource_selection.0.recipe.0.semantic_version", "x.x.x"),
+				),
+			},
 		},
 	})
 }
@@ -613,6 +623,49 @@ resource "aws_imagebuilder_lifecycle_policy" "test" {
     recipe {
       name             = aws_imagebuilder_image_recipe.test.name
       semantic_version = aws_imagebuilder_image_recipe.test.version
+    }
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName))
+}
+
+func testAccLifecyclePolicyConfig_resourceSelectionWithWildCardSemanticVersion(rName string) string {
+	return acctest.ConfigCompose(
+		testAccLifecyclePolicyConfig_base(rName),
+		testAccLifecyclePolicyConfig_baseComponent(rName),
+		fmt.Sprintf(`
+resource "aws_imagebuilder_image_recipe" "test" {
+  component {
+    component_arn = aws_imagebuilder_component.test.arn
+  }
+
+  name         = %[1]q
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
+  version      = "2.0.0"
+}
+
+resource "aws_imagebuilder_lifecycle_policy" "test" {
+  name           = %[1]q
+  description    = "Used for setting lifecycle policies"
+  execution_role = aws_iam_role.test.arn
+  resource_type  = "AMI_IMAGE"
+  policy_detail {
+    action {
+      type = "DELETE"
+    }
+    filter {
+      type            = "AGE"
+      value           = 6
+      retain_at_least = 10
+      unit            = "YEARS"
+    }
+  }
+  resource_selection {
+    recipe {
+      name             = aws_imagebuilder_image_recipe.test.name
+      semantic_version = "x.x.x"
     }
   }
 

--- a/website/docs/r/imagebuilder_lifecycle_policy.html.markdown
+++ b/website/docs/r/imagebuilder_lifecycle_policy.html.markdown
@@ -163,7 +163,7 @@ The following arguments are optional:
 The following arguments are required:
 
 * `name` - (Required) The name of an Image Builder recipe that the lifecycle policy uses for resource selection.
-* `semantic_version` - (Required) The version of the Image Builder recipe specified by the `name` field. Wildcard semantic version is supported (e.g. `1.0.x`, `1.x.x`, `x.x.x`). 
+* `semantic_version` - (Required) The version of the Image Builder recipe specified by the `name` field. Wildcard semantic version is supported (e.g. `1.0.x`, `1.x.x`, `x.x.x`).
 
 ## Attribute Reference
 

--- a/website/docs/r/imagebuilder_lifecycle_policy.html.markdown
+++ b/website/docs/r/imagebuilder_lifecycle_policy.html.markdown
@@ -163,7 +163,7 @@ The following arguments are optional:
 The following arguments are required:
 
 * `name` - (Required) The name of an Image Builder recipe that the lifecycle policy uses for resource selection.
-* `semantic_version` - (Required) The version of the Image Builder recipe specified by the name field.
+* `semantic_version` - (Required) The version of the Image Builder recipe specified by the `name` field. Wildcard semantic version is supported (e.g. `1.0.x`, `1.x.x`, `x.x.x`). 
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
This PR fixes the validation for `resource_selection.recipe.semantic_version` in `aws_imagebuilder_lifecycle_policy` to support wildcard semantic version  (e.g. `1.0.x`, `1.x.x`, `x.x.x`). 

The validation pattern in the current AWS provider is as follows:

```
^[0-9]+.[0-9]+.[0-9]+$
```

According to the AWS documentation:

https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_LifecyclePolicyResourceSelectionRecipe.html#imagebuilder-Type-LifecyclePolicyResourceSelectionRecipe-semanticVersion

the following pattern (including the wildcard `x`) is now supported by the AWS API:

```
^(?:[0-9]+|x).(?:[0-9]+|x).(?:[0-9]+|x)$
```

### Relations

Closes #47439

### References
https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_LifecyclePolicyResourceSelectionRecipe.html#imagebuilder-Type-LifecyclePolicyResourceSelectionRecipe-semanticVersion
https://docs.aws.amazon.com/imagebuilder/latest/userguide/doc-history.html - see entry for 2026-02-26

### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccImageBuilderLifecyclePolicy_' PKG=imagebuilder 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_imagebuilder_lifecycle_policy-allow_wildcard_for_semantic_version 🌿...
TF_ACC=1 go1.25.9 test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderLifecyclePolicy_'  -timeout 360m -vet=off
2026/04/15 01:16:22 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/15 01:16:22 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccImageBuilderLifecyclePolicy_Identity_basic
=== PAUSE TestAccImageBuilderLifecyclePolicy_Identity_basic
=== RUN   TestAccImageBuilderLifecyclePolicy_Identity_regionOverride
=== PAUSE TestAccImageBuilderLifecyclePolicy_Identity_regionOverride
=== RUN   TestAccImageBuilderLifecyclePolicy_Identity_ExistingResource_basic
=== PAUSE TestAccImageBuilderLifecyclePolicy_Identity_ExistingResource_basic
=== RUN   TestAccImageBuilderLifecyclePolicy_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccImageBuilderLifecyclePolicy_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccImageBuilderLifecyclePolicy_basic
=== PAUSE TestAccImageBuilderLifecyclePolicy_basic
=== RUN   TestAccImageBuilderLifecyclePolicy_policyDetails
=== PAUSE TestAccImageBuilderLifecyclePolicy_policyDetails
=== RUN   TestAccImageBuilderLifecyclePolicy_policyDetailsExclusionRulesAMIsIsPublic
=== PAUSE TestAccImageBuilderLifecyclePolicy_policyDetailsExclusionRulesAMIsIsPublic
=== RUN   TestAccImageBuilderLifecyclePolicy_resourceSelection
=== PAUSE TestAccImageBuilderLifecyclePolicy_resourceSelection
=== RUN   TestAccImageBuilderLifecyclePolicy_tags
=== PAUSE TestAccImageBuilderLifecyclePolicy_tags
=== RUN   TestAccImageBuilderLifecyclePolicy_disappears
=== PAUSE TestAccImageBuilderLifecyclePolicy_disappears
=== CONT  TestAccImageBuilderLifecyclePolicy_Identity_basic
=== CONT  TestAccImageBuilderLifecyclePolicy_policyDetails
=== CONT  TestAccImageBuilderLifecyclePolicy_tags
=== CONT  TestAccImageBuilderLifecyclePolicy_disappears
=== CONT  TestAccImageBuilderLifecyclePolicy_resourceSelection
=== CONT  TestAccImageBuilderLifecyclePolicy_Identity_ExistingResource_noRefreshNoChange
=== CONT  TestAccImageBuilderLifecyclePolicy_basic
=== CONT  TestAccImageBuilderLifecyclePolicy_policyDetailsExclusionRulesAMIsIsPublic
=== CONT  TestAccImageBuilderLifecyclePolicy_Identity_ExistingResource_basic
=== CONT  TestAccImageBuilderLifecyclePolicy_Identity_regionOverride
--- PASS: TestAccImageBuilderLifecyclePolicy_policyDetailsExclusionRulesAMIsIsPublic (92.89s)
--- PASS: TestAccImageBuilderLifecyclePolicy_disappears (101.42s)
--- PASS: TestAccImageBuilderLifecyclePolicy_basic (110.36s)
--- PASS: TestAccImageBuilderLifecyclePolicy_policyDetails (140.97s)
--- PASS: TestAccImageBuilderLifecyclePolicy_Identity_basic (146.73s)
--- PASS: TestAccImageBuilderLifecyclePolicy_Identity_ExistingResource_noRefreshNoChange (155.49s)
--- PASS: TestAccImageBuilderLifecyclePolicy_Identity_regionOverride (173.31s)
--- PASS: TestAccImageBuilderLifecyclePolicy_tags (181.36s)
--- PASS: TestAccImageBuilderLifecyclePolicy_resourceSelection (186.85s)
--- PASS: TestAccImageBuilderLifecyclePolicy_Identity_ExistingResource_basic (216.69s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       225.479s
```
