### PR TITLE
r/aws_pinpoint_app: Lower minimum of `limits.messages_per_second` from 50 to 1

### DIFF
--- a/.changelog/47636.txt
+++ b/.changelog/47636.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_pinpoint_app: Lower minimum of `limits.messages_per_second` from 50 to 1 to match the AWS API.
+```

--- a/internal/service/pinpoint/app.go
+++ b/internal/service/pinpoint/app.go
@@ -96,7 +96,7 @@ func resourceApp() *schema.Resource {
 						"messages_per_second": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IntBetween(50, 20000),
+							ValidateFunc: validation.IntBetween(1, 20000),
 						},
 						"total": {
 							Type:         schema.TypeInt,

--- a/internal/service/pinpoint/app_test.go
+++ b/internal/service/pinpoint/app_test.go
@@ -289,7 +289,7 @@ func TestAccPinpointApp_limits(t *testing.T) {
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
 							"daily":               knownvalue.Int64Exact(3),
 							"maximum_duration":    knownvalue.Int64Exact(600),
-							"messages_per_second": knownvalue.Int64Exact(50),
+							"messages_per_second": knownvalue.Int64Exact(1),
 							"total":               knownvalue.Int64Exact(100),
 						}),
 					})),
@@ -586,7 +586,7 @@ resource "aws_pinpoint_app" "test" {
   limits {
     daily               = 3
     maximum_duration    = 600
-    messages_per_second = 50
+    messages_per_second = 1
     total               = 100
   }
 }


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls (access controls, encryption, logging) in this pull request.

### Description

The schema validation for `limits.messages_per_second` on `aws_pinpoint_app` is hardcoded to `validation.IntBetween(50, 20000)`, but the AWS Pinpoint API itself accepts the range **1 - 20,000**. The provider's stricter lower bound prevents users from configuring legitimately-low send rates.

This is a real, practical problem: when delivering bulk email through SES via Pinpoint, downstream MTAs (notably Gmail) will rate-limit and induce delivery delays well below 50 messages/sec for accounts with limited reputation. We hit exactly this and needed to lower the application-level default to 30/sec, but the provider rejected the value, forcing us to bypass Terraform and configure the value manually via the AWS console — defeating the purpose of managing the resource in code.

This PR relaxes the schema validation to match the documented AWS API constraint:

- `internal/service/pinpoint/app.go`: `validation.IntBetween(50, 20000)` → `validation.IntBetween(1, 20000)`
- `internal/service/pinpoint/app_test.go`: update the existing `TestAccPinpointApp_limits` to set `messages_per_second = 1`, exercising the new lower bound

The upper bound (20,000) is unchanged and matches the API.

### Relations

No related issue.

### References

AWS API documentation for the `MessagesPerSecond` field of `CampaignLimits` (which is used both for application-level defaults and per-campaign overrides):

> The maximum number of messages that a campaign can send each second. For an application, this value specifies the default limit for the number of messages that campaigns can send each second. **The minimum value is 1. The maximum value is 20,000.**

— https://docs.aws.amazon.com/pinpoint/latest/apireference/apps-application-id-settings.html

### Output from Acceptance Testing

I was unable to run `make testacc` on my local machine — the full provider compile is prohibitively heavy on the hardware available to me and was disrupting other work. I'd appreciate it if maintainers could run the affected tests in CI / on a build host:

```console
% make testacc TESTS=TestAccPinpointApp_limits PKG=pinpoint
% make testacc TESTS=TestAccPinpointApp_limitsEmpty PKG=pinpoint
```

The change is a one-line schema relaxation plus a test-config value tweak, so I expect both tests to pass without further modification. Happy to address any feedback.