### PR TITLE
feat: make schedule_config optional

### DIFF
--- a/.changelog/47648.txt
+++ b/.changelog/47648.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_appintegrations_data_integration: Make `schedule_config` block optional
+```

--- a/.changelog/47648.txt
+++ b/.changelog/47648.txt
@@ -1,3 +1,3 @@
-```release-note:enhancement
+```release-note:bug
 resource/aws_appintegrations_data_integration: Make `schedule_config` block optional
 ```

--- a/internal/service/appintegrations/data_integration.go
+++ b/internal/service/appintegrations/data_integration.go
@@ -67,7 +67,7 @@ func resourceDataIntegration() *schema.Resource {
 			"schedule_config": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/internal/service/appintegrations/data_integration_test.go
+++ b/internal/service/appintegrations/data_integration_test.go
@@ -67,6 +67,44 @@ func TestAccAppIntegrationsDataIntegration_basic(t *testing.T) {
 	})
 }
 
+func TestAccAppIntegrationsDataIntegration_sourceURI_s3(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dataIntegration appintegrations.GetDataIntegrationOutput
+
+	rName := acctest.RandomWithPrefix(t, "resource-test-terraform")
+	bucketName := acctest.RandomWithPrefix(t, "tf-appintegrations-di")
+	description := "example description"
+
+	resourceName := "aws_appintegrations_data_integration.test"
+	sourceURI := fmt.Sprintf("S3://%s", bucketName)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataIntegrationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataIntegrationConfig_sourceURI_s3(rName, bucketName, description),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataIntegrationExists(ctx, t, resourceName, &dataIntegration),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "app-integrations", "data-integration/{id}"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, description),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrKMSKey, "aws_kms_key.test", names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "schedule_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "source_uri", sourceURI),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAppIntegrationsDataIntegration_updateDescription(t *testing.T) {
 	ctx := acctest.Context(t)
 	var dataIntegration appintegrations.GetDataIntegrationOutput
@@ -321,6 +359,58 @@ resource "aws_appintegrations_data_integration" "test" {
   }
 }
 `, rName, description, sourceUri, firstExecutionFrom))
+}
+
+func testAccDataIntegrationConfig_sourceURI_s3(rName, bucketName, description string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = "KMS key for app integrations data integration"
+  enable_key_rotation     = true
+  deletion_window_in_days = 7
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+	sid    = "AllowAppIntegrations"
+	effect = "Allow"
+
+	principals {
+	  type        = "Service"
+	  identifiers = ["app-integrations.amazonaws.com"]
+	}
+
+	actions = [
+	  "s3:ListBucket",
+	  "s3:GetObject",
+	  "s3:GetBucketLocation",
+	]
+
+	resources = [
+	  aws_s3_bucket.test.arn,
+	  "${aws_s3_bucket.test.arn}/*",
+	]
+  }
+}
+
+resource "aws_s3_bucket_policy" "test" {
+  bucket = aws_s3_bucket.test.id
+  policy = data.aws_iam_policy_document.test.json
+}
+
+resource "aws_appintegrations_data_integration" "test" {
+  depends_on = [aws_s3_bucket_policy.test]
+
+  name        = %[2]q
+  description = %[3]q
+  kms_key     = aws_kms_key.test.arn
+  source_uri  = "S3://${aws_s3_bucket.test.bucket}"
+}
+`, bucketName, rName, description)
 }
 
 func testAccDataIntegrationConfig_tags(rName, description, sourceUri, firstExecutionFrom string) string {

--- a/internal/service/appintegrations/data_integration_test.go
+++ b/internal/service/appintegrations/data_integration_test.go
@@ -376,24 +376,24 @@ resource "aws_s3_bucket" "test" {
 
 data "aws_iam_policy_document" "test" {
   statement {
-	sid    = "AllowAppIntegrations"
-	effect = "Allow"
+    sid    = "AllowAppIntegrations"
+    effect = "Allow"
 
-	principals {
-	  type        = "Service"
-	  identifiers = ["app-integrations.amazonaws.com"]
-	}
+    principals {
+      type        = "Service"
+      identifiers = ["app-integrations.amazonaws.com"]
+    }
 
-	actions = [
-	  "s3:ListBucket",
-	  "s3:GetObject",
-	  "s3:GetBucketLocation",
-	]
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:GetBucketLocation",
+    ]
 
-	resources = [
-	  aws_s3_bucket.test.arn,
-	  "${aws_s3_bucket.test.arn}/*",
-	]
+    resources = [
+      aws_s3_bucket.test.arn,
+      "${aws_s3_bucket.test.arn}/*",
+    ]
   }
 }
 

--- a/website/docs/r/appintegrations_data_integration.html.markdown
+++ b/website/docs/r/appintegrations_data_integration.html.markdown
@@ -39,7 +39,7 @@ This resource supports the following arguments:
 * `description` - (Optional) Specifies the description of the Data Integration.
 * `kms_key` - (Required) Specifies the KMS key Amazon Resource Name (ARN) for the Data Integration.
 * `name` - (Required) Specifies the name of the Data Integration.
-* `schedule_config` - (Required) A block that defines the name of the data and how often it should be pulled from the source. The Schedule Config block is documented below.
+* `schedule_config` - (Optional) A block that defines the name of the data and how often it should be pulled from the source. The Schedule Config block is documented below.
 * `source_uri` - (Required) Specifies the URI of the data source. Create an [AppFlow Connector Profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appflow_connector_profile) and reference the name of the profile in the URL. An example of this value for Salesforce is `Salesforce://AppFlow/example` where `example` is the name of the AppFlow Connector Profile.
 * `tags` - (Optional) Tags to apply to the Data Integration. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

The `schedule_config`  of resource [`aws_appintegrations_data_integration`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appintegrations_data_integration) is configured as `Required`, but actually needs to be `Optional`.

Having it configured as `Required` blocks the OP of  #47464  from doing below in Terraform

```shell
aws appintegrations create-data-integration \
  --name test2-s3 \
  --kms-key "arn:aws:kms:us-east-1:REDACTED_ACCOUNT_ID:key/REDACTED_KEY_ID" \
  --source-uri "s3://REDACTED_BUCKET_NAME" \
  --query Arn \
  --output text
```


An equivalent code snippet

```hcl
resource "aws_appintegrations_data_integration" "test" {
  name        = "test"
  description = "test"
  kms_key     = aws_kms_key.example.arn
  source_uri  = "S3://${aws_s3_bucket.test.bucket}"

  schedule_config { # added as it is "Required" in v6.42.0
    first_execution_from = "1439788442681"
    object               = "Account"
    schedule_expression  = "rate(1 hour)"
  }
}
```

fails with  `InvalidRequestException: Failed to create DataIntegration with name: test. Source S3 does not support structured data.` in provider version 6.42.0

### Relations

* Relates #47498  (update source_uri validation expression)
* Closes #47464 (original issue)


### References

- [AWS API Refernce - CreateDataIntegration](https://docs.aws.amazon.com/connect/latest/APIReference/API_connect-app-integrations_CreateDataIntegration.html)  
  showing `ScheduleConfig` as `Required: No`

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
export DATA_INTEGRATION_SOURCE_URI="Salesforce://AppFlow/test"         
make testacc T=TestAccAppIntegrationsDataIntegration_ K=appintegrations
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws_appintegrations_data_integration-make-schedule_config-optional 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/appintegrations/... -v -count 1 -parallel 20 -run='TestAccAppIntegrationsDataIntegration_'  -timeout 360m -vet=off
2026/04/28 19:42:59 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/28 19:42:59 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAppIntegrationsDataIntegration_basic
=== PAUSE TestAccAppIntegrationsDataIntegration_basic
=== RUN   TestAccAppIntegrationsDataIntegration_sourceURI_s3
=== PAUSE TestAccAppIntegrationsDataIntegration_sourceURI_s3
=== RUN   TestAccAppIntegrationsDataIntegration_updateDescription
=== PAUSE TestAccAppIntegrationsDataIntegration_updateDescription
=== RUN   TestAccAppIntegrationsDataIntegration_updateName
=== PAUSE TestAccAppIntegrationsDataIntegration_updateName
=== RUN   TestAccAppIntegrationsDataIntegration_updateTags
=== PAUSE TestAccAppIntegrationsDataIntegration_updateTags
=== CONT  TestAccAppIntegrationsDataIntegration_basic
=== CONT  TestAccAppIntegrationsDataIntegration_updateName
=== CONT  TestAccAppIntegrationsDataIntegration_updateDescription
=== CONT  TestAccAppIntegrationsDataIntegration_updateTags
=== CONT  TestAccAppIntegrationsDataIntegration_sourceURI_s3
--- PASS: TestAccAppIntegrationsDataIntegration_sourceURI_s3 (42.58s)
--- PASS: TestAccAppIntegrationsDataIntegration_basic (45.53s)
--- PASS: TestAccAppIntegrationsDataIntegration_updateDescription (65.57s)
--- PASS: TestAccAppIntegrationsDataIntegration_updateName (65.87s)
--- PASS: TestAccAppIntegrationsDataIntegration_updateTags (83.06s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appintegrations    83.235s
```
