### PR TITLE
r/aws_elasticache_user: store `user_id` in lowercase in state + r/aws_elasticache_user_group: store `user_group_id` in lowercase in state

### DIFF
--- a/.changelog/47705.txt
+++ b/.changelog/47705.txt
@@ -1,0 +1,6 @@
+```release-note:bug-fix
+resource/aws_elasticache_user: Fix `user_id` producing inconsistent final plan when using mixed-case values
+```
+```release-note:bug-fix
+resource/aws_elasticache_user_group: Fix `user_group_id` producing inconsistent final plan when using mixed-case values
+```

--- a/.changelog/47705.txt
+++ b/.changelog/47705.txt
@@ -1,6 +1,6 @@
-```release-note:bug-fix
+```release-note:bug
 resource/aws_elasticache_user: Fix `user_id` producing inconsistent final plan when using mixed-case values
 ```
-```release-note:bug-fix
+```release-note:bug
 resource/aws_elasticache_user_group: Fix `user_group_id` producing inconsistent final plan when using mixed-case values
 ```

--- a/internal/service/elasticache/user.go
+++ b/internal/service/elasticache/user.go
@@ -130,9 +130,10 @@ func resourceUser() *schema.Resource {
 				names.AttrTags:    tftags.TagsSchema(),
 				names.AttrTagsAll: tftags.TagsSchemaComputed(),
 				"user_id": {
-					Type:     schema.TypeString,
-					Required: true,
-					ForceNew: true,
+					Type:      schema.TypeString,
+					Required:  true,
+					ForceNew:  true,
+					StateFunc: sdkv2.ToLowerSchemaStateFunc,
 				},
 				names.AttrUserName: {
 					Type:     schema.TypeString,

--- a/internal/service/elasticache/user.go
+++ b/internal/service/elasticache/user.go
@@ -8,6 +8,7 @@ package elasticache
 import (
 	"context"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"

--- a/internal/service/elasticache/user.go
+++ b/internal/service/elasticache/user.go
@@ -8,7 +8,6 @@ package elasticache
 import (
 	"context"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"

--- a/internal/service/elasticache/user_group.go
+++ b/internal/service/elasticache/user_group.go
@@ -60,9 +60,10 @@ func resourceUserGroup() *schema.Resource {
 				names.AttrTags:    tftags.TagsSchema(),
 				names.AttrTagsAll: tftags.TagsSchemaComputed(),
 				"user_group_id": {
-					Type:     schema.TypeString,
-					Required: true,
-					ForceNew: true,
+					Type:      schema.TypeString,
+					Required:  true,
+					ForceNew:  true,
+					StateFunc: sdkv2.ToLowerSchemaStateFunc,
 				},
 				"user_ids": {
 					Type:     schema.TypeSet,

--- a/internal/service/elasticache/user_group.go
+++ b/internal/service/elasticache/user_group.go
@@ -8,6 +8,7 @@ package elasticache
 import (
 	"context"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"

--- a/internal/service/elasticache/user_group.go
+++ b/internal/service/elasticache/user_group.go
@@ -8,7 +8,6 @@ package elasticache
 import (
 	"context"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"

--- a/internal/service/elasticache/user_group_test.go
+++ b/internal/service/elasticache/user_group_test.go
@@ -6,6 +6,7 @@ package elasticache_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
@@ -38,6 +39,40 @@ func TestAccElastiCacheUserGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheUserGroup_mixedCase(t *testing.T) {
+	ctx := acctest.Context(t)
+	var userGroup awstypes.UserGroup
+	rName := acctest.RandomWithPrefix(t, "Tf-Acc")
+	resourceName := "aws_elasticache_user_group.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserGroupDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserGroupConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserGroupExists(ctx, t, resourceName, &userGroup),
+					resource.TestCheckResourceAttr(resourceName, "user_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_group_id", strings.ToLower(rName)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,

--- a/internal/service/elasticache/user_test.go
+++ b/internal/service/elasticache/user_test.go
@@ -6,6 +6,7 @@ package elasticache_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -41,6 +42,43 @@ func TestAccElastiCacheUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrUserName, "username1"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"no_password_required",
+					"passwords",
+				},
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheUser_mixedCase(t *testing.T) {
+	ctx := acctest.Context(t)
+	var user awstypes.User
+	rName := acctest.RandomWithPrefix(t, "Tf-Acc")
+	resourceName := "aws_elasticache_user.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, t, resourceName, &user),
+					resource.TestCheckResourceAttr(resourceName, "user_id", strings.ToLower(rName)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,


### PR DESCRIPTION
## Community Note

- Please vote on this issue by adding a 👍 reaction to the original issue to help the community and maintainers prioritize this request.
- Please do not leave "+1" or other comments that do not add relevant new information or questions.

## Description

The ElastiCache API stores `user_id` and `user_group_id` as lowercase strings ([documented behavior](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/elasticache/create-user.html): "This parameter is stored as a lowercase string"). When users specify camelCase or mixed-case values (e.g. `testUserId`), the API silently lowercases them. This causes Terraform to report "Provider produced inconsistent final plan" because the planned value (`testUserId`) differs from what the API returns (`testuserid`).

This also causes downstream `aws_elasticache_user_group` failures where `user_ids` set elements don't correlate with actual values.

## Changes

Added `StateFunc` to normalize values to lowercase at plan time in:
- `user_id` field on `aws_elasticache_user` (`user.go`)
- `user_group_id` field on `aws_elasticache_user_group` (`user_group.go`)

This ensures the planned state matches the API response, preventing the inconsistent plan error.

## How to reproduce the original bug

```hcl
resource "aws_elasticache_user" "test" {
  user_id       = "testUserId"
  user_name     = "testUserName"
  access_string = "on ~* +@all"
  engine        = "valkey"
  passwords     = ["password123456789"]
}

resource "aws_elasticache_user_group" "test" {
  engine        = "valkey"
  user_group_id = "userGroupId"
  user_ids      = [aws_elasticache_user.test.user_id]
}
```

Apply produces: `Provider produced inconsistent final plan ... planned set element cty.StringVal("testUserId") does not correlate with any element in actual.`
