### PR TITLE
🤖🤖🤖 ec2: clearer error when AMI is recently deregistered

### DIFF
--- a/.changelog/47675.txt
+++ b/.changelog/47675.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_instance: Return a clearer error when the configured `ami` cannot be found because it was recently deregistered, instead of the generic `empty result` message
+```

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -5,6 +5,7 @@ package ec2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"iter"
 	"slices"
@@ -4606,6 +4607,16 @@ func findImageByID(ctx context.Context, conn *ec2.Client, id string) (*awstypes.
 	}
 
 	output, err := findImage(ctx, conn, &input)
+
+	// DescribeImages returns an empty result for a short window after an AMI is
+	// deregistered before eventually returning InvalidAMIID.NotFound. Surface the
+	// AMI ID and the likely cause instead of the generic "empty result" message.
+	if errors.Is(err, tfresource.ErrEmptyResult) {
+		return nil, &retry.NotFoundError{
+			Message:   fmt.Sprintf("EC2 AMI (%s) not found, possibly because it was recently deregistered", id),
+			LastError: err,
+		}
+	}
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

Per the [`DescribeImages`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html) API reference: *"follows an eventual consistency model and returns empty results for deregistered images after a short interval"*, before eventually returning `InvalidAMIID.NotFound` once all referencing instances are terminated.

In that empty-result window, `findImageByID` was bubbling up `tfresource.ErrEmptyResult`, which surfaced to users as:

```
error collecting instance settings: empty result
```

with no hint that the AMI was the problem.

This PR maps the empty-result case in `findImageByID` to a `*retry.NotFoundError` whose message names the AMI ID and points at deregistration as the likely cause:

```
EC2 AMI (ami-0123456789abcdef0) not found, possibly because it was recently deregistered
```

The original error is preserved via `LastError`, so callers using `errors.Is`/`retry.NotFound` continue to work unchanged. Pattern mirrors existing usages of `errors.Is(err, tfresource.ErrEmptyResult)` in `internal/service/chimesdkvoice/global_settings.go` and `internal/service/sqs/queue_policy_list.go`.

Closes #26046

## AI Disclosure

This PR was prepared with the assistance of an AI agent (Claude). The agent traced the user-visible error message back through the call chain (`resourceInstanceCreate` → `buildInstanceOpts` → `findRootDeviceName` → `findImageByID` → `findImage` → `tfresource.AssertSingleValueResult`), cross-checked the AWS DescribeImages eventual-consistency behavior against AWS docs, verified that `tfresource.ErrEmptyResult` is the canonical sentinel used elsewhere in the repo, and produced the localized fix.

## Test plan

- [x] `gofmt -d internal/service/ec2/find.go` — clean
- [x] `go build ./internal/service/ec2/...` (Docker, golang:1.26)
- [x] `go vet ./internal/service/ec2/...`
- [x] `go test -short ./internal/service/ec2/...` — `ok 2.975s`
- [x] Test-target compile — `_test.go` files build clean
- [ ] CI runs the full unit + lint suite
- [ ] Reviewer to validate or run the relevant `TestAccEC2Instance_*` acceptance tests as needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)