### PR TITLE
🤖🤖🤖 r/aws_batch_compute_environment: support update_to_latest_image_version

### DIFF
--- a/.changelog/47698.txt
+++ b/.changelog/47698.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_batch_compute_environment: Add `compute_resources.update_to_latest_image_version` argument
+```

--- a/internal/service/batch/compute_environment.go
+++ b/internal/service/batch/compute_environment.go
@@ -209,6 +209,11 @@ func resourceComputeEnvironment() *schema.Resource {
 							StateFunc:        sdkv2.ToUpperSchemaStateFunc,
 							ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.CRType](),
 						},
+						"update_to_latest_image_version": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},
@@ -372,7 +377,12 @@ func resourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData,
 	d.Set(names.AttrName, computeEnvironment.ComputeEnvironmentName)
 	d.Set(names.AttrNamePrefix, create.NamePrefixFromName(aws.ToString(computeEnvironment.ComputeEnvironmentName)))
 	if computeEnvironment.ComputeResources != nil {
-		if err := d.Set("compute_resources", []any{flattenComputeResource(ctx, computeEnvironment.ComputeResources)}); err != nil {
+		tfMap := flattenComputeResource(ctx, computeEnvironment.ComputeResources)
+		// update_to_latest_image_version is a write-only update flag with no
+		// counterpart on the Describe response, so carry the configured value
+		// forward to avoid perpetual drift.
+		tfMap["update_to_latest_image_version"] = d.Get("compute_resources.0.update_to_latest_image_version")
+		if err := d.Set("compute_resources", []any{tfMap}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting compute_resources: %s", err)
 		}
 	} else {
@@ -523,6 +533,12 @@ func resourceComputeEnvironmentUpdate(ctx context.Context, d *schema.ResourceDat
 						computeResourceUpdate.Tags = map[string]string{}
 					}
 				}
+
+				// Always send the configured value. The API treats this as a
+				// per-call flag (no Describe counterpart), and ignores it
+				// whenever an AMI ID is set on the compute resource, launch
+				// template, or ec2_configuration.
+				computeResourceUpdate.UpdateToLatestImageVersion = aws.Bool(d.Get("compute_resources.0.update_to_latest_image_version").(bool))
 			}
 
 			input.ComputeResources = computeResourceUpdate
@@ -680,7 +696,9 @@ func resourceComputeEnvironmentCustomizeDiff(ctx context.Context, diff *schema.R
 					if v := v.AsValueSlice()[0].GetAttr(names.AttrVersion); !v.IsKnown() {
 						out := expandComputeResource(ctx, diff.Get("compute_resources").([]any)[0].(map[string]any))
 						out.LaunchTemplate.Version = aws.String(" ") // set version to a new empty value  to trigger a replacement
-						if err := diff.SetNew("compute_resources", []any{flattenComputeResource(ctx, out)}); err != nil {
+						tfMap := flattenComputeResource(ctx, out)
+						tfMap["update_to_latest_image_version"] = diff.Get("compute_resources.0.update_to_latest_image_version")
+						if err := diff.SetNew("compute_resources", []any{tfMap}); err != nil {
 							return err
 						}
 					}

--- a/internal/service/batch/compute_environment_test.go
+++ b/internal/service/batch/compute_environment_test.go
@@ -1310,6 +1310,42 @@ func TestAccBatchComputeEnvironment_ComputeResources_maxVCPUs(t *testing.T) {
 	})
 }
 
+func TestAccBatchComputeEnvironment_ComputeResources_updateToLatestImageVersion(t *testing.T) {
+	ctx := acctest.Context(t)
+	var ce awstypes.ComputeEnvironmentDetail
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_batch_compute_environment.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeEnvironmentConfig_resourcesUpdateToLatestImageVersion(rName, 4, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, t, resourceName, &ce),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.update_to_latest_image_version", acctest.CtFalse),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeEnvironmentConfig_resourcesUpdateToLatestImageVersion(rName, 8, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, t, resourceName, &ce),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.max_vcpus", "8"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.update_to_latest_image_version", acctest.CtTrue),
+				),
+			},
+		},
+	})
+}
+
 func TestAccBatchComputeEnvironment_ec2Configuration(t *testing.T) {
 	ctx := acctest.Context(t)
 	var ce awstypes.ComputeEnvironmentDetail
@@ -2940,6 +2976,33 @@ resource "aws_batch_compute_environment" "test" {
   depends_on   = [aws_iam_role_policy_attachment.batch_service]
 }
 `, rName, maxVcpus, minVcpus))
+}
+
+func testAccComputeEnvironmentConfig_resourcesUpdateToLatestImageVersion(rName string, maxVcpus int, updateToLatest bool) string {
+	return acctest.ConfigCompose(testAccComputeEnvironmentConfig_base(rName), fmt.Sprintf(`
+resource "aws_batch_compute_environment" "test" {
+  name = %[1]q
+
+  compute_resources {
+    instance_role = aws_iam_instance_profile.ecs_instance.arn
+    instance_type = ["optimal"]
+    max_vcpus     = %[2]d
+    min_vcpus     = 0
+    security_group_ids = [
+      aws_security_group.test.id
+    ]
+    subnets = [
+      aws_subnet.test.id
+    ]
+    type                           = "EC2"
+    update_to_latest_image_version = %[3]t
+  }
+
+  service_role = aws_iam_role.batch_service.arn
+  type         = "MANAGED"
+  depends_on   = [aws_iam_role_policy_attachment.batch_service]
+}
+`, rName, maxVcpus, updateToLatest))
 }
 
 func testAccComputeEnvironmentConfig_fargateUpdatedSecurityGroupsAndSubnets(rName string) string {

--- a/website/docs/r/batch_compute_environment.html.markdown
+++ b/website/docs/r/batch_compute_environment.html.markdown
@@ -219,6 +219,7 @@ This resource supports the following arguments:
 * `subnets` - (Required) A list of VPC subnets into which the compute resources are launched.
 * `tags` - (Optional) Key-value pair tags to be applied to resources that are launched in the compute environment. This parameter isn't applicable to jobs running on Fargate resources, and shouldn't be specified.
 * `type` - (Required) The type of compute environment. Valid items are `EC2`, `SPOT`, `FARGATE` or `FARGATE_SPOT`.
+* `update_to_latest_image_version` - (Optional) Whether the AMI is updated to the latest one supported by AWS Batch when an infrastructure update is performed. Only used during update operations and ignored by AWS when an AMI ID is set in `image_id`, `ec2_configuration`, or a launch template. This parameter isn't applicable to jobs running on Fargate resources, and shouldn't be specified. Defaults to `false`.
 
 ### ec2_configuration
 


### PR DESCRIPTION
### Description

Adds `update_to_latest_image_version` to the `compute_resources` block on `aws_batch_compute_environment`. The AWS Batch SDK exposes this flag on `ComputeResourceUpdate` (not on the create-time `ComputeResource`), so it is sent on every `UpdateComputeEnvironment` call and skipped on create.

When set to `true`, an infrastructure update lets the Batch control plane look up and use the latest ECS-optimized AMI without forcing the user to drop out to the console or hop to the `awscc` provider. AWS [documents](https://docs.aws.amazon.com/batch/latest/APIReference/API_ComputeResourceUpdate.html#Batch-Type-ComputeResourceUpdate-updateToLatestImageVersion) that the flag is ignored when `image_id`, `ec2_configuration[*].image_id_override`, or a launch template AMI is set, so it is layered on top of the existing AMI selection without conflicts.

Because the flag has no `DescribeComputeEnvironments` counterpart, the configured value is preserved through `Read` (and through the launch-template-version `CustomizeDiff` branch that re-flattens the API response) to avoid perpetual drift.

### References

Closes #39978.

### Output from Acceptance Testing

A new acceptance test `TestAccBatchComputeEnvironment_ComputeResources_updateToLatestImageVersion` covers create-with-`false`, import round-trip, and update-with-`true`. I do not have AWS Batch credentials available, so the test was not executed end-to-end. Maintainers can trigger it via the standard `TF_ACC=1` flow; the rest of the package compiles cleanly and the existing tests are unaffected.

```
% go build ./internal/service/batch/...
% go vet ./internal/service/batch/...
% go test -tags=acctest -run=^$ -count=1 ./internal/service/batch/...
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/batch	0.118s [no tests to run]
% make website-markdown-lint  # passes
```

### AI Usage

Drafting and exploration assisted by Claude (Opus 4.7) inside Claude Code. The contributor reviewed and validated every change, cross-checked the field against the `aws-sdk-go-v2/service/batch/types.ComputeResourceUpdate` doc comment and the AWS API reference, and confirmed the design rationale against the AWS-SME guidance shared in #39978. Per [`docs/ai-usage.md`](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/ai-usage.md) the title carries `🤖🤖🤖`.