### PR TITLE
🤖🤖🤖 docs/aws_lb_listener_certificate: use ACM ARN in import examples

### DIFF
--- a/website/docs/r/lb_listener_certificate.html.markdown
+++ b/website/docs/r/lb_listener_certificate.html.markdown
@@ -56,12 +56,12 @@ In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashico
 ```terraform
 import {
   to = aws_lb_listener_certificate.example
-  id = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/test/8e4497da625e2d8a/9ab28ade35828f96/67b3d2d36dd7c26b_arn:aws:iam::123456789012:server-certificate/tf-acc-test-6453083910015726063"
+  id = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/test/8e4497da625e2d8a/9ab28ade35828f96/67b3d2d36dd7c26b_arn:aws:acm:us-west-2:123456789012:certificate/abcdef00-1111-2222-3333-456789abcdef"
 }
 ```
 
 Using `terraform import`, import Listener Certificates using the listener arn and certificate arn, separated by an underscore (`_`). For example:
 
 ```console
-% terraform import aws_lb_listener_certificate.example arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/test/8e4497da625e2d8a/9ab28ade35828f96/67b3d2d36dd7c26b_arn:aws:iam::123456789012:server-certificate/tf-acc-test-6453083910015726063
+% terraform import aws_lb_listener_certificate.example arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/test/8e4497da625e2d8a/9ab28ade35828f96/67b3d2d36dd7c26b_arn:aws:acm:us-west-2:123456789012:certificate/abcdef00-1111-2222-3333-456789abcdef
 ```


### PR DESCRIPTION
## Summary

The Example Usage block for `aws_lb_listener_certificate` uses `aws_acm_certificate` as the source of the certificate ARN, but the Import section's example IDs combined the listener ARN with an IAM `server-certificate` ARN. Practitioners reading the doc end-to-end ended up confused about which ARN to substitute.

This swaps the IAM server-certificate ARN for an ACM certificate ARN of the same shape so the import examples are consistent with the resource example. Both the \`import\` block and the \`terraform import\` console example are updated.

Closes #40935.

## Output from Acceptance Testing

Documentation-only change; no acceptance tests are affected. \`make website\` covers the relevant lints (markdown-lint, misspell, terrafmt). The repository's \`.markdownlint.yml\` disables MD013 (line-length), so the slightly longer ACM ARN does not trip any rule.

No \`.changelog/*.txt\` is added — per [docs/changelog-process.md](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/changelog-process.md), "Resource and provider documentation updates" should not have a CHANGELOG entry.

## AI usage disclosure

Per [docs/ai-usage.md](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/ai-usage.md): this PR was prepared by an LLM agent on my behalf (hence the 🤖🤖🤖 in the title). I reviewed the diff, verified that the existing Example Usage already uses ACM, and confirmed the ARN-format swap is the minimal fix the issue describes. The new ARN is a placeholder of the documented ACM ARN shape; no real account/region is implied.