### PR TITLE
New List Resource: `aws_dynamodb_table`

### DIFF
--- a/.changelog/47518.txt
+++ b/.changelog/47518.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_dynamodb_table
+```

--- a/internal/service/dynamodb/service_package_gen.go
+++ b/internal/service/dynamodb/service_package_gen.go
@@ -7,6 +7,8 @@ package dynamodb
 
 import (
 	"context"
+	"iter"
+	"slices"
 	"unique"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -165,6 +167,21 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			Region:   inttypes.ResourceRegionDefault(),
 		},
 	}
+}
+
+func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttypes.ServicePackageSDKListResource] {
+	return slices.Values([]*inttypes.ServicePackageSDKListResource{
+		{
+			Factory:  newTableResourceAsListResource,
+			TypeName: "aws_dynamodb_table",
+			Name:     "Table",
+			Region:   inttypes.ResourceRegionDefault(),
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrARN,
+			}),
+			Identity: inttypes.RegionalSingleParameterIdentity(names.AttrName),
+		},
+	})
 }
 
 func (p *servicePackage) ServicePackageName() string {

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -1031,6 +1031,13 @@ func resourceTableRead(ctx context.Context, d *schema.ResourceData, meta any) di
 		return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionReading, resNameTable, d.Id(), err)
 	}
 
+	return resourceTableFlatten(ctx, c, d, table)
+}
+
+func resourceTableFlatten(ctx context.Context, c *conns.AWSClient, d *schema.ResourceData, table *awstypes.TableDescription) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := c.DynamoDBClient(ctx)
+
 	d.Set(names.AttrARN, table.TableArn)
 	d.Set(names.AttrName, table.TableName)
 
@@ -1097,6 +1104,7 @@ func resourceTableRead(ctx context.Context, d *schema.ResourceData, meta any) di
 
 	replicas := flattenReplicaDescriptions(table.Replicas)
 
+	var err error
 	if replicas, err = addReplicaPITRs(ctx, conn, d.Id(), replicas); err != nil {
 		return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionReading, resNameTable, d.Id(), err)
 	}

--- a/internal/service/dynamodb/table_list.go
+++ b/internal/service/dynamodb/table_list.go
@@ -1,0 +1,118 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dynamodb
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKListResource("aws_dynamodb_table")
+func newTableResourceAsListResource() inttypes.ListResourceForSDK {
+	l := tableListResource{}
+	l.SetResourceSchema(resourceTable())
+	return &l
+}
+
+type tableListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+type tableListResourceModel struct {
+	framework.WithRegionModel
+}
+
+func (l *tableListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	awsClient := l.Meta()
+	conn := awsClient.DynamoDBClient(ctx)
+
+	var query tableListResourceModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	tflog.Info(ctx, "Listing DynamoDB tables")
+	stream.Results = func(yield func(list.ListResult) bool) {
+		var input dynamodb.ListTablesInput
+		for tableName, err := range listTables(ctx, conn, &input) {
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrName), tableName)
+			result := request.NewListResult(ctx)
+
+			rd := l.ResourceData()
+			rd.SetId(tableName)
+			rd.Set(names.AttrName, tableName)
+
+			if request.IncludeResource {
+				table, err := findTableByName(ctx, conn, tableName)
+				if err != nil {
+					if retry.NotFound(err) {
+						continue
+					}
+					result = fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("reading DynamoDB Table (%s): %w", tableName, err))
+					yield(result)
+					return
+				}
+
+				diags := resourceTableFlatten(ctx, awsClient, rd, table)
+				if diags.HasError() || rd.Id() == "" {
+					tflog.Error(ctx, "Flattening DynamoDB table", map[string]any{
+						names.AttrName: tableName,
+					})
+					continue
+				}
+			}
+
+			result.DisplayName = tableName
+
+			l.SetResult(ctx, awsClient, request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+func listTables(ctx context.Context, conn *dynamodb.Client, input *dynamodb.ListTablesInput) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		pages := dynamodb.NewListTablesPaginator(conn, input)
+		for pages.HasMorePages() {
+			page, err := pages.NextPage(ctx)
+			if err != nil {
+				yield("", fmt.Errorf("listing DynamoDB Tables: %w", err))
+				return
+			}
+
+			for _, tableName := range page.TableNames {
+				if !yield(tableName, nil) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/service/dynamodb/table_list_test.go
+++ b/internal/service/dynamodb/table_list_test.go
@@ -1,0 +1,204 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dynamodb_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccDynamoDBTable_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_dynamodb_table.test[0]"
+	resourceName2 := "aws_dynamodb_table.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Table/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+
+					identity2.GetIdentity(resourceName2),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-1")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Table/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_dynamodb_table.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_dynamodb_table.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					tfquerycheck.ExpectNoResourceObject("aws_dynamodb_table.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_dynamodb_table.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_dynamodb_table.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringExact(rName+"-1")),
+					tfquerycheck.ExpectNoResourceObject("aws_dynamodb_table.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTable_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_dynamodb_table.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Table/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Table/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_dynamodb_table.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_dynamodb_table.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					querycheck.ExpectResourceKnownValues("aws_dynamodb_table.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("dynamodb", "table/"+rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("hash_key"), knownvalue.StringExact("TestTableHashKey")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("billing_mode"), knownvalue.StringExact("PROVISIONED")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTagsAll), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTable_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_dynamodb_table.test[0]"
+	resourceName2 := "aws_dynamodb_table.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Table/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+
+					identity2.GetIdentity(resourceName2),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-1")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Table/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_dynamodb_table.test", identity1.Checks()),
+
+					tfquerycheck.ExpectIdentityFunc("aws_dynamodb_table.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/dynamodb/testdata/Table/list_basic/main.tf
+++ b/internal/service/dynamodb/testdata/Table/list_basic/main.tf
@@ -1,0 +1,28 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_dynamodb_table" "test" {
+  count = var.resource_count
+
+  hash_key       = "TestTableHashKey"
+  name           = "${var.rName}-${count.index}"
+  read_capacity  = 1
+  write_capacity = 1
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/dynamodb/testdata/Table/list_basic/query.tfquery.hcl
+++ b/internal/service/dynamodb/testdata/Table/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_dynamodb_table" "test" {
+  provider = aws
+}

--- a/internal/service/dynamodb/testdata/Table/list_include_resource/main.tf
+++ b/internal/service/dynamodb/testdata/Table/list_include_resource/main.tf
@@ -1,0 +1,36 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_dynamodb_table" "test" {
+  count = var.resource_count
+
+  hash_key       = "TestTableHashKey"
+  name           = "${var.rName}-${count.index}"
+  read_capacity  = 1
+  write_capacity = 1
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  tags = var.resource_tags
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "resource_tags" {
+  description = "Tags to set on resource"
+  type        = map(string)
+  nullable    = false
+}

--- a/internal/service/dynamodb/testdata/Table/list_include_resource/query.tfquery.hcl
+++ b/internal/service/dynamodb/testdata/Table/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_dynamodb_table" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/dynamodb/testdata/Table/list_region_override/main.tf
+++ b/internal/service/dynamodb/testdata/Table/list_region_override/main.tf
@@ -1,0 +1,35 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_dynamodb_table" "test" {
+  count  = var.resource_count
+  region = var.region
+
+  hash_key       = "TestTableHashKey"
+  name           = "${var.rName}-${count.index}"
+  read_capacity  = 1
+  write_capacity = 1
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/dynamodb/testdata/Table/list_region_override/query.tfquery.hcl
+++ b/internal/service/dynamodb/testdata/Table/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_dynamodb_table" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}

--- a/website/docs/list-resources/dynamodb_table.html.markdown
+++ b/website/docs/list-resources/dynamodb_table.html.markdown
@@ -1,0 +1,25 @@
+---
+subcategory: "DynamoDB"
+layout: "aws"
+page_title: "AWS: aws_dynamodb_table"
+description: |-
+  Lists DynamoDB Table resources.
+---
+
+# List Resource: aws_dynamodb_table
+
+Lists DynamoDB Table resources.
+
+## Example Usage
+
+```terraform
+list "aws_dynamodb_table" "example" {
+  provider = aws
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Adds a list resource for `aws_dynamodb_table`.

### Relations

Closes #47225

### References

https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListTables.html

### Output from Acceptance Testing

```console
% make testacc PKG=dynamodb TESTARGS='-run=TestAccDynamoDBTable_List_'
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-list-resource-dynamodb_table 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/dynamodb/... -v -count 1 -parallel 20  -run=TestAccDynamoDBTable_List_ -timeout 360m -vet=off
2026/04/18 15:36:50 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/18 15:36:50 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDynamoDBTable_List_basic
=== PAUSE TestAccDynamoDBTable_List_basic
=== RUN   TestAccDynamoDBTable_List_includeResource
=== PAUSE TestAccDynamoDBTable_List_includeResource
=== RUN   TestAccDynamoDBTable_List_regionOverride
=== PAUSE TestAccDynamoDBTable_List_regionOverride
=== CONT  TestAccDynamoDBTable_List_basic
=== CONT  TestAccDynamoDBTable_List_regionOverride
=== CONT  TestAccDynamoDBTable_List_includeResource
--- PASS: TestAccDynamoDBTable_List_includeResource (48.03s)
--- PASS: TestAccDynamoDBTable_List_basic (48.75s)
--- PASS: TestAccDynamoDBTable_List_regionOverride (49.10s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   49.418s
```