### PR TITLE
fix(issue-47658): use int64 instead of int32 to avoid overflow

### DIFF
--- a/internal/service/directconnect/private_virtual_interface.go
+++ b/internal/service/directconnect/private_virtual_interface.go
@@ -69,7 +69,7 @@ func resourcePrivateVirtualInterface() *schema.Resource {
 				Type:         schema.TypeInt,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.IntInSlice([]int{1, 4294967294}),
+				ValidateFunc: validation.IntBetween(1, 4294967294),
 			},
 			"bgp_auth_key": {
 				Type:     schema.TypeString,

--- a/internal/service/directconnect/private_virtual_interface.go
+++ b/internal/service/directconnect/private_virtual_interface.go
@@ -66,9 +66,10 @@ func resourcePrivateVirtualInterface() *schema.Resource {
 				Computed: true,
 			},
 			"bgp_asn": {
-				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeInt,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntInSlice([]int{1, 4294967294}),
 			},
 			"bgp_auth_key": {
 				Type:     schema.TypeString,
@@ -144,7 +145,7 @@ func resourcePrivateVirtualInterfaceCreate(ctx context.Context, d *schema.Resour
 		ConnectionId: aws.String(d.Get(names.AttrConnectionID).(string)),
 		NewPrivateVirtualInterface: &awstypes.NewPrivateVirtualInterface{
 			AddressFamily:        awstypes.AddressFamily(d.Get("address_family").(string)),
-			Asn:                  int32(d.Get("bgp_asn").(int)),
+			Asn:                  int64(d.Get("bgp_asn").(int)),
 			EnableSiteLink:       aws.Bool(d.Get("sitelink_enabled").(bool)),
 			Mtu:                  aws.Int32(int32(d.Get("mtu").(int))),
 			Tags:                 getTagsIn(ctx),

--- a/internal/service/directconnect/private_virtual_interface.go
+++ b/internal/service/directconnect/private_virtual_interface.go
@@ -145,7 +145,7 @@ func resourcePrivateVirtualInterfaceCreate(ctx context.Context, d *schema.Resour
 		ConnectionId: aws.String(d.Get(names.AttrConnectionID).(string)),
 		NewPrivateVirtualInterface: &awstypes.NewPrivateVirtualInterface{
 			AddressFamily:        awstypes.AddressFamily(d.Get("address_family").(string)),
-			Asn:                  int64(d.Get("bgp_asn").(int)),
+			AsnLong:              aws.Int64(int64(d.Get("bgp_asn").(int))),
 			EnableSiteLink:       aws.Bool(d.Get("sitelink_enabled").(bool)),
 			Mtu:                  aws.Int32(int32(d.Get("mtu").(int))),
 			Tags:                 getTagsIn(ctx),
@@ -217,7 +217,7 @@ func resourcePrivateVirtualInterfaceRead(ctx context.Context, d *schema.Resource
 	}.String()
 	d.Set(names.AttrARN, arn)
 	d.Set("aws_device", vif.AwsDeviceV2)
-	d.Set("bgp_asn", vif.Asn)
+	d.Set("bgp_asn", vif.AsnLong)
 	d.Set("bgp_auth_key", vif.AuthKey)
 	d.Set(names.AttrConnectionID, vif.ConnectionId)
 	d.Set("customer_address", vif.CustomerAddress)

--- a/internal/service/directconnect/private_virtual_interface_test.go
+++ b/internal/service/directconnect/private_virtual_interface_test.go
@@ -26,7 +26,7 @@ func TestAccDirectConnectPrivateVirtualInterface_basic(t *testing.T) {
 	resourceName := "aws_dx_private_virtual_interface.test"
 	vpnGatewayResourceName := "aws_vpn_gateway.test"
 	rName := fmt.Sprintf("tf-testacc-private-vif-%s", acctest.RandString(t, 9))
-	bgpAsn := acctest.RandIntRange(t, 64512, 65534)
+	bgpAsn := acctest.RandIntRange(t, 1, 4294967294)
 	vlan := acctest.RandIntRange(t, 2049, 4094)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/directconnect/transit_virtual_interface.go
+++ b/internal/service/directconnect/transit_virtual_interface.go
@@ -137,7 +137,7 @@ func resourceTransitVirtualInterfaceCreate(ctx context.Context, d *schema.Resour
 		ConnectionId: aws.String(d.Get(names.AttrConnectionID).(string)),
 		NewTransitVirtualInterface: &awstypes.NewTransitVirtualInterface{
 			AddressFamily:          awstypes.AddressFamily(d.Get("address_family").(string)),
-			Asn:                    int32(d.Get("bgp_asn").(int)),
+			AsnLong:                aws.Int64(int64(d.Get("bgp_asn").(int))),
 			DirectConnectGatewayId: aws.String(d.Get("dx_gateway_id").(string)),
 			EnableSiteLink:         aws.Bool(d.Get("sitelink_enabled").(bool)),
 			Mtu:                    aws.Int32(int32(d.Get("mtu").(int))),
@@ -202,7 +202,7 @@ func resourceTransitVirtualInterfaceRead(ctx context.Context, d *schema.Resource
 	}.String()
 	d.Set(names.AttrARN, arn)
 	d.Set("aws_device", vif.AwsDeviceV2)
-	d.Set("bgp_asn", vif.Asn)
+	d.Set("bgp_asn", vif.AsnLong)
 	d.Set("bgp_auth_key", vif.AuthKey)
 	d.Set(names.AttrConnectionID, vif.ConnectionId)
 	d.Set("customer_address", vif.CustomerAddress)


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
Fix the type of the bgp_asn that cannot handle the documentation and API provided by AWS (int32 ins not enought)

### Relations

Closes #47658

### References

I did test the locally compiled provider on my project and it work with this code update.

### Output from Acceptance Testing

<img width="1021" height="176" alt="image" src="https://github.com/user-attachments/assets/449554a7-72d7-4e49-89fd-d0c5185b88c3" />