### PR TITLE
r/aws_redshift_cluster: handle restore encryption changes

### DIFF
--- a/.changelog/47444.txt
+++ b/.changelog/47444.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_redshift_cluster: Fix restore-from-snapshot encryption changes failing while streaming restore is in progress
+```

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -482,6 +482,10 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		inputC.KmsKeyId = aws.String(v.(string))
 	}
 
+	if isEncrypted {
+		inputR.Encrypted = aws.Bool(true)
+	}
+
 	if v, ok := d.GetOk("maintenance_track_name"); ok {
 		inputR.MaintenanceTrackName = aws.String(v.(string))
 		inputC.MaintenanceTrackName = aws.String(v.(string))
@@ -597,7 +601,10 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 			ClusterIdentifier: aws.String(d.Id()),
 			Encrypted:         aws.Bool(isEncrypted),
 		}
-		_, err := conn.ModifyCluster(ctx, &input)
+		_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidClusterStateFault](ctx, clusterInvalidClusterStateFaultTimeout,
+			func(ctx context.Context) (any, error) {
+				return conn.ModifyCluster(ctx, &input)
+			}, "streaming restore is in progress")
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating Redshift Cluster (%s): modifying Encrypted(%t): %s", d.Id(), isEncrypted, err)
 		}


### PR DESCRIPTION

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No

### Description
Set encrypted restores via RestoreFromClusterSnapshot when possible and retry post-restore ModifyCluster while Redshift reports streaming restore in progress.

Fixes failing acceptance tests:
- TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_trueToFalse
- TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_falseToTrue

Both failed during create before the fix with:
InvalidClusterState: Cluster cannot be resized when streaming restore is in progress

These failures in acceptance tests first showed for me when I was working on #47435.

Tested with:
- go test -buildvcs=false ./internal/service/redshift -run '^$' -vet=off
- make testacc PKG=redshift TESTS='TestAccRedshiftCluster_restoreFromSnapshot'

### References

- RestoreFromClusterSnapshot supports restore-time encryption for encrypted restores:
  https://docs.aws.amazon.com/redshift/latest/APIReference/API_RestoreFromClusterSnapshot.html

- Restored clusters can become available before all restore-related work is fully settled:
  https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-snapshot-restore-cluster-from-snapshot.html

- Changing Redshift cluster encryption is a migration that surfaces as resizing/read-only behavior:
  https://docs.aws.amazon.com/redshift/latest/mgmt/changing-cluster-encryption.html

- ModifyCluster encryption semantics:
  https://docs.aws.amazon.com/redshift/latest/APIReference/API_ModifyCluster.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=redshift TESTS='TestAccRedshiftCluster_restoreFromSnapshot'
P=3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-redshift-restore-snapshot-encryption 🌿...
TF_ACC=1 go1.25.9 test ./internal/service/redshift/... -v -count 1 -parallel 3 -run='TestAccRedshiftCluster_restoreFromSnapshot'  -timeout 360m -vet=off
2026/04/14 17:25:19 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/14 17:25:19 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRedshiftCluster_restoreFromSnapshot_Identifier
=== PAUSE TestAccRedshiftCluster_restoreFromSnapshot_Identifier
=== RUN   TestAccRedshiftCluster_restoreFromSnapshot_ARN
=== PAUSE TestAccRedshiftCluster_restoreFromSnapshot_ARN
=== RUN   TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_trueToFalse
=== PAUSE TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_trueToFalse
=== RUN   TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_falseToTrue
=== PAUSE TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_falseToTrue
=== CONT  TestAccRedshiftCluster_restoreFromSnapshot_Identifier
=== CONT  TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_trueToFalse
=== CONT  TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_falseToTrue
--- PASS: TestAccRedshiftCluster_restoreFromSnapshot_Identifier (735.73s)
=== CONT  TestAccRedshiftCluster_restoreFromSnapshot_ARN
--- PASS: TestAccRedshiftCluster_restoreFromSnapshot_ARN (718.28s)
--- PASS: TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_trueToFalse (1869.46s)
--- PASS: TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_falseToTrue (1954.57s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	1963.881s
```
