### PR TITLE
r/aws_lb_target_group_attachment: new list resource

### DIFF
--- a/.changelog/47724.txt
+++ b/.changelog/47724.txt
@@ -1,0 +1,6 @@
+```release-note:new-list-resource
+aws_lb_target_group_attachment
+```
+```release-note:new-list-resource
+aws_alb_target_group_attachment
+```

--- a/internal/service/elbv2/service_package_gen.go
+++ b/internal/service/elbv2/service_package_gen.go
@@ -357,6 +357,21 @@ func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttype
 			}),
 			Identity: inttypes.RegionalARNIdentity(),
 		},
+		{
+			Factory:  newTargetGroupAttachmentResourceAsListResource,
+			TypeName: "aws_lb_target_group_attachment",
+			Name:     "Target Group Attachment",
+			Region:   inttypes.ResourceRegionDefault(),
+			Identity: inttypes.RegionalParameterizedIdentity([]inttypes.IdentityAttribute{
+				inttypes.StringIdentityAttribute("target_group_arn", true),
+				inttypes.StringIdentityAttribute("target_id", true),
+				inttypes.IntIdentityAttribute(names.AttrPort, false),
+				inttypes.StringIdentityAttribute(names.AttrAvailabilityZone, false),
+				inttypes.StringIdentityAttribute("quic_server_id", false),
+			},
+				inttypes.WithMutableIdentity(),
+			),
+		},
 	})
 }
 

--- a/internal/service/elbv2/target_group_attachment_list.go
+++ b/internal/service/elbv2/target_group_attachment_list.go
@@ -1,0 +1,139 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package elbv2
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKListResource("aws_lb_target_group_attachment", name="Target Group Attachment")
+func newTargetGroupAttachmentResourceAsListResource() inttypes.ListResourceForSDK {
+	l := targetGroupAttachmentListResource{}
+	l.SetResourceSchema(resourceTargetGroupAttachment())
+	return &l
+}
+
+var _ list.ListResource = &targetGroupAttachmentListResource{}
+
+type targetGroupAttachmentListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+type listTargetGroupAttachmentModel struct {
+	framework.WithRegionModel
+	TargetGroupARN types.String `tfsdk:"target_group_arn"`
+}
+
+func (l *targetGroupAttachmentListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = listschema.Schema{
+		Attributes: map[string]listschema.Attribute{
+			"target_group_arn": listschema.StringAttribute{
+				Required:    true,
+				Description: "ARN of the Target Group to list Attachments from.",
+			},
+		},
+	}
+}
+
+func (l *targetGroupAttachmentListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	conn := l.Meta().ELBV2Client(ctx)
+
+	var query listTargetGroupAttachmentModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	targetGroupARN := query.TargetGroupARN.ValueString()
+	input := elasticloadbalancingv2.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(targetGroupARN),
+	}
+
+	tflog.Info(ctx, "Listing Resources", map[string]any{
+		logging.ResourceAttributeKey("target_group_arn"): targetGroupARN,
+	})
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		for item, err := range listTargetGroupAttachments(ctx, conn, &input) {
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+
+			targetID := aws.ToString(item.Target.Id)
+			if targetID == "" {
+				continue
+			}
+
+			ctx = tflog.SetField(ctx, logging.ResourceAttributeKey("target_id"), targetID)
+
+			result := request.NewListResult(ctx)
+			rd := l.ResourceData()
+			rd.Set("target_group_arn", targetGroupARN)
+			flattenTargetGroupAttachment(rd, item.Target)
+			rd.SetId(targetGroupAttachmentImportID{}.Create(rd))
+
+			if request.IncludeResource { //nolint:revive,staticcheck // Be explicit about IncludeResource handling.
+				// No-op, all readable attributes are already populated above.
+			}
+
+			result.DisplayName = fmt.Sprintf("%s (%s)", targetID, targetGroupARN)
+
+			l.SetResult(ctx, l.Meta(), request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+func listTargetGroupAttachments(ctx context.Context, conn *elasticloadbalancingv2.Client, input *elasticloadbalancingv2.DescribeTargetHealthInput) iter.Seq2[awstypes.TargetHealthDescription, error] {
+	return func(yield func(awstypes.TargetHealthDescription, error) bool) {
+		output, err := conn.DescribeTargetHealth(ctx, input)
+		if err != nil {
+			yield(awstypes.TargetHealthDescription{}, fmt.Errorf("listing ELB Target Group Attachment resources for target group (%s): %w", aws.ToString(input.TargetGroupArn), err))
+			return
+		}
+
+		for _, item := range output.TargetHealthDescriptions {
+			if !yield(item, nil) {
+				return
+			}
+		}
+	}
+}
+
+func flattenTargetGroupAttachment(d *schema.ResourceData, target *awstypes.TargetDescription) {
+	d.Set("target_id", target.Id)
+	d.Set(names.AttrPort, target.Port)
+	d.Set(names.AttrAvailabilityZone, target.AvailabilityZone)
+
+	if v := aws.ToString(target.QuicServerId); v != "" {
+		d.Set("quic_server_id", v)
+	}
+}

--- a/internal/service/elbv2/target_group_attachment_list_test.go
+++ b/internal/service/elbv2/target_group_attachment_list_test.go
@@ -1,0 +1,211 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package elbv2_test
+
+import (
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/terraform-plugin-testing/compare"
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccELBV2TargetGroupAttachment_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_lb_target_group_attachment.test[0]"
+	resourceName2 := "aws_lb_target_group_attachment.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		CheckDestroy:             testAccCheckTargetGroupAttachmentDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/TargetGroupAttachment/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.CompareValuePairs(resourceName1, tfjsonpath.New("target_group_arn"), "aws_lb_target_group.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
+					statecheck.CompareValuePairs(resourceName1, tfjsonpath.New("target_id"), "aws_instance.test[0]", tfjsonpath.New(names.AttrID), compare.ValuesSame()),
+					statecheck.ExpectIdentityValueMatchesState(resourceName1, tfjsonpath.New("target_group_arn")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName1, tfjsonpath.New("target_id")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName1, tfjsonpath.New(names.AttrPort)),
+
+					identity2.GetIdentity(resourceName2),
+					statecheck.CompareValuePairs(resourceName2, tfjsonpath.New("target_group_arn"), "aws_lb_target_group.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
+					statecheck.CompareValuePairs(resourceName2, tfjsonpath.New("target_id"), "aws_instance.test[1]", tfjsonpath.New(names.AttrID), compare.ValuesSame()),
+					statecheck.ExpectIdentityValueMatchesState(resourceName2, tfjsonpath.New("target_group_arn")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName2, tfjsonpath.New("target_id")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName2, tfjsonpath.New(names.AttrPort)),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/TargetGroupAttachment/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_lb_target_group_attachment.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_lb_target_group_attachment.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringRegexp(regexache.MustCompile(`^i-[a-f0-9]+ \(arn:aws[a-z-]*:elasticloadbalancing:[a-z0-9-]+:[0-9]{12}:targetgroup/.+/.+\)$`))),
+					tfquerycheck.ExpectNoResourceObject("aws_lb_target_group_attachment.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_lb_target_group_attachment.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_lb_target_group_attachment.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringRegexp(regexache.MustCompile(`^i-[a-f0-9]+ \(arn:aws[a-z-]*:elasticloadbalancing:[a-z0-9-]+:[0-9]{12}:targetgroup/.+/.+\)$`))),
+					tfquerycheck.ExpectNoResourceObject("aws_lb_target_group_attachment.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccELBV2TargetGroupAttachment_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_lb_target_group_attachment.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		CheckDestroy:             testAccCheckTargetGroupAttachmentDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/TargetGroupAttachment/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity.GetIdentity(resourceName),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New("target_group_arn"), "aws_lb_target_group.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New("target_id"), "aws_instance.test[0]", tfjsonpath.New(names.AttrID), compare.ValuesSame()),
+					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New("target_group_arn")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New("target_id")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrPort)),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/TargetGroupAttachment/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_lb_target_group_attachment.test", identity.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_lb_target_group_attachment.test", tfqueryfilter.ByResourceIdentityFunc(identity.Checks()), knownvalue.StringRegexp(regexache.MustCompile(`^i-[a-f0-9]+ \(arn:aws[a-z-]*:elasticloadbalancing:[a-z0-9-]+:[0-9]{12}:targetgroup/.+/.+\)$`))),
+					querycheck.ExpectResourceKnownValues("aws_lb_target_group_attachment.test", tfqueryfilter.ByResourceIdentityFunc(identity.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("target_group_arn"), tfknownvalue.RegionalARNRegexp("elasticloadbalancing", regexache.MustCompile(`targetgroup/.+/.+$`))),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("target_id"), knownvalue.StringRegexp(regexache.MustCompile(`^i-[a-f0-9]+$`))),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrPort), knownvalue.Int64Exact(80)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrAvailabilityZone), knownvalue.Null()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("quic_server_id"), knownvalue.Null()),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccELBV2TargetGroupAttachment_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_lb_target_group_attachment.test[0]"
+	resourceName2 := "aws_lb_target_group_attachment.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		CheckDestroy:             testAccCheckTargetGroupAttachmentDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/TargetGroupAttachment/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.AlternateRegion())),
+					statecheck.CompareValuePairs(resourceName1, tfjsonpath.New("target_group_arn"), "aws_lb_target_group.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
+					statecheck.CompareValuePairs(resourceName1, tfjsonpath.New("target_id"), "aws_instance.test[0]", tfjsonpath.New(names.AttrID), compare.ValuesSame()),
+					statecheck.ExpectIdentityValueMatchesState(resourceName1, tfjsonpath.New("target_group_arn")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName1, tfjsonpath.New("target_id")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName1, tfjsonpath.New(names.AttrPort)),
+
+					identity2.GetIdentity(resourceName2),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.AlternateRegion())),
+					statecheck.CompareValuePairs(resourceName2, tfjsonpath.New("target_group_arn"), "aws_lb_target_group.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
+					statecheck.CompareValuePairs(resourceName2, tfjsonpath.New("target_id"), "aws_instance.test[1]", tfjsonpath.New(names.AttrID), compare.ValuesSame()),
+					statecheck.ExpectIdentityValueMatchesState(resourceName2, tfjsonpath.New("target_group_arn")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName2, tfjsonpath.New("target_id")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName2, tfjsonpath.New(names.AttrPort)),
+				},
+			},
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/TargetGroupAttachment/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_lb_target_group_attachment.test", identity1.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_lb_target_group_attachment.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/elbv2/target_group_attachment_test.go
+++ b/internal/service/elbv2/target_group_attachment_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfelbv2 "github.com/hashicorp/terraform-provider-aws/internal/service/elbv2"
@@ -529,12 +530,14 @@ func testAccCheckTargetGroupAttachmentExists(ctx context.Context, t *testing.T, 
 
 func testAccCheckTargetGroupAttachmentDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.ProviderMeta(ctx, t).ELBV2Client(ctx)
-
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_lb_target_group_attachment" && rs.Type != "aws_alb_target_group_attachment" {
 				continue
 			}
+
+			// To support region override testing
+			ctx := conns.NewResourceContext(ctx, "", "", "", rs.Primary.Attributes[names.AttrRegion])
+			conn := acctest.ProviderMeta(ctx, t).ELBV2Client(ctx)
 
 			input := &elasticloadbalancingv2.DescribeTargetHealthInput{
 				TargetGroupArn: aws.String(rs.Primary.Attributes["target_group_arn"]),

--- a/internal/service/elbv2/testdata/TargetGroupAttachment/list_basic/main.tf
+++ b/internal/service/elbv2/testdata/TargetGroupAttachment/list_basic/main.tf
@@ -1,0 +1,79 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_lb_target_group_attachment" "test" {
+  count = var.resource_count
+
+  target_group_arn = aws_lb_target_group.test.arn
+  target_id        = aws_instance.test[count.index].id
+  port             = 80
+}
+
+data "aws_ami" "amzn2_ami" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-minimal-hvm-*"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+data "aws_availability_zones" "available" {
+  exclude_zone_ids = ["usw2-az4", "usgw1-az2"]
+  state            = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test" {
+  count = var.resource_count
+
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
+}
+
+resource "aws_instance" "test" {
+  count = var.resource_count
+
+  ami           = data.aws_ami.amzn2_ami.id
+  instance_type = "t3.micro"
+  subnet_id     = aws_subnet.test[count.index].id
+}
+
+resource "aws_lb_target_group" "test" {
+  name     = var.rName
+  port     = 443
+  protocol = "HTTPS"
+  vpc_id   = aws_vpc.test.id
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/elbv2/testdata/TargetGroupAttachment/list_basic/query.tfquery.hcl
+++ b/internal/service/elbv2/testdata/TargetGroupAttachment/list_basic/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_lb_target_group_attachment" "test" {
+  provider = aws
+
+  config {
+    target_group_arn = aws_lb_target_group.test.arn
+  }
+}

--- a/internal/service/elbv2/testdata/TargetGroupAttachment/list_include_resource/main.tf
+++ b/internal/service/elbv2/testdata/TargetGroupAttachment/list_include_resource/main.tf
@@ -1,0 +1,79 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_lb_target_group_attachment" "test" {
+  count = var.resource_count
+
+  target_group_arn = aws_lb_target_group.test.arn
+  target_id        = aws_instance.test[count.index].id
+  port             = 80
+}
+
+data "aws_ami" "amzn2_ami" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-minimal-hvm-*"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+data "aws_availability_zones" "available" {
+  exclude_zone_ids = ["usw2-az4", "usgw1-az2"]
+  state            = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test" {
+  count = var.resource_count
+
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
+}
+
+resource "aws_instance" "test" {
+  count = var.resource_count
+
+  ami           = data.aws_ami.amzn2_ami.id
+  instance_type = "t3.micro"
+  subnet_id     = aws_subnet.test[count.index].id
+}
+
+resource "aws_lb_target_group" "test" {
+  name     = var.rName
+  port     = 443
+  protocol = "HTTPS"
+  vpc_id   = aws_vpc.test.id
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/elbv2/testdata/TargetGroupAttachment/list_include_resource/query.tfquery.hcl
+++ b/internal/service/elbv2/testdata/TargetGroupAttachment/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,12 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_lb_target_group_attachment" "test" {
+  provider = aws
+
+  include_resource = true
+
+  config {
+    target_group_arn = aws_lb_target_group.test.arn
+  }
+}

--- a/internal/service/elbv2/testdata/TargetGroupAttachment/list_region_override/main.tf
+++ b/internal/service/elbv2/testdata/TargetGroupAttachment/list_region_override/main.tf
@@ -1,0 +1,96 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_lb_target_group_attachment" "test" {
+  region = var.region
+  count  = var.resource_count
+
+  target_group_arn = aws_lb_target_group.test.arn
+  target_id        = aws_instance.test[count.index].id
+  port             = 80
+}
+
+data "aws_ami" "amzn2_ami" {
+  region = var.region
+
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-minimal-hvm-*"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+data "aws_availability_zones" "available" {
+  region = var.region
+
+  exclude_zone_ids = ["usw2-az4", "usgw1-az2"]
+  state            = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  region = var.region
+
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test" {
+  region = var.region
+  count  = var.resource_count
+
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
+}
+
+resource "aws_instance" "test" {
+  region = var.region
+  count  = var.resource_count
+
+  ami           = data.aws_ami.amzn2_ami.id
+  instance_type = "t3.micro"
+  subnet_id     = aws_subnet.test[count.index].id
+}
+
+resource "aws_lb_target_group" "test" {
+  region = var.region
+
+  name     = var.rName
+  port     = 443
+  protocol = "HTTPS"
+  vpc_id   = aws_vpc.test.id
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/elbv2/testdata/TargetGroupAttachment/list_region_override/query.tfquery.hcl
+++ b/internal/service/elbv2/testdata/TargetGroupAttachment/list_region_override/query.tfquery.hcl
@@ -1,0 +1,11 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_lb_target_group_attachment" "test" {
+  provider = aws
+
+  config {
+    region           = var.region
+    target_group_arn = aws_lb_target_group.test.arn
+  }
+}

--- a/website/docs/list-resources/lb_target_group_attachment.html.markdown
+++ b/website/docs/list-resources/lb_target_group_attachment.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "ELB (Elastic Load Balancing)"
+layout: "aws"
+page_title: "AWS: aws_lb_target_group_attachment"
+description: |-
+  Lists ELB Target Group Attachment resources.
+---
+
+# List Resource: aws_lb_target_group_attachment
+
+Lists ELB Target Group Attachment resources.
+
+## Example Usage
+
+```terraform
+list "aws_lb_target_group_attachment" "example" {
+  provider = aws
+
+  config {
+    target_group_arn = aws_lb_target_group.example.arn
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.
+* `target_group_arn` - (Required) ARN of the Target Group to list attachments for.


### PR DESCRIPTION

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds list support to the `aws_lb_target_group_attachment` and `aws_alb_target_group_attachment` resource types.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47219
Relates https://github.com/hashicorp/terraform-provider-aws/issues/47005



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=elbv2 T=TestAccELBV2TargetGroupAttachment_List
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 tmp2 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2TargetGroupAttachment_List'  -timeout 360m -vet=off
2026/05/01 14:53:01 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/01 14:53:01 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccELBV2TargetGroupAttachment_List_includeResource (80.14s)
--- PASS: TestAccELBV2TargetGroupAttachment_List_basic (81.07s)
--- PASS: TestAccELBV2TargetGroupAttachment_List_regionOverride (287.93s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      295.294s
```

```console
% make t K=elbv2 T=TestAccELBV2TargetGroupAttachment_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-lb_target_group_attachment-list 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2TargetGroupAttachment_'  -timeout 360m -vet=off
2026/05/01 15:06:10 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/01 15:06:10 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccELBV2TargetGroupAttachment_lambda (84.12s)
--- PASS: TestAccELBV2TargetGroupAttachment_List_regionOverride (95.81s)
--- PASS: TestAccELBV2TargetGroupAttachment_List_basic (106.60s)
--- PASS: TestAccELBV2TargetGroupAttachment_List_includeResource (110.92s)
--- PASS: TestAccELBV2TargetGroupAttachment_basic (115.31s)
--- PASS: TestAccELBV2TargetGroupAttachment_disappears (119.52s)
--- PASS: TestAccELBV2TargetGroupAttachment_backwardsCompatibility (122.60s)
--- PASS: TestAccELBV2TargetGroupAttachment_ipAddress (124.70s)
--- PASS: TestAccELBV2TargetGroupAttachment_Identity_ExistingResource_noRefreshNoChange (125.80s)
--- PASS: TestAccELBV2TargetGroupAttachment_quic (132.21s)
--- PASS: TestAccELBV2TargetGroupAttachment_port (133.07s)
--- PASS: TestAccELBV2TargetGroupAttachment_quicServerId_tcpQuic (134.05s)
--- PASS: TestAccELBV2TargetGroupAttachment_Identity_basic (139.51s)
--- PASS: TestAccELBV2TargetGroupAttachment_Identity_ExistingResource_basic (139.97s)
--- PASS: TestAccELBV2TargetGroupAttachment_Identity_quicNoPort (140.48s)
--- PASS: TestAccELBV2TargetGroupAttachment_Identity_regionOverride (144.84s)
--- PASS: TestAccELBV2TargetGroupAttachment_Identity_quic (146.96s)
--- PASS: TestAccELBV2TargetGroupAttachment_Identity_noPort (158.25s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      165.959s
```