### PR TITLE
sesv2: add aws_sesv2_email_identity_configuration_set_attributes resource

### DIFF
--- a/.changelog/47621.txt
+++ b/.changelog/47621.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_sesv2_email_identity_configuration_set_attributes
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## 6.43.0 (Unreleased)
 
-FEATURES:
-
-* **New Resource:** `aws_sesv2_email_identity_configuration_set_attributes` ([#XXXXX](https://github.com/hashicorp/terraform-provider-aws/issues/XXXXX))
-
 ENHANCEMENTS:
 
 * resource/aws_bedrockagentcore_memory_strategy: Support `EPISODIC` as a valid value for `type` ([#47589](https://github.com/hashicorp/terraform-provider-aws/issues/47589))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 6.43.0 (Unreleased)
 
+FEATURES:
+
+* **New Resource:** `aws_sesv2_email_identity_configuration_set_attributes` ([#XXXXX](https://github.com/hashicorp/terraform-provider-aws/issues/XXXXX))
+
 ENHANCEMENTS:
 
 * resource/aws_bedrockagentcore_memory_strategy: Support `EPISODIC` as a valid value for `type` ([#47589](https://github.com/hashicorp/terraform-provider-aws/issues/47589))

--- a/internal/service/sesv2/email_identity_configuration_set_attributes.go
+++ b/internal/service/sesv2/email_identity_configuration_set_attributes.go
@@ -1,0 +1,177 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package sesv2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sesv2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_sesv2_email_identity_configuration_set_attributes", name="Email Identity Configuration Set Attributes")
+func newEmailIdentityConfigurationSetAttributesResource(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &emailIdentityConfigurationSetAttributesResource{}
+	return r, nil
+}
+
+const (
+	ResNameEmailIdentityConfigurationSetAttributes = "Email Identity Configuration Set Attributes"
+)
+
+type emailIdentityConfigurationSetAttributesResource struct {
+	framework.ResourceWithModel[emailIdentityConfigurationSetAttributesResourceModel]
+	framework.WithImportByID
+}
+
+func (r *emailIdentityConfigurationSetAttributesResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"configuration_set_name": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 64),
+				},
+			},
+			"email_identity": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			names.AttrID: framework.IDAttribute(),
+		},
+	}
+}
+
+func (r *emailIdentityConfigurationSetAttributesResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan emailIdentityConfigurationSetAttributesResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().SESV2Client(ctx)
+
+	emailIdentity := plan.EmailIdentity.ValueString()
+	input := &sesv2.PutEmailIdentityConfigurationSetAttributesInput{
+		EmailIdentity:        aws.String(emailIdentity),
+		ConfigurationSetName: plan.ConfigurationSetName.ValueStringPointer(),
+	}
+
+	_, err := conn.PutEmailIdentityConfigurationSetAttributes(ctx, input)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("creating SESv2 Email Identity Configuration Set Attributes (%s)", emailIdentity),
+			err.Error(),
+		)
+		return
+	}
+
+	plan.ID = fwflex.StringValueToFramework(ctx, emailIdentity)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *emailIdentityConfigurationSetAttributesResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state emailIdentityConfigurationSetAttributesResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().SESV2Client(ctx)
+
+	out, err := findEmailIdentityByID(ctx, conn, state.ID.ValueString())
+	if retry.NotFound(err) {
+		resp.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("reading SESv2 Email Identity Configuration Set Attributes (%s)", state.ID.ValueString()),
+			err.Error(),
+		)
+		return
+	}
+
+	state.EmailIdentity = state.ID
+	state.ConfigurationSetName = fwflex.StringToFramework(ctx, out.ConfigurationSetName)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *emailIdentityConfigurationSetAttributesResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan emailIdentityConfigurationSetAttributesResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().SESV2Client(ctx)
+
+	input := &sesv2.PutEmailIdentityConfigurationSetAttributesInput{
+		EmailIdentity:        plan.ID.ValueStringPointer(),
+		ConfigurationSetName: plan.ConfigurationSetName.ValueStringPointer(),
+	}
+
+	_, err := conn.PutEmailIdentityConfigurationSetAttributes(ctx, input)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("updating SESv2 Email Identity Configuration Set Attributes (%s)", plan.ID.ValueString()),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *emailIdentityConfigurationSetAttributesResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state emailIdentityConfigurationSetAttributesResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().SESV2Client(ctx)
+
+	_, err := conn.PutEmailIdentityConfigurationSetAttributes(ctx, &sesv2.PutEmailIdentityConfigurationSetAttributesInput{
+		EmailIdentity:        state.ID.ValueStringPointer(),
+		ConfigurationSetName: aws.String(""),
+	})
+	if errs.IsA[*awstypes.NotFoundException](err) {
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("deleting SESv2 Email Identity Configuration Set Attributes (%s)", state.ID.ValueString()),
+			err.Error(),
+		)
+		return
+	}
+}
+
+type emailIdentityConfigurationSetAttributesResourceModel struct {
+	framework.WithRegionModel
+	ConfigurationSetName types.String `tfsdk:"configuration_set_name"`
+	EmailIdentity        types.String `tfsdk:"email_identity"`
+	ID                   types.String `tfsdk:"id"`
+}

--- a/internal/service/sesv2/email_identity_configuration_set_attributes_test.go
+++ b/internal/service/sesv2/email_identity_configuration_set_attributes_test.go
@@ -1,0 +1,215 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package sesv2_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tfsesv2 "github.com/hashicorp/terraform-provider-aws/internal/service/sesv2"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSESV2EmailIdentityConfigurationSetAttributes_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	domain := acctest.RandomDomainName()
+	configSetName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sesv2_email_identity_configuration_set_attributes.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEmailIdentityConfigurationSetAttributesDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEmailIdentityConfigurationSetAttributesConfig_basic(domain, configSetName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEmailIdentityConfigurationSetAttributesExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "email_identity", "aws_sesv2_email_identity.test", "email_identity"),
+					resource.TestCheckResourceAttrPair(resourceName, "configuration_set_name", "aws_sesv2_configuration_set.test", "configuration_set_name"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSESV2EmailIdentityConfigurationSetAttributes_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	domain := acctest.RandomDomainName()
+	configSetName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sesv2_email_identity_configuration_set_attributes.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEmailIdentityConfigurationSetAttributesDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEmailIdentityConfigurationSetAttributesConfig_basic(domain, configSetName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEmailIdentityConfigurationSetAttributesExists(ctx, t, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, t, tfsesv2.ResourceEmailIdentityConfigurationSetAttributes, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccSESV2EmailIdentityConfigurationSetAttributes_disappearsEmailIdentity(t *testing.T) {
+	ctx := acctest.Context(t)
+	domain := acctest.RandomDomainName()
+	configSetName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sesv2_email_identity_configuration_set_attributes.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEmailIdentityConfigurationSetAttributesDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEmailIdentityConfigurationSetAttributesConfig_basic(domain, configSetName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEmailIdentityConfigurationSetAttributesExists(ctx, t, resourceName),
+					acctest.CheckSDKResourceDisappears(ctx, t, tfsesv2.ResourceEmailIdentity(), "aws_sesv2_email_identity.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccSESV2EmailIdentityConfigurationSetAttributes_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	domain := acctest.RandomDomainName()
+	configSetName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	configSetName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sesv2_email_identity_configuration_set_attributes.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEmailIdentityConfigurationSetAttributesDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEmailIdentityConfigurationSetAttributesConfig_basic(domain, configSetName1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEmailIdentityConfigurationSetAttributesExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "configuration_set_name", configSetName1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccEmailIdentityConfigurationSetAttributesConfig_updated(domain, configSetName1, configSetName2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEmailIdentityConfigurationSetAttributesExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "configuration_set_name", configSetName2),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckEmailIdentityConfigurationSetAttributesDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).SESV2Client(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_sesv2_email_identity_configuration_set_attributes" {
+				continue
+			}
+
+			out, err := tfsesv2.FindEmailIdentityByID(ctx, conn, rs.Primary.ID)
+			if retry.NotFound(err) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			if out.ConfigurationSetName == nil || *out.ConfigurationSetName == "" {
+				return nil
+			}
+			return fmt.Errorf("SESv2 Email Identity Configuration Set Attributes %s still configured with %s", rs.Primary.ID, *out.ConfigurationSetName)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckEmailIdentityConfigurationSetAttributesExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).SESV2Client(ctx)
+
+		out, err := tfsesv2.FindEmailIdentityByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if out.ConfigurationSetName == nil || *out.ConfigurationSetName == "" {
+			return fmt.Errorf("SESv2 Email Identity Configuration Set Attributes %s has no configuration set", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccEmailIdentityConfigurationSetAttributesConfig_basic(domain, configSetName string) string {
+	return fmt.Sprintf(`
+resource "aws_sesv2_email_identity" "test" {
+  email_identity = %[1]q
+}
+
+resource "aws_sesv2_configuration_set" "test" {
+  configuration_set_name = %[2]q
+}
+
+resource "aws_sesv2_email_identity_configuration_set_attributes" "test" {
+  email_identity         = aws_sesv2_email_identity.test.email_identity
+  configuration_set_name = aws_sesv2_configuration_set.test.configuration_set_name
+}
+`, domain, configSetName)
+}
+
+func testAccEmailIdentityConfigurationSetAttributesConfig_updated(domain, configSetName1, configSetName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_sesv2_email_identity" "test" {
+  email_identity = %[1]q
+}
+
+resource "aws_sesv2_configuration_set" "test" {
+  configuration_set_name = %[2]q
+}
+
+resource "aws_sesv2_configuration_set" "test2" {
+  configuration_set_name = %[3]q
+}
+
+resource "aws_sesv2_email_identity_configuration_set_attributes" "test" {
+  email_identity         = aws_sesv2_email_identity.test.email_identity
+  configuration_set_name = aws_sesv2_configuration_set.test2.configuration_set_name
+}
+`, domain, configSetName1, configSetName2)
+}

--- a/internal/service/sesv2/exports_test.go
+++ b/internal/service/sesv2/exports_test.go
@@ -5,18 +5,19 @@ package sesv2
 
 // Exports for use in tests only.
 var (
-	ResourceAccountVDMAttributes             = resourceAccountVDMAttributes
-	ResourceConfigurationSet                 = resourceConfigurationSet
-	ResourceConfigurationSetEventDestination = resourceConfigurationSetEventDestination
-	ResourceContactList                      = resourceContactList
-	ResourceDedicatedIPAssignment            = resourceDedicatedIPAssignment
-	ResourceDedicatedIPPool                  = resourceDedicatedIPPool
-	ResourceEmailIdentity                    = resourceEmailIdentity
-	ResourceEmailIdentityFeedbackAttributes  = resourceEmailIdentityFeedbackAttributes
-	ResourceEmailIdentityMailFromAttributes  = resourceEmailIdentityMailFromAttributes
-	ResourceEmailIdentityPolicy              = resourceEmailIdentityPolicy
-	ResourceTenant                           = newTenantResource
-	ResourceTenantResource                   = newTenantResourceAssociationResource
+	ResourceAccountVDMAttributes                        = resourceAccountVDMAttributes
+	ResourceConfigurationSet                            = resourceConfigurationSet
+	ResourceConfigurationSetEventDestination            = resourceConfigurationSetEventDestination
+	ResourceContactList                                 = resourceContactList
+	ResourceDedicatedIPAssignment                       = resourceDedicatedIPAssignment
+	ResourceDedicatedIPPool                             = resourceDedicatedIPPool
+	ResourceEmailIdentity                               = resourceEmailIdentity
+	ResourceEmailIdentityConfigurationSetAttributes     = newEmailIdentityConfigurationSetAttributesResource
+	ResourceEmailIdentityFeedbackAttributes             = resourceEmailIdentityFeedbackAttributes
+	ResourceEmailIdentityMailFromAttributes             = resourceEmailIdentityMailFromAttributes
+	ResourceEmailIdentityPolicy                         = resourceEmailIdentityPolicy
+	ResourceTenant                                      = newTenantResource
+	ResourceTenantResource                              = newTenantResourceAssociationResource
 
 	FindAccountSuppressionAttributes                 = findAccountSuppressionAttributes
 	FindAccountVDMAttributes                         = findAccountVDMAttributes

--- a/internal/service/sesv2/service_package_gen.go
+++ b/internal/service/sesv2/service_package_gen.go
@@ -33,6 +33,12 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			Region:   inttypes.ResourceRegionDefault(),
 		},
 		{
+			Factory:  newEmailIdentityConfigurationSetAttributesResource,
+			TypeName: "aws_sesv2_email_identity_configuration_set_attributes",
+			Name:     "Email Identity Configuration Set Attributes",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newTenantResource,
 			TypeName: "aws_sesv2_tenant",
 			Name:     "Tenant",

--- a/website/docs/r/sesv2_email_identity.html.markdown
+++ b/website/docs/r/sesv2_email_identity.html.markdown
@@ -56,6 +56,11 @@ resource "aws_sesv2_email_identity" "example" {
 }
 ```
 
+~> **NOTE on `configuration_set_name` and `aws_sesv2_email_identity_configuration_set_attributes`:**
+Terraform provides two ways to associate a configuration set with an email identity: the `configuration_set_name` argument on this resource, and the separate [`aws_sesv2_email_identity_configuration_set_attributes`](sesv2_email_identity_configuration_set_attributes) resource.
+Using both on the same identity at the same time will cause conflicts and undefined behavior.
+Use `aws_sesv2_email_identity_configuration_set_attributes` when you need to break a circular dependency between the identity and the configuration set (for example, when the configuration set requires the domain identity to already exist).
+
 ## Argument Reference
 
 The following arguments are required:

--- a/website/docs/r/sesv2_email_identity_configuration_set_attributes.html.markdown
+++ b/website/docs/r/sesv2_email_identity_configuration_set_attributes.html.markdown
@@ -1,0 +1,84 @@
+---
+subcategory: "SESv2 (Simple Email V2)"
+layout: "aws"
+page_title: "AWS: aws_sesv2_email_identity_configuration_set_attributes"
+description: |-
+  Manages an AWS SESv2 (Simple Email V2) Email Identity Configuration Set association.
+---
+
+# Resource: aws_sesv2_email_identity_configuration_set_attributes
+
+Manages the configuration set association for an SESv2 email identity.
+
+Use this resource instead of the `configuration_set_name` argument on `aws_sesv2_email_identity` when you need to break a circular dependency: for example, when an `aws_sesv2_configuration_set` with click/open tracking requires the domain identity to already exist, and `aws_sesv2_email_identity` requires the configuration set to already exist.
+
+~> **Note:** Do not use `configuration_set_name` in `aws_sesv2_email_identity` and `aws_sesv2_email_identity_configuration_set_attributes` on the same identity at the same time. Destroying this resource will disassociate the configuration set (set it to empty), not restore any previously configured value.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_sesv2_email_identity" "example" {
+  email_identity = "example.com"
+}
+
+resource "aws_sesv2_configuration_set" "example" {
+  configuration_set_name = "example"
+}
+
+resource "aws_sesv2_email_identity_configuration_set_attributes" "example" {
+  email_identity         = aws_sesv2_email_identity.example.email_identity
+  configuration_set_name = aws_sesv2_configuration_set.example.configuration_set_name
+}
+```
+
+### Breaking a Circular Dependency
+
+```terraform
+resource "aws_sesv2_email_identity" "example" {
+  email_identity = "example.com"
+}
+
+resource "aws_sesv2_configuration_set" "example" {
+  configuration_set_name = "example"
+
+  tracking_options {
+    custom_redirect_domain = "click.example.com"
+  }
+}
+
+resource "aws_sesv2_email_identity_configuration_set_attributes" "example" {
+  email_identity         = aws_sesv2_email_identity.example.email_identity
+  configuration_set_name = aws_sesv2_configuration_set.example.configuration_set_name
+}
+```
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `email_identity` - (Required, Forces new resource) The verified email identity (domain or email address).
+* `configuration_set_name` - (Required) Name of the configuration set to associate with the email identity.
+
+## Attribute Reference
+
+This resource exports no additional attributes.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import SESv2 (Simple Email V2) Email Identity Configuration Set Attributes using the `email_identity`. For example:
+
+```terraform
+import {
+  to = aws_sesv2_email_identity_configuration_set_attributes.example
+  id = "example.com"
+}
+```
+
+Using `terraform import`, import SESv2 (Simple Email V2) Email Identity Configuration Set Attributes using the `email_identity`. For example:
+
+```console
+% terraform import aws_sesv2_email_identity_configuration_set_attributes.example example.com
+```


### PR DESCRIPTION
## Description

Adds a new resource `aws_sesv2_email_identity_configuration_set_attributes` that wraps the `PutEmailIdentityConfigurationSetAttributes` API call, allowing users to associate a configuration set with an email identity as a standalone, post-creation step.

### Problem

A circular dependency exists at the AWS API level between these two resources:

- `aws_sesv2_email_identity` requires the configuration set to exist at
  creation time if `configuration_set_name` is set inline.
- `aws_sesv2_configuration_set` with click/open tracking
  (`tracking_options`) requires the domain identity to already be
  registered in SES.

Until now, the Terraform AWS provider had no native resource wrapping
`PutEmailIdentityConfigurationSetAttributes` in isolation, making it
impossible to express this association declaratively without resorting
to `local-exec` provisioners or external tooling.

### Solution

A new resource that follows the same pattern as `aws_sesv2_email_identity_mail_from_attributes` — a standalone resource that wraps a single `PutEmailIdentity*` API call. Users create the email identity and configuration set independently (no `configuration_set_name` on `aws_sesv2_email_identity`), then use this resource to associate them.

### Implementation notes

- Uses `terraform-plugin-framework` (not Plugin SDK v2)
- Resource ID = `email_identity` value; importable by email identity
- On destroy: calls `PutEmailIdentityConfigurationSetAttributes` with `ConfigurationSetName = ""` to disassociate (same pattern as `mail_from_attributes`)
- Read reuses the existing `findEmailIdentityByID` finder (`GetEmailIdentity` returns `ConfigurationSetName`)

## Acceptance tests
make testacc TESTS=TestAccSESV2EmailIdentityConfigurationSetAttributes TEST=./internal/service/sesv2/...

Tests cover: `basic`, `disappears`, `disappearsEmailIdentity`, `update`.

## References

- AWS API: [`PutEmailIdentityConfigurationSetAttributes`](https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_PutEmailIdentityConfigurationSetAttributes.html)
- Reference resource: `aws_sesv2_email_identity_mail_from_attributes`

## Checklist

- [x] New resource follows the guidelines in the contribution guide
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Acceptance tests written (basic, disappears, update)
- [x] Documentation added
- [x] Cross-reference note added to `aws_sesv2_email_identity` docs
- [x] CHANGELOG updated