### PR TITLE
r/aws_apigatewayv2_route: add list support

### DIFF
--- a/.changelog/47452.txt
+++ b/.changelog/47452.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_apigatewayv2_route
+```

--- a/internal/service/apigatewayv2/route.go
+++ b/internal/service/apigatewayv2/route.go
@@ -192,19 +192,9 @@ func resourceRouteRead(ctx context.Context, d *schema.ResourceData, meta any) di
 		return sdkdiag.AppendErrorf(diags, "reading API Gateway v2 Route (%s): %s", d.Id(), err)
 	}
 
-	d.Set("api_key_required", output.ApiKeyRequired)
-	d.Set("authorization_scopes", output.AuthorizationScopes)
-	d.Set("authorization_type", output.AuthorizationType)
-	d.Set("authorizer_id", output.AuthorizerId)
-	d.Set("model_selection_expression", output.ModelSelectionExpression)
-	d.Set("operation_name", output.OperationName)
-	d.Set("request_models", output.RequestModels)
-	if err := d.Set("request_parameter", flattenRouteRequestParameters(output.RequestParameters)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting request_parameter: %s", err)
+	if err := flattenRoute(d, output); err != nil {
+		return sdkdiag.AppendErrorf(diags, "flattening API Gateway v2 Route (%s): %s", d.Id(), err)
 	}
-	d.Set("route_key", output.RouteKey)
-	d.Set("route_response_selection_expression", output.RouteResponseSelectionExpression)
-	d.Set(names.AttrTarget, output.Target)
 
 	return diags
 }
@@ -434,6 +424,24 @@ func findRoutes(ctx context.Context, conn *apigatewayv2.Client, input *apigatewa
 	}
 
 	return output, nil
+}
+
+func flattenRoute(d *schema.ResourceData, output *apigatewayv2.GetRouteOutput) error {
+	d.Set("api_key_required", output.ApiKeyRequired)
+	d.Set("authorization_scopes", output.AuthorizationScopes)
+	d.Set("authorization_type", output.AuthorizationType)
+	d.Set("authorizer_id", output.AuthorizerId)
+	d.Set("model_selection_expression", output.ModelSelectionExpression)
+	d.Set("operation_name", output.OperationName)
+	d.Set("request_models", output.RequestModels)
+	if err := d.Set("request_parameter", flattenRouteRequestParameters(output.RequestParameters)); err != nil {
+		return fmt.Errorf("setting request_parameter: %w", err)
+	}
+	d.Set("route_key", output.RouteKey)
+	d.Set("route_response_selection_expression", output.RouteResponseSelectionExpression)
+	d.Set(names.AttrTarget, output.Target)
+
+	return nil
 }
 
 func expandRouteRequestParameters(tfList []any) map[string]awstypes.ParameterConstraints {

--- a/internal/service/apigatewayv2/route_list.go
+++ b/internal/service/apigatewayv2/route_list.go
@@ -1,0 +1,151 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package apigatewayv2
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKListResource("aws_apigatewayv2_route")
+func newRouteResourceAsListResource() inttypes.ListResourceForSDK {
+	l := routeListResource{}
+	l.SetResourceSchema(resourceRoute())
+	return &l
+}
+
+var _ list.ListResource = &routeListResource{}
+
+type routeListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+func (l *routeListResource) ListResourceConfigSchema(ctx context.Context, request list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = listschema.Schema{
+		Attributes: map[string]listschema.Attribute{
+			"api_id": listschema.StringAttribute{
+				Required:    true,
+				Description: "API identifier.",
+			},
+		},
+	}
+}
+
+func (l *routeListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	conn := l.Meta().APIGatewayV2Client(ctx)
+
+	var query listRouteModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	apiID := query.ApiId.ValueString()
+
+	tflog.Info(ctx, "Listing Resources", map[string]any{
+		logging.ResourceAttributeKey("api_id"): apiID,
+	})
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		input := apigatewayv2.GetRoutesInput{
+			ApiId: aws.String(apiID),
+		}
+		for item, err := range listRoutes(ctx, conn, &input) {
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+
+			routeID := aws.ToString(item.RouteId)
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey("route_id"), routeID)
+
+			result := request.NewListResult(ctx)
+
+			rd := l.ResourceData()
+			rd.SetId(routeID)
+			rd.Set("api_id", apiID)
+
+			if request.IncludeResource {
+				if err := flattenRoutePage(rd, item); err != nil {
+					tflog.Error(ctx, "Reading API Gateway V2 Route", map[string]any{
+						"error": err.Error(),
+					})
+					continue
+				}
+			}
+
+			result.DisplayName = aws.ToString(item.RouteKey)
+
+			l.SetResult(ctx, l.Meta(), request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+type listRouteModel struct {
+	framework.WithRegionModel
+	ApiId types.String `tfsdk:"api_id"`
+}
+
+func listRoutes(ctx context.Context, conn *apigatewayv2.Client, input *apigatewayv2.GetRoutesInput) iter.Seq2[awstypes.Route, error] {
+	return func(yield func(awstypes.Route, error) bool) {
+		err := getRoutesPages(ctx, conn, input, func(page *apigatewayv2.GetRoutesOutput, lastPage bool) bool {
+			if page == nil {
+				return !lastPage
+			}
+			for _, item := range page.Items {
+				if !yield(item, nil) {
+					return false
+				}
+			}
+			return !lastPage
+		})
+		if err != nil {
+			yield(awstypes.Route{}, fmt.Errorf("listing API Gateway V2 Route resources: %w", err))
+		}
+	}
+}
+
+func flattenRoutePage(d *schema.ResourceData, item awstypes.Route) error {
+	d.Set("api_key_required", item.ApiKeyRequired)
+	d.Set("authorization_scopes", item.AuthorizationScopes)
+	d.Set("authorization_type", item.AuthorizationType)
+	d.Set("authorizer_id", item.AuthorizerId)
+	d.Set("model_selection_expression", item.ModelSelectionExpression)
+	d.Set("operation_name", item.OperationName)
+	d.Set("request_models", item.RequestModels)
+	if err := d.Set("request_parameter", flattenRouteRequestParameters(item.RequestParameters)); err != nil {
+		return fmt.Errorf("setting request_parameter: %w", err)
+	}
+	d.Set("route_key", item.RouteKey)
+	d.Set("route_response_selection_expression", item.RouteResponseSelectionExpression)
+	d.Set(names.AttrTarget, item.Target)
+
+	return nil
+}

--- a/internal/service/apigatewayv2/route_list_test.go
+++ b/internal/service/apigatewayv2/route_list_test.go
@@ -1,0 +1,198 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package apigatewayv2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccAPIGatewayV2Route_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_apigatewayv2_route.test[0]"
+	resourceName2 := "aws_apigatewayv2_route.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
+		CheckDestroy:             testAccCheckRouteDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Route/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Route/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_apigatewayv2_route.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_apigatewayv2_route.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact("test-0")),
+					tfquerycheck.ExpectNoResourceObject("aws_apigatewayv2_route.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_apigatewayv2_route.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_apigatewayv2_route.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringExact("test-1")),
+					tfquerycheck.ExpectNoResourceObject("aws_apigatewayv2_route.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayV2Route_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_apigatewayv2_route.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
+		CheckDestroy:             testAccCheckRouteDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Route/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Route/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_apigatewayv2_route.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_apigatewayv2_route.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact("$connect")),
+					querycheck.ExpectResourceKnownValues("aws_apigatewayv2_route.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("api_id"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("route_key"), knownvalue.StringExact("$connect")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("api_key_required"), knownvalue.Bool(true)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("operation_name"), knownvalue.StringExact("GET")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("route_response_selection_expression"), knownvalue.StringExact("$default")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("model_selection_expression"), knownvalue.StringExact(names.AttrAction)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("authorization_type"), knownvalue.StringExact("NONE")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("request_parameter"), knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"request_parameter_key": knownvalue.StringExact("route.request.header.authorization"),
+								"required":              knownvalue.Bool(true),
+							}),
+						})),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayV2Route_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_apigatewayv2_route.test[0]"
+	resourceName2 := "aws_apigatewayv2_route.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
+		CheckDestroy:             testAccCheckRouteDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Route/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Route/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_apigatewayv2_route.test", identity1.Checks()),
+
+					tfquerycheck.ExpectIdentityFunc("aws_apigatewayv2_route.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/apigatewayv2/service_package_gen.go
+++ b/internal/service/apigatewayv2/service_package_gen.go
@@ -7,6 +7,8 @@ package apigatewayv2
 
 import (
 	"context"
+	"iter"
+	"slices"
 	"unique"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -161,6 +163,21 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			Region: unique.Make(inttypes.ResourceRegionDefault()),
 		},
 	}
+}
+
+func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttypes.ServicePackageSDKListResource] {
+	return slices.Values([]*inttypes.ServicePackageSDKListResource{
+		{
+			Factory:  newRouteResourceAsListResource,
+			TypeName: "aws_apigatewayv2_route",
+			Name:     "Route",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+			Identity: inttypes.RegionalParameterizedIdentity([]inttypes.IdentityAttribute{
+				inttypes.StringIdentityAttribute("api_id", true),
+				inttypes.StringIdentityAttribute(names.AttrID, true),
+			}),
+		},
+	})
 }
 
 func (p *servicePackage) ServicePackageName() string {

--- a/internal/service/apigatewayv2/testdata/Route/list_basic/main.tf
+++ b/internal/service/apigatewayv2/testdata/Route/list_basic/main.tf
@@ -1,0 +1,27 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_apigatewayv2_route" "test" {
+  count = var.resource_count
+
+  api_id    = aws_apigatewayv2_api.test.id
+  route_key = "test-${count.index}"
+}
+
+resource "aws_apigatewayv2_api" "test" {
+  name                       = var.rName
+  protocol_type              = "WEBSOCKET"
+  route_selection_expression = "$request.body.action"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/apigatewayv2/testdata/Route/list_basic/query.tfquery.hcl
+++ b/internal/service/apigatewayv2/testdata/Route/list_basic/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_apigatewayv2_route" "test" {
+  provider = aws
+
+  config {
+    api_id = aws_apigatewayv2_api.test.id
+  }
+}

--- a/internal/service/apigatewayv2/testdata/Route/list_include_resource/main.tf
+++ b/internal/service/apigatewayv2/testdata/Route/list_include_resource/main.tf
@@ -1,0 +1,38 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_apigatewayv2_route" "test" {
+  count = var.resource_count
+
+  api_id    = aws_apigatewayv2_api.test.id
+  route_key = "$connect"
+
+  api_key_required                    = true
+  operation_name                      = "GET"
+  route_response_selection_expression = "$default"
+  model_selection_expression          = "action"
+  authorization_type                  = "NONE"
+
+  request_parameter {
+    request_parameter_key = "route.request.header.authorization"
+    required              = true
+  }
+}
+
+resource "aws_apigatewayv2_api" "test" {
+  name                       = var.rName
+  protocol_type              = "WEBSOCKET"
+  route_selection_expression = "$request.body.action"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/apigatewayv2/testdata/Route/list_include_resource/query.tfquery.hcl
+++ b/internal/service/apigatewayv2/testdata/Route/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,12 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_apigatewayv2_route" "test" {
+  provider = aws
+
+  include_resource = true
+
+  config {
+    api_id = aws_apigatewayv2_api.test.id
+  }
+}

--- a/internal/service/apigatewayv2/testdata/Route/list_region_override/main.tf
+++ b/internal/service/apigatewayv2/testdata/Route/list_region_override/main.tf
@@ -1,0 +1,36 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_apigatewayv2_route" "test" {
+  count  = var.resource_count
+  region = var.region
+
+  api_id    = aws_apigatewayv2_api.test.id
+  route_key = "test-${count.index}"
+}
+
+resource "aws_apigatewayv2_api" "test" {
+  region = var.region
+
+  name                       = var.rName
+  protocol_type              = "WEBSOCKET"
+  route_selection_expression = "$request.body.action"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to create resources in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/apigatewayv2/testdata/Route/list_region_override/query.tfquery.hcl
+++ b/internal/service/apigatewayv2/testdata/Route/list_region_override/query.tfquery.hcl
@@ -1,0 +1,11 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_apigatewayv2_route" "test" {
+  provider = aws
+
+  config {
+    api_id = aws_apigatewayv2_api.test.id
+    region = var.region
+  }
+}

--- a/website/docs/list-resources/apigatewayv2_route.html.markdown
+++ b/website/docs/list-resources/apigatewayv2_route.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "API Gateway V2"
+layout: "aws"
+page_title: "AWS: aws_apigatewayv2_route"
+description: |-
+  Lists API Gateway V2 Route resources.
+---
+
+# List Resource: aws_apigatewayv2_route
+
+Lists API Gateway V2 Route resources.
+
+## Example Usage
+
+```terraform
+list "aws_apigatewayv2_route" "example" {
+  provider = aws
+
+  config {
+    api_id = aws_apigatewayv2_api.example.id
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `api_id` - (Required) API identifier.
+* `region` - (Optional) Region to query. Defaults to provider region.


### PR DESCRIPTION

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds list support for the `aws_apigatewayv2_route` resource.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Depends on #47441
Closes https://github.com/hashicorp/terraform-provider-aws/issues/47254
Relates https://github.com/hashicorp/terraform-provider-aws/issues/47005


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make t K=apigatewayv2 T=TestAccAPIGatewayV2Route_List
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-apigatewayv2_route-list 🌿...
TF_ACC=1 go1.25.9 test ./internal/service/apigatewayv2/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayV2Route_List'  -timeout 360m -vet=off
2026/04/14 16:26:39 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/14 16:26:39 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccAPIGatewayV2Route_List_regionOverride (20.77s)
--- PASS: TestAccAPIGatewayV2Route_List_includeResource (21.79s)
--- PASS: TestAccAPIGatewayV2Route_List_basic (21.86s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigatewayv2       28.916s
```

```console
% make t K=apigatewayv2 T=TestAccAPIGatewayV2Route_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-apigatewayv2_route-list 🌿...
TF_ACC=1 go1.25.9 test ./internal/service/apigatewayv2/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayV2Route_'  -timeout 360m -vet=off
2026/04/14 16:27:36 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/14 16:27:36 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccAPIGatewayV2Route_List_regionOverride (58.90s)
--- PASS: TestAccAPIGatewayV2Route_List_includeResource (58.93s)
--- PASS: TestAccAPIGatewayV2Route_List_basic (59.29s)
--- PASS: TestAccAPIGatewayV2Route_disappears (59.69s)
--- PASS: TestAccAPIGatewayV2Route_regionOverride (66.07s)
--- PASS: TestAccAPIGatewayV2Route_basic (66.45s)
--- PASS: TestAccAPIGatewayV2Route_target (66.50s)
--- PASS: TestAccAPIGatewayV2Route_model (66.73s)
--- PASS: TestAccAPIGatewayV2Route_Identity_regionOverride (86.44s)
--- PASS: TestAccAPIGatewayV2Route_Identity_ExistingResource_noRefreshNoChange (86.94s)
--- PASS: TestAccAPIGatewayV2Route_updateRouteKey (88.02s)
--- PASS: TestAccAPIGatewayV2Route_Identity_ExistingResource_basic (89.46s)
--- PASS: TestAccAPIGatewayV2Route_Identity_basic (90.08s)
--- PASS: TestAccAPIGatewayV2Route_simpleAttributes (102.35s)
--- PASS: TestAccAPIGatewayV2Route_requestParameters (102.95s)
--- PASS: TestAccAPIGatewayV2Route_jwtAuthorization (105.67s)
--- PASS: TestAccAPIGatewayV2Route_authorizer (105.93s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigatewayv2       113.086s
```