### PR TITLE
[Docs] Fix typo: ENTERPPRISE_AND_Q -> ENTERPRISE_AND_Q

### DIFF
--- a/website/docs/r/quicksight_account_subscription.html.markdown
+++ b/website/docs/r/quicksight_account_subscription.html.markdown
@@ -40,12 +40,12 @@ The following arguments are optional:
 * `author_group` - (Optional) Author group associated with your Active Directory or IAM Identity Center account.
 * `author_pro_group` - (Optional) Author PRO group associated with your Active Directory or IAM Identity Center account.
 * `aws_account_id` - (Optional, Forces new resource) AWS account ID. Defaults to automatically determined account ID of the Terraform AWS provider.
-* `contact_number` - (Optional) A 10-digit phone number for the author of the Amazon QuickSight account to use for future communications. This field is required if `ENTERPPRISE_AND_Q` is the selected edition of the new Amazon QuickSight account.
+* `contact_number` - (Optional) A 10-digit phone number for the author of the Amazon QuickSight account to use for future communications. This field is required if `ENTERPRISE_AND_Q` is the selected edition of the new Amazon QuickSight account.
 * `directory_id` - (Optional) Active Directory ID that is associated with your Amazon QuickSight account.
-* `email_address` - (Optional) Email address of the author of the Amazon QuickSight account to use for future communications. This field is required if `ENTERPPRISE_AND_Q` is the selected edition of the new Amazon QuickSight account.
-* `first_name` - (Optional) First name of the author of the Amazon QuickSight account to use for future communications. This field is required if `ENTERPPRISE_AND_Q` is the selected edition of the new Amazon QuickSight account.
+* `email_address` - (Optional) Email address of the author of the Amazon QuickSight account to use for future communications. This field is required if `ENTERPRISE_AND_Q` is the selected edition of the new Amazon QuickSight account.
+* `first_name` - (Optional) First name of the author of the Amazon QuickSight account to use for future communications. This field is required if `ENTERPRISE_AND_Q` is the selected edition of the new Amazon QuickSight account.
 * `iam_identity_center_instance_arn` - (Optional) The Amazon Resource Name (ARN) for the IAM Identity Center instance.
-* `last_name` - (Optional) Last name of the author of the Amazon QuickSight account to use for future communications. This field is required if `ENTERPPRISE_AND_Q` is the selected edition of the new Amazon QuickSight account.
+* `last_name` - (Optional) Last name of the author of the Amazon QuickSight account to use for future communications. This field is required if `ENTERPRISE_AND_Q` is the selected edition of the new Amazon QuickSight account.
 * `reader_group` - (Optional) Reader group associated with your Active Directory or IAM Identity Center account.
 * `reader_pro_group` - (Optional) Reader PRO group associated with your Active Directory or IAM Identity Center account.
 * `realm` - (Optional) Realm of the Active Directory that is associated with your Amazon QuickSight account.


### PR DESCRIPTION
## Summary

Fixes a typo in the Quicksight account subscription documentation.

## Changes

- `website/docs/r/quicksight_account_subscription.html.markdown`: `ENTERPPRISE_AND_Q` → `ENTERPRISE_AND_Q` (double P)

Closes hashicorp/terraform-provider-aws#47693