### PR TITLE
r/aws_apigatewayv2_api: add list support

### DIFF
--- a/.changelog/47472.txt
+++ b/.changelog/47472.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_apigatewayv2_api
+```

--- a/internal/service/apigatewayv2/api.go
+++ b/internal/service/apigatewayv2/api.go
@@ -257,24 +257,32 @@ func resourceAPIRead(ctx context.Context, d *schema.ResourceData, meta any) diag
 		return sdkdiag.AppendErrorf(diags, "reading API Gateway v2 API (%s): %s", d.Id(), err)
 	}
 
-	d.Set("api_endpoint", output.ApiEndpoint)
-	d.Set("api_key_selection_expression", output.ApiKeySelectionExpression)
-	d.Set(names.AttrARN, apiARN(ctx, meta.(*conns.AWSClient), d.Id()))
-	if err := d.Set("cors_configuration", flattenCORS(output.CorsConfiguration)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting cors_configuration: %s", err)
+	if err := resourceAPIFlatten(ctx, meta.(*conns.AWSClient), d, output); err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
 	}
-	d.Set(names.AttrDescription, output.Description)
-	d.Set("disable_execute_api_endpoint", output.DisableExecuteApiEndpoint)
-	d.Set("execution_arn", apiInvokeARN(ctx, meta.(*conns.AWSClient), d.Id()))
-	d.Set(names.AttrIPAddressType, output.IpAddressType)
-	d.Set(names.AttrName, output.Name)
-	d.Set("protocol_type", output.ProtocolType)
-	d.Set("route_selection_expression", output.RouteSelectionExpression)
-	d.Set(names.AttrVersion, output.Version)
-
-	setTagsOut(ctx, output.Tags)
 
 	return diags
+}
+
+func resourceAPIFlatten(ctx context.Context, awsClient *conns.AWSClient, d *schema.ResourceData, api *apigatewayv2.GetApiOutput) error {
+	d.Set("api_endpoint", api.ApiEndpoint)
+	d.Set("api_key_selection_expression", api.ApiKeySelectionExpression)
+	d.Set(names.AttrARN, apiARN(ctx, awsClient, d.Id()))
+	if err := d.Set("cors_configuration", flattenCORS(api.CorsConfiguration)); err != nil {
+		return fmt.Errorf("setting cors_configuration: %w", err)
+	}
+	d.Set(names.AttrDescription, api.Description)
+	d.Set("disable_execute_api_endpoint", api.DisableExecuteApiEndpoint)
+	d.Set("execution_arn", apiInvokeARN(ctx, awsClient, d.Id()))
+	d.Set(names.AttrIPAddressType, api.IpAddressType)
+	d.Set(names.AttrName, api.Name)
+	d.Set("protocol_type", api.ProtocolType)
+	d.Set("route_selection_expression", api.RouteSelectionExpression)
+	d.Set(names.AttrVersion, api.Version)
+
+	setTagsOut(ctx, api.Tags)
+
+	return nil
 }
 
 func resourceAPIUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/service/apigatewayv2/api_list.go
+++ b/internal/service/apigatewayv2/api_list.go
@@ -1,0 +1,134 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package apigatewayv2
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKListResource("aws_apigatewayv2_api")
+func newAPIResourceAsListResource() inttypes.ListResourceForSDK {
+	l := apiListResource{}
+	l.SetResourceSchema(resourceAPI())
+	return &l
+}
+
+var _ list.ListResource = &apiListResource{}
+
+type apiListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+func (l *apiListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	conn := l.Meta().APIGatewayV2Client(ctx)
+
+	var query listAPIModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	tflog.Info(ctx, "Listing Resources")
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		input := apigatewayv2.GetApisInput{}
+		for item, err := range listAPIs(ctx, conn, &input) {
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+
+			id := aws.ToString(item.ApiId)
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrID), id)
+
+			result := request.NewListResult(ctx)
+
+			rd := l.ResourceData()
+			rd.SetId(id)
+
+			if request.IncludeResource {
+				if err := resourceAPIFlattenPage(ctx, l.Meta(), rd, &item); err != nil {
+					tflog.Error(ctx, "Reading API Gateway V2 API", map[string]any{
+						"error": err.Error(),
+					})
+					continue
+				}
+			}
+
+			result.DisplayName = aws.ToString(item.Name)
+
+			l.SetResult(ctx, l.Meta(), request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+type listAPIModel struct {
+	framework.WithRegionModel
+}
+
+func listAPIs(ctx context.Context, conn *apigatewayv2.Client, input *apigatewayv2.GetApisInput) iter.Seq2[awstypes.Api, error] {
+	return func(yield func(awstypes.Api, error) bool) {
+		err := getAPIsPages(ctx, conn, input, func(page *apigatewayv2.GetApisOutput, lastPage bool) bool {
+			if page == nil {
+				return !lastPage
+			}
+			for _, item := range page.Items {
+				if !yield(item, nil) {
+					return false
+				}
+			}
+			return !lastPage
+		})
+		if err != nil {
+			yield(awstypes.Api{}, fmt.Errorf("listing API Gateway V2 API resources: %w", err))
+		}
+	}
+}
+
+func resourceAPIFlattenPage(ctx context.Context, awsClient *conns.AWSClient, d *schema.ResourceData, api *awstypes.Api) error {
+	d.Set("api_endpoint", api.ApiEndpoint)
+	d.Set("api_key_selection_expression", api.ApiKeySelectionExpression)
+	d.Set(names.AttrARN, apiARN(ctx, awsClient, d.Id()))
+	if err := d.Set("cors_configuration", flattenCORS(api.CorsConfiguration)); err != nil {
+		return fmt.Errorf("setting cors_configuration: %w", err)
+	}
+	d.Set(names.AttrDescription, api.Description)
+	d.Set("disable_execute_api_endpoint", api.DisableExecuteApiEndpoint)
+	d.Set("execution_arn", apiInvokeARN(ctx, awsClient, d.Id()))
+	d.Set(names.AttrIPAddressType, api.IpAddressType)
+	d.Set(names.AttrName, api.Name)
+	d.Set("protocol_type", api.ProtocolType)
+	d.Set("route_selection_expression", api.RouteSelectionExpression)
+	d.Set(names.AttrVersion, api.Version)
+
+	setTagsOut(ctx, api.Tags)
+
+	return nil
+}

--- a/internal/service/apigatewayv2/api_list_test.go
+++ b/internal/service/apigatewayv2/api_list_test.go
@@ -1,0 +1,215 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package apigatewayv2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccAPIGatewayV2API_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_apigatewayv2_api.test[0]"
+	resourceName2 := "aws_apigatewayv2_api.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
+		CheckDestroy:             testAccCheckAPIDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/API/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/API/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_apigatewayv2_api.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_apigatewayv2_api.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					tfquerycheck.ExpectNoResourceObject("aws_apigatewayv2_api.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_apigatewayv2_api.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_apigatewayv2_api.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringExact(rName+"-1")),
+					tfquerycheck.ExpectNoResourceObject("aws_apigatewayv2_api.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayV2API_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_apigatewayv2_api.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
+		CheckDestroy:             testAccCheckAPIDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/API/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/API/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_apigatewayv2_api.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_apigatewayv2_api.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					querycheck.ExpectResourceKnownValues("aws_apigatewayv2_api.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("api_endpoint"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("api_key_selection_expression"), knownvalue.StringExact("$request.header.x-api-key")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("body"), knownvalue.Null()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("cors_configuration"), knownvalue.ListExact([]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("credentials_arn"), knownvalue.Null()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrDescription), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("disable_execute_api_endpoint"), knownvalue.Bool(false)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("execution_arn"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("fail_on_warnings"), knownvalue.Null()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrIPAddressType), knownvalue.StringExact("ipv4")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("protocol_type"), knownvalue.StringExact("HTTP")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("route_key"), knownvalue.Null()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("route_selection_expression"), knownvalue.StringExact("$request.method $request.path")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTagsAll), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTarget), knownvalue.Null()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrVersion), knownvalue.StringExact("")),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayV2API_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_apigatewayv2_api.test[0]"
+	resourceName2 := "aws_apigatewayv2_api.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
+		CheckDestroy:             testAccCheckAPIDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/API/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/API/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_apigatewayv2_api.test", identity1.Checks()),
+
+					tfquerycheck.ExpectIdentityFunc("aws_apigatewayv2_api.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/apigatewayv2/service_package_gen.go
+++ b/internal/service/apigatewayv2/service_package_gen.go
@@ -172,6 +172,16 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttypes.ServicePackageSDKListResource] {
 	return slices.Values([]*inttypes.ServicePackageSDKListResource{
 		{
+			Factory:  newAPIResourceAsListResource,
+			TypeName: "aws_apigatewayv2_api",
+			Name:     "API",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrARN,
+			}),
+			Identity: inttypes.RegionalSingleParameterIdentity(names.AttrID),
+		},
+		{
 			Factory:  newRouteResourceAsListResource,
 			TypeName: "aws_apigatewayv2_route",
 			Name:     "Route",

--- a/internal/service/apigatewayv2/testdata/API/list_basic/main.tf
+++ b/internal/service/apigatewayv2/testdata/API/list_basic/main.tf
@@ -1,0 +1,21 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_apigatewayv2_api" "test" {
+  count = var.resource_count
+
+  name          = "${var.rName}-${count.index}"
+  protocol_type = "HTTP"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/apigatewayv2/testdata/API/list_basic/query.tfquery.hcl
+++ b/internal/service/apigatewayv2/testdata/API/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_apigatewayv2_api" "test" {
+  provider = aws
+}

--- a/internal/service/apigatewayv2/testdata/API/list_include_resource/main.tf
+++ b/internal/service/apigatewayv2/testdata/API/list_include_resource/main.tf
@@ -1,0 +1,29 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_apigatewayv2_api" "test" {
+  count = var.resource_count
+
+  name          = "${var.rName}-${count.index}"
+  protocol_type = "HTTP"
+
+  tags = var.resource_tags
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "resource_tags" {
+  description = "Tags to set on resource"
+  type        = map(string)
+  nullable    = false
+}

--- a/internal/service/apigatewayv2/testdata/API/list_include_resource/query.tfquery.hcl
+++ b/internal/service/apigatewayv2/testdata/API/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_apigatewayv2_api" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/apigatewayv2/testdata/API/list_region_override/main.tf
+++ b/internal/service/apigatewayv2/testdata/API/list_region_override/main.tf
@@ -1,0 +1,28 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_apigatewayv2_api" "test" {
+  count  = var.resource_count
+  region = var.region
+
+  name          = "${var.rName}-${count.index}"
+  protocol_type = "HTTP"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/apigatewayv2/testdata/API/list_region_override/query.tfquery.hcl
+++ b/internal/service/apigatewayv2/testdata/API/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_apigatewayv2_api" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}

--- a/website/docs/list-resources/apigatewayv2_api.html.markdown
+++ b/website/docs/list-resources/apigatewayv2_api.html.markdown
@@ -1,0 +1,25 @@
+---
+subcategory: "API Gateway V2"
+layout: "aws"
+page_title: "AWS: aws_apigatewayv2_api"
+description: |-
+  Lists API Gateway V2 API resources.
+---
+
+# List Resource: aws_apigatewayv2_api
+
+Lists API Gateway V2 API resources.
+
+## Example Usage
+
+```terraform
+list "aws_apigatewayv2_api" "example" {
+  provider = aws
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds list support for the `aws_apigatewayv2_api` resource.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #47465
Relates #47005 



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=apigatewayv2 T=TestAccAPIGatewayV2API_List
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-apigatewayv2_api-list 🌿...
TF_ACC=1 go1.25.9 test ./internal/service/apigatewayv2/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayV2API_List'  -timeout 360m -vet=off
2026/04/15 15:13:55 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/15 15:13:55 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccAPIGatewayV2API_List_regionOverride (17.71s)
--- PASS: TestAccAPIGatewayV2API_List_includeResource (19.21s)
--- PASS: TestAccAPIGatewayV2API_List_basic (19.36s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigatewayv2       26.374s
```

```console
% make t K=apigatewayv2 T=TestAccAPIGatewayV2API_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-apigatewayv2_api-list 🌿...
TF_ACC=1 go1.25.9 test ./internal/service/apigatewayv2/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayV2API_'  -timeout 360m -vet=off
2026/04/15 15:15:47 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/15 15:15:47 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccAPIGatewayV2API_List_includeResource (44.42s)
=== CONT  TestAccAPIGatewayV2API_OpenAPI_withTags
--- PASS: TestAccAPIGatewayV2API_List_regionOverride (46.81s)
=== CONT  TestAccAPIGatewayV2API_openAPI
--- PASS: TestAccAPIGatewayV2API_OpenAPI_noTitle (47.55s)
=== CONT  TestAccAPIGatewayV2API_allAttributesHTTP
--- PASS: TestAccAPIGatewayV2API_quickCreate (53.75s)
=== CONT  TestAccAPIGatewayV2API_allAttributesWebSocket
--- PASS: TestAccAPIGatewayV2API_Identity_regionOverride (84.33s)
=== CONT  TestAccAPIGatewayV2API_disappears
--- PASS: TestAccAPIGatewayV2API_Tags_DefaultTags_emptyResourceTag (94.73s)
=== CONT  TestAccAPIGatewayV2API_basicHTTP
--- PASS: TestAccAPIGatewayV2API_Identity_basic (95.40s)
=== CONT  TestAccAPIGatewayV2API_basicWebSocket
--- PASS: TestAccAPIGatewayV2API_Tags_DefaultTags_nullOverlappingResourceTag (100.42s)
=== CONT  TestAccAPIGatewayV2API_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccAPIGatewayV2API_Tags_DefaultTags_emptyProviderOnlyTag (101.11s)
=== CONT  TestAccAPIGatewayV2API_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccAPIGatewayV2API_Identity_ExistingResource_noRefreshNoChange (111.66s)
=== CONT  TestAccAPIGatewayV2API_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccAPIGatewayV2API_Identity_ExistingResource_basic (117.39s)
=== CONT  TestAccAPIGatewayV2API_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccAPIGatewayV2API_cors (132.87s)
=== CONT  TestAccAPIGatewayV2API_Tags_ComputedTag_onCreate
--- PASS: TestAccAPIGatewayV2API_OpenAPI_withMoreFields (132.96s)
=== CONT  TestAccAPIGatewayV2API_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccAPIGatewayV2API_Tags_null (133.28s)
=== CONT  TestAccAPIGatewayV2API_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccAPIGatewayV2API_OpenAPI_failOnWarnings (137.20s)
=== CONT  TestAccAPIGatewayV2API_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccAPIGatewayV2API_disappears (56.75s)
=== CONT  TestAccAPIGatewayV2API_tags
--- PASS: TestAccAPIGatewayV2API_basicHTTP (83.54s)
=== CONT  TestAccAPIGatewayV2API_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccAPIGatewayV2API_basicWebSocket (82.91s)
=== CONT  TestAccAPIGatewayV2API_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccAPIGatewayV2API_Tags_emptyMap (183.69s)
=== CONT  TestAccAPIGatewayV2API_Tags_addOnUpdate
--- PASS: TestAccAPIGatewayV2API_OpenAPI_withTags (144.60s)
=== CONT  TestAccAPIGatewayV2API_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccAPIGatewayV2API_OpenAPI_withCors (189.86s)
=== CONT  TestAccAPIGatewayV2API_List_basic
--- PASS: TestAccAPIGatewayV2API_openAPI (148.88s)
--- PASS: TestAccAPIGatewayV2API_Tags_DefaultTags_nullNonOverlappingResourceTag (99.91s)
--- PASS: TestAccAPIGatewayV2API_Tags_ComputedTag_onCreate (100.06s)
--- PASS: TestAccAPIGatewayV2API_Tags_EmptyTag_onCreate (251.60s)
--- PASS: TestAccAPIGatewayV2API_List_basic (62.57s)
--- PASS: TestAccAPIGatewayV2API_allAttributesHTTP (208.97s)
--- PASS: TestAccAPIGatewayV2API_allAttributesWebSocket (206.65s)
--- PASS: TestAccAPIGatewayV2API_Tags_ComputedTag_OnUpdate_replace (148.91s)
--- PASS: TestAccAPIGatewayV2API_Tags_ComputedTag_OnUpdate_add (146.68s)
--- PASS: TestAccAPIGatewayV2API_Tags_IgnoreTags_Overlap_defaultTag (168.11s)
--- PASS: TestAccAPIGatewayV2API_Tags_DefaultTags_overlapping (272.50s)
--- PASS: TestAccAPIGatewayV2API_Tags_EmptyTag_OnUpdate_replace (139.26s)
--- PASS: TestAccAPIGatewayV2API_Tags_DefaultTags_updateToResourceOnly (104.88s)
--- PASS: TestAccAPIGatewayV2API_Tags_DefaultTags_updateToProviderOnly (105.99s)
--- PASS: TestAccAPIGatewayV2API_Tags_IgnoreTags_Overlap_resourceTag (186.16s)
--- PASS: TestAccAPIGatewayV2API_Tags_addOnUpdate (102.99s)
--- PASS: TestAccAPIGatewayV2API_Tags_DefaultTags_providerOnly (293.01s)
--- PASS: TestAccAPIGatewayV2API_Tags_DefaultTags_nonOverlapping (164.61s)
--- PASS: TestAccAPIGatewayV2API_Tags_EmptyTag_OnUpdate_add (117.58s)
--- PASS: TestAccAPIGatewayV2API_tags (178.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigatewayv2       326.470s
```