### PR TITLE
td/route53resolver sweepers

### DIFF
--- a/internal/service/route53resolver/sweep.go
+++ b/internal/service/route53resolver/sweep.go
@@ -4,14 +4,17 @@
 package route53resolver
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/route53resolver"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/route53resolver/types"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -79,10 +82,7 @@ func RegisterSweepers() {
 		},
 	})
 
-	resource.AddTestSweepers("aws_route53_resolver_rule_association", &resource.Sweeper{
-		Name: "aws_route53_resolver_rule_association",
-		F:    sweepRuleAssociations,
-	})
+	awsv2.Register("aws_route53_resolver_rule_association", sweepRuleAssociations)
 
 	resource.AddTestSweepers("aws_route53_resolver_rule", &resource.Sweeper{
 		Name: "aws_route53_resolver_rule",
@@ -500,12 +500,7 @@ func sweepQueryLogsConfig(region string) error {
 	return nil
 }
 
-func sweepRuleAssociations(region string) error {
-	ctx := sweep.Context(region)
-	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-	if err != nil {
-		return fmt.Errorf("getting client: %w", err)
-	}
+func sweepRuleAssociations(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	conn := client.Route53ResolverClient(ctx)
 	input := &route53resolver.ListResolverRuleAssociationsInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
@@ -513,17 +508,16 @@ func sweepRuleAssociations(region string) error {
 	pages := route53resolver.NewListResolverRuleAssociationsPaginator(conn, input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-
-		if awsv2.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Route53 Resolver Rule Association sweep for %s: %s", region, err)
-			return nil
-		}
-
 		if err != nil {
-			return fmt.Errorf("error listing Route53 Resolver Rule Associations (%s): %w", region, err)
+			return nil, err
 		}
 
 		for _, v := range page.ResolverRuleAssociations {
+			// Cannot associate or disassociate system defined rules
+			if strings.Contains(strings.ToLower(aws.ToString(v.Id)), "autodefined") {
+				continue
+			}
+
 			r := resourceRuleAssociation()
 			d := r.Data(nil)
 			d.SetId(aws.ToString(v.Id))
@@ -534,13 +528,7 @@ func sweepRuleAssociations(region string) error {
 		}
 	}
 
-	err = sweep.SweepOrchestrator(ctx, sweepResources)
-
-	if err != nil {
-		return fmt.Errorf("error sweeping Route53 Resolver Rule Associations (%s): %w", region, err)
-	}
-
-	return nil
+	return sweepResources, nil
 }
 
 func sweepRules(region string) error {

--- a/internal/service/route53resolver/sweep.go
+++ b/internal/service/route53resolver/sweep.go
@@ -5,7 +5,6 @@ package route53resolver
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"strings"
 
@@ -13,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/route53resolver"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/route53resolver/types"
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
@@ -21,84 +19,23 @@ import (
 )
 
 func RegisterSweepers() {
-	resource.AddTestSweepers("aws_route53_resolver_dnssec_config", &resource.Sweeper{
-		Name: "aws_route53_resolver_dnssec_config",
-		F:    sweepDNSSECConfig,
-	})
-
-	resource.AddTestSweepers("aws_route53_resolver_endpoint", &resource.Sweeper{
-		Name: "aws_route53_resolver_endpoint",
-		F:    sweepEndpoints,
-		Dependencies: []string{
-			"aws_route53_resolver_rule",
-		},
-	})
-
-	resource.AddTestSweepers("aws_route53_resolver_firewall_config", &resource.Sweeper{
-		Name: "aws_route53_resolver_firewall_config",
-		F:    sweepFirewallConfigs,
-	})
-
-	resource.AddTestSweepers("aws_route53_resolver_firewall_domain_list", &resource.Sweeper{
-		Name: "aws_route53_resolver_firewall_domain_list",
-		F:    sweepFirewallDomainLists,
-		Dependencies: []string{
-			"aws_route53_resolver_firewall_rule",
-		},
-	})
-
-	resource.AddTestSweepers("aws_route53_resolver_firewall_rule_group_association", &resource.Sweeper{
-		Name: "aws_route53_resolver_firewall_rule_group_association",
-		F:    sweepFirewallRuleGroupAssociations,
-	})
-
-	resource.AddTestSweepers("aws_route53_resolver_firewall_rule_group", &resource.Sweeper{
-		Name: "aws_route53_resolver_firewall_rule_group",
-		F:    sweepFirewallRuleGroups,
-		Dependencies: []string{
-			"aws_route53_resolver_firewall_rule",
-			"aws_route53_resolver_firewall_rule_group_association",
-		},
-	})
-
-	resource.AddTestSweepers("aws_route53_resolver_firewall_rule", &resource.Sweeper{
-		Name: "aws_route53_resolver_firewall_rule",
-		F:    sweepFirewallRules,
-		Dependencies: []string{
-			"aws_route53_resolver_firewall_rule_group_association",
-		},
-	})
-
-	resource.AddTestSweepers("aws_route53_resolver_query_log_config_association", &resource.Sweeper{
-		Name: "aws_route53_resolver_query_log_config_association",
-		F:    sweepQueryLogConfigAssociations,
-	})
-
-	resource.AddTestSweepers("aws_route53_resolver_query_log_config", &resource.Sweeper{
-		Name: "aws_route53_resolver_query_log_config",
-		F:    sweepQueryLogsConfig,
-		Dependencies: []string{
-			"aws_route53_resolver_query_log_config_association",
-		},
-	})
-
+	awsv2.Register("aws_route53_resolver_dnssec_config", sweepDNSSECConfig)
+	awsv2.Register("aws_route53_resolver_endpoint", sweepEndpoints, "aws_route53_resolver_rule")
+	awsv2.Register("aws_route53_resolver_firewall_config", sweepFirewallConfigs)
+	awsv2.Register("aws_route53_resolver_firewall_domain_list", sweepFirewallDomainLists, "aws_route53_resolver_firewall_rule")
+	awsv2.Register("aws_route53_resolver_firewall_rule_group_association", sweepFirewallRuleGroupAssociations)
+	awsv2.Register("aws_route53_resolver_firewall_rule_group", sweepFirewallRuleGroups,
+		"aws_route53_resolver_firewall_rule",
+		"aws_route53_resolver_firewall_rule_group_association",
+	)
+	awsv2.Register("aws_route53_resolver_firewall_rule", sweepFirewallRules, "aws_route53_resolver_firewall_rule_group_association")
+	awsv2.Register("aws_route53_resolver_query_log_config_association", sweepQueryLogConfigAssociations)
+	awsv2.Register("aws_route53_resolver_query_log_config", sweepQueryLogsConfig, "aws_route53_resolver_query_log_config_association")
 	awsv2.Register("aws_route53_resolver_rule_association", sweepRuleAssociations)
-
-	resource.AddTestSweepers("aws_route53_resolver_rule", &resource.Sweeper{
-		Name: "aws_route53_resolver_rule",
-		F:    sweepRules,
-		Dependencies: []string{
-			"aws_route53_resolver_rule_association",
-		},
-	})
+	awsv2.Register("aws_route53_resolver_rule", sweepRules, "aws_route53_resolver_rule_association")
 }
 
-func sweepDNSSECConfig(region string) error {
-	ctx := sweep.Context(region)
-	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-	if err != nil {
-		return fmt.Errorf("getting client: %w", err)
-	}
+func sweepDNSSECConfig(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	conn := client.Route53ResolverClient(ctx)
 	input := &route53resolver.ListResolverDnssecConfigsInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
@@ -106,14 +43,8 @@ func sweepDNSSECConfig(region string) error {
 	pages := route53resolver.NewListResolverDnssecConfigsPaginator(conn, input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-
-		if awsv2.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Route53 Resolver DNSSEC Config sweep for %s: %s", region, err)
-			return nil
-		}
-
 		if err != nil {
-			return fmt.Errorf("error listing Route53 Resolver DNSSEC Configs (%s): %w", region, err)
+			return nil, err
 		}
 
 		for _, v := range page.ResolverDnssecConfigs {
@@ -126,21 +57,10 @@ func sweepDNSSECConfig(region string) error {
 		}
 	}
 
-	err = sweep.SweepOrchestrator(ctx, sweepResources)
-
-	if err != nil {
-		return fmt.Errorf("error sweeping Route53 Resolver DNSSEC Configs (%s): %w", region, err)
-	}
-
-	return nil
+	return sweepResources, nil
 }
 
-func sweepEndpoints(region string) error {
-	ctx := sweep.Context(region)
-	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-	if err != nil {
-		return fmt.Errorf("getting client: %w", err)
-	}
+func sweepEndpoints(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	conn := client.Route53ResolverClient(ctx)
 	input := &route53resolver.ListResolverEndpointsInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
@@ -148,14 +68,8 @@ func sweepEndpoints(region string) error {
 	pages := route53resolver.NewListResolverEndpointsPaginator(conn, input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-
-		if awsv2.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Route53 Resolver Endpoint sweep for %s: %s", region, err)
-			return nil
-		}
-
 		if err != nil {
-			return fmt.Errorf("error listing Route53 Resolver Endpoints (%s): %w", region, err)
+			return nil, err
 		}
 
 		for _, v := range page.ResolverEndpoints {
@@ -167,21 +81,10 @@ func sweepEndpoints(region string) error {
 		}
 	}
 
-	err = sweep.SweepOrchestrator(ctx, sweepResources)
-
-	if err != nil {
-		return fmt.Errorf("error sweeping Route53 Resolver Endpoints (%s): %w", region, err)
-	}
-
-	return nil
+	return sweepResources, nil
 }
 
-func sweepFirewallConfigs(region string) error {
-	ctx := sweep.Context(region)
-	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-	if err != nil {
-		return fmt.Errorf("getting client: %w", err)
-	}
+func sweepFirewallConfigs(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	conn := client.Route53ResolverClient(ctx)
 	input := &route53resolver.ListFirewallConfigsInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
@@ -189,14 +92,8 @@ func sweepFirewallConfigs(region string) error {
 	pages := route53resolver.NewListFirewallConfigsPaginator(conn, input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-
-		if awsv2.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Route53 Resolver Firewall Config sweep for %s: %s", region, err)
-			return nil
-		}
-
 		if err != nil {
-			return fmt.Errorf("error listing Route53 Resolver Firewall Configs (%s): %w", region, err)
+			return nil, err
 		}
 
 		for _, v := range page.FirewallConfigs {
@@ -209,21 +106,10 @@ func sweepFirewallConfigs(region string) error {
 		}
 	}
 
-	err = sweep.SweepOrchestrator(ctx, sweepResources)
-
-	if err != nil {
-		return fmt.Errorf("error sweeping Route53 Resolver Firewall Configs (%s): %w", region, err)
-	}
-
-	return nil
+	return sweepResources, nil
 }
 
-func sweepFirewallDomainLists(region string) error {
-	ctx := sweep.Context(region)
-	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-	if err != nil {
-		return fmt.Errorf("getting client: %w", err)
-	}
+func sweepFirewallDomainLists(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	conn := client.Route53ResolverClient(ctx)
 	input := &route53resolver.ListFirewallDomainListsInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
@@ -231,14 +117,8 @@ func sweepFirewallDomainLists(region string) error {
 	pages := route53resolver.NewListFirewallDomainListsPaginator(conn, input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-
-		if awsv2.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Route53 Resolver Firewall Domain List sweep for %s: %s", region, err)
-			return nil
-		}
-
 		if err != nil {
-			return fmt.Errorf("error listing Route53 Resolver Firewall Domain Lists (%s): %w", region, err)
+			return nil, err
 		}
 
 		for _, v := range page.FirewallDomainLists {
@@ -250,21 +130,10 @@ func sweepFirewallDomainLists(region string) error {
 		}
 	}
 
-	err = sweep.SweepOrchestrator(ctx, sweepResources)
-
-	if err != nil {
-		return fmt.Errorf("error sweeping Route53 Resolver Firewall Domain Lists (%s): %w", region, err)
-	}
-
-	return nil
+	return sweepResources, nil
 }
 
-func sweepFirewallRuleGroupAssociations(region string) error {
-	ctx := sweep.Context(region)
-	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-	if err != nil {
-		return fmt.Errorf("getting client: %w", err)
-	}
+func sweepFirewallRuleGroupAssociations(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	conn := client.Route53ResolverClient(ctx)
 	input := &route53resolver.ListFirewallRuleGroupAssociationsInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
@@ -272,14 +141,8 @@ func sweepFirewallRuleGroupAssociations(region string) error {
 	pages := route53resolver.NewListFirewallRuleGroupAssociationsPaginator(conn, input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-
-		if awsv2.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Route53 Resolver Firewall Rule Group Association sweep for %s: %s", region, err)
-			return nil
-		}
-
 		if err != nil {
-			return fmt.Errorf("error listing Route53 Resolver Firewall Rule Group Associations (%s): %w", region, err)
+			return nil, err
 		}
 
 		for _, v := range page.FirewallRuleGroupAssociations {
@@ -291,21 +154,10 @@ func sweepFirewallRuleGroupAssociations(region string) error {
 		}
 	}
 
-	err = sweep.SweepOrchestrator(ctx, sweepResources)
-
-	if err != nil {
-		return fmt.Errorf("error sweeping Route53 Resolver Firewall Rule Group Associations (%s): %w", region, err)
-	}
-
-	return nil
+	return sweepResources, nil
 }
 
-func sweepFirewallRuleGroups(region string) error {
-	ctx := sweep.Context(region)
-	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-	if err != nil {
-		return fmt.Errorf("getting client: %w", err)
-	}
+func sweepFirewallRuleGroups(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	conn := client.Route53ResolverClient(ctx)
 	input := &route53resolver.ListFirewallRuleGroupsInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
@@ -313,14 +165,8 @@ func sweepFirewallRuleGroups(region string) error {
 	pages := route53resolver.NewListFirewallRuleGroupsPaginator(conn, input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-
-		if awsv2.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Route53 Resolver Firewall Rule Group sweep for %s: %s", region, err)
-			return nil
-		}
-
 		if err != nil {
-			return fmt.Errorf("error listing Route53 Resolver Firewall Rule Groups (%s): %w", region, err)
+			return nil, err
 		}
 
 		for _, v := range page.FirewallRuleGroups {
@@ -339,21 +185,10 @@ func sweepFirewallRuleGroups(region string) error {
 		}
 	}
 
-	err = sweep.SweepOrchestrator(ctx, sweepResources)
-
-	if err != nil {
-		return fmt.Errorf("error sweeping Route53 Resolver Firewall Rule Groups (%s): %w", region, err)
-	}
-
-	return nil
+	return sweepResources, nil
 }
 
-func sweepFirewallRules(region string) error {
-	ctx := sweep.Context(region)
-	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-	if err != nil {
-		return fmt.Errorf("getting client: %w", err)
-	}
+func sweepFirewallRules(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	conn := client.Route53ResolverClient(ctx)
 	input := &route53resolver.ListFirewallRuleGroupsInput{}
 	var sweeperErrs *multierror.Error
@@ -362,14 +197,13 @@ func sweepFirewallRules(region string) error {
 	pages := route53resolver.NewListFirewallRuleGroupsPaginator(conn, input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-
 		if awsv2.SkipSweepError(err) {
-			log.Print(fmt.Errorf("[WARN] Skipping Route53 Resolver Firewall Rule sweep for %s: %w", region, err))
-			return sweeperErrs.ErrorOrNil()
+			return nil, err
 		}
 
 		if err != nil {
-			sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Route53 Resolver Firewall Rule Groups (%s): %w", region, err))
+			sweeperErrs = multierror.Append(sweeperErrs, err)
+			continue
 		}
 
 		for _, v := range page.FirewallRuleGroups {
@@ -393,7 +227,8 @@ func sweepFirewallRules(region string) error {
 				}
 
 				if err != nil {
-					sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Route53 Resolver Firewall Rules (%s): %w", region, err))
+					sweeperErrs = multierror.Append(sweeperErrs, err)
+					continue
 				}
 
 				for _, v := range page.FirewallRules {
@@ -407,21 +242,10 @@ func sweepFirewallRules(region string) error {
 		}
 	}
 
-	err = sweep.SweepOrchestrator(ctx, sweepResources)
-
-	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping Route53 Resolver Firewall Rules (%s): %w", region, err))
-	}
-
-	return sweeperErrs.ErrorOrNil()
+	return sweepResources, sweeperErrs.ErrorOrNil()
 }
 
-func sweepQueryLogConfigAssociations(region string) error {
-	ctx := sweep.Context(region)
-	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-	if err != nil {
-		return fmt.Errorf("getting client: %w", err)
-	}
+func sweepQueryLogConfigAssociations(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	conn := client.Route53ResolverClient(ctx)
 	input := &route53resolver.ListResolverQueryLogConfigAssociationsInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
@@ -429,14 +253,8 @@ func sweepQueryLogConfigAssociations(region string) error {
 	pages := route53resolver.NewListResolverQueryLogConfigAssociationsPaginator(conn, input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-
-		if awsv2.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Route53 Resolver Query Log Config Association sweep for %s: %s", region, err)
-			return nil
-		}
-
 		if err != nil {
-			return fmt.Errorf("error listing Route53 Resolver Query Log Config Associations (%s): %w", region, err)
+			return nil, err
 		}
 
 		for _, v := range page.ResolverQueryLogConfigAssociations {
@@ -450,21 +268,10 @@ func sweepQueryLogConfigAssociations(region string) error {
 		}
 	}
 
-	err = sweep.SweepOrchestrator(ctx, sweepResources)
-
-	if err != nil {
-		return fmt.Errorf("error sweeping Route53 Resolver Query Log Config Associations (%s): %w", region, err)
-	}
-
-	return nil
+	return sweepResources, nil
 }
 
-func sweepQueryLogsConfig(region string) error {
-	ctx := sweep.Context(region)
-	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-	if err != nil {
-		return fmt.Errorf("getting client: %w", err)
-	}
+func sweepQueryLogsConfig(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	conn := client.Route53ResolverClient(ctx)
 	input := &route53resolver.ListResolverQueryLogConfigsInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
@@ -472,14 +279,8 @@ func sweepQueryLogsConfig(region string) error {
 	pages := route53resolver.NewListResolverQueryLogConfigsPaginator(conn, input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-
-		if awsv2.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Route53 Resolver Query Log Config sweep for %s: %s", region, err)
-			return nil
-		}
-
 		if err != nil {
-			return fmt.Errorf("error listing Route53 Resolver Query Log Configs (%s): %w", region, err)
+			return nil, err
 		}
 
 		for _, v := range page.ResolverQueryLogConfigs {
@@ -491,13 +292,7 @@ func sweepQueryLogsConfig(region string) error {
 		}
 	}
 
-	err = sweep.SweepOrchestrator(ctx, sweepResources)
-
-	if err != nil {
-		return fmt.Errorf("error sweeping Route53 Resolver Query Log Configs (%s): %w", region, err)
-	}
-
-	return nil
+	return sweepResources, nil
 }
 
 func sweepRuleAssociations(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
@@ -513,14 +308,16 @@ func sweepRuleAssociations(ctx context.Context, client *conns.AWSClient) ([]swee
 		}
 
 		for _, v := range page.ResolverRuleAssociations {
+			id := aws.ToString(v.Id)
 			// Cannot associate or disassociate system defined rules
-			if strings.Contains(strings.ToLower(aws.ToString(v.Id)), "autodefined") {
+			if strings.Contains(strings.ToLower(id), "autodefined") {
+				log.Printf("[INFO] Skipping Route53 Resolver Rule Associations %s: System Defined", id)
 				continue
 			}
 
 			r := resourceRuleAssociation()
 			d := r.Data(nil)
-			d.SetId(aws.ToString(v.Id))
+			d.SetId(id)
 			d.Set("resolver_rule_id", v.ResolverRuleId)
 			d.Set(names.AttrVPCID, v.VPCId)
 
@@ -531,12 +328,7 @@ func sweepRuleAssociations(ctx context.Context, client *conns.AWSClient) ([]swee
 	return sweepResources, nil
 }
 
-func sweepRules(region string) error {
-	ctx := sweep.Context(region)
-	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-	if err != nil {
-		return fmt.Errorf("getting client: %w", err)
-	}
+func sweepRules(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	conn := client.Route53ResolverClient(ctx)
 	input := &route53resolver.ListResolverRulesInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
@@ -544,14 +336,8 @@ func sweepRules(region string) error {
 	pages := route53resolver.NewListResolverRulesPaginator(conn, input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-
-		if awsv2.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Route53 Resolver Rule sweep for %s: %s", region, err)
-			return nil
-		}
-
 		if err != nil {
-			return fmt.Errorf("error listing Route53 Resolver Rules (%s): %w", region, err)
+			return nil, err
 		}
 
 		for _, v := range page.ResolverRules {
@@ -567,11 +353,5 @@ func sweepRules(region string) error {
 		}
 	}
 
-	err = sweep.SweepOrchestrator(ctx, sweepResources)
-
-	if err != nil {
-		return fmt.Errorf("error sweeping Route53 Resolver Rules (%s): %w", region, err)
-	}
-
-	return nil
+	return sweepResources, nil
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Refactor sweepers, fix sweep errors

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make sweep SWEEPARGS='-sweep-allow-failures -sweep-run=aws_route53_resolver_ -sweep=us-west-2'

# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go1.26.2 test ./internal/sweep -v -sweep=us-west-2,us-east-1,us-east-2,us-west-1 -sweep-allow-failures -sweep-run=aws_route53_resolver_ -sweep=us-west-2 -timeout 360m -vet=off
2026/04/16 16:05:02 [DEBUG] Running Sweepers for region (us-west-2):
2026/04/16 16:05:02 [DEBUG] Sweeper (aws_route53_resolver_firewall_rule_group) has dependency (aws_route53_resolver_firewall_rule), running..
2026/04/16 16:05:02 [DEBUG] Sweeper (aws_route53_resolver_firewall_rule) has dependency (aws_route53_resolver_firewall_rule_group_association), running..
2026/04/16 16:05:02 [DEBUG] Running Sweeper (aws_route53_resolver_firewall_rule_group_association) in region (us-west-2)
2026/04/16 16:05:02 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_firewall_rule_group_association
2026-04-16T16:05:02.042-0500 [DEBUG] sweeper.aws-base: Resolving credentials provider: tf_resource_type=aws_route53_resolver_firewall_rule_group_association sweeper_region=us-west-2
2026-04-16T16:05:02.042-0500 [DEBUG] sweeper.aws-base: Using profile: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_firewall_rule_group_association tf_aws.profile=default tf_aws.profile.source=envvar
2026-04-16T16:05:02.042-0500 [DEBUG] sweeper.aws-base: Loading configuration: tf_resource_type=aws_route53_resolver_firewall_rule_group_association sweeper_region=us-west-2
2026-04-16T16:05:02.044-0500 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_firewall_rule_group_association
2026-04-16T16:05:02.044-0500 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_firewall_rule_group_association tf_aws.credentials_source="SharedConfigCredentials: /Users/adrianjohnson/.aws/credentials"
2026-04-16T16:05:02.044-0500 [DEBUG] sweeper.aws-base: Loading configuration: tf_resource_type=aws_route53_resolver_firewall_rule_group_association sweeper_region=us-west-2
2026/04/16 16:05:02 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_firewall_rule_group_association
2026-04-16T16:05:02.044-0500 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_firewall_rule_group_association
2026-04-16T16:05:02.412-0500 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_firewall_rule_group_association
2026/04/16 16:05:02 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_firewall_rule_group_association
2026/04/16 16:05:02 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_firewall_rule_group_association
2026/04/16 16:05:02 [DEBUG] Completed Sweeper (aws_route53_resolver_firewall_rule_group_association) in region (us-west-2) in 608.709459ms
2026/04/16 16:05:02 [DEBUG] Running Sweeper (aws_route53_resolver_firewall_rule) in region (us-west-2)
2026/04/16 16:05:02 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_firewall_rule
2026/04/16 16:05:02 [INFO] Skipping Route53 Resolver Firewall Rule Group rslvr-frg-1ba3acc5851b4587: ShareStatus=SHARED_WITH_ME
2026/04/16 16:05:02 [INFO] Skipping Route53 Resolver Firewall Rule Group rslvr-frg-995f6c4451e24109: ShareStatus=SHARED_WITH_ME
2026/04/16 16:05:02 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_firewall_rule
2026/04/16 16:05:02 [DEBUG] Completed Sweeper (aws_route53_resolver_firewall_rule) in region (us-west-2) in 107.62575ms
2026/04/16 16:05:02 [DEBUG] Sweeper (aws_route53_resolver_firewall_rule_group) has dependency (aws_route53_resolver_firewall_rule_group_association), running..
2026/04/16 16:05:02 [DEBUG] Sweeper (aws_route53_resolver_firewall_rule_group_association) already ran in region (us-west-2)
2026/04/16 16:05:02 [DEBUG] Running Sweeper (aws_route53_resolver_firewall_rule_group) in region (us-west-2)
2026/04/16 16:05:02 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_firewall_rule_group
2026/04/16 16:05:02 [INFO] Skipping Route53 Resolver Firewall Rule Group rslvr-frg-1ba3acc5851b4587: ShareStatus=SHARED_WITH_ME
2026/04/16 16:05:02 [INFO] Skipping Route53 Resolver Firewall Rule Group rslvr-frg-995f6c4451e24109: ShareStatus=SHARED_WITH_ME
2026/04/16 16:05:02 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_firewall_rule_group
2026/04/16 16:05:02 [DEBUG] Completed Sweeper (aws_route53_resolver_firewall_rule_group) in region (us-west-2) in 95.396958ms
2026/04/16 16:05:02 [DEBUG] Running Sweeper (aws_route53_resolver_dnssec_config) in region (us-west-2)
2026/04/16 16:05:02 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_dnssec_config
2026/04/16 16:05:02 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_dnssec_config
2026/04/16 16:05:02 [DEBUG] Completed Sweeper (aws_route53_resolver_dnssec_config) in region (us-west-2) in 86.854709ms
2026/04/16 16:05:02 [DEBUG] Sweeper (aws_route53_resolver_endpoint) has dependency (aws_route53_resolver_rule), running..
2026/04/16 16:05:02 [DEBUG] Sweeper (aws_route53_resolver_rule) has dependency (aws_route53_resolver_rule_association), running..
2026/04/16 16:05:02 [DEBUG] Running Sweeper (aws_route53_resolver_rule_association) in region (us-west-2)
2026/04/16 16:05:02 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_rule_association
2026/04/16 16:05:03 [INFO] Skipping Route53 Resolver Rule Associations rslvr-autodefined-assoc-vpc-fb633683-internet-resolver: System Defined
2026/04/16 16:05:03 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_rule_association
2026/04/16 16:05:03 [DEBUG] Completed Sweeper (aws_route53_resolver_rule_association) in region (us-west-2) in 206.746375ms
2026/04/16 16:05:03 [DEBUG] Running Sweeper (aws_route53_resolver_rule) in region (us-west-2)
2026/04/16 16:05:03 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_rule
2026/04/16 16:05:03 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_rule
2026/04/16 16:05:03 [DEBUG] Completed Sweeper (aws_route53_resolver_rule) in region (us-west-2) in 109.721542ms
2026/04/16 16:05:03 [DEBUG] Running Sweeper (aws_route53_resolver_endpoint) in region (us-west-2)
2026/04/16 16:05:03 [INFO]  sweeper: listing resources: tf_resource_type=aws_route53_resolver_endpoint sweeper_region=us-west-2
2026/04/16 16:05:03 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_endpoint
2026/04/16 16:05:03 [DEBUG] Completed Sweeper (aws_route53_resolver_endpoint) in region (us-west-2) in 107.413958ms
2026/04/16 16:05:03 [DEBUG] Sweeper (aws_route53_resolver_rule) has dependency (aws_route53_resolver_rule_association), running..
2026/04/16 16:05:03 [DEBUG] Sweeper (aws_route53_resolver_rule_association) already ran in region (us-west-2)
2026/04/16 16:05:03 [DEBUG] Sweeper (aws_route53_resolver_rule) already ran in region (us-west-2)
2026/04/16 16:05:03 [DEBUG] Sweeper (aws_route53_resolver_rule_association) already ran in region (us-west-2)
2026/04/16 16:05:03 [DEBUG] Sweeper (aws_route53_resolver_firewall_domain_list) has dependency (aws_route53_resolver_firewall_rule), running..
2026/04/16 16:05:03 [DEBUG] Sweeper (aws_route53_resolver_firewall_rule) has dependency (aws_route53_resolver_firewall_rule_group_association), running..
2026/04/16 16:05:03 [DEBUG] Sweeper (aws_route53_resolver_firewall_rule_group_association) already ran in region (us-west-2)
2026/04/16 16:05:03 [DEBUG] Sweeper (aws_route53_resolver_firewall_rule) already ran in region (us-west-2)
2026/04/16 16:05:03 [DEBUG] Running Sweeper (aws_route53_resolver_firewall_domain_list) in region (us-west-2)
2026/04/16 16:05:03 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_firewall_domain_list
2026/04/16 16:05:03 [DEBUG] Deleting Route53 Resolver Firewall Domain List: rslvr-fdl-fe17696f22a445f6
2026/04/16 16:05:03 [DEBUG] Deleting Route53 Resolver Firewall Domain List: rslvr-fdl-c80983a1f0284c99
2026/04/16 16:05:03 [DEBUG] Deleting Route53 Resolver Firewall Domain List: rslvr-fdl-d252ee1944404e15
2026/04/16 16:05:03 [DEBUG] Deleting Route53 Resolver Firewall Domain List: rslvr-fdl-23584f0fb4c24ebb
2026/04/16 16:05:03 [DEBUG] Completed Sweeper (aws_route53_resolver_firewall_domain_list) in region (us-west-2) in 279.776083ms
2026/04/16 16:05:03 [DEBUG] Sweeper (aws_route53_resolver_firewall_rule) has dependency (aws_route53_resolver_firewall_rule_group_association), running..
2026/04/16 16:05:03 [DEBUG] Sweeper (aws_route53_resolver_firewall_rule_group_association) already ran in region (us-west-2)
2026/04/16 16:05:03 [DEBUG] Sweeper (aws_route53_resolver_firewall_rule) already ran in region (us-west-2)
2026/04/16 16:05:03 [DEBUG] Sweeper (aws_route53_resolver_firewall_rule_group_association) already ran in region (us-west-2)
2026/04/16 16:05:03 [DEBUG] Sweeper (aws_route53_resolver_query_log_config) has dependency (aws_route53_resolver_query_log_config_association), running..
2026/04/16 16:05:03 [DEBUG] Running Sweeper (aws_route53_resolver_query_log_config_association) in region (us-west-2)
2026/04/16 16:05:03 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_query_log_config_association
2026/04/16 16:05:03 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_query_log_config_association
2026/04/16 16:05:03 [DEBUG] Completed Sweeper (aws_route53_resolver_query_log_config_association) in region (us-west-2) in 120.105625ms
2026/04/16 16:05:03 [DEBUG] Running Sweeper (aws_route53_resolver_query_log_config) in region (us-west-2)
2026/04/16 16:05:03 [INFO]  sweeper: listing resources: tf_resource_type=aws_route53_resolver_query_log_config sweeper_region=us-west-2
2026/04/16 16:05:03 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2 tf_resource_type=aws_route53_resolver_query_log_config
2026/04/16 16:05:03 [DEBUG] Completed Sweeper (aws_route53_resolver_query_log_config) in region (us-west-2) in 132.374167ms
2026/04/16 16:05:03 [DEBUG] Sweeper (aws_route53_resolver_query_log_config_association) already ran in region (us-west-2)
2026/04/16 16:05:03 [DEBUG] Running Sweeper (aws_route53_resolver_firewall_config) in region (us-west-2)
2026/04/16 16:05:03 [INFO]  sweeper: listing resources: tf_resource_type=aws_route53_resolver_firewall_config sweeper_region=us-west-2
2026/04/16 16:05:04 [DEBUG] Deleting Route53 Resolver Firewall Config: rslvr-fc-4d8190e405d83773
2026/04/16 16:05:04 [DEBUG] Completed Sweeper (aws_route53_resolver_firewall_config) in region (us-west-2) in 409.380833ms
2026/04/16 16:05:04 Completed Sweepers for region (us-west-2) in 2.265011917s
2026/04/16 16:05:04 Sweeper Tests for region (us-west-2) ran successfully:
2026/04/16 16:05:04     - aws_route53_resolver_query_log_config
2026/04/16 16:05:04     - aws_route53_resolver_firewall_config
2026/04/16 16:05:04     - aws_route53_resolver_firewall_rule_group_association
2026/04/16 16:05:04     - aws_route53_resolver_firewall_rule
2026/04/16 16:05:04     - aws_route53_resolver_firewall_rule_group
2026/04/16 16:05:04     - aws_route53_resolver_rule
2026/04/16 16:05:04     - aws_route53_resolver_dnssec_config
2026/04/16 16:05:04     - aws_route53_resolver_rule_association
2026/04/16 16:05:04     - aws_route53_resolver_endpoint
2026/04/16 16:05:04     - aws_route53_resolver_firewall_domain_list
2026/04/16 16:05:04     - aws_route53_resolver_query_log_config_association
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      10.948s
```

