### PR TITLE
support for EPISODIC type in aws_bedrockagentcore_memory_strategy

### DIFF
--- a/.changelog/47589.txt
+++ b/.changelog/47589.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_memory_strategy: 'EPISODIC' memory strategy included
+```

--- a/.changelog/47589.txt
+++ b/.changelog/47589.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_bedrockagentcore_memory_strategy: 'EPISODIC' memory strategy included
+resource/aws_bedrockagentcore_memory_strategy: Support `EPISODIC` as a valid value for `type`
 ```

--- a/.ci/.golangci4.yml
+++ b/.ci/.golangci4.yml
@@ -125,15 +125,15 @@ linters:
       - linters:
           - staticcheck
         path: internal/service/budgets/
-        text: 'SA1019: \w+\.\w+ is deprecated:'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated:'
       - linters:
           - staticcheck
         path: internal/service/chime/
-        text: 'SA1019: conn.\w+ is deprecated: Replaced by \w+ in the Amazon Chime SDK Voice Namespace'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated: Replaced by \w+ in the Amazon Chime SDK Voice Namespace'
       - linters:
           - staticcheck
         path: internal/service/cloudfront/
-        text: 'SA1019: \w+\.\w+ is deprecated: This member has been deprecated'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated: This member has been deprecated'
       - linters:
           - staticcheck
         path: internal/service/detective/
@@ -141,7 +141,7 @@ linters:
       - linters:
           - staticcheck
         path: internal/service/ecr/
-        text: 'SA1019: \w+\.\w+ is deprecated: This field is deprecated.'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated: This field is deprecated.'
       - linters:
           - staticcheck
         path: internal/service/elastictranscoder/
@@ -149,11 +149,11 @@ linters:
       - linters:
           - staticcheck
         path: internal/service/elastictranscoder/
-        text: 'SA1019: \w+\.\w+ is deprecated: AWS has deprecated this service. It is no longer available for use.'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated: AWS has deprecated this service. It is no longer available for use.'
       - linters:
           - staticcheck
         path: internal/service/elastictranscoder/
-        text: 'SA1019: \w+\.\w+\.\w+ is deprecated: AWS has deprecated this service. It is no longer available for use.'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated: AWS has deprecated this service. It is no longer available for use.'
       - linters:
           - staticcheck
         path: internal/service/evidently/
@@ -161,19 +161,15 @@ linters:
       - linters:
           - staticcheck
         path: internal/service/evidently/
-        text: 'SA1019: \w+\.\w+ is deprecated: AWS has deprecated this service. It is no longer available for use.'
-      - linters:
-          - staticcheck
-        path: internal/service/evidently/
-        text: 'SA1019: \w+\.\w+\.\w+ is deprecated: AWS has deprecated this service. It is no longer available for use.'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated: AWS has deprecated this service. It is no longer available for use.'
       - linters:
           - staticcheck
         path: internal/service/firehose/
-        text: 'SA1019: \w+\.\w+ is deprecated: (\w+) has been deprecated'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated: (\w+) has been deprecated'
       - linters:
           - staticcheck
         path: internal/service/fsx/
-        text: 'SA1019: \w+\.\w+ is deprecated: This property is deprecated'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated: This property is deprecated'
       - linters:
           - staticcheck
         path: internal/service/globalaccelerator/
@@ -181,7 +177,7 @@ linters:
       - linters:
           - staticcheck
         path: internal/service/guardduty/
-        text: 'SA1019: \w+\.\w+ is deprecated. This (input|operation|parameter|field) is deprecated'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated. This (input|operation|parameter|field) is deprecated'
       - linters:
           - staticcheck
         path: internal/service/identitystore/
@@ -189,7 +185,7 @@ linters:
       - linters:
           - staticcheck
         path: internal/service/neptune/
-        text: 'SA1019: \w+\.\w+ is deprecated:'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated:'
       - linters:
           - staticcheck
         path: internal/service/qldb/
@@ -197,35 +193,35 @@ linters:
       - linters:
           - staticcheck
         path: internal/service/qldb/
-        text: 'SA1019: \w+\.\w+ is deprecated:'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated:'
       - linters:
           - staticcheck
         path: internal/service/quicksight/
-        text: 'SA1019: \w+\.\w+ is deprecated:'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated:'
       - linters:
           - staticcheck
         path: internal/service/s3/
-        text: 'SA1019: \w+\.\w+ is deprecated:'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated:'
       - linters:
           - staticcheck
         path: internal/service/s3control/
-        text: 'SA1019: \w+\.\w+ is deprecated:'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated:'
       - linters:
           - staticcheck
         path: internal/service/securityhub/
-        text: 'SA1019: \w+\.\w+ is deprecated:'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated:'
       - linters:
           - staticcheck
         path: internal/service/servicediscovery/
-        text: 'SA1019: \w+\.\w+ is deprecated:'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated:'
       - linters:
           - staticcheck
         path: internal/service/wafv2/
-        text: 'SA1019: \w+\.\w+ is deprecated: Deprecated. Use'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated: Deprecated. Use'
       - linters:
           - staticcheck
         path: internal/service/worklink/
-        text: 'SA1019: \w+\.\w+ is deprecated: Amazon WorkLink is no longer supported. This will be removed in a future version of the SDK.'
+        text: 'SA1019: (\w+\.)+\w+ is deprecated: Amazon WorkLink is no longer supported. This will be removed in a future version of the SDK.'
 issues:
   max-issues-per-linter: 20
   max-same-issues: 10

--- a/.ci/.golangci4.yml
+++ b/.ci/.golangci4.yml
@@ -120,6 +120,10 @@ linters:
         text: 'SA1019: apiObject.ImageId is deprecated: This field is deprecated'
       - linters:
           - staticcheck
+        path: internal/service/bedrockagentcore/
+        text: 'SA1019: (\w+\.)+\w+ is deprecated:'
+      - linters:
+          - staticcheck
         path: internal/service/budgets/
         text: 'SA1019: \w+\.\w+ is deprecated:'
       - linters:

--- a/internal/service/bedrockagentcore/exports_test.go
+++ b/internal/service/bedrockagentcore/exports_test.go
@@ -26,7 +26,7 @@ var (
 	FindGatewayByID                      = findGatewayByID
 	FindGatewayTargetByTwoPartKey        = findGatewayTargetByTwoPartKey
 	FindMemoryByID                       = findMemoryByID
-	FindMemoryStrategyByID               = findMemoryStrategyByTwoPartKey
+	FindMemoryStrategyByTwoPartKey       = findMemoryStrategyByTwoPartKey
 	FindOAuth2CredentialProviderByName   = findOAuth2CredentialProviderByName
 	FindTokenVaultByID                   = findTokenVaultByID
 	FindWorkloadIdentityByName           = findWorkloadIdentityByName

--- a/internal/service/bedrockagentcore/memory_strategy.go
+++ b/internal/service/bedrockagentcore/memory_strategy.go
@@ -54,8 +54,6 @@ func newResourceMemoryStrategy(_ context.Context) (resource.ResourceWithConfigur
 }
 
 const (
-	ResNameMemoryStrategy = "Memory Strategy"
-
 	// Retry message substrings for transitional/ignored states
 	msgMemoryStrategiesBeingModified   = "Cannot update memory while strategies are being modified"
 	msgMemoryStrategyTransitionalState = "MemoryStrategy is in transitional state"
@@ -107,7 +105,7 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 		},
 		Blocks: map[string]schema.Block{
 			names.AttrConfiguration: schema.ListNestedBlock{
-				CustomType: fwtypes.NewListNestedObjectTypeOf[CustomConfigurationModel](ctx),
+				CustomType: fwtypes.NewListNestedObjectTypeOf[customConfigurationModel](ctx),
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
@@ -123,12 +121,12 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 					},
 					Blocks: map[string]schema.Block{
 						"consolidation": schema.ListNestedBlock{
-							CustomType: fwtypes.NewListNestedObjectTypeOf[OverrideDetailsModel](ctx),
+							CustomType: fwtypes.NewListNestedObjectTypeOf[overrideDetailsModel](ctx),
 							Validators: []validator.List{
 								listvalidator.SizeAtMost(1),
 							},
 							PlanModifiers: []planmodifier.List{
-								ErrorIfSingleBlockRemoved("consolidation"),
+								errorIfSingleBlockRemoved("consolidation"),
 							},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
@@ -142,10 +140,10 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 							},
 						},
 						"extraction": schema.ListNestedBlock{
-							CustomType: fwtypes.NewListNestedObjectTypeOf[OverrideDetailsModel](ctx),
+							CustomType: fwtypes.NewListNestedObjectTypeOf[overrideDetailsModel](ctx),
 							Validators: []validator.List{listvalidator.SizeAtMost(1)},
 							PlanModifiers: []planmodifier.List{
-								ErrorIfSingleBlockRemoved("extraction"),
+								errorIfSingleBlockRemoved("extraction"),
 							},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
@@ -170,23 +168,23 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 	}
 }
 
-type errorIfSingleBlockRemoved struct {
+type errorIfSingleBlockRemoved_ struct {
 	label string
 }
 
-func ErrorIfSingleBlockRemoved(label string) planmodifier.List {
-	return errorIfSingleBlockRemoved{label: label}
+func errorIfSingleBlockRemoved(label string) planmodifier.List {
+	return errorIfSingleBlockRemoved_{label: label}
 }
 
-func (m errorIfSingleBlockRemoved) Description(context.Context) string {
+func (m errorIfSingleBlockRemoved_) Description(context.Context) string {
 	return "Disallow removing previously configured " + m.label + " block"
 }
 
-func (m errorIfSingleBlockRemoved) MarkdownDescription(ctx context.Context) string {
+func (m errorIfSingleBlockRemoved_) MarkdownDescription(ctx context.Context) string {
 	return m.Description(ctx)
 }
 
-func (m errorIfSingleBlockRemoved) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+func (m errorIfSingleBlockRemoved_) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
 	// Skip create or destroy.
 	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
 		return
@@ -608,7 +606,7 @@ func findMemoryStrategyByTwoPartKey(ctx context.Context, conn *bedrockagentcorec
 
 type memoryStrategyResourceModel struct {
 	framework.WithRegionModel
-	Configuration          fwtypes.ListNestedObjectValueOf[CustomConfigurationModel] `tfsdk:"configuration"`
+	Configuration          fwtypes.ListNestedObjectValueOf[customConfigurationModel] `tfsdk:"configuration"`
 	Description            types.String                                              `tfsdk:"description"`
 	MemoryExecutionRoleARN fwtypes.ARN                                               `tfsdk:"memory_execution_role_arn"`
 	MemoryStrategyID       types.String                                              `tfsdk:"memory_strategy_id"`
@@ -724,25 +722,25 @@ func (m memoryStrategyResourceModel) expandToModifyMemoryStrategyInput(ctx conte
 	return &r, diags
 }
 
-type CustomConfigurationModel struct {
+type customConfigurationModel struct {
 	Type          fwtypes.StringEnum[awstypes.OverrideType]             `tfsdk:"type"`
-	Consolidation fwtypes.ListNestedObjectValueOf[OverrideDetailsModel] `tfsdk:"consolidation"`
-	Extraction    fwtypes.ListNestedObjectValueOf[OverrideDetailsModel] `tfsdk:"extraction"`
+	Consolidation fwtypes.ListNestedObjectValueOf[overrideDetailsModel] `tfsdk:"consolidation"`
+	Extraction    fwtypes.ListNestedObjectValueOf[overrideDetailsModel] `tfsdk:"extraction"`
 }
 
 var (
-	_ fwflex.TypedExpander = CustomConfigurationModel{}
-	_ fwflex.Flattener     = &CustomConfigurationModel{}
+	_ fwflex.TypedExpander = customConfigurationModel{}
+	_ fwflex.Flattener     = &customConfigurationModel{}
 )
 
-func (m *CustomConfigurationModel) Flatten(ctx context.Context, v any) (diags diag.Diagnostics) {
+func (m *customConfigurationModel) Flatten(ctx context.Context, v any) (diags diag.Diagnostics) {
 	var d diag.Diagnostics
 	switch t := v.(type) {
 	case awstypes.StrategyConfiguration:
 		m.Type = fwtypes.StringEnumValue(t.Type)
 
 		if t.Consolidation != nil {
-			var consolidation OverrideDetailsModel
+			var consolidation overrideDetailsModel
 			smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, t.Consolidation, &consolidation))
 			if diags.HasError() {
 				return diags
@@ -757,7 +755,7 @@ func (m *CustomConfigurationModel) Flatten(ctx context.Context, v any) (diags di
 		}
 
 		if t.Extraction != nil {
-			var extraction OverrideDetailsModel
+			var extraction overrideDetailsModel
 			smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, t.Extraction, &extraction))
 			if diags.HasError() {
 				return diags
@@ -778,7 +776,7 @@ func (m *CustomConfigurationModel) Flatten(ctx context.Context, v any) (diags di
 	}
 	return diags
 }
-func (m CustomConfigurationModel) ExpandTo(ctx context.Context, targetType reflect.Type) (result any, diags diag.Diagnostics) {
+func (m customConfigurationModel) ExpandTo(ctx context.Context, targetType reflect.Type) (result any, diags diag.Diagnostics) {
 	switch targetType {
 	case reflect.TypeFor[awstypes.CustomConfigurationInput]():
 		return m.expandToCustomConfigurationInput(ctx)
@@ -794,8 +792,8 @@ func (m CustomConfigurationModel) ExpandTo(ctx context.Context, targetType refle
 	return nil, diags
 }
 
-func (m CustomConfigurationModel) expandToCustomConfigurationInput(ctx context.Context) (result awstypes.CustomConfigurationInput, diags diag.Diagnostics) {
-	type modelAlias CustomConfigurationModel
+func (m customConfigurationModel) expandToCustomConfigurationInput(ctx context.Context) (result awstypes.CustomConfigurationInput, diags diag.Diagnostics) {
+	type modelAlias customConfigurationModel
 	alias := modelAlias(m)
 
 	switch m.Type.ValueEnum() {
@@ -840,10 +838,10 @@ func (m CustomConfigurationModel) expandToCustomConfigurationInput(ctx context.C
 	return nil, diags
 }
 
-func (m CustomConfigurationModel) expandToModifyStrategyConfiguration(ctx context.Context) (result *awstypes.ModifyStrategyConfiguration, diags diag.Diagnostics) {
+func (m customConfigurationModel) expandToModifyStrategyConfiguration(ctx context.Context) (result *awstypes.ModifyStrategyConfiguration, diags diag.Diagnostics) {
 	result = &awstypes.ModifyStrategyConfiguration{}
 
-	var consolidation, extraction *OverrideDetailsModel
+	var consolidation, extraction *overrideDetailsModel
 	var d diag.Diagnostics
 
 	if !m.Consolidation.IsNull() {
@@ -956,21 +954,16 @@ func (m CustomConfigurationModel) expandToModifyStrategyConfiguration(ctx contex
 	return result, diags
 }
 
-type OverrideConfigurationModel struct {
-	Consolidation fwtypes.ListNestedObjectValueOf[OverrideDetailsModel] `tfsdk:"consolidation"`
-	Extraction    fwtypes.ListNestedObjectValueOf[OverrideDetailsModel] `tfsdk:"extraction"`
-}
-
-type OverrideDetailsModel struct {
+type overrideDetailsModel struct {
 	AppendToPrompt types.String `tfsdk:"append_to_prompt"`
 	ModelID        types.String `tfsdk:"model_id"`
 }
 
 var (
-	_ fwflex.Flattener = &OverrideDetailsModel{}
+	_ fwflex.Flattener = &overrideDetailsModel{}
 )
 
-func (m *OverrideDetailsModel) Flatten(ctx context.Context, v any) (diags diag.Diagnostics) {
+func (m *overrideDetailsModel) Flatten(ctx context.Context, v any) (diags diag.Diagnostics) {
 	switch t := v.(type) {
 	// Consolidation
 	case awstypes.ConsolidationConfigurationMemberCustomConsolidationConfiguration:

--- a/internal/service/bedrockagentcore/memory_strategy.go
+++ b/internal/service/bedrockagentcore/memory_strategy.go
@@ -53,13 +53,6 @@ func newResourceMemoryStrategy(_ context.Context) (resource.ResourceWithConfigur
 	return r, nil
 }
 
-const (
-	// Retry message substrings for transitional/ignored states
-	msgMemoryStrategiesBeingModified   = "Cannot update memory while strategies are being modified"
-	msgMemoryStrategyTransitionalState = "MemoryStrategy is in transitional state"
-	msgDeleteNonExistentStrategy       = "Cannot delete non-existent memory strategies"
-)
-
 type resourceMemoryStrategy struct {
 	framework.ResourceWithModel[memoryStrategyResourceModel]
 	framework.WithTimeouts
@@ -276,9 +269,10 @@ func (r *resourceMemoryStrategy) Create(ctx context.Context, request resource.Cr
 		return
 	}
 
+	memoryID := fwflex.StringValueFromFramework(ctx, plan.MemoryID)
 	input := bedrockagentcorecontrol.UpdateMemoryInput{
 		ClientToken: aws.String(create.UniqueId(ctx)),
-		MemoryId:    plan.MemoryID.ValueStringPointer(),
+		MemoryId:    aws.String(memoryID),
 		MemoryStrategies: &awstypes.ModifyMemoryStrategies{
 			AddMemoryStrategies: []awstypes.MemoryStrategyInput{strategyInput},
 		},
@@ -288,7 +282,7 @@ func (r *resourceMemoryStrategy) Create(ctx context.Context, request resource.Cr
 		input.MemoryExecutionRoleArn = plan.MemoryExecutionRoleARN.ValueStringPointer()
 	}
 
-	withMemoryLock(plan.MemoryID.ValueString(), func() {
+	withMemoryLock(ctx, memoryID, func(ctx context.Context) {
 		createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
 		out, err := updateMemoryWithRetry(ctx, conn, createTimeout, &input, false)
 		if err != nil {
@@ -296,17 +290,18 @@ func (r *resourceMemoryStrategy) Create(ctx context.Context, request resource.Cr
 			return
 		}
 
+		name := fwflex.StringValueFromFramework(ctx, plan.Name)
 		var found *awstypes.MemoryStrategy
 		if out != nil && out.Memory != nil {
 			for i := range out.Memory.Strategies {
 				s := &out.Memory.Strategies[i]
-				if s.Name != nil && aws.ToString(s.Name) == plan.Name.ValueString() {
+				if s.Name != nil && aws.ToString(s.Name) == name {
 					found = s
 				}
 			}
 		}
 		if found == nil {
-			smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("create memory strategy: API response missing strategy name %q", plan.Name.ValueString()), smerr.ID, plan.GetIdentifier())
+			smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("create memory strategy: API response missing strategy name %q", name), smerr.ID, plan.GetIdentifier())
 			return
 		}
 		// For non-CUSTOM types, clear Configuration from the API response before
@@ -320,9 +315,9 @@ func (r *resourceMemoryStrategy) Create(ctx context.Context, request resource.Cr
 			return
 		}
 
-		_, err = waitMemoryStrategyCreated(ctx, conn, plan.MemoryID.ValueString(), plan.MemoryStrategyID.ValueString(), createTimeout)
+		_, err = waitMemoryStrategyCreated(ctx, conn, memoryID, fwflex.StringValueFromFramework(ctx, plan.MemoryStrategyID), createTimeout)
 		if err != nil {
-			response.State.SetAttribute(ctx, path.Root("memory_id"), plan.MemoryID.ValueString())
+			response.State.SetAttribute(ctx, path.Root("memory_id"), memoryID)
 			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, plan.GetIdentifier())
 			return
 		}
@@ -343,7 +338,8 @@ func (r *resourceMemoryStrategy) Read(ctx context.Context, request resource.Read
 		return
 	}
 
-	out, err := findMemoryStrategyByTwoPartKey(ctx, conn, state.MemoryID.ValueString(), state.MemoryStrategyID.ValueString())
+	memoryID, memoryStrategyID := fwflex.StringValueFromFramework(ctx, state.MemoryID), fwflex.StringValueFromFramework(ctx, state.MemoryStrategyID)
+	out, err := findMemoryStrategyByTwoPartKey(ctx, conn, memoryID, memoryStrategyID)
 	if retry.NotFound(err) {
 		smerr.AddOne(ctx, &response.Diagnostics, fwdiag.NewResourceNotFoundWarningDiagnostic(err))
 		response.State.RemoveResource(ctx)
@@ -351,7 +347,7 @@ func (r *resourceMemoryStrategy) Read(ctx context.Context, request resource.Read
 	}
 
 	if err != nil {
-		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, state.MemoryStrategyID.String())
+		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, memoryStrategyID)
 		return
 	}
 
@@ -393,9 +389,10 @@ func (r *resourceMemoryStrategy) Update(ctx context.Context, request resource.Up
 			return
 		}
 
+		memoryID, memoryStrategyID := fwflex.StringValueFromFramework(ctx, plan.MemoryID), fwflex.StringValueFromFramework(ctx, plan.MemoryStrategyID)
 		input := bedrockagentcorecontrol.UpdateMemoryInput{
 			ClientToken: aws.String(create.UniqueId(ctx)),
-			MemoryId:    plan.MemoryID.ValueStringPointer(),
+			MemoryId:    aws.String(memoryID),
 			MemoryStrategies: &awstypes.ModifyMemoryStrategies{
 				ModifyMemoryStrategies: []awstypes.ModifyMemoryStrategyInput{strategyInput},
 			},
@@ -405,24 +402,24 @@ func (r *resourceMemoryStrategy) Update(ctx context.Context, request resource.Up
 			input.MemoryExecutionRoleArn = plan.MemoryExecutionRoleARN.ValueStringPointer()
 		}
 
-		withMemoryLock(plan.MemoryID.ValueString(), func() {
+		withMemoryLock(ctx, memoryID, func(ctx context.Context) {
 			updateTimeout := r.UpdateTimeout(ctx, plan.Timeouts)
 			out, err := updateMemoryWithRetry(ctx, conn, updateTimeout, &input, false)
 			if err != nil {
-				smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, plan.MemoryStrategyID.String())
+				smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, memoryStrategyID)
 				return
 			}
 			var found *awstypes.MemoryStrategy
 			if out != nil && out.Memory != nil {
 				for i := range out.Memory.Strategies {
 					s := &out.Memory.Strategies[i]
-					if s.StrategyId != nil && aws.ToString(s.StrategyId) == plan.MemoryStrategyID.ValueString() {
+					if s.StrategyId != nil && aws.ToString(s.StrategyId) == memoryStrategyID {
 						found = s
 					}
 				}
 			}
 			if found == nil {
-				smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("update memory strategy: API response missing strategy id %q", plan.MemoryStrategyID.ValueString()))
+				smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("update memory strategy: API response missing strategy id %q", memoryStrategyID))
 				return
 			}
 			if plan.Type.ValueEnum() != awstypes.MemoryStrategyTypeCustom {
@@ -447,29 +444,30 @@ func (r *resourceMemoryStrategy) Delete(ctx context.Context, request resource.De
 		return
 	}
 
+	memoryID, memoryStrategyID := fwflex.StringValueFromFramework(ctx, state.MemoryID), fwflex.StringValueFromFramework(ctx, state.MemoryStrategyID)
 	input := bedrockagentcorecontrol.UpdateMemoryInput{
 		ClientToken: aws.String(create.UniqueId(ctx)),
-		MemoryId:    state.MemoryID.ValueStringPointer(),
+		MemoryId:    aws.String(memoryID),
 		MemoryStrategies: &awstypes.ModifyMemoryStrategies{
 			DeleteMemoryStrategies: []awstypes.DeleteMemoryStrategyInput{
 				{
-					MemoryStrategyId: state.MemoryStrategyID.ValueStringPointer(),
+					MemoryStrategyId: aws.String(memoryStrategyID),
 				},
 			},
 		},
 	}
 
-	withMemoryLock(state.MemoryID.ValueString(), func() {
+	withMemoryLock(ctx, memoryID, func(ctx context.Context) {
 		deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
 		_, err := updateMemoryWithRetry(ctx, conn, deleteTimeout, &input, true)
 		if err != nil {
-			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, state.MemoryStrategyID.String())
+			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, memoryStrategyID)
 			return
 		}
 
-		_, err = waitMemoryStrategyDeleted(ctx, conn, state.MemoryID.ValueString(), state.MemoryStrategyID.ValueString(), deleteTimeout)
+		_, err = waitMemoryStrategyDeleted(ctx, conn, memoryID, memoryStrategyID, deleteTimeout)
 		if err != nil {
-			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, state.MemoryStrategyID.String())
+			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, memoryStrategyID)
 			return
 		}
 	})
@@ -491,11 +489,11 @@ func (r *resourceMemoryStrategy) ImportState(ctx context.Context, request resour
 // strategy resources (add/modify/delete) do not race while the backend transitions strategy
 // state (e.g., Creating -> Active, Deleting -> removed) which could otherwise result in
 // ValidationExceptions or ConflictExceptions.
-func withMemoryLock(memoryID string, fn func()) {
+func withMemoryLock(ctx context.Context, memoryID string, fn func(ctx context.Context)) {
 	mutexKey := fmt.Sprintf("bedrockagentcore-memory-%s", memoryID)
 	conns.GlobalMutexKV.Lock(mutexKey)
 	defer conns.GlobalMutexKV.Unlock(mutexKey)
-	fn()
+	fn(ctx)
 }
 
 func updateMemoryWithRetry(
@@ -520,6 +518,12 @@ func updateMemoryWithRetry(
 // (deleteOp=true) a ValidationException containing msgDeleteNonExistentStrategy
 // is considered terminal (no retry, treated as success by caller after RetryWhen).
 func memoryStrategyRetryable(deleteOp bool) tfresource.Retryable {
+	const (
+		// Retry message substrings for transitional/ignored states
+		msgMemoryStrategiesBeingModified   = "Cannot update memory while strategies are being modified"
+		msgMemoryStrategyTransitionalState = "MemoryStrategy is in transitional state"
+		msgDeleteNonExistentStrategy       = "Cannot delete non-existent memory strategies"
+	)
 	return func(err error) (bool, error) {
 		if err == nil {
 			return false, nil

--- a/internal/service/bedrockagentcore/memory_strategy.go
+++ b/internal/service/bedrockagentcore/memory_strategy.go
@@ -311,6 +311,12 @@ func (r *resourceMemoryStrategy) Create(ctx context.Context, request resource.Cr
 			smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("create memory strategy: API response missing strategy name %q", plan.Name.ValueString()), smerr.ID, plan.GetIdentifier())
 			return
 		}
+		// For non-CUSTOM types, clear Configuration from the API response before
+		// flattening. The API returns a StrategyConfiguration with Type values
+		// (e.g. "EPISODIC") that are not valid OverrideType enum values.
+		if plan.Type.ValueEnum() != awstypes.MemoryStrategyTypeCustom {
+			found.Configuration = nil
+		}
 		smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, found, &plan, fwflex.WithFieldNamePrefix("Memory")))
 		if response.Diagnostics.HasError() {
 			return
@@ -349,6 +355,13 @@ func (r *resourceMemoryStrategy) Read(ctx context.Context, request resource.Read
 	if err != nil {
 		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, state.MemoryStrategyID.String())
 		return
+	}
+
+	// For non-CUSTOM types, clear Configuration from the API response before
+	// flattening. The API returns a StrategyConfiguration with Type values
+	// (e.g. "EPISODIC") that are not valid OverrideType enum values.
+	if state.Type.ValueEnum() != awstypes.MemoryStrategyTypeCustom {
+		out.Configuration = nil
 	}
 
 	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, out, &state, fwflex.WithFieldNamePrefix("Memory")))
@@ -413,6 +426,9 @@ func (r *resourceMemoryStrategy) Update(ctx context.Context, request resource.Up
 			if found == nil {
 				smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("update memory strategy: API response missing strategy id %q", plan.MemoryStrategyID.ValueString()))
 				return
+			}
+			if plan.Type.ValueEnum() != awstypes.MemoryStrategyTypeCustom {
+				found.Configuration = nil
 			}
 			smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, found, &plan, fwflex.WithFieldNamePrefix("Memory")))
 		})
@@ -667,6 +683,21 @@ func (m memoryStrategyResourceModel) expandToMemoryStrategyInput(ctx context.Con
 			return nil, diags
 		}
 		return &r, diags
+
+	case awstypes.MemoryStrategyTypeEpisodic:
+		var r awstypes.MemoryStrategyInputMemberEpisodicMemoryStrategy
+		r.Value.Name = m.Name.ValueStringPointer()
+		r.Value.Description = m.Description.ValueStringPointer()
+		smerr.AddEnrich(ctx, &diags, m.Namespaces.ElementsAs(ctx, &r.Value.Namespaces, false))
+		if diags.HasError() {
+			return nil, diags
+		}
+		// The API requires the reflection namespace to be the same as or a prefix
+		// of the episodic namespace. Set it to match the episodic namespaces.
+		r.Value.ReflectionConfiguration = &awstypes.EpisodicReflectionConfigurationInput{
+			Namespaces: r.Value.Namespaces,
+		}
+		return &r, diags
 	default:
 		diags.AddError(
 			"Unsupported Type",
@@ -683,6 +714,12 @@ func (m memoryStrategyResourceModel) expandToModifyMemoryStrategyInput(ctx conte
 	smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, alias, &r))
 	if diags.HasError() {
 		return nil, diags
+	}
+	// For non-CUSTOM types, Configuration should not be sent.
+	// Auto-flex may produce an empty ModifyStrategyConfiguration from the
+	// null model Configuration field, which the API rejects.
+	if m.Configuration.IsNull() || m.Configuration.IsUnknown() {
+		r.Configuration = nil
 	}
 	return &r, diags
 }
@@ -786,6 +823,14 @@ func (m CustomConfigurationModel) expandToCustomConfigurationInput(ctx context.C
 			return nil, diags
 		}
 		return &r, diags
+
+	case awstypes.OverrideTypeEpisodicOverride:
+		var r awstypes.CustomConfigurationInputMemberEpisodicOverride
+		smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, alias, &r.Value))
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &r, diags
 	default:
 		diags.AddError(
 			"Unsupported Type",
@@ -878,6 +923,29 @@ func (m CustomConfigurationModel) expandToModifyStrategyConfiguration(ctx contex
 				Value: &extractionInput,
 			}
 		}
+
+	case awstypes.OverrideTypeEpisodicOverride:
+		if consolidation != nil {
+			var consolidationInput awstypes.CustomConsolidationConfigurationInputMemberEpisodicConsolidationOverride
+			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, consolidation, &consolidationInput.Value))
+			if diags.HasError() {
+				return nil, diags
+			}
+			result.Consolidation = &awstypes.ModifyConsolidationConfigurationMemberCustomConsolidationConfiguration{
+				Value: &consolidationInput,
+			}
+		}
+
+		if extraction != nil {
+			var extractionInput awstypes.CustomExtractionConfigurationInputMemberEpisodicExtractionOverride
+			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, extraction, &extractionInput.Value))
+			if diags.HasError() {
+				return nil, diags
+			}
+			result.Extraction = &awstypes.ModifyExtractionConfigurationMemberCustomExtractionConfiguration{
+				Value: &extractionInput,
+			}
+		}
 	default:
 		diags.AddError(
 			"Unsupported Type",
@@ -914,6 +982,8 @@ func (m *OverrideDetailsModel) Flatten(ctx context.Context, v any) (diags diag.D
 		return m.Flatten(ctx, t.Value)
 	case *awstypes.CustomConsolidationConfigurationMemberUserPreferenceConsolidationOverride:
 		return m.Flatten(ctx, t.Value)
+	case *awstypes.CustomConsolidationConfigurationMemberEpisodicConsolidationOverride:
+		return m.Flatten(ctx, t.Value)
 
 	case awstypes.SemanticConsolidationOverride:
 		m.AppendToPrompt = types.StringPointerValue(t.AppendToPrompt)
@@ -930,6 +1000,11 @@ func (m *OverrideDetailsModel) Flatten(ctx context.Context, v any) (diags diag.D
 		m.ModelID = types.StringPointerValue(t.ModelId)
 		return diags
 
+	case awstypes.EpisodicConsolidationOverride:
+		m.AppendToPrompt = types.StringPointerValue(t.AppendToPrompt)
+		m.ModelID = types.StringPointerValue(t.ModelId)
+		return diags
+
 	//	Extraction
 	case awstypes.ExtractionConfigurationMemberCustomExtractionConfiguration:
 		return m.Flatten(ctx, t.Value)
@@ -938,6 +1013,8 @@ func (m *OverrideDetailsModel) Flatten(ctx context.Context, v any) (diags diag.D
 		return m.Flatten(ctx, t.Value)
 	case *awstypes.CustomExtractionConfigurationMemberUserPreferenceExtractionOverride:
 		return m.Flatten(ctx, t.Value)
+	case *awstypes.CustomExtractionConfigurationMemberEpisodicExtractionOverride:
+		return m.Flatten(ctx, t.Value)
 
 	case awstypes.SemanticExtractionOverride:
 		m.AppendToPrompt = types.StringPointerValue(t.AppendToPrompt)
@@ -945,6 +1022,11 @@ func (m *OverrideDetailsModel) Flatten(ctx context.Context, v any) (diags diag.D
 		return diags
 
 	case awstypes.UserPreferenceExtractionOverride:
+		m.AppendToPrompt = types.StringPointerValue(t.AppendToPrompt)
+		m.ModelID = types.StringPointerValue(t.ModelId)
+		return diags
+
+	case awstypes.EpisodicExtractionOverride:
 		m.AppendToPrompt = types.StringPointerValue(t.AppendToPrompt)
 		m.ModelID = types.StringPointerValue(t.ModelId)
 		return diags

--- a/internal/service/bedrockagentcore/memory_strategy_test.go
+++ b/internal/service/bedrockagentcore/memory_strategy_test.go
@@ -5,35 +5,24 @@ package bedrockagentcore_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfbedrockagentcore "github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-var memoryConfig = func(rName string) string {
-	return testAccMemoryConfig_basic(rName)
-}
-
 func TestAccBedrockAgentCoreMemoryStrategy_standard(t *testing.T) {
 	ctx := acctest.Context(t)
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
-	var memoryStrategy1, memoryStrategy2, memoryStrategy3, memoryStrategy4, memoryStrategy5 awstypes.MemoryStrategy
+	var m awstypes.MemoryStrategy
 	rName := strings.ReplaceAll(acctest.RandomWithPrefix(t, acctest.ResourcePrefix), "-", "_")
 	resourceName := "aws_bedrockagentcore_memory_strategy.test"
 
@@ -55,31 +44,39 @@ func TestAccBedrockAgentCoreMemoryStrategy_standard(t *testing.T) {
 			{
 				Config: testAccMemoryStrategyConfig_withExecutionRole(rName, "EPISODIC", "Episodic strategy", "/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &memoryStrategy1),
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &m),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "EPISODIC"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Episodic strategy"),
 					resource.TestCheckResourceAttr(resourceName, "namespaces.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "memory_strategy_id"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			// Step 2: Update episodic description (in-place)
 			{
 				Config: testAccMemoryStrategyConfig_withExecutionRole(rName, "EPISODIC", "Updated episodic strategy", "/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &memoryStrategy2),
-					testAccCheckMemoryStrategyNotRecreated(&memoryStrategy1, &memoryStrategy2),
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &m),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "EPISODIC"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Updated episodic strategy"),
 					resource.TestCheckResourceAttr(resourceName, "namespaces.#", "1"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			// Step 3: Change type episodic→semantic (replacement)
 			{
 				Config: testAccMemoryStrategyConfig_withExecutionRole(rName, "SEMANTIC", names.AttrDescription, "default"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &memoryStrategy3),
-					testAccCheckMemoryStrategyRecreated(&memoryStrategy2, &memoryStrategy3),
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &m),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "SEMANTIC"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, names.AttrDescription),
@@ -87,24 +84,32 @@ func TestAccBedrockAgentCoreMemoryStrategy_standard(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "namespaces.*", "default"),
 					resource.TestCheckResourceAttrSet(resourceName, "memory_strategy_id"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
 			},
 			// Step 4: Update description + namespace (in-place)
 			{
 				Config: testAccMemoryStrategyConfig_withExecutionRole(rName, "SEMANTIC", "Updated description", "custom"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &memoryStrategy4),
-					testAccCheckMemoryStrategyNotRecreated(&memoryStrategy3, &memoryStrategy4),
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &m),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Updated description"),
 					resource.TestCheckResourceAttr(resourceName, "namespaces.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "namespaces.*", "custom"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			// Step 5: Change type semantic→user_preference (replacement)
 			{
 				Config: testAccMemoryStrategyConfig_withExecutionRole(rName, "USER_PREFERENCE", "User preference strategy", "preferences"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &memoryStrategy5),
-					testAccCheckMemoryStrategyRecreated(&memoryStrategy4, &memoryStrategy5),
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &m),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "USER_PREFERENCE"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "User preference strategy"),
@@ -112,6 +117,11 @@ func TestAccBedrockAgentCoreMemoryStrategy_standard(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "namespaces.*", "preferences"),
 					resource.TestCheckResourceAttrSet(resourceName, "memory_strategy_id"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
 			},
 			// Step 6: Try to create ANOTHER user_preference strategy → should ERROR
 			{
@@ -122,7 +132,7 @@ func TestAccBedrockAgentCoreMemoryStrategy_standard(t *testing.T) {
 			{
 				ResourceName:                         resourceName,
 				ImportState:                          true,
-				ImportStateIdFunc:                    testAccMemoryStrategyImportStateIdFunc(resourceName),
+				ImportStateIdFunc:                    testAccMemoryStrategyImportStateIDFunc(resourceName),
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "memory_strategy_id",
 				ImportStateVerifyIgnore:              []string{"memory_execution_role_arn"},
@@ -133,11 +143,7 @@ func TestAccBedrockAgentCoreMemoryStrategy_standard(t *testing.T) {
 
 func TestAccBedrockAgentCoreMemoryStrategy_custom(t *testing.T) {
 	ctx := acctest.Context(t)
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
-	var r1, r2, r5 awstypes.MemoryStrategy
+	var m awstypes.MemoryStrategy
 	rName := strings.ReplaceAll(acctest.RandomWithPrefix(t, acctest.ResourcePrefix), "-", "_")
 	resourceName := "aws_bedrockagentcore_memory_strategy.test"
 
@@ -164,7 +170,7 @@ func TestAccBedrockAgentCoreMemoryStrategy_custom(t *testing.T) {
 			{
 				Config: testAccMemoryStrategyConfig_customConsolidationOnly(rName, "SEMANTIC_OVERRIDE", "Focus on semantic relationships", "anthropic.claude-3-haiku-20240307-v1:0"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &r1),
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &m),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "CUSTOM"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
@@ -175,13 +181,17 @@ func TestAccBedrockAgentCoreMemoryStrategy_custom(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.extraction.#", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "memory_strategy_id"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			// Step 3: Add extraction block and update consolidation properties (same override type)
 			{
 				Config: testAccMemoryStrategyConfig_custom(rName, "SEMANTIC_OVERRIDE", "Updated semantic consolidation", "anthropic.claude-3-sonnet-20240229-v1:0", "Extract semantic meaning", "anthropic.claude-3-haiku-20240307-v1:0"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &r2),
-					testAccCheckMemoryStrategyNotRecreated(&r1, &r2),
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &m),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.type", "SEMANTIC_OVERRIDE"),
@@ -192,6 +202,11 @@ func TestAccBedrockAgentCoreMemoryStrategy_custom(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.extraction.0.append_to_prompt", "Extract semantic meaning"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.extraction.0.model_id", "anthropic.claude-3-haiku-20240307-v1:0"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			// Step 4: Try to remove consolidation block → should ERROR
 			{
@@ -202,8 +217,7 @@ func TestAccBedrockAgentCoreMemoryStrategy_custom(t *testing.T) {
 			{
 				Config: testAccMemoryStrategyConfig_custom(rName, "USER_PREFERENCE_OVERRIDE", "Store user preferences", "anthropic.claude-3-sonnet-20240229-v1:0", "Extract user preferences", "anthropic.claude-3-haiku-20240307-v1:0"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &r5),
-					testAccCheckMemoryStrategyRecreated(&r2, &r5),
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &m),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "CUSTOM"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
@@ -216,6 +230,11 @@ func TestAccBedrockAgentCoreMemoryStrategy_custom(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.extraction.0.model_id", "anthropic.claude-3-haiku-20240307-v1:0"),
 					resource.TestCheckResourceAttrSet(resourceName, "memory_strategy_id"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
 			},
 			//// Step 6: SUMMARY_OVERRIDE with extraction block → ValidateConfig error
 			{
@@ -226,7 +245,7 @@ func TestAccBedrockAgentCoreMemoryStrategy_custom(t *testing.T) {
 			{
 				Config: testAccMemoryStrategyConfig_customConsolidationOnly(rName, "SUMMARY_OVERRIDE", "Summary consolidation only", "anthropic.claude-3-sonnet-20240229-v1:0"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &r5),
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &m),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "CUSTOM"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
@@ -247,7 +266,7 @@ func TestAccBedrockAgentCoreMemoryStrategy_custom(t *testing.T) {
 			{
 				ResourceName:                         resourceName,
 				ImportState:                          true,
-				ImportStateIdFunc:                    testAccMemoryStrategyImportStateIdFunc(resourceName),
+				ImportStateIdFunc:                    testAccMemoryStrategyImportStateIDFunc(resourceName),
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "memory_strategy_id",
 				ImportStateVerifyIgnore:              []string{"memory_execution_role_arn"},
@@ -302,81 +321,48 @@ func testAccCheckMemoryStrategyDestroy(ctx context.Context, t *testing.T) resour
 				continue
 			}
 
-			memoryStrategyId := rs.Primary.Attributes["memory_strategy_id"]
-			_, err := tfbedrockagentcore.FindMemoryStrategyByID(ctx, conn, rs.Primary.Attributes["memory_id"], memoryStrategyId)
+			_, err := tfbedrockagentcore.FindMemoryStrategyByTwoPartKey(ctx, conn, rs.Primary.Attributes["memory_id"], rs.Primary.Attributes["memory_strategy_id"])
 			if retry.NotFound(err) {
-				return nil
-			}
-			if err != nil {
-				return create.Error(names.BedrockAgentCore, create.ErrActionCheckingDestroyed, tfbedrockagentcore.ResNameMemoryStrategy, memoryStrategyId, err)
+				continue
 			}
 
-			return create.Error(names.BedrockAgentCore, create.ErrActionCheckingDestroyed, tfbedrockagentcore.ResNameMemoryStrategy, memoryStrategyId, errors.New("not destroyed"))
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("Bedrock Agent Core Memory Strategy %s,%s still exists", rs.Primary.Attributes["memory_id"], rs.Primary.Attributes["memory_strategy_id"])
 		}
 
 		return nil
 	}
 }
 
-func testAccCheckMemoryStrategyExists(ctx context.Context, t *testing.T, name string, memorystrategy *awstypes.MemoryStrategy) resource.TestCheckFunc {
+func testAccCheckMemoryStrategyExists(ctx context.Context, t *testing.T, n string, v *awstypes.MemoryStrategy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return create.Error(names.BedrockAgentCore, create.ErrActionCheckingExistence, tfbedrockagentcore.ResNameMemoryStrategy, name, errors.New("not found"))
-		}
-
-		memoryStrategyId := rs.Primary.Attributes["memory_strategy_id"]
-		if memoryStrategyId == "" {
-			return create.Error(names.BedrockAgentCore, create.ErrActionCheckingExistence, tfbedrockagentcore.ResNameMemoryStrategy, name, errors.New("not set"))
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		conn := acctest.ProviderMeta(ctx, t).BedrockAgentCoreClient(ctx)
 
-		resp, err := tfbedrockagentcore.FindMemoryStrategyByID(ctx, conn, rs.Primary.Attributes["memory_id"], memoryStrategyId)
+		resp, err := tfbedrockagentcore.FindMemoryStrategyByTwoPartKey(ctx, conn, rs.Primary.Attributes["memory_id"], rs.Primary.Attributes["memory_strategy_id"])
 		if err != nil {
-			return create.Error(names.BedrockAgentCore, create.ErrActionCheckingExistence, tfbedrockagentcore.ResNameMemoryStrategy, memoryStrategyId, err)
+			return err
 		}
 
-		*memorystrategy = *resp
+		*v = *resp
 
 		return nil
 	}
 }
 
-func testAccCheckMemoryStrategyNotRecreated(before, after *awstypes.MemoryStrategy) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if beforeID, afterID := aws.ToString(before.StrategyId), aws.ToString(after.StrategyId); beforeID != afterID {
-			return create.Error(names.BedrockAgentCore, create.ErrActionCheckingNotRecreated, tfbedrockagentcore.ResNameMemoryStrategy, beforeID, errors.New("recreated"))
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckMemoryStrategyRecreated(before, after *awstypes.MemoryStrategy) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if beforeID, afterID := aws.ToString(before.StrategyId), aws.ToString(after.StrategyId); beforeID == afterID {
-			return create.Error(names.BedrockAgentCore, create.ErrActionCheckingRecreated, tfbedrockagentcore.ResNameMemoryStrategy, beforeID, errors.New("not recreated"))
-		}
-
-		return nil
-	}
-}
-
-func testAccMemoryStrategyImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return "", fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		return fmt.Sprintf("%s,%s", rs.Primary.Attributes["memory_id"], rs.Primary.Attributes["memory_strategy_id"]), nil
-	}
+func testAccMemoryStrategyImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return acctest.AttrsImportStateIdFunc(resourceName, ",", "memory_id", "memory_strategy_id")
 }
 
 func testAccMemoryStrategyConfig(rName, strategyType, description, namespace string) string {
-	return acctest.ConfigCompose(memoryConfig(rName), fmt.Sprintf(`	
-
+	return acctest.ConfigCompose(testAccMemoryConfig_basic(rName), fmt.Sprintf(`	
 resource "aws_bedrockagentcore_memory_strategy" "test" {
   name        = %[1]q
   memory_id   = aws_bedrockagentcore_memory.test.id

--- a/internal/service/bedrockagentcore/memory_strategy_test.go
+++ b/internal/service/bedrockagentcore/memory_strategy_test.go
@@ -6,7 +6,6 @@ package bedrockagentcore_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/YakDriver/regexache"
@@ -23,7 +22,7 @@ import (
 func TestAccBedrockAgentCoreMemoryStrategy_standard(t *testing.T) {
 	ctx := acctest.Context(t)
 	var m awstypes.MemoryStrategy
-	rName := strings.ReplaceAll(acctest.RandomWithPrefix(t, acctest.ResourcePrefix), "-", "_")
+	rName := randomMemoryName(t)
 	resourceName := "aws_bedrockagentcore_memory_strategy.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -144,7 +143,7 @@ func TestAccBedrockAgentCoreMemoryStrategy_standard(t *testing.T) {
 func TestAccBedrockAgentCoreMemoryStrategy_custom(t *testing.T) {
 	ctx := acctest.Context(t)
 	var m awstypes.MemoryStrategy
-	rName := strings.ReplaceAll(acctest.RandomWithPrefix(t, acctest.ResourcePrefix), "-", "_")
+	rName := randomMemoryName(t)
 	resourceName := "aws_bedrockagentcore_memory_strategy.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -277,12 +276,8 @@ func TestAccBedrockAgentCoreMemoryStrategy_custom(t *testing.T) {
 
 func TestAccBedrockAgentCoreMemoryStrategy_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
-	var memorystrategy awstypes.MemoryStrategy
-	rName := strings.ReplaceAll(acctest.RandomWithPrefix(t, acctest.ResourcePrefix), "-", "_")
+	var m awstypes.MemoryStrategy
+	rName := randomMemoryName(t)
 	resourceName := "aws_bedrockagentcore_memory_strategy.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -296,13 +291,16 @@ func TestAccBedrockAgentCoreMemoryStrategy_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckMemoryStrategyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMemoryStrategyConfig(rName, "SEMANTIC", "Example Description", "default"),
+				Config: testAccMemoryStrategyConfig_basic(rName, "SEMANTIC", "Example Description", "default"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &memorystrategy),
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &m),
 					acctest.CheckFrameworkResourceDisappears(ctx, t, tfbedrockagentcore.ResourceMemoryStrategy, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
 					},
@@ -361,7 +359,7 @@ func testAccMemoryStrategyImportStateIDFunc(resourceName string) resource.Import
 	return acctest.AttrsImportStateIdFunc(resourceName, ",", "memory_id", "memory_strategy_id")
 }
 
-func testAccMemoryStrategyConfig(rName, strategyType, description, namespace string) string {
+func testAccMemoryStrategyConfig_basic(rName, strategyType, description, namespace string) string {
 	return acctest.ConfigCompose(testAccMemoryConfig_basic(rName), fmt.Sprintf(`	
 resource "aws_bedrockagentcore_memory_strategy" "test" {
   name        = %[1]q
@@ -375,7 +373,6 @@ resource "aws_bedrockagentcore_memory_strategy" "test" {
 
 func testAccMemoryStrategyConfig_withExecutionRole(rName, strategyType, description, namespace string) string {
 	return acctest.ConfigCompose(testAccMemoryConfig_memoryExecutionRole(rName), fmt.Sprintf(`
-
 resource "aws_bedrockagentcore_memory_strategy" "test" {
   name                      = %[1]q
   memory_id                 = aws_bedrockagentcore_memory.test.id
@@ -394,18 +391,16 @@ func testAccMemoryStrategyConfig_duplicateType(rName string, strategyType string
 		namespace = "/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"
 		duplicateNamespace = "/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"
 	}
-	return fmt.Sprintf(`
-%s
-
+	return acctest.ConfigCompose(testAccMemoryStrategyConfig_withExecutionRole(rName, strategyType, "Strategy for duplicate test", namespace), fmt.Sprintf(`	
 resource "aws_bedrockagentcore_memory_strategy" "test2" {
-  name                      = "%s_duplicate"
+  name                      = "%[1]s_duplicate"
   memory_id                 = aws_bedrockagentcore_memory.test.id
   memory_execution_role_arn = aws_bedrockagentcore_memory.test.memory_execution_role_arn
-  type                      = %q
+  type                      = %[2]q
   description               = "Duplicate strategy"
-  namespaces                = [%q]
+  namespaces                = [%[3]q]
 }
-`, testAccMemoryStrategyConfig_withExecutionRole(rName, strategyType, "Strategy for duplicate test", namespace), rName, strategyType, duplicateNamespace)
+`, rName, strategyType, duplicateNamespace))
 }
 
 func testAccMemoryStrategyConfig_custom(rName, overrideType, consolidationPrompt, consolidationModel, extractionPrompt, extractionModel string) string {
@@ -456,8 +451,6 @@ resource "aws_bedrockagentcore_memory_strategy" "test" {
 
 func testAccMemoryStrategyConfig_customExtractionOnly(rName, overrideType, extractionPrompt, extractionModel string) string {
 	return acctest.ConfigCompose(testAccMemoryConfig_memoryExecutionRole(rName), fmt.Sprintf(`
-
-
 resource "aws_bedrockagentcore_memory_strategy" "test" {
   name                      = %[1]q
   memory_id                 = aws_bedrockagentcore_memory.test.id

--- a/internal/service/bedrockagentcore/memory_strategy_test.go
+++ b/internal/service/bedrockagentcore/memory_strategy_test.go
@@ -33,7 +33,7 @@ func TestAccBedrockAgentCoreMemoryStrategy_standard(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	var memoryStrategy1, memoryStrategy2, memoryStrategy3, memoryStrategy4 awstypes.MemoryStrategy
+	var memoryStrategy1, memoryStrategy2, memoryStrategy3, memoryStrategy4, memoryStrategy5 awstypes.MemoryStrategy
 	rName := strings.ReplaceAll(acctest.RandomWithPrefix(t, acctest.ResourcePrefix), "-", "_")
 	resourceName := "aws_bedrockagentcore_memory_strategy.test"
 
@@ -47,15 +47,39 @@ func TestAccBedrockAgentCoreMemoryStrategy_standard(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckMemoryStrategyDestroy(ctx, t),
 		Steps: []resource.TestStep{
-			// Setup: Create memory
+			// Setup: Create memory with execution role (needed for EPISODIC steps)
 			{
-				Config: memoryConfig(rName),
+				Config: testAccMemoryConfig_memoryExecutionRole(rName),
 			},
-			// Step 1: Create semantic strategy
+			// Step 1: Create episodic strategy
 			{
-				Config: testAccMemoryStrategyConfig(rName, "SEMANTIC", names.AttrDescription, "default"),
+				Config: testAccMemoryStrategyConfig_withExecutionRole(rName, "EPISODIC", "Episodic strategy", "/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &memoryStrategy1),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "EPISODIC"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Episodic strategy"),
+					resource.TestCheckResourceAttr(resourceName, "namespaces.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "memory_strategy_id"),
+				),
+			},
+			// Step 2: Update episodic description (in-place)
+			{
+				Config: testAccMemoryStrategyConfig_withExecutionRole(rName, "EPISODIC", "Updated episodic strategy", "/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &memoryStrategy2),
+					testAccCheckMemoryStrategyNotRecreated(&memoryStrategy1, &memoryStrategy2),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "EPISODIC"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Updated episodic strategy"),
+					resource.TestCheckResourceAttr(resourceName, "namespaces.#", "1"),
+				),
+			},
+			// Step 3: Change type episodic→semantic (replacement)
+			{
+				Config: testAccMemoryStrategyConfig_withExecutionRole(rName, "SEMANTIC", names.AttrDescription, "default"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &memoryStrategy3),
+					testAccCheckMemoryStrategyRecreated(&memoryStrategy2, &memoryStrategy3),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "SEMANTIC"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, names.AttrDescription),
@@ -64,37 +88,23 @@ func TestAccBedrockAgentCoreMemoryStrategy_standard(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "memory_strategy_id"),
 				),
 			},
-			// Step 2: Update description + namespace (in-place)
+			// Step 4: Update description + namespace (in-place)
 			{
-				Config: testAccMemoryStrategyConfig(rName, "SEMANTIC", "Updated description", "custom"),
+				Config: testAccMemoryStrategyConfig_withExecutionRole(rName, "SEMANTIC", "Updated description", "custom"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &memoryStrategy2),
-					testAccCheckMemoryStrategyNotRecreated(&memoryStrategy1, &memoryStrategy2),
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &memoryStrategy4),
+					testAccCheckMemoryStrategyNotRecreated(&memoryStrategy3, &memoryStrategy4),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Updated description"),
 					resource.TestCheckResourceAttr(resourceName, "namespaces.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "namespaces.*", "custom"),
 				),
 			},
-			// Step 3: Change type semantic→summary (replacement)
+			// Step 5: Change type semantic→user_preference (replacement)
 			{
-				Config: testAccMemoryStrategyConfig(rName, "SUMMARIZATION", "Summary strategy", "{sessionId}"),
+				Config: testAccMemoryStrategyConfig_withExecutionRole(rName, "USER_PREFERENCE", "User preference strategy", "preferences"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &memoryStrategy3),
-					testAccCheckMemoryStrategyRecreated(&memoryStrategy2, &memoryStrategy3),
-					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttr(resourceName, names.AttrType, "SUMMARIZATION"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Summary strategy"),
-					resource.TestCheckResourceAttr(resourceName, "namespaces.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "namespaces.*", "{sessionId}"),
-					resource.TestCheckResourceAttrSet(resourceName, "memory_strategy_id"),
-				),
-			},
-			// Step 4: Change type summary→user_preference (replacement)
-			{
-				Config: testAccMemoryStrategyConfig(rName, "USER_PREFERENCE", "User preference strategy", "preferences"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &memoryStrategy4),
-					testAccCheckMemoryStrategyRecreated(&memoryStrategy3, &memoryStrategy4),
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &memoryStrategy5),
+					testAccCheckMemoryStrategyRecreated(&memoryStrategy4, &memoryStrategy5),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "USER_PREFERENCE"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "User preference strategy"),
@@ -103,18 +113,19 @@ func TestAccBedrockAgentCoreMemoryStrategy_standard(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "memory_strategy_id"),
 				),
 			},
-			// Step 5: Try to create ANOTHER user_preference strategy → should ERROR
+			// Step 6: Try to create ANOTHER user_preference strategy → should ERROR
 			{
-				Config:      testAccMemoryStrategyConfig_duplicateType(rName),
+				Config:      testAccMemoryStrategyConfig_duplicateType(rName, "USER_PREFERENCE"),
 				ExpectError: regexache.MustCompile("Found multiple strategies of type"),
 			},
-			// Step 6: Import test - verify composite ID import works
+			// Step 7: Import test - verify composite ID import works
 			{
 				ResourceName:                         resourceName,
 				ImportState:                          true,
 				ImportStateIdFunc:                    testAccMemoryStrategyImportStateIdFunc(resourceName),
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "memory_strategy_id",
+				ImportStateVerifyIgnore:              []string{"memory_execution_role_arn"},
 			},
 		},
 	})
@@ -376,18 +387,39 @@ resource "aws_bedrockagentcore_memory_strategy" "test" {
 `, rName, strategyType, description, namespace))
 }
 
-func testAccMemoryStrategyConfig_duplicateType(rName string) string {
+func testAccMemoryStrategyConfig_withExecutionRole(rName, strategyType, description, namespace string) string {
+	return acctest.ConfigCompose(testAccMemoryConfig_memoryExecutionRole(rName), fmt.Sprintf(`
+
+resource "aws_bedrockagentcore_memory_strategy" "test" {
+  name                      = %[1]q
+  memory_id                 = aws_bedrockagentcore_memory.test.id
+  memory_execution_role_arn = aws_bedrockagentcore_memory.test.memory_execution_role_arn
+  type                      = %[2]q
+  description               = %[3]q
+  namespaces                = [%[4]q]
+}
+`, rName, strategyType, description, namespace))
+}
+
+func testAccMemoryStrategyConfig_duplicateType(rName string, strategyType string) string {
+	namespace := "default"
+	duplicateNamespace := "duplicate"
+	if strategyType == "EPISODIC" {
+		namespace = "/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"
+		duplicateNamespace = "/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"
+	}
 	return fmt.Sprintf(`
 %s
 
 resource "aws_bedrockagentcore_memory_strategy" "test2" {
-  name        = "%s_duplicate"
-  memory_id   = aws_bedrockagentcore_memory.test.id
-  type        = "USER_PREFERENCE"
-  description = "Duplicate user preference strategy"
-  namespaces  = ["preferences2"]
+  name                      = "%s_duplicate"
+  memory_id                 = aws_bedrockagentcore_memory.test.id
+  memory_execution_role_arn = aws_bedrockagentcore_memory.test.memory_execution_role_arn
+  type                      = %q
+  description               = "Duplicate strategy"
+  namespaces                = [%q]
 }
-`, testAccMemoryStrategyConfig(rName, "USER_PREFERENCE", "User preference strategy", "preferences"), rName)
+`, testAccMemoryStrategyConfig_withExecutionRole(rName, strategyType, "Strategy for duplicate test", namespace), rName, strategyType, duplicateNamespace)
 }
 
 func testAccMemoryStrategyConfig_custom(rName, overrideType, consolidationPrompt, consolidationModel, extractionPrompt, extractionModel string) string {

--- a/internal/service/bedrockagentcore/memory_test.go
+++ b/internal/service/bedrockagentcore/memory_test.go
@@ -28,7 +28,7 @@ import (
 func TestAccBedrockAgentCoreMemory_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var m awstypes.Memory
-	rName := strings.ReplaceAll(acctest.RandomWithPrefix(t, acctest.ResourcePrefix), "-", "_")
+	rName := randomMemoryName(t)
 	resourceName := "aws_bedrockagentcore_memory.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -69,7 +69,7 @@ func TestAccBedrockAgentCoreMemory_basic(t *testing.T) {
 func TestAccBedrockAgentCoreMemory_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var m awstypes.Memory
-	rName := strings.ReplaceAll(acctest.RandomWithPrefix(t, acctest.ResourcePrefix), "-", "_")
+	rName := randomMemoryName(t)
 	resourceName := "aws_bedrockagentcore_memory.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -105,7 +105,7 @@ func TestAccBedrockAgentCoreMemory_disappears(t *testing.T) {
 func TestAccBedrockAgentCoreMemory_description(t *testing.T) {
 	ctx := acctest.Context(t)
 	var m awstypes.Memory
-	rName := strings.ReplaceAll(acctest.RandomWithPrefix(t, acctest.ResourcePrefix), "-", "_")
+	rName := randomMemoryName(t)
 	resourceName := "aws_bedrockagentcore_memory.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -158,7 +158,7 @@ func TestAccBedrockAgentCoreMemory_description(t *testing.T) {
 func TestAccBedrockAgentCoreMemory_memoryExecutionRole(t *testing.T) {
 	ctx := acctest.Context(t)
 	var m awstypes.Memory
-	rName := strings.ReplaceAll(acctest.RandomWithPrefix(t, acctest.ResourcePrefix), "-", "_")
+	rName := randomMemoryName(t)
 	resourceName := "aws_bedrockagentcore_memory.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/website/docs/r/bedrockagentcore_memory_strategy.html.markdown
+++ b/website/docs/r/bedrockagentcore_memory_strategy.html.markdown
@@ -13,7 +13,7 @@ Manages an AWS Bedrock AgentCore Memory Strategy. Memory strategies define how t
 **Important Limitations:**
 
 - Each memory can have a maximum of 6 strategies total
-- Only one strategy of each built-in type (`SEMANTIC`, `SUMMARIZATION`, `USER_PREFERENCE`) can exist per memory
+- Only one strategy of each built-in type (`SEMANTIC`, `SUMMARIZATION`, `USER_PREFERENCE`, `EPISODIC`) can exist per memory
 - Multiple `CUSTOM` strategies are allowed (subject to the total limit of 6)
 
 ## Example Usage
@@ -51,6 +51,18 @@ resource "aws_bedrockagentcore_memory_strategy" "user_pref" {
   type        = "USER_PREFERENCE"
   description = "User preference tracking strategy"
   namespaces  = ["preferences"]
+}
+```
+
+### Episodic Strategy
+
+```terraform
+resource "aws_bedrockagentcore_memory_strategy" "episodic" {
+  name        = "episodic-strategy"
+  memory_id   = aws_bedrockagentcore_memory.example.id
+  type        = "EPISODIC"
+  description = "Episodic memory strategy"
+  namespaces  = ["/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"]
 }
 ```
 
@@ -128,13 +140,40 @@ resource "aws_bedrockagentcore_memory_strategy" "custom_user_pref" {
 }
 ```
 
+### Custom Strategy with Episodic Override
+
+```terraform
+resource "aws_bedrockagentcore_memory_strategy" "custom_episodic" {
+  name                      = "custom-episodic-strategy"
+  memory_id                 = aws_bedrockagentcore_memory.example.id
+  memory_execution_role_arn = aws_bedrockagentcore_memory.example.memory_execution_role_arn
+  type                      = "CUSTOM"
+  description               = "Custom episodic processing strategy"
+  namespaces                = ["/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"]
+
+  configuration {
+    type = "EPISODIC_OVERRIDE"
+
+    consolidation {
+      append_to_prompt = "Consolidate episodic memories into coherent narratives"
+      model_id         = "anthropic.claude-3-sonnet-20240229-v1:0"
+    }
+
+    extraction {
+      append_to_prompt = "Extract key events and episodes from interactions"
+      model_id         = "anthropic.claude-3-haiku-20240307-v1:0"
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
 
 * `name` - (Required) Name of the memory strategy.
 * `memory_id` - (Required) ID of the memory to associate with this strategy. Changing this forces a new resource.
-* `type` - (Required) Type of memory strategy. Valid values: `SEMANTIC`, `SUMMARIZATION`, `USER_PREFERENCE`, `CUSTOM`. Changing this forces a new resource. Note that only one strategy of each built-in type (`SEMANTIC`, `SUMMARIZATION`, `USER_PREFERENCE`) can exist per memory.
+* `type` - (Required) Type of memory strategy. Valid values: `SEMANTIC`, `SUMMARIZATION`, `USER_PREFERENCE`, `EPISODIC`, `CUSTOM`. Changing this forces a new resource. Note that only one strategy of each built-in type (`SEMANTIC`, `SUMMARIZATION`, `USER_PREFERENCE`, `EPISODIC`) can exist per memory.
 * `namespaces` - (Required) Set of namespace identifiers where this strategy applies. Namespaces help organize and scope memory content.
 
 The following arguments are optional:
@@ -147,7 +186,7 @@ The following arguments are optional:
 
 The `configuration` block supports the following:
 
-* `type` - (Required) Type of custom override. Valid values: `SEMANTIC_OVERRIDE`, `SUMMARY_OVERRIDE`, `USER_PREFERENCE_OVERRIDE`. Changing this forces a new resource.
+* `type` - (Required) Type of custom override. Valid values: `SEMANTIC_OVERRIDE`, `SUMMARY_OVERRIDE`, `USER_PREFERENCE_OVERRIDE`, `EPISODIC_OVERRIDE`. Changing this forces a new resource.
 * `consolidation` - (Optional) Consolidation configuration for processing and organizing memory content. See [`consolidation`](#consolidation) below. Once added, this block cannot be removed without recreating the resource.
 * `extraction` - (Optional) Extraction configuration for identifying and extracting relevant information. See [`extraction`](#extraction) below. Cannot be used with `type` set to `SUMMARY_OVERRIDE`. Once added, this block cannot be removed without recreating the resource.
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Enabled EPISODIC memory type in aws_bedrockagentcore_memory_strategy resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #45599

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/cli/latest/reference/bedrock-agentcore-control/create-memory.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make testacc TESTARGS='-run=TestAccBedrockAgentCoreMemoryStrategy_standard' PKG=bedrockagentcore
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/bedrockagentcore/... -v -count 1 -parallel 20  -run=TestAccBedrockAgentCoreMemoryStrategy_standard -timeout 360m -vet=off
2026/04/22 22:52:30 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/22 22:52:30 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockAgentCoreMemoryStrategy_standard
=== PAUSE TestAccBedrockAgentCoreMemoryStrategy_standard
=== CONT  TestAccBedrockAgentCoreMemoryStrategy_standard
--- PASS: TestAccBedrockAgentCoreMemoryStrategy_standard (302.61s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore	308.575s
```
