### PR TITLE
🤖🤖🤖 docs/aws_rds_cluster: explain db_instance_parameter_group_name for major version upgrades

### DIFF
--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -194,6 +194,27 @@ resource "aws_rds_global_cluster" "example" {
 }
 ```
 
+### Major Version Upgrades
+
+Upgrading an Aurora or Multi-AZ DB cluster across a major engine version requires three arguments to be set together: `engine_version` (the target version), `allow_major_version_upgrade = true`, and `db_instance_parameter_group_name` pointing at a DB parameter group of the target engine family. RDS applies the new parameter group to every cluster instance during the version change, so the parameter group attached to each `aws_rds_cluster_instance` is not what governs the upgrade — it must be supplied on the cluster.
+
+```terraform
+resource "aws_db_parameter_group" "postgres15" {
+  name   = "aurora-postgres15"
+  family = "aurora-postgresql15"
+}
+
+resource "aws_rds_cluster" "example" {
+  cluster_identifier               = "example"
+  engine                           = "aurora-postgresql"
+  engine_version                   = "15.4"
+  allow_major_version_upgrade      = true
+  db_instance_parameter_group_name = aws_db_parameter_group.postgres15.name
+  master_username                  = "foo"
+  master_password                  = "must_be_eight_characters"
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
@@ -218,7 +239,7 @@ This resource supports the following arguments:
 * `database_name` - (Optional) Name for an automatically created database on cluster creation. There are different naming restrictions per database engine: [RDS Naming Constraints][5]
 * `db_cluster_instance_class` - (Optional, Required for Multi-AZ DB cluster) The compute and memory capacity of each DB instance in the Multi-AZ DB cluster, for example `db.m6g.xlarge`. Not all DB instance classes are available in all AWS Regions, or for all database engines. For the full list of DB instance classes and availability for your engine, see [DB instance class](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html) in the Amazon RDS User Guide.
 * `db_cluster_parameter_group_name` - (Optional) A cluster parameter group to associate with the cluster.
-* `db_instance_parameter_group_name` - (Optional) Instance parameter group to associate with all instances of the DB cluster. The `db_instance_parameter_group_name` parameter is only valid in combination with the `allow_major_version_upgrade` parameter.
+* `db_instance_parameter_group_name` - (Optional) Instance parameter group to associate with all instances of the DB cluster. The `db_instance_parameter_group_name` parameter is only valid in combination with the `allow_major_version_upgrade` parameter. When upgrading the engine to a new major version, the existing instance parameter group typically belongs to the prior engine family and is incompatible with the target version; supplying a parameter group of the new engine family here lets RDS apply it to all instances atomically with the upgrade. See [Major Version Upgrades](#major-version-upgrades) below and the [RDS upgrade process](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion.Process) in the AWS documentation.
 * `db_subnet_group_name` - (Optional) DB subnet group to associate with this DB cluster.
   **NOTE:** This must match the `db_subnet_group_name` specified on every [`aws_rds_cluster_instance`](/docs/providers/aws/r/rds_cluster_instance.html) in the cluster.
 * `db_system_id` - (Optional) For use with RDS Custom.


### PR DESCRIPTION
## Summary

The \`db_instance_parameter_group_name\` argument-reference entry already noted that it is "only valid in combination with the \`allow_major_version_upgrade\` parameter" but did not explain *why* a practitioner would need to set it. The mechanism is non-obvious: a custom instance parameter group attached to existing cluster instances typically belongs to the prior engine family, so a major version upgrade must hand RDS a parameter group of the target family at the cluster level for it to be applied atomically across all instances.

Two changes:

1. Expand the \`db_instance_parameter_group_name\` argument bullet with the rationale, and link to the [RDS upgrade-process documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion.Process).
2. Add a focused \`### Major Version Upgrades\` example under "Example Usage" that wires \`engine_version\`, \`allow_major_version_upgrade\`, and \`db_instance_parameter_group_name\` together with a matching \`aws_db_parameter_group\` of the target family.

Closes #27617.

## Output from Acceptance Testing

Documentation-only change. The new example follows the formatting conventions of the surrounding examples in the file (column-aligned \`=\`, \`terraform\` fenced block) so terrafmt should be a no-op.

No \`.changelog/*.txt\` is added — per docs/changelog-process.md, documentation updates should not have a CHANGELOG entry.

## AI usage disclosure

Per docs/ai-usage.md: this PR was prepared by an LLM agent on my behalf (hence the 🤖🤖🤖). I verified the cross-reference link target ([anchor \`#major-version-upgrades\`](#)) matches the new \`### Major Version Upgrades\` heading slug, and the example uses the documented \`aurora-postgresql{major}\` parameter-group family naming convention. Engine version \`15.4\` is illustrative.