### PR TITLE
resource/aws_flow_log: Converts `log_group_name` to `log_destination` when importing

### DIFF
--- a/.changelog/47699.txt
+++ b/.changelog/47699.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_flow_log: Prevents error when updating from earlier versions of the provider or importing VPC Flow Logs
+```

--- a/internal/service/ec2/vpc_flow_log.go
+++ b/internal/service/ec2/vpc_flow_log.go
@@ -297,7 +297,12 @@ func resourceLogFlowRead(ctx context.Context, d *schema.ResourceData, meta any) 
 		d.Set("destination_options", nil)
 	}
 	d.Set(names.AttrIAMRoleARN, fl.DeliverLogsPermissionArn)
-	d.Set("log_destination", fl.LogDestination)
+	if fl.LogDestinationType == awstypes.LogDestinationTypeCloudWatchLogs && fl.LogDestination == nil {
+		// Legacy usage of LogGroupName. Either importing or migrating from old version of the proivder
+		d.Set("log_destination", cloudwatchLogGroupARNFromName(ctx, c, aws.ToString(fl.LogGroupName)))
+	} else {
+		d.Set("log_destination", fl.LogDestination)
+	}
 	d.Set("log_destination_type", fl.LogDestinationType)
 	d.Set("log_format", fl.LogFormat)
 	d.Set("max_aggregation_interval", fl.MaxAggregationInterval)
@@ -399,4 +404,8 @@ func flattenDestinationOptionsResponse(apiObject *awstypes.DestinationOptionsRes
 
 func flowLogARN(ctx context.Context, c *conns.AWSClient, flowLogID string) string {
 	return c.RegionalARN(ctx, names.EC2, "vpc-flow-log/"+flowLogID)
+}
+
+func cloudwatchLogGroupARNFromName(ctx context.Context, c *conns.AWSClient, logGroupName string) string {
+	return c.RegionalARN(ctx, names.Logs, "log-group:"+logGroupName)
 }

--- a/internal/service/ec2/vpc_flow_log.go
+++ b/internal/service/ec2/vpc_flow_log.go
@@ -406,6 +406,10 @@ func flowLogARN(ctx context.Context, c *conns.AWSClient, flowLogID string) strin
 	return c.RegionalARN(ctx, names.EC2, "vpc-flow-log/"+flowLogID)
 }
 
-func cloudwatchLogGroupARNFromName(ctx context.Context, c *conns.AWSClient, logGroupName string) string {
+func cloudwatchLogGroupARNFromName(ctx context.Context, c regionalARNMaker, logGroupName string) string {
 	return c.RegionalARN(ctx, names.Logs, "log-group:"+logGroupName)
+}
+
+type regionalARNMaker interface {
+	RegionalARN(ctx context.Context, service, resource string) string
 }

--- a/internal/service/ec2/vpc_flow_log_migrate.go
+++ b/internal/service/ec2/vpc_flow_log_migrate.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -117,11 +118,17 @@ func flowLogSchemaV0() *schema.Resource {
 	}
 }
 
-func flowLogStateUpgradeV0(_ context.Context, rawState map[string]any, meta any) (map[string]any, error) {
+func flowLogStateUpgradeV0(ctx context.Context, rawState map[string]any, meta any) (map[string]any, error) {
 	if rawState == nil {
 		rawState = map[string]any{}
 	}
 
+	name, ok := rawState[names.AttrLogGroupName]
+	if ok && name != "" {
+		c := meta.(*conns.AWSClient)
+
+		rawState["log_destination"] = cloudwatchLogGroupARNFromName(ctx, c, name.(string))
+	}
 	delete(rawState, names.AttrLogGroupName)
 
 	return rawState, nil

--- a/internal/service/ec2/vpc_flow_log_migrate.go
+++ b/internal/service/ec2/vpc_flow_log_migrate.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -125,7 +124,7 @@ func flowLogStateUpgradeV0(ctx context.Context, rawState map[string]any, meta an
 
 	name, ok := rawState[names.AttrLogGroupName]
 	if ok && name != "" {
-		c := meta.(*conns.AWSClient)
+		c := meta.(regionalARNMaker)
 
 		rawState["log_destination"] = cloudwatchLogGroupARNFromName(ctx, c, name.(string))
 	}

--- a/internal/service/ec2/vpc_flow_log_migrate_test.go
+++ b/internal/service/ec2/vpc_flow_log_migrate_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )

--- a/internal/service/ec2/vpc_flow_log_migrate_test.go
+++ b/internal/service/ec2/vpc_flow_log_migrate_test.go
@@ -4,9 +4,11 @@
 package ec2_test
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/google/go-cmp/cmp"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -41,6 +43,7 @@ func TestFlowLogStateUpgradeV0(t *testing.T) {
 				names.AttrSubnetID:     "sn-12345678",
 			},
 			expected: map[string]any{
+				"log_destination":  "arn:aws:logs:us-east-1:123456789012:log-group:log-group-name",
 				names.AttrSubnetID: "sn-12345678",
 			},
 		},
@@ -50,7 +53,12 @@ func TestFlowLogStateUpgradeV0(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := tfec2.FlowLogStateUpgradeV0(t.Context(), tt.rawState, nil)
+			client := mockClient{
+				region:    "us-east-1",
+				accountID: acctest.Ct12Digit,
+			}
+
+			result, err := tfec2.FlowLogStateUpgradeV0(t.Context(), tt.rawState, client)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -92,7 +100,12 @@ func TestFlowLogStateUpgradeV0_complexState(t *testing.T) {
 		t.Fatalf("failed to unmarshal state JSON: %v", err)
 	}
 
-	result, err := tfec2.FlowLogStateUpgradeV0(t.Context(), rawState, nil)
+	client := mockClient{
+		region:    "us-east-1",
+		accountID: acctest.Ct12Digit,
+	}
+
+	result, err := tfec2.FlowLogStateUpgradeV0(t.Context(), rawState, client)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -104,4 +117,19 @@ func TestFlowLogStateUpgradeV0_complexState(t *testing.T) {
 	if result["log_destination"] != "arn:aws:logs:us-east-1:123456789012:log-group:/my/log-group" {
 		t.Errorf("expected log_destination to be preserved, got: %v", result["log_destination"])
 	}
+}
+
+type mockClient struct {
+	region    string
+	accountID string
+}
+
+func (m mockClient) RegionalARN(ctx context.Context, service, resource string) string {
+	return arn.ARN{
+		Partition: names.PartitionForRegion(m.region).ID(),
+		Service:   service,
+		Region:    m.region,
+		AccountID: m.accountID,
+		Resource:  resource,
+	}.String()
 }

--- a/internal/service/ec2/vpc_flow_log_migrate_test.go
+++ b/internal/service/ec2/vpc_flow_log_migrate_test.go
@@ -44,6 +44,7 @@ func TestFlowLogStateUpgradeV0(t *testing.T) {
 				names.AttrSubnetID:     "sn-12345678",
 			},
 			expected: map[string]any{
+				//lintignore:AWSAT003,AWSAT005
 				"log_destination":  "arn:aws:logs:us-east-1:123456789012:log-group:log-group-name",
 				names.AttrSubnetID: "sn-12345678",
 			},
@@ -55,7 +56,7 @@ func TestFlowLogStateUpgradeV0(t *testing.T) {
 			t.Parallel()
 
 			client := mockClient{
-				region:    "us-east-1",
+				region:    "us-east-1", //lintignore:AWSAT003
 				accountID: acctest.Ct12Digit,
 			}
 
@@ -102,7 +103,7 @@ func TestFlowLogStateUpgradeV0_complexState(t *testing.T) {
 	}
 
 	client := mockClient{
-		region:    "us-east-1",
+		region:    "us-east-1", //lintignore:AWSAT003
 		accountID: acctest.Ct12Digit,
 	}
 

--- a/internal/service/ec2/vpc_flow_log_test.go
+++ b/internal/service/ec2/vpc_flow_log_test.go
@@ -1608,9 +1608,9 @@ data "aws_partition" "current" {}
 func testAccVPCFlowLogConfig_upgradeFromV5LogGroupName_current(rName string) string {
 	return acctest.ConfigCompose(testAccFlowLogConfig_base(rName), fmt.Sprintf(`
 resource "aws_flow_log" "test" {
-  iam_role_arn   = aws_iam_role.test.arn
-  traffic_type   = "ALL"
-  vpc_id         = aws_vpc.test.id
+  iam_role_arn = aws_iam_role.test.arn
+  traffic_type = "ALL"
+  vpc_id       = aws_vpc.test.id
 
   log_destination      = aws_cloudwatch_log_group.test.arn
   log_destination_type = "cloud-watch-logs"

--- a/internal/service/ec2/vpc_flow_log_test.go
+++ b/internal/service/ec2/vpc_flow_log_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/YakDriver/regexache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -17,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
 	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
@@ -604,7 +606,7 @@ func TestAccVPCFlowLog_disappears(t *testing.T) {
 	})
 }
 
-func TestAccVPCFlowLog_upgradeFromV5(t *testing.T) {
+func TestAccVPCFlowLog_UpgradeFromV5_logDestination(t *testing.T) {
 	ctx := acctest.Context(t)
 	var flowLog awstypes.FlowLog
 	resourceName := "aws_flow_log.test"
@@ -632,7 +634,8 @@ func TestAccVPCFlowLog_upgradeFromV5(t *testing.T) {
 					},
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrLogGroupName), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrLogGroupName), knownvalue.StringExact(rName)),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New("log_destination"), "aws_cloudwatch_log_group.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
 				},
 			},
 			{
@@ -651,13 +654,14 @@ func TestAccVPCFlowLog_upgradeFromV5(t *testing.T) {
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoValue(resourceName, tfjsonpath.New(names.AttrLogGroupName)),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New("log_destination"), "aws_cloudwatch_log_group.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
 				},
 			},
 		},
 	})
 }
 
-func TestAccVPCFlowLog_upgradeFromV5PlanRefreshFalse(t *testing.T) {
+func TestAccVPCFlowLog_UpgradeFromV5_planRefreshFalse(t *testing.T) {
 	ctx := acctest.Context(t)
 	var flowLog awstypes.FlowLog
 	resourceName := "aws_flow_log.test"
@@ -711,6 +715,64 @@ func TestAccVPCFlowLog_upgradeFromV5PlanRefreshFalse(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					tfstatecheck.ExpectNoValue(resourceName, tfjsonpath.New(names.AttrLogGroupName)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccVPCFlowLog_UpgradeFromV5_logGroupName(t *testing.T) {
+	ctx := acctest.Context(t)
+	var flowLog awstypes.FlowLog
+	resourceName := "aws_flow_log.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
+		CheckDestroy: testAccCheckFlowLogDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.100.0",
+					},
+				},
+				Config: testAccVPCFlowLogConfig_upgradeFromV5LogGroupName_v5(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFlowLogExists(ctx, t, resourceName, &flowLog),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrLogGroupName), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("log_destination"), knownvalue.StringExact("")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("log_destination_type"), tfknownvalue.StringExact(awstypes.LogDestinationTypeCloudWatchLogs)),
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccVPCFlowLogConfig_upgradeFromV5LogGroupName_current(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFlowLogExists(ctx, t, resourceName, &flowLog),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoValue(resourceName, tfjsonpath.New(names.AttrLogGroupName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("log_destination"), tfknownvalue.RegionalARNExact("logs", "log-group:"+rName)),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New("log_destination"), "aws_cloudwatch_log_group.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("log_destination_type"), tfknownvalue.StringExact(awstypes.LogDestinationTypeCloudWatchLogs)),
 				},
 			},
 		},
@@ -1499,5 +1561,88 @@ resource "aws_iam_role_policy" "test" {
 }
 EOF
 }
+`, rName))
+}
+
+func testAccVPCFlowLogConfig_upgradeFromV5LogGroupName_v5(rName string) string {
+	return acctest.ConfigCompose(testAccFlowLogConfig_base(rName), fmt.Sprintf(`
+resource "aws_flow_log" "test" {
+  iam_role_arn = aws_iam_role.test.arn
+  traffic_type = "ALL"
+  vpc_id       = aws_vpc.test.id
+
+  log_group_name = aws_cloudwatch_log_group.test.name
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.${data.aws_partition.current.dns_suffix}"
+        ]
+      },
+      "Action": [
+        "sts:AssumeRole"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_log_group" "test" {
+  name = %[1]q
+}
+
+data "aws_partition" "current" {}
+`, rName))
+}
+
+func testAccVPCFlowLogConfig_upgradeFromV5LogGroupName_current(rName string) string {
+	return acctest.ConfigCompose(testAccFlowLogConfig_base(rName), fmt.Sprintf(`
+resource "aws_flow_log" "test" {
+  iam_role_arn   = aws_iam_role.test.arn
+  traffic_type   = "ALL"
+  vpc_id         = aws_vpc.test.id
+
+  log_destination      = aws_cloudwatch_log_group.test.arn
+  log_destination_type = "cloud-watch-logs"
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.${data.aws_partition.current.dns_suffix}"
+        ]
+      },
+      "Action": [
+        "sts:AssumeRole"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_log_group" "test" {
+  name = %[1]q
+}
+
+data "aws_partition" "current" {}
 `, rName))
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

VPC Flow Logs created by setting Log Group Name instead of Log Destination cause recreation. This could be caused by importing an existing VPC Flow Log or migrating an existing `aws_flow_log` from v5.x to v6.x

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #45770


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ec2 TESTS=TestAccVPCFlowLog_

--- PASS: TestAccVPCFlowLog_LogDestinationTypeS3_invalid (52.10s)
--- PASS: TestAccVPCFlowLog_disappears (98.18s)
--- PASS: TestAccVPCFlowLog_LogDestinationTypeS3DO_plainText (111.12s)
--- PASS: TestAccVPCFlowLog_LogDestinationTypeS3DOParquetHiveCompatible_perHour (111.13s)
--- PASS: TestAccVPCFlowLog_LogDestinationType_s3 (111.14s)
--- PASS: TestAccVPCFlowLog_LogDestinationTypeS3DOParquet_hiveCompatible (111.36s)
--- PASS: TestAccVPCFlowLog_LogDestinationType_maxAggregationInterval (111.40s)
--- PASS: TestAccVPCFlowLog_LogDestinationTypeS3DOPlainText_hiveCompatible (111.40s)
--- PASS: TestAccVPCFlowLog_basic (111.68s)
--- PASS: TestAccVPCFlowLog_subnetID (111.68s)
--- PASS: TestAccVPCFlowLog_logFormat (114.27s)
--- PASS: TestAccVPCFlowLog_LogDestinationTypeS3DO_parquet (74.31s)
--- PASS: TestAccVPCFlowLog_UpgradeFromV5_logDestination (131.53s)
--- PASS: TestAccVPCFlowLog_UpgradeFromV5_logGroupName (131.53s)
--- PASS: TestAccVPCFlowLog_UpgradeFromV5_planRefreshFalse (132.77s)
--- PASS: TestAccVPCFlowLog_LogDestinationType_cloudWatchLogs (137.28s)
--- PASS: TestAccVPCFlowLog_tags (148.71s)
--- PASS: TestAccVPCFlowLog_LogDestinationType_kinesisFirehose (157.01s)
--- PASS: TestAccVPCFlowLog_regionalNATGatewayID (244.89s)
--- PASS: TestAccVPCFlowLog_transitGatewayID (249.22s)
--- PASS: TestAccVPCFlowLog_transitGatewayAttachmentID (389.61s)
```
