### PR TITLE
resource/aws_msk_replicator: Add log_delivery configuration block

### DIFF
--- a/.changelog/47720.txt
+++ b/.changelog/47720.txt
@@ -1,0 +1,1 @@
+resource/aws_msk_replicator: Add `log_delivery` configuration block to support CloudWatch Logs, Firehose, and S3 log delivery

--- a/internal/service/kafka/replicator.go
+++ b/internal/service/kafka/replicator.go
@@ -117,7 +117,7 @@ func resourceReplicator() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"cloudwatch_logs": {
+						names.AttrCloudWatchLogs: {
 							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
@@ -345,6 +345,10 @@ func resourceReplicatorCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	if v, ok := d.GetOk("log_delivery"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 		input.LogDelivery = expandLogDelivery(v.([]any)[0].(map[string]any))
+
+		if input.LogDelivery == nil || input.LogDelivery.ReplicatorLogDelivery == nil {
+			return sdkdiag.AppendErrorf(diags, "creating MSK Replicator (%s): log_delivery must include at least one of %q, %q, or %q", name, names.AttrCloudWatchLogs, "firehose", "s3")
+		}
 	}
 
 	output, err := conn.CreateReplicator(ctx, input)
@@ -1009,7 +1013,7 @@ func expandLogDelivery(tfMap map[string]any) *types.LogDelivery {
 
 	apiObject := &types.LogDelivery{}
 
-	if v, ok := tfMap["cloudwatch_logs"].([]any); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap[names.AttrCloudWatchLogs].([]any); ok && len(v) > 0 && v[0] != nil {
 		apiObject.ReplicatorLogDelivery = &types.ReplicatorLogDelivery{
 			CloudWatchLogs: expandReplicatorCloudWatchLogs(v[0].(map[string]any)),
 		}
@@ -1098,7 +1102,7 @@ func flattenLogDelivery(apiObject *types.LogDelivery) map[string]any {
 	tfMap := map[string]any{}
 
 	if v := apiObject.ReplicatorLogDelivery.CloudWatchLogs; v != nil {
-		tfMap["cloudwatch_logs"] = []any{flattenReplicatorCloudWatchLogs(v)}
+		tfMap[names.AttrCloudWatchLogs] = []any{flattenReplicatorCloudWatchLogs(v)}
 	}
 
 	if v := apiObject.ReplicatorLogDelivery.Firehose; v != nil {

--- a/internal/service/kafka/replicator.go
+++ b/internal/service/kafka/replicator.go
@@ -118,9 +118,10 @@ func resourceReplicator() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						names.AttrCloudWatchLogs: {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
+							Type:         schema.TypeList,
+							Optional:     true,
+							MaxItems:     1,
+							AtLeastOneOf: []string{"log_delivery.0.cloudwatch_logs", "log_delivery.0.firehose", "log_delivery.0.s3"},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									names.AttrEnabled: {
@@ -135,9 +136,10 @@ func resourceReplicator() *schema.Resource {
 							},
 						},
 						"firehose": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
+							Type:         schema.TypeList,
+							Optional:     true,
+							MaxItems:     1,
+							AtLeastOneOf: []string{"log_delivery.0.cloudwatch_logs", "log_delivery.0.firehose", "log_delivery.0.s3"},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"delivery_stream": {
@@ -152,9 +154,10 @@ func resourceReplicator() *schema.Resource {
 							},
 						},
 						"s3": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
+							Type:         schema.TypeList,
+							Optional:     true,
+							MaxItems:     1,
+							AtLeastOneOf: []string{"log_delivery.0.cloudwatch_logs", "log_delivery.0.firehose", "log_delivery.0.s3"},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									names.AttrBucket: {

--- a/internal/service/kafka/replicator.go
+++ b/internal/service/kafka/replicator.go
@@ -110,6 +110,71 @@ func resourceReplicator() *schema.Resource {
 					},
 				},
 			},
+			"log_delivery": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cloudwatch_logs": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									names.AttrEnabled: {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+									"log_group": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"firehose": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"delivery_stream": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									names.AttrEnabled: {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+								},
+							},
+						},
+						"s3": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									names.AttrBucket: {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									names.AttrEnabled: {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+									names.AttrPrefix: {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"replication_info_list": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -278,6 +343,10 @@ func resourceReplicatorCreate(ctx context.Context, d *schema.ResourceData, meta 
 		input.Description = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("log_delivery"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.LogDelivery = expandLogDelivery(v.([]any)[0].(map[string]any))
+	}
+
 	output, err := conn.CreateReplicator(ctx, input)
 
 	if err != nil {
@@ -326,6 +395,11 @@ func resourceReplicatorRead(ctx context.Context, d *schema.ResourceData, meta an
 	d.Set("current_version", output.CurrentVersion)
 	d.Set(names.AttrDescription, output.ReplicatorDescription)
 	d.Set("kafka_cluster", flattenKafkaClusterDescriptions(output.KafkaClusters))
+	if output.LogDelivery != nil {
+		d.Set("log_delivery", []any{flattenLogDelivery(output.LogDelivery)})
+	} else {
+		d.Set("log_delivery", nil)
+	}
 	d.Set("replication_info_list", flattenReplicationInfoDescriptions(output.ReplicationInfoList, sourceARN, targetARN))
 	d.Set("replicator_name", output.ReplicatorName)
 	d.Set("service_execution_role_arn", output.ServiceExecutionRoleArn)
@@ -926,4 +1000,172 @@ func expandAmazonMSKCluster(tfMap map[string]any) *types.AmazonMskCluster { // n
 	}
 
 	return apiObject
+}
+
+func expandLogDelivery(tfMap map[string]any) *types.LogDelivery {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &types.LogDelivery{}
+
+	if v, ok := tfMap["cloudwatch_logs"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.ReplicatorLogDelivery = &types.ReplicatorLogDelivery{
+			CloudWatchLogs: expandReplicatorCloudWatchLogs(v[0].(map[string]any)),
+		}
+	}
+
+	if v, ok := tfMap["firehose"].([]any); ok && len(v) > 0 && v[0] != nil {
+		if apiObject.ReplicatorLogDelivery == nil {
+			apiObject.ReplicatorLogDelivery = &types.ReplicatorLogDelivery{}
+		}
+		apiObject.ReplicatorLogDelivery.Firehose = expandReplicatorFirehose(v[0].(map[string]any))
+	}
+
+	if v, ok := tfMap["s3"].([]any); ok && len(v) > 0 && v[0] != nil {
+		if apiObject.ReplicatorLogDelivery == nil {
+			apiObject.ReplicatorLogDelivery = &types.ReplicatorLogDelivery{}
+		}
+		apiObject.ReplicatorLogDelivery.S3 = expandReplicatorS3(v[0].(map[string]any))
+	}
+
+	return apiObject
+}
+
+func expandReplicatorCloudWatchLogs(tfMap map[string]any) *types.ReplicatorCloudWatchLogs {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &types.ReplicatorCloudWatchLogs{}
+
+	if v, ok := tfMap[names.AttrEnabled].(bool); ok {
+		apiObject.Enabled = aws.Bool(v)
+	}
+
+	if v, ok := tfMap["log_group"].(string); ok && v != "" {
+		apiObject.LogGroup = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func expandReplicatorFirehose(tfMap map[string]any) *types.ReplicatorFirehose {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &types.ReplicatorFirehose{}
+
+	if v, ok := tfMap[names.AttrEnabled].(bool); ok {
+		apiObject.Enabled = aws.Bool(v)
+	}
+
+	if v, ok := tfMap["delivery_stream"].(string); ok && v != "" {
+		apiObject.DeliveryStream = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func expandReplicatorS3(tfMap map[string]any) *types.ReplicatorS3 {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &types.ReplicatorS3{}
+
+	if v, ok := tfMap[names.AttrEnabled].(bool); ok {
+		apiObject.Enabled = aws.Bool(v)
+	}
+
+	if v, ok := tfMap[names.AttrBucket].(string); ok && v != "" {
+		apiObject.Bucket = aws.String(v)
+	}
+
+	if v, ok := tfMap[names.AttrPrefix].(string); ok && v != "" {
+		apiObject.Prefix = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func flattenLogDelivery(apiObject *types.LogDelivery) map[string]any {
+	if apiObject == nil || apiObject.ReplicatorLogDelivery == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if v := apiObject.ReplicatorLogDelivery.CloudWatchLogs; v != nil {
+		tfMap["cloudwatch_logs"] = []any{flattenReplicatorCloudWatchLogs(v)}
+	}
+
+	if v := apiObject.ReplicatorLogDelivery.Firehose; v != nil {
+		tfMap["firehose"] = []any{flattenReplicatorFirehose(v)}
+	}
+
+	if v := apiObject.ReplicatorLogDelivery.S3; v != nil {
+		tfMap["s3"] = []any{flattenReplicatorS3(v)}
+	}
+
+	return tfMap
+}
+
+func flattenReplicatorCloudWatchLogs(apiObject *types.ReplicatorCloudWatchLogs) map[string]any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if v := apiObject.Enabled; v != nil {
+		tfMap[names.AttrEnabled] = aws.ToBool(v)
+	}
+
+	if v := apiObject.LogGroup; v != nil {
+		tfMap["log_group"] = aws.ToString(v)
+	}
+
+	return tfMap
+}
+
+func flattenReplicatorFirehose(apiObject *types.ReplicatorFirehose) map[string]any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if v := apiObject.Enabled; v != nil {
+		tfMap[names.AttrEnabled] = aws.ToBool(v)
+	}
+
+	if v := apiObject.DeliveryStream; v != nil {
+		tfMap["delivery_stream"] = aws.ToString(v)
+	}
+
+	return tfMap
+}
+
+func flattenReplicatorS3(apiObject *types.ReplicatorS3) map[string]any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if v := apiObject.Enabled; v != nil {
+		tfMap[names.AttrEnabled] = aws.ToBool(v)
+	}
+
+	if v := apiObject.Bucket; v != nil {
+		tfMap[names.AttrBucket] = aws.ToString(v)
+	}
+
+	if v := apiObject.Prefix; v != nil {
+		tfMap[names.AttrPrefix] = aws.ToString(v)
+	}
+
+	return tfMap
 }

--- a/internal/service/kafka/replicator_test.go
+++ b/internal/service/kafka/replicator_test.go
@@ -1157,7 +1157,7 @@ func testAccReplicatorConfig_logDeliveryBase(rName, sourceCluster, targetCluster
 		testAccReplicatorConfig_source(sourceCluster),
 		testAccReplicatorConfig_target(targetCluster),
 		fmt.Sprintf(`
-`+extraResources+`
+%[2]s
 
 resource "aws_msk_replicator" "test" {
   replicator_name            = %[1]q
@@ -1199,7 +1199,7 @@ resource "aws_msk_replicator" "test" {
       consumer_groups_to_replicate = [".*"]
     }
   }
-`+logDelivery+`
+%[3]s
 }
-`, rName, sourceCluster, targetCluster))
+`, rName, extraResources, logDelivery))
 }

--- a/internal/service/kafka/replicator_test.go
+++ b/internal/service/kafka/replicator_test.go
@@ -6,6 +6,7 @@ package kafka_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/YakDriver/regexache"
@@ -401,7 +402,7 @@ func TestAccKafkaReplicator_logDelivery_empty(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccReplicatorConfig_logDeliveryEmpty(rName, sourceCluster, targetCluster),
-				ExpectError: regexache.MustCompile(`log_delivery must include at least one of`),
+				ExpectError: regexache.MustCompile(`Missing required argument|must be specified`),
 			},
 		},
 	})
@@ -1153,6 +1154,13 @@ func testAccReplicatorConfig_logDeliveryEmpty(rName, sourceCluster, targetCluste
 }
 
 func testAccReplicatorConfig_logDeliveryBase(rName, sourceCluster, targetCluster, extraResources, logDelivery string) string {
+	if strings.Contains(extraResources, "%[1]") {
+		extraResources = fmt.Sprintf(extraResources, rName)
+	}
+	if strings.Contains(logDelivery, "%[1]") {
+		logDelivery = fmt.Sprintf(logDelivery, rName)
+	}
+
 	return acctest.ConfigCompose(
 		testAccReplicatorConfig_source(sourceCluster),
 		testAccReplicatorConfig_target(targetCluster),

--- a/internal/service/kafka/replicator_test.go
+++ b/internal/service/kafka/replicator_test.go
@@ -766,3 +766,73 @@ resource "aws_msk_replicator" "test" {
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2, sourceCluster, targetCluster))
 }
+
+func testAccReplicatorConfig_logDelivery(rName, sourceCluster, targetCluster string) string {
+	return acctest.ConfigCompose(
+		testAccReplicatorConfig_source(sourceCluster),
+		testAccReplicatorConfig_target(targetCluster),
+		fmt.Sprintf(`
+resource "aws_cloudwatch_log_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_msk_replicator" "test" {
+  replicator_name            = %[1]q
+  description                = "test-description"
+  service_execution_role_arn = aws_iam_role.source.arn
+
+  kafka_cluster {
+    amazon_msk_cluster {
+      msk_cluster_arn = aws_msk_cluster.source.arn
+    }
+
+    vpc_config {
+      subnet_ids          = aws_subnet.source[*].id
+      security_groups_ids = [aws_security_group.source.id]
+    }
+  }
+
+  kafka_cluster {
+    amazon_msk_cluster {
+      msk_cluster_arn = aws_msk_cluster.target.arn
+    }
+
+    vpc_config {
+      subnet_ids          = aws_subnet.target[*].id
+      security_groups_ids = [aws_security_group.target.id]
+    }
+  }
+
+  replication_info_list {
+    source_kafka_cluster_arn = aws_msk_cluster.source.arn
+    target_kafka_cluster_arn = aws_msk_cluster.target.arn
+    target_compression_type  = "NONE"
+
+    topic_replication {
+      topics_to_replicate = [".*"]
+    }
+
+    consumer_group_replication {
+      consumer_groups_to_replicate = [".*"]
+    }
+  }
+
+  log_delivery {
+    cloudwatch_logs {
+      enabled   = true
+      log_group = aws_cloudwatch_log_group.test.name
+    }
+
+    s3 {
+      enabled = true
+      bucket  = aws_s3_bucket.test.id
+      prefix  = "logs/"
+    }
+  }
+}
+`, rName, sourceCluster, targetCluster))
+}

--- a/internal/service/kafka/replicator_test.go
+++ b/internal/service/kafka/replicator_test.go
@@ -159,6 +159,254 @@ func TestAccKafkaReplicator_update(t *testing.T) {
 	})
 }
 
+func TestAccKafkaReplicator_logDelivery(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var replicator kafka.DescribeReplicatorOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	sourceCluster := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	targetCluster := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_msk_replicator.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Kafka)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Kafka),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckReplicatorDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReplicatorConfig_logDelivery(rName, sourceCluster, targetCluster),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicatorExists(ctx, t, resourceName, &replicator),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "kafka", regexache.MustCompile(`replicator/`+rName+`/`+kafkaUUIDRegexPattern+`$`)),
+					resource.TestCheckResourceAttr(resourceName, "replicator_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.cloudwatch_logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.cloudwatch_logs.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttrPair(resourceName, "log_delivery.0.cloudwatch_logs.0.log_group", "aws_cloudwatch_log_group.test", names.AttrName),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.s3.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.s3.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttrPair(resourceName, "log_delivery.0.s3.0.bucket", "aws_s3_bucket.test", names.AttrBucket),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.s3.0.prefix", "logs/"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccKafkaReplicator_logDelivery_cloudWatchOnly(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var replicator kafka.DescribeReplicatorOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	sourceCluster := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	targetCluster := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_msk_replicator.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Kafka)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Kafka),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckReplicatorDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReplicatorConfig_logDeliveryCloudWatchOnly(rName, sourceCluster, targetCluster),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicatorExists(ctx, t, resourceName, &replicator),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.cloudwatch_logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.cloudwatch_logs.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttrPair(resourceName, "log_delivery.0.cloudwatch_logs.0.log_group", "aws_cloudwatch_log_group.test", names.AttrName),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.s3.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccKafkaReplicator_logDelivery_s3Only(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var replicator kafka.DescribeReplicatorOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	sourceCluster := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	targetCluster := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_msk_replicator.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Kafka)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Kafka),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckReplicatorDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReplicatorConfig_logDeliveryS3Only(rName, sourceCluster, targetCluster),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicatorExists(ctx, t, resourceName, &replicator),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.cloudwatch_logs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.s3.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.s3.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttrPair(resourceName, "log_delivery.0.s3.0.bucket", "aws_s3_bucket.test", names.AttrBucket),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.s3.0.prefix", "logs/s3-only/"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccKafkaReplicator_logDelivery_firehoseOnlyDisabled(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var replicator kafka.DescribeReplicatorOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	sourceCluster := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	targetCluster := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_msk_replicator.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Kafka)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Kafka),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckReplicatorDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReplicatorConfig_logDeliveryFirehoseOnlyDisabled(rName, sourceCluster, targetCluster),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicatorExists(ctx, t, resourceName, &replicator),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.cloudwatch_logs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.firehose.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.firehose.0.enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.firehose.0.delivery_stream", ""),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.s3.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccKafkaReplicator_logDelivery_allDestinations(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var replicator kafka.DescribeReplicatorOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	sourceCluster := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	targetCluster := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_msk_replicator.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Kafka)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Kafka),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckReplicatorDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReplicatorConfig_logDeliveryAllDestinations(rName, sourceCluster, targetCluster),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicatorExists(ctx, t, resourceName, &replicator),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.cloudwatch_logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.cloudwatch_logs.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.firehose.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.firehose.0.enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.s3.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.s3.0.enabled", acctest.CtTrue),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccKafkaReplicator_logDelivery_empty(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	sourceCluster := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	targetCluster := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Kafka)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Kafka),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccReplicatorConfig_logDeliveryEmpty(rName, sourceCluster, targetCluster),
+				ExpectError: regexache.MustCompile(`log_delivery must include at least one of`),
+			},
+		},
+	})
+}
+
 func TestAccKafkaReplicator_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -768,10 +1016,11 @@ resource "aws_msk_replicator" "test" {
 }
 
 func testAccReplicatorConfig_logDelivery(rName, sourceCluster, targetCluster string) string {
-	return acctest.ConfigCompose(
-		testAccReplicatorConfig_source(sourceCluster),
-		testAccReplicatorConfig_target(targetCluster),
-		fmt.Sprintf(`
+	return testAccReplicatorConfig_logDeliveryBase(
+		rName,
+		sourceCluster,
+		targetCluster,
+		`
 resource "aws_cloudwatch_log_group" "test" {
   name = %[1]q
 }
@@ -779,6 +1028,136 @@ resource "aws_cloudwatch_log_group" "test" {
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
+`,
+		`
+  log_delivery {
+    cloudwatch_logs {
+      enabled   = true
+      log_group = aws_cloudwatch_log_group.test.name
+    }
+
+    s3 {
+      enabled = true
+      bucket  = aws_s3_bucket.test.id
+      prefix  = "logs/"
+    }
+  }
+`,
+	)
+}
+
+func testAccReplicatorConfig_logDeliveryCloudWatchOnly(rName, sourceCluster, targetCluster string) string {
+	return testAccReplicatorConfig_logDeliveryBase(
+		rName,
+		sourceCluster,
+		targetCluster,
+		`
+resource "aws_cloudwatch_log_group" "test" {
+  name = %[1]q
+}
+`,
+		`
+  log_delivery {
+    cloudwatch_logs {
+      enabled   = true
+      log_group = aws_cloudwatch_log_group.test.name
+    }
+  }
+`,
+	)
+}
+
+func testAccReplicatorConfig_logDeliveryS3Only(rName, sourceCluster, targetCluster string) string {
+	return testAccReplicatorConfig_logDeliveryBase(
+		rName,
+		sourceCluster,
+		targetCluster,
+		`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+`,
+		`
+  log_delivery {
+    s3 {
+      enabled = true
+      bucket  = aws_s3_bucket.test.id
+      prefix  = "logs/s3-only/"
+    }
+  }
+`,
+	)
+}
+
+func testAccReplicatorConfig_logDeliveryFirehoseOnlyDisabled(rName, sourceCluster, targetCluster string) string {
+	return testAccReplicatorConfig_logDeliveryBase(
+		rName,
+		sourceCluster,
+		targetCluster,
+		"",
+		`
+  log_delivery {
+    firehose {
+      enabled = false
+    }
+  }
+`,
+	)
+}
+
+func testAccReplicatorConfig_logDeliveryAllDestinations(rName, sourceCluster, targetCluster string) string {
+	return testAccReplicatorConfig_logDeliveryBase(
+		rName,
+		sourceCluster,
+		targetCluster,
+		`
+resource "aws_cloudwatch_log_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+`,
+		`
+  log_delivery {
+    cloudwatch_logs {
+      enabled   = true
+      log_group = aws_cloudwatch_log_group.test.name
+    }
+
+    firehose {
+      enabled = false
+    }
+
+    s3 {
+      enabled = true
+      bucket  = aws_s3_bucket.test.id
+      prefix  = "logs/all-destinations/"
+    }
+  }
+`,
+	)
+}
+
+func testAccReplicatorConfig_logDeliveryEmpty(rName, sourceCluster, targetCluster string) string {
+	return testAccReplicatorConfig_logDeliveryBase(
+		rName,
+		sourceCluster,
+		targetCluster,
+		"",
+		`
+  log_delivery {}
+`,
+	)
+}
+
+func testAccReplicatorConfig_logDeliveryBase(rName, sourceCluster, targetCluster, extraResources, logDelivery string) string {
+	return acctest.ConfigCompose(
+		testAccReplicatorConfig_source(sourceCluster),
+		testAccReplicatorConfig_target(targetCluster),
+		fmt.Sprintf(`
+`+extraResources+`
 
 resource "aws_msk_replicator" "test" {
   replicator_name            = %[1]q
@@ -820,19 +1199,7 @@ resource "aws_msk_replicator" "test" {
       consumer_groups_to_replicate = [".*"]
     }
   }
-
-  log_delivery {
-    cloudwatch_logs {
-      enabled   = true
-      log_group = aws_cloudwatch_log_group.test.name
-    }
-
-    s3 {
-      enabled = true
-      bucket  = aws_s3_bucket.test.id
-      prefix  = "logs/"
-    }
-  }
+`+logDelivery+`
 }
 `, rName, sourceCluster, targetCluster))
 }

--- a/website/docs/r/msk_replicator.html.markdown
+++ b/website/docs/r/msk_replicator.html.markdown
@@ -75,6 +75,7 @@ This resource supports the following arguments:
 * `service_execution_role_arn` - (Required) The ARN of the IAM role used by the replicator to access resources in the customer's account (e.g source and target clusters).
 * `replication_info_list` - (Required) A list of replication configurations, where each configuration targets a given source cluster to target cluster replication flow.
 * `description` - (Optional) A summary description of the replicator.
+* `log_delivery` - (Optional) Configuration block for delivering replicator logs to customer destinations. Must include at least one of `cloudwatch_logs`, `firehose`, or `s3`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### kafka_cluster Argument Reference
@@ -115,6 +116,28 @@ This resource supports the following arguments:
 * `consumer_groups_to_exclude` - (Optional) List of regular expression patterns indicating the consumer groups that should not be replicated.
 * `detect_and_copy_new_consumer_groups` - (Optional) Whether to periodically check for new consumer groups.
 * `synchronise_consumer_group_offsets` - (Optional) Whether to periodically write the translated offsets to __consumer_offsets topic in target cluster.
+
+### log_delivery Argument Reference
+
+* `cloudwatch_logs` - (Optional) CloudWatch Logs destination configuration.
+* `firehose` - (Optional) Firehose destination configuration.
+* `s3` - (Optional) S3 destination configuration.
+
+### cloudwatch_logs Argument Reference
+
+* `enabled` - (Required) Whether log delivery to CloudWatch Logs is enabled.
+* `log_group` - (Optional) The CloudWatch log group destination.
+
+### firehose Argument Reference
+
+* `enabled` - (Required) Whether log delivery to Firehose is enabled.
+* `delivery_stream` - (Optional) The Firehose delivery stream destination.
+
+### s3 Argument Reference
+
+* `enabled` - (Required) Whether log delivery to S3 is enabled.
+* `bucket` - (Optional) The S3 bucket destination.
+* `prefix` - (Optional) The S3 prefix destination.
 
 ### topic_name_configuration
 


### PR DESCRIPTION
Adds support for the `log_delivery` configuration block in the `aws_msk_replicator` resource.

## Changes

This PR adds the `log_delivery` block to configure where MSK Replicator sends its logs. The block supports three destinations:

- CloudWatch Logs
- Kinesis Data Firehose
- S3

## Example Configuration

```hcl
resource "aws_msk_replicator" "example" {
  replicator_name            = "example"
  service_execution_role_arn = aws_iam_role.example.arn

  log_delivery {
    cloudwatch_logs {
      enabled   = true
      log_group = aws_cloudwatch_log_group.example.name
    }

    s3 {
      enabled = true
      bucket  = aws_s3_bucket.example.id
      prefix  = "replicator-logs/"
    }

    firehose {
      enabled         = true
      delivery_stream = aws_kinesis_firehose_delivery_stream.example.name
    }
  }

  # ... other configuration
}
```

## Implementation Notes

- The `log_delivery` block is marked `ForceNew: true` because the AWS API only allows setting log delivery when creating a replicator
- Uses Replicator-specific types: `ReplicatorCloudWatchLogs`, `ReplicatorFirehose`, `ReplicatorS3`
- Log destination resources (S3 buckets, CloudWatch log groups, Firehose streams) must be created separately

## Testing

I cannot run acceptance tests in my environment. Please run them on your side.

```bash
export ACCTEST_PARALLELISM=1

make testacc TESTS=TestAccKafkaReplicator_logDelivery PKG=kafka
make testacc TESTS=TestAccKafkaReplicator_logDelivery_cloudWatchOnly PKG=kafka
make testacc TESTS=TestAccKafkaReplicator_logDelivery_s3Only PKG=kafka
make testacc TESTS=TestAccKafkaReplicator_logDelivery_firehoseOnlyDisabled PKG=kafka
make testacc TESTS=TestAccKafkaReplicator_logDelivery_allDestinations PKG=kafka
make testacc TESTS=TestAccKafkaReplicator_logDelivery_empty PKG=kafka

```

## Checklist

- [x] Code compiles
- [x] Code formatted with `go fmt`
- [x] Changelog entry added
- [x] Test configuration added
- [ ] Acceptance tests run (unable to run locally)