### PR TITLE
r/aws_rds_global_cluster: fix minor version upgrade workflow for `mysql`

### DIFF
--- a/.changelog/47448.txt
+++ b/.changelog/47448.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+resource/aws_rds_global_cluster: Fix a regression in the minor version upgrade workflow for `MySQL` engine types triggered by upstream changes to the API error response text
+```
+```release-note:bug
+resource/aws_neptune_global_cluster: Fix a regression in the minor version upgrade workflow for `MySQL` engine types triggered by upstream changes to the API error response text
+```

--- a/internal/service/neptune/global_cluster.go
+++ b/internal/service/neptune/global_cluster.go
@@ -296,7 +296,12 @@ func globalClusterUpgradeEngineVersion(ctx context.Context, conn *neptune.Client
 
 	err := globalClusterUpgradeMajorEngineVersion(ctx, conn, d.Id(), d.Get(names.AttrEngineVersion).(string), timeout)
 
-	if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "doesn't support minor version upgrades") {
+	// Aurora PostgreSQL:
+	// "ModifyGlobalCluster doesn't support minor version upgrades for Aurora global databases."
+	//
+	// Aurora MySQL:
+	// "Amazon RDS can't perform minor version upgrades through ModifyGlobalCluster for this database engine."
+	if tfawserr.ErrMessageContainsAny(err, errCodeInvalidParameterValue, "doesn't support minor version upgrades", "can't perform minor version upgrades") {
 		if err := globalClusterUpgradeMinorEngineVersion(ctx, conn, d.Id(), d.Get(names.AttrEngineVersion).(string), d.Get("global_cluster_members").(*schema.Set), timeout); err != nil {
 			return fmt.Errorf("upgrading minor version of Neptune Global Cluster (%s): %w", d.Id(), err)
 		}
@@ -322,7 +327,7 @@ func globalClusterUpgradeMajorEngineVersion(ctx context.Context, conn *neptune.C
 			if errs.IsA[*awstypes.GlobalClusterNotFoundFault](err) {
 				return false, err
 			}
-			if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "doesn't support minor version upgrades") {
+			if tfawserr.ErrMessageContainsAny(err, errCodeInvalidParameterValue, "doesn't support minor version upgrades", "can't perform minor version upgrades") {
 				return false, err // NOT retryable, indicates minor upgrade or wrong order
 			}
 			return err != nil, err

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -557,7 +557,12 @@ func globalClusterUpgradeEngineVersion(ctx context.Context, conn *rds.Client, d 
 
 	err := globalClusterUpgradeMajorEngineVersion(ctx, conn, d.Id(), d.Get(names.AttrEngineVersion).(string), timeout)
 
-	if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "doesn't support minor version upgrades") {
+	// Aurora PostgreSQL:
+	// "ModifyGlobalCluster doesn't support minor version upgrades for Aurora global databases."
+	//
+	// Aurora MySQL:
+	// "Amazon RDS can't perform minor version upgrades through ModifyGlobalCluster for this database engine."
+	if tfawserr.ErrMessageContainsAny(err, errCodeInvalidParameterValue, "doesn't support minor version upgrades", "can't perform minor version upgrades") {
 		if err := globalClusterUpgradeMinorEngineVersion(ctx, conn, d.Id(), d.Get(names.AttrEngineVersion).(string), d.Get("global_cluster_members").(*schema.Set), timeout); err != nil {
 			return fmt.Errorf("upgrading minor version of RDS Global Cluster (%s): %w", d.Id(), err)
 		}
@@ -592,7 +597,7 @@ func globalClusterUpgradeMajorEngineVersion(ctx context.Context, conn *rds.Clien
 				return false, err
 			}
 
-			if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "doesn't support minor version upgrades") {
+			if tfawserr.ErrMessageContainsAny(err, errCodeInvalidParameterValue, "doesn't support minor version upgrades", "can't perform minor version upgrades") {
 				return false, err // NOT retryable !! AND indicates this should be a minor version upgrade
 			}
 

--- a/internal/service/rds/global_cluster_test.go
+++ b/internal/service/rds/global_cluster_test.go
@@ -304,6 +304,46 @@ func TestAccRDSGlobalCluster_EngineVersion_updateMinor(t *testing.T) {
 	})
 }
 
+func TestAccRDSGlobalCluster_EngineVersion_AuroraMySQL_updateMinor(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var globalCluster1, globalCluster2 types.GlobalCluster
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rds_global_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalCluster(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGlobalClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalClusterConfig_primaryMinorEngineVersionDynamic(rName, tfrds.InstanceEngineAuroraMySQL, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.test", "version_actual"),
+				),
+			},
+			{
+				Config: testAccGlobalClusterConfig_primaryMinorEngineVersionDynamic(rName, tfrds.InstanceEngineAuroraMySQL, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster2),
+					testAccCheckGlobalClusterNotRecreated(&globalCluster1, &globalCluster2),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.upgrade", "version_actual"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccRDSGlobalCluster_EngineVersion_updateMajor(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This addresses a regression caused by a change in the text of the `InvalidParameterValue` exception returned by the AWS API when a minor version upgrade is attempted on the global MySQL cluster.

Replicates the change from #45605, but accounts for a new change in wording that is specific to MySQL engines (see https://github.com/hashicorp/terraform-provider-aws/issues/45398#issuecomment-3671168999).

Aurora PostgreSQL:
- "ModifyGlobalCluster doesn't support minor version upgrades for Aurora global databases."

Aurora MySQL:
- "Amazon RDS can't perform minor version upgrades through ModifyGlobalCluster for this database engine."

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #45605
Relates #45398
Relates https://github.com/hashicorp/terraform-provider-aws/issues/45398#issuecomment-3671168999


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% VCR_MODE=RECORD_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/  make t K=rds T=TestAccRDSGlobalCluster_EngineVersion_AuroraMySQL_updateMinor
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-rds_global_cluster-minor-upgrade-mssql 🌿...
TF_ACC=1 go1.25.9 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSGlobalCluster_EngineVersion_AuroraMySQL_updateMinor'  -timeout 360m -vet=off
2026/04/14 10:00:11 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/14 10:00:11 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccRDSGlobalCluster_EngineVersion_AuroraMySQL_updateMinor (6790.41s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        6797.645s
```


```console
% VCR_MODE=RECORD_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/  make t K=rds T=TestAccRDSGlobalCluster_EngineVersion_updateMinor
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 tmp3 🌿...
TF_ACC=1 go1.25.9 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSGlobalCluster_EngineVersion_updateMinor'  -timeout 360m -vet=off
2026/04/13 16:50:14 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/13 16:50:14 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccRDSGlobalCluster_EngineVersion_updateMinor (1320.53s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_updateMinorMultiRegion (2803.93s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        2811.082s
```