### PR TITLE
resource/aws_dynamodb_global_secondary_index: Removes experimental flag

### DIFF
--- a/.changelog/47747.txt
+++ b/.changelog/47747.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_dynamodb_global_secondary_index: This resource type is no longer experimental. The schema and behavior are now subject to the backwards compatibility guarantee of the provider.
+```

--- a/internal/service/dynamodb/exports_test.go
+++ b/internal/service/dynamodb/exports_test.go
@@ -38,7 +38,3 @@ var (
 	UpdateDiffGSI                                = updateDiffGSI
 	CheckIfGSIRecreateAttributesChanged          = checkIfGSIRecreateAttributesChanged
 )
-
-const (
-	GlobalSecondaryIndexExperimentalFlagEnvVar = globalSecondaryIndexExperimentalFlagEnvVar
-)

--- a/internal/service/dynamodb/global_secondary_index.go
+++ b/internal/service/dynamodb/global_secondary_index.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -29,7 +28,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
@@ -40,7 +38,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
-	semconv "go.opentelemetry.io/otel/semconv/v1.38.0"
 )
 
 const (
@@ -58,7 +55,6 @@ const (
 // @Testing(hasNoPreExistingResource=true)
 // @Testing(importStateIdFunc=testAccGlobalSecondaryIndexImportStateIdFunc)
 // @Testing(importStateIdAttribute="arn")
-// @Testing(requireEnvVar="TF_AWS_EXPERIMENT_dynamodb_global_secondary_index")
 func newResourceGlobalSecondaryIndex(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resourceGlobalSecondaryIndex{}
 	r.SetDefaultCreateTimeout(30 * time.Minute)
@@ -67,10 +63,6 @@ func newResourceGlobalSecondaryIndex(_ context.Context) (resource.ResourceWithCo
 
 	return r, nil
 }
-
-var (
-	_ resource.ResourceWithValidateConfig = &resourceGlobalSecondaryIndex{}
-)
 
 type resourceGlobalSecondaryIndex struct {
 	framework.ResourceWithModel[resourceGlobalSecondaryIndexModel]
@@ -604,40 +596,6 @@ func (r *resourceGlobalSecondaryIndex) Delete(ctx context.Context, request resou
 			fmt.Sprintf(`Error while waiting for "%s" to be active after delete`, data.TableName.ValueString()),
 			err.Error(),
 		)
-	}
-}
-
-const (
-	globalSecondaryIndexExperimentalFlagEnvVar = "TF_AWS_EXPERIMENT_dynamodb_global_secondary_index"
-)
-
-func (r *resourceGlobalSecondaryIndex) ValidateConfig(ctx context.Context, request resource.ValidateConfigRequest, response *resource.ValidateConfigResponse) {
-	if flag := os.Getenv(globalSecondaryIndexExperimentalFlagEnvVar); flag != "" {
-		response.Diagnostics.AddWarning(
-			"Experimental Resource Type Enabled: \"aws_dynamodb_global_secondary_index\"",
-			fmt.Sprintf("The experimental resource type \"aws_dynamodb_global_secondary_index\" has been enabled by setting the environment variable \""+globalSecondaryIndexExperimentalFlagEnvVar+"\" to %q.", flag)+
-				"\n\nPlease be aware that experimental features are not covered by any SLA or support agreement, and may not be suitable for production workloads. "+
-				"Experimental features may change without notice, including removal from the provider.",
-		)
-		tflog.Info(ctx, "Experimental resource type enabled", map[string]any{
-			string(semconv.FeatureFlagKeyKey):           globalSecondaryIndexExperimentalFlagEnvVar,
-			string(semconv.FeatureFlagResultValueKey):   flag,
-			string(semconv.FeatureFlagResultVariantKey): "enabled", // nosemgrep:ci.literal-enabled-string-constant
-		})
-	} else {
-		response.Diagnostics.AddError(
-			"Experimental Resource Type Not Enabled: \"aws_dynamodb_global_secondary_index\"",
-			"The experimental resource type \"aws_dynamodb_global_secondary_index\" is not enabled. "+
-				"To enable this resource type, set the environment variable \""+globalSecondaryIndexExperimentalFlagEnvVar+"\" to any value before running Terraform."+
-				"\n\nPlease be aware that experimental features are not covered by any SLA or support agreement, and may not be suitable for production workloads. "+
-				"Experimental features may change without notice, including removal from the provider.",
-		)
-		tflog.Error(ctx, "Experimental resource type not enabled", map[string]any{
-			string(semconv.FeatureFlagKeyKey):                  globalSecondaryIndexExperimentalFlagEnvVar,
-			string(semconv.FeatureFlagResultValueKey):          nil,
-			string(semconv.FeatureFlagResultVariantKey):        "disabled",
-			string(semconv.FeatureFlagResultReasonDefault.Key): semconv.FeatureFlagResultReasonDefault.Value,
-		})
 	}
 }
 

--- a/internal/service/dynamodb/global_secondary_index_identity_gen_test.go
+++ b/internal/service/dynamodb/global_secondary_index_identity_gen_test.go
@@ -25,7 +25,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_Identity_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v awstypes.GlobalSecondaryIndexDescription
-	acctest.SkipIfEnvVarNotSet(t, "TF_AWS_EXPERIMENT_dynamodb_global_secondary_index")
 	resourceName := "aws_dynamodb_global_secondary_index.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
@@ -117,7 +116,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_Identity_basic(t *testing.T) {
 func TestAccDynamoDBGlobalSecondaryIndex_Identity_regionOverride(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	acctest.SkipIfEnvVarNotSet(t, "TF_AWS_EXPERIMENT_dynamodb_global_secondary_index")
 	resourceName := "aws_dynamodb_global_secondary_index.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 

--- a/internal/service/dynamodb/global_secondary_index_test.go
+++ b/internal/service/dynamodb/global_secondary_index_test.go
@@ -31,8 +31,6 @@ const (
 )
 
 func TestAccDynamoDBGlobalSecondaryIndex_basic(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -99,8 +97,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_basic(t *testing.T) {
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_disappears(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -136,8 +132,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_disappears(t *testing.T) {
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_disappears_table(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -173,8 +167,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_disappears_table(t *testing.T) {
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_provisioned_capacityChange(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -259,8 +251,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_provisioned_capacityChange(t *testing.T
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_provisioned_capacityChange_ignoreChanges(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -338,8 +328,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_provisioned_capacityChange_ignoreChange
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_provisioned_changeTableCapacity_gsiSameAsTable(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -425,8 +413,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_provisioned_changeTableCapacity_gsiSame
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_provisioned_changeTableCapacity_gsiDifferentFromTable(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -512,8 +498,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_provisioned_changeTableCapacity_gsiDiff
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_provisioned_warmThroughput_basic(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -573,8 +557,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_provisioned_warmThroughput_basic(t *tes
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_provisioned_warmThroughput_updateFromUnspecified(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -647,8 +629,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_provisioned_warmThroughput_updateFromUn
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_provisioned_warmThroughput_updateFromUnspecified_noChange(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -721,8 +701,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_provisioned_warmThroughput_updateFromUn
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_provisioned_throughputChanges(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	t.Parallel()
 
 	const (
@@ -863,8 +841,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_provisioned_throughputChanges(t *testin
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_basic(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -910,8 +886,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_basic(t *testing.T
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -962,8 +936,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput_capacityChange(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -1043,8 +1015,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput_capacityChange_ignoreChanges(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -1122,8 +1092,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput_unset_read(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -1196,8 +1164,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput_unset_write(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -1270,8 +1236,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_warmThroughput_basic(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -1318,8 +1282,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_warmThroughput_bas
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_warmThroughput_explicitDefault(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -1366,8 +1328,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_warmThroughput_exp
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_warmThroughput_updateFromUnspecified(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -1438,8 +1398,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_warmThroughput_upd
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_warmThroughput_updateFromUnspecified_noChange(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -1510,8 +1468,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_warmThroughput_upd
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_payPerRequest_throughputChanges(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	t.Parallel()
 
 	const (
@@ -1674,8 +1630,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_payPerRequest_throughputChanges(t *test
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_validate_Attributes(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 
 	rNameTable := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -1696,8 +1650,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_validate_Attributes(t *testing.T) {
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_validate_KeySchemas(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 
 	rNameTable := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -1709,10 +1661,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_validate_KeySchemas(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckGlobalSecondaryIndexDestroy(ctx, t),
 		Steps: []resource.TestStep{
-			{
-				Config:      testAccGlobalSecondaryIndexConfig_validateAttribute_numberOfKeySchemas(rNameTable, rName, 0, 0),
-				ExpectError: regexache.MustCompile(`Attribute key_schema must contain at least 1 and at most 4 elements with\s+"key_type" "HASH", got: 0`),
-			},
 			{
 				Config:      testAccGlobalSecondaryIndexConfig_validateAttribute_numberOfKeySchemas(rNameTable, rName, 5, 0),
 				ExpectError: regexache.MustCompile(`Attribute key_schema must contain at least 1 and at most 4 elements with\s+"key_type" "HASH", got: 5`),
@@ -1726,8 +1674,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_validate_KeySchemas(t *testing.T) {
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_payPerRequest_to_provisioned(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -1807,8 +1753,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_payPerRequest_to_provisioned(t *testing
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_provisioned_to_payPerRequest_unspecifiedCapacity(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -1876,8 +1820,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_provisioned_to_payPerRequest_unspecifie
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_provisioned_to_payPerRequest_specifiedCapacity(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -1957,8 +1899,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_provisioned_to_payPerRequest_specifiedC
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_keysNotOnTable_onCreate_hashOnly(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -2025,8 +1965,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_keysNotOnTable_onCreate_hashOnly(t *tes
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_keysNotOnTable_onCreate_hashAndSort(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -2103,8 +2041,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_keysNotOnTable_onCreate_hashAndSort(t *
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_keysNotOnTable_onUpdate_hashOnly(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -2235,8 +2171,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_keysNotOnTable_onUpdate_hashOnly(t *tes
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_keysNotOnTable_onUpdate_hashAndSort(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -2387,8 +2321,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_keysNotOnTable_onUpdate_hashAndSort(t *
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_nonKeyAttributes_onCreate(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -2435,8 +2367,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_nonKeyAttributes_onCreate(t *testing.T)
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_nonKeyAttributes_onUpdate(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -2503,8 +2433,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_nonKeyAttributes_onUpdate(t *testing.T)
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_concurrentGSI_create(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi1 awstypes.GlobalSecondaryIndexDescription
@@ -2537,8 +2465,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_concurrentGSI_create(t *testing.T) {
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_concurrentGSI_update(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi1 awstypes.GlobalSecondaryIndexDescription
@@ -2579,8 +2505,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_concurrentGSI_update(t *testing.T) {
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_concurrentGSI_delete(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi1 awstypes.GlobalSecondaryIndexDescription
@@ -2622,8 +2546,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_concurrentGSI_delete(t *testing.T) {
 
 // lintignore:AT002
 func TestAccDynamoDBGlobalSecondaryIndex_migrate_single_importcmd(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -2694,8 +2616,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_migrate_single_importcmd(t *testing.T) 
 
 // lintignore:AT002
 func TestAccDynamoDBGlobalSecondaryIndex_migrate_single_importblock(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi awstypes.GlobalSecondaryIndexDescription
@@ -2758,8 +2678,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_migrate_single_importblock(t *testing.T
 
 // lintignore:AT002
 func TestAccDynamoDBGlobalSecondaryIndex_migrate_multiple_importcmd(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 
@@ -2822,8 +2740,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_migrate_multiple_importcmd(t *testing.T
 
 // lintignore:AT002
 func TestAccDynamoDBGlobalSecondaryIndex_migrate_multiple_importblock(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 	var gsi1 awstypes.GlobalSecondaryIndexDescription
@@ -2903,8 +2819,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_migrate_multiple_importblock(t *testing
 }
 
 func TestAccDynamoDBGlobalSecondaryIndex_migrate_partial(t *testing.T) {
-	acctest.SkipIfEnvVarNotSet(t, tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar)
-
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
 
@@ -2955,29 +2869,6 @@ func TestAccDynamoDBGlobalSecondaryIndex_migrate_partial(t *testing.T) {
 					},
 				},
 				ExpectNonEmptyPlan: true,
-			},
-		},
-	})
-}
-
-func TestAccDynamoDBGlobalSecondaryIndex_featureFlagNotSet(t *testing.T) {
-	ctx := acctest.Context(t)
-
-	// Explicitly clear `TF_AWS_EXPERIMENT_dynamodb_global_secondary_index`
-	t.Setenv(tfdynamodb.GlobalSecondaryIndexExperimentalFlagEnvVar, "")
-
-	rNameTable := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-
-	acctest.Test(ctx, t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalSecondaryIndexDestroy(ctx, t),
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccGlobalSecondaryIndexConfig_basic(rNameTable, rName),
-				ExpectError: regexache.MustCompile(`Experimental Resource Type Not Enabled: "aws_dynamodb_global_secondary_index"`),
 			},
 		},
 	})

--- a/website/docs/r/dynamodb_global_secondary_index.html.markdown
+++ b/website/docs/r/dynamodb_global_secondary_index.html.markdown
@@ -8,12 +8,6 @@ description: |-
 
 # Resource: aws_dynamodb_global_secondary_index
 
-!> The resource type `aws_dynamodb_global_secondary_index` is an experimental feature. The schema or behavior may change without notice, and it is not subject to the backwards compatibility guarantee of the provider.
-
-~> The resource type `aws_dynamodb_global_secondary_index` can be enabled by setting the environment variable `TF_AWS_EXPERIMENT_dynamodb_global_secondary_index` to any value. If not enabled, use of `aws_dynamodb_global_secondary_index` will result in an error when running Terraform.
-
--> Please provide feedback, positive or negative, at https://github.com/hashicorp/terraform-provider-aws/issues/45640. User feedback will determine if this experiment is a success.
-
 !> **WARNING:** Do not combine `aws_dynamodb_global_secondary_index` resources in conjunction with `global_secondary_index` on [`aws_dynamodb_table`](dynamodb_table.html). Doing so may cause conflicts, perpertual differences, and Global Secondary Indexes being overwritten.
 
 ## Example Usage


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

The resource type `aws_dynamodb_global_secondary_index` was initially released as an experimental feature, and required the environment variable `TF_AWS_EXPERIMENT_dynamodb_global_secondary_index` to enable it.

Removes the experimental flag.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #45640

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=dynamodb TESTS=TestAccDynamoDBGlobalSecondaryIndex_

--- PASS: TestAccDynamoDBGlobalSecondaryIndex_migrate_multiple_importcmd (93.16s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_migrate_partial (96.17s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_migrate_single_importcmd (104.58s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_migrate_single_importblock (104.94s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_migrate_multiple_importblock (119.82s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_warmThroughput_basic (1091.04s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_basic (1092.34s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_nonKeyAttributes_onCreate (1094.60s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_warmThroughput_explicitDefault (1096.55s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput (1098.21s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_Identity_basic (1108.44s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_warmThroughput_updateFromUnspecified_noChange (1116.00s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput_capacityChange_ignoreChanges (1119.44s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput_unset_write (1122.13s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput_unset_read (1125.41s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_warmThroughput_basic (1053.10s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_warmThroughput_updateFromUnspecified (1072.41s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_validate_KeySchemas (3.03s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_warmThroughput_updateFromUnspecified_noChange (1196.10s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_warmThroughput_updateFromUnspecified (1200.39s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput_capacityChange (1207.12s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_validate_Attributes (24.64s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_capacityChange_ignoreChanges (1159.55s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_concurrentGSI_update (1360.63s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_concurrentGSI_create (1351.10s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_concurrentGSI_delete (1455.47s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_basic (333.10s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_nonKeyAttributes_onUpdate (1557.64s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_Identity_regionOverride (572.72s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_to_payPerRequest_specifiedCapacity (717.75s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_disappears (1043.99s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_keysNotOnTable_onCreate_hashOnly (1060.02s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_keysNotOnTable_onCreate_hashAndSort (1070.34s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_changeTableCapacity_gsiSameAsTable (1091.92s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_changeTableCapacity_gsiDifferentFromTable (1099.70s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_capacityChange (1072.64s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_disappears_table (1192.00s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_to_payPerRequest_unspecifiedCapacity (1266.01s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_throughputChanges (0.00s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_throughputChanges/change_warm (1067.05s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_throughputChanges/change_provisioned_change_warm,_less_than (1162.79s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_throughputChanges/change_provisioned_no_change_warm,_less_than (1063.26s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_throughputChanges/change_both_to_same (1064.43s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_throughputChanges/change_provisioned_to_match_warm (1062.57s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_keysNotOnTable_onUpdate_hashAndSort (1643.01s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_keysNotOnTable_onUpdate_hashOnly (1669.65s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_payPerRequest_throughputChanges (0.00s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_payPerRequest_throughputChanges/change_warm (344.02s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_payPerRequest_throughputChanges/change_on-demand_change_warm,_less_than (1169.75s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_payPerRequest_throughputChanges/change_on-demand_no_change_warm,_less_than (1066.74s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_payPerRequest_throughputChanges/change_both_to_same (1164.23s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_payPerRequest_throughputChanges/change_on-demand_to_match_warm (1174.82s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_payPerRequest_to_provisioned (2186.56s)
```
