### PR TITLE
feat: add support for aws backup plan rule id

### DIFF
--- a/.changelog/47749.txt
+++ b/.changelog/47749.txt
@@ -1,0 +1,8 @@
+```release-note:enhancement
+resource/aws_backup_plan: Add `rule.rule_id` attribute
+```
+
+```release-note:enhancement
+data-source/aws_backup_plan: Add `rule.rule_id` attribute
+```
+

--- a/internal/service/backup/plan.go
+++ b/internal/service/backup/plan.go
@@ -159,6 +159,10 @@ func resourcePlan() *schema.Resource {
 							},
 						},
 						"recovery_point_tags": tftags.TagsSchema(),
+						"rule_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"rule_name": {
 							Type:     schema.TypeString,
 							Required: true,
@@ -575,12 +579,13 @@ func flattenBackupRules(ctx context.Context, apiObjects []awstypes.BackupRule) [
 
 	for _, apiObject := range apiObjects {
 		tfMap := map[string]any{
-			"completion_window":                            aws.ToInt64(apiObject.CompletionWindowMinutes),
-			"enable_continuous_backup":                     aws.ToBool(apiObject.EnableContinuousBackup),
-			"rule_name":                                    aws.ToString(apiObject.RuleName),
-			names.AttrSchedule:                             aws.ToString(apiObject.ScheduleExpression),
-			"schedule_expression_timezone":                 aws.ToString(apiObject.ScheduleExpressionTimezone),
-			"start_window":                                 aws.ToInt64(apiObject.StartWindowMinutes),
+			"completion_window":            aws.ToInt64(apiObject.CompletionWindowMinutes),
+			"enable_continuous_backup":     aws.ToBool(apiObject.EnableContinuousBackup),
+			"rule_id":                      aws.ToString(apiObject.RuleId),
+			"rule_name":                    aws.ToString(apiObject.RuleName),
+			names.AttrSchedule:             aws.ToString(apiObject.ScheduleExpression),
+			"schedule_expression_timezone": aws.ToString(apiObject.ScheduleExpressionTimezone),
+			"start_window":                 aws.ToInt64(apiObject.StartWindowMinutes),
 			"target_logically_air_gapped_backup_vault_arn": aws.ToString(apiObject.TargetLogicallyAirGappedBackupVaultArn),
 			"target_vault_name":                            aws.ToString(apiObject.TargetBackupVaultName),
 		}

--- a/internal/service/backup/plan_data_source.go
+++ b/internal/service/backup/plan_data_source.go
@@ -102,6 +102,10 @@ func dataSourcePlan() *schema.Resource {
 							},
 						},
 						"recovery_point_tags": tftags.TagsSchema(),
+						"rule_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"rule_name": {
 							Type:     schema.TypeString,
 							Computed: true,

--- a/internal/service/backup/plan_data_source_test.go
+++ b/internal/service/backup/plan_data_source_test.go
@@ -5,6 +5,7 @@ package backup_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -33,6 +34,9 @@ func TestAccBackupPlanDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, acctest.CtRulePound, resourceName, acctest.CtRulePound),
 					resource.TestCheckResourceAttrPair(datasourceName, names.AttrRule, resourceName, names.AttrRule),
 					resource.TestCheckResourceAttrPair(datasourceName, "scan_setting", resourceName, "scan_setting"),
+					resource.TestMatchTypeSetElemNestedAttrs(datasourceName, "rule.*", map[string]*regexp.Regexp{
+						"rule_id": regexp.MustCompile(`^[a-f0-9-]+$`),
+					}),
 				),
 			},
 		},

--- a/internal/service/backup/plan_data_source_test.go
+++ b/internal/service/backup/plan_data_source_test.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -35,7 +36,7 @@ func TestAccBackupPlanDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, names.AttrRule, resourceName, names.AttrRule),
 					resource.TestCheckResourceAttrPair(datasourceName, "scan_setting", resourceName, "scan_setting"),
 					resource.TestMatchTypeSetElemNestedAttrs(datasourceName, "rule.*", map[string]*regexp.Regexp{
-						"rule_id": regexp.MustCompile(`^[a-f0-9-]+$`),
+						"rule_id": regexache.MustCompile(`^[a-f0-9-]+$`),
 					}),
 				),
 			},

--- a/internal/service/backup/plan_test.go
+++ b/internal/service/backup/plan_test.go
@@ -47,7 +47,7 @@ func TestAccBackupPlan_basic(t *testing.T) {
 						"lifecycle.#":                  "0",
 					}),
 					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
-						"rule_id": regexp.MustCompile(`^[a-f0-9-]+$`),
+						"rule_id": regexache.MustCompile(`^[a-f0-9-]+$`),
 					}),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrVersion),

--- a/internal/service/backup/plan_test.go
+++ b/internal/service/backup/plan_test.go
@@ -6,6 +6,7 @@ package backup_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/YakDriver/regexache"
@@ -44,6 +45,9 @@ func TestAccBackupPlan_basic(t *testing.T) {
 						names.AttrSchedule:             "cron(0 12 * * ? *)",
 						"schedule_expression_timezone": "Etc/UTC",
 						"lifecycle.#":                  "0",
+					}),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
+						"rule_id": regexp.MustCompile(`^[a-f0-9-]+$`),
 					}),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrVersion),

--- a/website/docs/d/backup_plan.html.markdown
+++ b/website/docs/d/backup_plan.html.markdown
@@ -31,7 +31,13 @@ This data source exports the following attributes in addition to the arguments a
 
 * `arn` - ARN of the backup plan.
 * `name` - Display name of a backup plan.
-* `rule` - Rules of a backup plan.
+* `rule` - Rules of a backup plan. See [`rule`](#rule-block) below.
 * `scan_setting` - Scanning configuration for the backup rule.
 * `tags` - Metadata that you can assign to help organize the plans you create.
 * `version` - Unique, randomly generated, Unicode, UTF-8 encoded string that serves as the version ID of the backup plan.
+
+### `rule` Block
+
+The `rule` configuration block exports the following attributes:
+
+* `rule_id` - Uniquely identifies a rule that is used to schedule the backup of a selection of resources.

--- a/website/docs/r/backup_plan.html.markdown
+++ b/website/docs/r/backup_plan.html.markdown
@@ -109,6 +109,12 @@ This resource exports the following attributes in addition to the arguments abov
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `version` - Unique, randomly generated, Unicode, UTF-8 encoded string that serves as the version ID of the backup plan.
 
+### `rule` Block
+
+The `rule` configuration block exports the following attributes:
+
+* `rule_id` - Uniquely identifies a rule that is used to schedule the backup of a selection of resources.
+
 ## Import
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Backup Plan using the `id`. For example:


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Each AWS Backup Plan [backup rule](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_BackupRule.html) contains a unique identifier `RuleId`. This attribute is added to the corresponding resource [`aws_backup_plan`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_plan) and data source [`aws_backup_plan`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/backup_plan).

### Relations

### References

- [AWS Docs - BackupRule](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_BackupRule.html)

### Output from Acceptance Testing

Resource 

```console
make testacc T=estAccBackupPlan_ K=backup
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws-backup-pland-add-rule-rule_id 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/backup/... -v -count 1 -parallel 20 -run='estAccBackupPlan_'  -timeout 360m -vet=off
2026/05/04 21:24:35 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/04 21:24:35 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBackupPlan_tags
=== PAUSE TestAccBackupPlan_tags
=== RUN   TestAccBackupPlan_Tags_null
=== PAUSE TestAccBackupPlan_Tags_null
=== RUN   TestAccBackupPlan_Tags_emptyMap
=== PAUSE TestAccBackupPlan_Tags_emptyMap
=== RUN   TestAccBackupPlan_Tags_addOnUpdate
=== PAUSE TestAccBackupPlan_Tags_addOnUpdate
=== RUN   TestAccBackupPlan_Tags_EmptyTag_onCreate
=== PAUSE TestAccBackupPlan_Tags_EmptyTag_onCreate
=== RUN   TestAccBackupPlan_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccBackupPlan_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccBackupPlan_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccBackupPlan_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccBackupPlan_Tags_DefaultTags_providerOnly
=== PAUSE TestAccBackupPlan_Tags_DefaultTags_providerOnly
=== RUN   TestAccBackupPlan_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccBackupPlan_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccBackupPlan_Tags_DefaultTags_overlapping
=== PAUSE TestAccBackupPlan_Tags_DefaultTags_overlapping
=== RUN   TestAccBackupPlan_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccBackupPlan_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccBackupPlan_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccBackupPlan_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccBackupPlan_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccBackupPlan_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccBackupPlan_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccBackupPlan_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccBackupPlan_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccBackupPlan_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccBackupPlan_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccBackupPlan_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccBackupPlan_Tags_ComputedTag_onCreate
=== PAUSE TestAccBackupPlan_Tags_ComputedTag_onCreate
=== RUN   TestAccBackupPlan_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccBackupPlan_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccBackupPlan_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccBackupPlan_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccBackupPlan_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccBackupPlan_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccBackupPlan_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccBackupPlan_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccBackupPlan_basic
=== PAUSE TestAccBackupPlan_basic
=== RUN   TestAccBackupPlan_disappears
=== PAUSE TestAccBackupPlan_disappears
=== RUN   TestAccBackupPlan_withRules
=== PAUSE TestAccBackupPlan_withRules
=== RUN   TestAccBackupPlan_withLifecycle
=== PAUSE TestAccBackupPlan_withLifecycle
=== RUN   TestAccBackupPlan_withRecoveryPointTags
=== PAUSE TestAccBackupPlan_withRecoveryPointTags
=== RUN   TestAccBackupPlan_RuleCopyAction_sameRegion
=== PAUSE TestAccBackupPlan_RuleCopyAction_sameRegion
=== RUN   TestAccBackupPlan_RuleCopyAction_noLifecycle
=== PAUSE TestAccBackupPlan_RuleCopyAction_noLifecycle
=== RUN   TestAccBackupPlan_RuleCopyAction_multiple
=== PAUSE TestAccBackupPlan_RuleCopyAction_multiple
=== RUN   TestAccBackupPlan_RuleCopyAction_crossRegion
=== PAUSE TestAccBackupPlan_RuleCopyAction_crossRegion
=== RUN   TestAccBackupPlan_advancedBackupSetting
=== PAUSE TestAccBackupPlan_advancedBackupSetting
=== RUN   TestAccBackupPlan_enableContinuousBackup
=== PAUSE TestAccBackupPlan_enableContinuousBackup
=== RUN   TestAccBackupPlan_upgradeScheduleExpressionTimezone
=== PAUSE TestAccBackupPlan_upgradeScheduleExpressionTimezone
=== RUN   TestAccBackupPlan_scheduleExpressionTimezone
=== PAUSE TestAccBackupPlan_scheduleExpressionTimezone
=== RUN   TestAccBackupPlan_targetLogicallyAirGappedVaultARN
=== PAUSE TestAccBackupPlan_targetLogicallyAirGappedVaultARN
=== RUN   TestAccBackupPlan_malwareScan
=== PAUSE TestAccBackupPlan_malwareScan
=== CONT  TestAccBackupPlan_tags
=== CONT  TestAccBackupPlan_Tags_ComputedTag_OnUpdate_replace
=== CONT  TestAccBackupPlan_Tags_ComputedTag_OnUpdate_add
=== CONT  TestAccBackupPlan_Tags_emptyMap
=== CONT  TestAccBackupPlan_Tags_addOnUpdate
=== CONT  TestAccBackupPlan_RuleCopyAction_noLifecycle
=== CONT  TestAccBackupPlan_Tags_DefaultTags_emptyProviderOnlyTag
=== CONT  TestAccBackupPlan_Tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccBackupPlan_Tags_ComputedTag_onCreate
=== CONT  TestAccBackupPlan_Tags_DefaultTags_overlapping
=== CONT  TestAccBackupPlan_withRules
=== CONT  TestAccBackupPlan_RuleCopyAction_sameRegion
=== CONT  TestAccBackupPlan_withRecoveryPointTags
=== CONT  TestAccBackupPlan_withLifecycle
=== CONT  TestAccBackupPlan_Tags_DefaultTags_updateToProviderOnly
=== CONT  TestAccBackupPlan_Tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccBackupPlan_Tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccBackupPlan_Tags_DefaultTags_emptyResourceTag
=== CONT  TestAccBackupPlan_basic
=== CONT  TestAccBackupPlan_disappears
--- PASS: TestAccBackupPlan_disappears (74.80s)
=== CONT  TestAccBackupPlan_upgradeScheduleExpressionTimezone
--- PASS: TestAccBackupPlan_basic (87.80s)
=== CONT  TestAccBackupPlan_malwareScan
--- PASS: TestAccBackupPlan_Tags_DefaultTags_emptyResourceTag (100.72s)
=== CONT  TestAccBackupPlan_scheduleExpressionTimezone
--- PASS: TestAccBackupPlan_Tags_DefaultTags_nullOverlappingResourceTag (100.72s)
=== CONT  TestAccBackupPlan_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccBackupPlan_Tags_DefaultTags_nullNonOverlappingResourceTag (100.81s)
=== CONT  TestAccBackupPlan_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccBackupPlan_Tags_DefaultTags_emptyProviderOnlyTag (101.73s)
=== CONT  TestAccBackupPlan_Tags_DefaultTags_providerOnly
--- PASS: TestAccBackupPlan_Tags_ComputedTag_onCreate (103.38s)
=== CONT  TestAccBackupPlan_targetLogicallyAirGappedVaultARN
--- PASS: TestAccBackupPlan_Tags_emptyMap (145.26s)
=== CONT  TestAccBackupPlan_advancedBackupSetting
--- PASS: TestAccBackupPlan_Tags_addOnUpdate (155.29s)
=== CONT  TestAccBackupPlan_enableContinuousBackup
--- PASS: TestAccBackupPlan_Tags_DefaultTags_updateToResourceOnly (161.74s)
=== CONT  TestAccBackupPlan_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccBackupPlan_Tags_ComputedTag_OnUpdate_replace (165.84s)
=== CONT  TestAccBackupPlan_Tags_EmptyTag_onCreate
--- PASS: TestAccBackupPlan_Tags_DefaultTags_updateToProviderOnly (166.56s)
=== CONT  TestAccBackupPlan_Tags_null
--- PASS: TestAccBackupPlan_Tags_ComputedTag_OnUpdate_add (167.38s)
=== CONT  TestAccBackupPlan_RuleCopyAction_crossRegion
--- PASS: TestAccBackupPlan_withRules (192.26s)
=== CONT  TestAccBackupPlan_RuleCopyAction_multiple
--- PASS: TestAccBackupPlan_withRecoveryPointTags (195.95s)
=== CONT  TestAccBackupPlan_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccBackupPlan_RuleCopyAction_noLifecycle (196.14s)
=== CONT  TestAccBackupPlan_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccBackupPlan_RuleCopyAction_sameRegion (196.15s)
--- PASS: TestAccBackupPlan_upgradeScheduleExpressionTimezone (129.42s)
--- PASS: TestAccBackupPlan_scheduleExpressionTimezone (131.68s)
--- PASS: TestAccBackupPlan_enableContinuousBackup (77.72s)
--- PASS: TestAccBackupPlan_Tags_EmptyTag_OnUpdate_replace (145.40s)
--- PASS: TestAccBackupPlan_Tags_DefaultTags_overlapping (252.68s)
--- PASS: TestAccBackupPlan_RuleCopyAction_multiple (67.88s)
--- PASS: TestAccBackupPlan_malwareScan (174.39s)
--- PASS: TestAccBackupPlan_advancedBackupSetting (117.54s)
--- PASS: TestAccBackupPlan_withLifecycle (269.36s)
--- PASS: TestAccBackupPlan_Tags_null (110.24s)
--- PASS: TestAccBackupPlan_RuleCopyAction_crossRegion (114.07s)
--- PASS: TestAccBackupPlan_Tags_EmptyTag_onCreate (128.51s)
--- PASS: TestAccBackupPlan_targetLogicallyAirGappedVaultARN (192.41s)
--- PASS: TestAccBackupPlan_tags (296.51s)
--- PASS: TestAccBackupPlan_Tags_DefaultTags_nonOverlapping (201.43s)
--- PASS: TestAccBackupPlan_Tags_IgnoreTags_Overlap_defaultTag (121.45s)
--- PASS: TestAccBackupPlan_Tags_EmptyTag_OnUpdate_add (156.47s)
--- PASS: TestAccBackupPlan_Tags_IgnoreTags_Overlap_resourceTag (132.91s)
--- PASS: TestAccBackupPlan_Tags_DefaultTags_providerOnly (232.06s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/backup     333.993s
```


Data source

```console
make testacc T=TestAccBackupPlanDataSource_ K=backup 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws-backup-pland-add-rule-rule_id 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/backup/... -v -count 1 -parallel 20 -run='TestAccBackupPlanDataSource_'  -timeout 360m -vet=off
2026/05/04 21:34:02 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/04 21:34:02 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBackupPlanDataSource_tags
=== PAUSE TestAccBackupPlanDataSource_tags
=== RUN   TestAccBackupPlanDataSource_Tags_nullMap
=== PAUSE TestAccBackupPlanDataSource_Tags_nullMap
=== RUN   TestAccBackupPlanDataSource_Tags_emptyMap
=== PAUSE TestAccBackupPlanDataSource_Tags_emptyMap
=== RUN   TestAccBackupPlanDataSource_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccBackupPlanDataSource_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccBackupPlanDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccBackupPlanDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccBackupPlanDataSource_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccBackupPlanDataSource_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccBackupPlanDataSource_basic
=== PAUSE TestAccBackupPlanDataSource_basic
=== CONT  TestAccBackupPlanDataSource_tags
=== CONT  TestAccBackupPlanDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== CONT  TestAccBackupPlanDataSource_Tags_IgnoreTags_Overlap_resourceTag
=== CONT  TestAccBackupPlanDataSource_Tags_emptyMap
=== CONT  TestAccBackupPlanDataSource_Tags_DefaultTags_nonOverlapping
=== CONT  TestAccBackupPlanDataSource_basic
=== CONT  TestAccBackupPlanDataSource_Tags_nullMap
--- PASS: TestAccBackupPlanDataSource_Tags_nullMap (35.26s)
--- PASS: TestAccBackupPlanDataSource_tags (35.67s)
--- PASS: TestAccBackupPlanDataSource_Tags_emptyMap (36.72s)
--- PASS: TestAccBackupPlanDataSource_Tags_DefaultTags_nonOverlapping (36.89s)
--- PASS: TestAccBackupPlanDataSource_basic (36.99s)
--- PASS: TestAccBackupPlanDataSource_Tags_IgnoreTags_Overlap_defaultTag (37.09s)
--- PASS: TestAccBackupPlanDataSource_Tags_IgnoreTags_Overlap_resourceTag (38.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/backup     39.112s
```