### PR TITLE
fix: allow IoT substitution templates in aws_iot_topic_rule metric_timestamp

### DIFF
--- a/.changelog/47759.txt
+++ b/.changelog/47759.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iot_topic_rule: Allow IoT substitution templates (e.g. `${timestamp()}`) as valid values for `metric_timestamp` in `cloudwatch_metric` blocks
+```

--- a/internal/service/iot/topic_rule.go
+++ b/internal/service/iot/topic_rule.go
@@ -146,9 +146,12 @@ func resourceTopicRule() *schema.Resource {
 								Required: true,
 							},
 							"metric_timestamp": {
-								Type:         schema.TypeString,
-								Optional:     true,
-								ValidateFunc: verify.ValidUTCTimestamp,
+								Type:     schema.TypeString,
+								Optional: true,
+								ValidateFunc: validation.Any(
+									verify.ValidUTCTimestamp,
+									validTopicRuleCloudWatchMetricTimestamp,
+								),
 							},
 							"metric_unit": {
 								Type:     schema.TypeString,
@@ -357,9 +360,12 @@ func resourceTopicRule() *schema.Resource {
 											Required: true,
 										},
 										"metric_timestamp": {
-											Type:         schema.TypeString,
-											Optional:     true,
-											ValidateFunc: verify.ValidUTCTimestamp,
+											Type:     schema.TypeString,
+											Optional: true,
+											ValidateFunc: validation.Any(
+												verify.ValidUTCTimestamp,
+												validTopicRuleCloudWatchMetricTimestamp,
+											),
 										},
 										"metric_unit": {
 											Type:     schema.TypeString,

--- a/internal/service/iot/validate.go
+++ b/internal/service/iot/validate.go
@@ -101,3 +101,16 @@ func validTopicRuleName(v any, s string) ([]string, []error) {
 
 	return nil, nil
 }
+
+// validTopicRuleCloudWatchMetricTimestamp accepts an IoT substitution template expression
+// (e.g. "${timestamp()}") as a metric_timestamp value. Used alongside verify.ValidUTCTimestamp
+// via validation.Any so that both static UTC timestamps and dynamic expressions are accepted.
+// https://docs.aws.amazon.com/iot/latest/developerguide/iot-substitution-templates.html
+func validTopicRuleCloudWatchMetricTimestamp(v any, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexache.MustCompile(`^\$\{.+\}$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q must be an IoT substitution template (e.g. ${timestamp()}), got: %q", k, value))
+	}
+	return
+}

--- a/internal/service/iot/validate_test.go
+++ b/internal/service/iot/validate_test.go
@@ -1,0 +1,41 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package iot
+
+import (
+	"testing"
+)
+
+func Test_validTopicRuleCloudWatchMetricTimestamp(t *testing.T) {
+	t.Parallel()
+
+	validCases := []string{
+		"${timestamp()}",
+		"${device_time}",
+		"${topic(3)}",
+		"${get(thing.attributes, 'time')}",
+	}
+
+	for _, v := range validCases {
+		_, errors := validTopicRuleCloudWatchMetricTimestamp(v, "metric_timestamp")
+		if len(errors) != 0 {
+			t.Errorf("expected %q to be valid, got errors: %v", v, errors)
+		}
+	}
+
+	invalidCases := []string{
+		"not-a-template",
+		"2023-01-01T00:00:00Z",
+		"${unclosed",
+		"just text",
+		"",
+	}
+
+	for _, v := range invalidCases {
+		_, errors := validTopicRuleCloudWatchMetricTimestamp(v, "metric_timestamp")
+		if len(errors) == 0 {
+			t.Errorf("expected %q to be invalid", v)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #45375

The `metric_timestamp` field in the `cloudwatch_metric` block of `aws_iot_topic_rule` was validated with `verify.ValidUTCTimestamp` only, which rejected valid [IoT substitution templates](https://docs.aws.amazon.com/iot/latest/developerguide/iot-substitution-templates.html) such as `${timestamp()}` or `${device_time}`.

This PR changes both `metric_timestamp` fields (main action block and `error_action` block) to use `validation.Any(verify.ValidUTCTimestamp, validTopicRuleCloudWatchMetricTimestamp)`, so both static UTC timestamps and dynamic substitution template expressions are accepted.

## Changes

- `internal/service/iot/validate.go` — added `validTopicRuleCloudWatchMetricTimestamp` validator that accepts `${...}` substitution template syntax
- `internal/service/iot/topic_rule.go` — updated `metric_timestamp` in both `cloudwatch_metric` schema blocks to use `validation.Any`
- `internal/service/iot/validate_test.go` — new unit tests covering valid substitution templates and invalid inputs

## Example

```hcl
resource "aws_iot_topic_rule" "example" {
  cloudwatch_metric {
    role_arn         = aws_iam_role.example.arn
    metric_namespace = "MyNamespace"
    metric_name      = "tx"
    metric_value     = "${tx}"
    metric_unit      = "Count"
    metric_timestamp = "${timestamp()}"  # previously rejected, now accepted
  }
}
```

## References

- Fixes #45375
- [AWS IoT Substitution Templates](https://docs.aws.amazon.com/iot/latest/developerguide/iot-substitution-templates.html)
- [CloudWatch metric action docs](https://docs.aws.amazon.com/iot/latest/developerguide/cloudwatch-metrics-rule-action.html)