### PR TITLE
resource/aws_ecs_express_gateway_service: Adds test for creating new ECS Express-Mode Service after deletion

### DIFF
--- a/internal/service/ecs/express_gateway_service_test.go
+++ b/internal/service/ecs/express_gateway_service_test.go
@@ -470,6 +470,52 @@ func TestAccECSExpressGatewayService_environmentVariableOrdering(t *testing.T) {
 	})
 }
 
+func TestAccECSExpressGatewayService_recreateAfterDeleting(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var service1, service2 awstypes.ECSExpressGatewayService
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ecs_express_gateway_service.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ECSEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExpressGatewayServiceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: Initial creation
+			{
+				Config: testAccExpressGatewayServiceConfig_basic(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExpressGatewayServiceExists(ctx, t, resourceName, &service1),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.image", "public.ecr.aws/nginx/nginx:1.28-alpine3.21-slim"),
+				),
+			},
+			// Step 2: Remove Service
+			{
+				Config: testAccExpressGatewayServiceConfig_base(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExpressGatewayServiceNotInState(ctx, t, resourceName),
+				),
+			},
+			// Step 3: Re-Create Service with same name
+			{
+				Config: testAccExpressGatewayServiceConfig_basic(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExpressGatewayServiceExists(ctx, t, resourceName, &service2),
+					resource.TestCheckResourceAttr(resourceName, "primary_container.0.image", "public.ecr.aws/nginx/nginx:1.28-alpine3.21-slim"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckExpressGatewayServiceDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).ECSClient(ctx)
@@ -516,6 +562,17 @@ func testAccCheckExpressGatewayServiceExists(ctx context.Context, t *testing.T, 
 		}
 
 		*v = *output
+
+		return nil
+	}
+}
+
+func testAccCheckExpressGatewayServiceNotInState(_ context.Context, _ *testing.T, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if ok {
+			return fmt.Errorf("ECS Express Gateway Service %q found", rs.Primary.Attributes["service_arn"])
+		}
 
 		return nil
 	}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Adds test to confirm that an ECS Express-Mode Service can be created after one with the same name was deleted. This was likely addressed in #47568

Closes #47438

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ecs TESTS=TestAccECSExpressGatewayService_recreateAfterDeleting

--- PASS: TestAccECSExpressGatewayService_recreateAfterDeleting (238.44s)
```
