### PR TITLE
resource/aws_cloudfront_multitenant_distribution: removes schema-level defaults on origins set-element sub-attributes that were causing flip-flopping plans

### DIFF
--- a/.changelog/47754.txt
+++ b/.changelog/47754.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudfront_multitenant_distribution: removes schema-level defaults on origins set-element sub-attributes that were causing flip-flopping plans
+```

--- a/internal/service/cloudfront/multitenant_distribution.go
+++ b/internal/service/cloudfront/multitenant_distribution.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -36,13 +36,6 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
-)
-
-const (
-	defaultConnectionAttempts     = 3
-	defaultConnectionTimeout      = 10
-	defaultOriginKeepaliveTimeout = 5
-	defaultOriginReadTimeout      = 30
 )
 
 // @FrameworkResource("aws_cloudfront_multitenant_distribution", name="Multi-tenant Distribution")
@@ -412,12 +405,16 @@ func (r *multiTenantDistributionResource) Schema(ctx context.Context, request re
 						"connection_attempts": schema.Int32Attribute{
 							Optional: true,
 							Computed: true,
-							Default:  int32default.StaticInt32(defaultConnectionAttempts),
+							PlanModifiers: []planmodifier.Int32{
+								int32planmodifier.UseStateForUnknown(),
+							},
 						},
 						"connection_timeout": schema.Int32Attribute{
 							Optional: true,
 							Computed: true,
-							Default:  int32default.StaticInt32(defaultConnectionTimeout),
+							PlanModifiers: []planmodifier.Int32{
+								int32planmodifier.UseStateForUnknown(),
+							},
 						},
 						names.AttrDomainName: schema.StringAttribute{
 							Required: true,
@@ -468,12 +465,16 @@ func (r *multiTenantDistributionResource) Schema(ctx context.Context, request re
 									"origin_keepalive_timeout": schema.Int32Attribute{
 										Optional: true,
 										Computed: true,
-										Default:  int32default.StaticInt32(defaultOriginKeepaliveTimeout),
+										PlanModifiers: []planmodifier.Int32{
+											int32planmodifier.UseStateForUnknown(),
+										},
 									},
 									"origin_read_timeout": schema.Int32Attribute{
 										Optional: true,
 										Computed: true,
-										Default:  int32default.StaticInt32(defaultOriginReadTimeout),
+										PlanModifiers: []planmodifier.Int32{
+											int32planmodifier.UseStateForUnknown(),
+										},
 									},
 									"origin_protocol_policy": schema.StringAttribute{
 										Required:   true,
@@ -507,12 +508,16 @@ func (r *multiTenantDistributionResource) Schema(ctx context.Context, request re
 									"origin_keepalive_timeout": schema.Int32Attribute{
 										Optional: true,
 										Computed: true,
-										Default:  int32default.StaticInt32(defaultOriginKeepaliveTimeout),
+										PlanModifiers: []planmodifier.Int32{
+											int32planmodifier.UseStateForUnknown(),
+										},
 									},
 									"origin_read_timeout": schema.Int32Attribute{
 										Optional: true,
 										Computed: true,
-										Default:  int32default.StaticInt32(defaultOriginReadTimeout),
+										PlanModifiers: []planmodifier.Int32{
+											int32planmodifier.UseStateForUnknown(),
+										},
 									},
 									"vpc_origin_id": schema.StringAttribute{
 										Required: true,

--- a/internal/service/cloudfront/multitenant_distribution_test.go
+++ b/internal/service/cloudfront/multitenant_distribution_test.go
@@ -42,6 +42,14 @@ func TestAccCloudFrontMultiTenantDistribution_basic(t *testing.T) {
 
 					// Check ResponseCompletionTimeout is not enabled with no value set
 					resource.TestCheckNoResourceAttr(resourceName, "origin.0.response_completion_timeout"),
+
+					// Check ConnectionAttempts and ConnectionTimeout exist in the state (server-side defaults)
+					resource.TestCheckResourceAttrSet(resourceName, "origin.0.connection_attempts"),
+					resource.TestCheckResourceAttrSet(resourceName, "origin.0.connection_timeout"),
+
+					// Check OriginKeepaliveTimeout and OriginReadTimeout exist in the state (server-side defaults)
+					resource.TestCheckResourceAttrSet(resourceName, "origin.0.custom_origin_config.0.origin_keepalive_timeout"),
+					resource.TestCheckResourceAttrSet(resourceName, "origin.0.custom_origin_config.0.origin_read_timeout"),
 				),
 			},
 			{
@@ -439,6 +447,39 @@ func TestAccCloudFrontMultiTenantDistribution_lambdaFunctionAssociationSwapBlock
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
 				),
+			},
+		},
+	})
+}
+
+// Ref: https://github.com/hashicorp/terraform-provider-aws/issues/47735
+func TestAccCloudFrontMultiTenantDistribution_customOriginTimeouts(t *testing.T) {
+	t.Parallel()
+
+	ctx := acctest.Context(t)
+	var distribution awstypes.Distribution
+	resourceName := "aws_cloudfront_multitenant_distribution.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMultiTenantDistributionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMultiTenantDistributionConfig_customOriginTimeouts(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.connection_timeout", "5"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.0.origin_keepalive_timeout", "30"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.0.origin_read_timeout", "60"),
+				),
+			},
+			{
+				Config:             testAccMultiTenantDistributionConfig_customOriginTimeouts(),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})
@@ -1197,4 +1238,52 @@ resource "aws_cloudfront_multitenant_distribution" "test" {
   }
 }
 `, rName, lambdaFunctionAssociationBlocks)
+}
+
+func testAccMultiTenantDistributionConfig_customOriginTimeouts() string {
+	return `
+resource "aws_cloudfront_multitenant_distribution" "test" {
+  enabled = false
+  comment = "Test multi-tenant distribution"
+
+  origin {
+    domain_name = "example.com"
+    id          = "example"
+
+    connection_timeout = 5
+
+    custom_origin_config {
+      http_port                = 80
+      https_port               = 443
+      origin_protocol_policy   = "https-only"
+      origin_ssl_protocols     = ["TLSv1.2"]
+      origin_keepalive_timeout = 30
+      origin_read_timeout      = 60
+    }
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "example"
+    viewer_protocol_policy = "redirect-to-https"
+    cache_policy_id        = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled policy
+
+    allowed_methods {
+      items          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+      cached_methods = ["GET", "HEAD", "OPTIONS"]
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tenant_config {}
+}
+`
 }

--- a/internal/service/cloudfront/multitenant_distribution_test.go
+++ b/internal/service/cloudfront/multitenant_distribution_test.go
@@ -477,8 +477,14 @@ func TestAccCloudFrontMultiTenantDistribution_customOriginTimeouts(t *testing.T)
 				),
 			},
 			{
-				Config:             testAccMultiTenantDistributionConfig_customOriginTimeouts(),
-				PlanOnly:           true,
+				Config: testAccMultiTenantDistributionConfig_customOriginTimeouts(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.connection_timeout", "5"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.0.origin_keepalive_timeout", "30"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.custom_origin_config.0.origin_read_timeout", "60"),
+				),
 				ExpectNonEmptyPlan: false,
 			},
 		},


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR fixes a bug causing flip-flopping plans when a user sets non-default values for `origin` sub-attributes with schema-level defaults. This is caused by a known bug in the terraform-plugin-framework when schema-level defaults are present on attributes nested within a `SetNestedBlock`.

The proposed fix is to remove the schema-level defaults and rely on the values returned by the AWS API.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47735
Closes #49133

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
terraform-plugin-framework issues:
* https://github.com/hashicorp/terraform-plugin-framework/issues/1256
* https://github.com/hashicorp/terraform-plugin-framework/issues/867
* https://github.com/hashicorp/terraform-plugin-framework/issues/783

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccCloudFrontMultiTenantDistribution_basic PKG=cloudfront
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws_cloudfront_multitenant_distribution-remove_schema_level_defaults_origin_attributes 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontMultiTenantDistribution_basic'  -timeout 360m -vet=off
2026/05/04 22:15:46 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/04 22:15:46 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudFrontMultiTenantDistribution_basic
=== PAUSE TestAccCloudFrontMultiTenantDistribution_basic
=== CONT  TestAccCloudFrontMultiTenantDistribution_basic
--- PASS: TestAccCloudFrontMultiTenantDistribution_basic (251.86s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 266.583s

% make testacc TESTS=TestAccCloudFrontMultiTenantDistribution_customOriginTimeouts PKG=cloudfront
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws_cloudfront_multitenant_distribution-remove_schema_level_defaults_origin_attributes 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontMultiTenantDistribution_customOriginTimeouts'  -timeout 360m -vet=off
2026/05/04 23:10:37 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/04 23:10:37 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudFrontMultiTenantDistribution_customOriginTimeouts
=== PAUSE TestAccCloudFrontMultiTenantDistribution_customOriginTimeouts
=== CONT  TestAccCloudFrontMultiTenantDistribution_customOriginTimeouts
--- PASS: TestAccCloudFrontMultiTenantDistribution_customOriginTimeouts (278.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 293.344s
```
