### PR TITLE
🤖🤖🤖 service/grafana: send empty NetworkAccessConfiguration array fields instead of nil

### DIFF
--- a/.changelog/47680.txt
+++ b/.changelog/47680.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_grafana_workspace: Fix `apply` failing with `missing required field, UpdateWorkspaceInput.NetworkAccessControl.VpceIds` (or its `PrefixListIds` counterpart) when only one of the two `network_access_control` lists is non-empty
+```

--- a/internal/service/grafana/grafana_test.go
+++ b/internal/service/grafana/grafana_test.go
@@ -37,6 +37,7 @@ func TestAccGrafana_serial(t *testing.T) {
 			"vpc":                      testAccWorkspace_vpc,
 			"configuration":            testAccWorkspace_configuration,
 			"networkAccess":            testAccWorkspace_networkAccess,
+			"networkAccessOnlyOneSide": testAccWorkspace_networkAccessOnlyOneSide,
 			"version":                  testAccWorkspace_version,
 			"kmsKeyId":                 testAccWorkspace_kmsKeyID,
 			"dataSourceBasic":          testAccWorkspaceDataSource_basic,

--- a/internal/service/grafana/workspace.go
+++ b/internal/service/grafana/workspace.go
@@ -588,11 +588,15 @@ func expandNetworkAccessControl(tfList []any) *awstypes.NetworkAccessConfigurati
 	tfMap := tfList[0].(map[string]any)
 	apiObject := awstypes.NetworkAccessConfiguration{}
 
-	if v, ok := tfMap["prefix_list_ids"].(*schema.Set); ok && v.Len() > 0 {
+	// The NetworkAccessConfiguration API treats prefixListIds and vpceIds as
+	// required but accepts an empty array for either, so always populate both
+	// fields rather than leaving an empty user-supplied set as a nil slice
+	// (which the API rejects as missing).
+	if v, ok := tfMap["prefix_list_ids"].(*schema.Set); ok {
 		apiObject.PrefixListIds = flex.ExpandStringValueSet(v)
 	}
 
-	if v, ok := tfMap["vpce_ids"].(*schema.Set); ok && v.Len() > 0 {
+	if v, ok := tfMap["vpce_ids"].(*schema.Set); ok {
 		apiObject.VpceIds = flex.ExpandStringValueSet(v)
 	}
 

--- a/internal/service/grafana/workspace_test.go
+++ b/internal/service/grafana/workspace_test.go
@@ -503,6 +503,49 @@ func testAccWorkspace_networkAccess(t *testing.T) {
 	})
 }
 
+// testAccWorkspace_networkAccessOnlyOneSide is a regression test for #30062:
+// the AWS API treats prefixListIds and vpceIds as required but accepts an
+// empty array for either, so the provider must transmit an empty slice rather
+// than a nil slice when the user supplies only one of the two.
+func testAccWorkspace_networkAccessOnlyOneSide(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.WorkspaceDescription
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_grafana_workspace.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.GrafanaEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GrafanaServiceID),
+		CheckDestroy:             testAccCheckWorkspaceDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkspaceConfig_networkAccessOnlyPrefixList(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckWorkspaceExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "network_access_control.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_access_control.0.prefix_list_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_access_control.0.vpce_ids.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccWorkspaceConfig_networkAccessOnlyVPCE(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckWorkspaceExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "network_access_control.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_access_control.0.prefix_list_ids.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "network_access_control.0.vpce_ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccWorkspace_version(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v1, v2, v3 awstypes.WorkspaceDescription
@@ -831,6 +874,64 @@ resource "aws_grafana_workspace" "test" {
   name                     = %[1]q
   description              = %[1]q
   role_arn                 = aws_iam_role.test.arn
+}
+`, rName))
+}
+
+func testAccWorkspaceConfig_networkAccessOnlyPrefixList(rName string) string {
+	return acctest.ConfigCompose(testAccWorkspaceConfig_base(rName), fmt.Sprintf(`
+resource "aws_ec2_managed_prefix_list" "test" {
+  name           = %[1]q
+  address_family = "IPv4"
+  max_entries    = 5
+}
+
+resource "aws_grafana_workspace" "test" {
+  account_access_type      = "CURRENT_ACCOUNT"
+  authentication_providers = ["SAML"]
+  permission_type          = "SERVICE_MANAGED"
+  name                     = %[1]q
+  description              = %[1]q
+  role_arn                 = aws_iam_role.test.arn
+
+  network_access_control {
+    prefix_list_ids = [aws_ec2_managed_prefix_list.test.id]
+    vpce_ids        = []
+  }
+}
+`, rName))
+}
+
+func testAccWorkspaceConfig_networkAccessOnlyVPCE(rName string) string {
+	return acctest.ConfigCompose(testAccWorkspaceConfig_base(rName), acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  description = %[1]q
+  vpc_id      = aws_vpc.test.id
+}
+
+data "aws_region" "current" {}
+
+resource "aws_vpc_endpoint" "test" {
+  private_dns_enabled = false
+  security_group_ids  = [aws_security_group.test.id]
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.grafana-workspace"
+  subnet_ids          = aws_subnet.test[*].id
+  vpc_endpoint_type   = "Interface"
+  vpc_id              = aws_vpc.test.id
+}
+
+resource "aws_grafana_workspace" "test" {
+  account_access_type      = "CURRENT_ACCOUNT"
+  authentication_providers = ["SAML"]
+  permission_type          = "SERVICE_MANAGED"
+  name                     = %[1]q
+  description              = %[1]q
+  role_arn                 = aws_iam_role.test.arn
+
+  network_access_control {
+    prefix_list_ids = []
+    vpce_ids        = [aws_vpc_endpoint.test.id]
+  }
 }
 `, rName))
 }


### PR DESCRIPTION
## Summary

Fix [#30062](https://github.com/hashicorp/terraform-provider-aws/issues/30062): when only one of `network_access_control.prefix_list_ids` or `network_access_control.vpce_ids` is non-empty on `aws_grafana_workspace`, apply (and update) fail with:

```
Error: ... InvalidParameter: 1 validation error(s) found. - missing required field,
UpdateWorkspaceInput.NetworkAccessControl.VpceIds.
```

The AWS [`NetworkAccessConfiguration` API reference](https://docs.aws.amazon.com/grafana/latest/APIReference/API_NetworkAccessConfiguration.html) is explicit about this:

> While both `prefixListIds` and `vpceIds` are required, you can pass in an empty array of strings for either parameter if you do not want to allow any of that type.

`expandNetworkAccessControl` only assigned each field when the corresponding `*schema.Set` had `Len() > 0`, leaving the other as a nil slice. The SDK marshalled the nil slice as missing rather than `[]`, and the API rejected it.

The fix drops the `&& v.Len() > 0` guard for both fields so an empty user-supplied set is sent as `[]string{}`. The early-return when both are empty is preserved (so users can still detach the configuration by setting both to `[]`-removal styles via existing semantics — and the "removed" code path on update still works because it goes through the explicit `RemoveNetworkAccessConfiguration` flag).

This matches AWS Console, CLI, and SDK behavior, and resolves the issues observed by users in the comment thread on #30062 (both `prefix_list_ids = [] / vpce_ids = […]` and `prefix_list_ids = […] / vpce_ids = []` configurations).

## Relations

Closes #30062.

## Output from Acceptance Testing

A new regression test, `TestAccGrafanaWorkspace_serial/Workspace/networkAccessOnlyOneSide`, exercises both single-side configurations:

1. Create with `prefix_list_ids = [aws_ec2_managed_prefix_list.test.id]` and `vpce_ids = []`.
2. Import (round-trip).
3. Update to `prefix_list_ids = []` and `vpce_ids = [aws_vpc_endpoint.test.id]`.

I do not currently have an AWS account configured to run the live acceptance test in CI, so this PR relies on the project's regular acceptance test pass. Local verification covered:

- \`gofmt -l internal/service/grafana/\` — clean.
- \`go build ./internal/service/grafana/...\` — clean.
- \`go vet ./internal/service/grafana/...\` — clean.
- \`go test -tags=acctest -run=^\$ -count=1 ./internal/service/grafana/...\` — compiles and links cleanly with the new test.

## AI usage disclosure

Per docs/ai-usage.md: this PR was prepared by an LLM agent on my behalf (hence the 🤖🤖🤖). I cross-checked the API contract against the official \`NetworkAccessConfiguration\` reference page and confirmed the bug reproduction matches the symptoms reported in the issue thread, including the secondary report from @zvickery covering the symmetric case.