### PR TITLE
r/aws_sqs_queues: Paginate past 1000 queues + add max_results

### DIFF
--- a/.changelog/47521.txt
+++ b/.changelog/47521.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+data-source/aws_sqs_queues: Fix pagination being capped at 1000 queue URLs when `queue_name_prefix` is unset or matches a large number of queues
+```
+
+```release-note:enhancement
+data-source/aws_sqs_queues: Add `max_results` argument to control the `ListQueues` API page size
+```

--- a/internal/service/sqs/queues_data_source.go
+++ b/internal/service/sqs/queues_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
@@ -22,6 +23,12 @@ func dataSourceQueues() *schema.Resource {
 		ReadWithoutTimeout: dataSourceQueuesRead,
 
 		Schema: map[string]*schema.Schema{
+			"max_results": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      1000,
+				ValidateFunc: validation.IntBetween(1, 1000),
+			},
 			"queue_name_prefix": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -39,7 +46,9 @@ func dataSourceQueuesRead(ctx context.Context, d *schema.ResourceData, meta any)
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SQSClient(ctx)
 
-	input := &sqs.ListQueuesInput{}
+	input := &sqs.ListQueuesInput{
+		MaxResults: aws.Int32(int32(d.Get("max_results").(int))),
+	}
 
 	if v, ok := d.GetOk("queue_name_prefix"); ok {
 		input.QueueNamePrefix = aws.String(v.(string))

--- a/internal/service/sqs/queues_data_source_test.go
+++ b/internal/service/sqs/queues_data_source_test.go
@@ -52,3 +52,45 @@ data "aws_sqs_queues" "test" {
 }
 `, rName)
 }
+
+func TestAccSQSQueuesDataSource_pagination(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_sqs_queues.test"
+
+	const (
+		queueCount = 7
+		pageSize   = 3
+	)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SQSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueuesDataSourceConfig_pagination(rName, queueCount, pageSize),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "queue_urls.#", fmt.Sprintf("%d", queueCount)),
+					resource.TestCheckResourceAttr(dataSourceName, "max_results", fmt.Sprintf("%d", pageSize)),
+				),
+			},
+		},
+	})
+}
+
+func testAccQueuesDataSourceConfig_pagination(rName string, count, pageSize int) string {
+	return fmt.Sprintf(`
+resource "aws_sqs_queue" "test" {
+  count = %[2]d
+  name  = "%[1]s-${count.index}"
+}
+
+data "aws_sqs_queues" "test" {
+  queue_name_prefix = %[1]q
+  max_results       = %[3]d
+
+  depends_on = [aws_sqs_queue.test]
+}
+`, rName, count, pageSize)
+}

--- a/website/docs/d/sqs_queues.html.markdown
+++ b/website/docs/d/sqs_queues.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Terraform data source for managing an AWS SQS (Simple Queue) Queues.
 
+Backed by the AWS SQS [`ListQueues`](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ListQueues.html) API.
+
 ## Example Usage
 
 ### Basic Usage
@@ -20,12 +22,24 @@ data "aws_sqs_queues" "example" {
 }
 ```
 
+### Tuning Page Size
+
+The data source paginates through all results automatically. `max_results` controls the page size passed to the AWS `ListQueues` API; it does not cap the total number of queues returned.
+
+```terraform
+data "aws_sqs_queues" "example" {
+  queue_name_prefix = "example"
+  max_results       = 500
+}
+```
+
 ## Argument Reference
 
 The following arguments are optional:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `queue_name_prefix` - (Optional) A string to use for filtering the list results. Only those queues whose name begins with the specified string are returned. Queue URLs and names are case-sensitive.
+* `max_results` - (Optional) Maximum number of queue URLs returned per [`ListQueues`](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ListQueues.html) API call (page size). Valid values are between `1` and `1000`. Defaults to `1000`. This setting only affects paging behaviour; all matching queue URLs are returned across pages regardless of the value.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Listing only returns 1000 items, and does not paginate, this fixes it.
Decided to add a max results as for testing it would take minutes to validate the creation of more than 1000 results, and it follows the aws api closely.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47521

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
[AWS SQS API Reference](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ListQueues.html)
Returns a list of your queues in the current region. The response includes a maximum of 1,000 results. If you specify a value for the optional QueueNamePrefix parameter, only queues with a name that begins with the specified value are returned.

The listQueues methods supports pagination. Set parameter MaxResults in the request to specify the maximum number of results to be returned in the response. If you do not set MaxResults, the response includes a maximum of 1,000 results. If you set MaxResults and there are additional results to display, the response includes a value for NextToken. Use NextToken as a parameter in your next request to listQueues to receive the next page of results. 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccSQSQueuesDataSource PKG=sqs
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/sqs/... -v -count 1 -parallel 20 -run='TestAccSQSQueuesDataSource'  -timeout 360m -vet=off
2026/04/20 12:49:31 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/20 12:49:31 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSQSQueuesDataSource_queueNamePrefix
=== PAUSE TestAccSQSQueuesDataSource_queueNamePrefix
=== RUN   TestAccSQSQueuesDataSource_pagination
=== PAUSE TestAccSQSQueuesDataSource_pagination
=== CONT  TestAccSQSQueuesDataSource_queueNamePrefix
=== CONT  TestAccSQSQueuesDataSource_pagination
--- PASS: TestAccSQSQueuesDataSource_queueNamePrefix (202.14s)
--- PASS: TestAccSQSQueuesDataSource_pagination (202.88s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	203.447s
```
