### PR TITLE
resource/aws_dynamodb_global_secondary_index: Handle unknown `key_type`

### DIFF
--- a/.changelog/47456.txt
+++ b/.changelog/47456.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_global_secondary_index: Fixes error when `key_type` is unknown during plan-time.
+```

--- a/internal/service/dynamodb/global_secondary_index.go
+++ b/internal/service/dynamodb/global_secondary_index.go
@@ -129,6 +129,7 @@ func (r *resourceGlobalSecondaryIndex) Schema(ctx context.Context, request resou
 				},
 				Validators: []validator.List{
 					listvalidator.IsRequired(),
+					listvalidator.SizeAtLeast(1),
 					globalSecondaryIndexKeySchemaListValidator{},
 				},
 				PlanModifiers: []planmodifier.List{

--- a/internal/service/dynamodb/global_secondary_index.go
+++ b/internal/service/dynamodb/global_secondary_index.go
@@ -128,6 +128,7 @@ func (r *resourceGlobalSecondaryIndex) Schema(ctx context.Context, request resou
 					},
 				},
 				Validators: []validator.List{
+					listvalidator.IsRequired(),
 					globalSecondaryIndexKeySchemaListValidator{},
 				},
 				PlanModifiers: []planmodifier.List{

--- a/internal/service/dynamodb/global_secondary_index_key_schema_list_validator.go
+++ b/internal/service/dynamodb/global_secondary_index_key_schema_list_validator.go
@@ -39,6 +39,11 @@ func (v globalSecondaryIndexKeySchemaListValidator) ValidateList(ctx context.Con
 
 	keySchemas := fwdiag.Must(keySchemaAttr.ToSlice(ctx))
 
+	// Empty value is handled by `Required` on element attributes and `listvalidator.SizeAtLeast(1)`
+	if len(keySchemas) == 0 {
+		return
+	}
+
 	if keySchemas[0].KeyType.ValueEnum() != awstypes.KeyTypeHash {
 		elementPath := request.Path.AtListIndex(0)
 		response.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(

--- a/internal/service/dynamodb/global_secondary_index_key_schema_list_validator.go
+++ b/internal/service/dynamodb/global_secondary_index_key_schema_list_validator.go
@@ -44,7 +44,11 @@ func (v globalSecondaryIndexKeySchemaListValidator) ValidateList(ctx context.Con
 		return
 	}
 
-	if keySchemas[0].KeyType.ValueEnum() != awstypes.KeyTypeHash {
+	firstKeySchema := keySchemas[0]
+	if firstKeySchema.KeyType.IsUnknown() {
+		return
+	}
+	if firstKeySchema.KeyType.ValueEnum() != awstypes.KeyTypeHash {
 		elementPath := request.Path.AtListIndex(0)
 		response.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(
 			elementPath,

--- a/internal/service/dynamodb/global_secondary_index_key_schema_list_validator.go
+++ b/internal/service/dynamodb/global_secondary_index_key_schema_list_validator.go
@@ -30,16 +30,7 @@ func (v globalSecondaryIndexKeySchemaListValidator) MarkdownDescription(_ contex
 }
 
 func (v globalSecondaryIndexKeySchemaListValidator) ValidateList(ctx context.Context, request validator.ListRequest, response *validator.ListResponse) {
-	if request.ConfigValue.IsUnknown() {
-		return
-	}
-
-	if request.ConfigValue.IsNull() {
-		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
-			request.Path,
-			fmt.Sprintf(`must contain at least %d and at most %d elements with "key_type" %q`, minNumberOfHashes, maxNumberOfHashes, awstypes.KeyTypeHash),
-			"0",
-		))
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
 		return
 	}
 

--- a/internal/service/dynamodb/global_secondary_index_key_schema_list_validator.go
+++ b/internal/service/dynamodb/global_secondary_index_key_schema_list_validator.go
@@ -61,8 +61,11 @@ func (v globalSecondaryIndexKeySchemaListValidator) ValidateList(ctx context.Con
 	var hashCount, rangeCount int
 	var lastKeyType awstypes.KeyType
 	for i, v := range keySchemas {
-		switch v.KeyType.ValueEnum() {
-		case awstypes.KeyTypeHash:
+		switch {
+		case v.KeyType.IsUnknown():
+			return
+
+		case v.KeyType.ValueEnum() == awstypes.KeyTypeHash:
 			if lastKeyType == awstypes.KeyTypeRange {
 				elementPath := request.Path.AtListIndex(i)
 				response.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(
@@ -73,7 +76,7 @@ func (v globalSecondaryIndexKeySchemaListValidator) ValidateList(ctx context.Con
 			}
 			hashCount++
 
-		case awstypes.KeyTypeRange:
+		case v.KeyType.ValueEnum() == awstypes.KeyTypeRange:
 			rangeCount++
 		}
 		lastKeyType = v.KeyType.ValueEnum()

--- a/internal/service/dynamodb/global_secondary_index_key_schema_list_validator.go
+++ b/internal/service/dynamodb/global_secondary_index_key_schema_list_validator.go
@@ -30,7 +30,11 @@ func (v globalSecondaryIndexKeySchemaListValidator) MarkdownDescription(_ contex
 }
 
 func (v globalSecondaryIndexKeySchemaListValidator) ValidateList(ctx context.Context, request validator.ListRequest, response *validator.ListResponse) {
-	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+	if request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	if request.ConfigValue.IsNull() {
 		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
 			request.Path,
 			fmt.Sprintf(`must contain at least %d and at most %d elements with "key_type" %q`, minNumberOfHashes, maxNumberOfHashes, awstypes.KeyTypeHash),

--- a/internal/service/dynamodb/global_secondary_index_key_schema_list_validator_test.go
+++ b/internal/service/dynamodb/global_secondary_index_key_schema_list_validator_test.go
@@ -56,6 +56,22 @@ func TestGlobalSecondaryIndexKeySchemaListValidator(t *testing.T) {
 			}),
 			expectError: false,
 		},
+
+		"multiple unknown type": {
+			value: fwtypes.NewListNestedObjectValueOfValueSliceMust(t.Context(), []keySchemaModel{
+				{
+					AttributeName: types.StringValue("attribute_name1"),
+					AttributeType: fwtypes.StringEnumValue(awstypes.ScalarAttributeTypeS),
+					KeyType:       fwtypes.StringEnumValue(awstypes.KeyTypeHash),
+				},
+				{
+					AttributeName: types.StringValue("attribute_name2"),
+					AttributeType: fwtypes.StringEnumValue(awstypes.ScalarAttributeTypeS),
+					KeyType:       fwtypes.StringEnumUnknown[awstypes.KeyType](),
+				},
+			}),
+			expectError: false,
+		},
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/service/dynamodb/global_secondary_index_key_schema_list_validator_test.go
+++ b/internal/service/dynamodb/global_secondary_index_key_schema_list_validator_test.go
@@ -25,8 +25,9 @@ func TestGlobalSecondaryIndexKeySchemaListValidator(t *testing.T) {
 			expectError: false,
 		},
 		"null": {
+			// Null value is handled by `listvalidator.IsRequired()`
 			value:       fwtypes.NewListNestedObjectValueOfNull[keySchemaModel](t.Context()),
-			expectError: true,
+			expectError: false,
 		},
 		"fully known": {
 			value: fwtypes.NewListNestedObjectValueOfValueSliceMust(t.Context(), []keySchemaModel{

--- a/internal/service/dynamodb/global_secondary_index_key_schema_list_validator_test.go
+++ b/internal/service/dynamodb/global_secondary_index_key_schema_list_validator_test.go
@@ -20,6 +20,10 @@ func TestGlobalSecondaryIndexKeySchemaListValidator(t *testing.T) {
 		value       fwtypes.ListNestedObjectValueOf[keySchemaModel]
 		expectError bool
 	}{
+		"unknown": {
+			value:       fwtypes.NewListNestedObjectValueOfUnknown[keySchemaModel](t.Context()),
+			expectError: false,
+		},
 		"null": {
 			value:       fwtypes.NewListNestedObjectValueOfNull[keySchemaModel](t.Context()),
 			expectError: true,

--- a/internal/service/dynamodb/global_secondary_index_key_schema_list_validator_test.go
+++ b/internal/service/dynamodb/global_secondary_index_key_schema_list_validator_test.go
@@ -45,6 +45,17 @@ func TestGlobalSecondaryIndexKeySchemaListValidator(t *testing.T) {
 			}),
 			expectError: false,
 		},
+
+		"single unknown type": {
+			value: fwtypes.NewListNestedObjectValueOfValueSliceMust(t.Context(), []keySchemaModel{
+				{
+					AttributeName: types.StringValue("attribute_name"),
+					AttributeType: fwtypes.StringEnumValue(awstypes.ScalarAttributeTypeS),
+					KeyType:       fwtypes.StringEnumUnknown[awstypes.KeyType](),
+				},
+			}),
+			expectError: false,
+		},
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/service/dynamodb/global_secondary_index_key_schema_list_validator_test.go
+++ b/internal/service/dynamodb/global_secondary_index_key_schema_list_validator_test.go
@@ -29,6 +29,12 @@ func TestGlobalSecondaryIndexKeySchemaListValidator(t *testing.T) {
 			value:       fwtypes.NewListNestedObjectValueOfNull[keySchemaModel](t.Context()),
 			expectError: false,
 		},
+		"empty": {
+			// Empty value is handled by `Required` on element attributes and `listvalidator.SizeAtLeast(1)`
+			value:       fwtypes.NewListNestedObjectValueOfValueSliceMust(t.Context(), []keySchemaModel{}),
+			expectError: false,
+		},
+
 		"fully known": {
 			value: fwtypes.NewListNestedObjectValueOfValueSliceMust(t.Context(), []keySchemaModel{
 				{

--- a/internal/service/dynamodb/global_secondary_index_key_schema_list_validator_test.go
+++ b/internal/service/dynamodb/global_secondary_index_key_schema_list_validator_test.go
@@ -1,0 +1,60 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dynamodb
+
+import (
+	"testing"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+)
+
+func TestGlobalSecondaryIndexKeySchemaListValidator(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		value       fwtypes.ListNestedObjectValueOf[keySchemaModel]
+		expectError bool
+	}{
+		"null": {
+			value:       fwtypes.NewListNestedObjectValueOfNull[keySchemaModel](t.Context()),
+			expectError: true,
+		},
+		"fully known": {
+			value: fwtypes.NewListNestedObjectValueOfValueSliceMust(t.Context(), []keySchemaModel{
+				{
+					AttributeName: types.StringValue("attribute_name"),
+					AttributeType: fwtypes.StringEnumValue(awstypes.ScalarAttributeTypeS),
+					KeyType:       fwtypes.StringEnumValue(awstypes.KeyTypeHash),
+				},
+			}),
+			expectError: false,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			request := validator.ListRequest{
+				Path:           path.Root("test"),
+				PathExpression: path.MatchRoot("test"),
+				ConfigValue:    testCase.value.ListValue,
+			}
+			response := validator.ListResponse{}
+
+			globalSecondaryIndexKeySchemaListValidator{}.ValidateList(t.Context(), request, &response)
+
+			if !response.Diagnostics.HasError() && testCase.expectError {
+				t.Fatal("expected error, got no error")
+			}
+
+			if response.Diagnostics.HasError() && !testCase.expectError {
+				t.Fatalf("got unexpected error: %s", response.Diagnostics)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

During plan-time validation, unknown values in `key_type` cause an error.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #46252

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=dynamodb TESTS=TestAccDynamoDBTable_

--- PASS: TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema (9.94s)
--- PASS: TestAccDynamoDBTable_GSI_validate_exactlyOneOfKeySchemaHashKey (10.45s)
--- PASS: TestAccDynamoDBTable_basic (117.73s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_emptyProviderOnlyTag (130.72s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nullOverlappingResourceTag (132.59s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_emptyResourceTag (134.02s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nullNonOverlappingResourceTag (138.66s)
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_onCreate (147.86s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleHashKeys (140.33s)
--- PASS: TestAccDynamoDBTable_GSI_rangeKeyExplicitEmptyString (171.88s)
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_replace (194.86s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_updateToResourceOnly (194.91s)
--- PASS: TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_noChange (190.83s)
--- PASS: TestAccDynamoDBTable_Tags_addOnUpdate (207.60s)
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_add (207.91s)
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_replace (219.44s)
--- PASS: TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_defaultTag (231.14s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleHashKey (127.90s)
--- PASS: TestAccDynamoDBTable_Tags_emptyMap (153.82s)
--- PASS: TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_resourceTag (291.22s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleRangeKey (165.16s)
--- PASS: TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_noChange (182.01s)
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (10.00s)
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (201.47s)
--- PASS: TestAccDynamoDBTable_tags (343.74s)
--- PASS: TestAccDynamoDBTable_TTL_validate (3.85s)
--- PASS: TestAccDynamoDBTable_lsiUpdate (88.34s)
--- PASS: TestAccDynamoDBTable_TTL_updateEnable (76.38s)
--- PASS: TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_addHashKey (430.89s)
--- PASS: TestAccDynamoDBTable_encryption (189.71s)
--- PASS: TestAccDynamoDBTable_TTL_disabled (100.67s)
--- PASS: TestAccDynamoDBTable_TTL_enabled (97.36s)
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (104.43s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_unknown (71.14s)
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (411.48s)
--- PASS: TestAccDynamoDBTable_extended (415.67s)
--- PASS: TestAccDynamoDBTable_GSI_unknown (48.12s)
--- PASS: TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed (6.18s)
--- PASS: TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed_onUpdate (56.93s)
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted (400.28s)
--- PASS: TestAccDynamoDBTable_Replica_singleCMK (407.80s)
--- PASS: TestAccDynamoDBTable_Replica_singleStreamSpecification (389.89s)
--- PASS: TestAccDynamoDBTable_nameKnownAfterApply (49.84s)
--- PASS: TestAccDynamoDBTable_Replica_tags_updateIsPropagated_oneOfTwo (652.11s)
--- PASS: TestAccDynamoDBTable_warmThroughputDefault (69.00s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleRangeKeys (79.29s)
--- PASS: TestAccDynamoDBTable_Tags_null (84.28s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tagsUpdate (703.96s)
--- FAIL: TestAccDynamoDBTable_restoreBackupARN (27.16s)
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncryptedAmazonOwned (530.37s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeGSI (111.46s)
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (285.87s)
--- PASS: TestAccDynamoDBTable_warmThroughput (159.99s)
--- PASS: TestAccDynamoDBTable_tableClass_migrate (62.78s)
--- PASS: TestAccDynamoDBTable_importTable (178.56s)
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_switchBilling (241.31s)
--- PASS: TestAccDynamoDBTable_tableClass_ConcurrentModification (83.36s)
--- PASS: TestAccDynamoDBTable_tableClassExplicitDefault (63.78s)
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (79.29s)
--- PASS: TestAccDynamoDBTable_Replica_pitr (651.37s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_maxSet (68.90s)
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_add (113.38s)
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (44.47s)
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (3.74s)
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_onCreate (83.33s)
--- PASS: TestAccDynamoDBTable_attributeUpdate (632.65s)
--- PASS: TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_DifferentFromTable (99.81s)
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_billingProvisioned (411.65s)
--- PASS: TestAccDynamoDBTable_streamSpecification (76.77s)
--- PASS: TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_SameAsTable (100.31s)
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_billingPayPerRequest (427.31s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeRangeKey (335.48s)
--- PASS: TestAccDynamoDBTable_Replica_pitrKMS (855.45s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_addRangeKey (342.42s)
--- PASS: TestAccDynamoDBTable_gsiOnDemandThroughput (116.83s)
--- PASS: TestAccDynamoDBTable_disappears (38.33s)
--- PASS: TestAccDynamoDBTable_onDemandThroughput (124.14s)
--- PASS: TestAccDynamoDBTable_streamSpecificationDiffs (213.81s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_updateToProviderOnly (65.02s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeHashKey (344.75s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestBasic (317.42s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (177.78s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_overlapping (122.48s)
--- PASS: TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_removeKey (363.46s)
--- PASS: TestAccDynamoDBTable_restoreCrossRegion (883.70s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (197.50s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (208.49s)
--- PASS: TestAccDynamoDBTable_enablePITR (124.07s)
--- PASS: TestAccDynamoDBTable_Replica_single (975.47s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (229.18s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nonOverlapping (154.78s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_MixedConsistencyModes (58.91s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_NotEnoughReplicas (84.06s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (157.40s)
--- PASS: TestAccDynamoDBTable_enablePITRWithCustomRecoveryPeriod (151.93s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (293.84s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_providerOnly (160.65s)
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (597.79s)
--- PASS: TestAccDynamoDBTable_Replica_multiple (1187.05s)
--- PASS: TestAccDynamoDBTable_Replica_upgradeV6_2_0 (353.82s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_addHashKey (389.30s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_nonPropagatedTagsAreUnmanaged (334.53s)
--- PASS: TestAccDynamoDBTable_backupEncryption (850.36s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_notPropagatedToAddedReplica (356.63s)
--- FAIL: TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_oneOfTwo (321.03s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_nonPropagatedTagsAreUnmanaged (385.70s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create_witness_too_many_replicas (60.59s)
--- PASS: TestAccDynamoDBTable_GSIvalidate_keySchema_tooManyRangeKeys (2.59s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica (387.77s)
--- PASS: TestAccDynamoDBTable_GSI_validate_keySchema_tooManyHashKeys (3.64s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_propagateToAddedReplica (395.27s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_twoOfTwo (390.65s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_twoOfTwo (393.44s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_TooManyReplicas (69.69s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_CreateEventuallyConsistent (525.75s)
--- PASS: TestAccDynamoDBTable_deletion_protection (84.32s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_oneOfTwo (382.45s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create_witness (265.00s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_pitrKMS (584.35s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tagsUpdate (591.74s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_pitr (320.78s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_pitr (338.32s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create (263.19s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_pitrKMS (490.13s)
--- PASS: TestAccDynamoDBTable_Replica_tags_propagateToAddedReplica (565.40s)
--- PASS: TestAccDynamoDBTable_Replica_tags_notPropagatedToAddedReplica (557.08s)
--- PASS: TestAccDynamoDBTable_Replica_tags_nonPropagatedTagsAreUnmanaged (590.79s)
--- PASS: TestAccDynamoDBTable_Replica_tags_updateIsPropagated_twoOfTwo (615.68s)
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (699.72s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_doubleAddCMK (840.98s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_doubleAddCMK (855.46s)
--- PASS: TestAccDynamoDBTable_Replica_deletionProtection (1312.92s)
--- FAIL: TestAccDynamoDBTable_Replica_doubleAddCMK (2532.16s)
--- PASS: TestAccDynamoDBTable_TTL_updateDisable (3665.42s)
```

Test failures are pre-existing