### PR TITLE
resource/aws_ecs_express_gateway_service: Various fixes and test fixes

### DIFF
--- a/.changelog/47568.txt
+++ b/.changelog/47568.txt
@@ -1,7 +1,11 @@
 ```release-note:bug
-resource/aws_ecs_express_gateway_service: Waits until the service in `INACTIVE` instead of `DRAINING`.
+resource/aws_ecs_express_gateway_service: Waits until the service is `INACTIVE` instead of `DRAINING`.
 ```
 
 ```release-note:bug
 resource/aws_ecs_express_gateway_service: Handles more transient API errors during creation and deletion.
+```
+
+```release-note:bug
+resource/aws_ecs_express_gateway_service: Marks resource for re-creation if it fails while waiting for creation.
 ```

--- a/.changelog/47568.txt
+++ b/.changelog/47568.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_ecs_express_gateway_service: Waits until the service in `INACTIVE` instead of `DRAINING`.
+```
+
+```release-note:bug
+resource/aws_ecs_express_gateway_service: Handles more transient API errors during creation and deletion.
+```

--- a/internal/acctest/knownvalue/regional_hostname_ondotaws_regexp.go
+++ b/internal/acctest/knownvalue/regional_hostname_ondotaws_regexp.go
@@ -50,7 +50,7 @@ func (v regionalHostnameOnDotAWSRegexp) buildHostnameString() string {
 	return fmt.Sprintf(`^%s\.%s\.%s\.%s$`, v.hostnameRegexp.String(), v.service, v.region, "on.aws")
 }
 
-func RegionalHostnameOnDotAWSRegexp(service string, hostname *regexp.Regexp) knownvalue.Check {
+func RegionalHostnameOnDotAWSRegexp(service string, hostname *regexp.Regexp) knownvalue.Check { // nosemgrep:ci.aws-in-func-name
 	return regionalHostnameOnDotAWSRegexp{
 		check:          "RegionalHostnameOnDotAWSRegexp",
 		region:         acctest.Region(),

--- a/internal/acctest/knownvalue/regional_hostname_ondotaws_regexp.go
+++ b/internal/acctest/knownvalue/regional_hostname_ondotaws_regexp.go
@@ -1,0 +1,60 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package knownvalue
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+var _ knownvalue.Check = regionalHostnameOnDotAWSRegexp{}
+
+type regionalHostnameOnDotAWSRegexp struct {
+	check          string
+	region         string
+	service        string
+	hostnameRegexp *regexp.Regexp
+}
+
+// CheckValue determines whether the passed value is of type string, and
+// contains a matching sequence of bytes.
+func (v regionalHostnameOnDotAWSRegexp) CheckValue(other any) error {
+	otherVal, ok := other.(string)
+
+	if !ok {
+		return fmt.Errorf("expected string value for %s check, got: %T", v.check, other)
+	}
+
+	re, err := regexp.Compile(v.buildHostnameString())
+	if err != nil {
+		return fmt.Errorf("unable to compile hostname regexp (%s): %w", v.buildHostnameString(), err)
+	}
+
+	if !re.MatchString(otherVal) {
+		return fmt.Errorf("expected regex match %s for %s check, got: %s", re.String(), v.check, otherVal)
+	}
+
+	return nil
+}
+
+// String returns the string representation of the value.
+func (v regionalHostnameOnDotAWSRegexp) String() string {
+	return v.buildHostnameString()
+}
+
+func (v regionalHostnameOnDotAWSRegexp) buildHostnameString() string {
+	return fmt.Sprintf(`^%s\.%s\.%s\.%s$`, v.hostnameRegexp.String(), v.service, v.region, "on.aws")
+}
+
+func RegionalHostnameOnDotAWSRegexp(service string, hostname *regexp.Regexp) knownvalue.Check {
+	return regionalHostnameOnDotAWSRegexp{
+		check:          "RegionalHostnameOnDotAWSRegexp",
+		region:         acctest.Region(),
+		service:        service,
+		hostnameRegexp: hostname,
+	}
+}

--- a/internal/acctest/knownvalue/regional_hostname_regexp.go
+++ b/internal/acctest/knownvalue/regional_hostname_regexp.go
@@ -1,0 +1,61 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package knownvalue
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+var _ knownvalue.Check = regionalHostnameRegexp{}
+
+type regionalHostnameRegexp struct {
+	check          string
+	region         string
+	service        string
+	hostnameRegexp *regexp.Regexp
+}
+
+// CheckValue determines whether the passed value is of type string, and
+// contains a matching sequence of bytes.
+func (v regionalHostnameRegexp) CheckValue(other any) error {
+	otherVal, ok := other.(string)
+
+	if !ok {
+		return fmt.Errorf("expected string value for %s check, got: %T", v.check, other)
+	}
+
+	re, err := regexp.Compile(v.buildHostnameString())
+	if err != nil {
+		return fmt.Errorf("unable to compile hostname regexp (%s): %w", v.buildHostnameString(), err)
+	}
+
+	if !re.MatchString(otherVal) {
+		return fmt.Errorf("expected regex match %s for %s check, got: %s", re.String(), v.check, otherVal)
+	}
+
+	return nil
+}
+
+// String returns the string representation of the value.
+func (v regionalHostnameRegexp) String() string {
+	return v.buildHostnameString()
+}
+
+func (v regionalHostnameRegexp) buildHostnameString() string {
+	return fmt.Sprintf(`^%s\.%s\.%s\.%s$`, v.hostnameRegexp.String(), v.service, v.region, names.PartitionForRegion(v.region).DNSSuffix())
+}
+
+func RegionalHostnameRegexp(service string, hostname *regexp.Regexp) knownvalue.Check {
+	return regionalHostnameRegexp{
+		check:          "RegionalHostnameRegexp",
+		region:         acctest.Region(),
+		service:        service,
+		hostnameRegexp: hostname,
+	}
+}

--- a/internal/service/ecs/express_gateway_service.go
+++ b/internal/service/ecs/express_gateway_service.go
@@ -487,12 +487,12 @@ func (r *expressGatewayServiceResource) Delete(ctx context.Context, req resource
 	_, err := conn.DeleteExpressGatewayService(ctx, &input)
 	if err != nil {
 		if errs.IsAErrorMessageContains[*awstypes.InvalidParameterException](err, "Resource not found") ||
-			errs.IsAErrorMessageContains[*awstypes.ServiceNotActiveException](err, "Cannot perform this operation on a service in INACTIVE status") ||
-			errs.IsAErrorMessageContains[*awstypes.ServiceNotActiveException](err, "Service is in DRAINING status") {
+			errs.IsAErrorMessageContains[*awstypes.ServiceNotActiveException](err, "Cannot perform this operation on a service in INACTIVE status") {
 			// Service was already deleted/inactive/draining - deletion is already in progress or complete
 			return
-		} else {
-			// Real error occurred
+		} else if !errs.IsAErrorMessageContains[*awstypes.ServiceNotActiveException](err, "Service is in DRAINING status") {
+			// Real error occurred.
+			// If service is in DRAINING status, fall-through to wait for it to become INACTIVE
 			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, serviceARN)
 			return
 		}

--- a/internal/service/ecs/express_gateway_service.go
+++ b/internal/service/ecs/express_gateway_service.go
@@ -950,14 +950,7 @@ func retryExpressGatewayServiceCreate(ctx context.Context, conn *ecs.Client, inp
 		func(ctx context.Context) (any, error) {
 			return conn.CreateExpressGatewayService(ctx, input)
 		},
-		func(err error) (bool, error) {
-			if errs.IsAErrorMessageContains[*awstypes.AccessDeniedException](err, "Cannot assume role") ||
-				errs.IsAErrorMessageContains[*awstypes.ClientException](err, "AWS was not able to validate the provided access credentials") ||
-				errs.IsAErrorMessageContains[*awstypes.AccessDeniedException](err, "is not authorized to perform: sts:AssumeRole") {
-				return true, err
-			}
-			return false, err
-		},
+		expressGatewayRetryable,
 	)
 	if err != nil {
 		return nil, err
@@ -974,17 +967,29 @@ func retryExpressGatewayServiceUpdate(ctx context.Context, conn *ecs.Client, inp
 		func(ctx context.Context) (any, error) {
 			return conn.UpdateExpressGatewayService(ctx, input)
 		},
-		func(err error) (bool, error) {
-			if errs.IsAErrorMessageContains[*awstypes.AccessDeniedException](err, "Cannot assume role") ||
-				errs.IsAErrorMessageContains[*awstypes.ClientException](err, "AWS was not able to validate the provided access credentials") ||
-				errs.IsAErrorMessageContains[*awstypes.AccessDeniedException](err, "is not authorized to perform: sts:AssumeRole") {
-				return true, err
-			}
-			return false, err
-		},
+		expressGatewayRetryable,
 	)
 	if err != nil {
 		return nil, err
 	}
 	return outputRaw.(*ecs.UpdateExpressGatewayServiceOutput), nil
+}
+
+func expressGatewayRetryable(err error) (bool, error) {
+	if errs.Contains(err, "is not authorized to perform") || // This message can occur with at least AccessDeniedException, ClientException, and InvalidParameterException
+		errs.Contains(err, "AWS was not able to validate the provided access credentials") || // This message can occur with at least ClientException and InvalidParameterException
+		errs.IsAErrorMessageContains[*awstypes.AccessDeniedException](err, "Cannot assume role") ||
+		errs.IsAErrorMessageContains[*awstypes.ClientException](err, "The security token included in the request is invalid") {
+		return true, err
+	}
+	return false, err
+}
+
+// newListExpressGatewayServicesPaginator returns a new paginator for ListServices that only returns Customer-managed Services.
+func newListExpressGatewayServicesPaginator(conn *ecs.Client, input *ecs.ListServicesInput) *ecs.ListServicesPaginator {
+	return ecs.NewListServicesPaginator(conn, &ecs.ListServicesInput{
+		Cluster:                input.Cluster,
+		LaunchType:             input.LaunchType,
+		ResourceManagementType: awstypes.ResourceManagementTypeEcs,
+	})
 }

--- a/internal/service/ecs/express_gateway_service.go
+++ b/internal/service/ecs/express_gateway_service.go
@@ -376,8 +376,7 @@ func (r *expressGatewayServiceResource) Update(ctx context.Context, req resource
 	conn := r.Meta().ECSClient(ctx)
 
 	diff, d := fwflex.Diff(ctx, plan, state, fwflex.WithIgnoredField("active_configurations"), fwflex.WithIgnoredField("current_deployment"),
-		fwflex.WithIgnoredField("scaling_target"), fwflex.WithIgnoredField(names.AttrTags), fwflex.WithIgnoredField(names.AttrTags),
-		fwflex.WithIgnoredField(names.AttrTagsAll))
+		fwflex.WithIgnoredField("scaling_target"), fwflex.WithIgnoredField(names.AttrTags), fwflex.WithIgnoredField(names.AttrTagsAll))
 	smerr.AddEnrich(ctx, &resp.Diagnostics, d)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/service/ecs/express_gateway_service.go
+++ b/internal/service/ecs/express_gateway_service.go
@@ -553,8 +553,8 @@ func waitExpressGatewayServiceStable(ctx context.Context, conn *ecs.Client, gate
 
 func waitExpressGatewayServiceInactive(ctx context.Context, conn *ecs.Client, id string, timeout time.Duration) (*awstypes.ECSExpressGatewayService, error) {
 	stateConf := &sdkretry.StateChangeConf{
-		Pending:    []string{gatewayServiceStatusActive},
-		Target:     []string{gatewayServiceStatusInactive, gatewayServiceStatusDraining},
+		Pending:    []string{gatewayServiceStatusActive, gatewayServiceStatusDraining},
+		Target:     []string{gatewayServiceStatusInactive},
 		Refresh:    statusExpressGatewayServiceForDeletion(ctx, conn, id),
 		Timeout:    timeout,
 		MinTimeout: 1 * time.Second,
@@ -587,15 +587,8 @@ func statusExpressGatewayServiceForDeletion(ctx context.Context, conn *ecs.Clien
 	return func() (any, string, error) {
 		output, err := findExpressGatewayServiceNoTagsByARN(ctx, conn, gatewayServiceARN)
 		if err != nil {
-			if retry.NotFound(err) || errs.IsAErrorMessageContains[*awstypes.InvalidParameterException](err, "Resource not found") ||
-				errs.IsAErrorMessageContains[*awstypes.ServiceNotActiveException](err, "Cannot perform this operation on a service in INACTIVE status") {
-				mockService := &awstypes.ECSExpressGatewayService{
-					ServiceArn: aws.String(gatewayServiceARN),
-					Status: &awstypes.ExpressGatewayServiceStatus{
-						StatusCode: awstypes.ExpressGatewayServiceStatusCodeInactive,
-					},
-				}
-				return mockService, gatewayServiceStatusInactive, nil
+			if retry.NotFound(err) || errs.IsAErrorMessageContains[*awstypes.InvalidParameterException](err, "Resource not found") {
+				return nil, "", nil
 			}
 			return nil, "", smarterr.NewError(err)
 		}

--- a/internal/service/ecs/express_gateway_service.go
+++ b/internal/service/ecs/express_gateway_service.go
@@ -248,6 +248,9 @@ func (r *expressGatewayServiceResource) Create(ctx context.Context, req resource
 		return
 	}
 
+	// Set a state value to trigger replacement on error
+	resp.State.SetAttribute(ctx, path.Root("service_arn"), out.Service.ServiceArn)
+
 	serviceARN := aws.ToString(out.Service.ServiceArn)
 	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
 	var waitOut *awstypes.ECSExpressGatewayService

--- a/internal/service/ecs/express_gateway_service_test.go
+++ b/internal/service/ecs/express_gateway_service_test.go
@@ -23,6 +23,13 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+// NOTE: When running these tests, the Express-Mode Service may get stuck while tearing down.
+// This is most likely due to a permissions issue, as most of the default permissions on the
+// policy "AmazonECSInfrastructureRoleforExpressGatewayServices" are gated on the condition key
+// "aws:ResourceTag/AmazonECSManaged = true".
+// To unblock deletion, add the policy "AdministratorAccess" to the IAM Role for the running Service.
+// Alternatively, destroy the ECS Cluster which contains the Service, which will also delete the Service.
+
 func TestAccECSExpressGatewayService_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -514,8 +521,8 @@ func testAccCheckExpressGatewayServiceExists(ctx context.Context, t *testing.T, 
 	}
 }
 
-func testAccExpressGatewayServiceConfig_base(rName string) string {
-	return fmt.Sprintf(`
+func testAccExpressGatewayServiceConfig_base(rName string, waitForSteadyState bool) string {
+	config := fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 data "aws_vpc" "default" {
@@ -562,7 +569,11 @@ POLICY
 
 resource "aws_iam_role_policy_attachment" "execution" {
   role       = aws_iam_role.execution.name
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+  policy_arn = data.aws_iam_policy.AmazonECSTaskExecutionRolePolicy.arn
+}
+
+data "aws_iam_policy" "AmazonECSTaskExecutionRolePolicy" {
+  name = "AmazonECSTaskExecutionRolePolicy"
 }
 
 resource "aws_iam_role_policy" "execution_logs" {
@@ -597,12 +608,35 @@ resource "aws_iam_role" "infrastructure" {
 }
 POLICY
 }
+`, rName)
 
+	// Many of the permissions in `AmazonECSInfrastructureRoleforExpressGatewayServices` are
+	// gated on the condition key "aws:ResourceTag/AmazonECSManaged = true".
+	// If we are not waiting for steady state, the resource may be deleted before those tags are applied,
+	// causing permission errors in teardown.
+	if waitForSteadyState {
+		return acctest.ConfigCompose(config, `
 resource "aws_iam_role_policy_attachment" "infrastructure" {
   role       = aws_iam_role.infrastructure.name
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonECSInfrastructureRoleforExpressGatewayServices"
+  policy_arn = data.aws_iam_policy.AmazonECSInfrastructureRoleforExpressGatewayServices.arn
 }
-`, rName)
+
+data "aws_iam_policy" "AmazonECSInfrastructureRoleforExpressGatewayServices" {
+  name = "AmazonECSInfrastructureRoleforExpressGatewayServices"
+}
+`)
+	} else {
+		return acctest.ConfigCompose(config, `
+resource "aws_iam_role_policy_attachment" "infrastructure" {
+  role       = aws_iam_role.infrastructure.name
+  policy_arn = data.aws_iam_policy.AdministratorAccess.arn
+}
+
+data "aws_iam_policy" "AdministratorAccess" {
+  name = "AdministratorAccess"
+}
+`)
+	}
 }
 
 func testAccExpressGatewayServiceConfig_basic(rName string, waitForSteadyState bool) string {
@@ -611,7 +645,7 @@ func testAccExpressGatewayServiceConfig_basic(rName string, waitForSteadyState b
 		waitForSteadyStateConfig = "wait_for_steady_state = true"
 	}
 
-	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName, waitForSteadyState), fmt.Sprintf(`
 resource "aws_ecs_express_gateway_service" "test" {
   execution_role_arn      = aws_iam_role.execution.arn
   infrastructure_role_arn = aws_iam_role.infrastructure.arn
@@ -635,7 +669,7 @@ func testAccExpressGatewayServiceConfig_updated(rName string, waitForSteadyState
 		waitForSteadyStateConfig = "wait_for_steady_state = true"
 	}
 
-	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName, waitForSteadyState), fmt.Sprintf(`
 resource "aws_ecs_express_gateway_service" "test" {
   execution_role_arn      = aws_iam_role.execution.arn
   infrastructure_role_arn = aws_iam_role.infrastructure.arn
@@ -661,7 +695,7 @@ resource "aws_ecs_express_gateway_service" "test" {
 }
 
 func testAccExpressGatewayServiceConfig_tags1(rName, tagKey1, tagValue1 string) string {
-	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName, false), fmt.Sprintf(`
 resource "aws_ecs_express_gateway_service" "test" {
   execution_role_arn      = aws_iam_role.execution.arn
   infrastructure_role_arn = aws_iam_role.infrastructure.arn
@@ -683,7 +717,7 @@ resource "aws_ecs_express_gateway_service" "test" {
 }
 
 func testAccExpressGatewayServiceConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName, false), fmt.Sprintf(`
 resource "aws_ecs_express_gateway_service" "test" {
   execution_role_arn      = aws_iam_role.execution.arn
   infrastructure_role_arn = aws_iam_role.infrastructure.arn
@@ -706,7 +740,7 @@ resource "aws_ecs_express_gateway_service" "test" {
 }
 
 func testAccExpressGatewayServiceConfig_networkConfiguration(rName string) string {
-	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName, false), fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
 }
@@ -816,7 +850,7 @@ resource "aws_ecs_express_gateway_service" "test" {
 }
 
 func testAccExpressGatewayServiceConfig_duplicate(rName string) string {
-	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName), `
+	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName, false), `
 resource "aws_ecs_express_gateway_service" "test" {
   execution_role_arn      = aws_iam_role.execution.arn
   infrastructure_role_arn = aws_iam_role.infrastructure.arn
@@ -850,7 +884,7 @@ resource "aws_ecs_express_gateway_service" "duplicate" {
 // testAccExpressGatewayServiceConfig_environmentVariableOrdering creates a service
 // with env vars in non-alphabetical order.
 func testAccExpressGatewayServiceConfig_environmentVariableOrdering(rName string) string {
-	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName), `
+	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName, false), `
 resource "aws_ecs_express_gateway_service" "test" {
   execution_role_arn      = aws_iam_role.execution.arn
   infrastructure_role_arn = aws_iam_role.infrastructure.arn
@@ -885,7 +919,7 @@ resource "aws_ecs_express_gateway_service" "test" {
 // testAccExpressGatewayServiceConfig_environmentVariableUpdated creates a service
 // with updated env vars to test ordering after add/remove.
 func testAccExpressGatewayServiceConfig_environmentVariableUpdated(rName string) string {
-	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName), `
+	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName, false), `
 resource "aws_ecs_express_gateway_service" "test" {
   execution_role_arn      = aws_iam_role.execution.arn
   infrastructure_role_arn = aws_iam_role.infrastructure.arn

--- a/internal/service/ecs/express_gateway_service_test.go
+++ b/internal/service/ecs/express_gateway_service_test.go
@@ -482,8 +482,7 @@ func testAccCheckExpressGatewayServiceDestroy(ctx context.Context, t *testing.T)
 				return err
 			}
 
-			if string(output.Status.StatusCode) == string(awstypes.ExpressGatewayServiceStatusCodeInactive) ||
-				string(output.Status.StatusCode) == string(awstypes.ExpressGatewayServiceStatusCodeDraining) {
+			if string(output.Status.StatusCode) == string(awstypes.ExpressGatewayServiceStatusCodeInactive) {
 				return nil
 			}
 

--- a/internal/service/ecs/express_gateway_service_test.go
+++ b/internal/service/ecs/express_gateway_service_test.go
@@ -66,8 +66,8 @@ func TestAccECSExpressGatewayService_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("health_check_path"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ingress_paths"), knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"access_type": tfknownvalue.StringExact(awstypes.AccessTypePublic),
-							"endpoint":    tfknownvalue.RegionalHostnameOnDotAWSRegexp("ecs", regexache.MustCompile(`https://ng-\w+`)),
+							"access_type":      tfknownvalue.StringExact(awstypes.AccessTypePublic),
+							names.AttrEndpoint: tfknownvalue.RegionalHostnameOnDotAWSRegexp("ecs", regexache.MustCompile(`https://ng-\w+`)),
 						},
 						),
 					})),

--- a/internal/service/ecs/express_gateway_service_test.go
+++ b/internal/service/ecs/express_gateway_service_test.go
@@ -53,10 +53,18 @@ func TestAccECSExpressGatewayService_basic(t *testing.T) {
 					},
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("cluster"), knownvalue.StringExact("default")),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("cpu"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("current_deployment"), knownvalue.Null()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("health_check_path"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ingress_paths"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ingress_paths"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"access_type": tfknownvalue.StringExact(awstypes.AccessTypePublic),
+							"endpoint":    tfknownvalue.RegionalHostnameOnDotAWSRegexp("ecs", regexache.MustCompile(`https://ng-\w+`)),
+						},
+						),
+					})),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrNetworkConfiguration), knownvalue.ListSizeExact(1)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("scaling_target"), knownvalue.ListSizeExact(1)),

--- a/internal/service/ecs/express_gateway_service_test.go
+++ b/internal/service/ecs/express_gateway_service_test.go
@@ -57,7 +57,6 @@ func TestAccECSExpressGatewayService_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("cpu"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("current_deployment"), knownvalue.Null()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("health_check_path"), knownvalue.NotNull()),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ingress_paths"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ingress_paths"), knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
 							"access_type": tfknownvalue.StringExact(awstypes.AccessTypePublic),
@@ -875,6 +874,11 @@ resource "aws_ecs_express_gateway_service" "test" {
       value = "first"
     }
   }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.execution,
+    aws_iam_role_policy_attachment.infrastructure,
+  ]
 }
 `)
 }
@@ -900,6 +904,11 @@ resource "aws_ecs_express_gateway_service" "test" {
       value = "fourth"
     }
   }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.execution,
+    aws_iam_role_policy_attachment.infrastructure,
+  ]
 }
 `)
 }

--- a/internal/service/ecs/express_gateway_service_test.go
+++ b/internal/service/ecs/express_gateway_service_test.go
@@ -622,6 +622,11 @@ resource "aws_ecs_express_gateway_service" "test" {
   primary_container {
     image = "public.ecr.aws/nginx/nginx:1.28-alpine3.21-slim"
   }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.execution,
+    aws_iam_role_policy_attachment.infrastructure,
+  ]
 }
 `, rName, waitForSteadyStateConfig))
 }
@@ -648,6 +653,11 @@ resource "aws_ecs_express_gateway_service" "test" {
     auto_scaling_metric       = "AVERAGE_CPU"
     auto_scaling_target_value = 60
   }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.execution,
+    aws_iam_role_policy_attachment.infrastructure,
+  ]
 }
 `, rName, waitForSteadyStateConfig))
 }
@@ -665,6 +675,11 @@ resource "aws_ecs_express_gateway_service" "test" {
   tags = {
     %[2]q = %[3]q
   }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.execution,
+    aws_iam_role_policy_attachment.infrastructure,
+  ]
 }
 `, rName, tagKey1, tagValue1))
 }
@@ -683,6 +698,11 @@ resource "aws_ecs_express_gateway_service" "test" {
     %[2]q = %[3]q
     %[4]q = %[5]q
   }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.execution,
+    aws_iam_role_policy_attachment.infrastructure,
+  ]
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
@@ -787,6 +807,12 @@ resource "aws_ecs_express_gateway_service" "test" {
     subnets         = [aws_subnet.test_subnet1.id, aws_subnet.test_subnet2.id]
     security_groups = [aws_security_group.test.id]
   }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.execution,
+    aws_iam_role_policy_attachment.infrastructure,
+    aws_iam_role_policy_attachment.task_role,
+  ]
 }
 `, rName))
 }
@@ -800,6 +826,11 @@ resource "aws_ecs_express_gateway_service" "test" {
   primary_container {
     image = "public.ecr.aws/nginx/nginx:1.28-alpine3.21-slim"
   }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.execution,
+    aws_iam_role_policy_attachment.infrastructure,
+  ]
 }
 
 resource "aws_ecs_express_gateway_service" "duplicate" {

--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -160,6 +160,7 @@ func TestAccECSService_basic(t *testing.T) {
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "ecs", fmt.Sprintf("service/%s/%s", clusterName, rName)),
 					resource.TestCheckResourceAttr(resourceName, "availability_zone_rebalancing", "ENABLED"),
 					resource.TestCheckResourceAttrPair(resourceName, "cluster", "aws_ecs_cluster.test", names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "service_registries.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "scheduling_strategy", "REPLICA"),
 					resource.TestCheckResourceAttrPair(resourceName, "task_definition", "aws_ecs_task_definition.test", names.AttrARN),
@@ -1555,6 +1556,7 @@ func TestAccECSService_clusterName(t *testing.T) {
 	ctx := acctest.Context(t)
 	var service awstypes.Service
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	clusterName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_ecs_service.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -1564,10 +1566,11 @@ func TestAccECSService_clusterName(t *testing.T) {
 		CheckDestroy:             testAccCheckServiceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceConfig_clusterName(rName),
+				Config: testAccServiceConfig_clusterName(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(ctx, t, resourceName, &service),
-					resource.TestCheckResourceAttr(resourceName, "cluster", rName),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "ecs", fmt.Sprintf("service/%s/%s", clusterName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "cluster", clusterName),
 				),
 			},
 		},
@@ -3415,7 +3418,7 @@ DEFINITION
 
 resource "aws_ecs_service" "test" {
   name            = %[1]q
-  cluster         = aws_ecs_cluster.test.id
+  cluster         = aws_ecs_cluster.test.arn
   task_definition = aws_ecs_task_definition.test.arn
   desired_count   = 1
 }
@@ -6277,14 +6280,14 @@ resource "aws_ecs_service" "test" {
 `, rName)
 }
 
-func testAccServiceConfig_clusterName(rName string) string {
+func testAccServiceConfig_clusterName(rName, clusterName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
-  name = %[1]q
+  name = %[2]q
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family = %[1]q
+  family = %[2]q
 
   container_definitions = <<DEFINITION
 [
@@ -6305,7 +6308,7 @@ resource "aws_ecs_service" "test" {
   task_definition = aws_ecs_task_definition.test.arn
   desired_count   = 1
 }
-`, rName)
+`, rName, clusterName)
 }
 
 func testAccServiceConfig_alb(rName string) string {

--- a/internal/service/ecs/sweep.go
+++ b/internal/service/ecs/sweep.go
@@ -4,14 +4,17 @@
 package ecs
 
 import (
+	"context"
 	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -29,9 +32,12 @@ func RegisterSweepers() {
 		Name: "aws_ecs_cluster",
 		F:    sweepClusters,
 		Dependencies: []string{
+			"aws_ecs_express_gateway_service",
 			"aws_ecs_service",
 		},
 	})
+
+	awsv2.Register("aws_ecs_express_gateway_service", sweepExpressGatewayServices)
 
 	resource.AddTestSweepers("aws_ecs_service", &resource.Sweeper{
 		Name: "aws_ecs_service",
@@ -42,6 +48,7 @@ func RegisterSweepers() {
 		Name: "aws_ecs_task_definition",
 		F:    sweepTaskDefinitions,
 		Dependencies: []string{
+			"aws_ecs_express_gateway_service",
 			"aws_ecs_service",
 		},
 	})
@@ -139,6 +146,41 @@ func sweepClusters(region string) error {
 	return nil
 }
 
+func sweepExpressGatewayServices(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	conn := client.ECSClient(ctx)
+	var sweepResources []sweep.Sweepable
+
+	var input ecs.ListClustersInput
+	pages := ecs.NewListClustersPaginator(conn, &input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, clusterARN := range page.ClusterArns {
+			input := ecs.ListServicesInput{
+				Cluster: aws.String(clusterARN),
+			}
+			pages := newListExpressGatewayServicesPaginator(conn, &input)
+			for pages.HasMorePages() {
+				page, err := pages.NextPage(ctx)
+				if err != nil {
+					return nil, err
+				}
+
+				for _, v := range page.ServiceArns {
+					sweepResources = append(sweepResources, framework.NewSweepResource(newExpressGatewayServiceResource, client,
+						framework.NewAttribute("service_arn", v)),
+					)
+				}
+			}
+		}
+	}
+
+	return sweepResources, nil
+}
+
 func sweepServices(region string) error {
 	ctx := sweep.Context(region)
 	client, err := sweep.SharedRegionalSweepClient(ctx, region)
@@ -147,7 +189,7 @@ func sweepServices(region string) error {
 	}
 	conn := client.ECSClient(ctx)
 	input := &ecs.ListClustersInput{}
-	sweepResources := make([]sweep.Sweepable, 0)
+	var sweepResources []sweep.Sweepable
 
 	pages := ecs.NewListClustersPaginator(conn, input)
 	for pages.HasMorePages() {

--- a/internal/service/elbv2/sweep.go
+++ b/internal/service/elbv2/sweep.go
@@ -23,6 +23,7 @@ func RegisterSweepers() {
 		F:    sweepLoadBalancers,
 		Dependencies: []string{
 			"aws_api_gateway_vpc_link",
+			"aws_ecs_express_gateway_service",
 			"aws_vpc_endpoint_service",
 			"aws_lb_listener",
 		},
@@ -32,6 +33,7 @@ func RegisterSweepers() {
 		Name: "aws_lb_target_group",
 		F:    sweepTargetGroups,
 		Dependencies: []string{
+			"aws_ecs_express_gateway_service",
 			"aws_lb",
 		},
 	})
@@ -39,6 +41,9 @@ func RegisterSweepers() {
 	resource.AddTestSweepers("aws_lb_listener", &resource.Sweeper{
 		Name: "aws_lb_listener",
 		F:    sweepListeners,
+		Dependencies: []string{
+			"aws_ecs_express_gateway_service",
+		},
 	})
 
 	awsv2.Register("aws_lb_trust_store", sweepTrustStore)

--- a/internal/service/iam/sweep.go
+++ b/internal/service/iam/sweep.go
@@ -46,6 +46,8 @@ func RegisterSweepers() {
 		Name: "aws_iam_policy",
 		F:    sweepPolicies,
 		Dependencies: []string{
+			"aws_ecs_express_gateway_service",
+			"aws_ecs_service",
 			"aws_iam_group",
 			"aws_iam_role",
 			"aws_iam_user",

--- a/website/docs/r/ecs_express_gateway_service.html.markdown
+++ b/website/docs/r/ecs_express_gateway_service.html.markdown
@@ -12,6 +12,8 @@ Manages an ECS Express service. The Express service provides a simplified way to
 
 Express services automatically handle infrastructure provisioning and updates through rolling deployments, ensuring high availability during service modifications. When you update an Express service, a new service revision is created and deployed with zero downtime.
 
+-> **Note:** To prevent a race condition during service deletion, make sure to set `depends_on` to the related `aws_iam_role_policy` or `aws_iam_role_policy_attachment` resources. Otherwise, the policy may be destroyed too soon and the ECS service will then get stuck in the `DRAINING` state.
+
 ## Example Usage
 
 ### Basic Usage


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Fixes:

* Waits for Express-Mode Service to be Inactive, not just Draining
* Adds several error conditions to retryable errors when creating and updating

Fixes several tests. Adds sweeper and updates dependencies.

Preparatory work for #47377

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc make testacc PKG=ecs TESTS='TestAccECSExpressGatewayService_'

--- PASS: TestAccECSExpressGatewayService_disappears (93.30s)
--- PASS: TestAccECSExpressGatewayService_update (135.10s)
--- FAIL: TestAccECSExpressGatewayService_basic (141.05s)
--- PASS: TestAccECSExpressGatewayService_networkConfiguration (142.25s)
--- FAIL: TestAccECSExpressGatewayService_tags (142.47s)
--- PASS: TestAccECSExpressGatewayService_checkIdempotency (144.83s)
--- PASS: TestAccECSExpressGatewayService_environmentVariableOrdering (171.38s)
```

Failures in `TestAccECSExpressGatewayService_basic` and `TestAccECSExpressGatewayService_tags` will be addressed by #47531