### PR TITLE
fix(kafka): Fix empty connectivityInfo in UpdateConnectivity API call for aws_msk_cluster

### DIFF
--- a/.changelog/pending-msk-connectivity.txt
+++ b/.changelog/pending-msk-connectivity.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_msk_cluster: Fix empty `connectivityInfo` body in `UpdateConnectivity` API call when updating `connectivity_info` sub-blocks with zero-value booleans
+```

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -734,8 +734,11 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 
 		var connectivityInfo types.ConnectivityInfo
-		if v, ok := d.GetOk("broker_node_group_info.0.connectivity_info.0.vpc_connectivity"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
-			connectivityInfo.VpcConnectivity = expandVPCConnectivity(v.([]any)[0].(map[string]any))
+		// Use d.Get instead of d.GetOk because GetOk returns false when all nested
+		// values are zero-values (e.g. booleans set to false), causing the
+		// VpcConnectivity field to be nil and the API request body to be empty.
+		if v := d.Get("broker_node_group_info.0.connectivity_info.0.vpc_connectivity").([]any); len(v) > 0 && v[0] != nil {
+			connectivityInfo.VpcConnectivity = expandVPCConnectivity(v[0].(map[string]any))
 		}
 		input.ConnectivityInfo = &connectivityInfo
 
@@ -764,8 +767,8 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 
 		var connectivityInfo types.ConnectivityInfo
-		if v, ok := d.GetOk("broker_node_group_info.0.connectivity_info.0.public_access"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
-			connectivityInfo.PublicAccess = expandPublicAccess(v.([]any)[0].(map[string]any))
+		if v := d.Get("broker_node_group_info.0.connectivity_info.0.public_access").([]any); len(v) > 0 && v[0] != nil {
+			connectivityInfo.PublicAccess = expandPublicAccess(v[0].(map[string]any))
 		}
 		input.ConnectivityInfo = &connectivityInfo
 
@@ -794,8 +797,8 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 
 		var connectivityInfo types.ConnectivityInfo
-		if v, ok := d.GetOk("broker_node_group_info.0.connectivity_info.0.network_type"); ok && v != "" {
-			connectivityInfo.NetworkType = types.NetworkType(v.(string))
+		if v := d.Get("broker_node_group_info.0.connectivity_info.0.network_type").(string); v != "" {
+			connectivityInfo.NetworkType = types.NetworkType(v)
 		}
 		input.ConnectivityInfo = &connectivityInfo
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

When updating `connectivity_info` sub-blocks (`vpc_connectivity`, `public_access`, `network_type`) on an existing `aws_msk_cluster`, the provider sends an empty `connectivityInfo` body `{}` to the `UpdateConnectivity` API, resulting in a `400 BadRequestException`.

**Root cause**: `d.GetOk()` returns `(value, false)` when all nested values are zero-values (e.g. booleans set to `false`). Since the code checks `ok` before populating the `ConnectivityInfo` struct, the field stays `nil` and the API request body is empty.

**Fix**: Replace `d.GetOk` with `d.Get` for all three `connectivity_info` sub-fields. The `HasChange` guard already ensures we only enter the update block when there is an actual diff, so `GetOk`'s "is it set?" check is redundant and harmful here.

**Error observed**:
```
{"invalidParameter":"ConnectivityInfo Or ZookeeperAccess","message":"This required parameter is missing."}
```

**HTTP request body** (from `TF_LOG=DEBUG`):
```json
{"connectivityInfo":{},"currentVersion":"K1XFE4LQM16OSW"}
```

### Relations

_No existing issue._

### References

- [Terraform AWS Provider docs: aws_msk_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster)
- Related older issue: #26887

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccKafkaCluster PKG=kafka

(pending - manual testing confirmed fix resolves the empty body issue)
```