### PR TITLE
🤖🤖🤖 r/aws_dsql_cluster: expose vpc_endpoint attribute

### DIFF
--- a/.changelog/47676.txt
+++ b/.changelog/47676.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dsql_cluster: Add `vpc_endpoint` attribute exposing the cluster's fully-qualified VPC connection endpoint
+```

--- a/internal/service/dsql/cluster.go
+++ b/internal/service/dsql/cluster.go
@@ -93,6 +93,12 @@ func (r *clusterResource) Schema(ctx context.Context, request resource.SchemaReq
 			},
 			names.AttrTags:    tftags.TagsAttribute(),
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+			"vpc_endpoint": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"vpc_endpoint_service_name": schema.StringAttribute{
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
@@ -181,7 +187,7 @@ func (r *clusterResource) Create(ctx context.Context, request resource.CreateReq
 		return
 	}
 
-	vpcEndpointServiceName, err := findVPCEndpointServiceNameByID(ctx, conn, id)
+	vpcEndpointServiceName, vpcEndpoint, err := findVPCEndpointServiceNameByID(ctx, conn, id)
 
 	if err != nil {
 		response.Diagnostics.AddError(fmt.Sprintf("reading Aurora DSQL Cluster (%s) VPC endpoint service name", id), err.Error())
@@ -190,6 +196,7 @@ func (r *clusterResource) Create(ctx context.Context, request resource.CreateReq
 	}
 
 	data.VPCEndpointServiceName = fwflex.StringToFramework(ctx, vpcEndpointServiceName)
+	data.VPCEndpoint = fwflex.StringToFramework(ctx, vpcEndpoint)
 
 	response.Diagnostics.Append(response.State.Set(ctx, data)...)
 }
@@ -235,7 +242,7 @@ func (r *clusterResource) Read(ctx context.Context, request resource.ReadRequest
 		}
 	}
 
-	vpcEndpointServiceName, err := findVPCEndpointServiceNameByID(ctx, conn, id)
+	vpcEndpointServiceName, vpcEndpoint, err := findVPCEndpointServiceNameByID(ctx, conn, id)
 
 	if err != nil {
 		response.Diagnostics.AddError(fmt.Sprintf("reading Aurora DSQL Cluster (%s) VPC endpoint service name", id), err.Error())
@@ -244,6 +251,7 @@ func (r *clusterResource) Read(ctx context.Context, request resource.ReadRequest
 	}
 
 	data.VPCEndpointServiceName = fwflex.StringToFramework(ctx, vpcEndpointServiceName)
+	data.VPCEndpoint = fwflex.StringToFramework(ctx, vpcEndpoint)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
@@ -390,27 +398,27 @@ func findClusterByID(ctx context.Context, conn *dsql.Client, id string) (*dsql.G
 	return output, nil
 }
 
-func findVPCEndpointServiceNameByID(ctx context.Context, conn *dsql.Client, id string) (*string, error) {
+func findVPCEndpointServiceNameByID(ctx context.Context, conn *dsql.Client, id string) (*string, *string, error) {
 	input := dsql.GetVpcEndpointServiceNameInput{
 		Identifier: aws.String(id),
 	}
 	output, err := conn.GetVpcEndpointServiceName(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
-		return nil, &retry.NotFoundError{
+		return nil, nil, &retry.NotFoundError{
 			LastError: err,
 		}
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if output == nil || output.ServiceName == nil {
-		return nil, tfresource.NewEmptyResultError()
+		return nil, nil, tfresource.NewEmptyResultError()
 	}
 
-	return output.ServiceName, nil
+	return output.ServiceName, output.ClusterVpcEndpoint, nil
 }
 
 func statusCluster(conn *dsql.Client, id string) retry.StateRefreshFunc {
@@ -556,6 +564,7 @@ type clusterResourceModel struct {
 	Tags                      tftags.Map                                                  `tfsdk:"tags"`
 	TagsAll                   tftags.Map                                                  `tfsdk:"tags_all"`
 	Timeouts                  timeouts.Value                                              `tfsdk:"timeouts"`
+	VPCEndpoint               types.String                                                `tfsdk:"vpc_endpoint"`
 	VPCEndpointServiceName    types.String                                                `tfsdk:"vpc_endpoint_service_name"`
 }
 

--- a/internal/service/dsql/cluster_test.go
+++ b/internal/service/dsql/cluster_test.go
@@ -60,6 +60,7 @@ func TestAccDSQLCluster_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrForceDestroy), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kms_encryption_key"), knownvalue.StringExact("AWS_OWNED_KMS_KEY")),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("vpc_endpoint"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("vpc_endpoint_service_name"), knownvalue.NotNull()),
 				},
 			},

--- a/website/docs/r/dsql_cluster.html.markdown
+++ b/website/docs/r/dsql_cluster.html.markdown
@@ -50,6 +50,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `multi_region_properties` - Multi-region properties of the DSQL Cluster.
     * `clusters` - List of DSQL Cluster ARNs peered to this cluster.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+* `vpc_endpoint` - The fully-qualified VPC connection endpoint for the cluster, in the form `<identifier>.<service-identifier>.<region>.on.aws`. Use this hostname when connecting to the cluster from a VPC over an AWS PrivateLink interface endpoint.
 * `vpc_endpoint_service_name` - The DSQL Cluster's VPC endpoint service name.
 
 ## Timeouts


### PR DESCRIPTION
## Description

The DSQL [`GetVpcEndpointServiceName`](https://docs.aws.amazon.com/aurora-dsql/latest/APIReference/API_GetVpcEndpointServiceName.html) API returns both `serviceName` and `clusterVpcEndpoint`. The latter is the fully-qualified hostname clients use to connect to a DSQL cluster over an AWS PrivateLink interface endpoint:

```
<cluster-id>.<service-identifier>.<region>.on.aws
```

The provider was only surfacing `ServiceName`, which forced users to hard-code the hostname or look it up out-of-band (CLI / Console) before they could wire the cluster into downstream Terraform resources such as `aws_route53_record`, SSM parameters, Kubernetes `Secret`s, or database connection configurations.

This PR adds a computed `vpc_endpoint` attribute populated from `ClusterVpcEndpoint`, alongside the existing `vpc_endpoint_service_name`:

- Schema: new computed `vpc_endpoint` with `UseStateForUnknown` plan modifier (matching `vpc_endpoint_service_name`).
- Model: new `VPCEndpoint` field.
- `findVPCEndpointServiceNameByID` returns both strings; `Create` and `Read` populate both attributes.
- `cluster_test.go`: extra `statecheck.ExpectKnownValue` line covering `vpc_endpoint` in `TestAccDSQLCluster_basic`.
- Registry docs: new bullet in the Attribute Reference section.

The SDK field is verified against `aws-sdk-go-v2/service/dsql@v1.12.9` (the version this repo pins): `GetVpcEndpointServiceNameOutput.ClusterVpcEndpoint *string`, documented as *"The VPC connection endpoint for the cluster."*. Cross-checked against the AWS API reference, the AWS SDK for Java, and Boto3.

Closes #47596

## AI Disclosure

This PR was prepared with the assistance of an AI agent (Claude). The agent inspected the SDK source via Docker (`golang:1.26` + the cached module cache), confirmed the field, traced the existing `findVPCEndpointServiceNameByID` plumbing, and produced the change. The change was reviewed and is being submitted by the human contributor.

## Test plan

- [x] `gofmt -d` — clean
- [x] `go build ./internal/service/dsql/...` (Docker, golang:1.26)
- [x] `go vet ./internal/service/dsql/...`
- [x] `go test -short ./internal/service/dsql/...` — `ok 0.731s`
- [x] Test-target compile — `_test.go` files build clean
- [x] `markdownlint-cli` on `dsql_cluster.html.markdown` — clean
- [ ] `make testacc PKG=dsql TESTS=TestAccDSQLCluster_basic` (requires AWS credentials; reviewer / CI to run)
- [ ] CI runs the full unit + lint suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)