### PR TITLE
r/aws_directory_service_directory: handle UnsupportedOperationException in GovCloud

### DIFF
--- a/.changelog/47660.txt
+++ b/.changelog/47660.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_directory_service_directory: Fix `UnsupportedOperationException` error when reading `enable_directory_data_access` in regions where Directory Service Data is not available (e.g. GovCloud)
+```

--- a/internal/service/ds/directory.go
+++ b/internal/service/ds/directory.go
@@ -366,10 +366,14 @@ func resourceDirectoryRead(ctx context.Context, d *schema.ResourceData, meta any
 
 	if dir.Type == awstypes.DirectoryTypeMicrosoftAd {
 		dda, err := getDirectoryDataAccess(ctx, conn, d.Id())
-		if err != nil {
+		if errs.IsA[*awstypes.UnsupportedOperationException](err) {
+			// Directory Service Data is not available in all regions (e.g. GovCloud).
+			d.Set("enable_directory_data_access", false)
+		} else if err != nil {
 			return sdkdiag.AppendErrorf(diags, "reading directory data access: %s", err)
+		} else {
+			d.Set("enable_directory_data_access", dda.DataAccessStatus == awstypes.DataAccessStatusEnabled)
 		}
-		d.Set("enable_directory_data_access", dda.DataAccessStatus == awstypes.DataAccessStatusEnabled)
 	} else {
 		d.Set("enable_directory_data_access", false)
 	}


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

When reading a MicrosoftAD directory in regions where Directory Service Data is not available (e.g. GovCloud), `DescribeDirectoryDataAccess` returns `UnsupportedOperationException`. The `resourceDirectoryRead` function did not handle this, causing plan/apply to fail for all existing MicrosoftAD directories in those regions, even when `enable_directory_data_access` is `false` or unset.

The fix catches `UnsupportedOperationException` in the Read path and defaults `enable_directory_data_access` to `false`, matching the behavior for non-MicrosoftAD directory types. This follows the same `errs.IsA[*awstypes.X]` pattern used elsewhere in the ds package.

### Relations

Closes #47607

### References

- The `errs.IsA` pattern is used in the same file for `EntityDoesNotExistException` (lines 447, 790, 911)
- The kinesisanalytics sweep handles a similar `UnsupportedOperationException` case (line 49)

### Output from Acceptance Testing

I do not have access to a GovCloud environment to run acceptance tests. The existing `TestAccDSDirectory_enableDirectoryDataAccess` test covers the happy path. The fix adds an error type check before the existing error return, so the happy path behavior is unchanged.