### PR TITLE
Technical debt: Replace references to `nodejs20.x` lambda runtime -- OpenCode version

### DIFF
--- a/examples/api-gateway-websocket-chat-app/main.tf
+++ b/examples/api-gateway-websocket-chat-app/main.tf
@@ -178,7 +178,7 @@ resource "aws_lambda_function" "OnConnectFunction" {
   function_name = "OnConnectFunction"
   role          = aws_iam_role.OnConnectRole.arn
   handler       = "app.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   memory_size   = 256
 
   environment {
@@ -262,7 +262,7 @@ resource "aws_lambda_function" "OnDisconnectFunction" {
   function_name = "OnDisconnectFunction"
   role          = aws_iam_role.OnDisconnectRole.arn
   handler       = "app.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   memory_size   = 256
 
   environment {
@@ -346,7 +346,7 @@ resource "aws_lambda_function" "SendMessageFunction" {
   function_name = "SendMessageFunction"
   role          = aws_iam_role.SendMessageRole.arn
   handler       = "app.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   memory_size   = 256
 
   environment {

--- a/examples/cognito-user-pool/main.tf
+++ b/examples/cognito-user-pool/main.tf
@@ -34,7 +34,7 @@ resource "aws_lambda_function" "main" {
   function_name = "terraform-example"
   role          = aws_iam_role.main.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role" "cidp" {

--- a/examples/ivschat/main.tf
+++ b/examples/ivschat/main.tf
@@ -38,7 +38,7 @@ resource "aws_lambda_function" "example" {
   function_name    = "tf-ivschat-message-handler"
   role             = aws_iam_role.example.arn
   source_code_hash = data.archive_file.message_review_handler.output_base64sha256
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   handler          = "index.handler"
 }
 

--- a/internal/service/apigateway/authorizer_test.go
+++ b/internal/service/apigateway/authorizer_test.go
@@ -446,7 +446,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.lambda.arn
   handler          = "exports.example"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
 }
 `, rName)
 }

--- a/internal/service/apigateway/deployment_test.go
+++ b/internal/service/apigateway/deployment_test.go
@@ -572,7 +572,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, rName))
 }

--- a/internal/service/apigateway/method_test.go
+++ b/internal/service/apigateway/method_test.go
@@ -375,7 +375,7 @@ resource "aws_lambda_function" "authorizer" {
   function_name    = %[1]q
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "exports.example"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
 }
 
 resource "aws_api_gateway_authorizer" "test" {

--- a/internal/service/apigatewayv2/authorizer_test.go
+++ b/internal/service/apigatewayv2/authorizer_test.go
@@ -441,7 +441,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/apigatewayv2/integration_test.go
+++ b/internal/service/apigatewayv2/integration_test.go
@@ -725,7 +725,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   depends_on = [aws_iam_role_policy.test]
 }

--- a/internal/service/appconfig/configuration_profile_test.go
+++ b/internal/service/appconfig/configuration_profile_test.go
@@ -466,7 +466,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, rName)
 }

--- a/internal/service/appsync/api_test.go
+++ b/internal/service/appsync/api_test.go
@@ -338,7 +338,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.lambda.arn
   handler          = "index.handler"
-  runtime          = "nodejs18.x"
+  runtime          = "nodejs22.x"
   source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
 
   depends_on = [aws_iam_role_policy.lambda_basic]

--- a/internal/service/appsync/datasource_test.go
+++ b/internal/service/appsync/datasource_test.go
@@ -843,7 +843,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.test"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/appsync/graphql_api_test.go
+++ b/internal/service/appsync/graphql_api_test.go
@@ -1614,7 +1614,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "lambdatest.handler"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   publish       = true
 }
 

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -1675,7 +1675,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   environment {
     variables = {

--- a/internal/service/bedrockagentcore/gateway_target_test.go
+++ b/internal/service/bedrockagentcore/gateway_target_test.go
@@ -741,7 +741,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.lambda.arn
   handler       = "lambdatest.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_bedrockagentcore_gateway" "test" {

--- a/internal/service/chimesdkvoice/sip_media_application_test.go
+++ b/internal/service/chimesdkvoice/sip_media_application_test.go
@@ -262,7 +262,7 @@ resource "aws_lambda_function" "test" {
   source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
   function_name    = %[1]q
   role             = aws_iam_role.test.arn
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   handler          = "index.handler"
 }
 `, rName)

--- a/internal/service/chimesdkvoice/sip_rule_test.go
+++ b/internal/service/chimesdkvoice/sip_rule_test.go
@@ -214,7 +214,7 @@ resource "aws_lambda_function" "test" {
   source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
   function_name    = %[1]q
   role             = aws_iam_role.test.arn
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   handler          = "index.handler"
 }
 

--- a/internal/service/cloudfront/multitenant_distribution_test.go
+++ b/internal/service/cloudfront/multitenant_distribution_test.go
@@ -1135,7 +1135,7 @@ resource "aws_lambda_function" "viewer_request" {
   function_name = "viewer-request-%[1]s"
   role          = aws_iam_role.lambda.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   publish       = true
   skip_destroy  = true
 }
@@ -1146,7 +1146,7 @@ resource "aws_lambda_function" "viewer_response" {
   function_name = "viewer-response-%[1]s"
   role          = aws_iam_role.lambda.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   publish       = true
   skip_destroy  = true
 }

--- a/internal/service/cloudtrail/trail_test.go
+++ b/internal/service/cloudtrail/trail_test.go
@@ -1502,7 +1502,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, rName))
 }

--- a/internal/service/cognitoidp/user_pool_test.go
+++ b/internal/service/cognitoidp/user_pool_test.go
@@ -2796,7 +2796,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_kms_key" "test" {
@@ -2853,7 +2853,7 @@ resource "aws_lambda_function" "second" {
   function_name = "%[1]s_second"
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_cognito_user_pool" "test" {
@@ -2899,7 +2899,7 @@ resource "aws_lambda_function" "second" {
   function_name = "%[1]s_second"
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_cognito_user_pool" "test" {
@@ -2953,7 +2953,7 @@ resource "aws_lambda_function" "second" {
   function_name = "%[1]s_second"
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_cognito_user_pool" "test" {
@@ -3009,7 +3009,7 @@ resource "aws_lambda_function" "second" {
   function_name = "%[1]s_second"
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_cognito_user_pool" "test" {

--- a/internal/service/configservice/config_rule_test.go
+++ b/internal/service/configservice/config_rule_test.go
@@ -545,7 +545,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_permission" "test" {

--- a/internal/service/configservice/organization_custom_rule_test.go
+++ b/internal/service/configservice/organization_custom_rule_test.go
@@ -570,7 +570,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_permission" "test" {
@@ -635,7 +635,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_organizations_organization" "test" {
@@ -714,7 +714,7 @@ resource "aws_lambda_function" "test2" {
   function_name = "%[1]s2"
   role          = aws_iam_role.lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_permission" "test2" {

--- a/internal/service/configservice/testdata/OrganizationCustomRule/basic/main_gen.tf
+++ b/internal/service/configservice/testdata/OrganizationCustomRule/basic/main_gen.tf
@@ -73,7 +73,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_permission" "test" {

--- a/internal/service/configservice/testdata/OrganizationCustomRule/basic_v6.39.0/main_gen.tf
+++ b/internal/service/configservice/testdata/OrganizationCustomRule/basic_v6.39.0/main_gen.tf
@@ -73,7 +73,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_permission" "test" {

--- a/internal/service/configservice/testdata/OrganizationCustomRule/region_override/main_gen.tf
+++ b/internal/service/configservice/testdata/OrganizationCustomRule/region_override/main_gen.tf
@@ -79,7 +79,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_permission" "test" {

--- a/internal/service/configservice/testdata/tmpl/organization_custom_rule_basic.gtpl
+++ b/internal/service/configservice/testdata/tmpl/organization_custom_rule_basic.gtpl
@@ -73,7 +73,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_permission" "test" {

--- a/internal/service/connect/lambda_function_association_data_source_test.go
+++ b/internal/service/connect/lambda_function_association_data_source_test.go
@@ -44,7 +44,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "exports.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/connect/lambda_function_association_test.go
+++ b/internal/service/connect/lambda_function_association_test.go
@@ -118,7 +118,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "exports.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/ec2/vpnclient_endpoint_test.go
+++ b/internal/service/ec2/vpnclient_endpoint_test.go
@@ -975,7 +975,7 @@ resource "aws_lambda_function" "test1" {
   function_name = "AWSClientVPN-%[1]s-1"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_function" "test2" {
@@ -983,7 +983,7 @@ resource "aws_lambda_function" "test2" {
   function_name = "AWSClientVPN-%[1]s-2"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 locals {

--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -4015,7 +4015,7 @@ resource "aws_lambda_function" "hook_success" {
   function_name    = "%[1]s-hook-success"
   role             = aws_iam_role.lambda_role.arn
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   source_code_hash = filebase64sha256("test-fixtures/success_lambda_func.zip")
 }
 
@@ -4024,7 +4024,7 @@ resource "aws_lambda_function" "hook_failure" {
   function_name    = "%[1]s-hook-failure"
   role             = aws_iam_role.lambda_role.arn
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   source_code_hash = filebase64sha256("test-fixtures/failure_lambda_func.zip")
 }
 `, rName))

--- a/internal/service/events/target_test.go
+++ b/internal/service/events/target_test.go
@@ -2624,7 +2624,7 @@ resource "aws_lambda_function" "test" {
   source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
   role             = aws_iam_role.test.arn
   handler          = "exports.example"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/firehose/delivery_stream_test.go
+++ b/internal/service/firehose/delivery_stream_test.go
@@ -2949,7 +2949,7 @@ resource "aws_lambda_function" "lambda_function_test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, rName)
 }

--- a/internal/service/fis/experiment_template_test.go
+++ b/internal/service/fis/experiment_template_test.go
@@ -1766,7 +1766,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test_fis.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   filename      = "test-fixtures/lambdatest.zip"
 
   tags = {

--- a/internal/service/iot/authorizer_test.go
+++ b/internal/service/iot/authorizer_test.go
@@ -279,7 +279,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.test.arn
   handler          = "exports.example"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
 }
 `, rName)
 }

--- a/internal/service/iot/provisioning_template_test.go
+++ b/internal/service/iot/provisioning_template_test.go
@@ -453,7 +453,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.test2.arn
   handler          = "lambda-preprovisioninghook.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
 }
 `, rName)
 }

--- a/internal/service/ivschat/room_test.go
+++ b/internal/service/ivschat/room_test.go
@@ -384,7 +384,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.test.arn
   source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   handler          = "index.handler"
 }
 

--- a/internal/service/kendra/data_source_test.go
+++ b/internal/service/kendra/data_source_test.go
@@ -2119,7 +2119,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[3]q
   role          = aws_iam_role.test_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role" "test_extraction_hook" {
@@ -3448,7 +3448,7 @@ resource "aws_lambda_function" "test2" {
   function_name = %[1]q
   role          = aws_iam_role.test_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_kendra_data_source" "test" {

--- a/internal/service/kinesisanalytics/application_test.go
+++ b/internal/service/kinesisanalytics/application_test.go
@@ -2050,7 +2050,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%[1]s_${count.index}"
   handler       = "exports.example"
   role          = aws_iam_role.test[0].arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {

--- a/internal/service/kinesisanalyticsv2/application_test.go
+++ b/internal/service/kinesisanalyticsv2/application_test.go
@@ -4501,7 +4501,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%[1]s_${count.index}"
   handler       = "exports.example"
   role          = aws_iam_role.test[0].arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {

--- a/internal/service/lambda/alias_data_source_test.go
+++ b/internal/service/lambda/alias_data_source_test.go
@@ -99,7 +99,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   publish       = true
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_alias" "test" {

--- a/internal/service/lambda/alias_test.go
+++ b/internal/service/lambda/alias_test.go
@@ -404,7 +404,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "exports.example"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
   publish          = "true"
 }
@@ -427,7 +427,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "exports.example"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
   publish          = "true"
 }
@@ -450,7 +450,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "exports.example"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   source_code_hash = filebase64sha256("test-fixtures/lambdatest_modified.zip")
   publish          = "true"
 }

--- a/internal/service/lambda/event_source_mapping_test.go
+++ b/internal/service/lambda/event_source_mapping_test.go
@@ -1954,7 +1954,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, rName)
 }
@@ -2006,7 +2006,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, rName)
 }
@@ -2069,7 +2069,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, rName)
 }
@@ -2142,7 +2142,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs18.x"
+  runtime       = "nodejs22.x"
 }
 `, rName, streamStatusAttribute, streamViewTypeAttribute)
 }
@@ -2217,7 +2217,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, rName))
 }
@@ -2275,7 +2275,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_security_group" "test" {
@@ -2380,7 +2380,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_mq_broker" "test" {
@@ -2482,7 +2482,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_docdb_subnet_group" "test" {
@@ -2751,7 +2751,7 @@ resource "aws_lambda_function" "test_update" {
   function_name = "%[1]s-update"
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_event_source_mapping" "test" {
@@ -2820,7 +2820,7 @@ resource "aws_lambda_function" "test_update" {
   function_name = "%[1]s-update"
   role          = aws_iam_role.test_update.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_event_source_mapping" "test" {

--- a/internal/service/lambda/function_data_source_test.go
+++ b/internal/service/lambda/function_data_source_test.go
@@ -540,7 +540,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_lambda_function" "test" {
@@ -557,7 +557,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   publish       = true
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_lambda_function" "test" {
@@ -575,7 +575,7 @@ resource "aws_lambda_function" "test" {
   handler                        = "exports.example"
   publish                        = true
   role                           = aws_iam_role.lambda.arn
-  runtime                        = "nodejs20.x"
+  runtime                        = "nodejs24.x"
   reserved_concurrent_executions = 10
 }
 
@@ -594,7 +594,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   publish       = true
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_lambda_function" "test" {
@@ -611,7 +611,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   publish       = false
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_lambda_function" "test" {
@@ -628,7 +628,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   publish       = true
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_alias" "test" {
@@ -649,7 +649,7 @@ func testAccFunctionDataSourceConfig_layers(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename            = "test-fixtures/lambdatest.zip"
   layer_name          = %[1]q
-  compatible_runtimes = ["nodejs20.x"]
+  compatible_runtimes = ["nodejs24.x"]
 }
 
 resource "aws_lambda_function" "test" {
@@ -658,7 +658,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   layers        = [aws_lambda_layer_version.test.arn]
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_lambda_function" "test" {
@@ -700,7 +700,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   vpc_config {
     security_group_ids = [aws_security_group.test.id]
@@ -721,7 +721,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   environment {
     variables = {
@@ -800,7 +800,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "lambdatest.handler"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   vpc_config {
     security_group_ids = [aws_security_group.test.id]
@@ -848,7 +848,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   architectures = ["arm64"]
 }
 
@@ -865,7 +865,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   ephemeral_storage {
     size = 1024
@@ -885,7 +885,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   logging_config {
     log_format            = "JSON"
@@ -907,7 +907,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   logging_config {
     log_format = "Text"
@@ -928,7 +928,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   tenancy_config {
     tenant_isolation_mode = "PER_TENANT"

--- a/internal/service/lambda/function_event_invoke_config_test.go
+++ b/internal/service/lambda/function_event_invoke_config_test.go
@@ -581,7 +581,7 @@ resource "aws_lambda_function" "test" {
   role          = aws_iam_role.test.arn
   handler       = "lambdapinpoint.handler"
   publish       = true
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   depends_on = [
     aws_iam_role_policy_attachment.test,

--- a/internal/service/lambda/function_recursion_config_test.go
+++ b/internal/service/lambda/function_recursion_config_test.go
@@ -219,7 +219,7 @@ resource "aws_lambda_function" "test" {
   source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
   function_name    = %[1]q
   role             = aws_iam_role.test.arn
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   handler          = "index.handler"
 }
 `, rName)

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -3213,7 +3213,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%s"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, funcName))
 }
@@ -3260,7 +3260,7 @@ resource "aws_lambda_function" "test" {
   publish       = false
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, fileName, rName))
 }
@@ -3343,7 +3343,7 @@ resource "aws_lambda_function" "test" {
   function_name           = %[1]q
   role                    = aws_iam_role.iam_for_lambda.arn
   handler                 = "exports.example"
-  runtime                 = "nodejs20.x"
+  runtime                 = "nodejs24.x"
   code_signing_config_arn = aws_lambda_code_signing_config.code_signing_config_1.arn
 }
 `, rName))
@@ -3358,7 +3358,7 @@ resource "aws_lambda_function" "test" {
   function_name           = %[1]q
   role                    = aws_iam_role.iam_for_lambda.arn
   handler                 = "exports.example"
-  runtime                 = "nodejs20.x"
+  runtime                 = "nodejs24.x"
   code_signing_config_arn = aws_lambda_code_signing_config.code_signing_config_2.arn
 }
 `, rName))
@@ -3373,7 +3373,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%s"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, rName))
 }
@@ -3387,7 +3387,7 @@ resource "aws_lambda_function" "test" {
   function_name                  = %[1]q
   role                           = aws_iam_role.iam_for_lambda.arn
   handler                        = "exports.example"
-  runtime                        = "nodejs20.x"
+  runtime                        = "nodejs24.x"
   reserved_concurrent_executions = 111
 }
 `, rName))
@@ -3402,7 +3402,7 @@ resource "aws_lambda_function" "test" {
   function_name                  = %[1]q
   role                           = aws_iam_role.iam_for_lambda.arn
   handler                        = "exports.example"
-  runtime                        = "nodejs20.x"
+  runtime                        = "nodejs24.x"
   reserved_concurrent_executions = 222
 }
 `, rName))
@@ -3418,7 +3418,7 @@ resource "aws_lambda_function" "test" {
   role                           = aws_iam_role.iam_for_lambda.arn
   handler                        = "exports.example"
   publish                        = true
-  runtime                        = "nodejs20.x"
+  runtime                        = "nodejs24.x"
   reserved_concurrent_executions = 222
 }
 `, rName))
@@ -3432,7 +3432,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, rName))
 }
@@ -3446,7 +3446,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   environment {
     variables = {
@@ -3466,7 +3466,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   environment {
     variables = {
@@ -3487,7 +3487,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, rName))
 }
@@ -3501,7 +3501,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.iam_for_lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   environment {
     variables = {
@@ -3570,7 +3570,7 @@ resource "aws_lambda_function" "test" {
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
   kms_key_arn   = aws_kms_key.test1.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   environment {
     variables = {
@@ -3617,7 +3617,7 @@ resource "aws_lambda_function" "test" {
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
   kms_key_arn   = aws_kms_key.test2.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   environment {
     variables = {
@@ -3638,7 +3638,7 @@ resource "aws_lambda_function" "test" {
   publish       = %[3]t
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, fileName, rName, publish))
 }
@@ -3667,7 +3667,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   dead_letter_config {
     target_arn = aws_sns_topic.test[0].arn
@@ -3691,7 +3691,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   dead_letter_config {
     target_arn = aws_sns_topic.test[1].arn
@@ -3715,7 +3715,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   dead_letter_config {
     target_arn = ""
@@ -3764,7 +3764,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   vpc_config {
     subnet_ids         = [aws_subnet.subnet_for_lambda.id]
@@ -3821,7 +3821,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   vpc_config {
     subnet_ids         = [aws_subnet.subnet_for_lambda_az2.id]
@@ -3913,7 +3913,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   architectures = ["arm64"]
 }
 `, rName))
@@ -3928,7 +3928,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   architectures = ["x86_64"]
 }
 `, rName))
@@ -3941,7 +3941,7 @@ func testAccFunctionConfig_architecturesARM64Layer(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename                 = "test-fixtures/lambdatest.zip"
   layer_name               = %[1]q
-  compatible_runtimes      = ["nodejs20.x"]
+  compatible_runtimes      = ["nodejs24.x"]
   compatible_architectures = ["arm64", "x86_64"]
 }
 
@@ -3950,7 +3950,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   architectures = ["arm64"]
   layers        = [aws_lambda_layer_version.test.arn]
 }
@@ -3964,7 +3964,7 @@ func testAccFunctionConfig_architecturesUpdateLayer(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename                 = "test-fixtures/lambdatest.zip"
   layer_name               = %[1]q
-  compatible_runtimes      = ["nodejs20.x"]
+  compatible_runtimes      = ["nodejs24.x"]
   compatible_architectures = ["arm64", "x86_64"]
 }
 
@@ -3973,7 +3973,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   architectures = ["x86_64"]
   layers        = [aws_lambda_layer_version.test.arn]
 }
@@ -3989,7 +3989,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   ephemeral_storage {
     size = 1024
@@ -4007,7 +4007,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   ephemeral_storage {
     size = 2048
@@ -4025,7 +4025,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   logging_config {
     log_format = "Text"
@@ -4044,7 +4044,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   logging_config {
     application_log_level = "TRACE"
@@ -4064,7 +4064,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   logging_config {
     log_format = "JSON"
@@ -4082,7 +4082,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   publish       = true
 
   logging_config {
@@ -4101,7 +4101,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   publish       = true
 
   logging_config {
@@ -4121,7 +4121,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   publish       = true
 
   logging_config {
@@ -4141,7 +4141,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   tracing_config {
     mode = "Active"
@@ -4159,7 +4159,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   tracing_config {
     mode = "PassThrough"
@@ -4202,7 +4202,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   kms_key_arn   = aws_kms_key.test.arn
   role          = aws_iam_role.iam_for_lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, rName))
 }
@@ -4216,7 +4216,7 @@ resource "aws_lambda_layer_version" "test" {
 
   filename            = "test-fixtures/lambdatest.zip"
   layer_name          = "%[1]s-${count.index}"
-  compatible_runtimes = ["nodejs20.x"]
+  compatible_runtimes = ["nodejs24.x"]
 }
 
 resource "aws_lambda_function" "test" {
@@ -4224,7 +4224,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   layers        = [aws_lambda_layer_version.test[0].arn]
 }
 `, rName))
@@ -4239,7 +4239,7 @@ resource "aws_lambda_layer_version" "test" {
 
   filename            = "test-fixtures/lambdatest.zip"
   layer_name          = "%[1]s-${count.index}"
-  compatible_runtimes = ["nodejs20.x"]
+  compatible_runtimes = ["nodejs24.x"]
 }
 
 resource "aws_lambda_function" "test" {
@@ -4247,7 +4247,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   layers        = aws_lambda_layer_version.test[*].arn
 }
 `, rName))
@@ -4262,7 +4262,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   vpc_config {
     subnet_ids         = [aws_subnet.subnet_for_lambda.id]
@@ -4281,7 +4281,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   vpc_config {
     subnet_ids         = [aws_subnet.subnet_for_lambda.id, aws_subnet.subnet_for_lambda_az2.id]
@@ -4320,7 +4320,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   publish       = true
   vpc_config {
     subnet_ids         = [aws_subnet.subnet_for_lambda.id]
@@ -4339,7 +4339,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   publish       = true
   vpc_config {
     security_group_ids = []
@@ -4358,7 +4358,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   vpc_config {
     subnet_ids         = [aws_subnet.test.id]
@@ -4379,7 +4379,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   replace_security_groups_on_destroy = true
 
@@ -4409,7 +4409,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   replace_security_groups_on_destroy = true
   replacement_security_group_ids     = [aws_security_group.test_replacement.id]
@@ -4431,7 +4431,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   vpc_config {
     subnet_ids         = []
@@ -4485,7 +4485,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, rName))
 }
@@ -4500,7 +4500,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[2]q
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "exports.example"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
 }
 `, filePath, rName))
 }
@@ -4514,7 +4514,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[2]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, filePath, rName))
 }
@@ -4549,7 +4549,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[2]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, filePath, rName))
 }
@@ -4587,7 +4587,7 @@ resource "aws_lambda_function" "test" {
   function_name     = %[3]q
   role              = aws_iam_role.iam_for_lambda.arn
   handler           = "exports.example"
-  runtime           = "nodejs20.x"
+  runtime           = "nodejs24.x"
 }
 `, key, path, rName))
 }
@@ -4614,7 +4614,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, rName, key, path))
 }
@@ -4641,7 +4641,7 @@ resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, rName))
 }
@@ -4668,7 +4668,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   vpc_config {
     subnet_ids         = [aws_subnet.subnet_for_lambda.id]
@@ -4687,7 +4687,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   vpc_config {
     ipv6_allowed_for_dual_stack = true
@@ -4755,7 +4755,7 @@ resource "aws_lambda_function" "test" {
   function_name      = %[1]q
   role               = aws_iam_role.iam_for_lambda.arn
   handler            = "exports.example"
-  runtime            = "nodejs20.x"
+  runtime            = "nodejs24.x"
   source_kms_key_arn = aws_kms_key.%[2]s.arn
 }
 `, rName, kmsIdentifier))
@@ -4770,7 +4770,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   tenancy_config {
     tenant_isolation_mode = "PER_TENANT"
@@ -4788,7 +4788,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   skip_destroy  = true
 }
 `, rName))
@@ -4837,7 +4837,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "exports.example"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   s3_bucket        = aws_s3_bucket.test.bucket
   s3_key           = %[3]q
   source_code_hash = aws_s3_object.test.checksum_sha256

--- a/internal/service/lambda/function_url_data_source_test.go
+++ b/internal/service/lambda/function_url_data_source_test.go
@@ -110,7 +110,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_function_url" "test" {

--- a/internal/service/lambda/function_url_test.go
+++ b/internal/service/lambda/function_url_test.go
@@ -408,7 +408,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_function_url" "test" {
@@ -425,7 +425,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_function_url" "test" {
@@ -451,7 +451,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_function_url" "test" {
@@ -477,7 +477,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   publish       = true
 }
 
@@ -512,7 +512,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_function_url" "test" {
@@ -530,7 +530,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   publish       = true
 }
 

--- a/internal/service/lambda/invocation_data_source_test.go
+++ b/internal/service/lambda/invocation_data_source_test.go
@@ -156,7 +156,7 @@ resource "aws_lambda_function" "lambda" {
   function_name = "%s"
   role          = aws_iam_role.lambda_role.arn
   handler       = "lambda_invocation.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   environment {
     variables = {
@@ -187,7 +187,7 @@ resource "aws_lambda_function" "lambda" {
   function_name = "%s"
   role          = aws_iam_role.lambda_role.arn
   handler       = "lambda_invocation.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   publish       = true
 
   environment {
@@ -220,7 +220,7 @@ resource "aws_lambda_function" "lambda" {
   function_name = "%s"
   role          = aws_iam_role.lambda_role.arn
   handler       = "lambda_invocation.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   publish       = true
 
   environment {
@@ -259,7 +259,7 @@ resource "aws_lambda_function" "lambda" {
   function_name = "%s"
   role          = aws_iam_role.lambda_role.arn
   handler       = "lambda_invocation.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   tenancy_config {
     tenant_isolation_mode = "PER_TENANT"
   }

--- a/internal/service/lambda/invocation_test.go
+++ b/internal/service/lambda/invocation_test.go
@@ -744,7 +744,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[2]q
   role          = aws_iam_role.test.arn
   handler       = "%[1]s.handler"
-  runtime       = "nodejs18.x"
+  runtime       = "nodejs22.x"
 
   environment {
     variables = {
@@ -766,7 +766,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[2]q
   role          = aws_iam_role.test.arn
   handler       = "%[1]s.handler"
-  runtime       = "nodejs18.x"
+  runtime       = "nodejs22.x"
   tenancy_config {
     tenant_isolation_mode = "PER_TENANT"
   }

--- a/internal/service/lambda/invoke_action_test.go
+++ b/internal/service/lambda/invoke_action_test.go
@@ -444,7 +444,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "lambda_invocation.handler"
-  runtime       = "nodejs18.x"
+  runtime       = "nodejs22.x"
 
   environment {
     variables = {
@@ -489,7 +489,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "lambda_invocation.handler"
-  runtime       = "nodejs18.x"
+  runtime       = "nodejs22.x"
   publish       = true
 
   environment {
@@ -602,7 +602,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "lambda_invocation.handler"
-  runtime       = "nodejs18.x"
+  runtime       = "nodejs22.x"
 
   tenancy_config {
     tenant_isolation_mode = "PER_TENANT"

--- a/internal/service/lambda/layer_version_data_source_test.go
+++ b/internal/service/lambda/layer_version_data_source_test.go
@@ -296,7 +296,7 @@ func testAccLayerVersionDataSourceConfig_basic(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename            = "test-fixtures/lambdatest.zip"
   layer_name          = %[1]q
-  compatible_runtimes = ["nodejs20.x"]
+  compatible_runtimes = ["nodejs24.x"]
 }
 
 data "aws_lambda_layer_version" "test" {
@@ -310,13 +310,13 @@ func testAccLayerVersionDataSourceConfig_version(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename            = "test-fixtures/lambdatest.zip"
   layer_name          = %[1]q
-  compatible_runtimes = ["nodejs20.x"]
+  compatible_runtimes = ["nodejs24.x"]
 }
 
 resource "aws_lambda_layer_version" "test_two" {
   filename            = "test-fixtures/lambdatest_modified.zip"
   layer_name          = %[1]q
-  compatible_runtimes = ["nodejs20.x"]
+  compatible_runtimes = ["nodejs24.x"]
 }
 
 data "aws_lambda_layer_version" "test" {
@@ -337,7 +337,7 @@ resource "aws_lambda_layer_version" "test" {
 resource "aws_lambda_layer_version" "test_two" {
   filename            = "test-fixtures/lambdatest_modified.zip"
   layer_name          = aws_lambda_layer_version.test.layer_name
-  compatible_runtimes = ["nodejs20.x"]
+  compatible_runtimes = ["nodejs24.x"]
 }
 
 data "aws_lambda_layer_version" "test" {
@@ -352,7 +352,7 @@ func testAccLayerVersionDataSourceConfig_architecturesX86(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename                 = "test-fixtures/lambdatest.zip"
   layer_name               = %[1]q
-  compatible_runtimes      = ["nodejs20.x"]
+  compatible_runtimes      = ["nodejs24.x"]
   compatible_architectures = ["x86_64"]
 }
 
@@ -369,7 +369,7 @@ func testAccLayerVersionDataSourceConfig_architecturesARM(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename                 = "test-fixtures/lambdatest.zip"
   layer_name               = %[1]q
-  compatible_runtimes      = ["nodejs20.x"]
+  compatible_runtimes      = ["nodejs24.x"]
   compatible_architectures = ["arm64"]
 }
 
@@ -385,7 +385,7 @@ func testAccLayerVersionDataSourceConfig_architecturesX86ARM(rName string) strin
 resource "aws_lambda_layer_version" "test" {
   filename                 = "test-fixtures/lambdatest.zip"
   layer_name               = %[1]q
-  compatible_runtimes      = ["nodejs20.x"]
+  compatible_runtimes      = ["nodejs24.x"]
   compatible_architectures = ["x86_64", "arm64"]
 }
 
@@ -401,7 +401,7 @@ func testAccLayerVersionDataSourceConfig_architecturesNone(rName string) string 
 resource "aws_lambda_layer_version" "test" {
   filename            = "test-fixtures/lambdatest.zip"
   layer_name          = %[1]q
-  compatible_runtimes = ["nodejs20.x"]
+  compatible_runtimes = ["nodejs24.x"]
 }
 
 data "aws_lambda_layer_version" "test" {
@@ -415,7 +415,7 @@ func testAccLayerVersionDataSourceConfig_arn(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename            = "test-fixtures/lambdatest.zip"
   layer_name          = %[1]q
-  compatible_runtimes = ["nodejs20.x"]
+  compatible_runtimes = ["nodejs24.x"]
 }
 
 data "aws_lambda_layer_version" "test" {
@@ -429,7 +429,7 @@ func testAccLayerVersionDataSourceConfig_arnWithoutVersion(rName string) string 
 resource "aws_lambda_layer_version" "test" {
   filename            = "test-fixtures/lambdatest.zip"
   layer_name          = %[1]q
-  compatible_runtimes = ["nodejs20.x"]
+  compatible_runtimes = ["nodejs24.x"]
 }
 
 data "aws_lambda_layer_version" "test" {

--- a/internal/service/lambda/layer_version_test.go
+++ b/internal/service/lambda/layer_version_test.go
@@ -347,7 +347,7 @@ func TestAccLambdaLayerVersion_skipDestroy(t *testing.T) {
 		CheckDestroy:             acctest.CheckDestroyNoop, // this purposely leaves dangling resources, since skip_destroy = true
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLayerVersionConfig_skipDestroy(rName, "nodejs18.x"),
+				Config: testAccLayerVersionConfig_skipDestroy(rName, "nodejs22.x"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerVersionExists(ctx, t, resourceName, &v),
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "lambda", fmt.Sprintf("layer:%s:1", rName)),
@@ -356,7 +356,7 @@ func TestAccLambdaLayerVersion_skipDestroy(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccLayerVersionConfig_skipDestroy(rName, "nodejs20.x"),
+				Config: testAccLayerVersionConfig_skipDestroy(rName, "nodejs24.x"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerVersionExists(ctx, t, resourceName, &v),
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "lambda", fmt.Sprintf("layer:%s:2", rName)),
@@ -484,7 +484,7 @@ resource "aws_lambda_layer_version" "test" {
   filename   = "test-fixtures/lambdatest.zip"
   layer_name = %[1]q
 
-  compatible_runtimes = ["nodejs18.x", "nodejs20.x"]
+  compatible_runtimes = ["nodejs22.x", "nodejs24.x"]
 }
 `, rName)
 }

--- a/internal/service/lambda/permission_test.go
+++ b/internal/service/lambda/permission_test.go
@@ -845,7 +845,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "exports.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role" "test" {
@@ -967,7 +967,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%s"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {

--- a/internal/service/lambda/provisioned_concurrency_config_test.go
+++ b/internal/service/lambda/provisioned_concurrency_config_test.go
@@ -397,7 +397,7 @@ resource "aws_lambda_function" "test" {
   role          = aws_iam_role.test.arn
   handler       = "lambdapinpoint.handler"
   publish       = true
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   depends_on = [aws_iam_role_policy_attachment.test]
 }

--- a/internal/service/lambda/runtime_management_config_test.go
+++ b/internal/service/lambda/runtime_management_config_test.go
@@ -99,7 +99,7 @@ func TestAccLambdaRuntimeManagementConfig_runtimeVersionARN(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_lambda_runtime_management_config.test"
 	functionResourceName := "aws_lambda_function.test"
-	var runtimeVersionARN string
+	var runtimeVersionARN *string
 	runtimeVersionConfigVars := config.Variables{}
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -133,8 +133,8 @@ func TestAccLambdaRuntimeManagementConfig_runtimeVersionARN(t *testing.T) {
 						t.Fatal("runtime version ARN not found")
 					}
 
-					runtimeVersionARN = *function.Configuration.RuntimeVersionConfig.RuntimeVersionArn
-					runtimeVersionConfigVars["runtime_version_arn"] = config.StringVariable(runtimeVersionARN)
+					runtimeVersionARN = function.Configuration.RuntimeVersionConfig.RuntimeVersionArn
+					runtimeVersionConfigVars["runtime_version_arn"] = config.StringVariable(*runtimeVersionARN)
 				},
 				Config:          testAccRuntimeManagementConfigConfig_runtimeVersionARN(rName),
 				ConfigVariables: runtimeVersionConfigVars,
@@ -142,7 +142,12 @@ func TestAccLambdaRuntimeManagementConfig_runtimeVersionARN(t *testing.T) {
 					testAccCheckRuntimeManagementConfigExists(ctx, t, resourceName, &cfg),
 					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceName, "function_name"),
 					resource.TestCheckResourceAttr(resourceName, "update_runtime_on", string(types.UpdateRuntimeOnManual)),
-					resource.TestCheckResourceAttr(resourceName, "runtime_version_arn", runtimeVersionARN),
+					resource.TestCheckResourceAttrWith(resourceName, "runtime_version_arn", func(value string) error {
+						if got, want := value, *runtimeVersionARN; got != want {
+							return fmt.Errorf("Attribute 'runtime_version_arn' expected %q, got: %s", want, got)
+						}
+						return nil
+					}),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrFunctionARN, "lambda", regexache.MustCompile(`function:+.`)),
 				),
 			},

--- a/internal/service/lambda/runtime_management_config_test.go
+++ b/internal/service/lambda/runtime_management_config_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
+	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -98,16 +99,12 @@ func TestAccLambdaRuntimeManagementConfig_runtimeVersionARN(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_lambda_runtime_management_config.test"
 	functionResourceName := "aws_lambda_function.test"
-	// nodejs18.x version hash in us-west-2, commercial partition
-	runtimeVersion := "b475b23763329123d9e6f79f51886d0e1054f727f5b90ec945fcb2a3ec09afdd"
+	var runtimeVersionARN string
+	runtimeVersionConfigVars := config.Variables{}
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			// The runtime version ARN contains a hash unique to a partition/region.
-			// There is currently no API to retrieve this ARN, so we have to hard-code
-			// the value and restrict this test to us-west-2 in the standard commercial
-			// partition.
 			acctest.PreCheckPartition(t, endpoints.AwsPartitionID)
 			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 			acctest.PreCheckPartitionHasService(t, names.LambdaEndpointID)
@@ -117,12 +114,35 @@ func TestAccLambdaRuntimeManagementConfig_runtimeVersionARN(t *testing.T) {
 		CheckDestroy:             testAccCheckRuntimeManagementConfigDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRuntimeManagementConfigConfig_runtimeVersionARN(rName, runtimeVersion),
+				Config: testAccRuntimeManagementConfigConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuntimeManagementConfigExists(ctx, t, resourceName, &cfg),
+					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceName, "function_name"),
+					resource.TestCheckResourceAttr(resourceName, "update_runtime_on", string(types.UpdateRuntimeOnFunctionUpdate)),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrFunctionARN, "lambda", regexache.MustCompile(`function:+.`)),
+				),
+			},
+			{
+				PreConfig: func() {
+					function, err := tflambda.FindFunctionByName(ctx, acctest.ProviderMeta(ctx, t).LambdaClient(ctx), rName)
+					if err != nil {
+						t.Fatalf("finding Lambda Function (%s): %s", rName, err)
+					}
+
+					if function.Configuration == nil || function.Configuration.RuntimeVersionConfig == nil || function.Configuration.RuntimeVersionConfig.RuntimeVersionArn == nil {
+						t.Fatal("runtime version ARN not found")
+					}
+
+					runtimeVersionARN = *function.Configuration.RuntimeVersionConfig.RuntimeVersionArn
+					runtimeVersionConfigVars["runtime_version_arn"] = config.StringVariable(runtimeVersionARN)
+				},
+				Config:          testAccRuntimeManagementConfigConfig_runtimeVersionARN(rName),
+				ConfigVariables: runtimeVersionConfigVars,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuntimeManagementConfigExists(ctx, t, resourceName, &cfg),
 					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceName, "function_name"),
 					resource.TestCheckResourceAttr(resourceName, "update_runtime_on", string(types.UpdateRuntimeOnManual)),
-					resource.TestMatchResourceAttr(resourceName, "runtime_version_arn", regexache.MustCompile(runtimeVersion)),
+					resource.TestCheckResourceAttr(resourceName, "runtime_version_arn", runtimeVersionARN),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrFunctionARN, "lambda", regexache.MustCompile(`function:+.`)),
 				),
 			},
@@ -203,7 +223,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs18.x"
+  runtime       = "nodejs22.x"
 }
 `, rName))
 }
@@ -219,16 +239,18 @@ resource "aws_lambda_runtime_management_config" "test" {
 `)
 }
 
-func testAccRuntimeManagementConfigConfig_runtimeVersionARN(rName, runtimeVersion string) string {
+func testAccRuntimeManagementConfigConfig_runtimeVersionARN(rName string) string {
 	return acctest.ConfigCompose(
 		testAccRuntimeManagementConfigConfigBase(rName),
-		fmt.Sprintf(`
-data "aws_region" "current" {}
+		`
+variable "runtime_version_arn" {
+  type = string
+}
 
 resource "aws_lambda_runtime_management_config" "test" {
   function_name       = aws_lambda_function.test.function_name
   update_runtime_on   = "Manual"
-  runtime_version_arn = "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.region}::runtime:%[1]s"
+  runtime_version_arn = var.runtime_version_arn
 }
-`, runtimeVersion))
+`)
 }

--- a/internal/service/lambda/testdata/EventSourceMapping/basic/main_gen.tf
+++ b/internal/service/lambda/testdata/EventSourceMapping/basic/main_gen.tf
@@ -52,7 +52,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 variable "rName" {

--- a/internal/service/lambda/testdata/EventSourceMapping/basic_v6.42.0/main_gen.tf
+++ b/internal/service/lambda/testdata/EventSourceMapping/basic_v6.42.0/main_gen.tf
@@ -52,7 +52,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 variable "rName" {

--- a/internal/service/lambda/testdata/EventSourceMapping/list_basic/main.tf
+++ b/internal/service/lambda/testdata/EventSourceMapping/list_basic/main.tf
@@ -58,7 +58,7 @@ resource "aws_lambda_function" "test" {
   function_name = "${var.rName}-${count.index}"
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 variable "rName" {

--- a/internal/service/lambda/testdata/EventSourceMapping/list_include_resource/main.tf
+++ b/internal/service/lambda/testdata/EventSourceMapping/list_include_resource/main.tf
@@ -59,7 +59,7 @@ resource "aws_lambda_function" "test" {
   function_name = "${var.rName}-${count.index}"
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 variable "rName" {

--- a/internal/service/lambda/testdata/EventSourceMapping/list_region_override/main.tf
+++ b/internal/service/lambda/testdata/EventSourceMapping/list_region_override/main.tf
@@ -61,7 +61,7 @@ resource "aws_lambda_function" "test" {
   function_name = "${var.rName}-${count.index}"
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 variable "rName" {

--- a/internal/service/lambda/testdata/EventSourceMapping/region_override/main_gen.tf
+++ b/internal/service/lambda/testdata/EventSourceMapping/region_override/main_gen.tf
@@ -58,7 +58,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 variable "rName" {

--- a/internal/service/lambda/testdata/Function/basic/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/basic/main_gen.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_partition" "current" {}

--- a/internal/service/lambda/testdata/Function/basic_v6.7.0/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/basic_v6.7.0/main_gen.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_partition" "current" {}

--- a/internal/service/lambda/testdata/Function/basic_v6.8.0/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/basic_v6.8.0/main_gen.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_partition" "current" {

--- a/internal/service/lambda/testdata/Function/data.tags/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/data.tags/main_gen.tf
@@ -11,7 +11,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   tags = var.resource_tags
 }

--- a/internal/service/lambda/testdata/Function/data.tags_defaults/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/data.tags_defaults/main_gen.tf
@@ -17,7 +17,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   tags = var.resource_tags
 }

--- a/internal/service/lambda/testdata/Function/data.tags_ignore/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/data.tags_ignore/main_gen.tf
@@ -20,7 +20,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   tags = var.resource_tags
 }

--- a/internal/service/lambda/testdata/Function/list_basic/main.tf
+++ b/internal/service/lambda/testdata/Function/list_basic/main.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "test" {
   function_name = "${var.rName}-${count.index}"
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_partition" "current" {}

--- a/internal/service/lambda/testdata/Function/list_include_resource/main.tf
+++ b/internal/service/lambda/testdata/Function/list_include_resource/main.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "test" {
   function_name = "${var.rName}-${count.index}"
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_partition" "current" {}

--- a/internal/service/lambda/testdata/Function/list_region_override/main.tf
+++ b/internal/service/lambda/testdata/Function/list_region_override/main.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_function" "test" {
   function_name = "${var.rName}-${count.index}"
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_partition" "current" {}

--- a/internal/service/lambda/testdata/Function/region_override/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/region_override/main_gen.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_partition" "current" {}

--- a/internal/service/lambda/testdata/Function/tags/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/tags/main_gen.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   tags = var.resource_tags
 }

--- a/internal/service/lambda/testdata/Function/tagsComputed1/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/tagsComputed1/main_gen.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   tags = {
     (var.unknownTagKey) = null_resource.test.id

--- a/internal/service/lambda/testdata/Function/tagsComputed2/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/tagsComputed2/main_gen.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   tags = {
     (var.unknownTagKey) = null_resource.test.id

--- a/internal/service/lambda/testdata/Function/tags_defaults/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/tags_defaults/main_gen.tf
@@ -12,7 +12,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   tags = var.resource_tags
 }

--- a/internal/service/lambda/testdata/Function/tags_ignore/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/tags_ignore/main_gen.tf
@@ -15,7 +15,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   tags = var.resource_tags
 }

--- a/internal/service/lambda/testdata/Permission/basic/main_gen.tf
+++ b/internal/service/lambda/testdata/Permission/basic/main_gen.tf
@@ -14,7 +14,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/lambda/testdata/Permission/basic_v6.9.0/main_gen.tf
+++ b/internal/service/lambda/testdata/Permission/basic_v6.9.0/main_gen.tf
@@ -14,7 +14,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/lambda/testdata/Permission/list_basic/main.tf
+++ b/internal/service/lambda/testdata/Permission/list_basic/main.tf
@@ -15,7 +15,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/lambda/testdata/Permission/list_include_resource/main.tf
+++ b/internal/service/lambda/testdata/Permission/list_include_resource/main.tf
@@ -15,7 +15,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/lambda/testdata/Permission/list_region_override/main.tf
+++ b/internal/service/lambda/testdata/Permission/list_region_override/main.tf
@@ -18,7 +18,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/lambda/testdata/Permission/region_override/main_gen.tf
+++ b/internal/service/lambda/testdata/Permission/region_override/main_gen.tf
@@ -18,7 +18,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/lambda/testdata/tmpl/event_source_mapping_basic.gtpl
+++ b/internal/service/lambda/testdata/tmpl/event_source_mapping_basic.gtpl
@@ -54,5 +54,5 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }

--- a/internal/service/lambda/testdata/tmpl/function_basic.gtpl
+++ b/internal/service/lambda/testdata/tmpl/function_basic.gtpl
@@ -4,7 +4,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
 {{- template "tags" . }}
 }

--- a/internal/service/lambda/testdata/tmpl/permission_basic.gtpl
+++ b/internal/service/lambda/testdata/tmpl/permission_basic.gtpl
@@ -13,7 +13,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/lexmodels/intent_test.go
+++ b/internal/service/lexmodels/intent_test.go
@@ -838,7 +838,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%[1]s"
   handler       = "lambdatest.handler"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, rName)
 }

--- a/internal/service/logs/account_policy_test.go
+++ b/internal/service/logs/account_policy_test.go
@@ -272,7 +272,7 @@ resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = %[1]q
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   handler       = "exports.handler"
 }
 

--- a/internal/service/logs/subscription_filter_test.go
+++ b/internal/service/logs/subscription_filter_test.go
@@ -651,7 +651,7 @@ resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = %[1]q
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   handler       = "exports.handler"
 }
 
@@ -704,7 +704,7 @@ resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%[1]s-${count.index}"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   handler       = "exports.handler"
 }
 

--- a/internal/service/pinpoint/app_test.go
+++ b/internal/service/pinpoint/app_test.go
@@ -528,7 +528,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "lambdapinpoint.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   publish       = true
 }
 

--- a/internal/service/pipes/pipe_test.go
+++ b/internal/service/pipes/pipe_test.go
@@ -3206,7 +3206,7 @@ resource "aws_lambda_function" "target" {
   function_name = "%[1]s-target"
   role          = aws_iam_role.target.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_pipes_pipe" "test" {

--- a/internal/service/s3/bucket_notification_test.go
+++ b/internal/service/s3/bucket_notification_test.go
@@ -574,7 +574,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_s3_bucket" "test" {
@@ -660,7 +660,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_alias" "test" {

--- a/internal/service/s3/object_test.go
+++ b/internal/service/s3/object_test.go
@@ -2519,7 +2519,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_s3control_object_lambda_access_point" "test" {

--- a/internal/service/s3control/object_lambda_access_point_test.go
+++ b/internal/service/s3control/object_lambda_access_point_test.go
@@ -218,7 +218,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, rName))
 }

--- a/internal/service/secretsmanager/secret_rotation_data_source_test.go
+++ b/internal/service/secretsmanager/secret_rotation_data_source_test.go
@@ -54,7 +54,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%[1]s-1"
   handler       = "exports.example"
   role          = aws_iam_role.iam_for_lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_permission" "test" {

--- a/internal/service/secretsmanager/secret_rotation_test.go
+++ b/internal/service/secretsmanager/secret_rotation_test.go
@@ -497,7 +497,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%[1]s-1"
   handler       = "exports.example"
   role          = aws_iam_role.iam_for_lambda.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_permission" "test" {

--- a/internal/service/secretsmanager/testdata/SecretRotation/basic/main_gen.tf
+++ b/internal/service/secretsmanager/testdata/SecretRotation/basic/main_gen.tf
@@ -59,7 +59,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_permission" "test" {

--- a/internal/service/secretsmanager/testdata/SecretRotation/basic_v6.8.0/main_gen.tf
+++ b/internal/service/secretsmanager/testdata/SecretRotation/basic_v6.8.0/main_gen.tf
@@ -59,7 +59,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_permission" "test" {

--- a/internal/service/secretsmanager/testdata/SecretRotation/region_override/main_gen.tf
+++ b/internal/service/secretsmanager/testdata/SecretRotation/region_override/main_gen.tf
@@ -63,7 +63,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_permission" "test" {

--- a/internal/service/secretsmanager/testdata/tmpl/secret_rotation_basic.gtpl
+++ b/internal/service/secretsmanager/testdata/tmpl/secret_rotation_basic.gtpl
@@ -58,7 +58,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_permission" "test" {

--- a/internal/service/servicecatalog/testdata/retry-tainted-update/product_template.yaml
+++ b/internal/service/servicecatalog/testdata/retry-tainted-update/product_template.yaml
@@ -25,7 +25,7 @@ Resources:
       FunctionName: !Sub '${AWS::StackName}-test-function'
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       Code:
         ZipFile: |
           // cfnresponse module inline

--- a/internal/service/ses/receipt_rule_test.go
+++ b/internal/service/ses/receipt_rule_test.go
@@ -695,7 +695,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.test.arn
   handler          = "exports.example"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
 }
 
 resource "aws_lambda_permission" "test" {

--- a/internal/service/sfn/alias_test.go
+++ b/internal/service/sfn/alias_test.go
@@ -203,7 +203,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role_policy" "for_sfn" {

--- a/internal/service/sfn/start_execution_action_test.go
+++ b/internal/service/sfn/start_execution_action_test.go
@@ -324,7 +324,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role" "for_sfn" {

--- a/internal/service/sfn/state_machine_test.go
+++ b/internal/service/sfn/state_machine_test.go
@@ -714,7 +714,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role_policy" "for_sfn" {

--- a/internal/service/sfn/testdata/Alias/basic/main_gen.tf
+++ b/internal/service/sfn/testdata/Alias/basic/main_gen.tf
@@ -82,7 +82,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_region" "current" {

--- a/internal/service/sfn/testdata/Alias/basic_v6.14.1/main_gen.tf
+++ b/internal/service/sfn/testdata/Alias/basic_v6.14.1/main_gen.tf
@@ -82,7 +82,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_region" "current" {

--- a/internal/service/sfn/testdata/Alias/region_override/main_gen.tf
+++ b/internal/service/sfn/testdata/Alias/region_override/main_gen.tf
@@ -88,7 +88,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_region" "current" {

--- a/internal/service/sfn/testdata/StateMachine/basic/main_gen.tf
+++ b/internal/service/sfn/testdata/StateMachine/basic/main_gen.tf
@@ -72,7 +72,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_region" "current" {

--- a/internal/service/sfn/testdata/StateMachine/basic_v6.13.0/main_gen.tf
+++ b/internal/service/sfn/testdata/StateMachine/basic_v6.13.0/main_gen.tf
@@ -72,7 +72,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_region" "current" {

--- a/internal/service/sfn/testdata/StateMachine/region_override/main_gen.tf
+++ b/internal/service/sfn/testdata/StateMachine/region_override/main_gen.tf
@@ -76,7 +76,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_region" "current" {

--- a/internal/service/sfn/testdata/tmpl/alias_basic.gtpl
+++ b/internal/service/sfn/testdata/tmpl/alias_basic.gtpl
@@ -82,7 +82,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_region" "current" {

--- a/internal/service/sfn/testdata/tmpl/state_machine_basic.gtpl
+++ b/internal/service/sfn/testdata/tmpl/state_machine_basic.gtpl
@@ -72,7 +72,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 data "aws_region" "current" {

--- a/internal/service/sns/topic_subscription_test.go
+++ b/internal/service/sns/topic_subscription_test.go
@@ -1413,7 +1413,7 @@ resource "aws_lambda_function" "authorizer" {
   function_name    = "%[1]s-2"
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "main.authenticate"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
 
   environment {
     variables = {

--- a/internal/service/ssm/maintenance_window_task_test.go
+++ b/internal/service/ssm/maintenance_window_task_test.go
@@ -1114,7 +1114,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 `, funcName))
 }

--- a/internal/service/transfer/server_test.go
+++ b/internal/service/transfer/server_test.go
@@ -2294,7 +2294,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_transfer_server" "test" {

--- a/internal/service/transfer/workflow_test.go
+++ b/internal/service/transfer/workflow_test.go
@@ -441,7 +441,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_efs_file_system" "test" {

--- a/website/docs/d/lambda_code_signing_config.html.markdown
+++ b/website/docs/d/lambda_code_signing_config.html.markdown
@@ -44,7 +44,7 @@ resource "aws_lambda_function" "example" {
   function_name           = "secure-function"
   role                    = aws_iam_role.lambda_role.arn
   handler                 = "index.handler"
-  runtime                 = "nodejs20.x"
+  runtime                 = "nodejs24.x"
   code_signing_config_arn = data.aws_lambda_code_signing_config.security_config.arn
 
   tags = {

--- a/website/docs/d/lambda_layer_version.html.markdown
+++ b/website/docs/d/lambda_layer_version.html.markdown
@@ -25,7 +25,7 @@ resource "aws_lambda_function" "example" {
   function_name = "example_function"
   role          = aws_iam_role.lambda_role.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   layers = [data.aws_lambda_layer_version.example.arn]
 }
@@ -117,7 +117,7 @@ resource "aws_lambda_function" "example" {
   function_name = "cross_account_example"
   role          = aws_iam_role.lambda_role.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   layers = [data.aws_lambda_layer_version.shared_layer.arn]
 }

--- a/website/docs/r/apigatewayv2_integration.html.markdown
+++ b/website/docs/r/apigatewayv2_integration.html.markdown
@@ -30,7 +30,7 @@ resource "aws_lambda_function" "example" {
   function_name = "Example"
   role          = aws_iam_role.example.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_apigatewayv2_integration" "example" {

--- a/website/docs/r/bedrockagentcore_gateway_target.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway_target.html.markdown
@@ -52,7 +52,7 @@ resource "aws_lambda_function" "example" {
   function_name = "example-function"
   role          = aws_iam_role.lambda_role.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_bedrockagentcore_gateway" "example" {

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -90,7 +90,7 @@ resource "aws_lambda_function" "lambda_processor" {
   function_name = "firehose_lambda_processor"
   role          = aws_iam_role.lambda_iam.arn
   handler       = "exports.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 ```
 

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -57,7 +57,7 @@ resource "aws_lambda_function" "example" {
   handler       = "index.handler"
   code_sha256   = data.archive_file.example.output_base64sha256
 
-  runtime = "nodejs20.x"
+  runtime = "nodejs24.x"
 
   environment {
     variables = {
@@ -104,7 +104,7 @@ resource "aws_lambda_layer_version" "example" {
   filename            = "layer.zip"
   layer_name          = "example_dependencies_layer"
   description         = "Common dependencies for Lambda functions"
-  compatible_runtimes = ["nodejs20.x", "python3.12"]
+  compatible_runtimes = ["nodejs24.x", "python3.12"]
 
   compatible_architectures = ["x86_64", "arm64"]
 }
@@ -115,7 +115,7 @@ resource "aws_lambda_function" "example" {
   function_name = "example_layered_function"
   role          = aws_iam_role.example.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   layers = [aws_lambda_layer_version.example.arn]
 
@@ -208,7 +208,7 @@ resource "aws_lambda_function" "example" {
   function_name = "example_efs_function"
   role          = aws_iam_role.example.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   vpc_config {
     subnet_ids         = var.subnet_ids
@@ -243,7 +243,7 @@ resource "aws_lambda_function" "example" {
   function_name = "example_function"
   role          = aws_iam_role.example.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   # Advanced logging configuration
   logging_config {
@@ -361,7 +361,7 @@ resource "aws_lambda_function" "example" {
   function_name = "example_function"
   role          = aws_iam_role.example.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   dead_letter_config {
     target_arn = aws_sqs_queue.dlq.arn
@@ -459,7 +459,7 @@ resource "aws_lambda_function" "example" {
   function_name = var.function_name
   role          = aws_iam_role.example.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   # Advanced logging configuration
   logging_config {
@@ -521,7 +521,7 @@ resource "aws_lambda_function" "example" {
   function_name = "example"
   role          = aws_iam_role.example.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   memory_size   = 2048
 
   publish = true

--- a/website/docs/r/lambda_function_recursion_config.html.markdown
+++ b/website/docs/r/lambda_function_recursion_config.html.markdown
@@ -42,7 +42,7 @@ resource "aws_lambda_function" "production_processor" {
   function_name = "production-data-processor"
   role          = aws_iam_role.lambda_role.arn
   handler       = "app.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 
   tags = {
     Environment = "production"

--- a/website/docs/r/lambda_layer_version.html.markdown
+++ b/website/docs/r/lambda_layer_version.html.markdown
@@ -23,7 +23,7 @@ resource "aws_lambda_layer_version" "example" {
   filename   = "lambda_layer_payload.zip"
   layer_name = "lambda_layer_name"
 
-  compatible_runtimes = ["nodejs20.x"]
+  compatible_runtimes = ["nodejs24.x"]
 }
 ```
 
@@ -36,7 +36,7 @@ resource "aws_lambda_layer_version" "example" {
 
   layer_name = "lambda_layer_name"
 
-  compatible_runtimes      = ["nodejs20.x", "python3.12"]
+  compatible_runtimes      = ["nodejs24.x", "python3.12"]
   compatible_architectures = ["x86_64", "arm64"]
 }
 ```
@@ -52,8 +52,8 @@ resource "aws_lambda_layer_version" "example" {
   source_code_hash = filebase64sha256("lambda_layer_payload.zip")
 
   compatible_runtimes = [
-    "nodejs18.x",
-    "nodejs20.x",
+    "nodejs22.x",
+    "nodejs24.x",
     "python3.11",
     "python3.12"
   ]

--- a/website/docs/r/lambda_layer_version_permission.html.markdown
+++ b/website/docs/r/lambda_layer_version_permission.html.markdown
@@ -24,7 +24,7 @@ resource "aws_lambda_layer_version" "example" {
   filename            = "layer.zip"
   layer_name          = "shared_utilities"
   description         = "Common utilities for Lambda functions"
-  compatible_runtimes = ["nodejs20.x", "python3.12"]
+  compatible_runtimes = ["nodejs24.x", "python3.12"]
 }
 
 # Grant permission to specific AWS account

--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -36,7 +36,7 @@ resource "aws_lambda_function" "test_lambda" {
   function_name = "lambda_function_name"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {

--- a/website/docs/r/s3_bucket_notification.html.markdown
+++ b/website/docs/r/s3_bucket_notification.html.markdown
@@ -135,7 +135,7 @@ resource "aws_lambda_function" "func" {
   function_name = "example_lambda_name"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_s3_bucket" "bucket" {
@@ -190,7 +190,7 @@ resource "aws_lambda_function" "func1" {
   function_name = "example_lambda_name1"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
 }
 
 resource "aws_lambda_permission" "allow_bucket2" {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

```
Your task is to fix https://github.com/hashicorp/terraform-provider-aws/issues/47709.
You are working on a branch that I have created for you.
Replace references to `nodejs20.x` in Go code, Terraform configuration and website documentation with `nodejs24.x`.
Don't touch the `.archive` or `.changelog` directories.
If there is a reference to another unsupported version like `nodejs18.x`, replace with `nodejs22.x`.
If the reference is in a generated configuration file (`*_gen.tf`) then be sure to modify the corresponding template file (`.gtpl`) in the `testdata` directory tree and run `go generate ./internal/service<servicename>` to regenerate the `.tf` file.
Create a git commit for each directory that has changed files and include an attribution to your agent name and model used.
Use the instructions in `docs/makefile-cheat-sheet.md` to work out which lint makefile targets can be used to check your work.
Stop when all commits are done; do NOT create a PR.
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/47709.
Going with this PR over Kiro's as the change required to `TestAccLambdaRuntimeManagementConfig_runtimeVersionARN` was spotted (even though it was not quite 100% correct). 
Closes https://github.com/hashicorp/terraform-provider-aws/pull/47712.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccLambdaEventSourceMapping_Kinesis_\|TestAccLambdaFunction_basic\|TestAccLambdaInvocation_basic\|TestAccLambdaLayerVersion_skipDestroy\|TestAccLambdaRuntimeManagementConfig_' PKG=lambda ACCTEST_PARALLELISM=4
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-lambda-nodejs20.x-opencode/copilot 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/lambda/... -v -count 1 -parallel 4  -run=TestAccLambdaEventSourceMapping_Kinesis_\|TestAccLambdaFunction_basic\|TestAccLambdaInvocation_basic\|TestAccLambdaLayerVersion_skipDestroy\|TestAccLambdaRuntimeManagementConfig_ -timeout 360m -vet=off
2026/05/01 08:50:13 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/01 08:50:13 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_basic
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_basic
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_batchWindow
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_batchWindow
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_bisectBatch
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_bisectBatch
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_destination
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_destination
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== RUN   TestAccLambdaInvocation_basic
=== PAUSE TestAccLambdaInvocation_basic
=== RUN   TestAccLambdaLayerVersion_skipDestroy
=== PAUSE TestAccLambdaLayerVersion_skipDestroy
=== RUN   TestAccLambdaRuntimeManagementConfig_basic
=== PAUSE TestAccLambdaRuntimeManagementConfig_basic
=== RUN   TestAccLambdaRuntimeManagementConfig_disappears_Function
=== PAUSE TestAccLambdaRuntimeManagementConfig_disappears_Function
=== RUN   TestAccLambdaRuntimeManagementConfig_runtimeVersionARN
=== PAUSE TestAccLambdaRuntimeManagementConfig_runtimeVersionARN
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_basic
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne
=== CONT  TestAccLambdaLayerVersion_skipDestroy
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts
--- PASS: TestAccLambdaLayerVersion_skipDestroy (24.69s)
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne (64.15s)
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts (64.28s)
=== CONT  TestAccLambdaRuntimeManagementConfig_disappears_Function
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_basic (87.59s)
=== CONT  TestAccLambdaRuntimeManagementConfig_runtimeVersionARN
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne (74.01s)
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor
--- PASS: TestAccLambdaRuntimeManagementConfig_disappears_Function (45.65s)
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds (61.96s)
=== CONT  TestAccLambdaFunction_basic
--- PASS: TestAccLambdaRuntimeManagementConfig_runtimeVersionARN (56.27s)
=== CONT  TestAccLambdaInvocation_basic
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor (62.17s)
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds (62.45s)
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_batchWindow
--- PASS: TestAccLambdaFunction_basic (47.46s)
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_destination
--- PASS: TestAccLambdaInvocation_basic (37.38s)
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_bisectBatch
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_batchWindow (62.52s)
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero (74.67s)
=== CONT  TestAccLambdaRuntimeManagementConfig_basic
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_destination (66.48s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_bisectBatch (70.90s)
--- PASS: TestAccLambdaRuntimeManagementConfig_basic (47.19s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp (50.63s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     291.249s```
