### PR TITLE
r/aws_cloudfront_multitenant_distribution: add owner_account_id to vpc_origin_config

### DIFF
--- a/.changelog/47692.txt
+++ b/.changelog/47692.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudfront_multitenant_distribution: Add `owner_account_id` argument to `vpc_origin_config` for cross-account VPC origin support
+```

--- a/internal/service/cloudfront/multitenant_distribution.go
+++ b/internal/service/cloudfront/multitenant_distribution.go
@@ -514,6 +514,9 @@ func (r *multiTenantDistributionResource) Schema(ctx context.Context, request re
 										Computed: true,
 										Default:  int32default.StaticInt32(defaultOriginReadTimeout),
 									},
+									names.AttrOwnerAccountID: schema.StringAttribute{
+										Optional: true,
+									},
 									"vpc_origin_id": schema.StringAttribute{
 										Required: true,
 									},
@@ -1099,6 +1102,7 @@ type originShieldModel struct {
 type vpcOriginConfigModel struct {
 	OriginKeepaliveTimeout types.Int32  `tfsdk:"origin_keepalive_timeout"`
 	OriginReadTimeout      types.Int32  `tfsdk:"origin_read_timeout"`
+	OwnerAccountID         types.String `tfsdk:"owner_account_id"`
 	VpcOriginID            types.String `tfsdk:"vpc_origin_id"`
 }
 

--- a/website/docs/r/cloudfront_multitenant_distribution.html.markdown
+++ b/website/docs/r/cloudfront_multitenant_distribution.html.markdown
@@ -225,6 +225,7 @@ Cache behavior supports all the same arguments as [Default Cache Behavior](#defa
 
 * `origin_keepalive_timeout` - (Optional) Custom keep-alive timeout, in seconds. By default, CloudFront uses a default timeout. Default: 5.
 * `origin_read_timeout` - (Optional) Custom read timeout, in seconds. By default, CloudFront uses a default timeout. Default: 30.
+* `owner_account_id` - (Optional) The AWS account ID that owns the VPC origin. Required when referencing a VPC origin from a different AWS account for cross-account VPC origin access.
 * `vpc_origin_id` - (Required) ID of the VPC origin that you want CloudFront to route requests to.
 
 ### Custom Error Response


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. This adds support for an existing AWS CloudFront API field (`OwnerAccountId`) which identifies the owning account of a cross-account VPC origin shared via RAM. Authorization is enforced by AWS based on the RAM share, not by this provider.

### Description

Adds support for cross-account VPC origins on `aws_cloudfront_multitenant_distribution` by exposing the `OwnerAccountId` field on the `vpc_origin_config` block. Mirrors the change made to `aws_cloudfront_distribution` in #45021.

Without this argument, CloudFront's `UpdateDistribution` / `CreateDistribution` API resolves `vpc_origin_id` against the caller's account and returns `404 EntityNotFound` when the underlying VPC origin is owned by another account and shared in via RAM - even when the share is properly accepted on the consuming account.

The change is purely additive:

- `internal/service/cloudfront/multitenant_distribution.go` - adds `owner_account_id` (Optional) to the schema and the corresponding `OwnerAccountID` field on `vpcOriginConfigModel`. Autoflex handles expand/flatten.
- `website/docs/r/cloudfront_multitenant_distribution.html.markdown` - argument reference.
- `.changelog/47692.txt` - release-note:enhancement.

### Relations

Closes #47692

### References

- #45021 - sibling fix for `aws_cloudfront_distribution` (SDKv2). This PR brings the same capability to the plugin-framework-based `aws_cloudfront_multitenant_distribution`.

### Output from Acceptance Testing

🙏 **I need help with the tests.**
I attempted to add `TestAccCloudFrontMultiTenantDistribution_vpcOriginConfigOwnerAccountID` mirroring #45021's `TestAccCloudFrontDistribution_vpcOriginConfigOwnerAccountID` (using `data.aws_caller_identity.current.account_id` as a same-account stand-in). The test fails consistently with:

```
Error: Provider produced inconsistent result after apply
.origin: planned set element ... \"owner_account_id\":cty.StringVal(\"...\") ... does not correlate with any element in actual.
```

Debug analysis confirmed CloudFront's `GetDistribution` response **omits** `OwnerAccountId` for same-account VPC origins (it's only echoed back for true cross-account references). Autoflex flattens the absent field to `null`, the `origin` `SetNestedBlock` element identity hash changes, and plugin-framework's strict plan/apply consistency check fails. The SDKv2-based sibling resource accepts the same test pattern because SDKv2 TypeSet semantics are more lenient (see also the comment introduced in \`fdb530ab63f\`: \"This prevents TypeSet hash mismatches when the field is absent vs empty string\").

I have **not** included an acceptance test in this PR, since the only setup that genuinely exercises the field requires two AWS accounts. I'd appreciate maintainer guidance on the preferred test pattern here - happy to add one in a follow-up:

1. A cross-account fixture (would need test infra changes / second account)
2. A unit test on the schema/model only
3. A same-account test plus a small bit of provider-side logic (e.g. preserving the planned `OwnerAccountID` in Read after autoflex flatten) to keep state consistent

anual verification was performed by deploying the change against a real cross-account RAM-shared VPC origin: the `404 EntityNotFound` reproducer no longer occurs and the multi-tenant distribution attaches the cross-account origin successfully.