### PR TITLE
generate/identitytests: Correct PlanCheck for single identity attribute when `plannableImportAction="Replace"`

### DIFF
--- a/internal/generate/identitytests/resource_test.go.gtpl
+++ b/internal/generate/identitytests/resource_test.go.gtpl
@@ -161,7 +161,17 @@ ImportPlanChecks: resource.ImportPlanChecks{
 		{{ else if .HasIDAttrDuplicates -}}
 			plancheck.ExpectKnownValue(resourceName, tfjsonpath.New({{ .IDAttrDuplicates }}), knownvalue.NotNull()),
 			plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
-		{{ else if gt (len .IdentityAttributes) 0 -}}
+		{{ else if eq (len .IdentityAttributes) 1 -}}
+			{{ if eq .PlannableResourceAction "Replace" -}}
+				{{ range .IdentityAttributes -}}
+				plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New({{ or .ResourceAttributeName .Name }})),
+				{{ end -}}
+			{{ else -}}
+				{{ range .IdentityAttributes -}}
+				plancheck.ExpectKnownValue(resourceName, tfjsonpath.New({{ or .ResourceAttributeName .Name }}), knownvalue.NotNull()),
+				{{ end -}}
+			{{ end -}}
+		{{ else if gt (len .IdentityAttributes) 1 -}}
 			{{ range .IdentityAttributes -}}
 				{{ if not .Optional -}}
 				plancheck.ExpectKnownValue(resourceName, tfjsonpath.New({{ or .ResourceAttributeName .Name }}), knownvalue.NotNull()),


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Noticed while adding RI to Timestream InfluxDB (#47052). If an import step results in resource replacement then the identity attribute will plan to `Unknown`.
Restricted to the single identity attribute case as for many multi-attribute parameterized identity resource, not all identity attributes will be unknown. 