### PR TITLE
docs(ssm_service_setting): Fix setting_id in example usage

### DIFF
--- a/website/docs/r/ssm_service_setting.html.markdown
+++ b/website/docs/r/ssm_service_setting.html.markdown
@@ -14,7 +14,7 @@ This setting defines how a user interacts with or uses a service or a feature of
 
 ```terraform
 resource "aws_ssm_service_setting" "test_setting" {
-  setting_id    = "arn:aws:ssm:us-east-1:123456789012:servicesetting/ssm/parameter-store/high-throughput-enabled"
+  setting_id    = "/ssm/parameter-store/high-throughput-enabled"
   setting_value = "true"
 }
 ```


### PR DESCRIPTION
The example usage showed a full ARN for setting_id, but the resource expects a short-form setting ID path like /ssm/parameter-store/high-throughput-enabled.
