### PR TITLE
[Enhancement] aws_cognito_user_pool: Add `web_authn_configuration.factor_configuration` argument

### DIFF
--- a/.changelog/47619.txt
+++ b/.changelog/47619.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cognito_user_pool: Add `web_authn_configuration.factor_configuration` argument
+```

--- a/internal/service/cognitoidp/user_pool.go
+++ b/internal/service/cognitoidp/user_pool.go
@@ -726,6 +726,12 @@ func resourceUserPool() *schema.Resource {
 							Optional:         true,
 							ValidateDiagFunc: enum.Validate[awstypes.UserVerificationType](),
 						},
+						"factor_configuration": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							ValidateDiagFunc: enum.Validate[awstypes.WebAuthnFactorConfigurationType](),
+						},
 					},
 				},
 			},
@@ -1433,6 +1439,10 @@ func expandWebAuthnConfigurationConfigType(tfList []any) *awstypes.WebAuthnConfi
 		apiObject.UserVerification = awstypes.UserVerificationType(v)
 	}
 
+	if v, ok := tfMap["factor_configuration"].(string); ok && v != "" {
+		apiObject.FactorConfiguration = awstypes.WebAuthnFactorConfigurationType(v)
+	}
+
 	return apiObject
 }
 
@@ -1499,6 +1509,10 @@ func flattenWebAuthnConfigType(apiObject *awstypes.WebAuthnConfigurationType) []
 
 	if v := apiObject.RelyingPartyId; v != nil {
 		tfMap["relying_party_id"] = aws.ToString(v)
+	}
+
+	if v := apiObject.FactorConfiguration; v != "" {
+		tfMap["factor_configuration"] = v
 	}
 
 	return []any{tfMap}

--- a/internal/service/cognitoidp/user_pool_test.go
+++ b/internal/service/cognitoidp/user_pool_test.go
@@ -1858,7 +1858,6 @@ func TestAccCognitoIDPUserPool_webAuthnConfiguration(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cognito_user_pool.test"
 	relyingPartyID := "123456789"
-	userVerification := awstypes.UserVerificationTypePreferred
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
@@ -1867,12 +1866,28 @@ func TestAccCognitoIDPUserPool_webAuthnConfiguration(t *testing.T) {
 		CheckDestroy:             testAccCheckUserPoolDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserPoolConfig_webAuthnConfiguration(rName, relyingPartyID, userVerification),
+				Config: testAccUserPoolConfig_webAuthnConfiguration(rName, relyingPartyID, awstypes.UserVerificationTypePreferred),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckUserPoolExists(ctx, t, resourceName, &pool),
 					resource.TestCheckResourceAttr(resourceName, "web_authn_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "web_authn_configuration.0.relying_party_id", relyingPartyID),
-					resource.TestCheckResourceAttr(resourceName, "web_authn_configuration.0.user_verification", string(userVerification)),
+					resource.TestCheckResourceAttr(resourceName, "web_authn_configuration.0.user_verification", string(awstypes.UserVerificationTypePreferred)),
+					resource.TestCheckResourceAttr(resourceName, "web_authn_configuration.0.factor_configuration", string(awstypes.WebAuthnFactorConfigurationTypeSingleFactor)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccUserPoolConfig_webAuthnConfiguration(rName, relyingPartyID, awstypes.UserVerificationTypeRequired),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolExists(ctx, t, resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "web_authn_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "web_authn_configuration.0.relying_party_id", relyingPartyID),
+					resource.TestCheckResourceAttr(resourceName, "web_authn_configuration.0.user_verification", string(awstypes.UserVerificationTypeRequired)),
+					resource.TestCheckResourceAttr(resourceName, "web_authn_configuration.0.factor_configuration", string(awstypes.WebAuthnFactorConfigurationTypeSingleFactor)),
 				),
 			},
 		},

--- a/internal/service/cognitoidp/user_pool_test.go
+++ b/internal/service/cognitoidp/user_pool_test.go
@@ -1879,6 +1879,49 @@ func TestAccCognitoIDPUserPool_webAuthnConfiguration(t *testing.T) {
 	})
 }
 
+func TestAccCognitoIDPUserPool_webAuthnConfigurationWithFactorConfiguration(t *testing.T) {
+	ctx := acctest.Context(t)
+	var pool awstypes.UserPoolType
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool.test"
+	relyingPartyID := "123456789"
+	userVerification := awstypes.UserVerificationTypePreferred
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolConfig_webAuthnConfigurationWithFactorConfiguration(rName, relyingPartyID, userVerification, awstypes.WebAuthnFactorConfigurationTypeMultiFactorWithUserVerification),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolExists(ctx, t, resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "web_authn_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "web_authn_configuration.0.relying_party_id", relyingPartyID),
+					resource.TestCheckResourceAttr(resourceName, "web_authn_configuration.0.user_verification", string(userVerification)),
+					resource.TestCheckResourceAttr(resourceName, "web_authn_configuration.0.factor_configuration", string(awstypes.WebAuthnFactorConfigurationTypeMultiFactorWithUserVerification)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccUserPoolConfig_webAuthnConfigurationWithFactorConfiguration(rName, relyingPartyID, userVerification, awstypes.WebAuthnFactorConfigurationTypeSingleFactor),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolExists(ctx, t, resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "web_authn_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "web_authn_configuration.0.relying_party_id", relyingPartyID),
+					resource.TestCheckResourceAttr(resourceName, "web_authn_configuration.0.user_verification", string(userVerification)),
+					resource.TestCheckResourceAttr(resourceName, "web_authn_configuration.0.factor_configuration", string(awstypes.WebAuthnFactorConfigurationTypeSingleFactor)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCognitoIDPUserPool_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	var pool awstypes.UserPoolType
@@ -3221,6 +3264,20 @@ resource "aws_cognito_user_pool" "test" {
   }
 }
 `, rName, relyingPartyID, userVerification)
+}
+
+func testAccUserPoolConfig_webAuthnConfigurationWithFactorConfiguration(rName, relyingPartyID string, userVerification awstypes.UserVerificationType, factorConfiguration awstypes.WebAuthnFactorConfigurationType) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+
+  web_authn_configuration {
+    relying_party_id     = %[2]q
+    user_verification    = %[3]q
+    factor_configuration = %[4]q
+  }
+}
+`, rName, relyingPartyID, userVerification, factorConfiguration)
 }
 
 func testAccUserPoolConfig_update(name string, mfaconfig, smsAuthMsg string) string {

--- a/website/docs/r/cognito_user_pool.html.markdown
+++ b/website/docs/r/cognito_user_pool.html.markdown
@@ -182,6 +182,7 @@ This resource supports the following arguments:
 
 * `relying_party_id` - (Optional) The authentication domain that passkeys providers use as a relying party.
 * `user_verification` - (Optional) If your user pool should require a passkey. Must be one of `required` or `preferred`.
+* `factor_configuration` - (Optional) Whether passkeys can be used as multi-factor authentication (MFA). Valid values are `SINGLE_FACTOR` and `MULTI_FACTOR_WITH_USER_VERIFICATION`. Default values is `SINGLE_FACTOR`.
 
 ### schema
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR adds the `web_authn_configuration.factor_configuration` argument to the `aws_cognito_user_pool` resource.

* This argument is marked as `Computed` because the AWS API returns a default value even when it is not explicitly specified.

#### Acceptance Tests

In addition to adding a new acceptance test for this argument, the existing `TestAccCognitoIDPUserPool_webAuthnConfiguration` test has been updated to include verification of updates to `web_authn_configuration.user_verification_type`.

* Rather than reviewing the full diff, it may be clearer to look at each commit individually:

  * a95621f54b458cf8a634c7226f983f4bb798b193
  * 37f06581d4d6d15b0b9ee4b85c853a4ebd3a978e

### Relations

Closes #47598

### References
https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_WebAuthnConfigurationType.html#CognitoUserPools-Type-WebAuthnConfigurationType-FactorConfiguration


### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccCognitoIDPUserPool_' PKG=cognitoidp
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_cognito_user_pool-add_factor_configuration 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPUserPool_'  -timeout 360m -vet=off
2026/04/24 18:50:13 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/24 18:50:13 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCognitoIDPUserPool_tags
=== PAUSE TestAccCognitoIDPUserPool_tags
=== RUN   TestAccCognitoIDPUserPool_Tags_null
=== PAUSE TestAccCognitoIDPUserPool_Tags_null
=== RUN   TestAccCognitoIDPUserPool_Tags_emptyMap
=== PAUSE TestAccCognitoIDPUserPool_Tags_emptyMap
=== RUN   TestAccCognitoIDPUserPool_Tags_addOnUpdate
=== PAUSE TestAccCognitoIDPUserPool_Tags_addOnUpdate
=== RUN   TestAccCognitoIDPUserPool_Tags_EmptyTag_onCreate
=== PAUSE TestAccCognitoIDPUserPool_Tags_EmptyTag_onCreate
=== RUN   TestAccCognitoIDPUserPool_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccCognitoIDPUserPool_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccCognitoIDPUserPool_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccCognitoIDPUserPool_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccCognitoIDPUserPool_Tags_DefaultTags_providerOnly
=== PAUSE TestAccCognitoIDPUserPool_Tags_DefaultTags_providerOnly
=== RUN   TestAccCognitoIDPUserPool_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccCognitoIDPUserPool_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccCognitoIDPUserPool_Tags_DefaultTags_overlapping
=== PAUSE TestAccCognitoIDPUserPool_Tags_DefaultTags_overlapping
=== RUN   TestAccCognitoIDPUserPool_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccCognitoIDPUserPool_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccCognitoIDPUserPool_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccCognitoIDPUserPool_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccCognitoIDPUserPool_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccCognitoIDPUserPool_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccCognitoIDPUserPool_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccCognitoIDPUserPool_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccCognitoIDPUserPool_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccCognitoIDPUserPool_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccCognitoIDPUserPool_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccCognitoIDPUserPool_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccCognitoIDPUserPool_Tags_ComputedTag_onCreate
=== PAUSE TestAccCognitoIDPUserPool_Tags_ComputedTag_onCreate
=== RUN   TestAccCognitoIDPUserPool_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccCognitoIDPUserPool_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccCognitoIDPUserPool_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccCognitoIDPUserPool_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccCognitoIDPUserPool_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccCognitoIDPUserPool_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccCognitoIDPUserPool_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccCognitoIDPUserPool_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccCognitoIDPUserPool_basic
=== PAUSE TestAccCognitoIDPUserPool_basic
=== RUN   TestAccCognitoIDPUserPool_deletionProtection
=== PAUSE TestAccCognitoIDPUserPool_deletionProtection
=== RUN   TestAccCognitoIDPUserPool_recovery
=== PAUSE TestAccCognitoIDPUserPool_recovery
=== RUN   TestAccCognitoIDPUserPool_withAdminCreateUser
=== PAUSE TestAccCognitoIDPUserPool_withAdminCreateUser
=== RUN   TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy
=== PAUSE TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy
=== RUN   TestAccCognitoIDPUserPool_withAdvancedSecurityMode
=== PAUSE TestAccCognitoIDPUserPool_withAdvancedSecurityMode
=== RUN   TestAccCognitoIDPUserPool_withAdvancedSecurityAdditionalFlows
=== PAUSE TestAccCognitoIDPUserPool_withAdvancedSecurityAdditionalFlows
=== RUN   TestAccCognitoIDPUserPool_withDevice
=== PAUSE TestAccCognitoIDPUserPool_withDevice
=== RUN   TestAccCognitoIDPUserPool_withEmailVerificationMessage
=== PAUSE TestAccCognitoIDPUserPool_withEmailVerificationMessage
=== RUN   TestAccCognitoIDPUserPool_passwordHistorySize
=== PAUSE TestAccCognitoIDPUserPool_passwordHistorySize
=== RUN   TestAccCognitoIDPUserPool_MFA_sms
=== PAUSE TestAccCognitoIDPUserPool_MFA_sms
=== RUN   TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA
=== PAUSE TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA
=== RUN   TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA
=== PAUSE TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA
=== RUN   TestAccCognitoIDPUserPool_MFA_softwareTokenMFA
=== PAUSE TestAccCognitoIDPUserPool_MFA_softwareTokenMFA
=== RUN   TestAccCognitoIDPUserPool_MFA_emailConfigurationMFA
    user_pool_test.go:669: skipping test; environment variable TEST_AWS_SES_VERIFIED_EMAIL_ARN must be set
--- SKIP: TestAccCognitoIDPUserPool_MFA_emailConfigurationMFA (0.00s)
=== RUN   TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS
=== PAUSE TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS
=== RUN   TestAccCognitoIDPUserPool_signInPolicy
=== PAUSE TestAccCognitoIDPUserPool_signInPolicy
=== RUN   TestAccCognitoIDPUserPool_smsAuthenticationMessage
=== PAUSE TestAccCognitoIDPUserPool_smsAuthenticationMessage
=== RUN   TestAccCognitoIDPUserPool_sms
=== PAUSE TestAccCognitoIDPUserPool_sms
=== RUN   TestAccCognitoIDPUserPool_SMS_snsRegion
=== PAUSE TestAccCognitoIDPUserPool_SMS_snsRegion
=== RUN   TestAccCognitoIDPUserPool_SMS_externalID
=== PAUSE TestAccCognitoIDPUserPool_SMS_externalID
=== RUN   TestAccCognitoIDPUserPool_SMS_snsCallerARN
=== PAUSE TestAccCognitoIDPUserPool_SMS_snsCallerARN
=== RUN   TestAccCognitoIDPUserPool_smsVerificationMessage
=== PAUSE TestAccCognitoIDPUserPool_smsVerificationMessage
=== RUN   TestAccCognitoIDPUserPool_withEmail
=== PAUSE TestAccCognitoIDPUserPool_withEmail
=== RUN   TestAccCognitoIDPUserPool_withEmailSource
    user_pool_test.go:1066: skipping test; environment variable TEST_AWS_SES_VERIFIED_EMAIL_ARN must be set
--- SKIP: TestAccCognitoIDPUserPool_withEmailSource (0.00s)
=== RUN   TestAccCognitoIDPUserPool_withAliasAttributes
=== PAUSE TestAccCognitoIDPUserPool_withAliasAttributes
=== RUN   TestAccCognitoIDPUserPool_withUsernameAttributes
=== PAUSE TestAccCognitoIDPUserPool_withUsernameAttributes
=== RUN   TestAccCognitoIDPUserPool_withPasswordPolicy
=== PAUSE TestAccCognitoIDPUserPool_withPasswordPolicy
=== RUN   TestAccCognitoIDPUserPool_usernameConfiguration
=== PAUSE TestAccCognitoIDPUserPool_usernameConfiguration
=== RUN   TestAccCognitoIDPUserPool_withLambda
=== PAUSE TestAccCognitoIDPUserPool_withLambda
=== RUN   TestAccCognitoIDPUserPool_WithLambda_email
=== PAUSE TestAccCognitoIDPUserPool_WithLambda_email
=== RUN   TestAccCognitoIDPUserPool_WithLambda_sms
=== PAUSE TestAccCognitoIDPUserPool_WithLambda_sms
=== RUN   TestAccCognitoIDPUserPool_WithLambda_preGenerationTokenConfig
=== PAUSE TestAccCognitoIDPUserPool_WithLambda_preGenerationTokenConfig
=== RUN   TestAccCognitoIDPUserPool_addLambda
=== PAUSE TestAccCognitoIDPUserPool_addLambda
=== RUN   TestAccCognitoIDPUserPool_schemaAttributes
=== PAUSE TestAccCognitoIDPUserPool_schemaAttributes
=== RUN   TestAccCognitoIDPUserPool_schemaAttributesRemoved
=== PAUSE TestAccCognitoIDPUserPool_schemaAttributesRemoved
=== RUN   TestAccCognitoIDPUserPool_schemaAttributesModified
=== PAUSE TestAccCognitoIDPUserPool_schemaAttributesModified
=== RUN   TestAccCognitoIDPUserPool_schemaAttributesStringAttributeConstraints
=== PAUSE TestAccCognitoIDPUserPool_schemaAttributesStringAttributeConstraints
=== RUN   TestAccCognitoIDPUserPool_withVerificationMessageTemplate
=== PAUSE TestAccCognitoIDPUserPool_withVerificationMessageTemplate
=== RUN   TestAccCognitoIDPUserPool_withVerificationMessageTemplateUTF8
=== PAUSE TestAccCognitoIDPUserPool_withVerificationMessageTemplateUTF8
=== RUN   TestAccCognitoIDPUserPool_webAuthnConfiguration
=== PAUSE TestAccCognitoIDPUserPool_webAuthnConfiguration
=== RUN   TestAccCognitoIDPUserPool_webAuthnConfigurationWithFactorConfiguration
=== PAUSE TestAccCognitoIDPUserPool_webAuthnConfigurationWithFactorConfiguration
=== RUN   TestAccCognitoIDPUserPool_update
=== PAUSE TestAccCognitoIDPUserPool_update
=== RUN   TestAccCognitoIDPUserPool_disappears
=== PAUSE TestAccCognitoIDPUserPool_disappears
=== RUN   TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings
=== PAUSE TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings
=== RUN   TestAccCognitoIDPUserPool_userPoolTier
=== PAUSE TestAccCognitoIDPUserPool_userPoolTier
=== RUN   TestAccCognitoIDPUserPool_nameUpdate
=== PAUSE TestAccCognitoIDPUserPool_nameUpdate
=== CONT  TestAccCognitoIDPUserPool_tags
=== CONT  TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA
=== CONT  TestAccCognitoIDPUserPool_Tags_ComputedTag_OnUpdate_add
=== CONT  TestAccCognitoIDPUserPool_Tags_DefaultTags_overlapping
=== CONT  TestAccCognitoIDPUserPool_Tags_DefaultTags_nonOverlapping
=== CONT  TestAccCognitoIDPUserPool_Tags_EmptyTag_onCreate
=== CONT  TestAccCognitoIDPUserPool_Tags_emptyMap
=== CONT  TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA
=== CONT  TestAccCognitoIDPUserPool_Tags_null
=== CONT  TestAccCognitoIDPUserPool_WithLambda_sms
=== CONT  TestAccCognitoIDPUserPool_MFA_sms
=== CONT  TestAccCognitoIDPUserPool_passwordHistorySize
=== CONT  TestAccCognitoIDPUserPool_nameUpdate
=== CONT  TestAccCognitoIDPUserPool_withEmailVerificationMessage
=== CONT  TestAccCognitoIDPUserPool_userPoolTier
=== CONT  TestAccCognitoIDPUserPool_withDevice
=== CONT  TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings
=== CONT  TestAccCognitoIDPUserPool_withAdvancedSecurityAdditionalFlows
=== CONT  TestAccCognitoIDPUserPool_withAdvancedSecurityMode
=== CONT  TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy
--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy (125.12s)
=== CONT  TestAccCognitoIDPUserPool_withAdminCreateUser
--- PASS: TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings (158.35s)
=== CONT  TestAccCognitoIDPUserPool_recovery
--- PASS: TestAccCognitoIDPUserPool_userPoolTier (168.76s)
=== CONT  TestAccCognitoIDPUserPool_deletionProtection
--- PASS: TestAccCognitoIDPUserPool_nameUpdate (171.55s)
=== CONT  TestAccCognitoIDPUserPool_basic
--- PASS: TestAccCognitoIDPUserPool_Tags_emptyMap (183.89s)
=== CONT  TestAccCognitoIDPUserPool_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccCognitoIDPUserPool_Tags_null (184.21s)
=== CONT  TestAccCognitoIDPUserPool_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccCognitoIDPUserPool_passwordHistorySize (187.28s)
=== CONT  TestAccCognitoIDPUserPool_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccCognitoIDPUserPool_withDevice (187.47s)
=== CONT  TestAccCognitoIDPUserPool_Tags_addOnUpdate
--- PASS: TestAccCognitoIDPUserPool_withAdvancedSecurityAdditionalFlows (187.72s)
=== CONT  TestAccCognitoIDPUserPool_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccCognitoIDPUserPool_withEmailVerificationMessage (187.73s)
=== CONT  TestAccCognitoIDPUserPool_Tags_DefaultTags_providerOnly
--- PASS: TestAccCognitoIDPUserPool_Tags_ComputedTag_OnUpdate_add (209.37s)
=== CONT  TestAccCognitoIDPUserPool_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA (209.38s)
=== CONT  TestAccCognitoIDPUserPool_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccCognitoIDPUserPool_Tags_EmptyTag_onCreate (231.52s)
=== CONT  TestAccCognitoIDPUserPool_Tags_ComputedTag_onCreate
--- PASS: TestAccCognitoIDPUserPool_withAdvancedSecurityMode (259.47s)
=== CONT  TestAccCognitoIDPUserPool_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccCognitoIDPUserPool_basic (111.68s)
=== CONT  TestAccCognitoIDPUserPool_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA (286.05s)
=== CONT  TestAccCognitoIDPUserPool_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccCognitoIDPUserPool_MFA_sms (299.13s)
=== CONT  TestAccCognitoIDPUserPool_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUser (181.71s)
=== CONT  TestAccCognitoIDPUserPool_withVerificationMessageTemplate
--- PASS: TestAccCognitoIDPUserPool_WithLambda_sms (322.99s)
=== CONT  TestAccCognitoIDPUserPool_disappears
--- PASS: TestAccCognitoIDPUserPool_Tags_DefaultTags_emptyProviderOnlyTag (124.64s)
=== CONT  TestAccCognitoIDPUserPool_update
--- PASS: TestAccCognitoIDPUserPool_Tags_DefaultTags_nonOverlapping (338.32s)
=== CONT  TestAccCognitoIDPUserPool_webAuthnConfigurationWithFactorConfiguration
=== CONT  TestAccCognitoIDPUserPool_webAuthnConfiguration
--- PASS: TestAccCognitoIDPUserPool_Tags_DefaultTags_overlapping (338.52s)
--- PASS: TestAccCognitoIDPUserPool_deletionProtection (185.45s)
=== CONT  TestAccCognitoIDPUserPool_withVerificationMessageTemplateUTF8
--- PASS: TestAccCognitoIDPUserPool_Tags_ComputedTag_onCreate (138.91s)
=== CONT  TestAccCognitoIDPUserPool_smsVerificationMessage
--- PASS: TestAccCognitoIDPUserPool_Tags_DefaultTags_nullNonOverlappingResourceTag (127.08s)
=== CONT  TestAccCognitoIDPUserPool_WithLambda_email
--- PASS: TestAccCognitoIDPUserPool_Tags_EmptyTag_OnUpdate_replace (211.82s)
=== CONT  TestAccCognitoIDPUserPool_withLambda
--- PASS: TestAccCognitoIDPUserPool_Tags_addOnUpdate (212.95s)
=== CONT  TestAccCognitoIDPUserPool_usernameConfiguration
--- PASS: TestAccCognitoIDPUserPool_Tags_ComputedTag_OnUpdate_replace (213.22s)
=== CONT  TestAccCognitoIDPUserPool_withPasswordPolicy
--- PASS: TestAccCognitoIDPUserPool_recovery (253.86s)
=== CONT  TestAccCognitoIDPUserPool_withUsernameAttributes
--- PASS: TestAccCognitoIDPUserPool_Tags_DefaultTags_nullOverlappingResourceTag (129.18s)
=== CONT  TestAccCognitoIDPUserPool_withAliasAttributes
--- PASS: TestAccCognitoIDPUserPool_disappears (99.56s)
=== CONT  TestAccCognitoIDPUserPool_withEmail
--- PASS: TestAccCognitoIDPUserPool_Tags_DefaultTags_emptyResourceTag (123.78s)
=== CONT  TestAccCognitoIDPUserPool_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccCognitoIDPUserPool_tags (441.99s)
=== CONT  TestAccCognitoIDPUserPool_sms
--- PASS: TestAccCognitoIDPUserPool_Tags_IgnoreTags_Overlap_defaultTag (261.95s)
=== CONT  TestAccCognitoIDPUserPool_SMS_snsCallerARN
--- PASS: TestAccCognitoIDPUserPool_withVerificationMessageTemplate (168.14s)
=== CONT  TestAccCognitoIDPUserPool_SMS_externalID
--- PASS: TestAccCognitoIDPUserPool_Tags_IgnoreTags_Overlap_resourceTag (295.48s)
=== CONT  TestAccCognitoIDPUserPool_SMS_snsRegion
--- PASS: TestAccCognitoIDPUserPool_Tags_DefaultTags_updateToResourceOnly (193.32s)
=== CONT  TestAccCognitoIDPUserPool_schemaAttributesRemoved
--- PASS: TestAccCognitoIDPUserPool_webAuthnConfiguration (163.90s)
=== CONT  TestAccCognitoIDPUserPool_schemaAttributesStringAttributeConstraints
--- PASS: TestAccCognitoIDPUserPool_webAuthnConfigurationWithFactorConfiguration (173.16s)
=== CONT  TestAccCognitoIDPUserPool_schemaAttributesModified
--- PASS: TestAccCognitoIDPUserPool_Tags_EmptyTag_OnUpdate_add (302.62s)
=== CONT  TestAccCognitoIDPUserPool_addLambda
--- PASS: TestAccCognitoIDPUserPool_withEmail (93.29s)
=== CONT  TestAccCognitoIDPUserPool_schemaAttributes
--- PASS: TestAccCognitoIDPUserPool_withVerificationMessageTemplateUTF8 (161.64s)
=== CONT  TestAccCognitoIDPUserPool_signInPolicy
--- PASS: TestAccCognitoIDPUserPool_smsVerificationMessage (158.58s)
=== CONT  TestAccCognitoIDPUserPool_smsAuthenticationMessage
--- PASS: TestAccCognitoIDPUserPool_withPasswordPolicy (145.59s)
=== CONT  TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS
--- PASS: TestAccCognitoIDPUserPool_usernameConfiguration (162.80s)
=== CONT  TestAccCognitoIDPUserPool_MFA_softwareTokenMFA
--- PASS: TestAccCognitoIDPUserPool_withUsernameAttributes (155.58s)
=== CONT  TestAccCognitoIDPUserPool_WithLambda_preGenerationTokenConfig
--- PASS: TestAccCognitoIDPUserPool_withAliasAttributes (155.40s)
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesRemoved (92.81s)
--- PASS: TestAccCognitoIDPUserPool_SMS_snsRegion (107.99s)
--- PASS: TestAccCognitoIDPUserPool_signInPolicy (73.39s)
--- PASS: TestAccCognitoIDPUserPool_Tags_DefaultTags_updateToProviderOnly (170.01s)
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesModified (82.54s)
--- PASS: TestAccCognitoIDPUserPool_update (260.14s)
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesStringAttributeConstraints (92.24s)
--- PASS: TestAccCognitoIDPUserPool_Tags_DefaultTags_providerOnly (406.99s)
--- PASS: TestAccCognitoIDPUserPool_WithLambda_email (230.30s)
--- PASS: TestAccCognitoIDPUserPool_SMS_snsCallerARN (170.84s)
--- PASS: TestAccCognitoIDPUserPool_schemaAttributes (107.65s)
--- PASS: TestAccCognitoIDPUserPool_withLambda (226.40s)
--- PASS: TestAccCognitoIDPUserPool_smsAuthenticationMessage (101.11s)
--- PASS: TestAccCognitoIDPUserPool_sms (188.32s)
--- PASS: TestAccCognitoIDPUserPool_SMS_externalID (156.38s)
--- PASS: TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS (102.85s)
--- PASS: TestAccCognitoIDPUserPool_addLambda (137.57s)
--- PASS: TestAccCognitoIDPUserPool_MFA_softwareTokenMFA (91.03s)
--- PASS: TestAccCognitoIDPUserPool_WithLambda_preGenerationTokenConfig (131.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 711.124s

```
