### PR TITLE
Add a GHA to close inactive PRs in Draft status (60 days)

### DIFF
--- a/.github/workflows/close_stale_draft_prs.yml
+++ b/.github/workflows/close_stale_draft_prs.yml
@@ -1,0 +1,45 @@
+# Copyright IBM Corp. 2014, 2026
+# "SPDX-License-Identifier: MPL-2.0"
+
+name: "Close Stale Draft PRs"
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  close-stale-drafts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close stale draft PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          # Calculate the date 60 days ago in ISO format (YYYY-MM-DD) GNU/BSD compatible
+          DATE=$(date -u -d "60 days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-60d +%Y-%m-%dT%H:%M:%SZ)
+
+          echo "Finding draft PRs updated before $DATE..."
+
+          # Use gh search prs to find open draft PRs matching the criteria
+          PRS=$(gh search prs \
+            --state open \
+            --repo ${{ github.repository }} \
+            --draft \
+            --updated "<$DATE" \
+            --json number \
+            -q '.[].number')
+
+          if [ -z "$PRS" ]; then
+            echo "No stale draft PRs found."
+            exit 0
+          fi
+
+          for PR in $PRS; do
+            echo "Processing PR #$PR"
+            echo -e "This draft pull request is being closed because it has been inactive for _60 days_ ⏳. This helps our maintainers find and focus on the active contributions.\n\nIf you would like to continue working on this, please reopen the pull request and mark it as ready for review when complete. Thank you!" \
+            | gh pr comment $PR --body-file -
+            gh pr close $PR
+          done

--- a/.github/workflows/close_stale_draft_prs.yml
+++ b/.github/workflows/close_stale_draft_prs.yml
@@ -51,7 +51,7 @@ jobs:
             if [ "$DRY_RUN" = "true" ]; then
               echo "[DRY RUN] Would comment on and close PR #$PR"
             else
-              echo -e "This draft pull request is being closed because it has been inactive for _60 days_ ⏳. This helps our maintainers find and focus on the active contributions.\n\nIf you would like to continue working on this, please reopen the pull request and mark it as ready for review when complete. Thank you!" \
+              echo -e "This draft pull request is being closed because it has been inactive for _60 days_ ⏳. This helps our maintainers find and focus on active contributions.\n\nIf you would like to continue working on this, please reopen the pull request and mark it as ready for review when complete. Thank you!" \
               | gh pr comment $PR --body-file -
               gh pr close $PR
             fi

--- a/.github/workflows/close_stale_draft_prs.yml
+++ b/.github/workflows/close_stale_draft_prs.yml
@@ -5,6 +5,13 @@ name: "Close Stale Draft PRs"
 on:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Describe actions without commenting or closing PRs"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   pull-requests: write
@@ -17,11 +24,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' &&
+            github.event.inputs.dry_run || 'true' }}
         run: |
           # Calculate the date 60 days ago in ISO format (YYYY-MM-DD) GNU/BSD compatible
           DATE=$(date -u -d "60 days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-60d +%Y-%m-%dT%H:%M:%SZ)
 
-          echo "Finding draft PRs updated before $DATE..."
+          echo "Finding draft PRs updated before $DATE (dry_run=$DRY_RUN)..."
 
           # Use gh search prs to find open draft PRs matching the criteria
           PRS=$(gh search prs \
@@ -39,7 +48,11 @@ jobs:
 
           for PR in $PRS; do
             echo "Processing PR #$PR"
-            echo -e "This draft pull request is being closed because it has been inactive for _60 days_ ⏳. This helps our maintainers find and focus on the active contributions.\n\nIf you would like to continue working on this, please reopen the pull request and mark it as ready for review when complete. Thank you!" \
-            | gh pr comment $PR --body-file -
-            gh pr close $PR
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[DRY RUN] Would comment on and close PR #$PR"
+            else
+              echo -e "This draft pull request is being closed because it has been inactive for _60 days_ ⏳. This helps our maintainers find and focus on the active contributions.\n\nIf you would like to continue working on this, please reopen the pull request and mark it as ready for review when complete. Thank you!" \
+              | gh pr comment $PR --body-file -
+              gh pr close $PR
+            fi
           done


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds a GHA triggered daily which closes inactive draft PRs with a comment if they have not been updated in 60 days. Has a dry-run mode that will default to true initially to make sure its working as expected.

