### PR TITLE
Framework schema validation: reduce memory usage at initialization

### DIFF
--- a/internal/framework/types/null.go
+++ b/internal/framework/types/null.go
@@ -7,14 +7,14 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 )
 
 // NullValueOf returns a null attr.Value for the specified `v`.
-func NullValueOf(ctx context.Context, v any) (attr.Value, error) {
+func NullValueOf(ctx context.Context, v any) (attr.Value, diag.Diagnostics) {
 	var attrType attr.Type
 	var tfType tftypes.Type
 
@@ -22,38 +22,38 @@ func NullValueOf(ctx context.Context, v any) (attr.Value, error) {
 	case basetypes.BoolValuable:
 		attrType = v.Type(ctx)
 		toType := attrType.(basetypes.BoolTypable)
-		return fwdiag.Must(toType.ValueFromBool(ctx, types.BoolNull())), nil
+		return toType.ValueFromBool(ctx, types.BoolNull())
 
 	case basetypes.Float32Valuable:
 		attrType = v.Type(ctx)
 		toType := attrType.(basetypes.Float32Typable)
-		return fwdiag.Must(toType.ValueFromFloat32(ctx, types.Float32Null())), nil
+		return toType.ValueFromFloat32(ctx, types.Float32Null())
 
 	case basetypes.Float64Valuable:
 		attrType = v.Type(ctx)
 		toType := attrType.(basetypes.Float64Typable)
-		return fwdiag.Must(toType.ValueFromFloat64(ctx, types.Float64Null())), nil
+		return toType.ValueFromFloat64(ctx, types.Float64Null())
 
 	case basetypes.Int32Valuable:
 		attrType = v.Type(ctx)
 		toType := attrType.(basetypes.Int32Typable)
-		return fwdiag.Must(toType.ValueFromInt32(ctx, types.Int32Null())), nil
+		return toType.ValueFromInt32(ctx, types.Int32Null())
 
 	case basetypes.Int64Valuable:
 		attrType = v.Type(ctx)
 		toType := attrType.(basetypes.Int64Typable)
-		return fwdiag.Must(toType.ValueFromInt64(ctx, types.Int64Null())), nil
+		return toType.ValueFromInt64(ctx, types.Int64Null())
 
 	case basetypes.StringValuable:
 		attrType = v.Type(ctx)
 		toType := attrType.(basetypes.StringTypable)
-		return fwdiag.Must(toType.ValueFromString(ctx, types.StringNull())), nil
+		return toType.ValueFromString(ctx, types.StringNull())
 
 	case basetypes.ListValuable:
 		attrType = v.Type(ctx)
 		if v, ok := attrType.(attr.TypeWithElementType); ok {
 			toType := attrType.(basetypes.ListTypable)
-			return fwdiag.Must(toType.ValueFromList(ctx, types.ListNull(v.ElementType()))), nil
+			return toType.ValueFromList(ctx, types.ListNull(v.ElementType()))
 		} else {
 			tfType = tftypes.List{}
 		}
@@ -62,7 +62,7 @@ func NullValueOf(ctx context.Context, v any) (attr.Value, error) {
 		attrType = v.Type(ctx)
 		if v, ok := attrType.(attr.TypeWithElementType); ok {
 			toType := attrType.(basetypes.SetTypable)
-			return fwdiag.Must(toType.ValueFromSet(ctx, types.SetNull(v.ElementType()))), nil
+			return toType.ValueFromSet(ctx, types.SetNull(v.ElementType()))
 		} else {
 			tfType = tftypes.Set{}
 		}
@@ -71,7 +71,7 @@ func NullValueOf(ctx context.Context, v any) (attr.Value, error) {
 		attrType = v.Type(ctx)
 		if v, ok := attrType.(attr.TypeWithElementType); ok {
 			toType := attrType.(basetypes.MapTypable)
-			return fwdiag.Must(toType.ValueFromMap(ctx, types.MapNull(v.ElementType()))), nil
+			return toType.ValueFromMap(ctx, types.MapNull(v.ElementType()))
 		} else {
 			tfType = tftypes.Map{}
 		}
@@ -80,7 +80,7 @@ func NullValueOf(ctx context.Context, v any) (attr.Value, error) {
 		attrType = v.Type(ctx)
 		if v, ok := attrType.(attr.TypeWithAttributeTypes); ok {
 			toType := attrType.(basetypes.ObjectTypable)
-			return fwdiag.Must(toType.ValueFromObject(ctx, types.ObjectNull(v.AttributeTypes()))), nil
+			return toType.ValueFromObject(ctx, types.ObjectNull(v.AttributeTypes()))
 		} else {
 			tfType = tftypes.Object{}
 		}
@@ -89,5 +89,9 @@ func NullValueOf(ctx context.Context, v any) (attr.Value, error) {
 		return nil, nil
 	}
 
-	return attrType.ValueFromTerraform(ctx, tftypes.NewValue(tfType, nil))
+	result, err := attrType.ValueFromTerraform(ctx, tftypes.NewValue(tfType, nil))
+	return result, diag.Diagnostics{diag.NewErrorDiagnostic(
+		"Incompatible Types",
+		err.Error(),
+	)}
 }

--- a/internal/framework/types/null.go
+++ b/internal/framework/types/null.go
@@ -7,9 +7,10 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	tfmaps "github.com/hashicorp/terraform-provider-aws/internal/maps"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 )
 
 // NullValueOf returns a null attr.Value for the specified `v`.
@@ -20,52 +21,70 @@ func NullValueOf(ctx context.Context, v any) (attr.Value, error) {
 	switch v := v.(type) {
 	case basetypes.BoolValuable:
 		attrType = v.Type(ctx)
-		tfType = tftypes.Bool
+		toType := attrType.(basetypes.BoolTypable)
+		return fwdiag.Must(toType.ValueFromBool(ctx, types.BoolNull())), nil
+
 	case basetypes.Float32Valuable:
 		attrType = v.Type(ctx)
-		tfType = tftypes.Number
+		toType := attrType.(basetypes.Float32Typable)
+		return fwdiag.Must(toType.ValueFromFloat32(ctx, types.Float32Null())), nil
+
 	case basetypes.Float64Valuable:
 		attrType = v.Type(ctx)
-		tfType = tftypes.Number
+		toType := attrType.(basetypes.Float64Typable)
+		return fwdiag.Must(toType.ValueFromFloat64(ctx, types.Float64Null())), nil
+
 	case basetypes.Int32Valuable:
 		attrType = v.Type(ctx)
-		tfType = tftypes.Number
+		toType := attrType.(basetypes.Int32Typable)
+		return fwdiag.Must(toType.ValueFromInt32(ctx, types.Int32Null())), nil
+
 	case basetypes.Int64Valuable:
 		attrType = v.Type(ctx)
-		tfType = tftypes.Number
+		toType := attrType.(basetypes.Int64Typable)
+		return fwdiag.Must(toType.ValueFromInt64(ctx, types.Int64Null())), nil
+
 	case basetypes.StringValuable:
 		attrType = v.Type(ctx)
-		tfType = tftypes.String
+		toType := attrType.(basetypes.StringTypable)
+		return fwdiag.Must(toType.ValueFromString(ctx, types.StringNull())), nil
+
 	case basetypes.ListValuable:
 		attrType = v.Type(ctx)
 		if v, ok := attrType.(attr.TypeWithElementType); ok {
-			tfType = tftypes.List{ElementType: v.ElementType().TerraformType(ctx)}
+			toType := attrType.(basetypes.ListTypable)
+			return fwdiag.Must(toType.ValueFromList(ctx, types.ListNull(v.ElementType()))), nil
 		} else {
 			tfType = tftypes.List{}
 		}
+
 	case basetypes.SetValuable:
 		attrType = v.Type(ctx)
 		if v, ok := attrType.(attr.TypeWithElementType); ok {
-			tfType = tftypes.Set{ElementType: v.ElementType().TerraformType(ctx)}
+			toType := attrType.(basetypes.SetTypable)
+			return fwdiag.Must(toType.ValueFromSet(ctx, types.SetNull(v.ElementType()))), nil
 		} else {
 			tfType = tftypes.Set{}
 		}
+
 	case basetypes.MapValuable:
 		attrType = v.Type(ctx)
 		if v, ok := attrType.(attr.TypeWithElementType); ok {
-			tfType = tftypes.Map{ElementType: v.ElementType().TerraformType(ctx)}
+			toType := attrType.(basetypes.MapTypable)
+			return fwdiag.Must(toType.ValueFromMap(ctx, types.MapNull(v.ElementType()))), nil
 		} else {
 			tfType = tftypes.Map{}
 		}
+
 	case basetypes.ObjectValuable:
 		attrType = v.Type(ctx)
 		if v, ok := attrType.(attr.TypeWithAttributeTypes); ok {
-			tfType = tftypes.Object{AttributeTypes: tfmaps.ApplyToAllValues(v.AttributeTypes(), func(attrType attr.Type) tftypes.Type {
-				return attrType.TerraformType(ctx)
-			})}
+			toType := attrType.(basetypes.ObjectTypable)
+			return fwdiag.Must(toType.ValueFromObject(ctx, types.ObjectNull(v.AttributeTypes()))), nil
 		} else {
 			tfType = tftypes.Object{}
 		}
+
 	default:
 		return nil, nil
 	}

--- a/internal/framework/types/null_test.go
+++ b/internal/framework/types/null_test.go
@@ -1,0 +1,221 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package types_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+)
+
+type enumString string
+
+const (
+	enumStringValue1 enumString = "value1"
+)
+
+func (enumString) Values() []enumString {
+	return []enumString{
+		enumStringValue1,
+	}
+}
+
+func TestNullValueOf_primitiveTypes(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    any
+		expected attr.Value
+	}{
+		"bool": {
+			input:    types.BoolValue(true),
+			expected: types.BoolNull(),
+		},
+		"float32": {
+			input:    types.Float32Value(1.0),
+			expected: types.Float32Null(),
+		},
+		"float64": {
+			input:    types.Float64Value(1.0),
+			expected: types.Float64Null(),
+		},
+		"int32": {
+			input:    types.Int32Value(1),
+			expected: types.Int32Null(),
+		},
+		"int64": {
+			input:    types.Int64Value(1),
+			expected: types.Int64Null(),
+		},
+		"string": {
+			input:    types.StringValue("test"),
+			expected: types.StringNull(),
+		},
+
+		"enum": {
+			input:    fwtypes.StringEnumValue(enumStringValue1),
+			expected: fwtypes.StringEnumNull[enumString](),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := fwtypes.NullValueOf(context.Background(), testCase.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if e, a := testCase.expected, got; !e.Equal(a) {
+				t.Errorf("Did not get Null value")
+			}
+		})
+	}
+}
+
+func TestNullValueOf_listTypes(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    any
+		expected attr.Value
+	}{
+		"typed": {
+			input:    fwtypes.NewListValueOfMust[types.String](context.Background(), []attr.Value{}),
+			expected: fwtypes.NewListValueOfNull[types.String](context.Background()),
+		},
+		"raw": {
+			input:    types.ListValueMust(types.StringType, []attr.Value{}),
+			expected: types.ListNull(types.StringType),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := fwtypes.NullValueOf(context.Background(), testCase.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if e, a := testCase.expected, got; !e.Equal(a) {
+				t.Errorf("Did not get Null value")
+			}
+		})
+	}
+}
+
+func TestNullValueOf_setTypes(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    any
+		expected attr.Value
+	}{
+		"typed": {
+			input:    fwtypes.NewSetValueOfMust[types.String](context.Background(), []attr.Value{}),
+			expected: fwtypes.NewSetValueOfNull[types.String](context.Background()),
+		},
+		"raw": {
+			input:    types.SetValueMust(types.StringType, []attr.Value{}),
+			expected: types.SetNull(types.StringType),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := fwtypes.NullValueOf(context.Background(), testCase.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if e, a := testCase.expected, got; !e.Equal(a) {
+				t.Errorf("Did not get Null value")
+			}
+		})
+	}
+}
+
+func TestNullValueOf_mapTypes(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    any
+		expected attr.Value
+	}{
+		"typed": {
+			input:    fwtypes.NewMapValueOfMust[types.String](context.Background(), map[string]attr.Value{}),
+			expected: fwtypes.NewMapValueOfNull[types.String](context.Background()),
+		},
+		"raw": {
+			input:    types.MapValueMust(types.StringType, map[string]attr.Value{}),
+			expected: types.MapNull(types.StringType),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := fwtypes.NullValueOf(context.Background(), testCase.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if e, a := testCase.expected, got; !e.Equal(a) {
+				t.Errorf("Did not get Null value")
+			}
+		})
+	}
+}
+
+func TestNullValueOf_objectTypes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	type object struct {
+		Name types.String `tfsdk:"name"`
+	}
+
+	testCases := map[string]struct {
+		input    any
+		expected attr.Value
+	}{
+		"typed": {
+			input: fwtypes.NewObjectValueOfMust(ctx, &object{
+				Name: types.StringValue("test"),
+			}),
+			expected: fwtypes.NewObjectValueOfNull[object](ctx),
+		},
+		"raw": {
+			input: types.ObjectValueMust(fwtypes.AttributeTypesMust[object](ctx), map[string]attr.Value{
+				"name": types.StringValue("test"),
+			}),
+			expected: types.ObjectNull(fwtypes.AttributeTypesMust[object](ctx)),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := fwtypes.NullValueOf(ctx, testCase.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if e, a := testCase.expected, got; !e.Equal(a) {
+				t.Errorf("Did not get Null value")
+			}
+		})
+	}
+}

--- a/internal/framework/types/null_test.go
+++ b/internal/framework/types/null_test.go
@@ -67,9 +67,9 @@ func TestNullValueOf_primitiveTypes(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := fwtypes.NullValueOf(context.Background(), testCase.input)
-			if err != nil {
-				t.Fatalf("unexpected error: %s", err)
+			got, diags := fwtypes.NullValueOf(context.Background(), testCase.input)
+			if diags.HasError() {
+				t.Fatalf("unexpected error: %s", diags[0].Summary())
 			}
 
 			if e, a := testCase.expected, got; !e.Equal(a) {
@@ -109,9 +109,9 @@ func TestNullValueOf_listTypes(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := fwtypes.NullValueOf(context.Background(), testCase.input)
-			if err != nil {
-				t.Fatalf("unexpected error: %s", err)
+			got, diags := fwtypes.NullValueOf(context.Background(), testCase.input)
+			if diags.HasError() {
+				t.Fatalf("unexpected error: %s", diags[0].Summary())
 			}
 
 			if e, a := testCase.expected, got; !e.Equal(a) {
@@ -151,9 +151,9 @@ func TestNullValueOf_setTypes(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := fwtypes.NullValueOf(context.Background(), testCase.input)
-			if err != nil {
-				t.Fatalf("unexpected error: %s", err)
+			got, diags := fwtypes.NullValueOf(context.Background(), testCase.input)
+			if diags.HasError() {
+				t.Fatalf("unexpected error: %s", diags[0].Summary())
 			}
 
 			if e, a := testCase.expected, got; !e.Equal(a) {
@@ -193,9 +193,9 @@ func TestNullValueOf_mapTypes(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := fwtypes.NullValueOf(context.Background(), testCase.input)
-			if err != nil {
-				t.Fatalf("unexpected error: %s", err)
+			got, diags := fwtypes.NullValueOf(context.Background(), testCase.input)
+			if diags.HasError() {
+				t.Fatalf("unexpected error: %s", diags[0].Summary())
 			}
 
 			if e, a := testCase.expected, got; !e.Equal(a) {
@@ -244,9 +244,9 @@ func TestNullValueOf_objectTypes(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := fwtypes.NullValueOf(ctx, testCase.input)
-			if err != nil {
-				t.Fatalf("unexpected error: %s", err)
+			got, diags := fwtypes.NullValueOf(ctx, testCase.input)
+			if diags.HasError() {
+				t.Fatalf("unexpected error: %s", diags[0].Summary())
 			}
 
 			if e, a := testCase.expected, got; !e.Equal(a) {

--- a/internal/framework/types/null_test.go
+++ b/internal/framework/types/null_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 )
 
@@ -89,9 +90,18 @@ func TestNullValueOf_listTypes(t *testing.T) {
 			input:    fwtypes.NewListValueOfMust[types.String](context.Background(), []attr.Value{}),
 			expected: fwtypes.NewListValueOfNull[types.String](context.Background()),
 		},
+		"typed uninitialized": {
+			input:    fwtypes.ListValueOf[types.String]{},
+			expected: fwtypes.NewListValueOfNull[types.String](context.Background()),
+		},
 		"raw": {
 			input:    types.ListValueMust(types.StringType, []attr.Value{}),
 			expected: types.ListNull(types.StringType),
+		},
+		"raw uninitialized": {
+			input: basetypes.ListValue{},
+			// To get "missing type"
+			expected: types.ListNull(basetypes.ListValue{}.Type(context.Background()).(attr.TypeWithElementType).ElementType()),
 		},
 	}
 
@@ -122,9 +132,18 @@ func TestNullValueOf_setTypes(t *testing.T) {
 			input:    fwtypes.NewSetValueOfMust[types.String](context.Background(), []attr.Value{}),
 			expected: fwtypes.NewSetValueOfNull[types.String](context.Background()),
 		},
+		"typed uninitialized": {
+			input:    fwtypes.SetValueOf[types.String]{},
+			expected: fwtypes.NewSetValueOfNull[types.String](context.Background()),
+		},
 		"raw": {
 			input:    types.SetValueMust(types.StringType, []attr.Value{}),
 			expected: types.SetNull(types.StringType),
+		},
+		"raw uninitialized": {
+			input: basetypes.SetValue{},
+			// To get "missing type"
+			expected: types.SetNull(basetypes.SetValue{}.Type(context.Background()).(attr.TypeWithElementType).ElementType()),
 		},
 	}
 
@@ -155,9 +174,18 @@ func TestNullValueOf_mapTypes(t *testing.T) {
 			input:    fwtypes.NewMapValueOfMust[types.String](context.Background(), map[string]attr.Value{}),
 			expected: fwtypes.NewMapValueOfNull[types.String](context.Background()),
 		},
+		"typed uninitialized": {
+			input:    fwtypes.MapValueOf[types.String]{},
+			expected: fwtypes.NewMapValueOfNull[types.String](context.Background()),
+		},
 		"raw": {
 			input:    types.MapValueMust(types.StringType, map[string]attr.Value{}),
 			expected: types.MapNull(types.StringType),
+		},
+		"raw uninitialized": {
+			input: basetypes.MapValue{},
+			// To get "missing type"
+			expected: types.MapNull(basetypes.MapValue{}.Type(context.Background()).(attr.TypeWithElementType).ElementType()),
 		},
 	}
 
@@ -196,11 +224,19 @@ func TestNullValueOf_objectTypes(t *testing.T) {
 			}),
 			expected: fwtypes.NewObjectValueOfNull[object](ctx),
 		},
+		"typed uninitialized": {
+			input:    fwtypes.ObjectValueOf[object]{},
+			expected: fwtypes.NewObjectValueOfNull[object](ctx),
+		},
 		"raw": {
 			input: types.ObjectValueMust(fwtypes.AttributeTypesMust[object](ctx), map[string]attr.Value{
 				"name": types.StringValue("test"),
 			}),
 			expected: types.ObjectNull(fwtypes.AttributeTypesMust[object](ctx)),
+		},
+		"raw uninitialized": {
+			input:    basetypes.ObjectValue{},
+			expected: basetypes.ObjectValue{},
 		},
 	}
 

--- a/internal/framework/types/objectof.go
+++ b/internal/framework/types/objectof.go
@@ -160,10 +160,9 @@ func NullOutObjectPtrFields[T any](ctx context.Context, t *T) diag.Diagnostics {
 			continue
 		}
 
-		attrValue, err := NullValueOf(ctx, fieldVal.Interface())
-
-		if err != nil {
-			diags.Append(diag.NewErrorDiagnostic("attr.Type.ValueFromTerraform", err.Error()))
+		attrValue, d := NullValueOf(ctx, fieldVal.Interface())
+		diags.Append(d...)
+		if diags.HasError() {
 			return diags
 		}
 

--- a/internal/framework/types/objectof_test.go
+++ b/internal/framework/types/objectof_test.go
@@ -180,21 +180,21 @@ func TestObjectValueOfEqual(t *testing.T) {
 func TestNullOutObjectPtrFields(t *testing.T) {
 	t.Parallel()
 
-	type b struct {
+	type inner struct {
 		F5 types.String `tfsdk:"f5"`
 		F6 types.Int32  `tfsdk:"f6"`
 	}
 
-	type A struct {
+	type Outer struct {
 		F1 types.Bool                        `tfsdk:"f1"`
 		F2 types.String                      `tfsdk:"f2"`
 		F3 fwtypes.ListValueOf[types.String] `tfsdk:"f3"`
 		F4 fwtypes.SetValueOf[types.Int64]   `tfsdk:"f4"`
-		b
+		inner
 	}
 
 	ctx := context.Background()
-	a := new(A)
+	a := new(Outer)
 	a.F1 = types.BoolValue(true)
 	a.F2 = types.StringValue("test")
 	a.F3 = fwtypes.NewListValueOfMust[types.String](ctx, []attr.Value{types.StringValue("test")})
@@ -223,5 +223,28 @@ func TestNullOutObjectPtrFields(t *testing.T) {
 	}
 	if !a.F6.IsNull() {
 		t.Errorf("expected F6 to be null")
+	}
+}
+
+func BenchmarkNullOutObjectPtrFields(b *testing.B) {
+	type inner struct {
+		F5 types.String `tfsdk:"f5"`
+		F6 types.Int32  `tfsdk:"f6"`
+	}
+
+	type Outer struct {
+		F1 types.Bool                        `tfsdk:"f1"`
+		F2 types.String                      `tfsdk:"f2"`
+		F3 fwtypes.ListValueOf[types.String] `tfsdk:"f3"`
+		F4 fwtypes.SetValueOf[types.Int64]   `tfsdk:"f4"`
+		inner
+	}
+	ctx := context.Background()
+
+	for b.Loop() {
+		var a Outer
+		if diags := fwtypes.NullOutObjectPtrFields(ctx, &a); diags.HasError() {
+			b.Fatalf("unexpected error: %v", diags)
+		}
 	}
 }

--- a/internal/framework/with_list.go
+++ b/internal/framework/with_list.go
@@ -136,9 +136,9 @@ func walkStructSetZeroAttrNull(ctx context.Context, value reflect.Value, diags *
 
 		if attrValue, ok := field.Interface().(attr.Value); ok {
 			if field.IsZero() {
-				nullValue, err := fwtypes.NullValueOf(ctx, attrValue)
-				if err != nil {
-					diags.AddError("Normalizing List Result", err.Error())
+				nullValue, d := fwtypes.NullValueOf(ctx, attrValue)
+				if d.HasError() {
+					diags.Append(d...)
 					return
 				}
 

--- a/internal/provider/factory_test.go
+++ b/internal/provider/factory_test.go
@@ -10,7 +10,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/provider"
 )
 
-// go test -bench=BenchmarkProtoV5ProviderServerFactory -benchtime 1x -benchmem -run=Bench -v ./internal/provider
+// To run this benchmark:
+// go test -bench=BenchmarkProtoV5ProviderServerFactory -benchtime 1x -benchmem -run=^$ -v ./internal/provider
 func BenchmarkProtoV5ProviderServerFactory(b *testing.B) {
 	_, p, err := provider.ProtoV5ProviderServerFactory(context.Background())
 

--- a/internal/provider/framework/provider_test.go
+++ b/internal/provider/framework/provider_test.go
@@ -32,7 +32,7 @@ import (
 // 	}
 // }
 
-func BenchmarkFrameworkProviderDataSourceSchemaInitialization(b *testing.B) {
+func BenchmarkFrameworkProvider_SchemaInitialization_DataSource(b *testing.B) {
 	ctx := b.Context()
 	primary, err := sdkv2.NewProvider(ctx)
 	if err != nil {
@@ -54,7 +54,7 @@ func BenchmarkFrameworkProviderDataSourceSchemaInitialization(b *testing.B) {
 	}
 }
 
-func BenchmarkFrameworkProviderResourceSchemaInitialization(b *testing.B) {
+func BenchmarkFrameworkProvider_SchemaInitialization_Resource(b *testing.B) {
 	ctx := b.Context()
 	primary, err := sdkv2.NewProvider(ctx)
 	if err != nil {

--- a/internal/provider/framework/provider_test.go
+++ b/internal/provider/framework/provider_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2"
 )
 
-// go test -bench=. -benchmem -run=Bench -v ./internal/provider/framework
+// To run these benchmarks:
+// go test -bench=. -benchmem -run=^$ -v ./internal/provider/framework
 
 // This logs Initialization an annoying number of times
 // func BenchmarkFrameworkProviderInitialization(b *testing.B) {

--- a/internal/provider/framework/provider_test.go
+++ b/internal/provider/framework/provider_test.go
@@ -48,7 +48,10 @@ func BenchmarkFrameworkProvider_validateResourceSchemas(b *testing.B) {
 	// Reset memory counters to zero, so that we only measure the schema validation.
 	b.ResetTimer()
 	for b.Loop() {
-		provider.validateResourceSchemas(ctx)
+		err := provider.validateResourceSchemas(ctx)
+		if err != nil {
+			b.Fatalf("Validating resource schemas: %s", err)
+		}
 	}
 }
 

--- a/internal/provider/framework/provider_test.go
+++ b/internal/provider/framework/provider_test.go
@@ -32,6 +32,26 @@ import (
 // 	}
 // }
 
+func BenchmarkFrameworkProvider_validateResourceSchemas(b *testing.B) {
+	ctx := b.Context()
+	primary, err := sdkv2.NewProvider(ctx)
+	if err != nil {
+		b.Fatalf("Initializing SDKv2 provider: %s", err)
+	}
+	p, err := NewProvider(ctx, primary)
+	if err != nil {
+		b.Fatalf("Initializing Framework provider: %s", err)
+	}
+
+	provider := p.(*frameworkProvider)
+
+	// Reset memory counters to zero, so that we only measure the schema validation.
+	b.ResetTimer()
+	for b.Loop() {
+		provider.validateResourceSchemas(ctx)
+	}
+}
+
 func BenchmarkFrameworkProvider_SchemaInitialization_DataSource(b *testing.B) {
 	ctx := b.Context()
 	primary, err := sdkv2.NewProvider(ctx)

--- a/internal/provider/sdkv2/provider_test.go
+++ b/internal/provider/sdkv2/provider_test.go
@@ -17,7 +17,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// go test -bench=BenchmarkSDKProviderInitialization -benchmem -run=Bench -v ./internal/provider/sdkv2
+// To run this benchmark:
+// go test -bench=BenchmarkSDKProviderInitialization -benchmem -run=^$ -v ./internal/provider/sdkv2
 func BenchmarkSDKProviderInitialization(b *testing.B) {
 	ctx := b.Context()
 	for b.Loop() {

--- a/internal/reflect/struct.go
+++ b/internal/reflect/struct.go
@@ -16,23 +16,42 @@ import (
 // index components from each struct as used by `reflect.Value.FieldByIndex`
 func StructFields(typ reflect.Type) iter.Seq[reflect.StructField] {
 	return func(yield func(reflect.StructField) bool) {
-		structFields_(typ, []int{}, yield)
+		structFields_(typ, yield)
 	}
 }
 
-func structFields_(typ reflect.Type, parentIndex []int, yield func(reflect.StructField) bool) bool {
+func structFields_(typ reflect.Type, yield func(reflect.StructField) bool) bool {
 	for i := range typ.NumField() {
 		field := typ.Field(i)
 
 		if field.Anonymous {
-			fieldIndexSequence := append(parentIndex, i) //nolint:gocritic // append re-assign is intentional
-			if !structFields_(field.Type, fieldIndexSequence, yield) {
+			fieldIndexSequence := []int{i}
+			if !structFieldsInner_(field.Type, fieldIndexSequence, yield) {
 				return false
 			}
 			continue
 		}
 
-		field.Index = append(parentIndex, i) //nolint:gocritic // append re-assign is intentional
+		if !yield(field) {
+			return false
+		}
+	}
+	return true
+}
+
+func structFieldsInner_(typ reflect.Type, parentIndex []int, yield func(reflect.StructField) bool) bool {
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		field.Index = append(parentIndex, field.Index...)
+
+		if field.Anonymous {
+			fieldIndexSequence := append(parentIndex, i) //nolint:gocritic // append re-assign is intentional
+			if !structFieldsInner_(field.Type, fieldIndexSequence, yield) {
+				return false
+			}
+			continue
+		}
+
 		if !yield(field) {
 			return false
 		}

--- a/internal/reflect/struct_test.go
+++ b/internal/reflect/struct_test.go
@@ -172,6 +172,143 @@ func TestStructFields(t *testing.T) {
 	}
 }
 
+func BenchmarkStructFields(b *testing.B) {
+	testCases := map[string]struct {
+		in       any
+		expected []reflect.StructField
+	}{
+		"empty struct": {
+			in:       struct{}{},
+			expected: nil,
+		},
+		"basic struct": {
+			in: ExampleStruct{},
+			expected: []reflect.StructField{
+				{
+					Name:      "Field1",
+					Index:     []int{0},
+					Anonymous: false,
+				},
+				{
+					Name:      "Field2",
+					Index:     []int{1},
+					Anonymous: false,
+				},
+				{
+					Name:      "unexportedField",
+					Index:     []int{2},
+					Anonymous: false,
+				},
+			},
+		},
+		"embedded struct": {
+			in: struct {
+				ExampleStruct
+				Field3 bool
+			}{},
+			expected: []reflect.StructField{
+				{
+					Name:      "Field1",
+					Index:     []int{0, 0},
+					Anonymous: false,
+				},
+				{
+					Name:      "Field2",
+					Index:     []int{0, 1},
+					Anonymous: false,
+				},
+				{
+					Name:      "unexportedField",
+					Index:     []int{0, 2},
+					Anonymous: false,
+				},
+				{
+					Name:      "Field3",
+					Index:     []int{1},
+					Anonymous: false,
+				},
+			},
+		},
+		"unexported embedded struct": {
+			in: struct {
+				unexportedStruct
+				Field3 bool
+			}{},
+			expected: []reflect.StructField{
+				{
+					Name:      "Field1",
+					Index:     []int{0, 0},
+					Anonymous: false,
+				},
+				{
+					Name:      "Field2",
+					Index:     []int{0, 1},
+					Anonymous: false,
+				},
+				{
+					Name:      "unexportedField",
+					Index:     []int{0, 2},
+					Anonymous: false,
+				},
+				{
+					Name:      "Field3",
+					Index:     []int{1},
+					Anonymous: false,
+				},
+			},
+		},
+		"nested embedded struct": {
+			in: struct {
+				NestedEmbedStruct
+				Field5 bool
+			}{},
+			expected: []reflect.StructField{
+				{
+					Name:      "Field3",
+					Index:     []int{0, 0},
+					Anonymous: false,
+				},
+				{
+					Name:      "Field1",
+					Index:     []int{0, 1, 0},
+					Anonymous: false,
+				},
+				{
+					Name:      "Field2",
+					Index:     []int{0, 1, 1},
+					Anonymous: false,
+				},
+				{
+					Name:      "unexportedField",
+					Index:     []int{0, 1, 2},
+					Anonymous: false,
+				},
+				{
+					Name:      "Field4",
+					Index:     []int{0, 2},
+					Anonymous: false,
+				},
+				{
+					Name:      "Field5",
+					Index:     []int{1},
+					Anonymous: false,
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		b.Run(name, func(b *testing.B) {
+			for b.Loop() {
+				var out []reflect.StructField
+				for v := range StructFields(reflect.TypeOf(testCase.in)) {
+					out = append(out, v)
+				}
+			}
+		})
+	}
+}
+
 func TestExportedStructFields(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

#### Starting Conditions

Running the benchmarks for `internal/provider/framework` we get:

| | Iterations | Time per Operation | Bytes per Operation | Allocations per Operation |
|-|-----------:|-------------------:|--------------------:|--------------------------:|
| BenchmarkFrameworkProvider_validateResourceSchemas-10         |  56 |  21111132 ns/op |  22792241 B/op |  351188 allocs/op |
| BenchmarkFrameworkProvider_SchemaInitialization_DataSource-10 | 110 |  10678396 ns/op |  10076999 B/op |  132738 allocs/op |
| BenchmarkFrameworkProvider_SchemaInitialization_Resource-10   |   5 | 243899017 ns/op | 262137081 B/op | 3608213 allocs/op |

Much of the memory usage in `provider.validateResourceSchemas` is from `types.NullOutObjectPtrFields`.
The benchmark for `types.NullOutObjectPtrFields` gives the following results:

| | Iterations | Time per Operation | Bytes per Operation | Allocations per Operation |
|-|-----------:|-------------------:|--------------------:|--------------------------:|
| BenchmarkNullOutObjectPtrFields-10 | 857992 | 1231 ns/op | 1552 B/op | 8 allocs/op |

`types.NullValueOf` allocates 752 MB, 56.09% of the allocated memory.

#### `types.NullValueOf`

`types.NullValueOf` roundtrips from `attr.Value` through `tftypes` and back to `attr.Value`.
By directly creating `attr.Value`s we get the result:

| | Iterations | Time per Operation | Bytes per Operation | Allocations per Operation |
|-|-----------:|-------------------:|--------------------:|--------------------------:|
| BenchmarkNullOutObjectPtrFields-10 | 1374900 | 869.1 ns/op | 880 B/op | 24 allocs/op |

`types.NullValueOf` now creates only 290 MB, 24.99% of the allocated memory.

`StructFields` iterator allocates 132 MB, 11.37% of the allocated memory.
`StructFields` has an "inefficient recursion in iterator StructFields" warning.

#### `StructFields` Iterator

Before the update to `StructFields`, the benchmark gives the results:

| | Iterations | Time per Operation | Bytes per Operation | Allocations per Operation |
|-|-----------:|-------------------:|--------------------:|--------------------------:|
| BenchmarkStructFields/empty_struct-10               | 26719140 |  44.61 ns/op |   56 B/op |  3 allocs/op |
| BenchmarkStructFields/basic_struct-10               |  4034526 | 295.5  ns/op |  792 B/op |  6 allocs/op |
| BenchmarkStructFields/embedded_struct-10            |  2768274 | 429.9  ns/op |  928 B/op | 12 allocs/op |
| BenchmarkStructFields/unexported_embedded_struct-10 |  2807506 | 423.8  ns/op |  928 B/op | 12 allocs/op |
| BenchmarkStructFields/nested_embedded_struct-10     |  1500784 | 808.9  ns/op | 2016 B/op | 21 allocs/op |

After the update, the benchmark results are:

| | Iterations | Time per Operation | Bytes per Operation | Allocations per Operation |
|-|-----------:|-------------------:|--------------------:|--------------------------:|
| BenchmarkStructFields/empty_struct-10               | 297567662 |   4.033 ns/op |    0 B/op |  0 allocs/op |
| BenchmarkStructFields/basic_struct-10               |   4045129 | 296.9 ns/op   |  760 B/op |  6 allocs/op |
| BenchmarkStructFields/embedded_struct-10            |   3141991 | 376.9 ns/op   |  808 B/op |  9 allocs/op |
| BenchmarkStructFields/unexported_embedded_struct-10 |   3197392 | 383.2 ns/op   |  808 B/op |  9 allocs/op |
| BenchmarkStructFields/nested_embedded_struct-10     |   1830408 | 652.2 ns/op   | 1816 B/op | 14 allocs/op |

`StructFields` iterator and inner functions now allocate 71.5 MB, 6.56% of the allocated memory.

#### Final Results

After the updates to `types.NullValueOf` and `reflect.StructFields`, the benchmark results are:

| | Iterations | Time per Operation | Bytes per Operation | Allocations per Operation |
|-|-----------:|-------------------:|--------------------:|--------------------------:|
| BenchmarkFrameworkProvider_validateResourceSchemas-10         |  75 |  15759549 ns/op |  14170806 B/op |  157690 allocs/op |
| BenchmarkFrameworkProvider_SchemaInitialization_DataSource-10 | 123 |   9624727 ns/op |   8859599 B/op |  110627 allocs/op |
| BenchmarkFrameworkProvider_SchemaInitialization_Resource-10   |   6 | 191729590 ns/op | 194724517 B/op | 2330940 allocs/op |

`provider.validateResourceSchemas`:
* Allocates 37.8% less memory
* Makes 55.1% fewer allocations
* Runs 25.3% faster