### PR TITLE
🤖🤖🤖 docs/cloudtrail: document identity-based import

### DIFF
--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -380,6 +380,27 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_cloudtrail.sample
+  identity = {
+    "arn" = "arn:aws:cloudtrail:us-east-1:123456789012:trail/my-sample-trail"
+  }
+}
+
+resource "aws_cloudtrail" "sample" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+- `arn` (String) ARN of the trail.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Cloudtrail Trails using the `arn`. For example:
 
 ```terraform


### PR DESCRIPTION
## Description

`aws_cloudtrail` carries the `@ArnIdentity` annotation (added in commit `863e411959e`, May 2025), so import via the modern Terraform v1.12+ `identity` block is supported. The registry docs only show the older `id = "<arn>"` form, which leaves the new path undiscoverable for users.

This PR mirrors the import section format used by `website/docs/r/acm_certificate.html.markdown` (the reference implementation called out in `docs/ai-agent-guides/arn-based-resource-identity.md`):

1. Lead with the `import { … identity = { "arn" = "…" } }` form for Terraform v1.12+.
2. Add an **Identity Schema** subsection.
3. Keep the existing v1.5+ `id = "<arn>"` and CLI `terraform import` examples for older Terraform versions.

No code changes; no changelog entry per `docs/changelog-process.md` (resource and provider documentation updates are excluded).

Closes #37179

## AI Disclosure

This PR was prepared with the assistance of an AI agent (Claude). The agent surveyed unclaimed `good first issue` items, verified that no existing PR was open, identified that `@ArnIdentity` was already wired into the resource and that only the docs were lagging, and produced the docs change. The change was reviewed and is being submitted by the human contributor.

## Test plan

- [x] `markdownlint-cli` (default repo config) — clean
- [x] `markdown-link-check` — all 10 links return 200
- [ ] CI \`make website\` runs the full lint suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)