### PR TITLE
Simplify route_table_id assignment in markdown

### DIFF
--- a/website/docs/d/route_tables.html.markdown
+++ b/website/docs/d/route_tables.html.markdown
@@ -28,7 +28,7 @@ data "aws_route_tables" "rts" {
 
 resource "aws_route" "r" {
   count                     = length(data.aws_route_tables.rts.ids)
-  route_table_id            = tolist(data.aws_route_tables.rts.ids)[count.index]
+  route_table_id            = data.aws_route_tables.rts.ids[count.index]
   destination_cidr_block    = "10.0.0.0/22"
   vpc_peering_connection_id = "pcx-0e9a7a9ecd137dc54"
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
As far as data.aws_route_tables.this.ids returns an object with type "list", there is no need to use tolist() for it.