### PR TITLE
[Enhancement] aws_s3files_file_system: Add `accept_bucket_warning` argument

### DIFF
--- a/.changelog/47510.txt
+++ b/.changelog/47510.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3files_file_system: Add `accept_bucket_warning` argument
+```

--- a/internal/service/s3files/file_system.go
+++ b/internal/service/s3files/file_system.go
@@ -59,6 +59,9 @@ type fileSystemResource struct {
 func (r *fileSystemResource) Schema(ctx context.Context, _ resource.SchemaRequest, response *resource.SchemaResponse) {
 	response.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"accept_bucket_warning": schema.BoolAttribute{
+				Optional: true,
+			},
 			names.AttrARN: framework.ARNAttributeComputedOnly(),
 			names.AttrBucket: schema.StringAttribute{
 				Required: true,
@@ -257,20 +260,21 @@ func (r *fileSystemResource) Delete(ctx context.Context, request resource.Delete
 
 type fileSystemResourceModel struct {
 	framework.WithRegionModel
-	ARN           types.String      `tfsdk:"arn"`
-	Bucket        types.String      `tfsdk:"bucket"`
-	CreationTime  timetypes.RFC3339 `tfsdk:"creation_time"`
-	ID            types.String      `tfsdk:"id"`
-	KmsKeyId      fwtypes.ARN       `tfsdk:"kms_key_id"`
-	Name          types.String      `tfsdk:"name"`
-	OwnerID       types.String      `tfsdk:"owner_id"`
-	Prefix        types.String      `tfsdk:"prefix" autoflex:",omitempty"`
-	RoleArn       fwtypes.ARN       `tfsdk:"role_arn"`
-	Status        types.String      `tfsdk:"status"`
-	StatusMessage types.String      `tfsdk:"status_message"`
-	Tags          tftags.Map        `tfsdk:"tags"`
-	TagsAll       tftags.Map        `tfsdk:"tags_all"`
-	Timeouts      timeouts.Value    `tfsdk:"timeouts"`
+	AcceptBucketWarning types.Bool        `tfsdk:"accept_bucket_warning" autoflex:",omitempty"`
+	ARN                 types.String      `tfsdk:"arn"`
+	Bucket              types.String      `tfsdk:"bucket"`
+	CreationTime        timetypes.RFC3339 `tfsdk:"creation_time"`
+	ID                  types.String      `tfsdk:"id"`
+	KmsKeyId            fwtypes.ARN       `tfsdk:"kms_key_id"`
+	Name                types.String      `tfsdk:"name"`
+	OwnerID             types.String      `tfsdk:"owner_id"`
+	Prefix              types.String      `tfsdk:"prefix" autoflex:",omitempty"`
+	RoleArn             fwtypes.ARN       `tfsdk:"role_arn"`
+	Status              types.String      `tfsdk:"status"`
+	StatusMessage       types.String      `tfsdk:"status_message"`
+	Tags                tftags.Map        `tfsdk:"tags"`
+	TagsAll             tftags.Map        `tfsdk:"tags_all"`
+	Timeouts            timeouts.Value    `tfsdk:"timeouts"`
 }
 
 func findFileSystemByID(ctx context.Context, conn *s3files.Client, id string) (*s3files.GetFileSystemOutput, error) {

--- a/internal/service/s3files/file_system_test.go
+++ b/internal/service/s3files/file_system_test.go
@@ -109,6 +109,44 @@ func TestAccS3FilesFileSystem_kmsKey(t *testing.T) {
 	})
 }
 
+func TestAccS3FilesFileSystem_acceptBucketWarning(t *testing.T) {
+	ctx := acctest.Context(t)
+	var fileSystem s3files.GetFileSystemOutput
+	resourceName := "aws_s3files_file_system.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3FilesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFileSystemDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFileSystemConfig_acceptBucketWarning(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFileSystemExists(ctx, t, resourceName, &fileSystem),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "s3files", regexache.MustCompile(`file-system/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "accept_bucket_warning", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(awstypes.LifeCycleStateAvailable)),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreationTime),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrOwnerID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"accept_bucket_warning",
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckFileSystemExists(ctx context.Context, t *testing.T, n string, v *s3files.GetFileSystemOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -316,6 +354,25 @@ resource "aws_s3files_file_system" "test" {
   bucket     = aws_s3_bucket.test.arn
   role_arn   = aws_iam_role.test.arn
   kms_key_id = aws_kms_key.test.arn
+
+  depends_on = [aws_s3_bucket_versioning.test]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccFileSystemConfig_acceptBucketWarning(rName string) string {
+	return acctest.ConfigCompose(
+		testAccFileSystemConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+
+  accept_bucket_warning = true
 
   depends_on = [aws_s3_bucket_versioning.test]
 

--- a/internal/service/s3files/file_system_test.go
+++ b/internal/service/s3files/file_system_test.go
@@ -128,7 +128,7 @@ func TestAccS3FilesFileSystem_acceptBucketWarning(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystemExists(ctx, t, resourceName, &fileSystem),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "s3files", regexache.MustCompile(`file-system/.+`)),
-					resource.TestCheckResourceAttr(resourceName, "accept_bucket_warning", "true"),
+					resource.TestCheckResourceAttr(resourceName, "accept_bucket_warning", acctest.CtTrue),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(awstypes.LifeCycleStateAvailable)),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreationTime),

--- a/website/docs/r/s3files_file_system.html.markdown
+++ b/website/docs/r/s3files_file_system.html.markdown
@@ -28,6 +28,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
+* `accept_bucket_warning` - (Optional) Set to `true` to acknowledge and accept any warnings related to the bucket configuration. If not specified, the operation may fail when such warnings are present. For example, warnings may be raised when creating a file system scoped to a prefix containing a large number of objects (approximately 12 million objects). See [the AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-synchronization.html#s3-files-sync-rename-move) for more details.
 * `kms_key_id` - (Optional) KMS key ID for encryption. Changing this value forces replacement.
 * `prefix` - (Optional) S3 bucket prefix. Changing this value forces replacement.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
This PR adds the `accept_bucket_warning` argument to the `aws_s3files_file_system` resource.

This argument is only effective during file system creation and does not represent part of the resource state.

Therefore, no AWS API (including the Read API) returns a value for `accept_bucket_warning`.

According to [the AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-synchronization.html#s3-files-sync-rename-move), this argument should be specified when creating a file system scoped to a prefix containing a large number of objects (approximately 12 million objects). While an acceptance test with `accept_bucket_warning` specified has been added, it is very difficult to create a test case where `accept_bucket_warning = true` is actually required. Instead, it was confirmed via debug log output that the value of `acceptBucketWarning` was passed to the `CreateFileSystem` API as expected.

```console
  http.request.body=
  | {"acceptBucketWarning":true,"bucket":"arn:aws:s3:::tf-acc-test-493503747196843040","clientToken":"terraform-20260417151643249600000001","roleArn":"arn:aws:iam::123456789012:role/tf-acc-test-493503747196843040","tags":[{"key":"Name","value":"tf-acc-test-4935
03747196843040"}]}
```

### Relations

Closes #47430

### References
https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3Files_CreateFileSystem.html#AmazonS3-S3Files_CreateFileSystem-request-acceptBucketWarning
https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-synchronization.html#s3-files-sync-rename-move


### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccS3FilesFileSystem_' PKG=s3files
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_s3files_file_system-add_accept_bucket_warning 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/s3files/... -v -count 1 -parallel 20 -run='TestAccS3FilesFileSystem_'  -timeout 360m -vet=off
2026/04/18 00:06:28 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/18 00:06:28 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3FilesFileSystem_Identity_basic
=== PAUSE TestAccS3FilesFileSystem_Identity_basic
=== RUN   TestAccS3FilesFileSystem_Identity_regionOverride
=== PAUSE TestAccS3FilesFileSystem_Identity_regionOverride
=== RUN   TestAccS3FilesFileSystem_List_basic
=== PAUSE TestAccS3FilesFileSystem_List_basic
=== RUN   TestAccS3FilesFileSystem_List_regionOverride
=== PAUSE TestAccS3FilesFileSystem_List_regionOverride
=== RUN   TestAccS3FilesFileSystem_List_includeResource
=== PAUSE TestAccS3FilesFileSystem_List_includeResource
=== RUN   TestAccS3FilesFileSystem_tags
=== PAUSE TestAccS3FilesFileSystem_tags
=== RUN   TestAccS3FilesFileSystem_Tags_null
=== PAUSE TestAccS3FilesFileSystem_Tags_null
=== RUN   TestAccS3FilesFileSystem_Tags_emptyMap
=== PAUSE TestAccS3FilesFileSystem_Tags_emptyMap
=== RUN   TestAccS3FilesFileSystem_Tags_addOnUpdate
=== PAUSE TestAccS3FilesFileSystem_Tags_addOnUpdate
=== RUN   TestAccS3FilesFileSystem_Tags_EmptyTag_onCreate
=== PAUSE TestAccS3FilesFileSystem_Tags_EmptyTag_onCreate
=== RUN   TestAccS3FilesFileSystem_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccS3FilesFileSystem_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccS3FilesFileSystem_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccS3FilesFileSystem_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccS3FilesFileSystem_Tags_DefaultTags_providerOnly
=== PAUSE TestAccS3FilesFileSystem_Tags_DefaultTags_providerOnly
=== RUN   TestAccS3FilesFileSystem_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccS3FilesFileSystem_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccS3FilesFileSystem_Tags_DefaultTags_overlapping
=== PAUSE TestAccS3FilesFileSystem_Tags_DefaultTags_overlapping
=== RUN   TestAccS3FilesFileSystem_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccS3FilesFileSystem_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccS3FilesFileSystem_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccS3FilesFileSystem_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccS3FilesFileSystem_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccS3FilesFileSystem_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccS3FilesFileSystem_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccS3FilesFileSystem_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccS3FilesFileSystem_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccS3FilesFileSystem_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccS3FilesFileSystem_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccS3FilesFileSystem_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccS3FilesFileSystem_Tags_ComputedTag_onCreate
=== PAUSE TestAccS3FilesFileSystem_Tags_ComputedTag_onCreate
=== RUN   TestAccS3FilesFileSystem_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccS3FilesFileSystem_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccS3FilesFileSystem_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccS3FilesFileSystem_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccS3FilesFileSystem_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccS3FilesFileSystem_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccS3FilesFileSystem_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccS3FilesFileSystem_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccS3FilesFileSystem_basic
=== PAUSE TestAccS3FilesFileSystem_basic
=== RUN   TestAccS3FilesFileSystem_disappears
=== PAUSE TestAccS3FilesFileSystem_disappears
=== RUN   TestAccS3FilesFileSystem_kmsKey
=== PAUSE TestAccS3FilesFileSystem_kmsKey
=== RUN   TestAccS3FilesFileSystem_acceptBucketWarning
=== PAUSE TestAccS3FilesFileSystem_acceptBucketWarning
=== CONT  TestAccS3FilesFileSystem_Identity_basic
=== CONT  TestAccS3FilesFileSystem_Tags_DefaultTags_updateToProviderOnly
=== CONT  TestAccS3FilesFileSystem_Tags_ComputedTag_OnUpdate_add
=== CONT  TestAccS3FilesFileSystem_Tags_ComputedTag_onCreate
=== CONT  TestAccS3FilesFileSystem_Tags_ComputedTag_OnUpdate_replace
=== CONT  TestAccS3FilesFileSystem_acceptBucketWarning
=== CONT  TestAccS3FilesFileSystem_kmsKey
=== CONT  TestAccS3FilesFileSystem_basic
=== CONT  TestAccS3FilesFileSystem_disappears
=== CONT  TestAccS3FilesFileSystem_Tags_IgnoreTags_Overlap_defaultTag
=== CONT  TestAccS3FilesFileSystem_Tags_addOnUpdate
=== CONT  TestAccS3FilesFileSystem_Tags_DefaultTags_overlapping
=== CONT  TestAccS3FilesFileSystem_Tags_DefaultTags_nonOverlapping
=== CONT  TestAccS3FilesFileSystem_Tags_DefaultTags_providerOnly
=== CONT  TestAccS3FilesFileSystem_Tags_EmptyTag_OnUpdate_replace
=== CONT  TestAccS3FilesFileSystem_Tags_EmptyTag_OnUpdate_add
=== CONT  TestAccS3FilesFileSystem_Tags_EmptyTag_onCreate
=== CONT  TestAccS3FilesFileSystem_Tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccS3FilesFileSystem_Tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccS3FilesFileSystem_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccS3FilesFileSystem_basic (114.38s)
=== CONT  TestAccS3FilesFileSystem_List_includeResource
--- PASS: TestAccS3FilesFileSystem_Identity_basic (142.15s)
=== CONT  TestAccS3FilesFileSystem_Tags_emptyMap
--- PASS: TestAccS3FilesFileSystem_Tags_addOnUpdate (152.64s)
=== CONT  TestAccS3FilesFileSystem_Tags_null
--- PASS: TestAccS3FilesFileSystem_Tags_DefaultTags_updateToProviderOnly (194.79s)
=== CONT  TestAccS3FilesFileSystem_tags
--- PASS: TestAccS3FilesFileSystem_acceptBucketWarning (202.13s)
=== CONT  TestAccS3FilesFileSystem_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccS3FilesFileSystem_Tags_IgnoreTags_Overlap_resourceTag (211.94s)
=== CONT  TestAccS3FilesFileSystem_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccS3FilesFileSystem_Tags_ComputedTag_OnUpdate_add (222.31s)
=== CONT  TestAccS3FilesFileSystem_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccS3FilesFileSystem_Tags_null (77.64s)
=== CONT  TestAccS3FilesFileSystem_List_basic
--- PASS: TestAccS3FilesFileSystem_kmsKey (245.17s)
=== CONT  TestAccS3FilesFileSystem_List_regionOverride
--- PASS: TestAccS3FilesFileSystem_Tags_DefaultTags_nullNonOverlappingResourceTag (251.94s)
=== CONT  TestAccS3FilesFileSystem_Identity_regionOverride
--- PASS: TestAccS3FilesFileSystem_disappears (265.20s)
--- PASS: TestAccS3FilesFileSystem_Tags_ComputedTag_onCreate (283.94s)
--- PASS: TestAccS3FilesFileSystem_Tags_DefaultTags_emptyProviderOnlyTag (75.18s)
--- PASS: TestAccS3FilesFileSystem_Tags_DefaultTags_emptyResourceTag (91.02s)
--- PASS: TestAccS3FilesFileSystem_Tags_DefaultTags_nonOverlapping (299.36s)
--- PASS: TestAccS3FilesFileSystem_Tags_emptyMap (167.09s)
--- PASS: TestAccS3FilesFileSystem_List_regionOverride (72.47s)
--- PASS: TestAccS3FilesFileSystem_List_includeResource (208.68s)
--- PASS: TestAccS3FilesFileSystem_Tags_DefaultTags_overlapping (323.97s)
--- PASS: TestAccS3FilesFileSystem_Tags_EmptyTag_onCreate (329.16s)
--- PASS: TestAccS3FilesFileSystem_Tags_DefaultTags_updateToResourceOnly (110.53s)
--- PASS: TestAccS3FilesFileSystem_Identity_regionOverride (92.15s)
--- PASS: TestAccS3FilesFileSystem_Tags_DefaultTags_providerOnly (353.29s)
--- PASS: TestAccS3FilesFileSystem_List_basic (134.97s)
--- PASS: TestAccS3FilesFileSystem_Tags_ComputedTag_OnUpdate_replace (368.49s)
--- PASS: TestAccS3FilesFileSystem_Tags_EmptyTag_OnUpdate_replace (383.88s)
--- PASS: TestAccS3FilesFileSystem_Tags_IgnoreTags_Overlap_defaultTag (396.11s)
--- PASS: TestAccS3FilesFileSystem_tags (205.36s)
--- PASS: TestAccS3FilesFileSystem_Tags_EmptyTag_OnUpdate_add (408.22s)
--- PASS: TestAccS3FilesFileSystem_Tags_DefaultTags_nullOverlappingResourceTag (478.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3files    484.016s

```
