### PR TITLE
fix: update a validation in the resource

### DIFF
--- a/.changelog/47574.txt
+++ b/.changelog/47574.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bedrock_guardrail: Update maximum length of `topic_policy_config.topics_config.definition` from 200 to 1000 to support standard tier.
+```

--- a/internal/service/bedrock/guardrail.go
+++ b/internal/service/bedrock/guardrail.go
@@ -381,7 +381,7 @@ func (r *guardrailResource) Schema(ctx context.Context, req resource.SchemaReque
 									"definition": schema.StringAttribute{
 										Required: true,
 										Validators: []validator.String{
-											stringvalidator.LengthBetween(1, 200),
+											stringvalidator.LengthBetween(1, 1000),
 										},
 									},
 									"examples": schema.ListAttribute{


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Update the validation of the [`topic_policy_config.topics_config.definition`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrock_guardrail#definition-1) attribute of resource [`aws_bedrock_guardrail`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrock_guardrail). This change reflects the fact that there are two safeguard tiers (`CLASSIC` and `STANDARD`) (see [here](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-tiers.html)) with different limits on the `definition` (200 vs 1,000).

Increasing the `maxLength` value from 200 to 1,000 unblock `STANDARD` tier usage in combination with an "extented" definitions.

### Relations

Closes #47544 

### References
- [AWS Docs - Safeguard tiers for guardrails policies
](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-tiers.html)

### Output from Acceptance Testing

There is an error "Error: reading Bedrock Foundation Model (amazon.titan-text-express-v1)" caused by `amazon.titan-text-express-v1` being no longer available.

Tests failing are for example:

- `TestAccBedrockGuardrail_contentPolicyConfigAction`
- `TestAccBedrockGuardrail_kmsKey`
- `TestAccBedrockGuardrail_wordConfigAction`

All of them use `testAccCustomModelConfig_base` that is used in the tests for the  custom model resource.

Please let me know what the preferred approach is. Should I review/ fix the custom model tests as part of this pull request or should that happen in a separate one?

```console
make testacc T=TestAccBedrockGuardrail_ K=bedrock 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws_bedrock_guardrail-update-validation 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/bedrock/... -v -count 1 -parallel 20 -run='TestAccBedrockGuardrail_'  -timeout 360m -vet=off
2026/04/22 19:49:52 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/22 19:49:52 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockGuardrail_tags
=== PAUSE TestAccBedrockGuardrail_tags
=== RUN   TestAccBedrockGuardrail_Tags_null
=== PAUSE TestAccBedrockGuardrail_Tags_null
=== RUN   TestAccBedrockGuardrail_Tags_emptyMap
=== PAUSE TestAccBedrockGuardrail_Tags_emptyMap
=== RUN   TestAccBedrockGuardrail_Tags_addOnUpdate
=== PAUSE TestAccBedrockGuardrail_Tags_addOnUpdate
=== RUN   TestAccBedrockGuardrail_Tags_EmptyTag_onCreate
=== PAUSE TestAccBedrockGuardrail_Tags_EmptyTag_onCreate
=== RUN   TestAccBedrockGuardrail_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccBedrockGuardrail_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccBedrockGuardrail_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccBedrockGuardrail_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccBedrockGuardrail_Tags_DefaultTags_providerOnly
=== PAUSE TestAccBedrockGuardrail_Tags_DefaultTags_providerOnly
=== RUN   TestAccBedrockGuardrail_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccBedrockGuardrail_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccBedrockGuardrail_Tags_DefaultTags_overlapping
=== PAUSE TestAccBedrockGuardrail_Tags_DefaultTags_overlapping
=== RUN   TestAccBedrockGuardrail_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccBedrockGuardrail_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccBedrockGuardrail_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccBedrockGuardrail_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccBedrockGuardrail_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccBedrockGuardrail_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccBedrockGuardrail_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccBedrockGuardrail_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccBedrockGuardrail_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccBedrockGuardrail_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccBedrockGuardrail_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccBedrockGuardrail_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccBedrockGuardrail_Tags_ComputedTag_onCreate
=== PAUSE TestAccBedrockGuardrail_Tags_ComputedTag_onCreate
=== RUN   TestAccBedrockGuardrail_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccBedrockGuardrail_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccBedrockGuardrail_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccBedrockGuardrail_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccBedrockGuardrail_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccBedrockGuardrail_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccBedrockGuardrail_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccBedrockGuardrail_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccBedrockGuardrail_basic
=== PAUSE TestAccBedrockGuardrail_basic
=== RUN   TestAccBedrockGuardrail_disappears
=== PAUSE TestAccBedrockGuardrail_disappears
=== RUN   TestAccBedrockGuardrail_kmsKey
=== PAUSE TestAccBedrockGuardrail_kmsKey
=== RUN   TestAccBedrockGuardrail_update
=== PAUSE TestAccBedrockGuardrail_update
=== RUN   TestAccBedrockGuardrail_wordConfigAction
=== PAUSE TestAccBedrockGuardrail_wordConfigAction
=== RUN   TestAccBedrockGuardrail_crossRegion
=== PAUSE TestAccBedrockGuardrail_crossRegion
=== RUN   TestAccBedrockGuardrail_contentPolicyConfigAction
=== PAUSE TestAccBedrockGuardrail_contentPolicyConfigAction
=== RUN   TestAccBedrockGuardrail_enhancedActions
=== PAUSE TestAccBedrockGuardrail_enhancedActions
=== CONT  TestAccBedrockGuardrail_tags
=== CONT  TestAccBedrockGuardrail_Tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccBedrockGuardrail_disappears
=== CONT  TestAccBedrockGuardrail_crossRegion
=== CONT  TestAccBedrockGuardrail_Tags_DefaultTags_nonOverlapping
=== CONT  TestAccBedrockGuardrail_Tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccBedrockGuardrail_Tags_DefaultTags_emptyProviderOnlyTag
=== CONT  TestAccBedrockGuardrail_Tags_DefaultTags_emptyResourceTag
=== CONT  TestAccBedrockGuardrail_Tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccBedrockGuardrail_Tags_DefaultTags_updateToProviderOnly
=== CONT  TestAccBedrockGuardrail_Tags_DefaultTags_overlapping
=== CONT  TestAccBedrockGuardrail_Tags_EmptyTag_onCreate
=== CONT  TestAccBedrockGuardrail_Tags_DefaultTags_providerOnly
=== CONT  TestAccBedrockGuardrail_Tags_EmptyTag_OnUpdate_replace
=== CONT  TestAccBedrockGuardrail_Tags_EmptyTag_OnUpdate_add
=== CONT  TestAccBedrockGuardrail_update
=== CONT  TestAccBedrockGuardrail_wordConfigAction
=== CONT  TestAccBedrockGuardrail_Tags_IgnoreTags_Overlap_defaultTag
=== CONT  TestAccBedrockGuardrail_basic
=== CONT  TestAccBedrockGuardrail_Tags_IgnoreTags_Overlap_resourceTag
=== NAME  TestAccBedrockGuardrail_update
    guardrail_test.go:149: Step 1/3 error: Error running pre-apply plan: exit status 1
        
        Error: reading Bedrock Foundation Model (amazon.titan-text-express-v1)
        
          with data.aws_bedrock_foundation_model.test,
          on terraform_plugin_test.tf line 119, in data "aws_bedrock_foundation_model" "test":
         119: data "aws_bedrock_foundation_model" "test" {
        
        operation error Bedrock: GetFoundationModel, https response error StatusCode:
        404, RequestID: 1fe38502-049f-4dbb-b1df-bd36644b35b8,
        ResourceNotFoundException: This model version has reached the end of its
        life. Use an active model version instead. Refer to the Model lifecycle topic
        in the AWS documentation for more details.
--- FAIL: TestAccBedrockGuardrail_update (9.84s)
=== CONT  TestAccBedrockGuardrail_enhancedActions
=== NAME  TestAccBedrockGuardrail_wordConfigAction
    guardrail_test.go:214: Step 1/3 error: Error running pre-apply plan: exit status 1
        
        Error: reading Bedrock Foundation Model (amazon.titan-text-express-v1)
        
          with data.aws_bedrock_foundation_model.test,
          on terraform_plugin_test.tf line 119, in data "aws_bedrock_foundation_model" "test":
         119: data "aws_bedrock_foundation_model" "test" {
        
        operation error Bedrock: GetFoundationModel, https response error StatusCode:
        404, RequestID: 71c9768d-d32c-49dc-93aa-3f540a570d6e,
        ResourceNotFoundException: This model version has reached the end of its
        life. Use an active model version instead. Refer to the Model lifecycle topic
        in the AWS documentation for more details.
--- FAIL: TestAccBedrockGuardrail_wordConfigAction (11.16s)
=== CONT  TestAccBedrockGuardrail_kmsKey
    guardrail_test.go:116: Step 1/2 error: Error running pre-apply plan: exit status 1
        
        Error: reading Bedrock Foundation Model (amazon.titan-text-express-v1)
        
          with data.aws_bedrock_foundation_model.test,
          on terraform_plugin_test.tf line 119, in data "aws_bedrock_foundation_model" "test":
         119: data "aws_bedrock_foundation_model" "test" {
        
        operation error Bedrock: GetFoundationModel, https response error StatusCode:
        404, RequestID: 93b6817f-2f4e-4934-af54-950b2b7f4401,
        ResourceNotFoundException: This model version has reached the end of its
        life. Use an active model version instead. Refer to the Model lifecycle topic
        in the AWS documentation for more details.
--- FAIL: TestAccBedrockGuardrail_kmsKey (8.90s)
=== CONT  TestAccBedrockGuardrail_contentPolicyConfigAction
    guardrail_test.go:341: Step 1/2 error: Error running pre-apply plan: exit status 1
        
        Error: reading Bedrock Foundation Model (amazon.titan-text-express-v1)
        
          with data.aws_bedrock_foundation_model.test,
          on terraform_plugin_test.tf line 119, in data "aws_bedrock_foundation_model" "test":
         119: data "aws_bedrock_foundation_model" "test" {
        
        operation error Bedrock: GetFoundationModel, https response error StatusCode:
        404, RequestID: 7e54c468-cfa5-4768-97ed-b546c0f449ab,
        ResourceNotFoundException: This model version has reached the end of its
        life. Use an active model version instead. Refer to the Model lifecycle topic
        in the AWS documentation for more details.
--- FAIL: TestAccBedrockGuardrail_contentPolicyConfigAction (8.30s)
=== CONT  TestAccBedrockGuardrail_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccBedrockGuardrail_disappears (68.24s)
=== CONT  TestAccBedrockGuardrail_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccBedrockGuardrail_crossRegion (79.73s)
=== CONT  TestAccBedrockGuardrail_Tags_ComputedTag_onCreate
--- PASS: TestAccBedrockGuardrail_basic (80.66s)
=== CONT  TestAccBedrockGuardrail_Tags_emptyMap
--- PASS: TestAccBedrockGuardrail_enhancedActions (78.29s)
=== CONT  TestAccBedrockGuardrail_Tags_addOnUpdate
--- PASS: TestAccBedrockGuardrail_Tags_DefaultTags_nullOverlappingResourceTag (93.66s)
=== CONT  TestAccBedrockGuardrail_Tags_null
--- PASS: TestAccBedrockGuardrail_Tags_DefaultTags_emptyProviderOnlyTag (94.17s)
--- PASS: TestAccBedrockGuardrail_Tags_DefaultTags_emptyResourceTag (94.17s)
--- PASS: TestAccBedrockGuardrail_Tags_DefaultTags_nullNonOverlappingResourceTag (122.23s)
--- PASS: TestAccBedrockGuardrail_Tags_DefaultTags_updateToResourceOnly (136.45s)
--- PASS: TestAccBedrockGuardrail_Tags_EmptyTag_OnUpdate_replace (145.88s)
--- PASS: TestAccBedrockGuardrail_Tags_DefaultTags_updateToProviderOnly (151.52s)
--- PASS: TestAccBedrockGuardrail_Tags_emptyMap (79.87s)
--- PASS: TestAccBedrockGuardrail_Tags_ComputedTag_OnUpdate_add (134.01s)
--- PASS: TestAccBedrockGuardrail_Tags_ComputedTag_onCreate (84.79s)
--- PASS: TestAccBedrockGuardrail_Tags_null (75.16s)
--- PASS: TestAccBedrockGuardrail_Tags_EmptyTag_onCreate (176.80s)
--- PASS: TestAccBedrockGuardrail_Tags_IgnoreTags_Overlap_defaultTag (180.63s)
--- PASS: TestAccBedrockGuardrail_Tags_IgnoreTags_Overlap_resourceTag (183.87s)
--- PASS: TestAccBedrockGuardrail_Tags_ComputedTag_OnUpdate_replace (119.64s)
--- PASS: TestAccBedrockGuardrail_Tags_addOnUpdate (109.16s)
--- PASS: TestAccBedrockGuardrail_Tags_DefaultTags_overlapping (199.13s)
--- PASS: TestAccBedrockGuardrail_Tags_EmptyTag_OnUpdate_add (199.75s)
--- PASS: TestAccBedrockGuardrail_Tags_DefaultTags_nonOverlapping (204.87s)
--- PASS: TestAccBedrockGuardrail_tags (225.04s)
--- PASS: TestAccBedrockGuardrail_Tags_DefaultTags_providerOnly (229.68s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/bedrock    229.879s
FAIL
make: *** [GNUmakefile:918: testacc] Fehler 1```
