### PR TITLE
New List Resource : `aws_ecr_repository_policy`

### DIFF
--- a/.changelog/47763.txt
+++ b/.changelog/47763.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_ecr_repository_policy
+```

--- a/internal/service/ecr/repository_policy.go
+++ b/internal/service/ecr/repository_policy.go
@@ -109,11 +109,15 @@ func resourceRepositoryPolicyRead(ctx context.Context, d *schema.ResourceData, m
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	d.Set(names.AttrPolicy, policyToSet)
-	d.Set("registry_id", output.RegistryId)
-	d.Set("repository", output.RepositoryName)
+	resourceRepositoryPolicyFlatten(d, output, policyToSet)
 
 	return diags
+}
+
+func resourceRepositoryPolicyFlatten(d *schema.ResourceData, output *ecr.GetRepositoryPolicyOutput, policy string) {
+	d.Set(names.AttrPolicy, policy)
+	d.Set("registry_id", output.RegistryId)
+	d.Set("repository", output.RepositoryName)
 }
 
 func resourceRepositoryPolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/service/ecr/repository_policy_list.go
+++ b/internal/service/ecr/repository_policy_list.go
@@ -1,0 +1,104 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ecr
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+)
+
+// @SDKListResource("aws_ecr_repository_policy")
+func newRepositoryPolicyResourceAsListResource() inttypes.ListResourceForSDK {
+	l := repositoryPolicyListResource{}
+	l.SetResourceSchema(resourceRepositoryPolicy())
+	return &l
+}
+
+var _ list.ListResource = &repositoryPolicyListResource{}
+
+type repositoryPolicyListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+type repositoryPolicyListResourceModel struct {
+	framework.WithRegionModel
+}
+
+func (l *repositoryPolicyListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	var query repositoryPolicyListResourceModel
+	if diags := request.Config.Get(ctx, &query); diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	conn := l.Meta().ECRClient(ctx)
+
+	tflog.Info(ctx, "Listing ECR repository policies")
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		input := &ecr.DescribeRepositoriesInput{}
+
+		for repository, err := range listRepositories(ctx, conn, input) {
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+
+			repositoryName := aws.ToString(repository.RepositoryName)
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey("repository"), repositoryName)
+
+			output, err := findRepositoryPolicyByRepositoryName(ctx, conn, repositoryName)
+			if retry.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("reading ECR Repository Policy (%s): %w", repositoryName, err))
+				yield(result)
+				return
+			}
+
+			result := request.NewListResult(ctx)
+
+			rd := l.ResourceData()
+			rd.SetId(repositoryName)
+			rd.Set("repository", repositoryName)
+
+			if request.IncludeResource {
+				policy, err := structure.NormalizeJsonString(aws.ToString(output.PolicyText))
+				if err != nil {
+					result := fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("normalizing ECR Repository Policy (%s): %w", repositoryName, err))
+					yield(result)
+					return
+				}
+
+				resourceRepositoryPolicyFlatten(rd, output, policy)
+			}
+
+			result.DisplayName = repositoryName
+
+			l.SetResult(ctx, l.Meta(), request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/service/ecr/repository_policy_list_test.go
+++ b/internal/service/ecr/repository_policy_list_test.go
@@ -122,7 +122,7 @@ func TestAccECRRepositoryPolicy_List_includeResource(t *testing.T) {
 						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.StringExact(rName+"-0")),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New("repository"), knownvalue.StringExact(rName+"-0")),
-						tfquerycheck.KnownValueCheck(tfjsonpath.New("registry_id"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("registry_id"), tfknownvalue.AccountID()),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrPolicy), knownvalue.NotNull()),
 					}),
 				},

--- a/internal/service/ecr/repository_policy_list_test.go
+++ b/internal/service/ecr/repository_policy_list_test.go
@@ -1,0 +1,186 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ecr_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccECRRepositoryPolicy_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_ecr_repository_policy.test[0]"
+	resourceName2 := "aws_ecr_repository_policy.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	repositoryName1 := tfstatecheck.StateValue()
+	repositoryName2 := tfstatecheck.StateValue()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		CheckDestroy:             testAccCheckRepositoryPolicyDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/RepositoryPolicy/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					repositoryName1.GetStateValue(resourceName1, tfjsonpath.New("repository")),
+					repositoryName2.GetStateValue(resourceName2, tfjsonpath.New("repository")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/RepositoryPolicy/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("aws_ecr_repository_policy.test", map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrRegion:    knownvalue.StringExact(acctest.Region()),
+						"repository":        repositoryName1.ValueCheck(),
+					}),
+					querycheck.ExpectIdentity("aws_ecr_repository_policy.test", map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrRegion:    knownvalue.StringExact(acctest.Region()),
+						"repository":        repositoryName2.ValueCheck(),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccECRRepositoryPolicy_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_ecr_repository_policy.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		CheckDestroy:             testAccCheckRepositoryPolicyDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/RepositoryPolicy/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/RepositoryPolicy/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_ecr_repository_policy.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_ecr_repository_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					querycheck.ExpectResourceKnownValues("aws_ecr_repository_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("repository"), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("registry_id"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrPolicy), knownvalue.NotNull()),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccECRRepositoryPolicy_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_ecr_repository_policy.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	repositoryName1 := tfstatecheck.StateValue()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		CheckDestroy:             testAccCheckRepositoryPolicyDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/RepositoryPolicy/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					repositoryName1.GetStateValue(resourceName1, tfjsonpath.New("repository")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/RepositoryPolicy/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("aws_ecr_repository_policy.test", map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrRegion:    knownvalue.StringExact(acctest.AlternateRegion()),
+						"repository":        repositoryName1.ValueCheck(),
+					}),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/ecr/service_package_gen.go
+++ b/internal/service/ecr/service_package_gen.go
@@ -191,6 +191,13 @@ func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttype
 			}),
 			Identity: inttypes.RegionalSingleParameterIdentity(inttypes.StringIdentityAttribute(names.AttrName, true)),
 		},
+		{
+			Factory:  newRepositoryPolicyResourceAsListResource,
+			TypeName: "aws_ecr_repository_policy",
+			Name:     "Repository Policy",
+			Region:   inttypes.ResourceRegionDefault(),
+			Identity: inttypes.RegionalSingleParameterIdentity(inttypes.StringIdentityAttribute("repository", true)),
+		},
 	})
 }
 

--- a/internal/service/ecr/testdata/RepositoryPolicy/list_basic/main.tf
+++ b/internal/service/ecr/testdata/RepositoryPolicy/list_basic/main.tf
@@ -1,0 +1,36 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ecr_repository_policy" "test" {
+  count = var.resource_count
+
+  repository = aws_ecr_repository.test[count.index].name
+
+  policy = jsonencode({
+    Version = "2008-10-17"
+    Statement = [{
+      Sid       = "${var.rName}-${count.index}"
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = "ecr:ListImages"
+    }]
+  })
+}
+
+resource "aws_ecr_repository" "test" {
+  count = var.resource_count
+
+  name = "${var.rName}-${count.index}"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/ecr/testdata/RepositoryPolicy/list_basic/query.tfquery.hcl
+++ b/internal/service/ecr/testdata/RepositoryPolicy/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ecr_repository_policy" "test" {
+  provider = aws
+}

--- a/internal/service/ecr/testdata/RepositoryPolicy/list_include_resource/main.tf
+++ b/internal/service/ecr/testdata/RepositoryPolicy/list_include_resource/main.tf
@@ -1,0 +1,36 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ecr_repository_policy" "test" {
+  count = var.resource_count
+
+  repository = aws_ecr_repository.test[count.index].name
+
+  policy = jsonencode({
+    Version = "2008-10-17"
+    Statement = [{
+      Sid       = "${var.rName}-${count.index}"
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = "ecr:ListImages"
+    }]
+  })
+}
+
+resource "aws_ecr_repository" "test" {
+  count = var.resource_count
+
+  name = "${var.rName}-${count.index}"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/ecr/testdata/RepositoryPolicy/list_include_resource/query.tfquery.hcl
+++ b/internal/service/ecr/testdata/RepositoryPolicy/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ecr_repository_policy" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/ecr/testdata/RepositoryPolicy/list_region_override/main.tf
+++ b/internal/service/ecr/testdata/RepositoryPolicy/list_region_override/main.tf
@@ -1,0 +1,44 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ecr_repository_policy" "test" {
+  count  = var.resource_count
+  region = var.region
+
+  repository = aws_ecr_repository.test[count.index].name
+
+  policy = jsonencode({
+    Version = "2008-10-17"
+    Statement = [{
+      Sid       = "${var.rName}-${count.index}"
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = "ecr:ListImages"
+    }]
+  })
+}
+
+resource "aws_ecr_repository" "test" {
+  count  = var.resource_count
+  region = var.region
+
+  name = "${var.rName}-${count.index}"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/ecr/testdata/RepositoryPolicy/list_region_override/query.tfquery.hcl
+++ b/internal/service/ecr/testdata/RepositoryPolicy/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ecr_repository_policy" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}

--- a/website/docs/list-resources/ecr_repository_policy.html.markdown
+++ b/website/docs/list-resources/ecr_repository_policy.html.markdown
@@ -1,0 +1,26 @@
+---
+subcategory: "ECR (Elastic Container Registry)"
+layout: "aws"
+page_title: "AWS: aws_ecr_repository_policy"
+description: |-
+  Lists ECR (Elastic Container Registry) Repository Policy resources.
+---
+
+# List Resource: aws_ecr_repository_policy
+
+Lists ECR (Elastic Container Registry) Repository Policy resources.
+Only repositories with an attached repository policy are returned.
+
+## Example Usage
+
+```terraform
+list "aws_ecr_repository_policy" "example" {
+  provider = aws
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

### Description

Adds list resource support for `aws_ecr_repository_policy`

### Relations

Closes #47223
Relates https://github.com/hashicorp/terraform-provider-aws/issues/47005

### Output from Acceptance Testing


```console
make t K=ecr T=TestAccECRRepositoryPolicy_          
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-list-resourcee-aws_ecr_repository_policy 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRRepositoryPolicy_'  -timeout 360m -vet=off
2026/05/05 16:14:45 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/05 16:14:45 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECRRepositoryPolicy_Identity_basic
=== PAUSE TestAccECRRepositoryPolicy_Identity_basic
=== RUN   TestAccECRRepositoryPolicy_Identity_regionOverride
=== PAUSE TestAccECRRepositoryPolicy_Identity_regionOverride
=== RUN   TestAccECRRepositoryPolicy_Identity_ExistingResource_basic
=== PAUSE TestAccECRRepositoryPolicy_Identity_ExistingResource_basic
=== RUN   TestAccECRRepositoryPolicy_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccECRRepositoryPolicy_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccECRRepositoryPolicy_List_basic
=== PAUSE TestAccECRRepositoryPolicy_List_basic
=== RUN   TestAccECRRepositoryPolicy_List_includeResource
=== PAUSE TestAccECRRepositoryPolicy_List_includeResource
=== RUN   TestAccECRRepositoryPolicy_List_regionOverride
=== PAUSE TestAccECRRepositoryPolicy_List_regionOverride
=== RUN   TestAccECRRepositoryPolicy_basic
=== PAUSE TestAccECRRepositoryPolicy_basic
=== RUN   TestAccECRRepositoryPolicy_IAM_basic
=== PAUSE TestAccECRRepositoryPolicy_IAM_basic
=== RUN   TestAccECRRepositoryPolicy_IAM_principalOrder
=== PAUSE TestAccECRRepositoryPolicy_IAM_principalOrder
=== RUN   TestAccECRRepositoryPolicy_disappears
=== PAUSE TestAccECRRepositoryPolicy_disappears
=== RUN   TestAccECRRepositoryPolicy_Disappears_repository
=== PAUSE TestAccECRRepositoryPolicy_Disappears_repository
=== CONT  TestAccECRRepositoryPolicy_Identity_basic
=== CONT  TestAccECRRepositoryPolicy_List_regionOverride
=== CONT  TestAccECRRepositoryPolicy_Identity_ExistingResource_noRefreshNoChange
=== CONT  TestAccECRRepositoryPolicy_Identity_ExistingResource_basic
=== CONT  TestAccECRRepositoryPolicy_List_includeResource
=== CONT  TestAccECRRepositoryPolicy_IAM_principalOrder
=== CONT  TestAccECRRepositoryPolicy_Disappears_repository
=== CONT  TestAccECRRepositoryPolicy_disappears
=== CONT  TestAccECRRepositoryPolicy_IAM_basic
=== CONT  TestAccECRRepositoryPolicy_Identity_regionOverride
=== CONT  TestAccECRRepositoryPolicy_basic
=== CONT  TestAccECRRepositoryPolicy_List_basic
--- PASS: TestAccECRRepositoryPolicy_Disappears_repository (92.97s)
--- PASS: TestAccECRRepositoryPolicy_disappears (93.92s)
--- PASS: TestAccECRRepositoryPolicy_List_regionOverride (95.98s)
--- PASS: TestAccECRRepositoryPolicy_List_includeResource (99.11s)
--- PASS: TestAccECRRepositoryPolicy_List_basic (99.35s)
--- PASS: TestAccECRRepositoryPolicy_IAM_basic (109.22s)
--- PASS: TestAccECRRepositoryPolicy_Identity_regionOverride (143.39s)
--- PASS: TestAccECRRepositoryPolicy_Identity_basic (148.09s)
--- PASS: TestAccECRRepositoryPolicy_basic (149.88s)
--- PASS: TestAccECRRepositoryPolicy_Identity_ExistingResource_noRefreshNoChange (153.14s)
--- PASS: TestAccECRRepositoryPolicy_Identity_ExistingResource_basic (164.12s)
--- PASS: TestAccECRRepositoryPolicy_IAM_principalOrder (174.78s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        187.561s
```
