### PR TITLE
Adds `@ExclusiveResource` annotation

### DIFF
--- a/internal/generate/identitytests/main.go
+++ b/internal/generate/identitytests/main.go
@@ -605,7 +605,7 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 					}
 				}
 
-			case "NoImport":
+			case "NoImport", "ExclusiveResource":
 				d.NoImport = true
 
 			case "Testing":

--- a/internal/generate/servicepackage/main.go
+++ b/internal/generate/servicepackage/main.go
@@ -103,6 +103,9 @@ func main() {
 
 		for key, value := range v.frameworkListResources {
 			if val, exists := v.frameworkResources[key]; exists {
+				if val.exclusiveResource {
+					g.Fatalf("Framework List Resource %q cannot be created for an @ExclusiveResource. Exclusive resources must not support list. See docs/design-decisions/no-import-support-for-exclusive-resource-types.md", key)
+				}
 				value.Name = val.Name
 				value.ResourceIdentity = val.ResourceIdentity
 				value.TransparentTagging = val.TransparentTagging
@@ -117,6 +120,9 @@ func main() {
 
 		for key, value := range v.sdkListResources {
 			if val, exists := v.sdkResources[key]; exists {
+				if val.exclusiveResource {
+					g.Fatalf("SDK List Resource %q cannot be created for an @ExclusiveResource. Exclusive resources must not support list. See docs/design-decisions/no-import-support-for-exclusive-resource-types.md", key)
+				}
 				value.Name = val.Name
 				value.ResourceIdentity = val.ResourceIdentity
 				value.TransparentTagging = val.TransparentTagging
@@ -235,6 +241,7 @@ type ResourceDatum struct {
 	TagsResourceType                  string
 	isARNFormatGlobal                 arnFormatState
 	wrappedImport                     common.TriBoolean
+	exclusiveResource                 bool
 	CustomImport                      bool
 	goImports                         []common.GoImport
 	HasIdentityFix                    bool
@@ -336,6 +343,9 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 	if slices.Contains(keys, "IdentityAttribute") && slices.Contains(keys, "ArnIdentity") {
 		v.errs = append(v.errs, fmt.Errorf(`only one of "IdentityAttribute" and "ArnIdentity" can be specified: %s`, fmt.Sprintf("%s.%s", v.packageName, v.functionName)))
 	}
+	if slices.Contains(keys, "ExclusiveResource") && (slices.Contains(keys, "WrappedImport") || slices.Contains(keys, "CustomImport") || slices.Contains(keys, "ImportIDHandler")) {
+		v.errs = append(v.errs, fmt.Errorf("%s.%s: @ExclusiveResource must not have import annotations (@WrappedImport, @CustomImport, @ImportIDHandler). Exclusive resources do not support import. See docs/design-decisions/no-import-support-for-exclusive-resource-types.md", v.packageName, v.functionName))
+	}
 
 	// Look first for per-resource annotations such as tagging and Region.
 	for _, line := range funcDecl.Doc.List {
@@ -432,6 +442,10 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 
 			case "NoImport":
 				d.wrappedImport = common.TriBooleanFalse
+
+			case "ExclusiveResource":
+				d.wrappedImport = common.TriBooleanFalse
+				d.exclusiveResource = true
 
 			case "IdentityFix":
 				d.HasIdentityFix = true
@@ -728,7 +742,7 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 					v.sdkListResources[typeName] = d
 				}
 
-			case "IdentityAttribute", "ArnIdentity", "ImportIDHandler", "MutableIdentity", "SingletonIdentity", "Region", "Tags", "WrappedImport", "V60SDKv2Fix", "IdentityFix", "NoImport", "CustomImport", "IdentityVersion", "CustomInherentRegionIdentity":
+			case "IdentityAttribute", "ArnIdentity", "ImportIDHandler", "MutableIdentity", "SingletonIdentity", "Region", "Tags", "WrappedImport", "V60SDKv2Fix", "IdentityFix", "NoImport", "ExclusiveResource", "CustomImport", "IdentityVersion", "CustomInherentRegionIdentity":
 				// Handled above.
 			case "ArnFormat", "IdAttrFormat", "Testing":
 				// Ignored.

--- a/internal/generate/tagstests/main.go
+++ b/internal/generate/tagstests/main.go
@@ -556,7 +556,7 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 					hasIdentifierAttribute = true
 				}
 
-			case "NoImport":
+			case "NoImport", "ExclusiveResource":
 				d.NoImport = true
 
 			case "Testing":


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description

This PR adds the `@ExclusiveResource` annotation to help prevent contributors from adding import or list support to exclusive resources, which can be risky.

Once this PR is merged, we can add the `@ExclusiveResource` annotation to all "exclusive‑style" resources.

This annotation permits identity annotations but blocks import and list support at generation time.


### Relations

Relates https://github.com/hashicorp/terraform-provider-aws/pull/47744



### Testing

#### Import

```console
go generate internal/service/iam/generate.go
Generating internal/service/iam/list_pages_gen.go
  iam.listGroupsForUser
  iam.listServiceSpecificCredentials
Generating internal/service/iam/tags_gen.go
Generating internal/service/iam/service_package_gen.go
iam.resourcePolicyAttachment: @ExclusiveResource must not have import annotations (@WrappedImport, @CustomImport, @ImportIDHandler). Exclusive resources do not support import. See docs/design-decisions/no-import-support-for-exclusive-resource-types.md
exit status 1
internal/service/iam/generate.go:6: running "go": exit status 1
```


#### List

```console
go generate generate.go
Generating internal/service/iam/list_pages_gen.go
  iam.listGroupsForUser
  iam.listServiceSpecificCredentials
Generating internal/service/iam/tags_gen.go
Generating internal/service/iam/service_package_gen.go
SDK List Resource "aws_iam_policy_attachment" cannot be created for an @ExclusiveResource. Exclusive resources must not support list. See docs/design-decisions/no-import-support-for-exclusive-resource-types.md
exit status 1
generate.go:6: running "go": exit status 1
```
