### PR TITLE
fix: update `source_uri` regex to match AWS resource documentation

### DIFF
--- a/.changelog/47498.txt
+++ b/.changelog/47498.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_appintegrations_data_integration: Fix `source_uri` regular expression validation
+```

--- a/internal/service/appintegrations/data_integration.go
+++ b/internal/service/appintegrations/data_integration.go
@@ -101,7 +101,7 @@ func resourceDataIntegration() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 1000),
-					validation.StringMatch(regexache.MustCompile(`^\w+\:\/\/\w+\/[\w/!@#+=.-]+$`), "should be a valid source uri"),
+					validation.StringMatch(regexache.MustCompile(`^(\w+\:\/\/[\w.-]+[\w/!@#+=.-]+$)|(\w+\:\/\/[\w.-]+[\w/!@#+=.-]+[\w/!@#+=.-]+[\w/!@#+=.,-]+$)`), "should be a valid source uri"),
 				),
 			},
 			names.AttrTags:    tftags.TagsSchema(),


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

The validation of `source_uri` is updated with the regex available in the current AWS documentation (see _References_ section)

* Old: `^\w+\:\/\/\w+\/[\w/!@#+=.-]+$`
* New: `^(\w+\:\/\/[\w.-]+[\w/!@#+=.-]+$)|(\w+\:\/\/[\w.-]+[\w/!@#+=.-]+[\w/!@#+=.-]+[\w/!@#+=.,-]+$)`

### Relations

- Relates  #47464 

### References

- [AWS Docs - CreateDataIntegration](https://docs.aws.amazon.com/connect/latest/APIReference/API_connect-app-integrations_CreateDataIntegration.html)

### Output from Acceptance Testing

```console
export DATA_INTEGRATION_SOURCE_URI="Salesforce://AppFlow/test"    
make testacc T=TestAccAppIntegrationsDataIntegration_ K=appintegrations
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws_appintegrations_data_integration-update-source-uri-validation 🌿...
TF_ACC=1 go1.25.9 test ./internal/service/appintegrations/... -v -count 1 -parallel 20 -run='TestAccAppIntegrationsDataIntegration_'  -timeout 360m -vet=off
2026/04/16 21:32:56 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/16 21:32:56 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAppIntegrationsDataIntegration_basic
=== PAUSE TestAccAppIntegrationsDataIntegration_basic
=== RUN   TestAccAppIntegrationsDataIntegration_updateDescription
=== PAUSE TestAccAppIntegrationsDataIntegration_updateDescription
=== RUN   TestAccAppIntegrationsDataIntegration_updateName
=== PAUSE TestAccAppIntegrationsDataIntegration_updateName
=== RUN   TestAccAppIntegrationsDataIntegration_updateTags
=== PAUSE TestAccAppIntegrationsDataIntegration_updateTags
=== CONT  TestAccAppIntegrationsDataIntegration_basic
=== CONT  TestAccAppIntegrationsDataIntegration_updateName
=== CONT  TestAccAppIntegrationsDataIntegration_updateTags
=== CONT  TestAccAppIntegrationsDataIntegration_updateDescription
--- PASS: TestAccAppIntegrationsDataIntegration_basic (46.44s)
--- PASS: TestAccAppIntegrationsDataIntegration_updateDescription (67.14s)
--- PASS: TestAccAppIntegrationsDataIntegration_updateName (67.44s)
--- PASS: TestAccAppIntegrationsDataIntegration_updateTags (85.25s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appintegrations    85.416s
...
```
