### PR TITLE
r/aws_savingsplans_savings_plan: prevent forced replacement on No Upfront plans

### DIFF
--- a/.changelog/47697.txt
+++ b/.changelog/47697.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_savingsplans_savings_plan: Prevent forced replacement on every apply for `No Upfront` plans by normalizing the AWS-returned `upfront_payment_amount` (`"0.00000000"`) to `null` in state
+```

--- a/internal/service/savingsplans/savings_plan.go
+++ b/internal/service/savingsplans/savings_plan.go
@@ -237,6 +237,13 @@ func (r *savingsPlanResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	// AWS returns "0.00000000" for upfront_payment_amount on No Upfront plans, but
+	// rejects that value on input. Normalize to null so subsequent plans don't
+	// detect drift and force replacement.
+	if savingsPlan.PaymentOption == awstypes.SavingsPlanPaymentOptionNoUpfront {
+		plan.UpfrontPaymentAmount = types.StringNull()
+	}
+
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, plan))
 }
 
@@ -266,6 +273,13 @@ func (r *savingsPlanResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 	state.SavingsPlanOfferingID = fwflex.StringToFramework(ctx, out.OfferingId)
+
+	// AWS returns "0.00000000" for upfront_payment_amount on No Upfront plans, but
+	// rejects that value on input. Normalize to null so subsequent plans don't
+	// detect drift and force replacement.
+	if out.PaymentOption == awstypes.SavingsPlanPaymentOptionNoUpfront {
+		state.UpfrontPaymentAmount = types.StringNull()
+	}
 
 	setTagsOut(ctx, out.Tags)
 


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

There are no changes to security controls (access controls, encryption, logging) in this pull request.

### Description

`aws_savingsplans_savings_plan` could not be applied idempotently when the underlying offering uses the **No Upfront** payment option. The AWS API behaves asymmetrically with respect to `upfront_payment_amount`:

- **Input:** `CreateSavingsPlan` rejects any `UpfrontPaymentAmount` value for No Upfront offerings:

  ```
  ValidationException: Upfront payment for No Upfront Savings Plans cannot be provided and automatically defaults to 0.
  ```

  So the user must omit the attribute (set it to `null`) in configuration.

- **Output:** `DescribeSavingsPlans` always returns `UpfrontPaymentAmount = "0.00000000"` for No Upfront plans.

The schema declares `upfront_payment_amount` as `Optional` with `RequiresReplace`. After a successful create with a `null` config, `flex.Flatten` writes `"0.00000000"` from the API response into state. On the next plan, Terraform sees `null` (config) ≠ `"0.00000000"` (state), and `RequiresReplace` triggers a forced replacement on every subsequent apply — putting users in a permanent drift loop. The same mismatch also produces a `Provider produced inconsistent result after apply` error during create (issue #46265).

#### Fix

In both `Create` and `Read`, after the standard flatten, normalize `UpfrontPaymentAmount` to `null` whenever the API-returned `PaymentOption` is `No Upfront`. This is a state-only normalization — no schema change, so no state migration is required, and no behavior change for All Upfront / Partial Upfront plans.

| Step | Before | After |
| --- | --- | --- |
| Create flatten (No Upfront, `null` config) | state = `"0.00000000"` (inconsistent-result error) | state = `null` |
| Read flatten | state = `"0.00000000"` | state = `null` |
| Subsequent plan | `null` vs `"0.00000000"` → forced replacement | `null` vs `null` → no-op |

### Relations

Closes #46265

Relates #46382 (related forced-replacement on import for All Upfront — different scenario, intentionally out of scope for this fix)

### References

- AWS SDK for Go v2 [`CreateSavingsPlanInput.UpfrontPaymentAmount`](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/savingsplans#CreateSavingsPlanInput) — *"This parameter is only supported if the payment option is Partial Upfront."*

### Output from Acceptance Testing

The existing acceptance test in `internal/service/savingsplans/savings_plan_test.go` is intentionally limited (with a placeholder offering ID and an `ExpectError` on `Offering ID not found`), because a real run of `TestAccSavingsPlansSavingsPlan_basic` purchases a real Savings Plan with an irrevocable financial commitment. For the same reason, this PR does not add a new acceptance test that creates a No Upfront plan.

The fix has been verified by inspection and by a clean build / vet:

```console
% go build ./internal/service/savingsplans/...
% go vet ./internal/service/savingsplans/...
% gofmt -l internal/service/savingsplans/savings_plan.go
(no output)
```

Manual verification (in the reporter's environment):

1. Apply with a No Upfront offering and `upfront_payment_amount` unset → plan created successfully.
2. Re-run `terraform plan` → no diff, no forced replacement.
3. Re-run `terraform apply` → no-op.

```console
% make testacc TESTS=TestAccSavingsPlansSavingsPlan_ PKG=savingsplans
# (skipped — see note above)
```