### PR TITLE
resource/aws_codebuild_project: always include vpc_config in UpdateProject

### DIFF
--- a/.changelog/47634.txt
+++ b/.changelog/47634.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_codebuild_project: Always include `vpc_config` in `UpdateProject` API requests when set in state, so that SCPs requiring `vpcConfig` on every call do not deny non-VPC attribute updates.
+```

--- a/internal/service/codebuild/project.go
+++ b/internal/service/codebuild/project.go
@@ -1156,12 +1156,12 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta any
 			input.TimeoutInMinutes = aws.Int32(int32(d.Get("build_timeout").(int)))
 		}
 
-		if d.HasChange(names.AttrVPCConfig) {
-			if v, ok := d.GetOk(names.AttrVPCConfig); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
-				input.VpcConfig = expandVPCConfig(v.([]any)[0].(map[string]any))
-			} else {
-				input.VpcConfig = &types.VpcConfig{}
-			}
+		// VpcConfig is always sent when set, so SCPs that require it on every
+		// UpdateProject call do not reject updates that touch only non-VPC attributes.
+		if v, ok := d.GetOk(names.AttrVPCConfig); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.VpcConfig = expandVPCConfig(v.([]any)[0].(map[string]any))
+		} else if d.HasChange(names.AttrVPCConfig) {
+			input.VpcConfig = &types.VpcConfig{}
 		}
 
 		// The documentation clearly says "The replacement set of tags for this build project."

--- a/internal/service/codebuild/project_test.go
+++ b/internal/service/codebuild/project_test.go
@@ -1894,6 +1894,51 @@ func TestAccCodeBuildProject_vpc(t *testing.T) {
 	})
 }
 
+// Regression test: updating only non-VPC attributes must keep `vpc_config`
+// populated in the UpdateProject request so SCPs that require `vpcConfig` on
+// every call do not deny the update.
+func TestAccCodeBuildProject_vpcUpdateDescription(t *testing.T) {
+	ctx := acctest.Context(t)
+	var project types.Project
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_codebuild_project.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+			testAccPreCheckSourceCredentialsForServerType(ctx, t, types.ServerTypeGithub)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeBuildServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckProjectDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProjectConfig_vpcWithDescription(rName, "description1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProjectExists(ctx, t, resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.subnets.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "vpc_config.0.vpc_id", regexache.MustCompile(`^vpc-`)),
+				),
+			},
+			{
+				Config: testAccProjectConfig_vpcWithDescription(rName, "description2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProjectExists(ctx, t, resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description2"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.subnets.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "vpc_config.0.vpc_id", regexache.MustCompile(`^vpc-`)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCodeBuildProject_windowsServer2019Container(t *testing.T) {
 	ctx := acctest.Context(t)
 	var project types.Project
@@ -4855,6 +4900,40 @@ resource "aws_codebuild_project" "test" {
   }
 }
 `, rName))
+}
+
+func testAccProjectConfig_vpcWithDescription(rName, description string) string {
+	return acctest.ConfigCompose(
+		testAccProjectConfig_baseServiceRole(rName),
+		testAccProjectConfig_baseVPC(rName),
+		fmt.Sprintf(`
+resource "aws_codebuild_project" "test" {
+  name         = %[1]q
+  description  = %[2]q
+  service_role = aws_iam_role.test.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "2"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    location = "https://github.com/hashicorp/packer.git"
+    type     = "GITHUB"
+  }
+
+  vpc_config {
+    security_group_ids = [aws_security_group.test.id]
+    subnets            = [aws_subnet.test[0].id]
+    vpc_id             = aws_vpc.test.id
+  }
+}
+`, rName, description))
 }
 
 func testAccProjectConfig_vpc2(rName string) string {


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. The `UpdateProject` request now consistently includes `vpcConfig` when it is set in state, which is information AWS already has about the project. No new IAM permissions are required.

### Description

`resource_aws_codebuild_project` previously omitted `vpcConfig` from `UpdateProject` API requests when no change was detected on the `vpc_config` block. The inner block in `resourceProjectUpdate` was guarded by `d.HasChange("vpc_config")`, so updates that touched only non-VPC attributes (e.g. `description`) did not include `vpcConfig` in the request payload.

Because AWS treats an omitted field as "no change", this is invisible in standard environments. However, in regulated environments that use AWS Organizations Service Control Policies (SCPs) to require `vpcConfig` on every `codebuild:UpdateProject` call, those updates are denied with `AccessDeniedException`, even though `vpc_config` is present in both Terraform state and the user's `.tf` configuration.

**Fix.** Always include `VpcConfig` in the `UpdateProject` input when `vpc_config` exists in state, regardless of `HasChange`. The empty-VpcConfig path (used to clear a previously-configured VPC) is kept under `HasChange` so removing the `vpc_config` block from configuration still sends an empty struct.

```go
// Before
if d.HasChange(names.AttrVPCConfig) {
    if v, ok := d.GetOk(names.AttrVPCConfig); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
        input.VpcConfig = expandVPCConfig(v.([]any)[0].(map[string]any))
    } else {
        input.VpcConfig = &types.VpcConfig{}
    }
}

// After
if v, ok := d.GetOk(names.AttrVPCConfig); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
    input.VpcConfig = expandVPCConfig(v.([]any)[0].(map[string]any))
} else if d.HasChange(names.AttrVPCConfig) {
    input.VpcConfig = &types.VpcConfig{}
}
```

#### Behavior matrix

| State | Before | After |
|---|---|---|
| `vpc_config` set, only non-VPC attrs change | `VpcConfig` omitted | `VpcConfig` included (current values) |
| `vpc_config` set, VPC attrs change | `VpcConfig` included | `VpcConfig` included (unchanged) |
| `vpc_config` removed from config | empty `VpcConfig{}` sent | empty `VpcConfig{}` sent (unchanged) |
| `vpc_config` never set | nothing sent | nothing sent (unchanged) |

#### Test strategy

A new acceptance test `TestAccCodeBuildProject_vpcUpdateDescription` was added. It updates only the `description` of a project that has `vpc_config` set, then verifies that `vpc_config` remains intact after the update. It does not directly assert that `vpcConfig` is present in the outgoing `UpdateProject` request, because:

- Reproducing the SCP behavior in acceptance tests would require Organizations management-account permissions, an applied SCP and its propagation delay, and there is no precedent in this repository for tests that exercise SCP enforcement.
- AWS already preserves the existing `vpcConfig` when the field is omitted, so the user-visible state is identical with or without the fix in standard environments.

The test is therefore a regression guard against re-introducing the original `HasChange` gate. The functional motivation (SCP-protected environments) is documented in the code comment and this PR description.

#### Related resources

`aws_lambda_function` has a similar pattern (see `internal/service/lambda/function.go:955-970`, where the `UpdateFunctionConfiguration` input is gated by `HasChanges("vpc_config.0.security_group_ids", "vpc_config.0.subnet_ids", "vpc_config.0.ipv6_allowed_for_dual_stack")`). This PR intentionally scopes the fix to CodeBuild; a follow-up PR for Lambda is planned.

### Relations

No prior issue. Filing this PR directly per the contribution guide for small bug fixes.

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccCodeBuildProject_vpcUpdateDescription PKG=codebuild
...
=== RUN   TestAccCodeBuildProject_vpcUpdateDescription
=== PAUSE TestAccCodeBuildProject_vpcUpdateDescription
=== CONT  TestAccCodeBuildProject_vpcUpdateDescription
--- PASS: TestAccCodeBuildProject_vpcUpdateDescription (68.92s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codebuild	74.339s

% make testacc TESTS='TestAccCodeBuildProject_vpc$' PKG=codebuild
...
=== RUN   TestAccCodeBuildProject_vpc
=== PAUSE TestAccCodeBuildProject_vpc
=== CONT  TestAccCodeBuildProject_vpc
--- PASS: TestAccCodeBuildProject_vpc (92.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codebuild	98.031s
```

### AI Usage

This PR was prepared with AI assistance (Claude Code). AI was used to:

- Draft the code change after I described the bug and the intended fix in plain language.
- Investigate related patterns in the codebase (e.g. confirming the same `HasChange`-gated `vpc_config` shape in `aws_lambda_function`).
- Draft the regression acceptance test.
- Draft this PR description and the CHANGELOG entry.

I (the human author) reviewed every change line-by-line before committing, ran the acceptance tests against my own AWS account, and take full ownership of the PR.
