### PR TITLE
service/sns: Add write-only support for platform_credential and platform_principal in aws_sns_platform_application

### DIFF
--- a/.changelog/47547
+++ b/.changelog/47547
@@ -1,0 +1,1 @@
+notes: service/sns: Add write-only credential support for platform applications

--- a/.changelog/47547
+++ b/.changelog/47547
@@ -1,1 +1,7 @@
-notes: service/sns: Add write-only credential support for platform applications
+```release-note:enhancement
+service/sns: Add write-only credential support for platform applications
+```
+
+```release-note:upgrade-note
+service/sns: When migrating an existing `aws_sns_platform_application` resource from `platform_credential` to `platform_credential_wo`, an explicit state move or manual reconfiguration is required.
+```

--- a/internal/service/sns/platform_application.go
+++ b/internal/service/sns/platform_application.go
@@ -73,9 +73,10 @@ var (
 			ForceNew: true,
 		},
 		"platform_credential": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			Sensitive:    true,
+			Type:      schema.TypeString,
+			Optional:  true,
+			Sensitive: true,
+			// ExactlyOneOf is used here because a credential is required by the AWS API.
 			ExactlyOneOf: []string{"platform_credential", "platform_credential_wo"},
 		},
 		"platform_credential_wo": {
@@ -85,9 +86,10 @@ var (
 			ExactlyOneOf: []string{"platform_credential", "platform_credential_wo"},
 		},
 		"platform_principal": {
-			Type:          schema.TypeString,
-			Optional:      true,
-			Sensitive:     true,
+			Type:      schema.TypeString,
+			Optional:  true,
+			Sensitive: true,
+			// ConflictsWith is used here (instead of ExactlyOneOf) because the principal attribute is optional in the AWS API.
 			ConflictsWith: []string{"platform_principal_wo"},
 		},
 		"platform_principal_wo": {
@@ -241,6 +243,10 @@ func resourcePlatformApplicationUpdate(ctx context.Context, d *schema.ResourceDa
 		} else if v, ok := d.GetOk("platform_principal_wo"); ok {
 			attributes[platformApplicationAttributeNamePlatformPrincipal] = v.(string)
 		}
+	}
+
+	if len(attributes) == 0 {
+		return append(diags, resourcePlatformApplicationRead(ctx, d, meta)...)
 	}
 
 	input := &sns.SetPlatformApplicationAttributesInput{

--- a/internal/service/sns/platform_application.go
+++ b/internal/service/sns/platform_application.go
@@ -73,14 +73,28 @@ var (
 			ForceNew: true,
 		},
 		"platform_credential": {
-			Type:      schema.TypeString,
-			Required:  true,
-			Sensitive: true,
+			Type:         schema.TypeString,
+			Optional:     true,
+			Sensitive:    true,
+			ExactlyOneOf: []string{"platform_credential", "platform_credential_wo"},
+		},
+		"platform_credential_wo": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Sensitive:    true,
+			ExactlyOneOf: []string{"platform_credential", "platform_credential_wo"},
 		},
 		"platform_principal": {
-			Type:      schema.TypeString,
-			Optional:  true,
-			Sensitive: true,
+			Type:          schema.TypeString,
+			Optional:      true,
+			Sensitive:     true,
+			ConflictsWith: []string{"platform_principal_wo"},
+		},
+		"platform_principal_wo": {
+			Type:          schema.TypeString,
+			Optional:      true,
+			Sensitive:     true,
+			ConflictsWith: []string{"platform_principal"},
 		},
 		"success_feedback_role_arn": {
 			Type:     schema.TypeString,
@@ -101,10 +115,12 @@ var (
 		"event_endpoint_updated_topic_arn": platformApplicationAttributeNameEventEndpointUpdated,
 		"failure_feedback_role_arn":        platformApplicationAttributeNameFailureFeedbackRoleARN,
 		"platform_credential":              platformApplicationAttributeNamePlatformCredential,
+		"platform_credential_wo":           platformApplicationAttributeNamePlatformCredential,
 		"platform_principal":               platformApplicationAttributeNamePlatformPrincipal,
+		"platform_principal_wo":            platformApplicationAttributeNamePlatformPrincipal,
 		"success_feedback_role_arn":        platformApplicationAttributeNameSuccessFeedbackRoleARN,
 		"success_feedback_sample_rate":     platformApplicationAttributeNameSuccessFeedbackSampleRate,
-	}, platformApplicationSchema).WithSkipUpdate("apple_platform_bundle_id").WithSkipUpdate("apple_platform_team_id").WithSkipUpdate("platform_credential").WithSkipUpdate("platform_principal")
+	}, platformApplicationSchema).WithSkipUpdate("apple_platform_bundle_id").WithSkipUpdate("apple_platform_team_id").WithSkipUpdate("platform_credential").WithSkipUpdate("platform_credential_wo").WithSkipUpdate("platform_principal").WithSkipUpdate("platform_principal_wo")
 )
 
 // @SDKResource("aws_sns_platform_application", name="Platform Application")
@@ -198,34 +214,35 @@ func resourcePlatformApplicationUpdate(ctx context.Context, d *schema.ResourceDa
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	if d.HasChanges("apple_platform_bundle_id", "apple_platform_team_id", "platform_credential", "platform_principal") {
-		// If APNS platform was configured with token-based authentication then the only way to update them
-		// is to update all 4 attributes as they must be specified together in the request.
+	if d.HasChanges("apple_platform_bundle_id", "apple_platform_team_id", "platform_credential", "platform_credential_wo", "platform_principal", "platform_principal_wo") {
+
 		if d.HasChanges("apple_platform_team_id", "apple_platform_bundle_id") {
 			attributes[platformApplicationAttributeNameApplePlatformTeamID] = d.Get("apple_platform_team_id").(string)
 			attributes[platformApplicationAttributeNameApplePlatformBundleID] = d.Get("apple_platform_bundle_id").(string)
 		}
 
-		// Prior to version 3.0.0 of the Terraform AWS Provider, the platform_credential and platform_principal
-		// attributes were stored in state as SHA256 hashes. If the changes to these two attributes are the only
-		// changes and if both of their changes only match updating the state value, then skip the API call.
 		oPCRaw, nPCRaw := d.GetChange("platform_credential")
 		oPPRaw, nPPRaw := d.GetChange("platform_principal")
+		oPCWORaw, nPCWORaw := d.GetChange("platform_credential_wo")
+		oPPWORaw, nPPWORaw := d.GetChange("platform_principal_wo")
 
-		if len(attributes) == 0 && isChangeSha256Removal(oPCRaw, nPCRaw) && isChangeSha256Removal(oPPRaw, nPPRaw) {
+		if len(attributes) == 0 && isChangeSha256Removal(oPCRaw, nPCRaw) && isChangeSha256Removal(oPPRaw, nPPRaw) && isChangeSha256Removal(oPCWORaw, nPCWORaw) && isChangeSha256Removal(oPPWORaw, nPPWORaw) {
 			return diags
 		}
 
-		attributes[platformApplicationAttributeNamePlatformCredential] = d.Get("platform_credential").(string)
-		// If the platform requires a principal it must also be specified, even if it didn't change
-		// since credential is stored as a hash, the only way to update principal is to update both
-		// as they must be specified together in the request.
+		if v, ok := d.GetOk("platform_credential"); ok {
+			attributes[platformApplicationAttributeNamePlatformCredential] = v.(string)
+		} else if v, ok := d.GetOk("platform_credential_wo"); ok {
+			attributes[platformApplicationAttributeNamePlatformCredential] = v.(string)
+		}
+
 		if v, ok := d.GetOk("platform_principal"); ok {
+			attributes[platformApplicationAttributeNamePlatformPrincipal] = v.(string)
+		} else if v, ok := d.GetOk("platform_principal_wo"); ok {
 			attributes[platformApplicationAttributeNamePlatformPrincipal] = v.(string)
 		}
 	}
 
-	// Make API call to update attributes
 	input := &sns.SetPlatformApplicationAttributesInput{
 		Attributes:             attributes,
 		PlatformApplicationArn: aws.String(d.Id()),

--- a/internal/service/sns/platform_application_test.go
+++ b/internal/service/sns/platform_application_test.go
@@ -624,7 +624,7 @@ resource "aws_sns_platform_application" "test" {
 `, name, platform.Name, platform.Credential, platform.Principal, attributeKey, attributeValue)
 }
 
-func testAccPlatformApplicationConfig_basicApnsWithTokenCredentials(name string, platform *TestAccPlatformApplication_gcmBasiPlatform, applePlatformTeamId string, applePlatformBundleId string) string {
+func testAccPlatformApplicationConfig_basicApnsWithTokenCredentials(name string, platform *testAccPlatformApplicationPlatform, applePlatformTeamId string, applePlatformBundleId string) string {
 	return fmt.Sprintf(`
 resource "aws_sns_platform_application" "test" {
   name                     = %[1]q

--- a/internal/service/sns/platform_application_test.go
+++ b/internal/service/sns/platform_application_test.go
@@ -624,7 +624,7 @@ resource "aws_sns_platform_application" "test" {
 `, name, platform.Name, platform.Credential, platform.Principal, attributeKey, attributeValue)
 }
 
-func testAccPlatformApplicationConfig_basicApnsWithTokenCredentials(name string, platform *testAccPlatformApplicationPlatform, applePlatformTeamId string, applePlatformBundleId string) string {
+func testAccPlatformApplicationConfig_basicApnsWithTokenCredentials(name string, platform *TestAccPlatformApplication_gcmBasiPlatform, applePlatformTeamId string, applePlatformBundleId string) string {
 	return fmt.Sprintf(`
 resource "aws_sns_platform_application" "test" {
   name                     = %[1]q
@@ -635,4 +635,55 @@ resource "aws_sns_platform_application" "test" {
   apple_platform_bundle_id = %[6]q
 }
 `, name, platform.Name, platform.Credential, platform.Principal, applePlatformTeamId, applePlatformBundleId)
+}
+
+func testAccPlatformApplicationConfig_gcmWriteOnly(rName, credentials string) string {
+	return fmt.Sprintf(`
+resource "aws_sns_platform_application" "test" {
+  name                   = %[1]q
+  platform               = "GCM"
+  platform_credential_wo = %[2]q
+}
+`, rName, credentials)
+}
+
+func TestAccSNSPlatformApplication_GCM_writeOnly(t *testing.T) {
+	ctx := acctest.Context(t)
+	apiKey := acctest.SkipIfEnvVarNotSet(t, "GCM_API_KEY")
+	resourceName := "aws_sns_platform_application.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SNSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPlatformApplicationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPlatformApplicationConfig_gcmWriteOnly(rName, apiKey),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPlatformApplicationExists(ctx, t, resourceName),
+					resource.TestCheckNoResourceAttr(resourceName, "apple_platform_bundle_id"),
+					resource.TestCheckNoResourceAttr(resourceName, "apple_platform_team_id"),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "sns", fmt.Sprintf("app/GCM/%s", rName)),
+					resource.TestCheckNoResourceAttr(resourceName, "event_delivery_failure_topic_arn"),
+					resource.TestCheckNoResourceAttr(resourceName, "event_endpoint_created_topic_arn"),
+					resource.TestCheckNoResourceAttr(resourceName, "event_endpoint_deleted_topic_arn"),
+					resource.TestCheckNoResourceAttr(resourceName, "event_endpoint_updated_topic_arn"),
+					resource.TestCheckNoResourceAttr(resourceName, "failure_feedback_role_arn"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "platform", "GCM"),
+					resource.TestCheckNoResourceAttr(resourceName, "success_feedback_role_arn"),
+					resource.TestCheckNoResourceAttr(resourceName, "success_feedback_sample_rate"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// Ignoramos los campos write-only en la verificación porque no se pueden leer de vuelta desde AWS
+				ImportStateVerifyIgnore: []string{"platform_credential_wo", "platform_principal_wo"},
+			},
+		},
+	})
 }

--- a/website/docs/r/sns_platform_application.html.markdown
+++ b/website/docs/r/sns_platform_application.html.markdown
@@ -53,13 +53,15 @@ This resource supports the following arguments:
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `name` - (Required) The friendly name for the SNS platform application
 * `platform` - (Required) The platform that the app is registered with. See [Platform][1] for supported platforms.
-* `platform_credential` - (Required) Application Platform credential. See [Credential][1] for type of credential required for platform. The value of this attribute when stored into the Terraform state is only a hash of the real value, so therefore it is not practical to use this as an attribute for other resources.
+* `platform_credential` - (Optional) Application Platform credential. See [Credential][1] for type of credential required for platform. The value of this attribute when stored into the Terraform state is only a hash of the real value, so therefore it is not practical to use this as an attribute for other resources.
+* `platform_credential_wo` - (Optional) The write-only, sensitive platform credential. **Note:** Drift detection is not possible for write-only attributes. If the credential is rotated in AWS, you must perform a `terraform apply` to push the new value. Users migrating from standard credentials to write-only credentials will need to perform an explicit state move or reconfigure.
 * `event_delivery_failure_topic_arn` - (Optional) The ARN of the SNS Topic triggered when a delivery to any of the platform endpoints associated with your platform application encounters a permanent failure.
 * `event_endpoint_created_topic_arn` - (Optional) The ARN of the SNS Topic triggered when a new platform endpoint is added to your platform application.
 * `event_endpoint_deleted_topic_arn` - (Optional) The ARN of the SNS Topic triggered when an existing platform endpoint is deleted from your platform application.
 * `event_endpoint_updated_topic_arn` - (Optional) The ARN of the SNS Topic triggered when an existing platform endpoint is changed from your platform application.
 * `failure_feedback_role_arn` - (Optional) The IAM role ARN permitted to receive failure feedback for this application and give SNS write access to use CloudWatch logs on your behalf.
 * `platform_principal` - (Optional) Application Platform principal. See [Principal][2] for type of principal required for platform. The value of this attribute when stored into the Terraform state is only a hash of the real value, so therefore it is not practical to use this as an attribute for other resources.
+* `platform_principal_wo` - (Optional) The write-only, sensitive platform principal. **Note:** Drift detection is not possible for write-only attributes.
 * `success_feedback_role_arn` - (Optional) The IAM role ARN permitted to receive success feedback for this application and give SNS write access to use CloudWatch logs on your behalf.
 * `success_feedback_sample_rate` - (Optional) The sample rate percentage (0-100) of successfully delivered messages.
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

**Yes.** This PR introduces `platform_credential_wo` and `platform_principal_wo` as write-only alternatives. Both attributes are marked `Sensitive` and are excluded from standard Terraform outputs, reducing the risk of accidental private key exposure in state files and logs.

### Description

This PR implements write-only credential support for the `aws_sns_platform_application` resource.

**Key changes:**
- **Schema:** Added `platform_credential_wo` and `platform_principal_wo` attributes.
- **Validation:** Implemented `ExactlyOneOf` and `ConflictsWith` to prevent simultaneous use of standard (`platform_credential`) and write-only (`platform_credential_wo`) attributes.
- **Update Logic:** Modified `resourcePlatformApplicationUpdate` to correctly detect and propagate changes when only the new write-only fields are modified.
- **Testing:** Added `TestAccSNSPlatformApplication_GCM_writeOnly` to verify write-only behavior.

### Relations

Closes #47293

### References

- [AWS SNS API - CreatePlatformApplication](https://docs.aws.amazon.com/sns/latest/api/API_CreatePlatformApplication.html)
- [AWS SNS API - SetPlatformApplicationAttributes](https://docs.aws.amazon.com/sns/latest/api/API_SetPlatformApplicationAttributes.html)

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccSNSPlatformApplication_GCM_writeOnly PKG=sns

--- PASS: TestAccSNSPlatformApplication_GCM_writeOnly (12.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sns  12.85s