### PR TITLE
resource/aws_s3_bucket: handle MalformedXML on CreateBucket for S3-compatible APIs

### DIFF
--- a/.changelog/47530.txt
+++ b/.changelog/47530.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket: Fix bucket creation on third-party S3-compatible APIs (e.g. OVH, Ceph RGW) by handling `MalformedXML` errors during tag-on-create and `CreateBucketConfiguration` operations
+```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -812,10 +812,21 @@ func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	}, errCodeOperationAborted)
 
 	if errs.Contains(err, "is not authorized to perform: s3:TagResource") ||
-		tfawserr.ErrCodeEquals(err, errCodeUnsupportedArgument) {
-		// Remove tags and try again
+		tfawserr.ErrCodeEquals(err, errCodeUnsupportedArgument, errCodeMalformedXML) {
+		// Remove tags and try again.
 		input.CreateBucketConfiguration.Tags = nil
 		tagOnCreate = false
+
+		_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
+			return conn.CreateBucket(ctx, input)
+		}, errCodeOperationAborted)
+	}
+
+	// If still MalformedXML after removing tags, the S3-compatible API does not
+	// support the CreateBucketConfiguration body at all. Remove it entirely and retry.
+	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/47061.
+	if tfawserr.ErrCodeEquals(err, errCodeMalformedXML) {
+		input.CreateBucketConfiguration = nil
 
 		_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) (any, error) {
 			return conn.CreateBucket(ctx, input)

--- a/internal/service/s3/errors.go
+++ b/internal/service/s3/errors.go
@@ -20,6 +20,7 @@ const (
 	errCodeInvalidBucketState                   = "InvalidBucketState"
 	errCodeInvalidRequest                       = "InvalidRequest"
 	errCodeMalformedPolicy                      = "MalformedPolicy"
+	errCodeMalformedXML                         = "MalformedXML"
 	errCodeMetadataConfigurationNotFound        = "MetadataConfigurationNotFound"
 	errCodeMethodNotAllowed                     = "MethodNotAllowed"
 	errCodeNoSuchBucket                         = "NoSuchBucket"


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Third-party S3-compatible APIs (e.g. OVH, Ceph RGW, MinIO) return `MalformedXML` when the `CreateBucket` request body contains XML elements they do not support.

Since v6.23.0, the provider sends tags in the `CreateBucketConfiguration` XML body for ABAC support. The fallback added in v6.29.0 (PR #46122) handles `UnsupportedArgument` by removing tags and retrying, but does not cover `MalformedXML`.

Some S3-compatible APIs reject the `CreateBucketConfiguration` body entirely (not just the tags), so removing tags alone is insufficient. This PR adds a two-level fallback for `CreateBucket`:

1. On `MalformedXML` (or `UnsupportedArgument`), remove tags and retry
2. If still `MalformedXML`, remove `CreateBucketConfiguration` entirely and retry with a bare request

Tested successfully against OVH S3 endpoints (OpenStack Swift / Ceph RGW backend).

### Relations

Closes #47061.
Relates #45784.
Relates #45292.
Relates #46202.

### Output from Acceptance Testing

Manually tested against OVH S3-compatible API (`s3.sbg.io.cloud.ovh.net`):
- Before fix: `CreateBucket` fails with `MalformedXML` on all non-us-east-1 regions
- After fix: `CreateBucket` succeeds after falling back to bare request (no `CreateBucketConfiguration` body)