### PR TITLE
fix(issue-47575): rename fields in s3files file_systems model

### DIFF
--- a/.changelog/47664.txt
+++ b/.changelog/47664.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_s3files_file_systems: Rename fields in `fileSystemsDataSourceFileSystemModel` for automatic mapping during fwflex.Flatten.
+```

--- a/internal/service/s3files/file_systems_data_source.go
+++ b/internal/service/s3files/file_systems_data_source.go
@@ -114,10 +114,10 @@ type fileSystemsDataSourceModel struct {
 }
 
 type fileSystemsDataSourceFileSystemModel struct {
-	ARN           types.String      `tfsdk:"arn"`
+	FileSystemARN types.String      `tfsdk:"arn"`
 	Bucket        types.String      `tfsdk:"bucket"`
 	CreationTime  timetypes.RFC3339 `tfsdk:"creation_time"`
-	ID            types.String      `tfsdk:"id"`
+	FileSystemID  types.String      `tfsdk:"id"`
 	KmsKeyId      fwtypes.ARN       `tfsdk:"kms_key_id"`
 	Name          types.String      `tfsdk:"name"`
 	OwnerID       types.String      `tfsdk:"owner_id"`


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Rename the fields in `fileSystemsDataSourceFileSystemModel` so fwflex correctly maps fields from sdk response to internal fields.

### Relations

Closes #47575 

### References

- https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3Files_ListFileSystemsDescription.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccS3FilesFileSystemsDataSource_basic PKG=s3files
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws_s3files_file_systems-st47575 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/s3files/... -v -count 1 -parallel 20 -run='TestAccS3FilesFileSystemsDataSource_basic'  -timeout 360m -vet=off
2026/04/28 11:44:13 Creating Terraform AWS Provider (SDKv2-style)...
2026/04/28 11:44:13 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3FilesFileSystemsDataSource_basic
=== PAUSE TestAccS3FilesFileSystemsDataSource_basic
=== CONT  TestAccS3FilesFileSystemsDataSource_basic
--- PASS: TestAccS3FilesFileSystemsDataSource_basic (64.80s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3files    71.206s
...
```
