### PR TITLE
Stale PR Workflow: enable cron trigger

### DIFF
--- a/.github/workflows/close_stale_draft_prs.yml
+++ b/.github/workflows/close_stale_draft_prs.yml
@@ -25,7 +25,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' &&
-            github.event.inputs.dry_run || 'true' }}
+            github.event.inputs.dry_run || 'false' }}
         run: |
           # Calculate the date 60 days ago in ISO format (YYYY-MM-DD) GNU/BSD compatible
           DATE=$(date -u -d "60 days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-60d +%Y-%m-%dT%H:%M:%SZ)


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Stale PR Workflow: enable cron trigger. Starting to close draft PRs after 60 days if they haven't been updated to keep maintainers focused. Contributors can always reopen and set to Ready For Review.