### PR TITLE
fix: fix bug with deleting s3files sync config when a prefix is specified

### DIFF
--- a/.changelog/47760.txt
+++ b/.changelog/47760.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3files_synchronization_configuration: Fix `Delete` to use the file system prefix when resetting the synchronization configuration
+```

--- a/internal/service/s3files/synchronization_configuration.go
+++ b/internal/service/s3files/synchronization_configuration.go
@@ -218,11 +218,19 @@ func (r *synchronizationConfigurationResource) Delete(ctx context.Context, reque
 
 	conn := r.Meta().S3FilesClient(ctx)
 
+	fileSystem, err := findFileSystemByID(ctx, conn, data.FileSystemID.ValueString())
+	if err != nil {
+		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, data.FileSystemID.ValueString())
+		return
+	}
+
+	prefix := aws.ToString(fileSystem.Prefix)
+
 	input := s3files.PutSynchronizationConfigurationInput{
 		FileSystemId: data.FileSystemID.ValueStringPointer(),
 		ImportDataRules: []awstypes.ImportDataRule{
 			{
-				Prefix:       aws.String(""),
+				Prefix:       aws.String(prefix),
 				Trigger:      awstypes.ImportTriggerOnDirectoryFirstAccess,
 				SizeLessThan: aws.Int64(131072),
 			},
@@ -235,7 +243,7 @@ func (r *synchronizationConfigurationResource) Delete(ctx context.Context, reque
 		LatestVersionNumber: data.LatestVersionNumber.ValueInt32Pointer(),
 	}
 
-	_, err := conn.PutSynchronizationConfiguration(ctx, &input)
+	_, err = conn.PutSynchronizationConfiguration(ctx, &input)
 	if err != nil {
 		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, data.FileSystemID.ValueString())
 	}

--- a/internal/service/s3files/synchronization_configuration_test.go
+++ b/internal/service/s3files/synchronization_configuration_test.go
@@ -183,3 +183,54 @@ resource "aws_s3files_synchronization_configuration" "test" {
 }
 `)
 }
+
+func TestAccS3FilesSynchronizationConfiguration_prefix(t *testing.T) {
+	ctx := acctest.Context(t)
+	var synchronization s3files.GetSynchronizationConfigurationOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_s3files_synchronization_configuration.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3FilesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSynchronizationConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSynchronizationConfigurationConfig_prefix(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSynchronizationConfigurationExists(ctx, t, resourceName, &synchronization),
+					resource.TestCheckResourceAttr(resourceName, "import_data_rule.0.prefix", "data/"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSynchronizationConfigurationConfig_prefix(rName string) string {
+	return acctest.ConfigCompose(
+		testAccFileSystemConfig_base(rName),
+		`
+resource "aws_s3files_file_system" "test" {
+  bucket   = aws_s3_bucket.test.arn
+  role_arn = aws_iam_role.test.arn
+  prefix   = "data/"
+
+  depends_on = [aws_s3_bucket_versioning.test]
+}
+
+resource "aws_s3files_synchronization_configuration" "test" {
+  file_system_id = aws_s3files_file_system.test.id
+
+  import_data_rule {
+    prefix         = "data/"
+    size_less_than = 131072
+    trigger        = "ON_DIRECTORY_FIRST_ACCESS"
+  }
+
+  expiration_data_rule {
+    days_after_last_access = 30
+  }
+}
+`)
+}


### PR DESCRIPTION
Fix a bug that causes delete operations on s3files synchronization configuration resources to fail when a prefix is specified. The bug is fixed by looking up the filesystem-specified prefix, if one exists, and specifying that in the importDataRules instead of always setting the prefix to an empty string.

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR fixes a bug in the `aws_s3files_synchronization_configuration` resource delete operation when a prefix is specified by looking up the configured prefix on the S3 Files filesystem and using the configured prefix in the import data rule rather than always setting the prefix in the rule to `""`.

I considered implementing a local function to find the longest common prefix of the import data rules in the configuration, but decided against it in favor of looking up the configuration on the filesystem. I would not mind changing implementations if the longest-common-prefix implementation would be preferred. I erred against it because it could still technically be incorrect, e.g. if the prefix on the filesystem is `data/` and the prefixes in the import data rules are `data/logs/somedir`, `data/logs/otherdir`, the longest common prefix ends up being `data/logs/` and not `data/` as configured on the filesystem if there are no synchronization configurations defined on the filesystem resource.

I also added a new acceptance test to the suite to catch this case in the future in case the implementation changes over time. The output of the test is included in the output section below.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47753 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

Here is the output of the new acceptance test I added with the prior implementation:

```console
--- PASS: TestAccS3FilesSynchronizationConfiguration_basic (44.49s)
--- PASS: TestAccS3FilesSynchronizationConfiguration_update (55.52s)
=== NAME  TestAccS3FilesSynchronizationConfiguration_prefix
    synchronization_configuration_test.go:193: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting S3 Files Synchronization Configuration
        
        ID: fs-03170416cf4650969
        Cause: operation error S3Files: PutSynchronizationConfiguration, ,
        ValidationException: Invalid importDataRules. Prefix must start with the file
        system prefix 'data/' for each rule."
        
--- FAIL: TestAccS3FilesSynchronizationConfiguration_prefix (60.05s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/s3files    63.913s
FAIL
```


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
TF_ACC=1 go test ./internal/service/s3files/... -run TestAccS3FilesSynchronizationConfiguration -v -timeout 30m
2026/05/04 19:15:33 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/04 19:15:33 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3FilesSynchronizationConfiguration_Identity_basic
=== PAUSE TestAccS3FilesSynchronizationConfiguration_Identity_basic
=== RUN   TestAccS3FilesSynchronizationConfiguration_Identity_regionOverride
=== PAUSE TestAccS3FilesSynchronizationConfiguration_Identity_regionOverride
=== RUN   TestAccS3FilesSynchronizationConfiguration_List_basic
=== PAUSE TestAccS3FilesSynchronizationConfiguration_List_basic
=== RUN   TestAccS3FilesSynchronizationConfiguration_List_regionOverride
=== PAUSE TestAccS3FilesSynchronizationConfiguration_List_regionOverride
=== RUN   TestAccS3FilesSynchronizationConfiguration_List_includeResource
=== PAUSE TestAccS3FilesSynchronizationConfiguration_List_includeResource
=== RUN   TestAccS3FilesSynchronizationConfiguration_basic
=== PAUSE TestAccS3FilesSynchronizationConfiguration_basic
=== RUN   TestAccS3FilesSynchronizationConfiguration_update
=== PAUSE TestAccS3FilesSynchronizationConfiguration_update
=== RUN   TestAccS3FilesSynchronizationConfiguration_prefix
=== PAUSE TestAccS3FilesSynchronizationConfiguration_prefix
=== CONT  TestAccS3FilesSynchronizationConfiguration_Identity_basic
=== CONT  TestAccS3FilesSynchronizationConfiguration_List_includeResource
=== CONT  TestAccS3FilesSynchronizationConfiguration_List_basic
=== CONT  TestAccS3FilesSynchronizationConfiguration_update
=== CONT  TestAccS3FilesSynchronizationConfiguration_List_regionOverride
=== CONT  TestAccS3FilesSynchronizationConfiguration_prefix
=== CONT  TestAccS3FilesSynchronizationConfiguration_Identity_regionOverride
=== CONT  TestAccS3FilesSynchronizationConfiguration_basic
=== NAME  TestAccS3FilesSynchronizationConfiguration_Identity_regionOverride
    synchronization_configuration_identity_gen_test.go:118: Terraform CLI version 1.9.8 is below minimum version 1.12.0: skipping test
=== NAME  TestAccS3FilesSynchronizationConfiguration_List_basic
    synchronization_configuration_list_test.go:31: Terraform CLI version 1.9.8 is below minimum version 1.14.0: skipping test
=== NAME  TestAccS3FilesSynchronizationConfiguration_Identity_basic
    synchronization_configuration_identity_gen_test.go:31: Terraform CLI version 1.9.8 is below minimum version 1.12.0: skipping test
=== NAME  TestAccS3FilesSynchronizationConfiguration_List_includeResource
    synchronization_configuration_list_test.go:115: Terraform CLI version 1.9.8 is below minimum version 1.14.0: skipping test
=== NAME  TestAccS3FilesSynchronizationConfiguration_List_regionOverride
    synchronization_configuration_list_test.go:72: Terraform CLI version 1.9.8 is below minimum version 1.14.0: skipping test
--- SKIP: TestAccS3FilesSynchronizationConfiguration_List_basic (0.50s)
--- SKIP: TestAccS3FilesSynchronizationConfiguration_Identity_basic (0.50s)
--- SKIP: TestAccS3FilesSynchronizationConfiguration_List_includeResource (0.50s)
--- SKIP: TestAccS3FilesSynchronizationConfiguration_Identity_regionOverride (0.50s)
--- SKIP: TestAccS3FilesSynchronizationConfiguration_List_regionOverride (0.50s)
--- PASS: TestAccS3FilesSynchronizationConfiguration_prefix (42.27s)
--- PASS: TestAccS3FilesSynchronizationConfiguration_basic (44.82s)
--- PASS: TestAccS3FilesSynchronizationConfiguration_update (56.12s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3files    59.975s
```
