### PR TITLE
redshift: treat Maintenance as pending during cluster create

### DIFF
--- a/.changelog/47460.txt
+++ b/.changelog/47460.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_redshift_cluster: Prevent failures during creation when the cluster enters `Maintenance`.
+```

--- a/internal/service/redshift/wait.go
+++ b/internal/service/redshift/wait.go
@@ -18,7 +18,7 @@ import (
 
 func waitClusterCreated(ctx context.Context, conn *redshift.Client, id string, timeout time.Duration) (*awstypes.Cluster, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{clusterAvailabilityStatusModifying, clusterAvailabilityStatusUnavailable},
+		Pending:    []string{clusterAvailabilityStatusMaintenance, clusterAvailabilityStatusModifying, clusterAvailabilityStatusUnavailable},
 		Target:     []string{clusterAvailabilityStatusAvailable},
 		Refresh:    statusClusterAvailability(conn, id),
 		Timeout:    timeout,


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No

### Description

Acceptance test TestAccRedshiftClusterSnapshot_Tags_ComputedTag_OnUpdate_add failed in Step 1/3 while creating the backing aws_redshift_cluster.test from internal/service/redshift/testdata/ClusterSnapshot/tags/main_gen.tf.

Original error:

> Error: creating Redshift Cluster (tf-acc-test-8275424384619408802): waiting for completion: unexpected state 'Maintenance', wanted target 'Available'. last error: creating

Amazon Redshift documents ClusterAvailabilityStatus values as Available, Unavailable, Maintenance, Modifying, and Failed in the Cluster API reference. AWS re:Post also describes Maintenance as a normal state while Redshift applies updates or performs system tasks. waitClusterCreated should therefore treat Maintenance as pending, matching the existing Redshift update and delete waiters.

I'm not sure how I can force a maintenance state intentionally to have a test that breaks always without this change, so didn't add it. Normally in other software I would cover this with unit tests but somehow I don't see many around Redshift here so I guess there's a good reason for it so I didn't add unit tests either.

### Relations

This error was originally found when I was running the acceptance tests for #47435.

### References

- https://docs.aws.amazon.com/redshift/latest/APIReference/API_Cluster.html
- https://repost.aws/knowledge-center/redshift-cluster-status


### Output from Acceptance Testing

I tried to run all the tests that create a cluster. The failed test cases are fixed in #47444

<details><summary>Output</summary>

```console
$ TF_ACC=1 go1.25.9 test ./internal/service/redshift/ -v -count 1 -parallel 4 -run='^(TestAccRedshiftCluster(_|$)|TestAccRedshiftClusterSnapshot(_|$)|TestAccRedshiftClusterDataSource(_|$)|TestAccRedshiftClusterCredentialsDataSource(_|$)|TestAccRedshiftClusterIAMRoles(_|$)|TestAccRedshiftEndpointAccess(_|$)|TestAccRedshiftEndpointAuthorization(_|$)|TestAccRedshiftLogging(_|$)|TestAccRedshiftPartner(_|$)|TestAccRedshiftResourcePolicy(_|$)|TestAccRedshiftSnapshotCopy(_|$)|TestAccRedshiftSnapshotScheduleAssociation(_|$)|TestAccRedshiftUsageLimit(_|$))' -timeout 360m
2026/04/14 21:56:03 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/14 21:56:03 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRedshiftClusterCredentialsDataSource_basic
=== PAUSE TestAccRedshiftClusterCredentialsDataSource_basic
=== RUN   TestAccRedshiftClusterDataSource_tags
=== PAUSE TestAccRedshiftClusterDataSource_tags
=== RUN   TestAccRedshiftClusterDataSource_Tags_nullMap
=== PAUSE TestAccRedshiftClusterDataSource_Tags_nullMap
=== RUN   TestAccRedshiftClusterDataSource_Tags_emptyMap
=== PAUSE TestAccRedshiftClusterDataSource_Tags_emptyMap
=== RUN   TestAccRedshiftClusterDataSource_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccRedshiftClusterDataSource_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccRedshiftClusterDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccRedshiftClusterDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccRedshiftClusterDataSource_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccRedshiftClusterDataSource_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccRedshiftClusterDataSource_basic
=== PAUSE TestAccRedshiftClusterDataSource_basic
=== RUN   TestAccRedshiftClusterDataSource_vpc
=== PAUSE TestAccRedshiftClusterDataSource_vpc
=== RUN   TestAccRedshiftClusterDataSource_logging
=== PAUSE TestAccRedshiftClusterDataSource_logging
=== RUN   TestAccRedshiftClusterDataSource_availabilityZoneRelocationEnabled
=== PAUSE TestAccRedshiftClusterDataSource_availabilityZoneRelocationEnabled
=== RUN   TestAccRedshiftClusterDataSource_multiAZEnabled
=== PAUSE TestAccRedshiftClusterDataSource_multiAZEnabled
=== RUN   TestAccRedshiftClusterIAMRoles_basic
=== PAUSE TestAccRedshiftClusterIAMRoles_basic
=== RUN   TestAccRedshiftClusterIAMRoles_disappears
=== PAUSE TestAccRedshiftClusterIAMRoles_disappears
=== RUN   TestAccRedshiftClusterSnapshot_tags
=== PAUSE TestAccRedshiftClusterSnapshot_tags
=== RUN   TestAccRedshiftClusterSnapshot_Tags_null
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_null
=== RUN   TestAccRedshiftClusterSnapshot_Tags_emptyMap
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_emptyMap
=== RUN   TestAccRedshiftClusterSnapshot_Tags_addOnUpdate
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_addOnUpdate
=== RUN   TestAccRedshiftClusterSnapshot_Tags_EmptyTag_onCreate
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_EmptyTag_onCreate
=== RUN   TestAccRedshiftClusterSnapshot_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccRedshiftClusterSnapshot_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccRedshiftClusterSnapshot_Tags_DefaultTags_providerOnly
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_DefaultTags_providerOnly
=== RUN   TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccRedshiftClusterSnapshot_Tags_DefaultTags_overlapping
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_DefaultTags_overlapping
=== RUN   TestAccRedshiftClusterSnapshot_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccRedshiftClusterSnapshot_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccRedshiftClusterSnapshot_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccRedshiftClusterSnapshot_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccRedshiftClusterSnapshot_Tags_ComputedTag_onCreate
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_ComputedTag_onCreate
=== RUN   TestAccRedshiftClusterSnapshot_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccRedshiftClusterSnapshot_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccRedshiftClusterSnapshot_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccRedshiftClusterSnapshot_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccRedshiftClusterSnapshot_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccRedshiftClusterSnapshot_basic
=== PAUSE TestAccRedshiftClusterSnapshot_basic
=== RUN   TestAccRedshiftClusterSnapshot_disappears
=== PAUSE TestAccRedshiftClusterSnapshot_disappears
=== RUN   TestAccRedshiftCluster_tags
=== PAUSE TestAccRedshiftCluster_tags
=== RUN   TestAccRedshiftCluster_Tags_null
=== PAUSE TestAccRedshiftCluster_Tags_null
=== RUN   TestAccRedshiftCluster_Tags_emptyMap
=== PAUSE TestAccRedshiftCluster_Tags_emptyMap
=== RUN   TestAccRedshiftCluster_Tags_addOnUpdate
=== PAUSE TestAccRedshiftCluster_Tags_addOnUpdate
=== RUN   TestAccRedshiftCluster_Tags_EmptyTag_onCreate
=== PAUSE TestAccRedshiftCluster_Tags_EmptyTag_onCreate
=== RUN   TestAccRedshiftCluster_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccRedshiftCluster_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccRedshiftCluster_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccRedshiftCluster_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccRedshiftCluster_Tags_DefaultTags_providerOnly
=== PAUSE TestAccRedshiftCluster_Tags_DefaultTags_providerOnly
=== RUN   TestAccRedshiftCluster_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccRedshiftCluster_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccRedshiftCluster_Tags_DefaultTags_overlapping
=== PAUSE TestAccRedshiftCluster_Tags_DefaultTags_overlapping
=== RUN   TestAccRedshiftCluster_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccRedshiftCluster_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccRedshiftCluster_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccRedshiftCluster_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccRedshiftCluster_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccRedshiftCluster_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccRedshiftCluster_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccRedshiftCluster_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccRedshiftCluster_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccRedshiftCluster_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccRedshiftCluster_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccRedshiftCluster_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccRedshiftCluster_Tags_ComputedTag_onCreate
=== PAUSE TestAccRedshiftCluster_Tags_ComputedTag_onCreate
=== RUN   TestAccRedshiftCluster_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccRedshiftCluster_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccRedshiftCluster_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccRedshiftCluster_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccRedshiftCluster_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccRedshiftCluster_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccRedshiftCluster_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccRedshiftCluster_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccRedshiftCluster_basic
=== PAUSE TestAccRedshiftCluster_basic
=== RUN   TestAccRedshiftCluster_aqua
=== PAUSE TestAccRedshiftCluster_aqua
=== RUN   TestAccRedshiftCluster_disappears
=== PAUSE TestAccRedshiftCluster_disappears
=== RUN   TestAccRedshiftCluster_withFinalSnapshot
=== PAUSE TestAccRedshiftCluster_withFinalSnapshot
=== RUN   TestAccRedshiftCluster_kmsKey
=== PAUSE TestAccRedshiftCluster_kmsKey
=== RUN   TestAccRedshiftCluster_enhancedVPCRoutingEnabled
=== PAUSE TestAccRedshiftCluster_enhancedVPCRoutingEnabled
=== RUN   TestAccRedshiftCluster_iamRoles
=== PAUSE TestAccRedshiftCluster_iamRoles
=== RUN   TestAccRedshiftCluster_publiclyAccessible
=== PAUSE TestAccRedshiftCluster_publiclyAccessible
=== RUN   TestAccRedshiftCluster_publiclyAccessible_default
=== PAUSE TestAccRedshiftCluster_publiclyAccessible_default
=== RUN   TestAccRedshiftCluster_updateNodeCount
=== PAUSE TestAccRedshiftCluster_updateNodeCount
=== RUN   TestAccRedshiftCluster_updateNodeType
=== PAUSE TestAccRedshiftCluster_updateNodeType
=== RUN   TestAccRedshiftCluster_masterUsername
=== PAUSE TestAccRedshiftCluster_masterUsername
=== RUN   TestAccRedshiftCluster_masterUsername_invalid
=== PAUSE TestAccRedshiftCluster_masterUsername_invalid
=== RUN   TestAccRedshiftCluster_changeAvailabilityZone
=== PAUSE TestAccRedshiftCluster_changeAvailabilityZone
=== RUN   TestAccRedshiftCluster_changeAvailabilityZoneAndSetAvailabilityZoneRelocation
=== PAUSE TestAccRedshiftCluster_changeAvailabilityZoneAndSetAvailabilityZoneRelocation
=== RUN   TestAccRedshiftCluster_changeAvailabilityZone_availabilityZoneRelocationNotSet
=== PAUSE TestAccRedshiftCluster_changeAvailabilityZone_availabilityZoneRelocationNotSet
=== RUN   TestAccRedshiftCluster_changeEncryption_unsetToFalse
=== PAUSE TestAccRedshiftCluster_changeEncryption_unsetToFalse
=== RUN   TestAccRedshiftCluster_changeEncryption_unsetToTrue
=== PAUSE TestAccRedshiftCluster_changeEncryption_unsetToTrue
=== RUN   TestAccRedshiftCluster_changeEncryption_trueToFalse
=== PAUSE TestAccRedshiftCluster_changeEncryption_trueToFalse
=== RUN   TestAccRedshiftCluster_changeEncryption_falseToTrue
=== PAUSE TestAccRedshiftCluster_changeEncryption_falseToTrue
=== RUN   TestAccRedshiftCluster_changeEncryption_falseToUnset
=== PAUSE TestAccRedshiftCluster_changeEncryption_falseToUnset
=== RUN   TestAccRedshiftCluster_changeEncryption_trueToUnset
=== PAUSE TestAccRedshiftCluster_changeEncryption_trueToUnset
=== RUN   TestAccRedshiftCluster_availabilityZoneRelocation
=== PAUSE TestAccRedshiftCluster_availabilityZoneRelocation
=== RUN   TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible
=== PAUSE TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible
=== RUN   TestAccRedshiftCluster_restoreFromSnapshot_Identifier
=== PAUSE TestAccRedshiftCluster_restoreFromSnapshot_Identifier
=== RUN   TestAccRedshiftCluster_restoreFromSnapshot_ARN
=== PAUSE TestAccRedshiftCluster_restoreFromSnapshot_ARN
=== RUN   TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_trueToFalse
=== PAUSE TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_trueToFalse
=== RUN   TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_falseToTrue
=== PAUSE TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_falseToTrue
=== RUN   TestAccRedshiftCluster_manageMasterPassword
=== PAUSE TestAccRedshiftCluster_manageMasterPassword
=== RUN   TestAccRedshiftCluster_multiAZ
=== PAUSE TestAccRedshiftCluster_multiAZ
=== RUN   TestAccRedshiftCluster_passwordWriteOnly
=== PAUSE TestAccRedshiftCluster_passwordWriteOnly
=== RUN   TestAccRedshiftCluster_port
=== PAUSE TestAccRedshiftCluster_port
=== RUN   TestAccRedshiftEndpointAccess_basic
=== PAUSE TestAccRedshiftEndpointAccess_basic
=== RUN   TestAccRedshiftEndpointAccess_sgs
=== PAUSE TestAccRedshiftEndpointAccess_sgs
=== RUN   TestAccRedshiftEndpointAccess_disappears
=== PAUSE TestAccRedshiftEndpointAccess_disappears
=== RUN   TestAccRedshiftEndpointAccess_disappears_cluster
=== PAUSE TestAccRedshiftEndpointAccess_disappears_cluster
=== RUN   TestAccRedshiftEndpointAuthorization_basic
=== PAUSE TestAccRedshiftEndpointAuthorization_basic
=== RUN   TestAccRedshiftEndpointAuthorization_vpcs
=== PAUSE TestAccRedshiftEndpointAuthorization_vpcs
=== RUN   TestAccRedshiftEndpointAuthorization_disappears
=== PAUSE TestAccRedshiftEndpointAuthorization_disappears
=== RUN   TestAccRedshiftEndpointAuthorization_disappears_cluster
=== PAUSE TestAccRedshiftEndpointAuthorization_disappears_cluster
=== RUN   TestAccRedshiftLogging_basic
=== PAUSE TestAccRedshiftLogging_basic
=== RUN   TestAccRedshiftLogging_disappears
=== PAUSE TestAccRedshiftLogging_disappears
=== RUN   TestAccRedshiftLogging_disappears_Cluster
=== PAUSE TestAccRedshiftLogging_disappears_Cluster
=== RUN   TestAccRedshiftLogging_s3
=== PAUSE TestAccRedshiftLogging_s3
=== RUN   TestAccRedshiftPartner_basic
=== PAUSE TestAccRedshiftPartner_basic
=== RUN   TestAccRedshiftPartner_disappears
=== PAUSE TestAccRedshiftPartner_disappears
=== RUN   TestAccRedshiftPartner_disappears_cluster
=== PAUSE TestAccRedshiftPartner_disappears_cluster
=== RUN   TestAccRedshiftResourcePolicy_basic
=== PAUSE TestAccRedshiftResourcePolicy_basic
=== RUN   TestAccRedshiftResourcePolicy_disappears
=== PAUSE TestAccRedshiftResourcePolicy_disappears
=== RUN   TestAccRedshiftSnapshotCopy_basic
=== PAUSE TestAccRedshiftSnapshotCopy_basic
=== RUN   TestAccRedshiftSnapshotCopy_disappears
=== PAUSE TestAccRedshiftSnapshotCopy_disappears
=== RUN   TestAccRedshiftSnapshotCopy_disappears_Cluster
=== PAUSE TestAccRedshiftSnapshotCopy_disappears_Cluster
=== RUN   TestAccRedshiftSnapshotCopy_retentionPeriod
=== PAUSE TestAccRedshiftSnapshotCopy_retentionPeriod
=== RUN   TestAccRedshiftSnapshotScheduleAssociation_basic
=== PAUSE TestAccRedshiftSnapshotScheduleAssociation_basic
=== RUN   TestAccRedshiftSnapshotScheduleAssociation_disappears
=== PAUSE TestAccRedshiftSnapshotScheduleAssociation_disappears
=== RUN   TestAccRedshiftSnapshotScheduleAssociation_disappears_cluster
=== PAUSE TestAccRedshiftSnapshotScheduleAssociation_disappears_cluster
=== RUN   TestAccRedshiftUsageLimit_tags
=== PAUSE TestAccRedshiftUsageLimit_tags
=== RUN   TestAccRedshiftUsageLimit_Tags_null
=== PAUSE TestAccRedshiftUsageLimit_Tags_null
=== RUN   TestAccRedshiftUsageLimit_Tags_emptyMap
=== PAUSE TestAccRedshiftUsageLimit_Tags_emptyMap
=== RUN   TestAccRedshiftUsageLimit_Tags_addOnUpdate
=== PAUSE TestAccRedshiftUsageLimit_Tags_addOnUpdate
=== RUN   TestAccRedshiftUsageLimit_Tags_EmptyTag_onCreate
=== PAUSE TestAccRedshiftUsageLimit_Tags_EmptyTag_onCreate
=== RUN   TestAccRedshiftUsageLimit_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccRedshiftUsageLimit_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccRedshiftUsageLimit_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccRedshiftUsageLimit_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccRedshiftUsageLimit_Tags_DefaultTags_providerOnly
=== PAUSE TestAccRedshiftUsageLimit_Tags_DefaultTags_providerOnly
=== RUN   TestAccRedshiftUsageLimit_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccRedshiftUsageLimit_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccRedshiftUsageLimit_Tags_DefaultTags_overlapping
=== PAUSE TestAccRedshiftUsageLimit_Tags_DefaultTags_overlapping
=== RUN   TestAccRedshiftUsageLimit_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccRedshiftUsageLimit_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccRedshiftUsageLimit_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccRedshiftUsageLimit_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccRedshiftUsageLimit_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccRedshiftUsageLimit_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccRedshiftUsageLimit_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccRedshiftUsageLimit_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccRedshiftUsageLimit_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccRedshiftUsageLimit_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccRedshiftUsageLimit_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccRedshiftUsageLimit_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccRedshiftUsageLimit_Tags_ComputedTag_onCreate
=== PAUSE TestAccRedshiftUsageLimit_Tags_ComputedTag_onCreate
=== RUN   TestAccRedshiftUsageLimit_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccRedshiftUsageLimit_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccRedshiftUsageLimit_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccRedshiftUsageLimit_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccRedshiftUsageLimit_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccRedshiftUsageLimit_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccRedshiftUsageLimit_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccRedshiftUsageLimit_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccRedshiftUsageLimit_basic
=== PAUSE TestAccRedshiftUsageLimit_basic
=== RUN   TestAccRedshiftUsageLimit_disappears
=== PAUSE TestAccRedshiftUsageLimit_disappears
=== CONT  TestAccRedshiftClusterCredentialsDataSource_basic
=== CONT  TestAccRedshiftCluster_masterUsername
=== CONT  TestAccRedshiftUsageLimit_disappears
=== CONT  TestAccRedshiftPartner_disappears
--- PASS: TestAccRedshiftUsageLimit_disappears (253.10s)
=== CONT  TestAccRedshiftClusterSnapshot_basic
--- PASS: TestAccRedshiftClusterCredentialsDataSource_basic (278.24s)
=== CONT  TestAccRedshiftCluster_updateNodeType
--- PASS: TestAccRedshiftPartner_disappears (307.44s)
=== CONT  TestAccRedshiftCluster_updateNodeCount
--- PASS: TestAccRedshiftCluster_masterUsername (539.29s)
=== CONT  TestAccRedshiftCluster_publiclyAccessible_default
--- PASS: TestAccRedshiftClusterSnapshot_basic (512.35s)
=== CONT  TestAccRedshiftCluster_publiclyAccessible
--- PASS: TestAccRedshiftCluster_publiclyAccessible_default (357.79s)
=== CONT  TestAccRedshiftCluster_iamRoles
--- PASS: TestAccRedshiftCluster_publiclyAccessible (343.07s)
=== CONT  TestAccRedshiftCluster_enhancedVPCRoutingEnabled
--- PASS: TestAccRedshiftCluster_iamRoles (322.63s)
=== CONT  TestAccRedshiftCluster_kmsKey
--- PASS: TestAccRedshiftCluster_updateNodeCount (966.29s)
=== CONT  TestAccRedshiftCluster_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccRedshiftCluster_updateNodeType (1039.33s)
=== CONT  TestAccRedshiftCluster_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccRedshiftCluster_kmsKey (285.27s)
=== CONT  TestAccRedshiftCluster_Tags_DefaultTags_overlapping
--- PASS: TestAccRedshiftCluster_Tags_DefaultTags_updateToResourceOnly (326.01s)
=== CONT  TestAccRedshiftCluster_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccRedshiftCluster_Tags_DefaultTags_updateToProviderOnly (319.78s)
=== CONT  TestAccRedshiftCluster_Tags_DefaultTags_providerOnly
--- PASS: TestAccRedshiftCluster_enhancedVPCRoutingEnabled (579.75s)
=== CONT  TestAccRedshiftCluster_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccRedshiftCluster_Tags_DefaultTags_overlapping (370.49s)
=== CONT  TestAccRedshiftCluster_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccRedshiftCluster_Tags_DefaultTags_nonOverlapping (384.29s)
=== CONT  TestAccRedshiftCluster_Tags_EmptyTag_onCreate
--- PASS: TestAccRedshiftCluster_Tags_EmptyTag_OnUpdate_replace (346.76s)
=== CONT  TestAccRedshiftCluster_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccRedshiftCluster_Tags_DefaultTags_providerOnly (425.45s)
=== CONT  TestAccRedshiftCluster_Tags_addOnUpdate
--- PASS: TestAccRedshiftCluster_Tags_EmptyTag_OnUpdate_add (387.29s)
=== CONT  TestAccRedshiftCluster_withFinalSnapshot
--- PASS: TestAccRedshiftCluster_Tags_EmptyTag_onCreate (357.66s)
=== CONT  TestAccRedshiftCluster_Tags_emptyMap
--- PASS: TestAccRedshiftCluster_Tags_DefaultTags_emptyResourceTag (313.56s)
=== CONT  TestAccRedshiftCluster_disappears
--- PASS: TestAccRedshiftCluster_Tags_addOnUpdate (307.81s)
=== CONT  TestAccRedshiftCluster_Tags_null
--- PASS: TestAccRedshiftCluster_withFinalSnapshot (367.79s)
=== CONT  TestAccRedshiftCluster_aqua
--- PASS: TestAccRedshiftCluster_disappears (282.51s)
=== CONT  TestAccRedshiftCluster_tags
--- PASS: TestAccRedshiftCluster_Tags_emptyMap (294.86s)
=== CONT  TestAccRedshiftCluster_basic
--- PASS: TestAccRedshiftCluster_Tags_null (304.20s)
=== CONT  TestAccRedshiftClusterSnapshot_disappears
--- PASS: TestAccRedshiftCluster_aqua (270.46s)
=== CONT  TestAccRedshiftCluster_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccRedshiftCluster_basic (293.90s)
=== CONT  TestAccRedshiftCluster_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccRedshiftCluster_tags (389.28s)
=== CONT  TestAccRedshiftUsageLimit_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccRedshiftClusterSnapshot_disappears (416.84s)
=== CONT  TestAccRedshiftCluster_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccRedshiftCluster_Tags_IgnoreTags_Overlap_resourceTag (361.68s)
=== CONT  TestAccRedshiftUsageLimit_basic
--- PASS: TestAccRedshiftCluster_Tags_IgnoreTags_Overlap_defaultTag (338.05s)
=== CONT  TestAccRedshiftCluster_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccRedshiftUsageLimit_Tags_EmptyTag_OnUpdate_replace (299.31s)
=== CONT  TestAccRedshiftUsageLimit_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccRedshiftCluster_Tags_ComputedTag_OnUpdate_replace (317.96s)
=== CONT  TestAccRedshiftCluster_Tags_ComputedTag_onCreate
--- PASS: TestAccRedshiftUsageLimit_basic (315.83s)
=== CONT  TestAccRedshiftUsageLimit_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccRedshiftCluster_Tags_ComputedTag_OnUpdate_add (325.52s)
=== CONT  TestAccRedshiftCluster_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccRedshiftUsageLimit_Tags_IgnoreTags_Overlap_resourceTag (342.60s)
=== CONT  TestAccRedshiftUsageLimit_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccRedshiftCluster_Tags_ComputedTag_onCreate (271.52s)
=== CONT  TestAccRedshiftCluster_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccRedshiftCluster_Tags_DefaultTags_nullNonOverlappingResourceTag (292.70s)
=== CONT  TestAccRedshiftUsageLimit_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccRedshiftUsageLimit_Tags_IgnoreTags_Overlap_defaultTag (353.96s)
=== CONT  TestAccRedshiftCluster_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccRedshiftCluster_Tags_DefaultTags_nullOverlappingResourceTag (273.39s)
=== CONT  TestAccRedshiftUsageLimit_Tags_ComputedTag_onCreate
--- PASS: TestAccRedshiftUsageLimit_Tags_ComputedTag_OnUpdate_replace (320.49s)
=== CONT  TestAccRedshiftUsageLimit_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccRedshiftUsageLimit_Tags_ComputedTag_OnUpdate_add (310.78s)
=== CONT  TestAccRedshiftSnapshotScheduleAssociation_disappears
--- PASS: TestAccRedshiftUsageLimit_Tags_ComputedTag_onCreate (291.15s)
=== CONT  TestAccRedshiftUsageLimit_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccRedshiftUsageLimit_Tags_DefaultTags_nullNonOverlappingResourceTag (310.54s)
=== CONT  TestAccRedshiftUsageLimit_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccRedshiftCluster_Tags_DefaultTags_emptyProviderOnlyTag (421.89s)
=== CONT  TestAccRedshiftUsageLimit_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccRedshiftSnapshotScheduleAssociation_disappears (353.63s)
=== CONT  TestAccRedshiftUsageLimit_Tags_EmptyTag_onCreate
--- PASS: TestAccRedshiftUsageLimit_Tags_DefaultTags_emptyProviderOnlyTag (284.43s)
=== CONT  TestAccRedshiftUsageLimit_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccRedshiftUsageLimit_Tags_EmptyTag_OnUpdate_add (367.77s)
=== CONT  TestAccRedshiftUsageLimit_Tags_addOnUpdate
--- PASS: TestAccRedshiftUsageLimit_Tags_EmptyTag_onCreate (294.24s)
=== CONT  TestAccRedshiftUsageLimit_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccRedshiftUsageLimit_Tags_DefaultTags_nullOverlappingResourceTag (609.27s)
=== CONT  TestAccRedshiftUsageLimit_Tags_emptyMap
--- PASS: TestAccRedshiftUsageLimit_Tags_DefaultTags_emptyResourceTag (312.30s)
=== CONT  TestAccRedshiftUsageLimit_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccRedshiftUsageLimit_Tags_addOnUpdate (331.08s)
=== CONT  TestAccRedshiftUsageLimit_Tags_null
--- PASS: TestAccRedshiftUsageLimit_Tags_emptyMap (344.93s)
=== CONT  TestAccRedshiftUsageLimit_Tags_DefaultTags_overlapping
--- PASS: TestAccRedshiftUsageLimit_Tags_DefaultTags_updateToResourceOnly (362.48s)
=== CONT  TestAccRedshiftUsageLimit_tags
--- PASS: TestAccRedshiftUsageLimit_Tags_DefaultTags_updateToProviderOnly (322.25s)
=== CONT  TestAccRedshiftUsageLimit_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccRedshiftUsageLimit_Tags_null (326.25s)
=== CONT  TestAccRedshiftSnapshotScheduleAssociation_disappears_cluster
--- PASS: TestAccRedshiftUsageLimit_Tags_DefaultTags_overlapping (370.86s)
=== CONT  TestAccRedshiftUsageLimit_Tags_DefaultTags_providerOnly
--- PASS: TestAccRedshiftUsageLimit_tags (391.94s)
=== CONT  TestAccRedshiftCluster_manageMasterPassword
--- PASS: TestAccRedshiftUsageLimit_Tags_DefaultTags_nonOverlapping (329.36s)
=== CONT  TestAccRedshiftCluster_changeEncryption_falseToUnset
--- PASS: TestAccRedshiftSnapshotScheduleAssociation_disappears_cluster (327.77s)
=== CONT  TestAccRedshiftPartner_basic
--- PASS: TestAccRedshiftCluster_manageMasterPassword (301.94s)
=== CONT  TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_falseToTrue
--- PASS: TestAccRedshiftUsageLimit_Tags_DefaultTags_providerOnly (383.84s)
=== CONT  TestAccRedshiftLogging_s3
--- PASS: TestAccRedshiftPartner_basic (433.67s)
=== CONT  TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_trueToFalse
--- PASS: TestAccRedshiftLogging_s3 (351.11s)
=== CONT  TestAccRedshiftLogging_disappears_Cluster
=== NAME  TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_trueToFalse
    cluster_test.go:1034: Step 1/2 error: Error running apply: exit status 1

        Error: creating Redshift Cluster (tf-acc-test-9078387521232074105-restored): modifying Encrypted(false): operation error Redshift: ModifyCluster, https response error StatusCode: 400, RequestID: a245f800-cd77-423d-af77-dc3f5d09f58e, InvalidClusterState: Cluster cannot be resized when streaming restore is in progress

          with aws_redshift_cluster.restored,
          on terraform_plugin_test.tf line 33, in resource "aws_redshift_cluster" "restored":
          33: resource "aws_redshift_cluster" "restored" {

--- PASS: TestAccRedshiftLogging_disappears_Cluster (304.15s)
=== CONT  TestAccRedshiftCluster_restoreFromSnapshot_ARN
--- FAIL: TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_trueToFalse (724.60s)
=== CONT  TestAccRedshiftLogging_disappears
=== NAME  TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_falseToTrue
    cluster_test.go:1078: Step 1/2 error: Error running apply: exit status 1

        Error: creating Redshift Cluster (tf-acc-test-7202192914388965181-restored): modifying Encrypted(true): operation error Redshift: ModifyCluster, https response error StatusCode: 400, RequestID: 3a45d206-8e89-4313-a11e-af639f9446d7, InvalidClusterState: Cluster cannot be resized when streaming restore is in progress

          with aws_redshift_cluster.restored,
          on terraform_plugin_test.tf line 33, in resource "aws_redshift_cluster" "restored":
          33: resource "aws_redshift_cluster" "restored" {

--- PASS: TestAccRedshiftLogging_disappears (324.98s)
=== CONT  TestAccRedshiftCluster_restoreFromSnapshot_Identifier
=== NAME  TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_falseToTrue
    panic.go:615: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: deleting Redshift Cluster Snapshot (tf-acc-test-7202192914388965181): operation error Redshift: DeleteClusterSnapshot, https response error StatusCode: 400, RequestID: 7f00a519-ab9f-41ef-9e6d-35f9bb391c49, InvalidClusterSnapshotState: You can't delete snapshot tf-acc-test-7202192914388965181 because it is used by cluster deleted-11336634. The snapshot can be deleted after a newer backup is created.

--- FAIL: TestAccRedshiftCluster_restoreFromSnapshot_ChangeEncryption_falseToTrue (1359.61s)
=== CONT  TestAccRedshiftLogging_basic
--- PASS: TestAccRedshiftCluster_restoreFromSnapshot_ARN (665.20s)
=== CONT  TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible
--- PASS: TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible (265.99s)
=== CONT  TestAccRedshiftEndpointAuthorization_disappears_cluster
    endpoint_authorization_test.go:141: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRedshiftEndpointAuthorization_disappears_cluster (0.00s)
=== CONT  TestAccRedshiftCluster_availabilityZoneRelocation
--- PASS: TestAccRedshiftLogging_basic (289.51s)
=== CONT  TestAccRedshiftEndpointAuthorization_disappears
    endpoint_authorization_test.go:114: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRedshiftEndpointAuthorization_disappears (0.00s)
=== CONT  TestAccRedshiftCluster_changeEncryption_trueToUnset
--- PASS: TestAccRedshiftCluster_changeEncryption_falseToUnset (2089.58s)
=== CONT  TestAccRedshiftEndpointAuthorization_vpcs
    endpoint_authorization_test.go:65: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRedshiftEndpointAuthorization_vpcs (0.00s)
=== CONT  TestAccRedshiftSnapshotCopy_disappears
--- PASS: TestAccRedshiftCluster_availabilityZoneRelocation (229.81s)
=== CONT  TestAccRedshiftEndpointAuthorization_basic
    endpoint_authorization_test.go:29: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRedshiftEndpointAuthorization_basic (0.00s)
=== CONT  TestAccRedshiftSnapshotScheduleAssociation_basic
--- PASS: TestAccRedshiftCluster_restoreFromSnapshot_Identifier (737.88s)
=== CONT  TestAccRedshiftEndpointAccess_disappears_cluster
--- PASS: TestAccRedshiftCluster_changeEncryption_trueToUnset (327.93s)
=== CONT  TestAccRedshiftSnapshotCopy_retentionPeriod
--- PASS: TestAccRedshiftSnapshotCopy_disappears (254.24s)
=== CONT  TestAccRedshiftEndpointAccess_disappears
--- PASS: TestAccRedshiftSnapshotScheduleAssociation_basic (337.86s)
=== CONT  TestAccRedshiftSnapshotCopy_disappears_Cluster
--- PASS: TestAccRedshiftSnapshotCopy_retentionPeriod (277.09s)
=== CONT  TestAccRedshiftEndpointAccess_sgs
--- PASS: TestAccRedshiftEndpointAccess_disappears_cluster (350.05s)
=== CONT  TestAccRedshiftCluster_changeEncryption_unsetToFalse
--- PASS: TestAccRedshiftSnapshotCopy_disappears_Cluster (284.87s)
=== CONT  TestAccRedshiftEndpointAccess_basic
--- PASS: TestAccRedshiftEndpointAccess_disappears (459.23s)
=== CONT  TestAccRedshiftCluster_changeEncryption_falseToTrue
--- PASS: TestAccRedshiftEndpointAccess_sgs (519.34s)
=== CONT  TestAccRedshiftCluster_port
--- PASS: TestAccRedshiftEndpointAccess_basic (430.33s)
=== CONT  TestAccRedshiftCluster_changeEncryption_trueToFalse
--- PASS: TestAccRedshiftCluster_port (330.96s)
=== CONT  TestAccRedshiftCluster_passwordWriteOnly
--- PASS: TestAccRedshiftCluster_passwordWriteOnly (533.56s)
=== CONT  TestAccRedshiftCluster_multiAZ
--- PASS: TestAccRedshiftCluster_changeEncryption_unsetToFalse (1415.08s)
=== CONT  TestAccRedshiftCluster_changeEncryption_unsetToTrue
--- PASS: TestAccRedshiftCluster_changeEncryption_unsetToTrue (260.61s)
=== CONT  TestAccRedshiftCluster_changeAvailabilityZoneAndSetAvailabilityZoneRelocation
--- PASS: TestAccRedshiftCluster_multiAZ (629.48s)
=== CONT  TestAccRedshiftCluster_changeAvailabilityZone
--- PASS: TestAccRedshiftCluster_changeAvailabilityZoneAndSetAvailabilityZoneRelocation (376.97s)
=== CONT  TestAccRedshiftCluster_changeAvailabilityZone_availabilityZoneRelocationNotSet
--- PASS: TestAccRedshiftCluster_changeEncryption_trueToFalse (1498.30s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_EmptyTag_onCreate
--- PASS: TestAccRedshiftCluster_changeEncryption_falseToTrue (2057.15s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccRedshiftCluster_changeAvailabilityZone_availabilityZoneRelocationNotSet (266.41s)
=== CONT  TestAccRedshiftResourcePolicy_disappears
    resource_policy_test.go:57: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRedshiftResourcePolicy_disappears (0.00s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccRedshiftCluster_changeAvailabilityZone (377.81s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccRedshiftClusterSnapshot_Tags_EmptyTag_onCreate (412.59s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccRedshiftClusterSnapshot_Tags_IgnoreTags_Overlap_defaultTag (441.07s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_ComputedTag_onCreate
--- PASS: TestAccRedshiftClusterSnapshot_Tags_ComputedTag_OnUpdate_replace (418.15s)
=== CONT  TestAccRedshiftSnapshotCopy_basic
--- PASS: TestAccRedshiftClusterSnapshot_Tags_ComputedTag_OnUpdate_add (417.24s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccRedshiftClusterSnapshot_Tags_IgnoreTags_Overlap_resourceTag (431.48s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccRedshiftSnapshotCopy_basic (311.57s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccRedshiftClusterSnapshot_Tags_ComputedTag_onCreate (444.72s)
=== CONT  TestAccRedshiftClusterDataSource_logging
--- PASS: TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nullNonOverlappingResourceTag (468.45s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nullOverlappingResourceTag (418.08s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccRedshiftClusterSnapshot_Tags_DefaultTags_emptyProviderOnlyTag (377.59s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccRedshiftClusterDataSource_logging (319.65s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_addOnUpdate
--- PASS: TestAccRedshiftClusterSnapshot_Tags_DefaultTags_emptyResourceTag (418.66s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_DefaultTags_overlapping
--- PASS: TestAccRedshiftClusterSnapshot_Tags_DefaultTags_updateToResourceOnly (429.98s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccRedshiftClusterSnapshot_Tags_DefaultTags_updateToProviderOnly (378.18s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_emptyMap
--- PASS: TestAccRedshiftClusterSnapshot_Tags_addOnUpdate (437.49s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_DefaultTags_providerOnly
--- PASS: TestAccRedshiftClusterSnapshot_Tags_DefaultTags_overlapping (366.35s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_null
--- PASS: TestAccRedshiftClusterSnapshot_Tags_DefaultTags_nonOverlapping (396.58s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccRedshiftClusterSnapshot_Tags_emptyMap (434.12s)
=== CONT  TestAccRedshiftClusterSnapshot_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccRedshiftClusterSnapshot_Tags_DefaultTags_providerOnly (431.04s)
=== CONT  TestAccRedshiftClusterSnapshot_tags
--- PASS: TestAccRedshiftClusterSnapshot_Tags_null (456.04s)
=== CONT  TestAccRedshiftClusterDataSource_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccRedshiftClusterSnapshot_Tags_EmptyTag_OnUpdate_replace (382.42s)
=== CONT  TestAccRedshiftClusterIAMRoles_disappears
--- PASS: TestAccRedshiftClusterSnapshot_Tags_EmptyTag_OnUpdate_add (408.55s)
=== CONT  TestAccRedshiftClusterDataSource_vpc
--- PASS: TestAccRedshiftClusterDataSource_Tags_IgnoreTags_Overlap_defaultTag (292.98s)
=== CONT  TestAccRedshiftClusterIAMRoles_basic
--- PASS: TestAccRedshiftClusterSnapshot_tags (440.10s)
=== CONT  TestAccRedshiftClusterDataSource_basic
--- PASS: TestAccRedshiftClusterIAMRoles_disappears (281.73s)
=== CONT  TestAccRedshiftClusterDataSource_multiAZEnabled
--- PASS: TestAccRedshiftClusterDataSource_vpc (250.71s)
=== CONT  TestAccRedshiftClusterDataSource_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccRedshiftClusterDataSource_basic (247.41s)
=== CONT  TestAccRedshiftClusterDataSource_Tags_emptyMap
--- PASS: TestAccRedshiftClusterIAMRoles_basic (349.39s)
=== CONT  TestAccRedshiftClusterDataSource_availabilityZoneRelocationEnabled
--- PASS: TestAccRedshiftClusterDataSource_multiAZEnabled (306.44s)
=== CONT  TestAccRedshiftClusterDataSource_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccRedshiftClusterDataSource_Tags_IgnoreTags_Overlap_resourceTag (285.13s)
=== CONT  TestAccRedshiftClusterDataSource_tags
--- PASS: TestAccRedshiftClusterDataSource_Tags_emptyMap (272.50s)
=== CONT  TestAccRedshiftClusterDataSource_Tags_nullMap
=== CONT  TestAccRedshiftResourcePolicy_basic
--- PASS: TestAccRedshiftClusterDataSource_availabilityZoneRelocationEnabled (254.17s)
=== NAME  TestAccRedshiftResourcePolicy_basic
    resource_policy_test.go:27: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRedshiftResourcePolicy_basic (0.00s)
=== CONT  TestAccRedshiftPartner_disappears_cluster
--- PASS: TestAccRedshiftClusterDataSource_tags (250.78s)
=== CONT  TestAccRedshiftCluster_masterUsername_invalid
--- PASS: TestAccRedshiftCluster_masterUsername_invalid (5.47s)
--- PASS: TestAccRedshiftClusterDataSource_Tags_DefaultTags_nonOverlapping (292.89s)
--- PASS: TestAccRedshiftClusterDataSource_Tags_nullMap (300.85s)
--- PASS: TestAccRedshiftPartner_disappears_cluster (281.85s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	13861.818s
FAIL
```
</details>
