### PR TITLE
docs(aws_kinesis_firehose_delivery_stream): Add Datadog references to HTTP endpoint destination docs

### DIFF
--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -629,7 +629,9 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
 }
 ```
 
-### HTTP Endpoint (e.g., New Relic) Destination
+### HTTP Endpoint (e.g., New Relic, Datadog) Destination
+
+The HTTP endpoint destination can be used with any vendor that exposes a compatible HTTP intake, including [New Relic](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/connect/aws-firehose/) and [Datadog](https://docs.datadoghq.com/integrations/amazon_kinesis_data_firehose/). Refer to each vendor's documentation for the correct intake URL and authentication requirements.
 
 ```terraform
 resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
@@ -874,7 +876,7 @@ The `splunk_configuration` configuration block supports the following arguments:
 
 The `http_endpoint_configuration` configuration block supports the following arguments:
 
-* `url` - (Required) The HTTP endpoint URL to which Kinesis Firehose sends your data.
+* `url` - (Required) The HTTP endpoint URL to which Kinesis Firehose sends your data. Refer to the target vendor's documentation for the correct intake URL (for example, [New Relic](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/connect/aws-firehose/) or [Datadog](https://docs.datadoghq.com/integrations/amazon_kinesis_data_firehose/)).
 * `name` - (Optional) The HTTP endpoint name.
 * `access_key` - (Optional) The access key required for Kinesis Firehose to authenticate with the HTTP endpoint selected as the destination.
 * `role_arn` - (Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`.


### PR DESCRIPTION
## Rollback Plan
If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls
No.

### Description
Addresses #43477. Users configuring `aws_kinesis_firehose_delivery_stream` with Datadog as the HTTP endpoint destination currently have no in-docs pointer to the correct intake URL or integration guide. Per the design nudge from @AdamJCavanaugh on #43477, this PR keeps the change minimal: add a vendor-docs reference in the existing `http_endpoint_configuration` block (and update the section heading so Datadog users can find the existing example).

### Relations
Closes #43477

### References
- Datadog — Amazon Kinesis Data Firehose integration: https://docs.datadoghq.com/integrations/amazon_kinesis_data_firehose/
- New Relic — AWS Firehose integration: https://docs.newrelic.com/docs/infrastructure/amazon-integrations/connect/aws-firehose/

### Output from Acceptance Testing
N/A — documentation-only change.