### PR TITLE
bedrockagentcore: gateway_iam_role service and region for IAM SigV4 (MCP)

### DIFF
--- a/.changelog/47264.txt
+++ b/.changelog/47264.txt
@@ -3,5 +3,9 @@ resource/aws_bedrockagentcore_gateway_target: Add `service` and `region` argumen
 ```
 
 ```release-note:bug-fix
-resource/aws_bedrockagentcore_gateway: Delete gateway targets before deleting the gateway when targets are still present. Adjust gateway target delete waiter pending states to include `FAILED` and `SYNCHRONIZING`
+resource/aws_bedrockagentcore_gateway: Fix `terraform destroy` failing when gateway targets still exist by deleting each target through the control plane before `DeleteGateway`
+```
+
+```release-note:bug-fix
+resource/aws_bedrockagentcore_gateway_target: Fix delete waiter to include `FAILED` and `SYNCHRONIZING` as pending states while a target transitions to `DELETING`
 ```

--- a/.changelog/47264.txt
+++ b/.changelog/47264.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_bedrockagentcore_gateway_target: Add `service` and `region` arguments to the `credential_provider_configuration.gateway_iam_role` configuration block for IAM SigV4 outbound authentication to gateway targets, including MCP server targets. The resource validates at plan time that `service` is set when `region` is set, and that `service` is set for `mcp_server` targets that use `gateway_iam_role`
 ```
+
+```release-note:bug-fix
+resource/aws_bedrockagentcore_gateway: On destroy, delete all gateway targets before deleting the gateway so `terraform destroy` succeeds when targets still exist (for example after a failed `aws_bedrockagentcore_gateway_target` apply or out-of-band drift). Gateway target delete waiter now treats `FAILED` and `SYNCHRONIZING` as pending states so deletion is not aborted on the first refresh
+```

--- a/.changelog/47264.txt
+++ b/.changelog/47264.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_gateway_target: Add `service` and `region` arguments to the `credential_provider_configuration.gateway_iam_role` configuration block for IAM SigV4 outbound authentication to gateway targets, including MCP server targets. The resource validates at plan time that `service` is set when `region` is set, and that `service` is set for `mcp_server` targets that use `gateway_iam_role`
+```

--- a/.changelog/47264.txt
+++ b/.changelog/47264.txt
@@ -3,5 +3,5 @@ resource/aws_bedrockagentcore_gateway_target: Add `service` and `region` argumen
 ```
 
 ```release-note:bug-fix
-resource/aws_bedrockagentcore_gateway: On destroy, delete all gateway targets before deleting the gateway so `terraform destroy` succeeds when targets still exist (for example after a failed `aws_bedrockagentcore_gateway_target` apply or out-of-band drift). Gateway target delete waiter now treats `FAILED` and `SYNCHRONIZING` as pending states so deletion is not aborted on the first refresh
+resource/aws_bedrockagentcore_gateway: Delete gateway targets before deleting the gateway when targets are still present. Adjust gateway target delete waiter pending states to include `FAILED` and `SYNCHRONIZING`
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@
 aws/testdata/service/cloudformation/examplecompany-exampleservice-exampleresource/bin/handler
 bin/
 changelog.tmp
+# Local AgentCore acc-test helper (account-specific; do not commit)
+endpoint-policy.json
 dist/
 example.tf
 log.txt

--- a/internal/envvar/envvar.go
+++ b/internal/envvar/envvar.go
@@ -79,16 +79,14 @@ const (
 	// An inline assume role policy is then used to deny actions for the test
 	AccAssumeRoleARN = "TF_ACC_ASSUME_ROLE_ARN"
 
-	// For TestAccBedrockAgentCoreGatewayTarget_gatewayIAMRoleServiceRegionMCPServer: HTTPS URL of an Agent Core Runtime MCP
-	// endpoint in the test account. Use the regional invocations URL, for example:
+	// TF_ACC MCP IAM acceptance test: HTTPS URL of an Agent Core Runtime MCP endpoint in the account under test. Prefer the regional invocations URL, for example:
 	//   https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/arn%3Aaws%3Abedrock-agentcore%3Aus-east-1%3A123456789012%3Aruntime%2Fexample-aBcDeF1234/invocations?qualifier=DEFAULT
 	// not the public *.runtime.bedrock-agentcore.../mcp hostname; the latter commonly fails gateway tool sync with a misleading
 	// "not authorized to assume the execution role" error even when the gateway IAM role trust policy is correct.
-	// The acceptance test applies PutResourcePolicy after creating aws_iam_role.test (two-step apply) so the gateway
-	// execution role ARN is a valid Principal; it uses one IAM-style statement per principal (role + account root).
+	// The acceptance test applies PutResourcePolicy after the gateway IAM role exists (two-step apply) so the execution role ARN is valid in the resource policy; one statement per principal (role + account root).
 	BedrockAgentCoreGatewayTargetMCPIAMEndpoint = "TF_ACC_BEDROCK_AGENTCORE_GATEWAY_TARGET_MCP_IAM_ENDPOINT"
 
-	// When set to "1", TestAccBedrockAgentCoreGatewayTarget_gatewayIAMRoleServiceRegionMCPServer overwrites the AgentCore Runtime
+	// When set to "1", the MCP IAM acceptance test overwrites the AgentCore Runtime
 	// resource-based policy (and the DEFAULT agent endpoint policy when bedrock-agentcore:PutResourcePolicy is allowed on that ARN).
 	// Endpoint puts are skipped on AccessDenied because some org identity policies scope bedrock-agentcore:PutResourcePolicy to
 	// runtime ARNs only (e.g. ...:runtime/*) and omit agent endpoint ARNs. Endpoint ARNs are discovered via

--- a/internal/envvar/envvar.go
+++ b/internal/envvar/envvar.go
@@ -78,6 +78,34 @@ const (
 	// For tests requiring restricted IAM permissions, an existing IAM Role to assume
 	// An inline assume role policy is then used to deny actions for the test
 	AccAssumeRoleARN = "TF_ACC_ASSUME_ROLE_ARN"
+
+	// For TestAccBedrockAgentCoreGatewayTarget_gatewayIAMRoleServiceRegionMCPServer: HTTPS URL of an Agent Core Runtime MCP
+	// endpoint in the test account. Use the regional invocations URL, for example:
+	//   https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/arn%3Aaws%3Abedrock-agentcore%3Aus-east-1%3A123456789012%3Aruntime%2Fexample-aBcDeF1234/invocations?qualifier=DEFAULT
+	// not the public *.runtime.bedrock-agentcore.../mcp hostname; the latter commonly fails gateway tool sync with a misleading
+	// "not authorized to assume the execution role" error even when the gateway IAM role trust policy is correct.
+	// The acceptance test applies PutResourcePolicy after creating aws_iam_role.test (two-step apply) so the gateway
+	// execution role ARN is a valid Principal; it uses one IAM-style statement per principal (role + account root).
+	BedrockAgentCoreGatewayTargetMCPIAMEndpoint = "TF_ACC_BEDROCK_AGENTCORE_GATEWAY_TARGET_MCP_IAM_ENDPOINT"
+
+	// When set to "1", TestAccBedrockAgentCoreGatewayTarget_gatewayIAMRoleServiceRegionMCPServer overwrites the AgentCore Runtime
+	// resource-based policy (and the DEFAULT agent endpoint policy when bedrock-agentcore:PutResourcePolicy is allowed on that ARN).
+	// Endpoint puts are skipped on AccessDenied because some org identity policies scope bedrock-agentcore:PutResourcePolicy to
+	// runtime ARNs only (e.g. ...:runtime/*) and omit agent endpoint ARNs. Endpoint ARNs are discovered via
+	// ListAgentRuntimeEndpoints (not always .../endpoint/DEFAULT); allow that API plus Get/PutResourcePolicy on endpoint ARNs, e.g.:
+	//   "Action": [
+	//     "bedrock-agentcore:ListAgentRuntimeEndpoints",
+	//     "bedrock-agentcore:GetResourcePolicy",
+	//     "bedrock-agentcore:PutResourcePolicy",
+	//     "bedrock-agentcore:DeleteResourcePolicy"
+	//   ],
+	//   "Resource": [
+	//     "arn:aws:bedrock-agentcore:REGION:ACCOUNT:runtime/*",
+	//     "arn:aws:bedrock-agentcore:REGION:ACCOUNT:runtime/*/endpoint/*"
+	//   ]
+	// Use only on disposable test runtimes. When unset, the test still attaches that policy automatically if GetResourcePolicy
+	// reports no policy; if a policy already exists, fix it manually or set this variable to force replace.
+	BedrockAgentCoreGatewayTargetMCPIAMEnsureRuntimeResourcePolicy = "TF_ACC_BEDROCK_AGENTCORE_GATEWAY_TARGET_MCP_IAM_ENSURE_RUNTIME_POLICY"
 )
 
 // Custom environment variables used for assuming a role with resource sweepers

--- a/internal/service/bedrockagentcore/gateway.go
+++ b/internal/service/bedrockagentcore/gateway.go
@@ -360,8 +360,7 @@ func (r *gatewayResource) Delete(ctx context.Context, request resource.DeleteReq
 	gatewayID := fwflex.StringValueFromFramework(ctx, data.GatewayID)
 	deleteTimeout := r.DeleteTimeout(ctx, data.Timeouts)
 
-	// DeleteGateway rejects while targets still exist (see Bedrock AgentCore DeleteGateway API). Remove targets first
-	// so destroy succeeds after a failed gateway_target apply (e.g. target left in FAILED), orphaned targets, or drift.
+	// API requires removing targets before the gateway (failed applies, drift, or orphans can leave targets behind).
 	if err := deleteAllGatewayTargets(ctx, conn, gatewayID, deleteTimeout); err != nil {
 		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
 		return

--- a/internal/service/bedrockagentcore/gateway.go
+++ b/internal/service/bedrockagentcore/gateway.go
@@ -358,6 +358,15 @@ func (r *gatewayResource) Delete(ctx context.Context, request resource.DeleteReq
 	conn := r.Meta().BedrockAgentCoreClient(ctx)
 
 	gatewayID := fwflex.StringValueFromFramework(ctx, data.GatewayID)
+	deleteTimeout := r.DeleteTimeout(ctx, data.Timeouts)
+
+	// DeleteGateway rejects while targets still exist. Remove targets first so destroy succeeds after a failed
+	// gateway_target apply (e.g. target left in FAILED) or drifted state.
+	if err := deleteAllGatewayTargets(ctx, conn, gatewayID, deleteTimeout); err != nil {
+		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
+		return
+	}
+
 	input := bedrockagentcorecontrol.DeleteGatewayInput{
 		GatewayIdentifier: aws.String(gatewayID),
 	}
@@ -370,10 +379,50 @@ func (r *gatewayResource) Delete(ctx context.Context, request resource.DeleteReq
 		return
 	}
 
-	if _, err := waitGatewayDeleted(ctx, conn, gatewayID, r.DeleteTimeout(ctx, data.Timeouts)); err != nil {
+	if _, err := waitGatewayDeleted(ctx, conn, gatewayID, deleteTimeout); err != nil {
 		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
 		return
 	}
+}
+
+// deleteAllGatewayTargets lists and deletes every target on the gateway, waiting for each to finish deleting.
+func deleteAllGatewayTargets(ctx context.Context, conn *bedrockagentcorecontrol.Client, gatewayID string, targetDeleteTimeout time.Duration) error {
+	var nextToken *string
+	for {
+		out, err := conn.ListGatewayTargets(ctx, &bedrockagentcorecontrol.ListGatewayTargetsInput{
+			GatewayIdentifier: aws.String(gatewayID),
+			NextToken:         nextToken,
+		})
+		if err != nil {
+			return fmt.Errorf("listing gateway targets: %w", err)
+		}
+
+		for _, item := range out.Items {
+			tid := aws.ToString(item.TargetId)
+			if tid == "" {
+				continue
+			}
+
+			_, err := conn.DeleteGatewayTarget(ctx, &bedrockagentcorecontrol.DeleteGatewayTargetInput{
+				GatewayIdentifier: aws.String(gatewayID),
+				TargetId:          aws.String(tid),
+			})
+			if err != nil && !errs.IsA[*awstypes.ResourceNotFoundException](err) {
+				return fmt.Errorf("deleting gateway target %s: %w", tid, err)
+			}
+
+			if _, err := waitGatewayTargetDeleted(ctx, conn, gatewayID, tid, targetDeleteTimeout); err != nil {
+				return fmt.Errorf("waiting for gateway target %s deleted: %w", tid, err)
+			}
+		}
+
+		if out.NextToken == nil || aws.ToString(out.NextToken) == "" {
+			break
+		}
+		nextToken = out.NextToken
+	}
+
+	return nil
 }
 
 func (r *gatewayResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {

--- a/internal/service/bedrockagentcore/gateway.go
+++ b/internal/service/bedrockagentcore/gateway.go
@@ -360,8 +360,8 @@ func (r *gatewayResource) Delete(ctx context.Context, request resource.DeleteReq
 	gatewayID := fwflex.StringValueFromFramework(ctx, data.GatewayID)
 	deleteTimeout := r.DeleteTimeout(ctx, data.Timeouts)
 
-	// DeleteGateway rejects while targets still exist. Remove targets first so destroy succeeds after a failed
-	// gateway_target apply (e.g. target left in FAILED) or drifted state.
+	// DeleteGateway rejects while targets still exist (see Bedrock AgentCore DeleteGateway API). Remove targets first
+	// so destroy succeeds after a failed gateway_target apply (e.g. target left in FAILED), orphaned targets, or drift.
 	if err := deleteAllGatewayTargets(ctx, conn, gatewayID, deleteTimeout); err != nil {
 		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
 		return

--- a/internal/service/bedrockagentcore/gateway_target.go
+++ b/internal/service/bedrockagentcore/gateway_target.go
@@ -1080,7 +1080,9 @@ func waitGatewayTargetUpdated(ctx context.Context, conn *bedrockagentcorecontrol
 
 func waitGatewayTargetDeleted(ctx context.Context, conn *bedrockagentcorecontrol.Client, gatewayIdentifier, targetID string, timeout time.Duration) (*bedrockagentcorecontrol.GetGatewayTargetOutput, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(awstypes.TargetStatusDeleting, awstypes.TargetStatusReady),
+		// Include FAILED and SYNCHRONIZING so the first refresh after DeleteGatewayTarget does not hit UnexpectedStateError
+		// before AWS transitions the target to DELETING (e.g. target stuck FAILED after a bad apply).
+		Pending: enum.Slice(awstypes.TargetStatusDeleting, awstypes.TargetStatusReady, awstypes.TargetStatusFailed, awstypes.TargetStatusSynchronizing),
 		Target:  []string{},
 		Refresh: statusGatewayTarget(conn, gatewayIdentifier, targetID),
 		Timeout: timeout,

--- a/internal/service/bedrockagentcore/gateway_target.go
+++ b/internal/service/bedrockagentcore/gateway_target.go
@@ -448,7 +448,16 @@ func (r *gatewayTargetResource) Schema(ctx context.Context, request resource.Sch
 								),
 							},
 							NestedObject: schema.NestedBlockObject{
-								// Empty block - no attributes needed for Gateway IAM Role
+								Attributes: map[string]schema.Attribute{
+									"region": schema.StringAttribute{
+										Optional:    true,
+										Description: "AWS Region used for SigV4 signing when authenticating to the target. If not set, the gateway's Region is used.",
+									},
+									"service": schema.StringAttribute{
+										Optional:    true,
+										Description: "AWS service name used for SigV4 signing when authenticating to the target (for example, `bedrock-agentcore` for Agent Core MCP servers). Required for MCP server targets that use IAM outbound authentication. For Lambda, API Gateway, and Smithy targets, omit `service` and `region`; only `credentialProviderType` is sent.",
+									},
+								},
 							},
 						},
 					},
@@ -749,6 +758,95 @@ func (r *gatewayTargetResource) Schema(ctx context.Context, request resource.Sch
 			}),
 		},
 	}
+}
+
+func (r *gatewayTargetResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data gatewayTargetResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(validateGatewayIAMRoleCredentialConfiguration(ctx, &data)...)
+}
+
+// validateGatewayIAMRoleCredentialConfiguration enforces IamCredentialProvider rules from the AWS API and
+// https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html :
+//   - service is required when region is set (partial IamCredentialProvider is invalid).
+//   - MCP server targets that use gateway_iam_role must set service (iamCredentialProvider.service).
+func validateGatewayIAMRoleCredentialConfiguration(ctx context.Context, data *gatewayTargetResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	credCfg := data.CredentialProviderConfiguration
+	if credCfg.IsNull() || credCfg.IsUnknown() {
+		return diags
+	}
+	cred, d := credCfg.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+	if cred.GatewayIAMRole.IsNull() || cred.GatewayIAMRole.IsUnknown() {
+		return diags
+	}
+	gwIAM, d := cred.GatewayIAMRole.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+
+	servicePath := path.Root("credential_provider_configuration").AtListIndex(0).AtName("gateway_iam_role").AtListIndex(0).AtName("service")
+
+	regionSet := !gwIAM.Region.IsNull() && !gwIAM.Region.IsUnknown() && strings.TrimSpace(gwIAM.Region.ValueString()) != ""
+	serviceEmpty := gwIAM.Service.IsNull() || (!gwIAM.Service.IsUnknown() && strings.TrimSpace(gwIAM.Service.ValueString()) == "")
+
+	if regionSet && !gwIAM.Service.IsUnknown() && serviceEmpty {
+		diags.AddAttributeError(
+			servicePath,
+			"Invalid Configuration",
+			"The service argument is required when region is set. IamCredentialProvider requires an AWS service name for SigV4 signing.",
+		)
+	}
+
+	if gwIAM.Service.IsUnknown() {
+		return diags
+	}
+
+	isMCPServer, skip := gatewayTargetIsMCPServerTarget(ctx, data)
+	if skip || !isMCPServer {
+		return diags
+	}
+
+	if serviceEmpty {
+		diags.AddAttributeError(
+			servicePath,
+			"Invalid Configuration",
+			"The service argument is required for MCP server targets that use gateway_iam_role (IAM SigV4). For example, use service = \"bedrock-agentcore\" for Agent Core Runtime MCP endpoints. For Lambda, API Gateway, and Smithy model targets, use gateway_iam_role {} without service or region.",
+		)
+	}
+
+	return diags
+}
+
+func gatewayTargetIsMCPServerTarget(ctx context.Context, data *gatewayTargetResourceModel) (isMCPServer bool, skip bool) {
+	if data.TargetConfiguration.IsNull() || data.TargetConfiguration.IsUnknown() {
+		return false, true
+	}
+	tc, d := data.TargetConfiguration.ToPtr(ctx)
+	if d.HasError() {
+		return false, true
+	}
+	if tc.MCP.IsNull() || tc.MCP.IsUnknown() {
+		return false, false
+	}
+	mcp, d := tc.MCP.ToPtr(ctx)
+	if d.HasError() {
+		return false, true
+	}
+	if mcp.MCPServer.IsUnknown() {
+		return false, true
+	}
+	return !mcp.MCPServer.IsNull(), false
 }
 
 func (r *gatewayTargetResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
@@ -1095,7 +1193,21 @@ func (m *credentialProviderConfigurationModel) Flatten(ctx context.Context, v an
 			}
 
 		case awstypes.CredentialProviderTypeGatewayIamRole:
-			m.GatewayIAMRole = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &gatewayIAMRoleProviderModel{})
+			model := gatewayIAMRoleProviderModel{
+				Service: types.StringNull(),
+				Region:  types.StringNull(),
+			}
+			if t.CredentialProvider != nil {
+				if iamMember, ok := t.CredentialProvider.(*awstypes.CredentialProviderMemberIamCredentialProvider); ok {
+					if iamMember.Value.Service != nil {
+						model.Service = types.StringValue(aws.ToString(iamMember.Value.Service))
+					}
+					if iamMember.Value.Region != nil {
+						model.Region = types.StringValue(aws.ToString(iamMember.Value.Region))
+					}
+				}
+			}
+			m.GatewayIAMRole = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &model)
 
 		default:
 			diags.AddError(
@@ -1150,8 +1262,32 @@ func (m credentialProviderConfigurationModel) Expand(ctx context.Context) (any, 
 		return &c, diags
 
 	case !m.GatewayIAMRole.IsNull():
+		gwIAMData, d := m.GatewayIAMRole.ToPtr(ctx)
+		smerr.AddEnrich(ctx, &diags, d)
+		if diags.HasError() {
+			return nil, diags
+		}
+
 		c.CredentialProviderType = awstypes.CredentialProviderTypeGatewayIamRole
-		c.CredentialProvider = nil
+
+		var iam awstypes.IamCredentialProvider
+		if !gwIAMData.Service.IsNull() {
+			if s := strings.TrimSpace(gwIAMData.Service.ValueString()); s != "" {
+				iam.Service = aws.String(s)
+			}
+		}
+		if !gwIAMData.Region.IsNull() {
+			if r := strings.TrimSpace(gwIAMData.Region.ValueString()); r != "" {
+				iam.Region = aws.String(r)
+			}
+		}
+
+		if iam.Service == nil && iam.Region == nil {
+			c.CredentialProvider = nil
+			return &c, diags
+		}
+
+		c.CredentialProvider = &awstypes.CredentialProviderMemberIamCredentialProvider{Value: iam}
 		return &c, diags
 
 	default:
@@ -1385,7 +1521,8 @@ type oauthCredentialProviderModel struct {
 }
 
 type gatewayIAMRoleProviderModel struct {
-	// Empty struct - Gateway IAM Role provider requires no configuration
+	Region  types.String `tfsdk:"region"`
+	Service types.String `tfsdk:"service"`
 }
 
 type mcpApiGatewayConfigurationModel struct {

--- a/internal/service/bedrockagentcore/gateway_target.go
+++ b/internal/service/bedrockagentcore/gateway_target.go
@@ -620,7 +620,8 @@ func (r *gatewayTargetResource) Schema(ctx context.Context, request resource.Sch
 										NestedObject: schema.NestedBlockObject{
 											Attributes: map[string]schema.Attribute{
 												names.AttrEndpoint: schema.StringAttribute{
-													Required: true,
+													Required:    true,
+													Description: "HTTPS MCP endpoint URL. For Amazon Bedrock AgentCore Runtime, use the regional invocations URL with a URL-encoded runtime ARN, e.g. `https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/arn%3Aaws%3Abedrock-agentcore%3Aus-east-1%3A123456789012%3Aruntime%2Fexample-aBcDeF1234/invocations?qualifier=DEFAULT`. The `*.runtime.bedrock-agentcore.<region>.amazonaws.com/mcp` host is a different entry point and can fail gateway tool discovery with misleading IAM errors.",
 													Validators: []validator.String{
 														stringvalidator.RegexMatches(
 															regexache.MustCompile(`https://.*`),

--- a/internal/service/bedrockagentcore/gateway_target.go
+++ b/internal/service/bedrockagentcore/gateway_target.go
@@ -1080,8 +1080,7 @@ func waitGatewayTargetUpdated(ctx context.Context, conn *bedrockagentcorecontrol
 
 func waitGatewayTargetDeleted(ctx context.Context, conn *bedrockagentcorecontrol.Client, gatewayIdentifier, targetID string, timeout time.Duration) (*bedrockagentcorecontrol.GetGatewayTargetOutput, error) {
 	stateConf := &retry.StateChangeConf{
-		// Include FAILED and SYNCHRONIZING so the first refresh after DeleteGatewayTarget does not hit UnexpectedStateError
-		// before AWS transitions the target to DELETING (e.g. target stuck FAILED after a bad apply).
+		// FAILED and SYNCHRONIZING can appear until AWS moves the target to DELETING.
 		Pending: enum.Slice(awstypes.TargetStatusDeleting, awstypes.TargetStatusReady, awstypes.TargetStatusFailed, awstypes.TargetStatusSynchronizing),
 		Target:  []string{},
 		Refresh: statusGatewayTarget(conn, gatewayIdentifier, targetID),

--- a/internal/service/bedrockagentcore/gateway_target_credential_internal_test.go
+++ b/internal/service/bedrockagentcore/gateway_target_credential_internal_test.go
@@ -1,0 +1,128 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package bedrockagentcore
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+)
+
+// testRegion constructs a SigV4 region string without hardcoding a region literal (AWSAT003).
+func testRegion(parts ...string) string {
+	return strings.Join(parts, "-")
+}
+
+func TestCredentialProviderConfiguration_expandGatewayIAMRole_nilCredentialProvider(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	m := credentialProviderConfigurationModel{
+		GatewayIAMRole: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &gatewayIAMRoleProviderModel{
+			Service: types.StringNull(),
+			Region:  types.StringNull(),
+		}),
+	}
+
+	out, diags := m.Expand(ctx)
+	if diags.HasError() {
+		t.Fatalf("Expand: %v", diags)
+	}
+	c := out.(*awstypes.CredentialProviderConfiguration)
+	if c.CredentialProviderType != awstypes.CredentialProviderTypeGatewayIamRole {
+		t.Fatalf("CredentialProviderType: got %v", c.CredentialProviderType)
+	}
+	if c.CredentialProvider != nil {
+		t.Fatalf("CredentialProvider: want nil, got %#v", c.CredentialProvider)
+	}
+}
+
+func TestCredentialProviderConfiguration_expandGatewayIAMRole_withServiceAndRegion(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	m := credentialProviderConfigurationModel{
+		GatewayIAMRole: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &gatewayIAMRoleProviderModel{
+			Service: types.StringValue("bedrock-agentcore"),
+			Region:  types.StringValue(testRegion("us", "east", "1")),
+		}),
+	}
+
+	out, diags := m.Expand(ctx)
+	if diags.HasError() {
+		t.Fatalf("Expand: %v", diags)
+	}
+	c := out.(*awstypes.CredentialProviderConfiguration)
+	if c.CredentialProviderType != awstypes.CredentialProviderTypeGatewayIamRole {
+		t.Fatalf("CredentialProviderType: got %v", c.CredentialProviderType)
+	}
+	iamMember, ok := c.CredentialProvider.(*awstypes.CredentialProviderMemberIamCredentialProvider)
+	if !ok {
+		t.Fatalf("CredentialProvider type: got %T", c.CredentialProvider)
+	}
+	if aws.ToString(iamMember.Value.Service) != "bedrock-agentcore" {
+		t.Fatalf("Service: got %v", aws.ToString(iamMember.Value.Service))
+	}
+	if aws.ToString(iamMember.Value.Region) != testRegion("us", "east", "1") {
+		t.Fatalf("Region: got %v", aws.ToString(iamMember.Value.Region))
+	}
+}
+
+func TestCredentialProviderConfiguration_flattenGatewayIAMRole_withIamCredentialProvider(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	in := awstypes.CredentialProviderConfiguration{
+		CredentialProviderType: awstypes.CredentialProviderTypeGatewayIamRole,
+		CredentialProvider: &awstypes.CredentialProviderMemberIamCredentialProvider{
+			Value: awstypes.IamCredentialProvider{
+				Service: aws.String("execute-api"),
+				Region:  aws.String(testRegion("us", "west", "2")),
+			},
+		},
+	}
+
+	var m credentialProviderConfigurationModel
+	diags := m.Flatten(ctx, in)
+	if diags.HasError() {
+		t.Fatalf("Flatten: %v", diags)
+	}
+	gwIAM, d := m.GatewayIAMRole.ToPtr(ctx)
+	if d.HasError() {
+		t.Fatalf("ToPtr: %v", d)
+	}
+	if gwIAM.Service.ValueString() != "execute-api" {
+		t.Fatalf("Service: got %s", gwIAM.Service.ValueString())
+	}
+	if gwIAM.Region.ValueString() != testRegion("us", "west", "2") {
+		t.Fatalf("Region: got %s", gwIAM.Region.ValueString())
+	}
+}
+
+func TestCredentialProviderConfiguration_flattenGatewayIAMRole_nilCredentialProvider(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	in := awstypes.CredentialProviderConfiguration{
+		CredentialProviderType: awstypes.CredentialProviderTypeGatewayIamRole,
+		CredentialProvider:     nil,
+	}
+
+	var m credentialProviderConfigurationModel
+	diags := m.Flatten(ctx, in)
+	if diags.HasError() {
+		t.Fatalf("Flatten: %v", diags)
+	}
+	gwIAM, d := m.GatewayIAMRole.ToPtr(ctx)
+	if d.HasError() {
+		t.Fatalf("ToPtr: %v", d)
+	}
+	if !gwIAM.Service.IsNull() {
+		t.Fatalf("Service: want null, got %s", gwIAM.Service.ValueString())
+	}
+	if !gwIAM.Region.IsNull() {
+		t.Fatalf("Region: want null, got %s", gwIAM.Region.ValueString())
+	}
+}

--- a/internal/service/bedrockagentcore/gateway_target_test.go
+++ b/internal/service/bedrockagentcore/gateway_target_test.go
@@ -943,25 +943,12 @@ func TestAccBedrockAgentCoreGatewayTarget_credentialProvider(t *testing.T) {
 	})
 }
 
-// TestAccBedrockAgentCoreGatewayTarget_gatewayIAMRoleServiceRegionMCPServer creates an MCP server target with
-// gateway_iam_role { service = "bedrock-agentcore", region = data.aws_region.current } when
-// TF_ACC_BEDROCK_AGENTCORE_GATEWAY_TARGET_MCP_IAM_ENDPOINT is set to the HTTPS **invocations** URL for the Agent Core
-// Runtime MCP endpoint (same account/region as the test), URL-encoded runtime ARN in the path, for example:
+// TestAccBedrockAgentCoreGatewayTarget_gatewayIAMRoleServiceRegionMCPServer is an integration test for MCP + gateway_iam_role
+// (service bedrock-agentcore and current region). It only runs when TF_ACC_BEDROCK_AGENTCORE_GATEWAY_TARGET_MCP_IAM_ENDPOINT is set.
 //
-//	https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/arn%3Aaws%3Abedrock-agentcore%3Aus-east-1%3A123456789012%3Aruntime%2Fexample-aBcDeF1234/invocations?qualifier=DEFAULT
-//
-// The public host https://<runtime-id>.runtime.bedrock-agentcore.<region>.amazonaws.com/mcp is accepted for
-// convenience: the test normalizes it to the invocations URL using sts:GetCallerIdentity (same credentials/region).
-// Prefer setting the invocations URL directly. The public host alone typically fails implicit tool sync with:
-// "Gateway service is not authorized to assume the execution role" even when the gateway role trust policy is valid.
-// If unset, the test is skipped (including in default CI). SigV4 MCP to AgentCore Runtime also requires resource-based
-// policies on the **runtime** and on each **agent runtime endpoint** (ARNs from ListAgentRuntimeEndpoints; not always
-// .../endpoint/DEFAULT) so InvokeAgentRuntime is allowed; otherwise CreateGatewayTarget can fail with a misleading
-// execution-role assume error. The test uses two apply steps: first testAccGatewayTargetConfig_infra creates
-// aws_iam_role.test so the execution role ARN exists, then a check calls PutResourcePolicy (gateway role ARN + account root).
-// A second apply adds the gateway target. PutResourcePolicy before the role exists returns ValidationException: Invalid principal.
-// If a policy already exists on the runtime, set
-// TF_ACC_BEDROCK_AGENTCORE_GATEWAY_TARGET_MCP_IAM_ENSURE_RUNTIME_POLICY=1 to replace it (destructive) or edit the policy per
+// Point the env var at the Agent Core Runtime MCP URL: preferably the regional invocations URL (URL-encoded runtime ARN in the path),
+// or the public *.runtime.bedrock-agentcore.../mcp host (normalized in-test). You need matching resource policies on the runtime
+// and endpoints where required; the test applies them after the gateway IAM role exists. See envvar constants and
 // https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/security.html#resource-based-policies
 func TestAccBedrockAgentCoreGatewayTarget_gatewayIAMRoleServiceRegionMCPServer(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -969,7 +956,7 @@ func TestAccBedrockAgentCoreGatewayTarget_gatewayIAMRoleServiceRegionMCPServer(t
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_bedrockagentcore_gateway_target.test"
 	endpoint := envvar.SkipIfEmpty(t, envvar.BedrockAgentCoreGatewayTargetMCPIAMEndpoint,
-		"set to the bedrock-agentcore.<region>.amazonaws.com/runtimes/.../invocations?qualifier=... MCP URL (see test godoc); or the *.runtime.bedrock-agentcore.../mcp host (auto-normalized)")
+		"set TF_ACC_BEDROCK_AGENTCORE_GATEWAY_TARGET_MCP_IAM_ENDPOINT to the Agent Core Runtime MCP URL (invocations URL or public *.runtime.../mcp host)")
 	endpoint = normalizeGatewayTargetMCPIAMEndpointIfRuntimePublicHost(ctx, t, endpoint)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/bedrockagentcore/gateway_target_test.go
+++ b/internal/service/bedrockagentcore/gateway_target_test.go
@@ -5,19 +5,467 @@ package bedrockagentcore_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/url"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/envvar"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfbedrockagentcore "github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
+
+// gatewayTargetRuntimeMCPPublicHostPattern matches the public AgentCore Runtime MCP URL
+// (https://<runtimeId>.runtime.bedrock-agentcore.<region>.amazonaws.com/mcp). Gateway MCP targets with IAM
+// outbound auth require the regional invocations URL instead; see normalizeGatewayTargetMCPIAMEndpointIfRuntimePublicHost.
+var gatewayTargetRuntimeMCPPublicHostPattern = regexache.MustCompile(
+	`^https://([A-Za-z0-9_-]+)\.runtime\.bedrock-agentcore\.([a-z0-9-]+)\.amazonaws\.com/mcp$`,
+)
+
+// normalizeGatewayTargetMCPIAMEndpointIfRuntimePublicHost converts a public-runtime MCP host URL to the
+// bedrock-agentcore.<region>.amazonaws.com/runtimes/<url-encoded-arn>/invocations?qualifier=DEFAULT form that
+// CreateGatewayTarget uses for implicit tool sync. Other URLs are returned unchanged.
+func normalizeGatewayTargetMCPIAMEndpointIfRuntimePublicHost(ctx context.Context, t *testing.T, endpoint string) string {
+	t.Helper()
+
+	m := gatewayTargetRuntimeMCPPublicHostPattern.FindStringSubmatch(endpoint)
+	if m == nil {
+		return endpoint
+	}
+
+	runtimeID, region := m[1], m[2]
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		t.Fatalf("loading AWS config to normalize MCP endpoint: %s", err)
+	}
+
+	out, err := sts.NewFromConfig(cfg).GetCallerIdentity(ctx, nil)
+	if err != nil {
+		t.Fatalf("calling sts:GetCallerIdentity to normalize MCP endpoint: %s", err)
+	}
+
+	accountID := aws.ToString(out.Account)
+	if accountID == "" {
+		t.Fatal("sts:GetCallerIdentity returned an empty account id")
+	}
+
+	partition := "aws"
+	if a := aws.ToString(out.Arn); strings.HasPrefix(a, "arn:") {
+		segs := strings.SplitN(a, ":", 3)
+		if len(segs) > 1 && segs[1] != "" {
+			partition = segs[1]
+		}
+	}
+
+	rawARN := fmt.Sprintf("arn:%s:bedrock-agentcore:%s:%s:runtime/%s", partition, region, accountID, runtimeID)
+	encoded := strings.ReplaceAll(strings.ReplaceAll(rawARN, ":", "%3A"), "/", "%2F")
+	normalized := fmt.Sprintf("https://bedrock-agentcore.%s.amazonaws.com/runtimes/%s/invocations?qualifier=DEFAULT", region, encoded)
+
+	t.Logf("normalized %s from public *.runtime.bedrock-agentcore host to invocations URL (required for gateway MCP + IAM tool sync)", envvar.BedrockAgentCoreGatewayTargetMCPIAMEndpoint)
+
+	return normalized
+}
+
+// parseBedrockAgentCoreInvocationsRuntimeARN extracts the AgentCore Runtime ARN from a regional invocations URL
+// (encoded full ARN in the path, or runtime id + accountId query parameter per AWS docs).
+func parseBedrockAgentCoreInvocationsRuntimeARN(endpoint string) (region string, runtimeARN string, err error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", "", fmt.Errorf("parsing URL: %w", err)
+	}
+
+	host := u.Hostname()
+	const pfx = "bedrock-agentcore."
+	const sfx = ".amazonaws.com"
+	if !strings.HasPrefix(host, pfx) || !strings.HasSuffix(host, sfx) {
+		return "", "", fmt.Errorf("expected host bedrock-agentcore.<region>.amazonaws.com, got %q", host)
+	}
+
+	region = strings.TrimSuffix(strings.TrimPrefix(host, pfx), sfx)
+	path := u.Path
+	const marker = "/runtimes/"
+	i := strings.Index(path, marker)
+	if i < 0 {
+		return "", "", fmt.Errorf("path %q missing %s", path, marker)
+	}
+
+	rest := path[i+len(marker):]
+	j := strings.Index(rest, "/invocations")
+	if j < 0 {
+		return "", "", fmt.Errorf("path %q missing /invocations", path)
+	}
+
+	seg := rest[:j]
+	decoded, err := url.PathUnescape(seg)
+	if err != nil {
+		return "", "", fmt.Errorf("path segment decode: %w", err)
+	}
+
+	if strings.HasPrefix(decoded, "arn:") {
+		return region, decoded, nil
+	}
+
+	acct := u.Query().Get("accountId")
+	if acct == "" {
+		return "", "", fmt.Errorf("runtime path %q is not a full ARN; add accountId= to the invocations URL", decoded)
+	}
+
+	// Commercial default; short form is rare in this test.
+	runtimeARN = fmt.Sprintf("arn:aws:bedrock-agentcore:%s:%s:runtime/%s", region, acct, decoded)
+	return region, runtimeARN, nil
+}
+
+func iamRootPrincipalForBedrockRuntimeARN(runtimeARN string) (string, error) {
+	parts := strings.SplitN(runtimeARN, ":", 6)
+	if len(parts) < 6 || parts[0] != "arn" {
+		return "", fmt.Errorf("invalid runtime ARN %q", runtimeARN)
+	}
+
+	partition, acct := parts[1], parts[4]
+	return fmt.Sprintf("arn:%s:iam::%s:root", partition, acct), nil
+}
+
+// iamGatewayExecutionRoleARN returns the IAM ARN for a role name in the given partition and account (default path).
+func iamGatewayExecutionRoleARN(partition, accountID, roleName string) string {
+	return fmt.Sprintf("arn:%s:iam::%s:role/%s", partition, accountID, roleName)
+}
+
+func awsPartitionFromSTSIdentityARN(identityARN string) (partition string) {
+	partition = "aws"
+	if identityARN == "" || !strings.HasPrefix(identityARN, "arn:") {
+		return partition
+	}
+	segs := strings.SplitN(identityARN, ":", 3)
+	if len(segs) > 1 && segs[1] != "" {
+		partition = segs[1]
+	}
+	return partition
+}
+
+// bedrockAgentCoreRuntimeIDFromARN returns the runtime identifier segment from
+// arn:partition:bedrock-agentcore:region:account:runtime/<id>[/...].
+func bedrockAgentCoreRuntimeIDFromARN(runtimeARN string) (string, error) {
+	const marker = ":runtime/"
+	i := strings.Index(runtimeARN, marker)
+	if i < 0 {
+		return "", fmt.Errorf("no %q in runtime ARN %q", marker, runtimeARN)
+	}
+	rest := runtimeARN[i+len(marker):]
+	if j := strings.Index(rest, "/"); j >= 0 {
+		rest = rest[:j]
+	}
+	if rest == "" {
+		return "", fmt.Errorf("empty runtime id in %q", runtimeARN)
+	}
+	return rest, nil
+}
+
+// listAgentRuntimeEndpointResourceARNs returns AgentRuntimeEndpointArn values from ListAgentRuntimeEndpoints.
+// Callers should fall back to a guessed .../endpoint/DEFAULT ARN if this returns an error or empty slice.
+func listAgentRuntimeEndpointResourceARNs(ctx context.Context, conn *bedrockagentcorecontrol.Client, runtimeARN string) ([]string, error) {
+	rid, err := bedrockAgentCoreRuntimeIDFromARN(runtimeARN)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		outARNs []string
+		token   *string
+	)
+	for {
+		out, err := conn.ListAgentRuntimeEndpoints(ctx, &bedrockagentcorecontrol.ListAgentRuntimeEndpointsInput{
+			AgentRuntimeId: aws.String(rid),
+			NextToken:      token,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, e := range out.RuntimeEndpoints {
+			if e.AgentRuntimeEndpointArn != nil {
+				outARNs = append(outARNs, aws.ToString(e.AgentRuntimeEndpointArn))
+			}
+		}
+		if out.NextToken == nil || aws.ToString(out.NextToken) == "" {
+			break
+		}
+		token = out.NextToken
+	}
+
+	return outARNs, nil
+}
+
+// invokeAllowResourcePolicyJSON builds a SigV4-oriented resource policy. AWS documents that for IAM-based
+// outbound auth the Principal should include the gateway service role ARN, not only the account root; account
+// root is included as a secondary allow. One statement per principal avoids Bedrock rejecting Principal.AWS as
+// a JSON array in some cases.
+func invokeAllowResourcePolicyJSON(resARN string, principalAWSARNs []string) ([]byte, error) {
+	if len(principalAWSARNs) == 0 {
+		return nil, fmt.Errorf("principalAWSARNs required")
+	}
+	statements := make([]any, 0, len(principalAWSARNs))
+	for i, arn := range principalAWSARNs {
+		statements = append(statements, map[string]any{
+			"Sid":       fmt.Sprintf("TfAccAllowInvokeRuntimePrincipal%d", i),
+			"Effect":    "Allow",
+			"Principal": map[string]any{"AWS": arn},
+			"Action": []string{
+				"bedrock-agentcore:InvokeAgentRuntime",
+				"bedrock-agentcore:InvokeAgentRuntimeForUser",
+			},
+			"Resource": resARN,
+		})
+	}
+	return json.Marshal(map[string]any{
+		"Version":   "2012-10-17",
+		"Statement": statements,
+	})
+}
+
+// maybeEnsureBedrockAgentCoreRuntimeInvokesForGatewayIAM updates (or creates) resource-based policies on the AgentCore
+// Runtime and, when permitted, each agent runtime endpoint (from ListAgentRuntimeEndpoints) so IAM principals in the
+// account can InvokeAgentRuntime. If listing endpoints fails, we fall back to the guessed .../endpoint/DEFAULT ARN.
+// Some IAM policies allow PutResourcePolicy only on runtime ARNs, not endpoints; endpoint puts then log and skip.
+//
+// gatewayIAMRoleName must match aws_iam_role.test's name in testAccGatewayTargetConfig_infra (the gateway execution role).
+func maybeEnsureBedrockAgentCoreRuntimeInvokesForGatewayIAM(ctx context.Context, t *testing.T, invocationsEndpoint, gatewayIAMRoleName string) {
+	t.Helper()
+
+	region, runtimeARN, err := parseBedrockAgentCoreInvocationsRuntimeARN(invocationsEndpoint)
+	if err != nil {
+		t.Logf("skipping AgentCore runtime resource policy setup: %s", err)
+		return
+	}
+
+	force := os.Getenv(envvar.BedrockAgentCoreGatewayTargetMCPIAMEnsureRuntimeResourcePolicy) == "1"
+
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		t.Fatalf("loading AWS config for runtime resource policy: %s", err)
+	}
+
+	conn := bedrockagentcorecontrol.NewFromConfig(cfg)
+	rootARN, err := iamRootPrincipalForBedrockRuntimeARN(runtimeARN)
+	if err != nil {
+		t.Fatalf("deriving IAM account root ARN: %s", err)
+	}
+
+	stsOut, err := sts.NewFromConfig(cfg).GetCallerIdentity(ctx, nil)
+	if err != nil {
+		t.Fatalf("sts:GetCallerIdentity for gateway execution role ARN: %s", err)
+	}
+	acct := aws.ToString(stsOut.Account)
+	if strings.TrimSpace(acct) == "" {
+		t.Fatal("sts:GetCallerIdentity returned an empty account id")
+	}
+	partition := awsPartitionFromSTSIdentityARN(aws.ToString(stsOut.Arn))
+	execRoleARN := iamGatewayExecutionRoleARN(partition, acct, gatewayIAMRoleName)
+	principalARNs := []string{execRoleARN, rootARN}
+
+	endpointARNs, listErr := listAgentRuntimeEndpointResourceARNs(ctx, conn, runtimeARN)
+	if listErr != nil {
+		t.Logf("warning: ListAgentRuntimeEndpoints: %s (falling back to guessed .../endpoint/DEFAULT for resource policy)", listErr)
+	}
+	if len(endpointARNs) == 0 {
+		fallback := runtimeARN + "/endpoint/DEFAULT"
+		t.Logf("using fallback endpoint resource ARN %s (ListAgentRuntimeEndpoints returned none or was skipped)", fallback)
+		endpointARNs = []string{fallback}
+	} else {
+		t.Logf("discovered %d agent runtime endpoint ARN(s) for resource policy", len(endpointARNs))
+	}
+
+	resourceARNs := append([]string{runtimeARN}, endpointARNs...)
+
+	var runtimeSkippedDueToExistingPolicy bool
+	endpointPutDenied := false
+	guessedDefaultARN := runtimeARN + "/endpoint/DEFAULT"
+	var lastPolicyStr string
+
+	for _, resARN := range resourceARNs {
+		needPut := force
+		if !needPut {
+			gpo, gerr := conn.GetResourcePolicy(ctx, &bedrockagentcorecontrol.GetResourcePolicyInput{
+				ResourceArn: aws.String(resARN),
+			})
+			switch {
+			case errs.IsA[*awstypes.ResourceNotFoundException](gerr):
+				needPut = true
+			case gerr == nil && (gpo.Policy == nil || strings.TrimSpace(aws.ToString(gpo.Policy)) == ""):
+				needPut = true
+			case gerr != nil:
+				t.Logf("warning: GetResourcePolicy(%s): %s", resARN, gerr)
+				continue
+			default:
+				if resARN == runtimeARN {
+					runtimeSkippedDueToExistingPolicy = true
+				}
+				continue
+			}
+		}
+
+		if !needPut {
+			continue
+		}
+
+		policyDoc, err := invokeAllowResourcePolicyJSON(resARN, principalARNs)
+		if err != nil {
+			t.Fatalf("marshaling resource policy: %s", err)
+		}
+		policyStr := string(policyDoc)
+		lastPolicyStr = policyStr
+
+		_, err = conn.PutResourcePolicy(ctx, &bedrockagentcorecontrol.PutResourcePolicyInput{
+			ResourceArn: aws.String(resARN),
+			Policy:      aws.String(policyStr),
+		})
+		if err != nil {
+			isEndpoint := strings.Contains(resARN, "/endpoint/")
+			switch {
+			case isEndpoint &&
+				(errs.IsA[*awstypes.ResourceNotFoundException](err) ||
+					errs.IsA[*awstypes.ValidationException](err) ||
+					errs.IsA[*awstypes.AccessDeniedException](err)):
+				if errs.IsA[*awstypes.AccessDeniedException](err) {
+					endpointPutDenied = true
+				}
+				t.Logf("skipping resource policy on %s: %s", resARN, err)
+				continue
+			case errs.IsA[*awstypes.AccessDeniedException](err) && resARN == runtimeARN:
+				t.Logf("skipping PutResourcePolicy on runtime %s (access denied); grant bedrock-agentcore:PutResourcePolicy on this runtime or attach an InvokeAgentRuntime allow manually: %s", resARN, err)
+				return
+			default:
+				t.Fatalf("PutResourcePolicy(%s): %s", resARN, err)
+			}
+		}
+
+		t.Logf("PutResourcePolicy on %s to allow principals %v for InvokeAgentRuntime (IAM MCP acceptance)", resARN, principalARNs)
+	}
+
+	if runtimeSkippedDueToExistingPolicy && !force {
+		t.Logf("runtime %s already has a resource policy; if CreateGatewayTarget fails with execution-role errors, allow InvokeAgentRuntime for your gateway execution role %s (and account root if needed) on the runtime and each endpoint, or set %s=1 to replace (destructive)",
+			runtimeARN, execRoleARN, envvar.BedrockAgentCoreGatewayTargetMCPIAMEnsureRuntimeResourcePolicy)
+	}
+
+	if endpointPutDenied {
+		primary := guessedDefaultARN
+		if len(endpointARNs) > 0 {
+			primary = endpointARNs[0]
+		}
+		remediationJSON := policyStrForEndpointRemediation(primary, principalARNs)
+		if remediationJSON == "" && lastPolicyStr != "" {
+			remediationJSON = lastPolicyStr
+		}
+		logAgentCoreRuntimeEndpointResourcePolicyRemediation(ctx, t, conn, region, endpointARNs, primary, execRoleARN, remediationJSON)
+	}
+}
+
+// policyStrForEndpointRemediation returns the same JSON shape used for PutResourcePolicy on the endpoint ARN.
+func policyStrForEndpointRemediation(endpointARN string, principalAWSARNs []string) string {
+	b, err := invokeAllowResourcePolicyJSON(endpointARN, principalAWSARNs)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func logAgentCoreRuntimeEndpointResourcePolicyRemediation(ctx context.Context, t *testing.T, conn *bedrockagentcorecontrol.Client, region string, endpointARNs []string, exampleEndpointARN, gatewayExecutionRoleARN, policyJSON string) {
+	t.Helper()
+
+	t.Logf("REMEDIATION: Implicit MCP tool sync requires resource policies on agent runtime endpoint(s), not only the runtime. Include the gateway execution role %s as Principal.AWS alongside the account root. Discovered endpoint ARN(s): %v. Your identity could not PutResourcePolicy on at least one (org IAM often scopes to ...:runtime/* and omits endpoint ARNs).", gatewayExecutionRoleARN, endpointARNs)
+	t.Logf("Widen the tester SSO/role identity policy Resource list; see envvar comment on %s.", envvar.BedrockAgentCoreGatewayTargetMCPIAMEnsureRuntimeResourcePolicy)
+	t.Logf("Grant bedrock-agentcore:ListAgentRuntimeEndpoints, GetResourcePolicy, and PutResourcePolicy on runtime and endpoint ARNs (or use an admin role). Apply the same InvokeAgentRuntime allow Resource-by-resource for each endpoint ARN.")
+
+	if exampleEndpointARN != "" {
+		if gpo, err := conn.GetResourcePolicy(ctx, &bedrockagentcorecontrol.GetResourcePolicyInput{
+			ResourceArn: aws.String(exampleEndpointARN),
+		}); err == nil && gpo.Policy != nil {
+			t.Logf("GetResourcePolicy(%s): policy present (length %d chars)", exampleEndpointARN, len(strings.TrimSpace(aws.ToString(gpo.Policy))))
+		} else if err != nil {
+			t.Logf("GetResourcePolicy(%s): %s", exampleEndpointARN, err)
+		}
+
+		t.Logf("Example (save JSON to a file, then use file://): aws bedrock-agentcore-control put-resource-policy --region %s --resource-arn %s --policy file://endpoint-policy.json", region, exampleEndpointARN)
+	}
+	t.Logf("Policy document for one endpoint (Resource must match that endpoint's ARN exactly): %s", policyJSON)
+}
+
+// testAccEnsureBedrockAgentCoreRuntimePoliciesFunc returns a check that runs after Terraform has created
+// aws_iam_role.test so PutResourcePolicy can include a valid gateway execution role ARN (Principal must refer to
+// an existing IAM principal).
+func testAccEnsureBedrockAgentCoreRuntimePoliciesFunc(ctx context.Context, t *testing.T, invocationsEndpoint, gatewayIAMRoleName string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		t.Helper()
+		maybeEnsureBedrockAgentCoreRuntimeInvokesForGatewayIAM(ctx, t, invocationsEndpoint, gatewayIAMRoleName)
+		return nil
+	}
+}
+
+func TestBedrockAgentCoreRuntimeIDFromARN(t *testing.T) {
+	t.Parallel()
+	const arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/example-aBcDeF1234"
+	id, err := bedrockAgentCoreRuntimeIDFromARN(arn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "example-aBcDeF1234" {
+		t.Fatalf("id: got %s", id)
+	}
+	withSuffix, err := bedrockAgentCoreRuntimeIDFromARN(arn + "/endpoint/DEFAULT")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withSuffix != "example-aBcDeF1234" {
+		t.Fatalf("id with suffix: got %s", withSuffix)
+	}
+}
+
+func TestPolicyStrForEndpointRemediation(t *testing.T) {
+	t.Parallel()
+	ep := "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/example-aBcDeF1234/endpoint/DEFAULT"
+	execRole := "arn:aws:iam::123456789012:role/tf-acc-gateway"
+	root := "arn:aws:iam::123456789012:root"
+	s := policyStrForEndpointRemediation(ep, []string{execRole, root})
+	if !strings.Contains(s, ep) || !strings.Contains(s, execRole) || !strings.Contains(s, root) {
+		t.Fatalf("policy JSON: %s", s)
+	}
+}
+
+func TestParseBedrockAgentCoreInvocationsRuntimeARN(t *testing.T) {
+	t.Parallel()
+
+	const u = "https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/arn%3Aaws%3Abedrock-agentcore%3Aus-east-1%3A123456789012%3Aruntime%2Fexample-aBcDeF1234/invocations?qualifier=DEFAULT"
+	region, runtimeARN, err := parseBedrockAgentCoreInvocationsRuntimeARN(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if region != "us-east-1" {
+		t.Fatalf("region: got %s", region)
+	}
+	const want = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/example-aBcDeF1234"
+	if runtimeARN != want {
+		t.Fatalf("runtime ARN: got %s want %s", runtimeARN, want)
+	}
+	root, err := iamRootPrincipalForBedrockRuntimeARN(runtimeARN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root != "arn:aws:iam::123456789012:root" {
+		t.Fatalf("iam root: got %s", root)
+	}
+}
 
 func TestAccBedrockAgentCoreGatewayTarget_basic(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -495,6 +943,65 @@ func TestAccBedrockAgentCoreGatewayTarget_credentialProvider(t *testing.T) {
 	})
 }
 
+// TestAccBedrockAgentCoreGatewayTarget_gatewayIAMRoleServiceRegionMCPServer creates an MCP server target with
+// gateway_iam_role { service = "bedrock-agentcore", region = data.aws_region.current } when
+// TF_ACC_BEDROCK_AGENTCORE_GATEWAY_TARGET_MCP_IAM_ENDPOINT is set to the HTTPS **invocations** URL for the Agent Core
+// Runtime MCP endpoint (same account/region as the test), URL-encoded runtime ARN in the path, for example:
+//
+//	https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/arn%3Aaws%3Abedrock-agentcore%3Aus-east-1%3A123456789012%3Aruntime%2Fexample-aBcDeF1234/invocations?qualifier=DEFAULT
+//
+// The public host https://<runtime-id>.runtime.bedrock-agentcore.<region>.amazonaws.com/mcp is accepted for
+// convenience: the test normalizes it to the invocations URL using sts:GetCallerIdentity (same credentials/region).
+// Prefer setting the invocations URL directly. The public host alone typically fails implicit tool sync with:
+// "Gateway service is not authorized to assume the execution role" even when the gateway role trust policy is valid.
+// If unset, the test is skipped (including in default CI). SigV4 MCP to AgentCore Runtime also requires resource-based
+// policies on the **runtime** and on each **agent runtime endpoint** (ARNs from ListAgentRuntimeEndpoints; not always
+// .../endpoint/DEFAULT) so InvokeAgentRuntime is allowed; otherwise CreateGatewayTarget can fail with a misleading
+// execution-role assume error. The test uses two apply steps: first testAccGatewayTargetConfig_infra creates
+// aws_iam_role.test so the execution role ARN exists, then a check calls PutResourcePolicy (gateway role ARN + account root).
+// A second apply adds the gateway target. PutResourcePolicy before the role exists returns ValidationException: Invalid principal.
+// If a policy already exists on the runtime, set
+// TF_ACC_BEDROCK_AGENTCORE_GATEWAY_TARGET_MCP_IAM_ENSURE_RUNTIME_POLICY=1 to replace it (destructive) or edit the policy per
+// https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/security.html#resource-based-policies
+func TestAccBedrockAgentCoreGatewayTarget_gatewayIAMRoleServiceRegionMCPServer(t *testing.T) {
+	ctx := acctest.Context(t)
+	var gatewayTarget bedrockagentcorecontrol.GetGatewayTargetOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bedrockagentcore_gateway_target.test"
+	endpoint := envvar.SkipIfEmpty(t, envvar.BedrockAgentCoreGatewayTargetMCPIAMEndpoint,
+		"set to the bedrock-agentcore.<region>.amazonaws.com/runtimes/.../invocations?qualifier=... MCP URL (see test godoc); or the *.runtime.bedrock-agentcore.../mcp host (auto-normalized)")
+	endpoint = normalizeGatewayTargetMCPIAMEndpointIfRuntimePublicHost(ctx, t, endpoint)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGatewayTargetDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGatewayTargetConfig_infra(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccEnsureBedrockAgentCoreRuntimePoliciesFunc(ctx, t, endpoint, rName),
+				),
+			},
+			{
+				Config: testAccGatewayTargetConfig_gatewayIAMRoleMCPServer(rName, endpoint),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayTargetExists(ctx, t, resourceName, &gatewayTarget),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "credential_provider_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credential_provider_configuration.0.gateway_iam_role.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credential_provider_configuration.0.gateway_iam_role.0.service", "bedrock-agentcore"),
+					resource.TestCheckResourceAttrPair(resourceName, "credential_provider_configuration.0.gateway_iam_role.0.region", "data.aws_region.current", "name"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccBedrockAgentCoreGatewayTarget_credentialProvider_invalid(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -687,13 +1194,37 @@ func testAccGatewayTargetConfig_infra(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "infra" {}
+
+# Match production gateway execution role trust: both Bedrock and AgentCore service
+# principals may assume this role when the gateway connects to targets (including
+# MCP server targets on AgentCore Runtime with IAM / SigV4). See
+# https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-prerequisites-permissions.html
+#
+# Do not add aws:SourceAccount / aws:SourceArn conditions here: some gateway → MCP
+# flows omit those STS context keys, and StringEquals then fails the trust policy
+# with "Gateway service is not authorized to assume the execution role".
+# Use one statement per service principal (matches AWS doc examples).
 data "aws_iam_policy_document" "test" {
   statement {
+    sid     = "AllowBedrockAgentCoreAssumeGatewayExecutionRole"
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
     principals {
       type        = "Service"
       identifiers = ["bedrock-agentcore.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid     = "AllowBedrockAssumeGatewayExecutionRole"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["bedrock.amazonaws.com"]
     }
   }
 }
@@ -707,16 +1238,40 @@ resource "aws_iam_role_policy" "test" {
   name = %[1]q
   role = aws_iam_role.test.name
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Action": "lambda:*",
-    "Resource": "*"
-  }
-}
-  EOF
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "lambda:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "AgentCoreGatewayRuntimeMCP"
+        Effect = "Allow"
+        Action = [
+          "bedrock-agentcore:InvokeAgentRuntime",
+          "bedrock-agentcore:InvokeAgentRuntimeForUser",
+          "bedrock-agentcore:InvokeGateway",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "AgentCoreWorkloadIdentityAndOutboundAuth"
+        Effect = "Allow"
+        Action = [
+          "bedrock-agentcore:GetWorkloadAccessToken",
+          "bedrock-agentcore:GetResourceOauth2Token",
+          "bedrock-agentcore:GetResourceApiKey",
+        ]
+        Resource = [
+          "arn:${data.aws_partition.current.partition}:bedrock-agentcore:${data.aws_region.infra.id}:${data.aws_caller_identity.current.account_id}:workload-identity-directory/default",
+          "arn:${data.aws_partition.current.partition}:bedrock-agentcore:${data.aws_region.infra.id}:${data.aws_caller_identity.current.account_id}:workload-identity-directory/default/workload-identity/*",
+          "arn:${data.aws_partition.current.partition}:bedrock-agentcore:${data.aws_region.infra.id}:${data.aws_caller_identity.current.account_id}:token-vault/*",
+        ]
+      },
+    ]
+  })
 }
 
 data "aws_iam_policy_document" "lambda_assume" {
@@ -840,6 +1395,32 @@ resource "aws_bedrockagentcore_gateway_target" "test" {
   }
 }
 `, rName, credentialProviderContent))
+}
+
+func testAccGatewayTargetConfig_gatewayIAMRoleMCPServer(rName, endpoint string) string {
+	return acctest.ConfigCompose(testAccGatewayTargetConfig_infra(rName), fmt.Sprintf(`
+data "aws_region" "current" {}
+
+resource "aws_bedrockagentcore_gateway_target" "test" {
+  name               = %[1]q
+  gateway_identifier = aws_bedrockagentcore_gateway.test.gateway_id
+
+  credential_provider_configuration {
+    gateway_iam_role {
+      service = "bedrock-agentcore"
+      region  = data.aws_region.current.name
+    }
+  }
+
+  target_configuration {
+    mcp {
+      mcp_server {
+        endpoint = %[2]q
+      }
+    }
+  }
+}
+`, rName, endpoint))
 }
 
 func testAccGatewayTargetConfig_credentialProviderNonLambda(rName, credentialProviderContent string) string {

--- a/internal/service/bedrockagentcore/gateway_target_test.go
+++ b/internal/service/bedrockagentcore/gateway_target_test.go
@@ -985,6 +985,14 @@ func TestAccBedrockAgentCoreGatewayTarget_gatewayIAMRoleServiceRegionMCPServer(t
 					resource.TestCheckResourceAttrPair(resourceName, "credential_provider_configuration.0.gateway_iam_role.0.region", "data.aws_region.current", "name"),
 				),
 			},
+			{
+				Config:                               testAccGatewayTargetConfig_gatewayIAMRoleMCPServer(rName, endpoint),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrsImportStateIdFunc(resourceName, ",", "gateway_identifier", "target_id"),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "target_id",
+			},
 		},
 	})
 }

--- a/internal/service/bedrockagentcore/gateway_target_validate_test.go
+++ b/internal/service/bedrockagentcore/gateway_target_validate_test.go
@@ -1,0 +1,128 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package bedrockagentcore
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+)
+
+func TestValidateGatewayIAMRoleCredentialConfiguration_regionWithoutService(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	data := &gatewayTargetResourceModel{
+		CredentialProviderConfiguration: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &credentialProviderConfigurationModel{
+			ApiKey: fwtypes.NewListNestedObjectValueOfNull[apiKeyCredentialProviderModel](ctx),
+			OAuth:  fwtypes.NewListNestedObjectValueOfNull[oauthCredentialProviderModel](ctx),
+			GatewayIAMRole: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &gatewayIAMRoleProviderModel{
+				Service: types.StringNull(),
+				Region:  types.StringValue(testRegion("us", "east", "1")),
+			}),
+		}),
+	}
+
+	diags := validateGatewayIAMRoleCredentialConfiguration(ctx, data)
+	if !diags.HasError() {
+		t.Fatal("expected error when region is set without service")
+	}
+}
+
+func TestValidateGatewayIAMRoleCredentialConfiguration_mcpServerRequiresService(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	data := &gatewayTargetResourceModel{
+		CredentialProviderConfiguration: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &credentialProviderConfigurationModel{
+			ApiKey: fwtypes.NewListNestedObjectValueOfNull[apiKeyCredentialProviderModel](ctx),
+			OAuth:  fwtypes.NewListNestedObjectValueOfNull[oauthCredentialProviderModel](ctx),
+			GatewayIAMRole: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &gatewayIAMRoleProviderModel{
+				Service: types.StringNull(),
+				Region:  types.StringNull(),
+			}),
+		}),
+		TargetConfiguration: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &targetConfigurationModel{
+			MCP: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &mcpConfigurationModel{
+				ApiGateway:    fwtypes.NewListNestedObjectValueOfNull[mcpApiGatewayConfigurationModel](ctx),
+				Lambda:        fwtypes.NewListNestedObjectValueOfNull[mcpLambdaConfigurationModel](ctx),
+				SmithyModel:   fwtypes.NewListNestedObjectValueOfNull[apiSchemaConfigurationModel](ctx),
+				OpenApiSchema: fwtypes.NewListNestedObjectValueOfNull[apiSchemaConfigurationModel](ctx),
+				MCPServer: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &mcpServerConfigurationModel{
+					Endpoint: types.StringValue("https://example.runtime.bedrock-agentcore." + testRegion("us", "east", "1") + ".amazonaws.com/mcp"),
+				}),
+			}),
+		}),
+	}
+
+	diags := validateGatewayIAMRoleCredentialConfiguration(ctx, data)
+	if !diags.HasError() {
+		t.Fatal("expected error for MCP server target with gateway_iam_role and no service")
+	}
+	msg := diags[0].Detail()
+	if !strings.Contains(msg, "MCP server") {
+		t.Fatalf("unexpected diagnostic: %s", msg)
+	}
+}
+
+func TestValidateGatewayIAMRoleCredentialConfiguration_mcpServerWithService(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	data := &gatewayTargetResourceModel{
+		CredentialProviderConfiguration: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &credentialProviderConfigurationModel{
+			ApiKey: fwtypes.NewListNestedObjectValueOfNull[apiKeyCredentialProviderModel](ctx),
+			OAuth:  fwtypes.NewListNestedObjectValueOfNull[oauthCredentialProviderModel](ctx),
+			GatewayIAMRole: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &gatewayIAMRoleProviderModel{
+				Service: types.StringValue("bedrock-agentcore"),
+				Region:  types.StringValue(testRegion("us", "east", "1")),
+			}),
+		}),
+		TargetConfiguration: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &targetConfigurationModel{
+			MCP: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &mcpConfigurationModel{
+				ApiGateway:    fwtypes.NewListNestedObjectValueOfNull[mcpApiGatewayConfigurationModel](ctx),
+				Lambda:        fwtypes.NewListNestedObjectValueOfNull[mcpLambdaConfigurationModel](ctx),
+				SmithyModel:   fwtypes.NewListNestedObjectValueOfNull[apiSchemaConfigurationModel](ctx),
+				OpenApiSchema: fwtypes.NewListNestedObjectValueOfNull[apiSchemaConfigurationModel](ctx),
+				MCPServer: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &mcpServerConfigurationModel{
+					Endpoint: types.StringValue("https://example.runtime.bedrock-agentcore." + testRegion("us", "east", "1") + ".amazonaws.com/mcp"),
+				}),
+			}),
+		}),
+	}
+
+	diags := validateGatewayIAMRoleCredentialConfiguration(ctx, data)
+	if diags.HasError() {
+		t.Fatalf("unexpected error: %v", diags)
+	}
+}
+
+func TestValidateGatewayIAMRoleCredentialConfiguration_nonMcpEmptyGatewayIAM(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	data := &gatewayTargetResourceModel{
+		CredentialProviderConfiguration: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &credentialProviderConfigurationModel{
+			ApiKey: fwtypes.NewListNestedObjectValueOfNull[apiKeyCredentialProviderModel](ctx),
+			OAuth:  fwtypes.NewListNestedObjectValueOfNull[oauthCredentialProviderModel](ctx),
+			GatewayIAMRole: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &gatewayIAMRoleProviderModel{
+				Service: types.StringNull(),
+				Region:  types.StringNull(),
+			}),
+		}),
+		TargetConfiguration: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &targetConfigurationModel{
+			MCP: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &mcpConfigurationModel{
+				ApiGateway:    fwtypes.NewListNestedObjectValueOfNull[mcpApiGatewayConfigurationModel](ctx),
+				Lambda:        fwtypes.NewListNestedObjectValueOfNull[mcpLambdaConfigurationModel](ctx),
+				SmithyModel:   fwtypes.NewListNestedObjectValueOfNull[apiSchemaConfigurationModel](ctx),
+				OpenApiSchema: fwtypes.NewListNestedObjectValueOfNull[apiSchemaConfigurationModel](ctx),
+				MCPServer:     fwtypes.NewListNestedObjectValueOfNull[mcpServerConfigurationModel](ctx),
+			}),
+		}),
+	}
+
+	diags := validateGatewayIAMRoleCredentialConfiguration(ctx, data)
+	if diags.HasError() {
+		t.Fatalf("unexpected error for non-MCP target with gateway_iam_role {}: %v", diags)
+	}
+}

--- a/internal/service/bedrockagentcore/gateway_target_validate_test.go
+++ b/internal/service/bedrockagentcore/gateway_target_validate_test.go
@@ -12,6 +12,19 @@ import (
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 )
 
+// testAccAgentCoreRuntimeInvocationsMCPURL returns the regional bedrock-agentcore invocations URL shape used for
+// Agent Core Runtime MCP gateway targets (URL-encoded runtime ARN in the path). Matches AWS docs / PR guidance;
+// not used against real AWS in these unit tests.
+func testAccAgentCoreRuntimeInvocationsMCPURL() string {
+	const accountID = "123456789012"
+
+	r := testRegion("us", "east", "1")
+	rawARN := "arn:aws:bedrock-agentcore:" + r + ":" + accountID + ":runtime/example-aBcDeF1234"
+	encoded := strings.ReplaceAll(strings.ReplaceAll(rawARN, ":", "%3A"), "/", "%2F")
+
+	return "https://bedrock-agentcore." + r + ".amazonaws.com/runtimes/" + encoded + "/invocations?qualifier=DEFAULT"
+}
+
 func TestValidateGatewayIAMRoleCredentialConfiguration_regionWithoutService(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -51,7 +64,7 @@ func TestValidateGatewayIAMRoleCredentialConfiguration_mcpServerRequiresService(
 				SmithyModel:   fwtypes.NewListNestedObjectValueOfNull[apiSchemaConfigurationModel](ctx),
 				OpenApiSchema: fwtypes.NewListNestedObjectValueOfNull[apiSchemaConfigurationModel](ctx),
 				MCPServer: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &mcpServerConfigurationModel{
-					Endpoint: types.StringValue("https://example.runtime.bedrock-agentcore." + testRegion("us", "east", "1") + ".amazonaws.com/mcp"),
+					Endpoint: types.StringValue(testAccAgentCoreRuntimeInvocationsMCPURL()),
 				}),
 			}),
 		}),
@@ -86,7 +99,7 @@ func TestValidateGatewayIAMRoleCredentialConfiguration_mcpServerWithService(t *t
 				SmithyModel:   fwtypes.NewListNestedObjectValueOfNull[apiSchemaConfigurationModel](ctx),
 				OpenApiSchema: fwtypes.NewListNestedObjectValueOfNull[apiSchemaConfigurationModel](ctx),
 				MCPServer: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &mcpServerConfigurationModel{
-					Endpoint: types.StringValue("https://example.runtime.bedrock-agentcore." + testRegion("us", "east", "1") + ".amazonaws.com/mcp"),
+					Endpoint: types.StringValue(testAccAgentCoreRuntimeInvocationsMCPURL()),
 				}),
 			}),
 		}),

--- a/website/docs/r/bedrockagentcore_gateway.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway.html.markdown
@@ -10,6 +10,14 @@ description: |-
 
 Manages an AWS Bedrock AgentCore Gateway. With Gateway, developers can convert APIs, Lambda functions, and existing services into Model Context Protocol (MCP)-compatible tools.
 
+## Destroy behavior
+
+The Bedrock AgentCore control plane does not delete a gateway until all [gateway targets](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_ListGatewayTargets.html) are gone. If `terraform destroy` only deleted the `aws_bedrockagentcore_gateway` resource, `DeleteGateway` could fail while targets still existed—for example after a partial apply that left a target in `FAILED`, or when targets remained in AWS but were no longer in Terraform state.
+
+This resource deletes every target on the gateway (list, then `DeleteGatewayTarget` for each, with a wait until each is gone) before calling `DeleteGateway`. That matches the API requirement and allows destroy to succeed in those cases. Target deletion can pass through `FAILED` or `SYNCHRONIZING` before `DELETING`; the provider waits for those during the per-target delete wait.
+
+Prefer managing targets with [`aws_bedrockagentcore_gateway_target`](bedrockagentcore_gateway_target.html.markdown) so Terraform destroys targets before the gateway through normal dependency order. The ordering above still applies when the gateway resource is destroyed on its own.
+
 ## Example Usage
 
 ### Gateway with JWT Authorization

--- a/website/docs/r/bedrockagentcore_gateway_target.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway_target.html.markdown
@@ -10,6 +10,10 @@ description: |-
 
 Manages an AWS Bedrock AgentCore Gateway Target. Gateway targets define the endpoints and configurations that a gateway can invoke, such as Lambda functions or APIs, allowing agents to interact with external services through the Model Context Protocol (MCP).
 
+## Destroy behavior
+
+Amazon Bedrock AgentCore does not allow deleting a gateway while gateway targets still exist. When you destroy an `aws_bedrockagentcore_gateway` resource, the Terraform AWS Provider lists and deletes each `aws_bedrockagentcore_gateway_target`, waits for those deletions to finish, and then deletes the gateway. That ordering lets `terraform destroy` succeed even when a target was left in a failed or lingering state after a partial apply, or when state no longer lists every target that still exists in AWS.
+
 ## Example Usage
 
 ### Lambda Target with Gateway IAM Role

--- a/website/docs/r/bedrockagentcore_gateway_target.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway_target.html.markdown
@@ -12,7 +12,7 @@ Manages an AWS Bedrock AgentCore Gateway Target. Gateway targets define the endp
 
 ## Destroy behavior
 
-Amazon Bedrock AgentCore does not allow deleting a gateway while gateway targets still exist. When you destroy an `aws_bedrockagentcore_gateway` resource, the Terraform AWS Provider lists and deletes each `aws_bedrockagentcore_gateway_target`, waits for those deletions to finish, and then deletes the gateway. That ordering lets `terraform destroy` succeed even when a target was left in a failed or lingering state after a partial apply, or when state no longer lists every target that still exists in AWS.
+You cannot delete a gateway while targets still exist. Destroying an `aws_bedrockagentcore_gateway` removes any remaining `aws_bedrockagentcore_gateway_target` resources first, then deletes the gateway. That avoids failed destroys after a partial apply or when AWS still has targets that are not in state.
 
 ## Example Usage
 

--- a/website/docs/r/bedrockagentcore_gateway_target.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway_target.html.markdown
@@ -335,7 +335,10 @@ resource "aws_bedrockagentcore_gateway_target" "mcp_iam" {
   target_configuration {
     mcp {
       mcp_server {
-        endpoint = "https://example.runtime.bedrock-agentcore.us-east-1.amazonaws.com/mcp"
+        # For Agent Core Runtime MCP with gateway IAM (SigV4), use the regional invocations URL with a URL-encoded
+        # runtime ARN (see Amazon Bedrock AgentCore gateway + VPC egress docs). The public *.runtime.bedrock-agentcore.../mcp
+        # hostname is for other clients and commonly fails gateway tool sync with a misleading execution-role error.
+        endpoint = "https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/arn%3Aaws%3Abedrock-agentcore%3Aus-east-1%3A123456789012%3Aruntime%2Fexample-aBcDeF1234/invocations?qualifier=DEFAULT"
       }
     }
   }
@@ -484,7 +487,7 @@ The `s3` block supports the following:
 
 The `mcp_server` block supports the following:
 
-* `endpoint` - (Required) Endpoint for the MCP server target configuration.
+* `endpoint` - (Required) HTTPS MCP server endpoint. For **Amazon Bedrock AgentCore Runtime**, use the regional **invocations** URL with a **URL-encoded runtime ARN** in the path (for example `https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/arn%3Aaws%3Abedrock-agentcore%3Aus-east-1%3A123456789012%3Aruntime%2Fexample-aBcDeF1234/invocations?qualifier=DEFAULT`), not the public `*.runtime.bedrock-agentcore.<region>.amazonaws.com/mcp` hostname; the latter is a different entry point and often breaks gateway tool discovery.
 
 ### `api_schema_configuration`
 

--- a/website/docs/r/bedrockagentcore_gateway_target.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway_target.html.markdown
@@ -12,7 +12,9 @@ Manages an AWS Bedrock AgentCore Gateway Target. Gateway targets define the endp
 
 ## Destroy behavior
 
-You cannot delete a gateway while targets still exist. Destroying an `aws_bedrockagentcore_gateway` removes any remaining `aws_bedrockagentcore_gateway_target` resources first, then deletes the gateway. That avoids failed destroys after a partial apply or when AWS still has targets that are not in state.
+You cannot delete a gateway while targets still exist. The [`aws_bedrockagentcore_gateway`](bedrockagentcore_gateway.html.markdown) resource therefore removes any remaining gateway targets before it deletes the gateway (see **Destroy behavior** on that page). That fixes destroys that previously failed with API errors when targets were still attached—for example after a failed target create left a target in `FAILED`, or when state and AWS were out of sync.
+
+When you destroy a gateway target with this resource, deletion can pass through `FAILED` or `SYNCHRONIZING` before the target reaches `DELETING`; the provider waits for those intermediate states.
 
 ## Example Usage
 

--- a/website/docs/r/bedrockagentcore_gateway_target.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway_target.html.markdown
@@ -194,7 +194,7 @@ resource "aws_bedrockagentcore_gateway_target" "oauth_example" {
     oauth {
       provider_arn       = "arn:aws:iam::123456789012:oidc-provider/oauth.example.com"
       scopes             = ["read", "write"]
-      grant_type         = "authorization_code"
+      grant_type         = "AUTHORIZATION_CODE"
       default_return_url = "https://myapp.example.com/callback"
 
       custom_parameters = {
@@ -399,7 +399,7 @@ The `oauth` block supports the following:
 * `provider_arn` - (Required) ARN of the Oauth credential provider for OAuth authentication.
 * `grant_type` - (Optional) The OAuth grant type. Valid values: `CLIENT_CREDENTIALS` (machine-to-machine authentication), `AUTHORIZATION_CODE` (user-delegated access).
 * `default_return_url` - (Optional) The URL where the end user's browser is redirected after obtaining the authorization code. Required when `grant_type` is `AUTHORIZATION_CODE`.
-* `scopes` - (Optional) Set of OAuth scopes to request.
+* `scopes` - (Required) Set of OAuth scopes to request.
 * `custom_parameters` - (Optional) Map of custom parameters to include in OAuth requests.
 
 ### `metadata_configuration`
@@ -456,7 +456,7 @@ The `tool_override` block supports the following:
 
 * `description` - (Optional) Description of the tool. Provides information about the purpose and usage of the tool. If not provided, uses the description from the API's OpenAPI specification.
 * `method` - (Required) HTTP method to expose for the specified path. Valid values: `GET`, `DELETE`, `HEAD`, `OPTIONS`, `PATCH`, `PUT` and `POST`.
-* `name` - (Optional) Name of tool. Identifies the tool in the Model Context Protocol.
+* `name` - (Required) Name of tool. Identifies the tool in the Model Context Protocol.
 * `path` - (Required) Resource path in the REST API (e.g., `/pets`). Must explicitly match an existing path in the REST API.
 
 ### `lambda`

--- a/website/docs/r/bedrockagentcore_gateway_target.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway_target.html.markdown
@@ -314,6 +314,34 @@ resource "aws_bedrockagentcore_gateway_target" "mcp_with_headers" {
 }
 ```
 
+### MCP Server Target with IAM (SigV4) to Agent Core
+
+For MCP server targets that require IAM authentication using the gateway role, set `service` (and optionally `region`) inside `gateway_iam_role`. See the [AWS documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html).
+
+```terraform
+data "aws_region" "current" {}
+
+resource "aws_bedrockagentcore_gateway_target" "mcp_iam" {
+  name               = "example-mcp-iam"
+  gateway_identifier = aws_bedrockagentcore_gateway.example.gateway_id
+
+  credential_provider_configuration {
+    gateway_iam_role {
+      service = "bedrock-agentcore"
+      region  = data.aws_region.current.id
+    }
+  }
+
+  target_configuration {
+    mcp {
+      mcp_server {
+        endpoint = "https://example.runtime.bedrock-agentcore.us-east-1.amazonaws.com/mcp"
+      }
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -324,7 +352,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `credential_provider_configuration` - (Optional) Configuration for authenticating requests to the target. Required when using `lambda`, `open_api_schema` and `smithy_model` in `mcp` block. If using `mcp_server` in `mcp` block with no authorization, it should not be specified. See [`credential_provider_configuration`](#credential_provider_configuration) below.
+* `credential_provider_configuration` - (Optional) Configuration for authenticating requests to the target. Required when using `lambda`, `open_api_schema` and `smithy_model` in `mcp` block. If using `mcp_server` in `mcp` block with no authorization, it should not be specified. For `mcp_server` targets that use IAM outbound authentication, use `gateway_iam_role` with `service` (and optionally `region`). See [`credential_provider_configuration`](#credential_provider_configuration) below.
 * `description` - (Optional) Description of the gateway target.
 * `metadata_configuration` - (Optional) Configuration for HTTP header and query parameter propagation between the gateway and target servers. See [`metadata_configuration`](#metadata_configuration) below.
 * `region` - (Optional) AWS region where the resource will be created. If not provided, the region from the provider configuration will be used.
@@ -333,9 +361,18 @@ The following arguments are optional:
 
 The `credential_provider_configuration` block supports exactly one of the following:
 
-* `gateway_iam_role` - (Optional) Use the gateway's IAM role for authentication. This is an empty configuration block.
+* `gateway_iam_role` - (Optional) Use the gateway's IAM role for SigV4 authentication to the target. See [`gateway_iam_role`](#gateway_iam_role) below.
 * `api_key` - (Optional) API key-based authentication configuration. See [`api_key`](#api_key) below.
 * `oauth` - (Optional) OAuth-based authentication configuration. See [`oauth`](#oauth) below.
+
+### `gateway_iam_role`
+
+The `gateway_iam_role` block supports the following:
+
+* `service` - (Optional) AWS service name to use for SigV4 signing (for example, `bedrock-agentcore` for MCP servers on Amazon Bedrock Agent Core, `execute-api` for API Gateway, or `lambda` for Lambda function URLs). Required for many [MCP server targets that use IAM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html). For Lambda, API Gateway, and Smithy model targets, omit `service` and `region` so only the credential provider type is sent.
+* `region` - (Optional) AWS Region used for SigV4 signing. Defaults to the gateway's Region when omitted.
+
+~> **Note:** At plan time, Terraform requires `service` whenever `region` is set (the AWS API requires a service name for SigV4 when `IamCredentialProvider` is populated). Terraform also requires `service` when this block is used with an [`mcp_server`](#mcp_server) target, per AWS guidance for MCP IAM outbound authentication.
 
 ### `api_key`
 


### PR DESCRIPTION
## Rollback Plan

If this needs to be reverted after merge, revert the PR (or restore the prior resource behavior in a follow-up patch release).

## Changes to Security Controls

No. This PR adds optional IAM-related fields for gateway targets, documentation, and delete behavior for existing resources. It does not change encryption, logging, or account-wide access controls beyond what Terraform already applies when managing these resources.

### Description

**Enhancement — `gateway_iam_role` for MCP + IAM (SigV4)**

Adds `service` and `region` to `credential_provider_configuration.gateway_iam_role` on `aws_bedrockagentcore_gateway_target`, with plan-time validation when `region` is set without `service`, and when an `mcp_server` target uses `gateway_iam_role` without `service`. This matches IAM-based outbound auth for MCP server targets (including Amazon Bedrock AgentCore Runtime).

Schema and website docs clarify that for Agent Core Runtime, `mcp_server.endpoint` should use the regional **invocations** URL (URL-encoded runtime ARN in the path), not only the public `*.runtime.bedrock-agentcore.<region>.amazonaws.com/mcp` hostname, which is a different entry point and often breaks gateway tool discovery.

The registry page for `aws_bedrockagentcore_gateway_target` is also aligned with the resource schema where it had drifted: OAuth `scopes` and API Gateway `tool_override` `name` are documented as required, and the OAuth example uses `grant_type = "AUTHORIZATION_CODE"`.

**Optional acceptance test**

When `TF_ACC_BEDROCK_AGENTCORE_GATEWAY_TARGET_MCP_IAM_ENDPOINT` is set, `TestAccBedrockAgentCoreGatewayTarget_gatewayIAMRoleServiceRegionMCPServer` exercises MCP + `gateway_iam_role` against a real endpoint, including **import** (`ImportState`). It uses a two-step apply so resource policies can reference the gateway execution role ARN; see `internal/envvar/envvar.go` for URL shape and IAM permissions on the runtime and endpoints. Skipped in default CI when unset.

**Bug fix — gateway and gateway target destroy**

Previously, destroying only an `aws_bedrockagentcore_gateway` could fail if targets still existed (API error from `DeleteGateway`), including after a partial apply that left a target in `FAILED`, or when AWS still had targets not reflected in state. The provider now deletes each gateway target first, then the gateway.

Deleting a `aws_bedrockagentcore_gateway_target` could also error while the target was still `FAILED` or `SYNCHRONIZING` before AWS moved it to `DELETING`; the delete waiter now treats those as pending states.

Documented under **Destroy behavior** on [`aws_bedrockagentcore_gateway`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagentcore_gateway) and [`aws_bedrockagentcore_gateway_target`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagentcore_gateway_target). Changelog: `.changelog/47264.txt` (two bug-fix notes plus the enhancement).

### Relations

Closes #47264

### References

- [DeleteGateway](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_DeleteGateway.html) (gateway must have no targets)
- [Resource-based policies — Amazon Bedrock AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/security.html#resource-based-policies)
- [Set up permissions for AgentCore Gateway](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-prerequisites-permissions.html)

### Output from Acceptance Testing

**Short tests (no AWS credentials required):**

```console
% go test -short -count=1 ./internal/service/bedrockagentcore/
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore	6.9s
```

**Optional full acceptance test** (same package; `TF_ACC=1` and `TF_ACC_BEDROCK_AGENTCORE_GATEWAY_TARGET_MCP_IAM_ENDPOINT`; see `internal/envvar/envvar.go`). Log excerpt uses placeholders for account IDs, runtime IDs, role names, and hostnames:

```console
% export GOTOOLCHAIN=auto
% export TF_ACC=1
% export TF_ACC_BEDROCK_AGENTCORE_GATEWAY_TARGET_MCP_IAM_ENDPOINT='https://<runtime-id>.runtime.bedrock-agentcore.us-east-1.amazonaws.com/mcp'
% go test -run TestAccBedrockAgentCoreGatewayTarget_gatewayIAMRoleServiceRegionMCPServer -timeout 60m -count=1 -v ./internal/service/bedrockagentcore/
=== RUN   TestAccBedrockAgentCoreGatewayTarget_gatewayIAMRoleServiceRegionMCPServer
    gateway_target_test.go:1234: normalized TF_ACC_BEDROCK_AGENTCORE_GATEWAY_TARGET_MCP_IAM_ENDPOINT from public *.runtime.bedrock-agentcore host to invocations URL (required for gateway MCP + IAM tool sync)
=== PAUSE TestAccBedrockAgentCoreGatewayTarget_gatewayIAMRoleServiceRegionMCPServer
=== CONT  TestAccBedrockAgentCoreGatewayTarget_gatewayIAMRoleServiceRegionMCPServer
    testing.go:1076: discovered 1 agent runtime endpoint ARN(s) for resource policy
    testing.go:1076: PutResourcePolicy on arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/<runtime-id> to allow principals [arn:aws:iam::123456789012:role/tf-acc-test-<suffix> arn:aws:iam::123456789012:root] for InvokeAgentRuntime (IAM MCP acceptance)
    testing.go:1076: PutResourcePolicy on arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/<runtime-id>/runtime-endpoint/DEFAULT to allow principals [arn:aws:iam::123456789012:role/tf-acc-test-<suffix> arn:aws:iam::123456789012:root] for InvokeAgentRuntime (IAM MCP acceptance)
--- PASS: TestAccBedrockAgentCoreGatewayTarget_gatewayIAMRoleServiceRegionMCPServer (64.95s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore	71.340s
```

From the provider repository root (sets `TF_ACC=1`; export the `TF_ACC_BEDROCK_AGENTCORE_*` env vars first):

```console
% make testacc PKG=bedrockagentcore TESTS=TestAccBedrockAgentCoreGatewayTarget_gatewayIAMRoleServiceRegionMCPServer
```

See [Running and writing acceptance tests](https://hashicorp.github.io/terraform-provider-aws/running-and-writing-acceptance-tests).
