### PR TITLE
resource/aws_bedrockagentcore_agent_runtime: Add AGUI protocol documentation and test coverage

### DIFF
--- a/.changelog/47611.txt
+++ b/.changelog/47611.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_agent_runtime: Add `AGUI` protocol documentation and test coverage for `protocol_configuration.server_protocol`
+```

--- a/internal/service/bedrockagentcore/agent_runtime_test.go
+++ b/internal/service/bedrockagentcore/agent_runtime_test.go
@@ -680,6 +680,24 @@ func TestAccBedrockAgentCoreAgentRuntime_protocolConfiguration(t *testing.T) {
 					})),
 				},
 			},
+			{
+				Config: testAccAgentRuntimeConfig_protocolConfiguration(rName, rImageUri, "AGUI"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAgentRuntimeExists(ctx, t, resourceName, &agentRuntime),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("protocol_configuration"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"server_protocol": tfknownvalue.StringExact(awstypes.ServerProtocolAgui),
+						}),
+					})),
+				},
+			},
 		},
 	})
 }

--- a/website/docs/r/bedrockagentcore_agent_runtime.html.markdown
+++ b/website/docs/r/bedrockagentcore_agent_runtime.html.markdown
@@ -107,6 +107,30 @@ resource "aws_bedrockagentcore_agent_runtime" "example" {
 }
 ```
 
+### AG-UI Protocol
+
+```terraform
+resource "aws_bedrockagentcore_agent_runtime" "example" {
+  agent_runtime_name = "example_agui_runtime"
+  description        = "Agent runtime with AG-UI streaming protocol"
+  role_arn           = aws_iam_role.example.arn
+
+  agent_runtime_artifact {
+    container_configuration {
+      container_uri = "${aws_ecr_repository.example.repository_url}:v1.0"
+    }
+  }
+
+  network_configuration {
+    network_mode = "PUBLIC"
+  }
+
+  protocol_configuration {
+    server_protocol = "AGUI"
+  }
+}
+```
+
 ### Agent runtime artifact from S3 with Code Configuration
 
 ```terraform
@@ -251,7 +275,7 @@ The `network_mode_config` block supports the following:
 
 The `protocol_configuration` block supports the following:
 
-* `server_protocol` - (Optional) Server protocol for the agent runtime. Valid values: `HTTP`, `MCP`, `A2A`.
+* `server_protocol` - (Optional) Server protocol for the agent runtime. Valid values: `HTTP`, `MCP`, `A2A`, `AGUI`.
 
 ### `request_header_configuration`
 


### PR DESCRIPTION
### Description

Adds documentation, acceptance test coverage, and a changelog entry for `AGUI` (Agent-User Interface) as a valid value for `protocol_configuration.server_protocol` on the `aws_bedrockagentcore_agent_runtime` resource.

AWS [announced AG-UI protocol support for Bedrock AgentCore Runtime](https://aws.amazon.com/about-aws/whats-new/2026/03/amazon-bedrock-agentcore-runtime-ag-ui-protocol/) in March 2026. The underlying SDK (`bedrockagentcorecontrol v1.30.0+`) includes [`ServerProtocolAgui`](https://github.com/aws/aws-sdk-go-v2/blob/main/service/bedrockagentcorecontrol/types/enums.go#L1327) in the `ServerProtocol` enum, and the provider schema uses `fwtypes.StringEnumType[awstypes.ServerProtocol]()` ([agent_runtime.go L268](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/bedrockagentcore/agent_runtime.go#L268)) which auto-derives valid values from the SDK's `Values()` function — so no Go code changes are needed.

### Changes

- Added AG-UI protocol example to documentation
- Updated `server_protocol` valid values list in docs to include `AGUI`
- Extended `protocolConfiguration` acceptance test with an AGUI step (HTTP → MCP → AGUI)
- Added changelog entry

### References

- [AWS Announcement: Amazon Bedrock AgentCore Runtime AG-UI Protocol](https://aws.amazon.com/about-aws/whats-new/2026/03/amazon-bedrock-agentcore-runtime-ag-ui-protocol/)
- [AG-UI Protocol Spec](https://github.com/ag-ui-protocol/ag-ui)
- [SDK enum source: `ServerProtocolAgui`](https://github.com/aws/aws-sdk-go-v2/blob/main/service/bedrockagentcorecontrol/types/enums.go#L1327)
