### PR TITLE
d/aws_outposts_asset: Fix nil pointer dereference panic 🤖🤖🤖

### DIFF
--- a/.changelog/47450.txt
+++ b/.changelog/47450.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_outposts_asset: Fix nil pointer dereference panic when asset has no `ComputeAttributes` or `AssetLocation`
+```

--- a/internal/service/outposts/outpost_asset_data_source.go
+++ b/internal/service/outposts/outpost_asset_data_source.go
@@ -95,9 +95,13 @@ func DataSourceOutpostAssetRead(ctx context.Context, d *schema.ResourceData, met
 	d.SetId(aws.ToString(outpost_id))
 	d.Set("asset_id", asset.AssetId)
 	d.Set("asset_type", asset.AssetType)
-	d.Set("host_id", asset.ComputeAttributes.HostId)
-	d.Set("instance_families", asset.ComputeAttributes.InstanceFamilies)
-	d.Set("rack_elevation", asset.AssetLocation.RackElevation)
+	if asset.ComputeAttributes != nil {
+		d.Set("host_id", asset.ComputeAttributes.HostId)
+		d.Set("instance_families", asset.ComputeAttributes.InstanceFamilies)
+	}
+	if asset.AssetLocation != nil {
+		d.Set("rack_elevation", asset.AssetLocation.RackElevation)
+	}
 	d.Set("rack_id", asset.RackId)
 	return diags
 }


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Fixes a nil pointer dereference panic in the `aws_outposts_asset` data source when the asset's `ComputeAttributes` or `AssetLocation` is `nil`.

Not all Outpost assets are compute assets — non-compute assets (e.g., storage) returned by the `ListAssets` API may have `ComputeAttributes == nil`. Similarly, `AssetLocation` can be `nil`. Accessing fields on these nil pointers causes the provider to crash with:

```
panic: runtime error: invalid memory address or nil pointer dereference
```

This fix adds nil guards before accessing `ComputeAttributes.HostId`, `ComputeAttributes.InstanceFamilies`, and `AssetLocation.RackElevation`.

### Relations

Relates #47153

### References

- [AWS Outposts `ListAssets` API — AssetInfo](https://docs.aws.amazon.com/outposts/latest/APIReference/API_AssetInfo.html)
- Stack trace from `terraform-provider-aws_v6.39.0_x5`:
  ```
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal 0xc0000005 code=0x0 addr=0x0 pc=0x7ff692051ab1]

  goroutine 563 [running]:
  github.com/hashicorp/terraform-provider-aws/internal/service/outposts.DataSourceOutpostAssetRead(...)
    .../outpost_asset_data_source.go:98 +0x391
  ```

### Output from Acceptance Testing

Test was skipped as no Outpost is available in the test environment.

```console
% make testacc TESTS=TestAccOutpostsAssetDataSource_basic PKG=outposts

=== RUN   TestAccOutpostsAssetDataSource_basic
    outpost_asset_data_source_test.go:20: skipping since no Outposts found
--- SKIP: TestAccOutpostsAssetDataSource_basic (2.05s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/outposts
```

### AI Disclosure

This PR was generated with AI assistance (Kiro CLI agent). The nil guard fix was identified by analyzing the stack trace and source code. All code has been reviewed and understood by the contributor.
