### PR TITLE
🤖🤖🤖 r/aws_cloudwatch_event_target: retry post-create read for EventBridge eventual consistency

### DIFF
--- a/.changelog/47688.txt
+++ b/.changelog/47688.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_event_target: Retry the post-create read to handle EventBridge `ListTargetsByRule` eventual consistency, fixing intermittent `empty result` errors on apply
+```

--- a/internal/service/events/target.go
+++ b/internal/service/events/target.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"math"
 	"strings"
+	"time"
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -531,6 +532,17 @@ func resourceTargetCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	d.SetId(id)
+
+	const (
+		timeout = 2 * time.Minute
+	)
+	_, err = tfresource.RetryWhenNotFound(ctx, timeout, func(ctx context.Context) (any, error) {
+		return findTargetByThreePartKey(ctx, conn, eventBusName, ruleName, targetID)
+	})
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for EventBridge Target (%s) create: %s", d.Id(), err)
+	}
 
 	return append(diags, resourceTargetRead(ctx, d, meta)...)
 }


### PR DESCRIPTION
### Description

Wraps the post-create read of `aws_cloudwatch_event_target` in `tfresource.RetryWhenNotFound` (2-minute timeout), mirroring the fix already applied to `aws_cloudwatch_event_rule` in `internal/service/events/rule.go` (lines 174-183, added by #25846 which closed #24376).

After `PutTargets` returns successfully (no `FailedEntries`), the immediately-following `ListTargetsByRule` call inside `resourceTargetRead` can intermittently return no matching target due to EventBridge's eventual consistency. The target *was* successfully created in AWS; the failure is purely in the post-create read, surfacing as:

```
Error: reading EventBridge Target (<rule>-<target_id>): empty result
```

This was reported in #47687 — same class of bug as #24376 for `aws_cloudwatch_event_rule`.

### How

The retry covers every not-found flavor that `findTargetByThreePartKey` produces:

- `findTargets` (target.go:657) already wraps `ValidationException`, `ResourceNotFoundException`, and the legacy ` not found$` message into `retry.NotFoundError`.
- `AssertSingleValueResult` returns an `*emptyResultError` (the source of the user-visible `empty result` error). That type implements `As(**retry.NotFoundError)` in `internal/tfresource/not_found_error.go` (lines 36-54), so `retry.NotFound(err)` matches it.

Therefore `tfresource.RetryWhenNotFound` retries on all of them, exactly as the rule-side fix does.

### Relations

Closes #47687.

Precedent: #24376 / #25846 (same fix on `aws_cloudwatch_event_rule`).

### References

* Bug report: #47687
* Prior precedent issue: #24376
* Prior precedent fix: #25846 (added retry-after-create in `rule.go`)

### Output from Acceptance Testing

Acceptance tests not added — #25846 did not add a retry-specific test for the equivalent rule-side fix either, and reproducing the eventual-consistency race deterministically is impractical without a mocked API. The change is a behaviour-preserving retry wrapper around an existing read; existing acceptance tests for `aws_cloudwatch_event_target` continue to exercise the same successful path.

`go build ./internal/service/events/...` and `go vet ./internal/service/events/...` pass locally.

### GenAI / LLM Assisted Development

Per the AI usage policy: this PR was prepared with Claude Code assistance — used to trace the code path, identify the precedent fix in #25846, and draft the patch. The author has independently verified:

- The code paths cited (rule.go:174-183, target.go:529-535, target.go:657, tfresource/not_found_error.go:36-54).
- That the patch builds and vets clean.
- That the fix mirrors the existing rule-side pattern with no scope expansion (only `resourceTargetCreate` is touched, matching #25846).

Author owns the change and can explain it on its own merits. The 🤖🤖🤖 marker is included in the PR title per the policy.
