### PR TITLE
fix: suppress perpetual diff for cloudwatch_logging_options when disabled

### DIFF
--- a/.changelog/47474.txt
+++ b/.changelog/47474.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_kinesis_firehose_delivery_stream: Fix perpetual diff for `cloudwatch_logging_options` when `enabled` is `false`
+```

--- a/internal/service/firehose/delivery_stream.go
+++ b/internal/service/firehose/delivery_stream.go
@@ -98,6 +98,23 @@ func resourceDeliveryStream() *schema.Resource {
 		MigrateState:  MigrateState,
 		SchemaFunc: func() map[string]*schema.Schema {
 			cloudWatchLoggingOptionsSchema := func() *schema.Schema {
+				// diffSuppressCloudWatchLoggingOptionsDisabled suppresses diffs for
+				// log_group_name and log_stream_name when cloudwatch_logging_options
+				// is disabled (enabled = false). The AWS API returns empty strings for
+				// these fields when logging is disabled, causing a perpetual diff
+				// against user-specified values.
+				diffSuppressCloudWatchLoggingOptionsDisabled := func(k, old, new string, d *schema.ResourceData) bool {
+					// Derive the enabled key from the current attribute key path.
+					// k is like "...cloudwatch_logging_options.0.log_group_name",
+					// so we find the last dot and replace the field name with "enabled".
+					enabledKey := k[:strings.LastIndex(k, ".")] + "." + names.AttrEnabled
+					enabled, ok := d.GetOk(enabledKey)
+					if ok && enabled.(bool) {
+						return false
+					}
+					return true
+				}
+
 				return &schema.Schema{
 					Type:     schema.TypeList,
 					MaxItems: 1,
@@ -111,12 +128,14 @@ func resourceDeliveryStream() *schema.Resource {
 								Default:  false,
 							},
 							names.AttrLogGroupName: {
-								Type:     schema.TypeString,
-								Optional: true,
+								Type:             schema.TypeString,
+								Optional:         true,
+								DiffSuppressFunc: diffSuppressCloudWatchLoggingOptionsDisabled,
 							},
 							"log_stream_name": {
-								Type:     schema.TypeString,
-								Optional: true,
+								Type:             schema.TypeString,
+								Optional:         true,
+								DiffSuppressFunc: diffSuppressCloudWatchLoggingOptionsDisabled,
 							},
 						},
 					},


### PR DESCRIPTION
## Summary

Fixes #40446

When `cloudwatch_logging_options.enabled` is `false` on an `aws_kinesis_firehose_delivery_stream`, the AWS API returns empty strings for `log_group_name` and `log_stream_name`. If the user specifies values for these fields in their configuration (which is common -- they may toggle logging on/off via a variable), Terraform detects a diff on every plan and continually reapplies the same settings.

This PR adds a `DiffSuppressFunc` to both `log_group_name` and `log_stream_name` within the `cloudwatch_logging_options` schema. When the sibling `enabled` field is `false`, diffs on these fields are suppressed. This follows the same pattern used in the Athena workgroup resource (`diffSuppressWorkGroupConfigurationMonitoringCloudWatchLogging`).

The fix applies to all destination types that use `cloudwatch_logging_options` (Elasticsearch, Extended S3, HTTP Endpoint, Iceberg, OpenSearch, OpenSearch Serverless, Redshift, Snowflake, Splunk) since they all share the same `cloudWatchLoggingOptionsSchema()` function.

## Changes

- `internal/service/firehose/delivery_stream.go`: Added `diffSuppressCloudWatchLoggingOptionsDisabled` function and wired it as `DiffSuppressFunc` on `log_group_name` and `log_stream_name` fields.

## Test plan

- [x] Verify `go build ./internal/service/firehose/` passes
- [x] Verify `go vet ./internal/service/firehose/` passes
- [x] Create a Firehose delivery stream with `cloudwatch_logging_options` where `enabled = false` and `log_group_name`/`log_stream_name` are set
- [x] Run `terraform plan` and confirm no diff is detected
- [x] Toggle `enabled = true`, apply, then set `enabled = false` again and confirm no perpetual diff
- [x] Run existing acceptance tests: `go test ./internal/service/firehose/ -run TestAcc`