### PR TITLE
Fix/sfn state machine hang

### DIFF
--- a/internal/service/sfn/state_machine.go
+++ b/internal/service/sfn/state_machine.go
@@ -21,6 +21,7 @@ import (
 	sdkid "github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
@@ -231,13 +232,32 @@ func resourceStateMachineCreate(ctx context.Context, d *schema.ResourceData, met
 		input.TracingConfiguration = expandTracingConfiguration(v.([]any)[0].(map[string]any))
 	}
 
+	timeoutCreate := d.Timeout(schema.TimeoutCreate)
+	accessDeniedTimeout := 2 * time.Minute
+	if timeoutCreate < accessDeniedTimeout {
+		accessDeniedTimeout = timeoutCreate
+	}
+
+	startTime := time.Now()
+
 	// This is done to deal with IAM eventual consistency.
 	// Note: the instance may be in a deleting mode, hence the retry
 	// when creating the step function. This can happen when we are
 	// updating the resource (since there is no update API call).
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
+	outputRaw, err := tfresource.RetryWhen(ctx, timeoutCreate, func(ctx context.Context) (any, error) {
 		return conn.CreateStateMachine(ctx, input)
-	}, "StateMachineDeleting", "AccessDeniedException")
+	}, func(err error) (bool, error) {
+		if tfawserr.ErrCodeEquals(err, "StateMachineDeleting") {
+			return true, err
+		}
+		if tfawserr.ErrCodeEquals(err, "AccessDeniedException") {
+			if time.Since(startTime) > accessDeniedTimeout {
+				return false, err
+			}
+			return true, err
+		}
+		return false, err
+	})
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Step Functions State Machine (%s): %s", name, err)


### PR DESCRIPTION
## Rollback Plan
If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls
No changes to security controls.

### Description
We cap the retry wait time for `AccessDeniedException` inside `aws_sfn_state_machine` creation to a maximum of 2 minutes. Previously, it would catch an `AccessDeniedException` (often thrown when CloudWatch Logs permissions are absent) and retry endlessly up to the full resource timeout (e.g., 5-30 minutes). Now, it safely waits up to 2 minutes for IAM eventual consistency propagation without hanging indefinitely for entirely missing permissions.

### Relations
Relates #7893
