### PR TITLE
Listing ELBv2 resources: Prevent errors when no results returned

### DIFF
--- a/.changelog/47455.txt
+++ b/.changelog/47455.txt
@@ -1,0 +1,15 @@
+```release-note:bug
+list-resource/aws_lb: Fixes error when no results are returned
+```
+
+```release-note:bug
+list-resource/aws_lb_listener: Fixes error when no results are returned
+```
+
+```release-note:bug
+list-resource/aws_lb_listener_rule: Fixes error when no results are returned
+```
+
+```release-note:bug
+list-resource/aws_lb_target_group: Fixes error when no results are returned
+```

--- a/internal/service/elbv2/tags.go
+++ b/internal/service/elbv2/tags.go
@@ -17,6 +17,10 @@ type tagDescriber interface {
 }
 
 func batchListTags(ctx context.Context, conn tagDescriber, identifiers []string, optFns ...func(*elasticloadbalancingv2.Options)) (map[string][]awstypes.Tag, error) {
+	if len(identifiers) == 0 {
+		return make(map[string][]awstypes.Tag, 0), nil
+	}
+
 	input := elasticloadbalancingv2.DescribeTagsInput{
 		ResourceArns: identifiers,
 	}

--- a/internal/service/elbv2/tags.go
+++ b/internal/service/elbv2/tags.go
@@ -12,7 +12,11 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 )
 
-func batchListTags(ctx context.Context, conn *elasticloadbalancingv2.Client, identifiers []string, optFns ...func(*elasticloadbalancingv2.Options)) (map[string][]awstypes.Tag, error) {
+type tagDescriber interface {
+	DescribeTags(ctx context.Context, params *elasticloadbalancingv2.DescribeTagsInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeTagsOutput, error)
+}
+
+func batchListTags(ctx context.Context, conn tagDescriber, identifiers []string, optFns ...func(*elasticloadbalancingv2.Options)) (map[string][]awstypes.Tag, error) {
 	input := elasticloadbalancingv2.DescribeTagsInput{
 		ResourceArns: identifiers,
 	}

--- a/internal/service/elbv2/tags_test.go
+++ b/internal/service/elbv2/tags_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/aws/smithy-go"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
@@ -22,6 +23,9 @@ func TestBatchListTags(t *testing.T) {
 	testCases := map[string]struct {
 		tagsByIdentifier map[string][]awstypes.Tag
 	}{
+		"empty": {
+			tagsByIdentifier: map[string][]awstypes.Tag{},
+		},
 		"single": {
 			tagsByIdentifier: map[string][]awstypes.Tag{
 				"id1": {
@@ -89,6 +93,17 @@ type mockTagDescriber struct {
 }
 
 func (m *mockTagDescriber) DescribeTags(ctx context.Context, params *elasticloadbalancingv2.DescribeTagsInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeTagsOutput, error) {
+	if len(params.ResourceArns) == 0 {
+		return nil, &smithy.OperationError{
+			ServiceID:     "Elastic Load Balancing v2",
+			OperationName: "DescribeTags",
+			Err: &smithy.GenericAPIError{
+				Code:    "ValidationError",
+				Message: "An ARN must be specified",
+			},
+		}
+	}
+
 	output := &elasticloadbalancingv2.DescribeTagsOutput{
 		TagDescriptions: []awstypes.TagDescription{},
 	}

--- a/internal/service/elbv2/tags_test.go
+++ b/internal/service/elbv2/tags_test.go
@@ -1,0 +1,106 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package elbv2
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestBatchListTags(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		tagsByIdentifier map[string][]awstypes.Tag
+	}{
+		"single": {
+			tagsByIdentifier: map[string][]awstypes.Tag{
+				"id1": {
+					{
+						Key:   aws.String("Environment"),
+						Value: aws.String("Production"),
+					},
+					{
+						Key:   aws.String("Owner"),
+						Value: aws.String("TeamA"),
+					},
+				},
+			},
+		},
+		"multiple": {
+			tagsByIdentifier: map[string][]awstypes.Tag{
+				"id1": {
+					{
+						Key:   aws.String("Environment"),
+						Value: aws.String("Production"),
+					},
+					{
+						Key:   aws.String("Owner"),
+						Value: aws.String("TeamA"),
+					},
+				},
+				"id2": {
+					{
+						Key:   aws.String("Environment"),
+						Value: aws.String("Production"),
+					},
+					{
+						Key:   aws.String("Owner"),
+						Value: aws.String("TeamA"),
+					},
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			conn := &mockTagDescriber{
+				tagsByIdentifier: testCase.tagsByIdentifier,
+			}
+
+			identifiers := slices.Collect(maps.Keys(testCase.tagsByIdentifier))
+
+			got, err := batchListTags(t.Context(), conn, identifiers)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.tagsByIdentifier, got, cmpopts.IgnoreUnexported(awstypes.Tag{})); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+type mockTagDescriber struct {
+	tagsByIdentifier map[string][]awstypes.Tag
+}
+
+func (m *mockTagDescriber) DescribeTags(ctx context.Context, params *elasticloadbalancingv2.DescribeTagsInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeTagsOutput, error) {
+	output := &elasticloadbalancingv2.DescribeTagsOutput{
+		TagDescriptions: []awstypes.TagDescription{},
+	}
+
+	for _, identifier := range params.ResourceArns {
+		if tags, ok := m.tagsByIdentifier[identifier]; ok {
+			output.TagDescriptions = append(output.TagDescriptions, awstypes.TagDescription{
+				ResourceArn: aws.String(identifier),
+				Tags:        tags,
+			})
+		}
+	}
+
+	return output, nil
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

When listing ELBv2 resources, there is an error when setting `include_resource` and there are no results.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47423

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elbv2 TESTS=_List_

--- PASS: TestAccELBV2TargetGroup_List_includeResource (61.99s)
--- PASS: TestAccELBV2TargetGroup_List_basic (62.13s)
--- PASS: TestAccELBV2TargetGroup_List_regionOverride (64.70s)
--- PASS: TestAccELBV2ListenerRule_List_includeResource (212.70s)
--- PASS: TestAccELBV2Listener_List_includeResource (217.40s)
--- PASS: TestAccELBV2ListenerRule_List_basic (222.17s)
--- PASS: TestAccELBV2LoadBalancer_List_includeResource (225.50s)
--- PASS: TestAccELBV2Listener_List_basic (226.54s)
--- PASS: TestAccELBV2LoadBalancer_List_basic (228.65s)
--- PASS: TestAccELBV2Listener_List_regionOverride (231.54s)
--- PASS: TestAccELBV2LoadBalancer_List_regionOverride (238.77s)
--- PASS: TestAccELBV2ListenerRule_List_regionOverride (255.06s)
```
