### PR TITLE
docs: add missing `skaff` subcommands

### DIFF
--- a/docs/skaff.md
+++ b/docs/skaff.md
@@ -31,12 +31,13 @@ These files are heavily commented with instructions, serving as the best way to 
     ```
 
 1. Change into the appropriate directory.
-    - For resources and data sources, this is the service directory where the new entity will reside, e.g. `internal/service/mq`.
+    - For resources, data sources, ephemeral resources, and list resources this is the service directory where the new entity will reside, e.g. `internal/service/mq`.
     - For functions, this is `internal/functions`.
-1. Generate the resource, data source or function. For example,
+1. Generate the code scaffolding. For example,
     - `skaff resource --name BrokerReboot`.
     - `skaff datasource --name IAMRole`.
     - `skaff function --name ARNParse`.
+    - `skaff list --name EBSVolume`.
 
 To get help, enter `skaff` without arguments.
 
@@ -49,14 +50,18 @@ skaff --help
 ```
 
 ```
+Create scaffolding for the Terraform AWS Provider
+
 Usage:
   skaff [command]
 
 Available Commands:
   completion  Generate the autocompletion script for the specified shell
   datasource  Create scaffolding for a data source
+  ephemeral   Create scaffolding for an ephemeral resource
   function    Create scaffolding for a function
   help        Help about any command
+  list        Create scaffolding for a list resource
   resource    Create scaffolding for a resource
 
 Flags:
@@ -65,7 +70,7 @@ Flags:
 
 ### Autocompletion
 
-Generate the autocompletion script for `skaff` for the specified shell
+Generate the autocompletion script for `skaff` for the specified shell.
 
 ```console
 skaff completion --help
@@ -83,13 +88,11 @@ Available Commands:
 
 Flags:
   -h, --help   help for completion
-
-Use "skaff completion [command] --help" for more information about a command
 ```
 
 ### Data Source
 
-Create scaffolding for a data source
+Create scaffolding for a data source.
 
 ```console
 skaff datasource --help
@@ -106,6 +109,28 @@ Flags:
   -f, --force              force creation, overwriting existing files
   -h, --help               help for datasource
   -t, --include-tags       Indicate that this resource has tags and the code for tagging should be generated
+  -n, --name string        name of the entity
+  -s, --snakename string   if skaff doesn't get it right, explicitly give name in snake case (e.g., db_vpc_instance)
+```
+
+### Ephemeral Resource
+
+Create scaffolding for an ephemeral resource.
+
+```console
+% skaff ephemeral --help
+```
+
+```
+Create scaffolding for an ephemeral resource
+
+Usage:
+  skaff ephemeral [flags]
+
+Flags:
+  -c, --clear-comments     do not include instructional comments in source
+  -f, --force              force creation, overwriting existing files
+  -h, --help               help for ephemeral
   -n, --name string        name of the entity
   -s, --snakename string   if skaff doesn't get it right, explicitly give name in snake case (e.g., db_vpc_instance)
 ```
@@ -133,9 +158,32 @@ Flags:
   -s, --snakename string     if skaff doesn't get it right, explicitly give name in snake case (e.g., arn_build)
 ```
 
+### List Resource
+
+Create scaffolding for a list resource.
+
+```console
+% skaff list --help
+```
+
+```
+Create scaffolding for a list resource
+
+Usage:
+  skaff list [flags]
+
+Flags:
+  -c, --clear-comments     do not include instructional comments in source
+  -f, --force              force creation, overwriting existing files
+  -p, --framework          use scaffolding for resources written using framework
+  -h, --help               help for list
+  -n, --name string        name of the entity
+  -s, --snakename string   if skaff doesn't get it right, explicitly give name in snake case (e.g., db_vpc_instance)
+```
+
 ### Resource
 
-Create scaffolding for a resource
+Create scaffolding for a resource.
 
 ```console
 skaff resource --help


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds documentation for the `skaff ephemeral` and `skaff list` subcommands.
