### PR TITLE
networkmanager: update VPN routing policy label in-place

### DIFF
--- a/.changelog/47541.txt
+++ b/.changelog/47541.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_networkmanager_site_to_site_vpn_attachment: Enable in-place updates of `routing_policy_label` argument. This functionality requires the `networkmanager: PutAttachmentRoutingPolicyLabel` and `networkmanager: RemoveAttachmentRoutingPolicyLabel` IAM permissions
+```

--- a/internal/service/networkmanager/site_to_site_vpn_attachment.go
+++ b/internal/service/networkmanager/site_to_site_vpn_attachment.go
@@ -87,7 +87,6 @@ func resourceSiteToSiteVPNAttachment() *schema.Resource {
 			"routing_policy_label": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(0, 256),
 			},
 			"segment_name": {
@@ -182,8 +181,41 @@ func resourceSiteToSiteVPNAttachmentRead(ctx context.Context, d *schema.Resource
 }
 
 func resourceSiteToSiteVPNAttachmentUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Tags only.
-	return resourceSiteToSiteVPNAttachmentRead(ctx, d, meta)
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).NetworkManagerClient(ctx)
+
+	// An update (via transparent tagging) to tags can put the attachment into PENDING_NETWORK_UPDATE state.
+	if _, err := waitSiteToSiteVPNAttachmentUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Site To Site VPN Attachment (%s) update: %s", d.Id(), err)
+	}
+
+	if d.HasChange("routing_policy_label") {
+		if v, ok := d.GetOk("routing_policy_label"); ok {
+			input := networkmanager.PutAttachmentRoutingPolicyLabelInput{
+				AttachmentId:       aws.String(d.Id()),
+				CoreNetworkId:      aws.String(d.Get("core_network_id").(string)),
+				RoutingPolicyLabel: aws.String(v.(string)),
+			}
+			_, err := conn.PutAttachmentRoutingPolicyLabel(ctx, &input)
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "updating Network Manager Site To Site VPN Attachment (%s) routing policy label: %s", d.Id(), err)
+			}
+		} else {
+			input := networkmanager.RemoveAttachmentRoutingPolicyLabelInput{
+				AttachmentId:  aws.String(d.Id()),
+				CoreNetworkId: aws.String(d.Get("core_network_id").(string)),
+			}
+			_, err := conn.RemoveAttachmentRoutingPolicyLabel(ctx, &input)
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "updating Network Manager Site To Site VPN Attachment (%s) routing policy label: %s", d.Id(), err)
+			}
+		}
+		if _, err := waitSiteToSiteVPNAttachmentUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Site To Site VPN Attachment (%s) routing policy label update: %s", d.Id(), err)
+		}
+	}
+
+	return append(diags, resourceSiteToSiteVPNAttachmentRead(ctx, d, meta)...)
 }
 
 func resourceSiteToSiteVPNAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -317,6 +349,25 @@ func waitSiteToSiteVPNAttachmentAvailable(ctx context.Context, conn *networkmana
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.AttachmentStateCreating, awstypes.AttachmentStatePendingAttachmentAcceptance, awstypes.AttachmentStatePendingNetworkUpdate),
 		Target:  enum.Slice(awstypes.AttachmentStateAvailable),
+		Timeout: timeout,
+		Refresh: statusSiteToSiteVPNAttachment(conn, id),
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*awstypes.SiteToSiteVpnAttachment); ok {
+		retry.SetLastError(err, attachmentsError(output.Attachment.LastModificationErrors))
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitSiteToSiteVPNAttachmentUpdated(ctx context.Context, conn *networkmanager.Client, id string, timeout time.Duration) (*awstypes.SiteToSiteVpnAttachment, error) { //nolint:unparam
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(awstypes.AttachmentStatePendingNetworkUpdate, awstypes.AttachmentStateUpdating),
+		Target:  enum.Slice(awstypes.AttachmentStateAvailable, awstypes.AttachmentStatePendingTagAcceptance),
 		Timeout: timeout,
 		Refresh: statusSiteToSiteVPNAttachment(conn, id),
 	}

--- a/internal/service/networkmanager/site_to_site_vpn_attachment_test.go
+++ b/internal/service/networkmanager/site_to_site_vpn_attachment_test.go
@@ -12,6 +12,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/networkmanager/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
@@ -132,7 +133,7 @@ func TestAccNetworkManagerSiteToSiteVPNAttachment_routingPolicyLabel(t *testing.
 
 func TestAccNetworkManagerSiteToSiteVPNAttachment_routingPolicyLabelUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v awstypes.SiteToSiteVpnAttachment
+	var v1, v2 awstypes.SiteToSiteVpnAttachment
 	resourceName := "aws_networkmanager_site_to_site_vpn_attachment.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	bgpASN := acctest.RandIntRange(t, 64512, 65534)
@@ -151,16 +152,38 @@ func TestAccNetworkManagerSiteToSiteVPNAttachment_routingPolicyLabelUpdate(t *te
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSiteToSiteVPNAttachmentConfig_routingPolicyLabel(rName, bgpASN, vpnIP, label1),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSiteToSiteVPNAttachmentExists(ctx, t, resourceName, &v),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSiteToSiteVPNAttachmentExists(ctx, t, resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "routing_policy_label", label1),
 				),
 			},
 			{
 				Config: testAccSiteToSiteVPNAttachmentConfig_routingPolicyLabel(rName, bgpASN, vpnIP, label2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSiteToSiteVPNAttachmentExists(ctx, t, resourceName, &v),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSiteToSiteVPNAttachmentExists(ctx, t, resourceName, &v2),
 					resource.TestCheckResourceAttr(resourceName, "routing_policy_label", label2),
+				),
+			},
+			{
+				Config: testAccSiteToSiteVPNAttachmentConfig_routingPolicyLabelRemoved(rName, bgpASN, vpnIP, label2),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSiteToSiteVPNAttachmentExists(ctx, t, resourceName, &v2),
+					resource.TestCheckResourceAttr(resourceName, "routing_policy_label", ""),
 				),
 			},
 		},
@@ -335,6 +358,24 @@ resource "aws_networkmanager_attachment_accepter" "test" {
   attachment_type = aws_networkmanager_site_to_site_vpn_attachment.test.attachment_type
 }
 `, label))
+}
+
+func testAccSiteToSiteVPNAttachmentConfig_routingPolicyLabelRemoved(rName string, bgpASN int, vpnIP, label string) string {
+	return acctest.ConfigCompose(testAccSiteToSiteVPNAttachmentConfig_baseWithRoutingPolicy(rName, bgpASN, vpnIP, label), `
+resource "aws_networkmanager_site_to_site_vpn_attachment" "test" {
+  core_network_id    = aws_networkmanager_core_network_policy_attachment.test.core_network_id
+  vpn_connection_arn = aws_vpn_connection.test.arn
+
+  tags = {
+    segment = "shared"
+  }
+}
+
+resource "aws_networkmanager_attachment_accepter" "test" {
+  attachment_id   = aws_networkmanager_site_to_site_vpn_attachment.test.id
+  attachment_type = aws_networkmanager_site_to_site_vpn_attachment.test.attachment_type
+}
+`)
 }
 
 func testAccSiteToSiteVPNAttachmentConfig_baseWithRoutingPolicy(rName string, bgpASN int, vpnIP, label string) string {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.

### Description

This PR updates `aws_networkmanager_site_to_site_vpn_attachment` so changes to `routing_policy_label` are applied in-place instead of forcing replacement of the attachment.

The resource now uses the Network Manager attachment routing policy label APIs to add, update, or remove the routing policy label on the existing site-to-site VPN attachment. This matches the existing behavior of `aws_networkmanager_vpc_attachment`.

### Relations

Closes #47538

### References

### Output from Acceptance Testing

```console

