### PR TITLE
r/aws_lb_target_group_attachment(test): fix `List_includeResource` test

### DIFF
--- a/internal/service/elbv2/target_group_attachment_list_test.go
+++ b/internal/service/elbv2/target_group_attachment_list_test.go
@@ -137,7 +137,7 @@ func TestAccELBV2TargetGroupAttachment_List_includeResource(t *testing.T) {
 						tfquerycheck.KnownValueCheck(tfjsonpath.New("target_group_arn"), tfknownvalue.RegionalARNRegexp("elasticloadbalancing", regexache.MustCompile(`targetgroup/.+/.+$`))),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New("target_id"), knownvalue.StringRegexp(regexache.MustCompile(`^i-[a-f0-9]+$`))),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrPort), knownvalue.Int64Exact(80)),
-						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrAvailabilityZone), knownvalue.Null()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrAvailabilityZone), knownvalue.StringExact("")),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New("quic_server_id"), knownvalue.Null()),
 					}),
 				},


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Follow up from #47724 to fix a test case which was inadvertently broken during the final rebase.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #47724


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=elbv2 T=TestAccELBV2TargetGroupAttachment_List
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 tmp2 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2TargetGroupAttachment_List'  -timeout 360m -vet=off
2026/05/04 10:55:50 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/04 10:55:50 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccELBV2TargetGroupAttachment_List_includeResource (80.30s)
--- PASS: TestAccELBV2TargetGroupAttachment_List_basic (81.02s)
--- PASS: TestAccELBV2TargetGroupAttachment_List_regionOverride (307.67s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      315.649s
```
