### PR TITLE
resource/aws_ecs_express_gateway_service: Prevents error when `current_deployment` changes

### DIFF
--- a/.changelog/47694.txt
+++ b/.changelog/47694.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_ecs_express_gateway_service: Prevents errors when value of `current_deployment` changes.
+```
+
+```release-note:enhancement
+resource/aws_ecs_express_gateway_service: Deprecates `current_deployment`.
+```

--- a/internal/service/ecs/express_gateway_service.go
+++ b/internal/service/ecs/express_gateway_service.go
@@ -79,9 +79,6 @@ func (r *expressGatewayServiceResource) Schema(ctx context.Context, req resource
 			},
 			"current_deployment": schema.StringAttribute{
 				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			names.AttrExecutionRoleARN: schema.StringAttribute{
 				CustomType: fwtypes.ARNType,

--- a/internal/service/ecs/express_gateway_service.go
+++ b/internal/service/ecs/express_gateway_service.go
@@ -78,7 +78,8 @@ func (r *expressGatewayServiceResource) Schema(ctx context.Context, req resource
 				},
 			},
 			"current_deployment": schema.StringAttribute{
-				Computed: true,
+				Computed:           true,
+				DeprecationMessage: "This attribute will be removed in a future verion of the provider.",
 			},
 			names.AttrExecutionRoleARN: schema.StringAttribute{
 				CustomType: fwtypes.ARNType,

--- a/website/docs/r/ecs_express_gateway_service.html.markdown
+++ b/website/docs/r/ecs_express_gateway_service.html.markdown
@@ -171,7 +171,7 @@ The `scaling_target` configuration block supports the following:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `current_deployment` - ARN of the current deployment.
+* `current_deployment` - (**Deprecated**) ARN of the current deployment.
 * `ingress_paths` - List of ingress paths with access type and endpoint information.
 * `service_arn` - ARN of the Express Gateway Service.
 * `service_revision_arn` - ARN of the service revision.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

The attribute `current_deployment` reflects a value that is only returned by the AWS API when it is actively making a deployment. Typically this should not be the case whether `wait_for_steady_state` is `true` or `false`, but may happen due to timing of API calls.

The attribute `current_deployment` will now be purely-`Computed` so that changes will not cause an error. The attribute will be removed in a future version of the provider in Issue #47695

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47377
