### PR TITLE
r/aws_quicksight_dashboard: pass theme_arn in Create/Update and read it back

### DIFF
--- a/.changelog/47661.txt
+++ b/.changelog/47661.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_quicksight_dashboard: Fix `theme_arn` not being passed to `CreateDashboard` and `UpdateDashboard` API calls, and not being read back from the API
+```

--- a/internal/service/quicksight/dashboard.go
+++ b/internal/service/quicksight/dashboard.go
@@ -156,6 +156,10 @@ func resourceDashboardCreate(ctx context.Context, d *schema.ResourceData, meta a
 		input.SourceEntity = quicksightschema.ExpandDashboardSourceEntity(v.([]any))
 	}
 
+	if v, ok := d.GetOk("theme_arn"); ok {
+		input.ThemeArn = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("version_description"); ok {
 		input.VersionDescription = aws.String(v.(string))
 	}
@@ -222,6 +226,8 @@ func resourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta any
 		return sdkdiag.AppendErrorf(diags, "setting dashboard_publish_options: %s", err)
 	}
 
+	d.Set("theme_arn", outputDDD.ThemeArn)
+
 	permissions, err := findDashboardPermissionsByTwoPartKey(ctx, conn, awsAccountID, dashboardID)
 
 	if err != nil {
@@ -264,6 +270,10 @@ func resourceDashboardUpdate(ctx context.Context, d *schema.ResourceData, meta a
 
 		if v, ok := d.GetOk(names.AttrParameters); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 			inputUD.Parameters = quicksightschema.ExpandParameters(d.Get(names.AttrParameters).([]any))
+		}
+
+		if v, ok := d.GetOk("theme_arn"); ok {
+			inputUD.ThemeArn = aws.String(v.(string))
 		}
 
 		output, err := conn.UpdateDashboard(ctx, inputUD)


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

The `theme_arn` attribute on `aws_quicksight_dashboard` is accepted in configuration and stored in Terraform state, but the provider never includes `ThemeArn` in the `CreateDashboard` or `UpdateDashboard` API request bodies. The dashboard is created/updated without the theme. The Read function also never reads `ThemeArn` back from the API, so Terraform reports the state as matching even though the theme was never applied.

This wires `ThemeArn` through all three CRUD paths:

- **Create**: include `ThemeArn` in `CreateDashboardInput` when `theme_arn` is set
- **Update**: include `ThemeArn` in `UpdateDashboardInput` when `theme_arn` is set
- **Read**: set `theme_arn` from `DescribeDashboardDefinition` response (`outputDDD.ThemeArn`)

The fix follows the same `d.GetOk` / `aws.String` pattern used for other optional string attributes in the same resource (e.g. `version_description`, `source_entity`).

### Relations

Closes #47623

### References

- `CreateDashboardInput.ThemeArn` field: [AWS SDK Go v2 docs](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/quicksight#CreateDashboardInput)
- `DescribeDashboardDefinitionOutput.ThemeArn` field: [AWS SDK Go v2 docs](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/quicksight#DescribeDashboardDefinitionOutput)

### Output from Acceptance Testing

I do not have a QuickSight Enterprise subscription to run acceptance tests. The change adds three `GetOk` + field assignment blocks and one `d.Set` call, following the exact pattern of surrounding code. No logic branches or error handling paths are modified.