### PR TITLE
Provider: Removes run-time validation for Framework-based resource types

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -925,7 +925,7 @@ testacc: prereq-go fmt-check testacc-schema ## Run acceptance tests
 		echo "See the contributing guide for more information: https://hashicorp.github.io/terraform-provider-aws/running-and-writing-acceptance-tests"; \
 		exit 1; \
 	fi
-	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT) -vet=off
+	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT) -vet=off -buildvcs=false
 
 testacc-lint: ## [CI] Acceptance Test Linting / terrafmt
 	@echo "make: Acceptance Test Linting / terrafmt..."

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -912,7 +912,7 @@ test-shard: prereq-go ## Run unit tests for a specific shard (CI only: SHARD=0 T
 test-naming: ## Check test naming conventions
 	@.ci/scripts/check-test-naming.sh
 
-testacc: prereq-go fmt-check ## Run acceptance tests
+testacc: prereq-go fmt-check testacc-schema ## Run acceptance tests
 	@branch=$$(git rev-parse --abbrev-ref HEAD); \
 	printf "make: Running acceptance tests on branch: \033[1m%s\033[0m...\n" "🌿 $$branch 🌿"
 	@if [ "$(TESTARGS)" = "-run=TestAccXXX" ]; then \
@@ -944,6 +944,13 @@ testacc-lint-fix-core: ## Fix acceptance test linter findings in core directorie
 	@find . -name '*_test.go' -type f ! -path './internal/service/*' ! -path './.git/*' ! -path './vendor/*' ! -path './tools/*' \
 		| sort -u \
 		| xargs -I {} terrafmt fmt --fmtcompat {}
+
+testacc-schema: ## Validate schemas
+	@echo "make: Validating schemas"
+	@$(GO_VER) test -vet=off -buildvcs=false \
+		./internal/provider/sdkv2 -run=TestProviderInit
+	@$(GO_VER) test -vet=off -buildvcs=false \
+		./internal/provider/framework -run=TestProviderInit
 
 terraform-fmt: ## Format all .tf, .tfvars, .tftest.hcl, and .tfquery.hcl files
 	@echo "make: Formatting .tf, .tfvars, .tftest.hcl, and .tfquery.hcl files..."

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -603,6 +603,13 @@ sanity: prereq-go ## Run sanity check (failures allowed)
 		exit 1; \
 	fi
 
+schema-validate: ## Validate schemas
+	@echo "make: Validating schemas"
+	@$(GO_VER) test -vet=off -buildvcs=false \
+		./internal/provider/sdkv2 -run=TestProviderInit
+	@$(GO_VER) test -vet=off -buildvcs=false \
+		./internal/provider/framework -run=TestProviderInit
+
 semgrep: semgrep-code-quality semgrep-naming semgrep-naming-cae semgrep-service-naming ## [CI] Run all CI Semgrep checks
 
 semgrep-all: semgrep-test semgrep-validate ## Run semgrep on all files
@@ -912,7 +919,7 @@ test-shard: prereq-go ## Run unit tests for a specific shard (CI only: SHARD=0 T
 test-naming: ## Check test naming conventions
 	@.ci/scripts/check-test-naming.sh
 
-testacc: prereq-go fmt-check testacc-schema ## Run acceptance tests
+testacc: prereq-go fmt-check schema-validate ## Run acceptance tests
 	@branch=$$(git rev-parse --abbrev-ref HEAD); \
 	printf "make: Running acceptance tests on branch: \033[1m%s\033[0m...\n" "🌿 $$branch 🌿"
 	@if [ "$(TESTARGS)" = "-run=TestAccXXX" ]; then \
@@ -944,13 +951,6 @@ testacc-lint-fix-core: ## Fix acceptance test linter findings in core directorie
 	@find . -name '*_test.go' -type f ! -path './internal/service/*' ! -path './.git/*' ! -path './vendor/*' ! -path './tools/*' \
 		| sort -u \
 		| xargs -I {} terrafmt fmt --fmtcompat {}
-
-testacc-schema: ## Validate schemas
-	@echo "make: Validating schemas"
-	@$(GO_VER) test -vet=off -buildvcs=false \
-		./internal/provider/sdkv2 -run=TestProviderInit
-	@$(GO_VER) test -vet=off -buildvcs=false \
-		./internal/provider/framework -run=TestProviderInit
 
 terraform-fmt: ## Format all .tf, .tfvars, .tftest.hcl, and .tfquery.hcl files
 	@echo "make: Formatting .tf, .tfvars, .tftest.hcl, and .tfquery.hcl files..."

--- a/docs/makefile-cheat-sheet.md
+++ b/docs/makefile-cheat-sheet.md
@@ -146,6 +146,7 @@ Variables are often defined before the `make` call on the same line, such as `MY
 | `provider-markdown-lint` | Provider Check / markdown-lint | ✔️ |  |  |
 | `sane`<sup>D</sup> | Run sane check |  |  | `ACCTEST_PARALLELISM`, `ACCTEST_TIMEOUT`, `GO_VER`, `TEST_COUNT` |
 | `sanity`<sup>D</sup> | Run sanity check (failures allowed) |  |  | `ACCTEST_PARALLELISM`, `ACCTEST_TIMEOUT`, `GO_VER`, `TEST_COUNT` |
+| `schema-validate` | Validate schemas | | | `GO_VER` |
 | `semgrep`<sup>M</sup> | Run all CI Semgrep checks | ✔️ |  | `K`, `PKG`, `PKG_NAME`, `SEMGREP_ARGS` |
 | `semgrep-all`<sup>D</sup> | Run semgrep on all files |  |  | `K`, `PKG`, `PKG_NAME`, `SEMGREP_ARGS` |
 | `semgrep-code-quality`<sup>D</sup> | Semgrep Checks / Code Quality Scan | ✔️ |  | `K`, `PKG`, `PKG_NAME`, `SEMGREP_ARGS` |

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -5,43 +5,26 @@ package framework
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"iter"
 	"log"
-	"reflect"
 	"slices"
-	"sync"
-	"unique"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/action"
-	aschema "github.com/hashicorp/terraform-plugin-framework/action/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
-	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
-	empemeralschema "github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
 	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/metaschema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	tffunction "github.com/hashicorp/terraform-provider-aws/internal/function"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
-	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
-	tfunique "github.com/hashicorp/terraform-provider-aws/internal/unique"
-	"github.com/hashicorp/terraform-provider-aws/names"
-)
-
-var (
-	resourceSchemasValidated sync.Once
 )
 
 var (
@@ -75,16 +58,6 @@ func NewProvider(ctx context.Context, primary interface{ Meta() any }) (provider
 		primary:            primary,
 		resources:          make([]func() resource.Resource, 0),
 		servicePackages:    primary.Meta().(*conns.AWSClient).ServicePackages(ctx),
-	}
-
-	// Because we try and share resource schemas as much as possible,
-	// we need to ensure that we only validate the resource schemas once.
-	var err error
-	resourceSchemasValidated.Do(func() {
-		err = provider.validateResourceSchemas(ctx)
-	})
-	if err != nil {
-		return nil, err
 	}
 
 	provider.initialize(ctx)
@@ -483,184 +456,4 @@ func (p *frameworkProvider) initialize(ctx context.Context) {
 			}
 		}
 	}
-}
-
-// validateResourceSchemas is called from `New` to validate Terraform Plugin Framework-style resource schemas.
-func (p *frameworkProvider) validateResourceSchemas(ctx context.Context) error {
-	var errs []error
-
-	for sp := range p.servicePackages {
-		for _, dataSourceSpec := range sp.FrameworkDataSources(ctx) {
-			typeName := dataSourceSpec.TypeName
-			inner, err := dataSourceSpec.Factory(ctx)
-
-			if err != nil {
-				errs = append(errs, fmt.Errorf("creating data source type (%s): %w", typeName, err))
-				continue
-			}
-
-			schemaResponse := datasource.SchemaResponse{}
-			inner.Schema(ctx, datasource.SchemaRequest{}, &schemaResponse)
-
-			if err := validateSchemaRegionForDataSource(dataSourceSpec.Region, schemaResponse.Schema); err != nil {
-				errs = append(errs, fmt.Errorf("data source type %q: %w", typeName, err))
-				continue
-			}
-
-			if err := validateSchemaTagsForDataSource(dataSourceSpec.Tags, schemaResponse.Schema); err != nil {
-				errs = append(errs, fmt.Errorf("data source type %q: %w", typeName, err))
-				continue
-			}
-		}
-
-		if v, ok := sp.(conns.ServicePackageWithEphemeralResources); ok {
-			for _, ephemeralResourceSpec := range v.EphemeralResources(ctx) {
-				typeName := ephemeralResourceSpec.TypeName
-				inner, err := ephemeralResourceSpec.Factory(ctx)
-
-				if err != nil {
-					errs = append(errs, fmt.Errorf("creating ephemeral resource type (%s): %w", typeName, err))
-					continue
-				}
-
-				schemaResponse := ephemeral.SchemaResponse{}
-				inner.Schema(ctx, ephemeral.SchemaRequest{}, &schemaResponse)
-
-				if err := validateSchemaRegionForEphemeralResource(ephemeralResourceSpec.Region, schemaResponse.Schema); err != nil {
-					errs = append(errs, fmt.Errorf("ephemeral resource type %q: %w", typeName, err))
-					continue
-				}
-			}
-		}
-
-		if v, ok := sp.(conns.ServicePackageWithActions); ok {
-			for _, actionSpec := range v.Actions(ctx) {
-				typeName := actionSpec.TypeName
-				inner, err := actionSpec.Factory(ctx)
-
-				if err != nil {
-					errs = append(errs, fmt.Errorf("creating action type (%s): %w", typeName, err))
-					continue
-				}
-
-				schemaResponse := action.SchemaResponse{}
-				inner.Schema(ctx, action.SchemaRequest{}, &schemaResponse)
-
-				if err := validateSchemaRegionForAction(actionSpec.Region, schemaResponse.Schema); err != nil {
-					errs = append(errs, fmt.Errorf("action type %q: %w", typeName, err))
-					continue
-				}
-			}
-		}
-
-		for _, resourceSpec := range sp.FrameworkResources(ctx) {
-			typeName := resourceSpec.TypeName
-			inner, err := resourceSpec.Factory(ctx)
-
-			if err != nil {
-				errs = append(errs, fmt.Errorf("creating resource type (%s): %w", typeName, err))
-				continue
-			}
-
-			schemaResponse := resource.SchemaResponse{}
-			inner.Schema(ctx, resource.SchemaRequest{}, &schemaResponse)
-
-			if err := validateSchemaRegionForResource(resourceSpec.Region, schemaResponse.Schema); err != nil {
-				errs = append(errs, fmt.Errorf("resource type %q: %w", typeName, err))
-				continue
-			}
-
-			if err := validateSchemaTagsForResource(resourceSpec.Tags, schemaResponse.Schema); err != nil {
-				errs = append(errs, fmt.Errorf("resource type %q: %w", typeName, err))
-				continue
-			}
-
-			if resourceSpec.Import.WrappedImport {
-				if resourceSpec.Import.SetIDAttr {
-					if _, ok := resourceSpec.Import.ImportID.(inttypes.FrameworkImportIDCreator); !ok {
-						errs = append(errs, fmt.Errorf("resource type %q: importer sets `%s` attribute, but creator isn't configured", resourceSpec.TypeName, names.AttrID))
-						continue
-					}
-				}
-
-				if _, ok := inner.(framework.ImportByIdentityer); !ok {
-					errs = append(errs, fmt.Errorf("resource type %q: cannot configure importer, does not implement %q", resourceSpec.TypeName, reflect.TypeFor[framework.ImportByIdentityer]()))
-					continue
-				}
-			}
-		}
-	}
-
-	return errors.Join(errs...)
-}
-
-func validateSchemaRegionForDataSource(regionSpec unique.Handle[inttypes.ServicePackageResourceRegion], schema datasourceschema.Schema) error {
-	if !tfunique.IsHandleNil(regionSpec) && regionSpec.Value().IsOverrideEnabled {
-		if _, ok := schema.Attributes[names.AttrRegion]; ok {
-			return fmt.Errorf("configured for enhanced regions but defines `%s` attribute in schema", names.AttrRegion)
-		}
-	}
-	return nil
-}
-
-func validateSchemaRegionForEphemeralResource(regionSpec unique.Handle[inttypes.ServicePackageResourceRegion], schema empemeralschema.Schema) error {
-	if !tfunique.IsHandleNil(regionSpec) && regionSpec.Value().IsOverrideEnabled {
-		if _, ok := schema.Attributes[names.AttrRegion]; ok {
-			return fmt.Errorf("configured for enhanced regions but defines `%s` attribute in schema", names.AttrRegion)
-		}
-	}
-	return nil
-}
-
-func validateSchemaRegionForAction(regionSpec unique.Handle[inttypes.ServicePackageResourceRegion], schemaIface any) error {
-	if !tfunique.IsHandleNil(regionSpec) && regionSpec.Value().IsOverrideEnabled {
-		if schema, ok := schemaIface.(aschema.Schema); ok {
-			if _, ok := schema.Attributes[names.AttrRegion]; ok {
-				return fmt.Errorf("configured for enhanced regions but defines `%s` attribute in schema", names.AttrRegion)
-			}
-		}
-	}
-	return nil
-}
-
-func validateSchemaRegionForResource(regionSpec unique.Handle[inttypes.ServicePackageResourceRegion], schema resourceschema.Schema) error {
-	if !tfunique.IsHandleNil(regionSpec) && regionSpec.Value().IsOverrideEnabled {
-		if _, ok := schema.Attributes[names.AttrRegion]; ok {
-			return fmt.Errorf("configured for enhanced regions but defines `%s` attribute in schema", names.AttrRegion)
-		}
-	}
-	return nil
-}
-
-func validateSchemaTagsForDataSource(tagsSpec unique.Handle[inttypes.ServicePackageResourceTags], schema datasourceschema.Schema) error {
-	if !tfunique.IsHandleNil(tagsSpec) {
-		if v, ok := schema.Attributes[names.AttrTags]; ok {
-			if !v.IsComputed() {
-				return fmt.Errorf("`%s` attribute must be Computed", names.AttrTags)
-			}
-		} else {
-			return fmt.Errorf("configured for tags but no `%s` attribute defined in schema", names.AttrTags)
-		}
-	}
-	return nil
-}
-
-func validateSchemaTagsForResource(tagsSpec unique.Handle[inttypes.ServicePackageResourceTags], schema resourceschema.Schema) error {
-	if !tfunique.IsHandleNil(tagsSpec) {
-		if v, ok := schema.Attributes[names.AttrTags]; ok {
-			if v.IsComputed() {
-				return fmt.Errorf("`%s` attribute cannot be Computed", names.AttrTags)
-			}
-		} else {
-			return fmt.Errorf("configured for tags but no `%s` attribute defined in schema", names.AttrTags)
-		}
-		if v, ok := schema.Attributes[names.AttrTagsAll]; ok {
-			if !v.IsComputed() {
-				return fmt.Errorf("`%s` attribute must be Computed", names.AttrTagsAll)
-			}
-		} else {
-			return fmt.Errorf("configured for tags but no `%s` attribute defined in schema", names.AttrTagsAll)
-		}
-	}
-	return nil
 }

--- a/internal/provider/framework/provider_test.go
+++ b/internal/provider/framework/provider_test.go
@@ -11,6 +11,28 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2"
 )
 
+func TestProviderInit(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	primary, err := sdkv2.NewProvider(ctx)
+	if err != nil {
+		t.Fatalf("Initializing SDKv2 provider: %s", err)
+	}
+
+	p, err := NewProvider(ctx, primary)
+	if err != nil {
+		t.Fatalf("Initializing Framework provider: %s", err)
+	}
+
+	provider := p.(*frameworkProvider)
+
+	err = provider.validateResourceSchemas(ctx)
+	if err != nil {
+		t.Errorf("Validating resource schemas: %s", err)
+	}
+}
+
 // To run these benchmarks:
 // go test -bench=. -benchmem -run=^$ -v ./internal/provider/framework
 

--- a/internal/provider/framework/provider_test.go
+++ b/internal/provider/framework/provider_test.go
@@ -12,7 +12,7 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-framework/action"
-	aschema "github.com/hashicorp/terraform-plugin-framework/action/schema"
+	actionschema "github.com/hashicorp/terraform-plugin-framework/action/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
@@ -241,12 +241,10 @@ func validateSchemaRegionForEphemeralResource(regionSpec unique.Handle[inttypes.
 	return nil
 }
 
-func validateSchemaRegionForAction(regionSpec unique.Handle[inttypes.ServicePackageResourceRegion], schemaIface any) error {
+func validateSchemaRegionForAction(regionSpec unique.Handle[inttypes.ServicePackageResourceRegion], schema actionschema.Schema) error {
 	if !tfunique.IsHandleNil(regionSpec) && regionSpec.Value().IsOverrideEnabled {
-		if schema, ok := schemaIface.(aschema.Schema); ok {
-			if _, ok := schema.Attributes[names.AttrRegion]; ok {
-				return fmt.Errorf("configured for enhanced regions but defines `%s` attribute in schema", names.AttrRegion)
-			}
+		if _, ok := schema.Attributes[names.AttrRegion]; ok {
+			return fmt.Errorf("configured for enhanced regions but defines `%s` attribute in schema", names.AttrRegion)
 		}
 	}
 	return nil

--- a/internal/provider/framework/provider_test.go
+++ b/internal/provider/framework/provider_test.go
@@ -43,7 +43,7 @@ func TestProviderInit(t *testing.T) {
 
 	provider := p.(*frameworkProvider)
 
-	err = provider.validateResourceSchemas(ctx)
+	err = validateResourceSchemas(ctx, provider)
 	if err != nil {
 		t.Errorf("Validating resource schemas: %s", err)
 	}
@@ -115,7 +115,7 @@ func BenchmarkFrameworkProvider_SchemaInitialization_Resource(b *testing.B) {
 }
 
 // validateResourceSchemas is called in a unit test to validate Terraform Plugin Framework-style resource schemas.
-func (p *frameworkProvider) validateResourceSchemas(ctx context.Context) error {
+func validateResourceSchemas(ctx context.Context, p *frameworkProvider) error {
 	var errs []error
 
 	for sp := range p.servicePackages {

--- a/internal/provider/framework/provider_test.go
+++ b/internal/provider/framework/provider_test.go
@@ -5,7 +5,6 @@ package framework
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -43,10 +42,7 @@ func TestProviderInit(t *testing.T) {
 
 	provider := p.(*frameworkProvider)
 
-	err = validateResourceSchemas(ctx, provider)
-	if err != nil {
-		t.Errorf("Validating resource schemas: %s", err)
-	}
+	validateResourceSchemas(ctx, t, provider)
 }
 
 // To run these benchmarks:
@@ -115,8 +111,8 @@ func BenchmarkFrameworkProvider_SchemaInitialization_Resource(b *testing.B) {
 }
 
 // validateResourceSchemas is called in a unit test to validate Terraform Plugin Framework-style resource schemas.
-func validateResourceSchemas(ctx context.Context, p *frameworkProvider) error {
-	var errs []error
+func validateResourceSchemas(ctx context.Context, t *testing.T, p *frameworkProvider) {
+	t.Helper()
 
 	for sp := range p.servicePackages {
 		for _, dataSourceSpec := range sp.FrameworkDataSources(ctx) {
@@ -124,7 +120,7 @@ func validateResourceSchemas(ctx context.Context, p *frameworkProvider) error {
 			inner, err := dataSourceSpec.Factory(ctx)
 
 			if err != nil {
-				errs = append(errs, fmt.Errorf("creating data source type (%s): %w", typeName, err))
+				t.Errorf("creating data source type (%s): %s", typeName, err)
 				continue
 			}
 
@@ -132,12 +128,12 @@ func validateResourceSchemas(ctx context.Context, p *frameworkProvider) error {
 			inner.Schema(ctx, datasource.SchemaRequest{}, &schemaResponse)
 
 			if err := validateSchemaRegionForDataSource(dataSourceSpec.Region, schemaResponse.Schema); err != nil {
-				errs = append(errs, fmt.Errorf("data source type %q: %w", typeName, err))
+				t.Errorf("data source type %q: %s", typeName, err)
 				continue
 			}
 
 			if err := validateSchemaTagsForDataSource(dataSourceSpec.Tags, schemaResponse.Schema); err != nil {
-				errs = append(errs, fmt.Errorf("data source type %q: %w", typeName, err))
+				t.Errorf("data source type %q: %s", typeName, err)
 				continue
 			}
 		}
@@ -148,7 +144,7 @@ func validateResourceSchemas(ctx context.Context, p *frameworkProvider) error {
 				inner, err := ephemeralResourceSpec.Factory(ctx)
 
 				if err != nil {
-					errs = append(errs, fmt.Errorf("creating ephemeral resource type (%s): %w", typeName, err))
+					t.Errorf("creating ephemeral resource type (%s): %s", typeName, err)
 					continue
 				}
 
@@ -156,7 +152,7 @@ func validateResourceSchemas(ctx context.Context, p *frameworkProvider) error {
 				inner.Schema(ctx, ephemeral.SchemaRequest{}, &schemaResponse)
 
 				if err := validateSchemaRegionForEphemeralResource(ephemeralResourceSpec.Region, schemaResponse.Schema); err != nil {
-					errs = append(errs, fmt.Errorf("ephemeral resource type %q: %w", typeName, err))
+					t.Errorf("ephemeral resource type %q: %s", typeName, err)
 					continue
 				}
 			}
@@ -168,7 +164,7 @@ func validateResourceSchemas(ctx context.Context, p *frameworkProvider) error {
 				inner, err := actionSpec.Factory(ctx)
 
 				if err != nil {
-					errs = append(errs, fmt.Errorf("creating action type (%s): %w", typeName, err))
+					t.Errorf("creating action type (%s): %s", typeName, err)
 					continue
 				}
 
@@ -176,7 +172,7 @@ func validateResourceSchemas(ctx context.Context, p *frameworkProvider) error {
 				inner.Schema(ctx, action.SchemaRequest{}, &schemaResponse)
 
 				if err := validateSchemaRegionForAction(actionSpec.Region, schemaResponse.Schema); err != nil {
-					errs = append(errs, fmt.Errorf("action type %q: %w", typeName, err))
+					t.Errorf("action type %q: %s", typeName, err)
 					continue
 				}
 			}
@@ -187,7 +183,7 @@ func validateResourceSchemas(ctx context.Context, p *frameworkProvider) error {
 			inner, err := resourceSpec.Factory(ctx)
 
 			if err != nil {
-				errs = append(errs, fmt.Errorf("creating resource type (%s): %w", typeName, err))
+				t.Errorf("creating resource type (%s): %s", typeName, err)
 				continue
 			}
 
@@ -195,32 +191,30 @@ func validateResourceSchemas(ctx context.Context, p *frameworkProvider) error {
 			inner.Schema(ctx, resource.SchemaRequest{}, &schemaResponse)
 
 			if err := validateSchemaRegionForResource(resourceSpec.Region, schemaResponse.Schema); err != nil {
-				errs = append(errs, fmt.Errorf("resource type %q: %w", typeName, err))
+				t.Errorf("resource type %q: %s", typeName, err)
 				continue
 			}
 
 			if err := validateSchemaTagsForResource(resourceSpec.Tags, schemaResponse.Schema); err != nil {
-				errs = append(errs, fmt.Errorf("resource type %q: %w", typeName, err))
+				t.Errorf("resource type %q: %s", typeName, err)
 				continue
 			}
 
 			if resourceSpec.Import.WrappedImport {
 				if resourceSpec.Import.SetIDAttr {
 					if _, ok := resourceSpec.Import.ImportID.(inttypes.FrameworkImportIDCreator); !ok {
-						errs = append(errs, fmt.Errorf("resource type %q: importer sets `%s` attribute, but creator isn't configured", resourceSpec.TypeName, names.AttrID))
+						t.Errorf("resource type %q: importer sets `%s` attribute, but creator isn't configured", resourceSpec.TypeName, names.AttrID)
 						continue
 					}
 				}
 
 				if _, ok := inner.(framework.ImportByIdentityer); !ok {
-					errs = append(errs, fmt.Errorf("resource type %q: cannot configure importer, does not implement %q", resourceSpec.TypeName, reflect.TypeFor[framework.ImportByIdentityer]()))
+					t.Errorf("resource type %q: cannot configure importer, does not implement %q", resourceSpec.TypeName, reflect.TypeFor[framework.ImportByIdentityer]())
 					continue
 				}
 			}
 		}
 	}
-
-	return errors.Join(errs...)
 }
 
 func validateSchemaRegionForDataSource(regionSpec unique.Handle[inttypes.ServicePackageResourceRegion], schema datasourceschema.Schema) error {

--- a/internal/provider/framework/provider_test.go
+++ b/internal/provider/framework/provider_test.go
@@ -4,11 +4,27 @@
 package framework
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
 	"testing"
+	"unique"
 
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	aschema "github.com/hashicorp/terraform-plugin-framework/action/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	ephemeralschema "github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	tfunique "github.com/hashicorp/terraform-provider-aws/internal/unique"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestProviderInit(t *testing.T) {
@@ -54,29 +70,6 @@ func TestProviderInit(t *testing.T) {
 // 	}
 // }
 
-func BenchmarkFrameworkProvider_validateResourceSchemas(b *testing.B) {
-	ctx := b.Context()
-	primary, err := sdkv2.NewProvider(ctx)
-	if err != nil {
-		b.Fatalf("Initializing SDKv2 provider: %s", err)
-	}
-	p, err := NewProvider(ctx, primary)
-	if err != nil {
-		b.Fatalf("Initializing Framework provider: %s", err)
-	}
-
-	provider := p.(*frameworkProvider)
-
-	// Reset memory counters to zero, so that we only measure the schema validation.
-	b.ResetTimer()
-	for b.Loop() {
-		err := provider.validateResourceSchemas(ctx)
-		if err != nil {
-			b.Fatalf("Validating resource schemas: %s", err)
-		}
-	}
-}
-
 func BenchmarkFrameworkProvider_SchemaInitialization_DataSource(b *testing.B) {
 	ctx := b.Context()
 	primary, err := sdkv2.NewProvider(ctx)
@@ -119,4 +112,184 @@ func BenchmarkFrameworkProvider_SchemaInitialization_Resource(b *testing.B) {
 			r.Schema(ctx, resource.SchemaRequest{}, &resource.SchemaResponse{})
 		}
 	}
+}
+
+// validateResourceSchemas is called in a unit test to validate Terraform Plugin Framework-style resource schemas.
+func (p *frameworkProvider) validateResourceSchemas(ctx context.Context) error {
+	var errs []error
+
+	for sp := range p.servicePackages {
+		for _, dataSourceSpec := range sp.FrameworkDataSources(ctx) {
+			typeName := dataSourceSpec.TypeName
+			inner, err := dataSourceSpec.Factory(ctx)
+
+			if err != nil {
+				errs = append(errs, fmt.Errorf("creating data source type (%s): %w", typeName, err))
+				continue
+			}
+
+			schemaResponse := datasource.SchemaResponse{}
+			inner.Schema(ctx, datasource.SchemaRequest{}, &schemaResponse)
+
+			if err := validateSchemaRegionForDataSource(dataSourceSpec.Region, schemaResponse.Schema); err != nil {
+				errs = append(errs, fmt.Errorf("data source type %q: %w", typeName, err))
+				continue
+			}
+
+			if err := validateSchemaTagsForDataSource(dataSourceSpec.Tags, schemaResponse.Schema); err != nil {
+				errs = append(errs, fmt.Errorf("data source type %q: %w", typeName, err))
+				continue
+			}
+		}
+
+		if v, ok := sp.(conns.ServicePackageWithEphemeralResources); ok {
+			for _, ephemeralResourceSpec := range v.EphemeralResources(ctx) {
+				typeName := ephemeralResourceSpec.TypeName
+				inner, err := ephemeralResourceSpec.Factory(ctx)
+
+				if err != nil {
+					errs = append(errs, fmt.Errorf("creating ephemeral resource type (%s): %w", typeName, err))
+					continue
+				}
+
+				schemaResponse := ephemeral.SchemaResponse{}
+				inner.Schema(ctx, ephemeral.SchemaRequest{}, &schemaResponse)
+
+				if err := validateSchemaRegionForEphemeralResource(ephemeralResourceSpec.Region, schemaResponse.Schema); err != nil {
+					errs = append(errs, fmt.Errorf("ephemeral resource type %q: %w", typeName, err))
+					continue
+				}
+			}
+		}
+
+		if v, ok := sp.(conns.ServicePackageWithActions); ok {
+			for _, actionSpec := range v.Actions(ctx) {
+				typeName := actionSpec.TypeName
+				inner, err := actionSpec.Factory(ctx)
+
+				if err != nil {
+					errs = append(errs, fmt.Errorf("creating action type (%s): %w", typeName, err))
+					continue
+				}
+
+				schemaResponse := action.SchemaResponse{}
+				inner.Schema(ctx, action.SchemaRequest{}, &schemaResponse)
+
+				if err := validateSchemaRegionForAction(actionSpec.Region, schemaResponse.Schema); err != nil {
+					errs = append(errs, fmt.Errorf("action type %q: %w", typeName, err))
+					continue
+				}
+			}
+		}
+
+		for _, resourceSpec := range sp.FrameworkResources(ctx) {
+			typeName := resourceSpec.TypeName
+			inner, err := resourceSpec.Factory(ctx)
+
+			if err != nil {
+				errs = append(errs, fmt.Errorf("creating resource type (%s): %w", typeName, err))
+				continue
+			}
+
+			schemaResponse := resource.SchemaResponse{}
+			inner.Schema(ctx, resource.SchemaRequest{}, &schemaResponse)
+
+			if err := validateSchemaRegionForResource(resourceSpec.Region, schemaResponse.Schema); err != nil {
+				errs = append(errs, fmt.Errorf("resource type %q: %w", typeName, err))
+				continue
+			}
+
+			if err := validateSchemaTagsForResource(resourceSpec.Tags, schemaResponse.Schema); err != nil {
+				errs = append(errs, fmt.Errorf("resource type %q: %w", typeName, err))
+				continue
+			}
+
+			if resourceSpec.Import.WrappedImport {
+				if resourceSpec.Import.SetIDAttr {
+					if _, ok := resourceSpec.Import.ImportID.(inttypes.FrameworkImportIDCreator); !ok {
+						errs = append(errs, fmt.Errorf("resource type %q: importer sets `%s` attribute, but creator isn't configured", resourceSpec.TypeName, names.AttrID))
+						continue
+					}
+				}
+
+				if _, ok := inner.(framework.ImportByIdentityer); !ok {
+					errs = append(errs, fmt.Errorf("resource type %q: cannot configure importer, does not implement %q", resourceSpec.TypeName, reflect.TypeFor[framework.ImportByIdentityer]()))
+					continue
+				}
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func validateSchemaRegionForDataSource(regionSpec unique.Handle[inttypes.ServicePackageResourceRegion], schema datasourceschema.Schema) error {
+	if !tfunique.IsHandleNil(regionSpec) && regionSpec.Value().IsOverrideEnabled {
+		if _, ok := schema.Attributes[names.AttrRegion]; ok {
+			return fmt.Errorf("configured for enhanced regions but defines `%s` attribute in schema", names.AttrRegion)
+		}
+	}
+	return nil
+}
+
+func validateSchemaRegionForEphemeralResource(regionSpec unique.Handle[inttypes.ServicePackageResourceRegion], schema ephemeralschema.Schema) error {
+	if !tfunique.IsHandleNil(regionSpec) && regionSpec.Value().IsOverrideEnabled {
+		if _, ok := schema.Attributes[names.AttrRegion]; ok {
+			return fmt.Errorf("configured for enhanced regions but defines `%s` attribute in schema", names.AttrRegion)
+		}
+	}
+	return nil
+}
+
+func validateSchemaRegionForAction(regionSpec unique.Handle[inttypes.ServicePackageResourceRegion], schemaIface any) error {
+	if !tfunique.IsHandleNil(regionSpec) && regionSpec.Value().IsOverrideEnabled {
+		if schema, ok := schemaIface.(aschema.Schema); ok {
+			if _, ok := schema.Attributes[names.AttrRegion]; ok {
+				return fmt.Errorf("configured for enhanced regions but defines `%s` attribute in schema", names.AttrRegion)
+			}
+		}
+	}
+	return nil
+}
+
+func validateSchemaRegionForResource(regionSpec unique.Handle[inttypes.ServicePackageResourceRegion], schema resourceschema.Schema) error {
+	if !tfunique.IsHandleNil(regionSpec) && regionSpec.Value().IsOverrideEnabled {
+		if _, ok := schema.Attributes[names.AttrRegion]; ok {
+			return fmt.Errorf("configured for enhanced regions but defines `%s` attribute in schema", names.AttrRegion)
+		}
+	}
+	return nil
+}
+
+func validateSchemaTagsForDataSource(tagsSpec unique.Handle[inttypes.ServicePackageResourceTags], schema datasourceschema.Schema) error {
+	if !tfunique.IsHandleNil(tagsSpec) {
+		if v, ok := schema.Attributes[names.AttrTags]; ok {
+			if !v.IsComputed() {
+				return fmt.Errorf("`%s` attribute must be Computed", names.AttrTags)
+			}
+		} else {
+			return fmt.Errorf("configured for tags but no `%s` attribute defined in schema", names.AttrTags)
+		}
+	}
+	return nil
+}
+
+func validateSchemaTagsForResource(tagsSpec unique.Handle[inttypes.ServicePackageResourceTags], schema resourceschema.Schema) error {
+	if !tfunique.IsHandleNil(tagsSpec) {
+		if v, ok := schema.Attributes[names.AttrTags]; ok {
+			if v.IsComputed() {
+				return fmt.Errorf("`%s` attribute cannot be Computed", names.AttrTags)
+			}
+		} else {
+			return fmt.Errorf("configured for tags but no `%s` attribute defined in schema", names.AttrTags)
+		}
+		if v, ok := schema.Attributes[names.AttrTagsAll]; ok {
+			if !v.IsComputed() {
+				return fmt.Errorf("`%s` attribute must be Computed", names.AttrTagsAll)
+			}
+		} else {
+			return fmt.Errorf("configured for tags but no `%s` attribute defined in schema", names.AttrTagsAll)
+		}
+	}
+	return nil
 }

--- a/internal/provider/sdkv2/provider_test.go
+++ b/internal/provider/sdkv2/provider_test.go
@@ -29,20 +29,20 @@ func BenchmarkSDKProviderInitialization(b *testing.B) {
 	}
 }
 
-func TestProvider(t *testing.T) {
+func TestProviderInit(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
 	p, err := NewProvider(ctx)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Initializing SDKv2 provider: %s", err)
 	}
 
 	p.TerraformVersion = "1.0.0"
 
 	err = p.InternalValidate()
 	if err != nil {
-		t.Fatal(err)
+		t.Errorf("Validating resource schemas: %s", err)
 	}
 }
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Removes run-time validation for Framework-based resource types and adds validation step to Makefile directives.

Will reduce memory usage when initializing the provider. Only the schemas for resource types that are used in the configuration should be allocated.

Relates: #47003

|        | Iteration Count | Time per Operation | Bytes per Operation | Allocations per Operation |
|--------|----------------:|-------------------:|--------------------:|--------------------------:|
| Before |   58 | 17366403 ns/op | 15072518 B/op | 167863 allocs/op |
| After  | 6097 |   185166 ns/op |   244381 B/op |   2420 allocs/op |
