### PR TITLE
cloudformation/aws_cloudformation_stack_instances: Fix update behavior for DIFFERENCE filter

### DIFF
--- a/.changelog/47721.txt
+++ b/.changelog/47721.txt
@@ -1,0 +1,1 @@
+release-note:bug resource/aws_cloudformation_stack_instances: Fix update behavior for DIFFERENCE filter

--- a/internal/service/cloudformation/stack_instances.go
+++ b/internal/service/cloudformation/stack_instances.go
@@ -426,13 +426,28 @@ func resourceStackInstancesUpdate(ctx context.Context, d *schema.ResourceData, m
 		oRaw, nRaw := d.GetChange(AttrDTAccounts)
 		o, n := oRaw.(*schema.Set), nRaw.(*schema.Set)
 
-		if axe := o.Difference(n); axe.Len() > 0 {
+		var axe, add *schema.Set
+
+		// Revisamos si el filtro es de tipo "DIFFERENCE" (lista de exclusión)
+		filterType := d.Get("deployment_targets.0.account_filter_type").(string)
+		if filterType == string(awstypes.AccountFilterTypeDifference) {
+			// Invertimos la lógica: agregar a la lista significa borrar de AWS,
+			// sacar de la lista significa crear en AWS
+			axe = n.Difference(o)
+			add = o.Difference(n)
+		} else {
+			// Lógica normal
+			axe = o.Difference(n)
+			add = n.Difference(o)
+		}
+
+		if axe.Len() > 0 {
 			if err := deleteStackInstances(ctx, d, meta, accounts, regions, flex.ExpandStringValueSet(axe), dtOUs); err != nil {
 				return create.AppendDiagError(diags, names.CloudFormation, create.ErrActionDeleting, ResNameStackInstances, d.Id(), err)
 			}
 		}
 
-		if add := n.Difference(o); add.Len() > 0 {
+		if add.Len() > 0 {
 			diags = append(diags, resourceStackInstancesCreate(ctx, d, meta)...)
 			if diags.HasError() {
 				return diags


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
No.

### Description
When the `account_filter_type` is set to `"DIFFERENCE"` in `deployment_targets`, the list of accounts acts as an exclusion list. Therefore, adding an account to the list implies excluding it (meaning the instance should be deleted), and removing an account from the list implies including it (meaning the instance should be created).

The `Update` logic for `aws_cloudformation_stack_instances` was previously hardcoded to always treat list additions as `CreateStackInstances` and list removals as `DeleteStackInstances`, ignoring the filter type entirely. This caused unexpected and destructive behavior when users updated their exclusion lists.

This PR introduces a check for the `DIFFERENCE` filter type in the `resourceStackInstancesUpdate` function. If present, it inverts the diff calculation logic (`axe` vs `add`) to ensure the correct CloudFormation API actions are triggered.

### Relations
Closes #47721

### References
* Issue #47721: [aws_cloudformation_stack_instances - Removing account from DIFFERENCE filter triggers delete action](https://github.com/hashicorp/terraform-provider-aws/issues/47721)

### Output from Acceptance Testing
<!--
Note: Full acceptance tests require AWS credentials. 
Code has been validated locally with `make fmt` and `go build`.
-->
```console
% make fmt
make: Fixing source code with gofmt...

% go build -o terraform-provider-aws .
# Success (No errors)