### PR TITLE
r/`aws_nat_gateway`: Allow updating `secondary_private_ip_address_count` in-place for private NAT gateways

### DIFF
--- a/.changelog/47477.txt
+++ b/.changelog/47477.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_nat_gateway: Allow updating `secondary_private_ip_address_count` in-place for private NAT gateways
+```

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -1741,6 +1741,39 @@ func statusNATGatewayAddressByNATGatewayIDAndPrivateIP(conn *ec2.Client, natGate
 	}
 }
 
+func statusNATGatewaySecondaryPrivateIPAddressCount(conn *ec2.Client, natGatewayID string, expectedCount int) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
+		output, err := findNATGatewayByID(ctx, conn, natGatewayID)
+
+		if retry.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		secondaryCount := 0
+		for _, natGatewayAddress := range output.NatGatewayAddresses {
+			if !aws.ToBool(natGatewayAddress.IsPrimary) && aws.ToString(natGatewayAddress.PrivateIp) != "" {
+				if natGatewayAddress.Status == awstypes.NatGatewayAddressStatusFailed {
+					return output, string(natGatewayAddress.Status), nil
+				}
+
+				if natGatewayAddress.Status == awstypes.NatGatewayAddressStatusSucceeded {
+					secondaryCount++
+				}
+			}
+		}
+
+		if secondaryCount == expectedCount {
+			return output, "ready", nil
+		}
+
+		return output, "pending", nil
+	}
+}
+
 func statusNATGatewayAttachedAppliances(conn *ec2.Client, id string) retry.StateRefreshFunc {
 	return func(ctx context.Context) (any, string, error) {
 		output, err := findNATGatewayByID(ctx, conn, id)

--- a/internal/service/ec2/vpc_nat_gateway.go
+++ b/internal/service/ec2/vpc_nat_gateway.go
@@ -434,7 +434,12 @@ func resourceNATGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	case awstypes.AvailabilityModeZonal:
 		switch awstypes.ConnectivityType(d.Get("connectivity_type").(string)) {
 		case awstypes.ConnectivityTypePrivate:
-			if d.HasChanges("secondary_private_ip_addresses") {
+			countRaw := d.GetRawConfig().GetAttr("secondary_private_ip_address_count")
+			countConfigured := countRaw.IsKnown() && !countRaw.IsNull()
+			addressesRaw := d.GetRawConfig().GetAttr("secondary_private_ip_addresses")
+			addressesConfigured := addressesRaw.IsKnown() && !addressesRaw.IsNull()
+
+			if addressesConfigured && d.HasChange("secondary_private_ip_addresses") {
 				o, n := d.GetChange("secondary_private_ip_addresses")
 				os, ns := o.(*schema.Set), n.(*schema.Set)
 
@@ -470,6 +475,57 @@ func resourceNATGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta 
 					}
 
 					for _, privateIP := range flex.ExpandStringValueSet(del) {
+						if _, err := waitNATGatewayAddressUnassigned(ctx, conn, d.Id(), privateIP, d.Timeout(schema.TimeoutUpdate)); err != nil {
+							return sdkdiag.AppendErrorf(diags, "waiting for EC2 NAT Gateway (%s) private IP address (%s) unassign: %s", d.Id(), privateIP, err)
+						}
+					}
+				}
+			}
+
+			if countConfigured && d.HasChange("secondary_private_ip_address_count") {
+				o, n := d.GetChange("secondary_private_ip_address_count")
+				oldCount, newCount := o.(int), n.(int)
+
+				delta := newCount - oldCount
+
+				if delta > 0 {
+					input := &ec2.AssignPrivateNatGatewayAddressInput{
+						NatGatewayId:          aws.String(d.Id()),
+						PrivateIpAddressCount: aws.Int32(int32(delta)),
+					}
+
+					_, err := conn.AssignPrivateNatGatewayAddress(ctx, input)
+
+					if err != nil {
+						return sdkdiag.AppendErrorf(diags, "assigning EC2 NAT Gateway (%s) private IP address count: %s", d.Id(), err)
+					}
+
+					if _, err := waitNATGatewaySecondaryPrivateIPAddressCount(ctx, conn, d.Id(), newCount, d.Timeout(schema.TimeoutUpdate)); err != nil {
+						return sdkdiag.AppendErrorf(diags, "waiting for EC2 NAT Gateway (%s) secondary private IP address count (%d): %s", d.Id(), newCount, err)
+					}
+				}
+
+				if delta < 0 {
+					removeCount := -delta
+
+					sIPs, _ := d.GetChange("secondary_private_ip_addresses")
+					secondaryPrivateIPs := sIPs.(*schema.Set).List()
+
+					privateIPsToUnassign := secondaryPrivateIPs[:removeCount]
+
+					input := &ec2.UnassignPrivateNatGatewayAddressInput{
+						NatGatewayId:            aws.String(d.Id()),
+						PrivateIpAddresses:      flex.ExpandStringValueList(privateIPsToUnassign),
+						MaxDrainDurationSeconds: aws.Int32(50),
+					}
+
+					_, err := conn.UnassignPrivateNatGatewayAddress(ctx, input)
+
+					if err != nil {
+						return sdkdiag.AppendErrorf(diags, "unassigning EC2 NAT Gateway (%s) private IP addresses: %s", d.Id(), err)
+					}
+
+					for _, privateIP := range flex.ExpandStringValueList(privateIPsToUnassign) {
 						if _, err := waitNATGatewayAddressUnassigned(ctx, conn, d.Id(), privateIP, d.Timeout(schema.TimeoutUpdate)); err != nil {
 							return sdkdiag.AppendErrorf(diags, "waiting for EC2 NAT Gateway (%s) private IP address (%s) unassign: %s", d.Id(), privateIP, err)
 						}
@@ -656,15 +712,18 @@ func resourceNATGatewayCustomizeDiff(ctx context.Context, diff *schema.ResourceD
 			return fmt.Errorf(`secondary_allocation_ids is not supported with connectivity_type = "%s"`, connectivityType)
 		}
 
-		if diff.Id() != "" && diff.HasChange("secondary_private_ip_address_count") {
-			if v := diff.GetRawConfig().GetAttr("secondary_private_ip_address_count"); v.IsKnown() && !v.IsNull() {
-				if err := diff.ForceNew("secondary_private_ip_address_count"); err != nil {
-					return fmt.Errorf("setting secondary_private_ip_address_count to ForceNew: %w", err)
-				}
+		countRaw := diff.GetRawConfig().GetAttr("secondary_private_ip_address_count")
+		countConfigured := countRaw.IsKnown() && !countRaw.IsNull()
+		addressesRaw := diff.GetRawConfig().GetAttr("secondary_private_ip_addresses")
+		addressesConfigured := addressesRaw.IsKnown() && !addressesRaw.IsNull()
+
+		if diff.Id() != "" && countConfigured && diff.HasChange("secondary_private_ip_address_count") {
+			if err := diff.SetNewComputed("secondary_private_ip_addresses"); err != nil {
+				return fmt.Errorf("setting secondary_private_ip_addresses to Computed: %w", err)
 			}
 		}
 
-		if diff.Id() != "" && diff.HasChange("secondary_private_ip_addresses") {
+		if diff.Id() != "" && addressesConfigured && diff.HasChange("secondary_private_ip_addresses") {
 			if err := diff.SetNewComputed("secondary_private_ip_address_count"); err != nil {
 				return fmt.Errorf("setting secondary_private_ip_address_count to Computed: %w", err)
 			}

--- a/internal/service/ec2/vpc_nat_gateway.go
+++ b/internal/service/ec2/vpc_nat_gateway.go
@@ -449,9 +449,7 @@ func resourceNATGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta 
 						PrivateIpAddresses: flex.ExpandStringValueSet(add),
 					}
 
-					_, err := conn.AssignPrivateNatGatewayAddress(ctx, input)
-
-					if err != nil {
+					if _, err := conn.AssignPrivateNatGatewayAddress(ctx, input); err != nil {
 						return sdkdiag.AppendErrorf(diags, "assigning EC2 NAT Gateway (%s) private IP addresses: %s", d.Id(), err)
 					}
 

--- a/internal/service/ec2/vpc_nat_gateway.go
+++ b/internal/service/ec2/vpc_nat_gateway.go
@@ -475,7 +475,7 @@ func resourceNATGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta 
 					}
 
 					for _, privateIP := range flex.ExpandStringValueSet(del) {
-						if _, err := waitNATGatewayAddressUnassigned(ctx, conn, d.Id(), privateIP, d.Timeout(schema.TimeoutUpdate)); err != nil {
+						if err := waitNATGatewayAddressUnassigned(ctx, conn, d.Id(), privateIP, d.Timeout(schema.TimeoutUpdate)); err != nil {
 							return sdkdiag.AppendErrorf(diags, "waiting for EC2 NAT Gateway (%s) private IP address (%s) unassign: %s", d.Id(), privateIP, err)
 						}
 					}
@@ -526,7 +526,7 @@ func resourceNATGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta 
 					}
 
 					for _, privateIP := range flex.ExpandStringValueList(privateIPsToUnassign) {
-						if _, err := waitNATGatewayAddressUnassigned(ctx, conn, d.Id(), privateIP, d.Timeout(schema.TimeoutUpdate)); err != nil {
+						if err := waitNATGatewayAddressUnassigned(ctx, conn, d.Id(), privateIP, d.Timeout(schema.TimeoutUpdate)); err != nil {
 							return sdkdiag.AppendErrorf(diags, "waiting for EC2 NAT Gateway (%s) private IP address (%s) unassign: %s", d.Id(), privateIP, err)
 						}
 					}

--- a/internal/service/ec2/vpc_nat_gateway.go
+++ b/internal/service/ec2/vpc_nat_gateway.go
@@ -514,9 +514,8 @@ func resourceNATGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta 
 					privateIPsToUnassign := secondaryPrivateIPs[:removeCount]
 
 					input := &ec2.UnassignPrivateNatGatewayAddressInput{
-						NatGatewayId:            aws.String(d.Id()),
-						PrivateIpAddresses:      flex.ExpandStringValueList(privateIPsToUnassign),
-						MaxDrainDurationSeconds: aws.Int32(50),
+						NatGatewayId:       aws.String(d.Id()),
+						PrivateIpAddresses: flex.ExpandStringValueList(privateIPsToUnassign),
 					}
 
 					_, err := conn.UnassignPrivateNatGatewayAddress(ctx, input)

--- a/internal/service/ec2/vpc_nat_gateway.go
+++ b/internal/service/ec2/vpc_nat_gateway.go
@@ -492,9 +492,7 @@ func resourceNATGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta 
 						PrivateIpAddressCount: aws.Int32(int32(delta)),
 					}
 
-					_, err := conn.AssignPrivateNatGatewayAddress(ctx, input)
-
-					if err != nil {
+					if _, err := conn.AssignPrivateNatGatewayAddress(ctx, input); err != nil {
 						return sdkdiag.AppendErrorf(diags, "assigning EC2 NAT Gateway (%s) private IP address count: %s", d.Id(), err)
 					}
 
@@ -516,9 +514,7 @@ func resourceNATGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta 
 						PrivateIpAddresses: flex.ExpandStringValueList(privateIPsToUnassign),
 					}
 
-					_, err := conn.UnassignPrivateNatGatewayAddress(ctx, input)
-
-					if err != nil {
+					if _, err := conn.UnassignPrivateNatGatewayAddress(ctx, input); err != nil {
 						return sdkdiag.AppendErrorf(diags, "unassigning EC2 NAT Gateway (%s) private IP addresses: %s", d.Id(), err)
 					}
 

--- a/internal/service/ec2/vpc_nat_gateway_test.go
+++ b/internal/service/ec2/vpc_nat_gateway_test.go
@@ -438,6 +438,62 @@ func TestAccVPCNATGateway_secondaryPrivateIPAddressCountToSpecific(t *testing.T)
 	})
 }
 
+func TestAccVPCNATGateway_secondaryPrivateIPAddressCount_updateInPlace(t *testing.T) {
+	ctx := acctest.Context(t)
+	var natGateway awstypes.NatGateway
+	resourceName := "aws_nat_gateway.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	countStart := 0
+	countUp := 3
+	countDown := 1
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckNATGatewayDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCNATGatewayConfig_secondaryPrivateIPAddressCount(rName, countStart),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckNATGatewayExists(ctx, t, resourceName, &natGateway),
+					resource.TestCheckResourceAttr(resourceName, "secondary_private_ip_address_count", strconv.Itoa(countStart)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				Config: testAccVPCNATGatewayConfig_secondaryPrivateIPAddressCount(rName, countUp),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckNATGatewayExists(ctx, t, resourceName, &natGateway),
+					resource.TestCheckResourceAttr(resourceName, "secondary_private_ip_address_count", strconv.Itoa(countUp)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				Config: testAccVPCNATGatewayConfig_secondaryPrivateIPAddressCount(rName, countDown),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckNATGatewayExists(ctx, t, resourceName, &natGateway),
+					resource.TestCheckResourceAttr(resourceName, "secondary_private_ip_address_count", strconv.Itoa(countDown)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccVPCNATGateway_secondaryPrivateIPAddresses(t *testing.T) {
 	ctx := acctest.Context(t)
 	var natGateway awstypes.NatGateway

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -1554,6 +1554,31 @@ func waitNATGatewayAddressUnassigned(ctx context.Context, conn *ec2.Client, natG
 	return nil, err
 }
 
+func waitNATGatewaySecondaryPrivateIPAddressCount(ctx context.Context, conn *ec2.Client, natGatewayID string, expectedCount int, timeout time.Duration) (*awstypes.NatGateway, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:                   []string{"pending"},
+		Target:                    []string{"ready"},
+		Refresh:                   statusNATGatewaySecondaryPrivateIPAddressCount(conn, natGatewayID, expectedCount),
+		Timeout:                   timeout,
+		ContinuousTargetOccurence: 4,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*awstypes.NatGateway); ok {
+		for _, natGatewayAddress := range output.NatGatewayAddresses {
+			if !aws.ToBool(natGatewayAddress.IsPrimary) && natGatewayAddress.Status == awstypes.NatGatewayAddressStatusFailed {
+				retry.SetLastError(err, errors.New(aws.ToString(natGatewayAddress.FailureMessage)))
+				break
+			}
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
 func waitNATGatewayCreated(ctx context.Context, conn *ec2.Client, id string, timeout time.Duration) (*awstypes.NatGateway, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.NatGatewayStatePending),

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -1533,7 +1533,7 @@ func waitNATGatewayAddressDisassociated(ctx context.Context, conn *ec2.Client, n
 	return nil, err
 }
 
-func waitNATGatewayAddressUnassigned(ctx context.Context, conn *ec2.Client, natGatewayID, privateIP string, timeout time.Duration) (*awstypes.NatGatewayAddress, error) {
+func waitNATGatewayAddressUnassigned(ctx context.Context, conn *ec2.Client, natGatewayID, privateIP string, timeout time.Duration) error {
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.NatGatewayAddressStatusSucceeded, awstypes.NatGatewayAddressStatusUnassigning),
 		Target:  []string{},
@@ -1547,11 +1547,9 @@ func waitNATGatewayAddressUnassigned(ctx context.Context, conn *ec2.Client, natG
 		if output.Status == awstypes.NatGatewayAddressStatusFailed {
 			retry.SetLastError(err, errors.New(aws.ToString(output.FailureMessage)))
 		}
-
-		return output, err
 	}
 
-	return nil, err
+	return err
 }
 
 func waitNATGatewaySecondaryPrivateIPAddressCount(ctx context.Context, conn *ec2.Client, natGatewayID string, expectedCount int, timeout time.Duration) (*awstypes.NatGateway, error) {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Updates support for private AWS NAT Gateway to allow `secondary_private_ip_address_count` to be updated in place

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47476 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
❯ make testacc TESTS=TestAccVPCNATGateway_ PKG=ec2 ACCTEST_PARALLELISM=3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 fix/private-natgw-secondary-ip-count 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/ec2/... -v -count 1 -parallel 3 -run='TestAccVPCNATGateway_'  -timeout 360m -vet=off
2026/04/17 10:42:47 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/17 10:42:47 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCNATGateway_Identity_basic
=== PAUSE TestAccVPCNATGateway_Identity_basic
=== RUN   TestAccVPCNATGateway_Identity_regionOverride
=== PAUSE TestAccVPCNATGateway_Identity_regionOverride
=== RUN   TestAccVPCNATGateway_Identity_ExistingResource_basic
=== PAUSE TestAccVPCNATGateway_Identity_ExistingResource_basic
=== RUN   TestAccVPCNATGateway_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccVPCNATGateway_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccVPCNATGateway_List_basic
=== PAUSE TestAccVPCNATGateway_List_basic
=== RUN   TestAccVPCNATGateway_List_includeResource
=== PAUSE TestAccVPCNATGateway_List_includeResource
=== RUN   TestAccVPCNATGateway_List_regionOverride
=== PAUSE TestAccVPCNATGateway_List_regionOverride
=== RUN   TestAccVPCNATGateway_basic
=== PAUSE TestAccVPCNATGateway_basic
=== RUN   TestAccVPCNATGateway_disappears
=== PAUSE TestAccVPCNATGateway_disappears
=== RUN   TestAccVPCNATGateway_ConnectivityType_private
=== PAUSE TestAccVPCNATGateway_ConnectivityType_private
=== RUN   TestAccVPCNATGateway_privateIP
=== PAUSE TestAccVPCNATGateway_privateIP
=== RUN   TestAccVPCNATGateway_tags
=== PAUSE TestAccVPCNATGateway_tags
=== RUN   TestAccVPCNATGateway_secondaryAllocationIDs
=== PAUSE TestAccVPCNATGateway_secondaryAllocationIDs
=== RUN   TestAccVPCNATGateway_addSecondaryAllocationIDs
=== PAUSE TestAccVPCNATGateway_addSecondaryAllocationIDs
=== RUN   TestAccVPCNATGateway_secondaryPrivateIPAddressCount
=== PAUSE TestAccVPCNATGateway_secondaryPrivateIPAddressCount
=== RUN   TestAccVPCNATGateway_secondaryPrivateIPAddressCountToSpecific
=== PAUSE TestAccVPCNATGateway_secondaryPrivateIPAddressCountToSpecific
=== RUN   TestAccVPCNATGateway_secondaryPrivateIPAddressCount_updateInPlace
=== PAUSE TestAccVPCNATGateway_secondaryPrivateIPAddressCount_updateInPlace
=== RUN   TestAccVPCNATGateway_secondaryPrivateIPAddresses
=== PAUSE TestAccVPCNATGateway_secondaryPrivateIPAddresses
=== RUN   TestAccVPCNATGateway_SecondaryPrivateIPAddresses_private
=== PAUSE TestAccVPCNATGateway_SecondaryPrivateIPAddresses_private
=== RUN   TestAccVPCNATGateway_availabilityModeRegionalAuto
=== PAUSE TestAccVPCNATGateway_availabilityModeRegionalAuto
=== RUN   TestAccVPCNATGateway_availabilityModeRegionalManual_AddAndRemove
=== PAUSE TestAccVPCNATGateway_availabilityModeRegionalManual_AddAndRemove
=== RUN   TestAccVPCNATGateway_availabilityModeRegionalManual_ReplaceAndRemove
=== PAUSE TestAccVPCNATGateway_availabilityModeRegionalManual_ReplaceAndRemove
=== RUN   TestAccVPCNATGateway_availabilityModeRegionalManual_AZNameToAZID
=== PAUSE TestAccVPCNATGateway_availabilityModeRegionalManual_AZNameToAZID
=== RUN   TestAccVPCNATGateway_availabilityModeRegionalManual_AZIDToAZName
=== PAUSE TestAccVPCNATGateway_availabilityModeRegionalManual_AZIDToAZName
=== RUN   TestAccVPCNATGateway_availabilityModeRegionalSwitchMode
=== PAUSE TestAccVPCNATGateway_availabilityModeRegionalSwitchMode
=== CONT  TestAccVPCNATGateway_Identity_basic
=== CONT  TestAccVPCNATGateway_addSecondaryAllocationIDs
=== CONT  TestAccVPCNATGateway_availabilityModeRegionalAuto
--- PASS: TestAccVPCNATGateway_availabilityModeRegionalAuto (231.90s)
=== CONT  TestAccVPCNATGateway_availabilityModeRegionalManual_AZNameToAZID
--- PASS: TestAccVPCNATGateway_Identity_basic (237.58s)
=== CONT  TestAccVPCNATGateway_availabilityModeRegionalSwitchMode
--- PASS: TestAccVPCNATGateway_addSecondaryAllocationIDs (640.60s)
=== CONT  TestAccVPCNATGateway_availabilityModeRegionalManual_AZIDToAZName
--- PASS: TestAccVPCNATGateway_availabilityModeRegionalSwitchMode (586.87s)
=== CONT  TestAccVPCNATGateway_basic
--- PASS: TestAccVPCNATGateway_basic (216.86s)
=== CONT  TestAccVPCNATGateway_secondaryAllocationIDs
--- PASS: TestAccVPCNATGateway_availabilityModeRegionalManual_AZNameToAZID (1116.32s)
=== CONT  TestAccVPCNATGateway_tags
--- PASS: TestAccVPCNATGateway_tags (273.59s)
=== CONT  TestAccVPCNATGateway_privateIP
--- PASS: TestAccVPCNATGateway_secondaryAllocationIDs (695.90s)
=== CONT  TestAccVPCNATGateway_ConnectivityType_private
--- PASS: TestAccVPCNATGateway_availabilityModeRegionalManual_AZIDToAZName (1135.33s)
=== CONT  TestAccVPCNATGateway_disappears
--- PASS: TestAccVPCNATGateway_privateIP (218.80s)
=== CONT  TestAccVPCNATGateway_availabilityModeRegionalManual_ReplaceAndRemove
--- PASS: TestAccVPCNATGateway_ConnectivityType_private (197.84s)
=== CONT  TestAccVPCNATGateway_availabilityModeRegionalManual_AddAndRemove
--- PASS: TestAccVPCNATGateway_disappears (273.12s)
=== CONT  TestAccVPCNATGateway_List_basic
--- PASS: TestAccVPCNATGateway_List_basic (232.93s)
=== CONT  TestAccVPCNATGateway_List_regionOverride
--- PASS: TestAccVPCNATGateway_List_regionOverride (218.14s)
=== CONT  TestAccVPCNATGateway_List_includeResource
--- PASS: TestAccVPCNATGateway_availabilityModeRegionalManual_AddAndRemove (674.57s)
=== CONT  TestAccVPCNATGateway_secondaryPrivateIPAddressCount_updateInPlace
--- PASS: TestAccVPCNATGateway_List_includeResource (182.95s)
=== CONT  TestAccVPCNATGateway_SecondaryPrivateIPAddresses_private
--- PASS: TestAccVPCNATGateway_availabilityModeRegionalManual_ReplaceAndRemove (1101.38s)
=== CONT  TestAccVPCNATGateway_secondaryPrivateIPAddresses
--- PASS: TestAccVPCNATGateway_secondaryPrivateIPAddressCount_updateInPlace (343.51s)
=== CONT  TestAccVPCNATGateway_Identity_ExistingResource_basic
--- PASS: TestAccVPCNATGateway_Identity_ExistingResource_basic (288.23s)
=== CONT  TestAccVPCNATGateway_Identity_ExistingResource_noRefreshNoChange
--- PASS: TestAccVPCNATGateway_SecondaryPrivateIPAddresses_private (610.15s)
=== CONT  TestAccVPCNATGateway_Identity_regionOverride
--- PASS: TestAccVPCNATGateway_Identity_ExistingResource_noRefreshNoChange (257.99s)
=== CONT  TestAccVPCNATGateway_secondaryPrivateIPAddressCountToSpecific
--- PASS: TestAccVPCNATGateway_Identity_regionOverride (257.70s)
=== CONT  TestAccVPCNATGateway_secondaryPrivateIPAddressCount
--- PASS: TestAccVPCNATGateway_secondaryPrivateIPAddresses (659.82s)
--- PASS: TestAccVPCNATGateway_secondaryPrivateIPAddressCount (215.30s)
--- PASS: TestAccVPCNATGateway_secondaryPrivateIPAddressCountToSpecific (594.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        4093.839s
...
```
