### PR TITLE
New List Resource: `aws_dynamodb_global_secondary_index`

### DIFF
--- a/.changelog/47785.txt
+++ b/.changelog/47785.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_dynamodb_global_secondary_index
+```

--- a/internal/service/dynamodb/global_secondary_index.go
+++ b/internal/service/dynamodb/global_secondary_index.go
@@ -599,21 +599,6 @@ func (r *resourceGlobalSecondaryIndex) Delete(ctx context.Context, request resou
 	}
 }
 
-type resourceGlobalSecondaryIndexModel struct {
-	framework.WithRegionModel
-
-	ARN                   types.String                                                `tfsdk:"arn"`
-	IndexName             types.String                                                `tfsdk:"index_name"`
-	KeySchema             fwtypes.ListNestedObjectValueOf[keySchemaModel]             `tfsdk:"key_schema"`
-	TableName             types.String                                                `tfsdk:"table_name"`
-	OnDemandThroughput    fwtypes.ListNestedObjectValueOf[onDemandThroughputModel]    `tfsdk:"on_demand_throughput"`
-	Projection            fwtypes.ListNestedObjectValueOf[projectionModel]            `tfsdk:"projection"`
-	ProvisionedThroughput fwtypes.ListNestedObjectValueOf[provisionedThroughputModel] `tfsdk:"provisioned_throughput"`
-	WarmThroughput        fwtypes.ObjectValueOf[warmThroughputModel]                  `tfsdk:"warm_throughput"`
-
-	Timeouts timeouts.Value `tfsdk:"timeouts"`
-}
-
 func flattenGlobalSecondaryIndex(ctx context.Context, data *resourceGlobalSecondaryIndexModel, index *awstypes.GlobalSecondaryIndexDescription, table *awstypes.TableDescription) diag.Diagnostics { // nosemgrep:ci.semgrep.framework.manual-flattener-functions
 	var diags diag.Diagnostics
 
@@ -656,6 +641,21 @@ func flattenGlobalSecondaryIndex(ctx context.Context, data *resourceGlobalSecond
 	}
 
 	return diags
+}
+
+type resourceGlobalSecondaryIndexModel struct {
+	framework.WithRegionModel
+
+	ARN                   types.String                                                `tfsdk:"arn"`
+	IndexName             types.String                                                `tfsdk:"index_name"`
+	KeySchema             fwtypes.ListNestedObjectValueOf[keySchemaModel]             `tfsdk:"key_schema"`
+	TableName             types.String                                                `tfsdk:"table_name"`
+	OnDemandThroughput    fwtypes.ListNestedObjectValueOf[onDemandThroughputModel]    `tfsdk:"on_demand_throughput"`
+	Projection            fwtypes.ListNestedObjectValueOf[projectionModel]            `tfsdk:"projection"`
+	ProvisionedThroughput fwtypes.ListNestedObjectValueOf[provisionedThroughputModel] `tfsdk:"provisioned_throughput"`
+	WarmThroughput        fwtypes.ObjectValueOf[warmThroughputModel]                  `tfsdk:"warm_throughput"`
+
+	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }
 
 type onDemandThroughputModel struct {

--- a/internal/service/dynamodb/global_secondary_index_list.go
+++ b/internal/service/dynamodb/global_secondary_index_list.go
@@ -1,0 +1,94 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dynamodb
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkListResource("aws_dynamodb_global_secondary_index")
+func newGlobalSecondaryIndexResourceAsListResource() list.ListResourceWithConfigure {
+	return &globalSecondaryIndexListResource{}
+}
+
+var _ list.ListResource = &globalSecondaryIndexListResource{}
+
+type globalSecondaryIndexListResource struct {
+	resourceGlobalSecondaryIndex
+	framework.WithList
+}
+
+type globalSecondaryIndexListModel struct {
+	framework.WithRegionModel
+	TableName types.String `tfsdk:"table_name"`
+}
+
+func (l *globalSecondaryIndexListResource) ListResourceConfigSchema(ctx context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = listschema.Schema{
+		Attributes: map[string]listschema.Attribute{
+			names.AttrTableName: listschema.StringAttribute{
+				Required:    true,
+				Description: "Name of the DynamoDB table.",
+			},
+		},
+		Blocks: map[string]listschema.Block{},
+	}
+}
+
+func (l *globalSecondaryIndexListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	var query globalSecondaryIndexListModel
+	if diags := request.Config.Get(ctx, &query); diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	conn := l.Meta().DynamoDBClient(ctx)
+
+	tableName := query.TableName.ValueString()
+
+	tflog.Info(ctx, "Listing DynamoDB Global Secondary Indexes", map[string]any{
+		logging.ResourceAttributeKey(names.AttrTableName): tableName,
+	})
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		table, err := findTableByName(ctx, conn, tableName)
+		if err != nil {
+			result := fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("reading DynamoDB Table (%s): %w", tableName, err))
+			yield(result)
+			return
+		}
+
+		for _, index := range table.GlobalSecondaryIndexes {
+			indexName := aws.ToString(index.IndexName)
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey("index_name"), indexName)
+
+			result := request.NewListResult(ctx)
+
+			var data resourceGlobalSecondaryIndexModel
+			l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
+				result.Diagnostics.Append(flattenGlobalSecondaryIndex(ctx, &data, &index, table)...)
+				if result.Diagnostics.HasError() {
+					return
+				}
+
+				result.DisplayName = indexName
+			})
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/service/dynamodb/global_secondary_index_list_test.go
+++ b/internal/service/dynamodb/global_secondary_index_list_test.go
@@ -1,0 +1,201 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dynamodb_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccDynamoDBGlobalSecondaryIndex_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_dynamodb_global_secondary_index.test[0]"
+	resourceName2 := "aws_dynamodb_global_secondary_index.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		CheckDestroy:             testAccCheckGlobalSecondaryIndexDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/GlobalSecondaryIndex/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/GlobalSecondaryIndex/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_dynamodb_global_secondary_index.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_dynamodb_global_secondary_index.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					tfquerycheck.ExpectNoResourceObject("aws_dynamodb_global_secondary_index.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_dynamodb_global_secondary_index.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_dynamodb_global_secondary_index.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringExact(rName+"-1")),
+					tfquerycheck.ExpectNoResourceObject("aws_dynamodb_global_secondary_index.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBGlobalSecondaryIndex_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_dynamodb_global_secondary_index.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		CheckDestroy:             testAccCheckGlobalSecondaryIndexDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/GlobalSecondaryIndex/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/GlobalSecondaryIndex/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_dynamodb_global_secondary_index.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_dynamodb_global_secondary_index.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					querycheck.ExpectResourceKnownValues("aws_dynamodb_global_secondary_index.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("dynamodb", "table/"+rName+"/index/"+rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("index_name"), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("key_schema"), knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"attribute_name": knownvalue.StringExact(rName + "-0"),
+								"attribute_type": knownvalue.StringExact("S"),
+								"key_type":       knownvalue.StringExact("HASH"),
+							}),
+						})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("projection"), knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"non_key_attributes": knownvalue.Null(),
+								"projection_type":    knownvalue.StringExact("ALL"),
+							}),
+						})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("provisioned_throughput"), knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"read_capacity_units":  knownvalue.Int64Exact(1),
+								"write_capacity_units": knownvalue.Int64Exact(1),
+							}),
+						})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTableName), knownvalue.StringExact(rName)),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBGlobalSecondaryIndex_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_dynamodb_global_secondary_index.test[0]"
+	resourceName2 := "aws_dynamodb_global_secondary_index.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		CheckDestroy:             testAccCheckGlobalSecondaryIndexDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/GlobalSecondaryIndex/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/GlobalSecondaryIndex/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_dynamodb_global_secondary_index.test", identity1.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_dynamodb_global_secondary_index.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/dynamodb/service_package_gen.go
+++ b/internal/service/dynamodb/service_package_gen.go
@@ -7,6 +7,8 @@ package dynamodb
 
 import (
 	"context"
+	"iter"
+	"slices"
 	"unique"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -75,6 +77,21 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			},
 		},
 	}
+}
+
+func (p *servicePackage) FrameworkListResources(ctx context.Context) iter.Seq[*inttypes.ServicePackageFrameworkListResource] {
+	return slices.Values([]*inttypes.ServicePackageFrameworkListResource{
+		{
+			Factory:  newGlobalSecondaryIndexResourceAsListResource,
+			TypeName: "aws_dynamodb_global_secondary_index",
+			Name:     "Global Secondary Index",
+			Region:   inttypes.ResourceRegionDefault(),
+			Identity: inttypes.RegionalParameterizedIdentity([]inttypes.IdentityAttribute{
+				inttypes.StringIdentityAttribute(names.AttrTableName, true),
+				inttypes.StringIdentityAttribute("index_name", true),
+			}),
+		},
+	})
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*inttypes.ServicePackageSDKDataSource {

--- a/internal/service/dynamodb/testdata/GlobalSecondaryIndex/list_basic/main.tf
+++ b/internal/service/dynamodb/testdata/GlobalSecondaryIndex/list_basic/main.tf
@@ -1,0 +1,48 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_dynamodb_global_secondary_index" "test" {
+  count = var.resource_count
+
+  table_name = aws_dynamodb_table.test.name
+  index_name = "${var.rName}-${count.index}"
+
+  projection {
+    projection_type = "ALL"
+  }
+
+  provisioned_throughput {
+    read_capacity_units  = 1
+    write_capacity_units = 1
+  }
+
+  key_schema {
+    attribute_name = "${var.rName}-${count.index}"
+    attribute_type = "S"
+    key_type       = "HASH"
+  }
+}
+
+resource "aws_dynamodb_table" "test" {
+  name           = var.rName
+  hash_key       = var.rName
+  read_capacity  = 1
+  write_capacity = 1
+
+  attribute {
+    name = var.rName
+    type = "S"
+  }
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/dynamodb/testdata/GlobalSecondaryIndex/list_basic/query.tfquery.hcl
+++ b/internal/service/dynamodb/testdata/GlobalSecondaryIndex/list_basic/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_dynamodb_global_secondary_index" "test" {
+  provider = aws
+
+  config {
+    table_name = aws_dynamodb_table.test.name
+  }
+}

--- a/internal/service/dynamodb/testdata/GlobalSecondaryIndex/list_include_resource/main.tf
+++ b/internal/service/dynamodb/testdata/GlobalSecondaryIndex/list_include_resource/main.tf
@@ -1,0 +1,48 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_dynamodb_global_secondary_index" "test" {
+  count = var.resource_count
+
+  table_name = aws_dynamodb_table.test.name
+  index_name = "${var.rName}-${count.index}"
+
+  projection {
+    projection_type = "ALL"
+  }
+
+  provisioned_throughput {
+    read_capacity_units  = 1
+    write_capacity_units = 1
+  }
+
+  key_schema {
+    attribute_name = "${var.rName}-${count.index}"
+    attribute_type = "S"
+    key_type       = "HASH"
+  }
+}
+
+resource "aws_dynamodb_table" "test" {
+  name           = var.rName
+  hash_key       = var.rName
+  read_capacity  = 1
+  write_capacity = 1
+
+  attribute {
+    name = var.rName
+    type = "S"
+  }
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/dynamodb/testdata/GlobalSecondaryIndex/list_include_resource/query.tfquery.hcl
+++ b/internal/service/dynamodb/testdata/GlobalSecondaryIndex/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,12 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_dynamodb_global_secondary_index" "test" {
+  provider = aws
+
+  include_resource = true
+
+  config {
+    table_name = aws_dynamodb_table.test.name
+  }
+}

--- a/internal/service/dynamodb/testdata/GlobalSecondaryIndex/list_region_override/main.tf
+++ b/internal/service/dynamodb/testdata/GlobalSecondaryIndex/list_region_override/main.tf
@@ -1,0 +1,56 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_dynamodb_global_secondary_index" "test" {
+  count  = var.resource_count
+  region = var.region
+
+  table_name = aws_dynamodb_table.test.name
+  index_name = "${var.rName}-${count.index}"
+
+  projection {
+    projection_type = "ALL"
+  }
+
+  provisioned_throughput {
+    read_capacity_units  = 1
+    write_capacity_units = 1
+  }
+
+  key_schema {
+    attribute_name = "${var.rName}-${count.index}"
+    attribute_type = "S"
+    key_type       = "HASH"
+  }
+}
+
+resource "aws_dynamodb_table" "test" {
+  region         = var.region
+  name           = var.rName
+  hash_key       = var.rName
+  read_capacity  = 1
+  write_capacity = 1
+
+  attribute {
+    name = var.rName
+    type = "S"
+  }
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/dynamodb/testdata/GlobalSecondaryIndex/list_region_override/query.tfquery.hcl
+++ b/internal/service/dynamodb/testdata/GlobalSecondaryIndex/list_region_override/query.tfquery.hcl
@@ -1,0 +1,11 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_dynamodb_global_secondary_index" "test" {
+  provider = aws
+
+  config {
+    table_name = aws_dynamodb_table.test.name
+    region     = var.region
+  }
+}

--- a/website/docs/list-resources/dynamodb_global_secondary_index.html.markdown
+++ b/website/docs/list-resources/dynamodb_global_secondary_index.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "DynamoDB"
+layout: "aws"
+page_title: "AWS: aws_dynamodb_global_secondary_index"
+description: |-
+  Lists DynamoDB Global Secondary Index resources.
+---
+
+# List Resource: aws_dynamodb_global_secondary_index
+
+Lists DynamoDB Global Secondary Index resources.
+
+## Example Usage
+
+```terraform
+list "aws_dynamodb_global_secondary_index" "example" {
+  provider = aws
+
+  config {
+    table_name = "my-table"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.
+* `table_name` - (Required) Name of the DynamoDB table.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Adds list resource `aws_dynamodb_global_secondary_index`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=dynamodb TESTS=TestAccDynamoDBGlobalSecondaryIndex_

--- PASS: TestAccDynamoDBGlobalSecondaryIndex_validate_KeySchemas (22.59s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_validate_Attributes (54.02s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_migrate_single_importcmd (108.22s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_disappears (345.97s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput_capacityChange_ignoreChanges (394.19s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_warmThroughput_basic (396.31s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput_capacityChange (416.53s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_basic (443.62s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_nonKeyAttributes_onUpdate (651.17s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_concurrentGSI_create (723.31s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_nonKeyAttributes_onCreate (793.68s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_migrate_multiple_importblock (84.04s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_keysNotOnTable_onUpdate_hashOnly (961.53s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_migrate_partial (69.49s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_migrate_multiple_importcmd (67.28s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput (1088.62s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_warmThroughput_explicitDefault (1093.85s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_Identity_basic (1109.55s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput_unset_read (1112.16s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_onDemandThroughput_unset_write (1115.77s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_List_regionOverride (677.86s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_capacityChange_ignoreChanges (1058.05s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_warmThroughput_basic (1174.72s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_migrate_single_importblock (78.23s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_capacityChange (368.17s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_keysNotOnTable_onUpdate_hashAndSort (1393.77s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_changeTableCapacity_gsiDifferentFromTable (1086.27s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_List_includeResource (1042.34s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_Identity_regionOverride (346.67s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_basic (1048.75s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_payPerRequest_to_provisioned (1469.42s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_changeTableCapacity_gsiSameAsTable (1078.30s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_concurrentGSI_update (1536.92s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_concurrentGSI_delete (1545.85s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_warmThroughput_updateFromUnspecified_noChange (1070.06s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_warmThroughput_updateFromUnspecified_noChange (1054.81s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_warmThroughput_updateFromUnspecified (1065.57s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_keysNotOnTable_onCreate_hashOnly (1054.62s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_keysNotOnTable_onCreate_hashAndSort (1050.12s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_billingPayPerRequest_warmThroughput_updateFromUnspecified (1180.48s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_disappears_table (1186.79s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_List_basic (1394.68s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_throughputChanges (0.00s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_throughputChanges/change_warm (1062.40s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_throughputChanges/change_provisioned_to_match_warm (1075.52s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_throughputChanges/change_both_to_same (1069.31s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_throughputChanges/change_provisioned_change_warm,_less_than (1070.25s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_throughputChanges/change_provisioned_no_change_warm,_less_than (1065.42s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_payPerRequest_throughputChanges (0.00s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_payPerRequest_throughputChanges/change_warm (341.65s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_payPerRequest_throughputChanges/change_both_to_same (453.40s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_payPerRequest_throughputChanges/change_on-demand_to_match_warm (1065.98s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_payPerRequest_throughputChanges/change_on-demand_change_warm,_less_than (1066.31s)
    --- PASS: TestAccDynamoDBGlobalSecondaryIndex_payPerRequest_throughputChanges/change_on-demand_no_change_warm,_less_than (1171.07s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_to_payPerRequest_specifiedCapacity (1576.94s)
--- PASS: TestAccDynamoDBGlobalSecondaryIndex_provisioned_to_payPerRequest_unspecifiedCapacity (2184.15s)
```
