### PR TITLE
resource/aws_msk_cluster: Correct vpc_connectivity state path in UpdateConnectivity

### DIFF
--- a/.changelog/47515.txt
+++ b/.changelog/47515.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_msk_cluster: Fix `broker_node_group_info` `vpc_connectivity` updates by correcting the Terraform state path used in `GetOk`
+```

--- a/.changelog/47515.txt
+++ b/.changelog/47515.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_msk_cluster: Fix `broker_node_group_info` `vpc_connectivity` updates by correcting the Terraform state path used in `GetOk`
+resource/aws_msk_cluster: Fix a request parameter error when updating `broker_node_group_info.vpc_connectivity` configuration block. This fixes a regression introduced in [v6.40.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#6400-april-8-2026)
 ```

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -734,7 +734,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 
 		var connectivityInfo types.ConnectivityInfo
-		if v, ok := d.GetOk("broker_node_group_info.0.connectivity_info.0,vpc_connectivity"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		if v, ok := d.GetOk("broker_node_group_info.0.connectivity_info.0.vpc_connectivity"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 			connectivityInfo.VpcConnectivity = expandVPCConnectivity(v.([]any)[0].(map[string]any))
 		}
 		input.ConnectivityInfo = &connectivityInfo


### PR DESCRIPTION
`aws_msk_cluster` update logic had a typo in the Terraform state path used by `GetOk`: it used `...0,vpc_connectivity` (comma) instead of `...0.vpc_connectivity` (dot).  
Because of that, `GetOk` could not read `vpc_connectivity` from state, so VPC connectivity changes might be skipped during updates.

The fix changes the path to the correct dotted form so `GetOk` matches `HasChange` and VPC connectivity settings are correctly included in `UpdateConnectivity`.