### PR TITLE
internal/acctest: make domain name generation `go-vcr` compatible

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1891,32 +1891,36 @@ const domainNameTestTopLevelDomain domainName = "test"
 // "<random>.<random>.test"
 // The top level domain ".test" is reserved by IANA for testing purposes:
 // https://datatracker.ietf.org/doc/html/rfc6761
-func RandomSubdomain() string {
-	return string(RandomDomain().RandomSubdomain())
+func RandomSubdomain(t *testing.T) string {
+	t.Helper()
+	return string(RandomDomain(t).RandomSubdomain(t))
 }
 
 // RandomDomainName creates a random two-level domain name in the form
 // "<random>.test"
 // The top level domain ".test" is reserved by IANA for testing purposes:
 // https://datatracker.ietf.org/doc/html/rfc6761
-func RandomDomainName() string {
-	return string(RandomDomain())
+func RandomDomainName(t *testing.T) string {
+	t.Helper()
+	return string(RandomDomain(t))
 }
 
 // RandomFQDomainName creates a random fully-qualified two-level domain name in the form
 // "<random>.test."
 // The top level domain ".test" is reserved by IANA for testing purposes:
 // https://datatracker.ietf.org/doc/html/rfc6761
-func RandomFQDomainName() string {
-	return string(RandomDomain().FQDN())
+func RandomFQDomainName(t *testing.T) string {
+	t.Helper()
+	return string(RandomDomain(t).FQDN())
 }
 
 func (d domainName) Subdomain(name string) domainName {
 	return domainName(fmt.Sprintf("%s.%s", name, d))
 }
 
-func (d domainName) RandomSubdomain() domainName {
-	return d.Subdomain(sdkacctest.RandString(8)) //nolint:mnd // standard length of 8
+func (d domainName) RandomSubdomain(t *testing.T) domainName {
+	t.Helper()
+	return d.Subdomain(RandString(t, 8)) //nolint:mnd // standard length of 8
 }
 
 func (d domainName) FQDN() domainName {
@@ -1927,8 +1931,9 @@ func (d domainName) String() string {
 	return string(d)
 }
 
-func RandomDomain() domainName {
-	return domainNameTestTopLevelDomain.RandomSubdomain()
+func RandomDomain(t *testing.T) domainName {
+	t.Helper()
+	return domainNameTestTopLevelDomain.RandomSubdomain(t)
 }
 
 // DefaultEmailAddress is the default email address to set as a

--- a/internal/generate/identitytests/main.go
+++ b/internal/generate/identitytests/main.go
@@ -696,7 +696,7 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 
 	if tlsKey {
 		if len(tlsKeyCN) == 0 {
-			tlsKeyCN = "acctest.RandomDomain().String()"
+			tlsKeyCN = "acctest.RandomDomain(t).String()"
 			d.GoImports = append(d.GoImports,
 				common.GoImport{
 					Path: "github.com/hashicorp/terraform-provider-aws/internal/acctest",

--- a/internal/generate/tagstests/main.go
+++ b/internal/generate/tagstests/main.go
@@ -650,7 +650,7 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 
 	if tlsKey {
 		if len(tlsKeyCN) == 0 {
-			tlsKeyCN = "acctest.RandomDomain().String()"
+			tlsKeyCN = "acctest.RandomDomain(t).String()"
 			d.GoImports = append(d.GoImports,
 				common.GoImport{
 					Path: "github.com/hashicorp/terraform-provider-aws/internal/acctest",

--- a/internal/generate/tests/annotations.go
+++ b/internal/generate/tests/annotations.go
@@ -468,7 +468,7 @@ func ParseTestingAnnotations(args common.Args, stuff *CommonArgs) error {
 		)
 		stuff.InitCodeBlocks = append(stuff.InitCodeBlocks, CodeBlock{
 			Code: fmt.Sprintf(
-				`domain := acctest.RandomDomainName()
+				`domain := acctest.RandomDomainName(t)
 %s := acctest.RandomEmailAddress(domain)`, varName),
 		})
 		stuff.AdditionalTfVars_[varName] = TFVar{
@@ -488,7 +488,7 @@ func ParseTestingAnnotations(args common.Args, stuff *CommonArgs) error {
 			},
 		)
 		stuff.InitCodeBlocks = append(stuff.InitCodeBlocks, CodeBlock{
-			Code: fmt.Sprintf(`%s := acctest.RandomDomainName()`, varName),
+			Code: fmt.Sprintf(`%s := acctest.RandomDomainName(t)`, varName),
 		})
 		stuff.AdditionalTfVars_[varName] = TFVar{
 			GoVarName: varName,
@@ -514,10 +514,10 @@ func ParseTestingAnnotations(args common.Args, stuff *CommonArgs) error {
 			},
 		)
 		stuff.InitCodeBlocks = append(stuff.InitCodeBlocks, CodeBlock{
-			Code: fmt.Sprintf(`%s := acctest.RandomDomain()`, parentName),
+			Code: fmt.Sprintf(`%s := acctest.RandomDomain(t)`, parentName),
 		})
 		stuff.InitCodeBlocks = append(stuff.InitCodeBlocks, CodeBlock{
-			Code: fmt.Sprintf(`%s := %s.RandomSubdomain()`, varName, parentName),
+			Code: fmt.Sprintf(`%s := %s.RandomSubdomain(t)`, varName, parentName),
 		})
 		stuff.AdditionalTfVars_[parentName] = TFVar{
 			GoVarName: fmt.Sprintf("%s.String()", parentName),

--- a/internal/service/account/alternate_contact_test.go
+++ b/internal/service/account/alternate_contact_test.go
@@ -20,7 +20,7 @@ import (
 func testAccAlternateContact_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_account_alternate_contact.test"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	emailAddress1 := acctest.RandomEmailAddress(domain)
 	emailAddress2 := acctest.RandomEmailAddress(domain)
 	rName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -68,7 +68,7 @@ func testAccAlternateContact_basic(t *testing.T) {
 func testAccAlternateContact_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_account_alternate_contact.test"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	emailAddress := acctest.RandomEmailAddress(domain)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
@@ -93,7 +93,7 @@ func testAccAlternateContact_disappears(t *testing.T) {
 func testAccAlternateContact_accountID(t *testing.T) { // nosemgrep:ci.account-in-func-name
 	ctx := acctest.Context(t)
 	resourceName := "aws_account_alternate_contact.test"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	emailAddress1 := acctest.RandomEmailAddress(domain)
 	emailAddress2 := acctest.RandomEmailAddress(domain)
 	rName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)

--- a/internal/service/acm/certificate_data_source_tags_gen_test.go
+++ b/internal/service/acm/certificate_data_source_tags_gen_test.go
@@ -23,7 +23,7 @@ func TestAccACMCertificateDataSource_tags(t *testing.T) {
 
 	dataSourceName := "data.aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -57,7 +57,7 @@ func TestAccACMCertificateDataSource_Tags_nullMap(t *testing.T) {
 
 	dataSourceName := "data.aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -87,7 +87,7 @@ func TestAccACMCertificateDataSource_Tags_emptyMap(t *testing.T) {
 
 	dataSourceName := "data.aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -117,7 +117,7 @@ func TestAccACMCertificateDataSource_Tags_DefaultTags_nonOverlapping(t *testing.
 
 	dataSourceName := "data.aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -155,7 +155,7 @@ func TestAccACMCertificateDataSource_Tags_IgnoreTags_Overlap_defaultTag(t *testi
 
 	dataSourceName := "data.aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -199,7 +199,7 @@ func TestAccACMCertificateDataSource_Tags_IgnoreTags_Overlap_resourceTag(t *test
 
 	dataSourceName := "data.aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{

--- a/internal/service/acm/certificate_data_source_test.go
+++ b/internal/service/acm/certificate_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccACMCertificateDataSource_byDomain(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
 	dataSourceName := "data.aws_acm_certificate.test"
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048) // ListCertificates: Default filtering returns only RSA_2048 certificates.
-	domain := acctest.RandomDomain().String()
+	domain := acctest.RandomDomain(t).String()
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -41,7 +41,7 @@ func TestAccACMCertificateDataSource_byDomain(t *testing.T) {
 func TestAccACMCertificateDataSource_byDomainNoMatch(t *testing.T) {
 	ctx := acctest.Context(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048) // ListCertificates: Default filtering returns only RSA_2048 certificates.
-	domain := acctest.RandomDomain().String()
+	domain := acctest.RandomDomain(t).String()
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -60,7 +60,7 @@ func TestAccACMCertificateDataSource_byDomainNoMatch(t *testing.T) {
 func TestAccACMCertificateDataSource_byDomainMultiple(t *testing.T) {
 	ctx := acctest.Context(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048) // ListCertificates: Default filtering returns only RSA_2048 certificates.
-	domain := acctest.RandomDomain().String()
+	domain := acctest.RandomDomain(t).String()
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -81,7 +81,7 @@ func TestAccACMCertificateDataSource_byDomainAndTags(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
 	dataSourceName := "data.aws_acm_certificate.test"
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048) // ListCertificates: Default filtering returns only RSA_2048 certificates.
-	domain := acctest.RandomDomain().String()
+	domain := acctest.RandomDomain(t).String()
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domain)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
@@ -106,7 +106,7 @@ func TestAccACMCertificateDataSource_byDomainAndStatuses(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
 	dataSourceName := "data.aws_acm_certificate.test"
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048) // ListCertificates: Default filtering returns only RSA_2048 certificates.
-	domain := acctest.RandomDomain().String()
+	domain := acctest.RandomDomain(t).String()
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -130,7 +130,7 @@ func TestAccACMCertificateDataSource_byDomainAndKeyTypes(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
 	dataSourceName := "data.aws_acm_certificate.test"
 	key := acctest.TLSRSAPrivateKeyPEM(t, 4096)
-	domain := acctest.RandomDomain().String()
+	domain := acctest.RandomDomain(t).String()
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -154,7 +154,7 @@ func TestAccACMCertificateDataSource_byDomainAndTypes(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
 	dataSourceName := "data.aws_acm_certificate.test"
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048) // ListCertificates: Default filtering returns only RSA_2048 certificates.
-	domain := acctest.RandomDomain().String()
+	domain := acctest.RandomDomain(t).String()
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -176,7 +176,7 @@ func TestAccACMCertificateDataSource_byDomainAndTypes(t *testing.T) {
 func TestAccACMCertificateDataSource_byDomainAndTypesNoMatch(t *testing.T) {
 	ctx := acctest.Context(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048) // ListCertificates: Default filtering returns only RSA_2048 certificates.
-	domain := acctest.RandomDomain().String()
+	domain := acctest.RandomDomain(t).String()
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -197,7 +197,7 @@ func TestAccACMCertificateDataSource_byDomainAndKeyTypesMostRecent(t *testing.T)
 	resourceName := "aws_acm_certificate.test3"
 	dataSourceName := "data.aws_acm_certificate.test"
 	key := acctest.TLSRSAPrivateKeyPEM(t, 4096)
-	domain := acctest.RandomDomain().String()
+	domain := acctest.RandomDomain(t).String()
 
 	// Create 3 certificates, a minute apart.
 	certificate1 := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domain)
@@ -243,7 +243,7 @@ func TestAccACMCertificateDataSource_byTags(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
 	dataSourceName := "data.aws_acm_certificate.test"
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048) // ListCertificates: Default filtering returns only RSA_2048 certificates.
-	domain := acctest.RandomDomain().String()
+	domain := acctest.RandomDomain(t).String()
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domain)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
@@ -266,7 +266,7 @@ func TestAccACMCertificateDataSource_byTags(t *testing.T) {
 func TestAccACMCertificateDataSource_byTagsNoMatch(t *testing.T) {
 	ctx := acctest.Context(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048) // ListCertificates: Default filtering returns only RSA_2048 certificates.
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, acctest.RandomDomain().String())
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, acctest.RandomDomain(t).String())
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -287,7 +287,7 @@ func TestAccACMCertificateDataSource_byTagsAndKeyTypes(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
 	dataSourceName := "data.aws_acm_certificate.test"
 	key := acctest.TLSRSAPrivateKeyPEM(t, 4096)
-	domain := acctest.RandomDomain().String()
+	domain := acctest.RandomDomain(t).String()
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domain)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 

--- a/internal/service/acm/certificate_identity_gen_test.go
+++ b/internal/service/acm/certificate_identity_gen_test.go
@@ -28,7 +28,7 @@ func TestAccACMCertificate_Identity_basic(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -125,7 +125,7 @@ func TestAccACMCertificate_Identity_regionOverride(t *testing.T) {
 
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -265,7 +265,7 @@ func TestAccACMCertificate_Identity_ExistingResource_basic(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -348,7 +348,7 @@ func TestAccACMCertificate_Identity_ExistingResource_noRefreshNoChange(t *testin
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{

--- a/internal/service/acm/certificate_tags_gen_test.go
+++ b/internal/service/acm/certificate_tags_gen_test.go
@@ -26,7 +26,7 @@ func TestAccACMCertificate_tags(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -233,7 +233,7 @@ func TestAccACMCertificate_Tags_null(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -311,7 +311,7 @@ func TestAccACMCertificate_Tags_emptyMap(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -385,7 +385,7 @@ func TestAccACMCertificate_Tags_addOnUpdate(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -477,7 +477,7 @@ func TestAccACMCertificate_Tags_EmptyTag_onCreate(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -581,7 +581,7 @@ func TestAccACMCertificate_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -734,7 +734,7 @@ func TestAccACMCertificate_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -834,7 +834,7 @@ func TestAccACMCertificate_Tags_DefaultTags_providerOnly(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1040,7 +1040,7 @@ func TestAccACMCertificate_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1220,7 +1220,7 @@ func TestAccACMCertificate_Tags_DefaultTags_overlapping(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1416,7 +1416,7 @@ func TestAccACMCertificate_Tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1517,7 +1517,7 @@ func TestAccACMCertificate_Tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1617,7 +1617,7 @@ func TestAccACMCertificate_Tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1692,7 +1692,7 @@ func TestAccACMCertificate_Tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1759,7 +1759,7 @@ func TestAccACMCertificate_Tags_DefaultTags_nullOverlappingResourceTag(t *testin
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1831,7 +1831,7 @@ func TestAccACMCertificate_Tags_DefaultTags_nullNonOverlappingResourceTag(t *tes
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1903,7 +1903,7 @@ func TestAccACMCertificate_Tags_ComputedTag_onCreate(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1968,7 +1968,7 @@ func TestAccACMCertificate_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -2076,7 +2076,7 @@ func TestAccACMCertificate_Tags_ComputedTag_OnUpdate_replace(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -2174,7 +2174,7 @@ func TestAccACMCertificate_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -2344,7 +2344,7 @@ func TestAccACMCertificate_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T) {
 	var v types.CertificateDetail
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -205,8 +205,8 @@ func TestAccACMCertificate_privateCertificate_renewable(t *testing.T) {
 	ctx := acctest.Context(t)
 	certificateAuthorityResourceName := "aws_acmpca_certificate_authority.test"
 	resourceName := "aws_acm_certificate.test"
-	commonName := acctest.RandomDomain()
-	certificateDomainName := commonName.RandomSubdomain().String()
+	commonName := acctest.RandomDomain(t)
+	certificateDomainName := commonName.RandomSubdomain(t).String()
 	var v1, v2, v3, v4 types.CertificateDetail
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -333,8 +333,8 @@ func TestAccACMCertificate_privateCertificate_noRenewalPermission(t *testing.T) 
 	ctx := acctest.Context(t)
 	certificateAuthorityResourceName := "aws_acmpca_certificate_authority.test"
 	resourceName := "aws_acm_certificate.test"
-	commonName := acctest.RandomDomain()
-	certificateDomainName := commonName.RandomSubdomain().String()
+	commonName := acctest.RandomDomain(t)
+	certificateDomainName := commonName.RandomSubdomain(t).String()
 	var v1, v2, v3 types.CertificateDetail
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -452,8 +452,8 @@ func TestAccACMCertificate_privateCertificate_noRenewalPermission(t *testing.T) 
 func TestAccACMCertificate_privateCertificate_pendingRenewalGoDuration(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
-	commonName := acctest.RandomDomain()
-	certificateDomainName := commonName.RandomSubdomain().String()
+	commonName := acctest.RandomDomain(t)
+	certificateDomainName := commonName.RandomSubdomain(t).String()
 	duration := (395 * 24 * time.Hour).String()
 	var v1, v2 types.CertificateDetail
 
@@ -527,8 +527,8 @@ func TestAccACMCertificate_privateCertificate_pendingRenewalGoDuration(t *testin
 func TestAccACMCertificate_privateCertificate_pendingRenewalRFC3339Duration(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
-	commonName := acctest.RandomDomain()
-	certificateDomainName := commonName.RandomSubdomain().String()
+	commonName := acctest.RandomDomain(t)
+	certificateDomainName := commonName.RandomSubdomain(t).String()
 	duration := "P395D"
 	var v1, v2 types.CertificateDetail
 
@@ -602,8 +602,8 @@ func TestAccACMCertificate_privateCertificate_pendingRenewalRFC3339Duration(t *t
 func TestAccACMCertificate_privateCertificate_addEarlyRenewalPast(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
-	commonName := acctest.RandomDomain()
-	certificateDomainName := commonName.RandomSubdomain().String()
+	commonName := acctest.RandomDomain(t)
+	certificateDomainName := commonName.RandomSubdomain(t).String()
 	duration := (395 * 24 * time.Hour).String()
 	var v1, v2, v3 types.CertificateDetail
 
@@ -691,8 +691,8 @@ func TestAccACMCertificate_privateCertificate_addEarlyRenewalPast(t *testing.T) 
 func TestAccACMCertificate_privateCertificate_addEarlyRenewalPastIneligible(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
-	commonName := acctest.RandomDomain()
-	certificateDomainName := commonName.RandomSubdomain().String()
+	commonName := acctest.RandomDomain(t)
+	certificateDomainName := commonName.RandomSubdomain(t).String()
 	duration := (395 * 24 * time.Hour).String()
 	var v1, v2 types.CertificateDetail
 
@@ -744,8 +744,8 @@ func TestAccACMCertificate_privateCertificate_addEarlyRenewalPastIneligible(t *t
 func TestAccACMCertificate_privateCertificate_addEarlyRenewalFuture(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
-	commonName := acctest.RandomDomain()
-	certificateDomainName := commonName.RandomSubdomain().String()
+	commonName := acctest.RandomDomain(t)
+	certificateDomainName := commonName.RandomSubdomain(t).String()
 	duration := (90 * 24 * time.Hour).String()
 	var v1, v2, v3 types.CertificateDetail
 
@@ -830,8 +830,8 @@ func TestAccACMCertificate_privateCertificate_addEarlyRenewalFuture(t *testing.T
 func TestAccACMCertificate_privateCertificate_updateEarlyRenewalFuture(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
-	commonName := acctest.RandomDomain()
-	certificateDomainName := commonName.RandomSubdomain().String()
+	commonName := acctest.RandomDomain(t)
+	certificateDomainName := commonName.RandomSubdomain(t).String()
 	duration := (395 * 24 * time.Hour).String()
 	durationUpdated := (90 * 24 * time.Hour).String()
 	var v1, v2 types.CertificateDetail
@@ -902,8 +902,8 @@ func TestAccACMCertificate_privateCertificate_updateEarlyRenewalFuture(t *testin
 func TestAccACMCertificate_privateCertificate_removeEarlyRenewal(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
-	commonName := acctest.RandomDomain()
-	certificateDomainName := commonName.RandomSubdomain().String()
+	commonName := acctest.RandomDomain(t)
+	certificateDomainName := commonName.RandomSubdomain(t).String()
 	duration := (395 * 24 * time.Hour).String()
 	var v1, v2 types.CertificateDetail
 
@@ -1519,7 +1519,7 @@ func TestAccACMCertificate_Imported_domainName(t *testing.T) {
 	newCaKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	newCaCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(t, newCaKey)
 	newCertificate := acctest.TLSRSAX509LocallySignedCertificatePEM(t, newCaKey, newCaCertificate, key, commonName)
-	withoutChainDomain := acctest.RandomDomainName()
+	withoutChainDomain := acctest.RandomDomainName(t)
 	var v1, v2, v3 types.CertificateDetail
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/acmpca/certificate_authority.go
+++ b/internal/service/acmpca/certificate_authority.go
@@ -43,7 +43,7 @@ const (
 // @V60SDKv2Fix
 // @CustomImport
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/acmpca/types;types.CertificateAuthority")
-// @Testing(generator="acctest.RandomDomainName()")
+// @Testing(generator="acctest.RandomDomainName(t)")
 // @Testing(importIgnore="permanent_deletion_time_in_days")
 func resourceCertificateAuthority() *schema.Resource {
 	//lintignore:R011

--- a/internal/service/acmpca/certificate_authority_certificate.go
+++ b/internal/service/acmpca/certificate_authority_certificate.go
@@ -28,7 +28,7 @@ import (
 // @ArnIdentity("certificate_authority_arn")
 // @V60SDKv2Fix
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/acmpca;acmpca.GetCertificateAuthorityCertificateOutput")
-// @Testing(generator="acctest.RandomDomainName()")
+// @Testing(generator="acctest.RandomDomainName(t)")
 // @Testing(checkDestroyNoop=true)
 func resourceCertificateAuthorityCertificate() *schema.Resource {
 	return &schema.Resource{

--- a/internal/service/acmpca/certificate_authority_certificate_identity_gen_test.go
+++ b/internal/service/acmpca/certificate_authority_certificate_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccACMPCACertificateAuthorityCertificate_Identity_basic(t *testing.T) {
 
 	var v acmpca.GetCertificateAuthorityCertificateOutput
 	resourceName := "aws_acmpca_certificate_authority_certificate.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -112,7 +112,7 @@ func TestAccACMPCACertificateAuthorityCertificate_Identity_regionOverride(t *tes
 	ctx := acctest.Context(t)
 
 	resourceName := "aws_acmpca_certificate_authority_certificate.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -233,7 +233,7 @@ func TestAccACMPCACertificateAuthorityCertificate_Identity_ExistingResource_basi
 
 	var v acmpca.GetCertificateAuthorityCertificateOutput
 	resourceName := "aws_acmpca_certificate_authority_certificate.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -312,7 +312,7 @@ func TestAccACMPCACertificateAuthorityCertificate_Identity_ExistingResource_noRe
 
 	var v acmpca.GetCertificateAuthorityCertificateOutput
 	resourceName := "aws_acmpca_certificate_authority_certificate.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{

--- a/internal/service/acmpca/certificate_authority_certificate_test.go
+++ b/internal/service/acmpca/certificate_authority_certificate_test.go
@@ -20,7 +20,7 @@ func TestAccACMPCACertificateAuthorityCertificate_rootCA(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v acmpca.GetCertificateAuthorityCertificateOutput
 	resourceName := "aws_acmpca_certificate_authority_certificate.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -51,7 +51,7 @@ func TestAccACMPCACertificateAuthorityCertificate_updateRootCA(t *testing.T) {
 	var v acmpca.GetCertificateAuthorityCertificateOutput
 	resourceName := "aws_acmpca_certificate_authority_certificate.test"
 	updatedResourceName := "aws_acmpca_certificate_authority_certificate.updated"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -85,7 +85,7 @@ func TestAccACMPCACertificateAuthorityCertificate_subordinateCA(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v acmpca.GetCertificateAuthorityCertificateOutput
 	resourceName := "aws_acmpca_certificate_authority_certificate.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/acmpca/certificate_authority_data_source_test.go
+++ b/internal/service/acmpca/certificate_authority_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccACMPCACertificateAuthorityDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acmpca_certificate_authority.test"
 	datasourceName := "data.aws_acmpca_certificate_authority.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -55,7 +55,7 @@ func TestAccACMPCACertificateAuthorityDataSource_s3ObjectACL(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acmpca_certificate_authority.test"
 	datasourceName := "data.aws_acmpca_certificate_authority.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/acmpca/certificate_authority_identity_gen_test.go
+++ b/internal/service/acmpca/certificate_authority_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccACMPCACertificateAuthority_Identity_basic(t *testing.T) {
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -119,7 +119,7 @@ func TestAccACMPCACertificateAuthority_Identity_regionOverride(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -252,7 +252,7 @@ func TestAccACMPCACertificateAuthority_Identity_ExistingResource_basic(t *testin
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -331,7 +331,7 @@ func TestAccACMPCACertificateAuthority_Identity_ExistingResource_noRefreshNoChan
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{

--- a/internal/service/acmpca/certificate_authority_tags_gen_test.go
+++ b/internal/service/acmpca/certificate_authority_tags_gen_test.go
@@ -25,7 +25,7 @@ func TestAccACMPCACertificateAuthority_tags(t *testing.T) {
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -223,7 +223,7 @@ func TestAccACMPCACertificateAuthority_Tags_null(t *testing.T) {
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -297,7 +297,7 @@ func TestAccACMPCACertificateAuthority_Tags_emptyMap(t *testing.T) {
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -367,7 +367,7 @@ func TestAccACMPCACertificateAuthority_Tags_addOnUpdate(t *testing.T) {
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -455,7 +455,7 @@ func TestAccACMPCACertificateAuthority_Tags_EmptyTag_onCreate(t *testing.T) {
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -554,7 +554,7 @@ func TestAccACMPCACertificateAuthority_Tags_EmptyTag_OnUpdate_add(t *testing.T) 
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -701,7 +701,7 @@ func TestAccACMPCACertificateAuthority_Tags_EmptyTag_OnUpdate_replace(t *testing
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -797,7 +797,7 @@ func TestAccACMPCACertificateAuthority_Tags_DefaultTags_providerOnly(t *testing.
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -994,7 +994,7 @@ func TestAccACMPCACertificateAuthority_Tags_DefaultTags_nonOverlapping(t *testin
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1167,7 +1167,7 @@ func TestAccACMPCACertificateAuthority_Tags_DefaultTags_overlapping(t *testing.T
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1356,7 +1356,7 @@ func TestAccACMPCACertificateAuthority_Tags_DefaultTags_updateToProviderOnly(t *
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1453,7 +1453,7 @@ func TestAccACMPCACertificateAuthority_Tags_DefaultTags_updateToResourceOnly(t *
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1549,7 +1549,7 @@ func TestAccACMPCACertificateAuthority_Tags_DefaultTags_emptyResourceTag(t *test
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1621,7 +1621,7 @@ func TestAccACMPCACertificateAuthority_Tags_DefaultTags_emptyProviderOnlyTag(t *
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1685,7 +1685,7 @@ func TestAccACMPCACertificateAuthority_Tags_DefaultTags_nullOverlappingResourceT
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1754,7 +1754,7 @@ func TestAccACMPCACertificateAuthority_Tags_DefaultTags_nullNonOverlappingResour
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1823,7 +1823,7 @@ func TestAccACMPCACertificateAuthority_Tags_ComputedTag_onCreate(t *testing.T) {
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1885,7 +1885,7 @@ func TestAccACMPCACertificateAuthority_Tags_ComputedTag_OnUpdate_add(t *testing.
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1989,7 +1989,7 @@ func TestAccACMPCACertificateAuthority_Tags_ComputedTag_OnUpdate_replace(t *test
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -2083,7 +2083,7 @@ func TestAccACMPCACertificateAuthority_Tags_IgnoreTags_Overlap_defaultTag(t *tes
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -2249,7 +2249,7 @@ func TestAccACMPCACertificateAuthority_Tags_IgnoreTags_Overlap_resourceTag(t *te
 
 	var v types.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{

--- a/internal/service/acmpca/certificate_authority_test.go
+++ b/internal/service/acmpca/certificate_authority_test.go
@@ -25,7 +25,7 @@ func TestAccACMPCACertificateAuthority_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var certificateAuthority awstypes.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -73,7 +73,7 @@ func TestAccACMPCACertificateAuthority_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var certificateAuthority awstypes.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -97,7 +97,7 @@ func TestAccACMPCACertificateAuthority_enabledDeprecated(t *testing.T) {
 	ctx := acctest.Context(t)
 	var certificateAuthority awstypes.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -145,7 +145,7 @@ func TestAccACMPCACertificateAuthority_usageMode(t *testing.T) {
 	ctx := acctest.Context(t)
 	var certificateAuthority awstypes.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -176,7 +176,7 @@ func TestAccACMPCACertificateAuthority_keyStorageSecurityStandard(t *testing.T) 
 	ctx := acctest.Context(t)
 	var certificateAuthority awstypes.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -211,7 +211,7 @@ func TestAccACMPCACertificateAuthority_deleteFromActiveState(t *testing.T) {
 	ctx := acctest.Context(t)
 	var certificateAuthority awstypes.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -235,7 +235,7 @@ func TestAccACMPCACertificateAuthority_RevocationConfiguration_empty(t *testing.
 	ctx := acctest.Context(t)
 	var certificateAuthority awstypes.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -284,7 +284,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME(t *testing.T) {
 	var certificateAuthority awstypes.CertificateAuthority
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_acmpca_certificate_authority.test"
-	domain := acctest.RandomDomain()
+	domain := acctest.RandomDomain(t)
 	commonName := domain.String()
 	customCName := domain.Subdomain("crl").String()
 	customCName2 := domain.Subdomain("crl2").String()
@@ -375,7 +375,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_customPath(t *testing.T) {
 	var certificateAuthority awstypes.CertificateAuthority
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_acmpca_certificate_authority.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 	customPath1 := "root"
 	customPath2 := "root/ca"
 
@@ -442,7 +442,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_enabled(t *testing.T) {
 	var certificateAuthority awstypes.CertificateAuthority
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_acmpca_certificate_authority.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -514,7 +514,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays(t *testing
 	var certificateAuthority awstypes.CertificateAuthority
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_acmpca_certificate_authority.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -576,7 +576,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL(t *testing.T) {
 	var certificateAuthority awstypes.CertificateAuthority
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_acmpca_certificate_authority.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -627,7 +627,7 @@ func TestAccACMPCACertificateAuthority_RevocationOcsp_enabled(t *testing.T) {
 	ctx := acctest.Context(t)
 	var certificateAuthority awstypes.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -694,7 +694,7 @@ func TestAccACMPCACertificateAuthority_RevocationOcsp_customCNAME(t *testing.T) 
 	ctx := acctest.Context(t)
 	var certificateAuthority awstypes.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
-	domain := acctest.RandomDomain()
+	domain := acctest.RandomDomain(t)
 	commonName := domain.String()
 	customCName := domain.Subdomain("ocspl").String()
 	customCName2 := domain.Subdomain("ocsp2").String()

--- a/internal/service/acmpca/certificate_data_source_test.go
+++ b/internal/service/acmpca/certificate_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccACMPCACertificateDataSource_basic(t *testing.T) {
 	resourceName := "aws_acmpca_certificate.test"
 	dataSourceName := "data.aws_acmpca_certificate.test"
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/acmpca/certificate_test.go
+++ b/internal/service/acmpca/certificate_test.go
@@ -27,7 +27,7 @@ func TestAccACMPCACertificate_rootCertificate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acmpca_certificate.test"
 	certificateAuthorityResourceName := "aws_acmpca_certificate_authority.test"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -71,7 +71,7 @@ func TestAccACMPCACertificate_rootCertificateWithAPIPassthrough(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acmpca_certificate.test"
 	certificateAuthorityResourceName := "aws_acmpca_certificate_authority.test"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -116,7 +116,7 @@ func TestAccACMPCACertificate_subordinateCertificate(t *testing.T) {
 	resourceName := "aws_acmpca_certificate.test"
 	rootCertificateAuthorityResourceName := "aws_acmpca_certificate_authority.root"
 	subordinateCertificateAuthorityResourceName := "aws_acmpca_certificate_authority.test"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -158,9 +158,9 @@ func TestAccACMPCACertificate_subordinateCertificate(t *testing.T) {
 func TestAccACMPCACertificate_endEntityCertificate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acmpca_certificate.test"
-	csrDomain := acctest.RandomDomainName()
+	csrDomain := acctest.RandomDomainName(t)
 	csr, _ := acctest.TLSRSAX509CertificateRequestPEM(t, 4096, csrDomain)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -201,9 +201,9 @@ func TestAccACMPCACertificate_endEntityCertificate(t *testing.T) {
 func TestAccACMPCACertificate_Validity_endDate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acmpca_certificate.test"
-	csrDomain := acctest.RandomDomainName()
+	csrDomain := acctest.RandomDomainName(t)
 	csr, _ := acctest.TLSRSAX509CertificateRequestPEM(t, 4096, csrDomain)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	later := time.Now().Add(time.Minute * 10).Format(time.RFC3339)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -245,9 +245,9 @@ func TestAccACMPCACertificate_Validity_endDate(t *testing.T) {
 func TestAccACMPCACertificate_Validity_absolute(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acmpca_certificate.test"
-	csrDomain := acctest.RandomDomainName()
+	csrDomain := acctest.RandomDomainName(t)
 	csr, _ := acctest.TLSRSAX509CertificateRequestPEM(t, 4096, csrDomain)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	later := time.Now().Add(time.Minute * 10).Unix()
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/acmpca/permission_test.go
+++ b/internal/service/acmpca/permission_test.go
@@ -21,7 +21,7 @@ func TestAccACMPCAPermission_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var permission types.Permission
 	resourceName := "aws_acmpca_permission.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -50,7 +50,7 @@ func TestAccACMPCAPermission_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var permission types.Permission
 	resourceName := "aws_acmpca_permission.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -74,7 +74,7 @@ func TestAccACMPCAPermission_sourceAccount(t *testing.T) {
 	ctx := acctest.Context(t)
 	var permission types.Permission
 	resourceName := "aws_acmpca_permission.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/apigateway/base_path_mapping_test.go
+++ b/internal/service/apigateway/base_path_mapping_test.go
@@ -23,7 +23,7 @@ func TestAccAPIGatewayBasePathMapping_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetBasePathMappingOutput
 	resourceName := "aws_api_gateway_base_path_mapping.test"
-	name := acctest.RandomSubdomain()
+	name := acctest.RandomSubdomain(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, name)
 
@@ -52,7 +52,7 @@ func TestAccAPIGatewayBasePathMapping_private(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetBasePathMappingOutput
 	resourceName := "aws_api_gateway_base_path_mapping.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
@@ -82,7 +82,7 @@ func TestAccAPIGatewayBasePathMapping_BasePath_empty(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetBasePathMappingOutput
 	resourceName := "aws_api_gateway_base_path_mapping.test"
-	name := acctest.RandomSubdomain()
+	name := acctest.RandomSubdomain(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, name)
 
@@ -111,7 +111,7 @@ func TestAccAPIGatewayBasePathMapping_updates(t *testing.T) {
 	ctx := acctest.Context(t)
 	var confFirst, conf apigateway.GetBasePathMappingOutput
 	resourceName := "aws_api_gateway_base_path_mapping.test"
-	name := acctest.RandomSubdomain()
+	name := acctest.RandomSubdomain(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, name)
 
@@ -160,7 +160,7 @@ func TestAccAPIGatewayBasePathMapping_updates(t *testing.T) {
 func TestAccAPIGatewayBasePathMapping_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetBasePathMappingOutput
-	name := acctest.RandomSubdomain()
+	name := acctest.RandomSubdomain(t)
 	resourceName := "aws_api_gateway_base_path_mapping.test"
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, name)
@@ -186,7 +186,7 @@ func TestAccAPIGatewayBasePathMapping_disappears(t *testing.T) {
 func TestAccAPIGatewayBasePathMapping_updateIDFormat(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetBasePathMappingOutput
-	name := acctest.RandomSubdomain()
+	name := acctest.RandomSubdomain(t)
 	resourceName := "aws_api_gateway_base_path_mapping.test"
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, name)

--- a/internal/service/apigateway/domain_name.go
+++ b/internal/service/apigateway/domain_name.go
@@ -33,7 +33,7 @@ import (
 // @SDKResource("aws_api_gateway_domain_name", name="Domain Name")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigateway;apigateway.GetDomainNameOutput")
-// @Testing(generator="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.RandomSubdomain()")
+// @Testing(generator="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.RandomSubdomain(t)")
 // @Testing(tlsKey=true, tlsKeyDomain="rName")
 func resourceDomainName() *schema.Resource {
 	return &schema.Resource{

--- a/internal/service/apigateway/domain_name_access_association.go
+++ b/internal/service/apigateway/domain_name_access_association.go
@@ -34,7 +34,7 @@ import (
 // @Tags(identifierAttribute="arn")
 // @ArnIdentity(identityDuplicateAttributes="id")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigateway/types;awstypes;awstypes.DomainNameAccessAssociation")
-// @Testing(generator="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.RandomSubdomain()")
+// @Testing(generator="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.RandomSubdomain(t)")
 // @Testing(tlsKey=true, tlsKeyDomain="rName")
 // @Testing(preIdentityVersion="v5.100.0")
 func newDomainNameAccessAssociationResource(context.Context) (resource.ResourceWithConfigure, error) {

--- a/internal/service/apigateway/domain_name_access_association_identity_gen_test.go
+++ b/internal/service/apigateway/domain_name_access_association_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Identity_basic(t *testing.T) {
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -122,7 +122,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Identity_regionOverride(t *tes
 	ctx := acctest.Context(t)
 
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -257,7 +257,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Identity_ExistingResource_basi
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -345,7 +345,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Identity_ExistingResource_noRe
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 

--- a/internal/service/apigateway/domain_name_access_association_tags_gen_test.go
+++ b/internal/service/apigateway/domain_name_access_association_tags_gen_test.go
@@ -25,7 +25,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags(t *testing.T) {
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -229,7 +229,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_null(t *testing.T) {
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -301,7 +301,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_emptyMap(t *testing.T) {
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -361,7 +361,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_addOnUpdate(t *testing.T)
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -453,7 +453,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_EmptyTag_onCreate(t *test
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -557,7 +557,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_EmptyTag_OnUpdate_add(t *
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -712,7 +712,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_EmptyTag_OnUpdate_replace
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -814,7 +814,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_DefaultTags_providerOnly(
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1017,7 +1017,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_DefaultTags_nonOverlappin
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1195,7 +1195,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_DefaultTags_overlapping(t
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1389,7 +1389,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_DefaultTags_updateToProvi
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1491,7 +1491,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_DefaultTags_updateToResou
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1592,7 +1592,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_DefaultTags_emptyResource
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1668,7 +1668,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_DefaultTags_emptyProvider
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1736,7 +1736,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_DefaultTags_nullOverlappi
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1815,7 +1815,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_DefaultTags_nullNonOverla
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1896,7 +1896,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_ComputedTag_onCreate(t *t
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1961,7 +1961,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_ComputedTag_OnUpdate_add(
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -2070,7 +2070,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_ComputedTag_OnUpdate_repl
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -2169,7 +2169,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_IgnoreTags_Overlap_defaul
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -2343,7 +2343,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Tags_IgnoreTags_Overlap_resour
 
 	var v awstypes.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 

--- a/internal/service/apigateway/domain_name_access_association_test.go
+++ b/internal/service/apigateway/domain_name_access_association_test.go
@@ -22,7 +22,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_basic(t *testing.T) {
 	var v types.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomSubdomain()
+	domain := acctest.RandomSubdomain(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domain)
 
@@ -54,7 +54,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_disappears(t *testing.T) {
 	var v types.DomainNameAccessAssociation
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomSubdomain()
+	domain := acctest.RandomSubdomain(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domain)
 

--- a/internal/service/apigateway/domain_name_data_source.go
+++ b/internal/service/apigateway/domain_name_data_source.go
@@ -20,7 +20,7 @@ import (
 
 // @SDKDataSource("aws_api_gateway_domain_name", name="Domain Name")
 // @Tags
-// @Testing(generator="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.RandomSubdomain()")
+// @Testing(generator="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.RandomSubdomain(t)")
 // @Testing(tlsKey=true, tlsKeyDomain="rName")
 // @Testing(tagsIdentifierAttribute="arn")
 func dataSourceDomainName() *schema.Resource {

--- a/internal/service/apigateway/domain_name_data_source_tags_gen_test.go
+++ b/internal/service/apigateway/domain_name_data_source_tags_gen_test.go
@@ -27,7 +27,7 @@ func TestAccAPIGatewayDomainNameDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	dataSourceName := "data.aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -63,7 +63,7 @@ func TestAccAPIGatewayDomainNameDataSource_Tags_nullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	dataSourceName := "data.aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -95,7 +95,7 @@ func TestAccAPIGatewayDomainNameDataSource_Tags_emptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	dataSourceName := "data.aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -127,7 +127,7 @@ func TestAccAPIGatewayDomainNameDataSource_Tags_DefaultTags_nonOverlapping(t *te
 	ctx := acctest.Context(t)
 
 	dataSourceName := "data.aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -167,7 +167,7 @@ func TestAccAPIGatewayDomainNameDataSource_Tags_IgnoreTags_Overlap_defaultTag(t 
 	ctx := acctest.Context(t)
 
 	dataSourceName := "data.aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -213,7 +213,7 @@ func TestAccAPIGatewayDomainNameDataSource_Tags_IgnoreTags_Overlap_resourceTag(t
 	ctx := acctest.Context(t)
 
 	dataSourceName := "data.aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 

--- a/internal/service/apigateway/domain_name_data_source_test.go
+++ b/internal/service/apigateway/domain_name_data_source_test.go
@@ -16,7 +16,7 @@ func TestAccAPIGatewayDomainNameDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_domain_name.test"
 	dataSourceName := "data.aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 

--- a/internal/service/apigateway/domain_name_tags_gen_test.go
+++ b/internal/service/apigateway/domain_name_tags_gen_test.go
@@ -25,7 +25,7 @@ func TestAccAPIGatewayDomainName_tags(t *testing.T) {
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -229,7 +229,7 @@ func TestAccAPIGatewayDomainName_Tags_null(t *testing.T) {
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -308,7 +308,7 @@ func TestAccAPIGatewayDomainName_Tags_emptyMap(t *testing.T) {
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -383,7 +383,7 @@ func TestAccAPIGatewayDomainName_Tags_addOnUpdate(t *testing.T) {
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -476,7 +476,7 @@ func TestAccAPIGatewayDomainName_Tags_EmptyTag_onCreate(t *testing.T) {
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -579,7 +579,7 @@ func TestAccAPIGatewayDomainName_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -732,7 +732,7 @@ func TestAccAPIGatewayDomainName_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -833,7 +833,7 @@ func TestAccAPIGatewayDomainName_Tags_DefaultTags_providerOnly(t *testing.T) {
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1036,7 +1036,7 @@ func TestAccAPIGatewayDomainName_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1214,7 +1214,7 @@ func TestAccAPIGatewayDomainName_Tags_DefaultTags_overlapping(t *testing.T) {
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1408,7 +1408,7 @@ func TestAccAPIGatewayDomainName_Tags_DefaultTags_updateToProviderOnly(t *testin
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1510,7 +1510,7 @@ func TestAccAPIGatewayDomainName_Tags_DefaultTags_updateToResourceOnly(t *testin
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1611,7 +1611,7 @@ func TestAccAPIGatewayDomainName_Tags_DefaultTags_emptyResourceTag(t *testing.T)
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1686,7 +1686,7 @@ func TestAccAPIGatewayDomainName_Tags_DefaultTags_emptyProviderOnlyTag(t *testin
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1753,7 +1753,7 @@ func TestAccAPIGatewayDomainName_Tags_DefaultTags_nullOverlappingResourceTag(t *
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1825,7 +1825,7 @@ func TestAccAPIGatewayDomainName_Tags_DefaultTags_nullNonOverlappingResourceTag(
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1897,7 +1897,7 @@ func TestAccAPIGatewayDomainName_Tags_ComputedTag_onCreate(t *testing.T) {
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1962,7 +1962,7 @@ func TestAccAPIGatewayDomainName_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -2071,7 +2071,7 @@ func TestAccAPIGatewayDomainName_Tags_ComputedTag_OnUpdate_replace(t *testing.T)
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -2170,7 +2170,7 @@ func TestAccAPIGatewayDomainName_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -2344,7 +2344,7 @@ func TestAccAPIGatewayDomainName_Tags_IgnoreTags_Overlap_resourceTag(t *testing.
 
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 

--- a/internal/service/apigateway/domain_name_test.go
+++ b/internal/service/apigateway/domain_name_test.go
@@ -130,7 +130,7 @@ func TestAccAPIGatewayDomainName_regionalCertificateARN(t *testing.T) {
 	ctx := acctest.Context(t)
 	var domainName apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
@@ -171,7 +171,7 @@ func TestAccAPIGatewayDomainName_regionalCertificateName(t *testing.T) {
 	}
 	var domainName apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	domainWildcard := fmt.Sprintf("*.%s", domain)
 	rName := fmt.Sprintf("%s.%s", acctest.RandString(t, 8), domain)
 	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
@@ -208,7 +208,7 @@ func TestAccAPIGatewayDomainName_securityPolicy(t *testing.T) {
 	ctx := acctest.Context(t)
 	var domainName apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
@@ -239,7 +239,7 @@ func TestAccAPIGatewayDomainName_securityPolicyEnhanced(t *testing.T) {
 	ctx := acctest.Context(t)
 	var domainName apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
@@ -270,7 +270,7 @@ func TestAccAPIGatewayDomainName_securityPolicyEnhancedUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var domainName apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
@@ -330,7 +330,7 @@ func TestAccAPIGatewayDomainName_private(t *testing.T) {
 	ctx := acctest.Context(t)
 	var domainName apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
@@ -360,7 +360,7 @@ func TestAccAPIGatewayDomainName_privatePolicy(t *testing.T) {
 	ctx := acctest.Context(t)
 	var domainName apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
@@ -391,7 +391,7 @@ func TestAccAPIGatewayDomainName_privatePolicy_added(t *testing.T) {
 	ctx := acctest.Context(t)
 	var domainName apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
@@ -429,7 +429,7 @@ func TestAccAPIGatewayDomainName_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var domainName apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
@@ -454,7 +454,7 @@ func TestAccAPIGatewayDomainName_disappears(t *testing.T) {
 func TestAccAPIGatewayDomainName_MutualTLSAuthentication_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
-	domain := fmt.Sprintf("%s.%s", acctest.RandomSubdomain(), rootDomain)
+	domain := fmt.Sprintf("%s.%s", acctest.RandomSubdomain(t), rootDomain)
 	var v apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
 	acmCertificateResourceName := "aws_acm_certificate.test"
@@ -510,7 +510,7 @@ func TestAccAPIGatewayDomainName_MutualTLSAuthentication_basic(t *testing.T) {
 func TestAccAPIGatewayDomainName_MutualTLSAuthentication_ownership(t *testing.T) {
 	ctx := acctest.Context(t)
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
-	domain := fmt.Sprintf("%s.%s", acctest.RandomSubdomain(), rootDomain)
+	domain := fmt.Sprintf("%s.%s", acctest.RandomSubdomain(t), rootDomain)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domain)
 	var v apigateway.GetDomainNameOutput
@@ -550,7 +550,7 @@ func TestAccAPIGatewayDomainName_updateIDFormat(t *testing.T) {
 	ctx := acctest.Context(t)
 	var domainName apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
@@ -605,7 +605,7 @@ func TestAccAPIGatewayDomainName_ipAddressType(t *testing.T) {
 	ctx := acctest.Context(t)
 	var domainName apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
@@ -652,7 +652,7 @@ func TestAccAPIGatewayDomainName_routingMode(t *testing.T) {
 	ctx := acctest.Context(t)
 	var domainName apigateway.GetDomainNameOutput
 	resourceName := "aws_api_gateway_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 

--- a/internal/service/apigatewayv2/domain_name.go
+++ b/internal/service/apigatewayv2/domain_name.go
@@ -31,7 +31,7 @@ import (
 // @SDKResource("aws_apigatewayv2_domain_name", name="Domain Name")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/apigatewayv2;apigatewayv2.GetDomainNameOutput")
-// @Testing(generator="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.RandomSubdomain()")
+// @Testing(generator="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.RandomSubdomain(t)")
 // @Testing(tlsKey=true)
 // @Testing(tlsKeyDomain=rName)
 func resourceDomainName() *schema.Resource {

--- a/internal/service/apigatewayv2/domain_name_tags_gen_test.go
+++ b/internal/service/apigatewayv2/domain_name_tags_gen_test.go
@@ -25,7 +25,7 @@ func TestAccAPIGatewayV2DomainName_tags(t *testing.T) {
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -229,7 +229,7 @@ func TestAccAPIGatewayV2DomainName_Tags_null(t *testing.T) {
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -308,7 +308,7 @@ func TestAccAPIGatewayV2DomainName_Tags_emptyMap(t *testing.T) {
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -383,7 +383,7 @@ func TestAccAPIGatewayV2DomainName_Tags_addOnUpdate(t *testing.T) {
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -476,7 +476,7 @@ func TestAccAPIGatewayV2DomainName_Tags_EmptyTag_onCreate(t *testing.T) {
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -579,7 +579,7 @@ func TestAccAPIGatewayV2DomainName_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -732,7 +732,7 @@ func TestAccAPIGatewayV2DomainName_Tags_EmptyTag_OnUpdate_replace(t *testing.T) 
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -833,7 +833,7 @@ func TestAccAPIGatewayV2DomainName_Tags_DefaultTags_providerOnly(t *testing.T) {
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1036,7 +1036,7 @@ func TestAccAPIGatewayV2DomainName_Tags_DefaultTags_nonOverlapping(t *testing.T)
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1214,7 +1214,7 @@ func TestAccAPIGatewayV2DomainName_Tags_DefaultTags_overlapping(t *testing.T) {
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1408,7 +1408,7 @@ func TestAccAPIGatewayV2DomainName_Tags_DefaultTags_updateToProviderOnly(t *test
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1510,7 +1510,7 @@ func TestAccAPIGatewayV2DomainName_Tags_DefaultTags_updateToResourceOnly(t *test
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1611,7 +1611,7 @@ func TestAccAPIGatewayV2DomainName_Tags_DefaultTags_emptyResourceTag(t *testing.
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1686,7 +1686,7 @@ func TestAccAPIGatewayV2DomainName_Tags_DefaultTags_emptyProviderOnlyTag(t *test
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1753,7 +1753,7 @@ func TestAccAPIGatewayV2DomainName_Tags_DefaultTags_nullOverlappingResourceTag(t
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1825,7 +1825,7 @@ func TestAccAPIGatewayV2DomainName_Tags_DefaultTags_nullNonOverlappingResourceTa
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1897,7 +1897,7 @@ func TestAccAPIGatewayV2DomainName_Tags_ComputedTag_onCreate(t *testing.T) {
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -1962,7 +1962,7 @@ func TestAccAPIGatewayV2DomainName_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -2071,7 +2071,7 @@ func TestAccAPIGatewayV2DomainName_Tags_ComputedTag_OnUpdate_replace(t *testing.
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -2170,7 +2170,7 @@ func TestAccAPIGatewayV2DomainName_Tags_IgnoreTags_Overlap_defaultTag(t *testing
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
@@ -2344,7 +2344,7 @@ func TestAccAPIGatewayV2DomainName_Tags_IgnoreTags_Overlap_resourceTag(t *testin
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
-	rName := acctest.RandomSubdomain()
+	rName := acctest.RandomSubdomain(t)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 

--- a/internal/service/appmesh/virtual_gateway_test.go
+++ b/internal/service/appmesh/virtual_gateway_test.go
@@ -419,7 +419,7 @@ func testAccVirtualGateway_ListenerTLS(t *testing.T) {
 
 	meshName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	vgName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.AppMeshEndpointID) },

--- a/internal/service/appmesh/virtual_node_test.go
+++ b/internal/service/appmesh/virtual_node_test.go
@@ -95,7 +95,7 @@ func testAccVirtualNode_backendClientPolicyACM(t *testing.T) {
 
 	meshName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	vnName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.AppMeshEndpointID) },
@@ -913,7 +913,7 @@ func testAccVirtualNode_listenerTLS(t *testing.T) {
 
 	meshName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	vnName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.AppMeshEndpointID) },

--- a/internal/service/appstream/directory_config_test.go
+++ b/internal/service/appstream/directory_config_test.go
@@ -24,7 +24,7 @@ func TestAccAppStreamDirectoryConfig_basic(t *testing.T) {
 	var v1, v2 awstypes.DirectoryConfig
 	resourceName := "aws_appstream_directory_config.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	rUserName := fmt.Sprintf("%s\\%s", domain, acctest.RandString(t, 10))
 	rPassword := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	rUserNameUpdated := fmt.Sprintf("%s\\%s", domain, acctest.RandString(t, 10))
@@ -79,7 +79,7 @@ func TestAccAppStreamDirectoryConfig_disappears(t *testing.T) {
 	var v awstypes.DirectoryConfig
 	resourceName := "aws_appstream_directory_config.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	rUserName := fmt.Sprintf("%s\\%s", domain, acctest.RandString(t, 10))
 	rPassword := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	orgUnitDN := orgUnitFromDomain("Test", domain)
@@ -107,7 +107,7 @@ func TestAccAppStreamDirectoryConfig_OrganizationalUnitDistinguishedNames(t *tes
 	var v1, v2, v3 awstypes.DirectoryConfig
 	resourceName := "aws_appstream_directory_config.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	rUserName := fmt.Sprintf("%s\\%s", domain, acctest.RandString(t, 10))
 	rPassword := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	orgUnitDN1 := orgUnitFromDomain("One", domain)
@@ -156,7 +156,7 @@ func TestAccAppStreamDirectoryConfig_CertificateBasedAuthParameters(t *testing.T
 	var v1, v2 awstypes.DirectoryConfig
 	resourceName := "aws_appstream_directory_config.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	rUserName := fmt.Sprintf("%s\\%s", domain, acctest.RandString(t, 10))
 	rPassword := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	rUserNameUpdated := fmt.Sprintf("%s\\%s", domain, acctest.RandString(t, 10))

--- a/internal/service/appstream/user_stack_association_test.go
+++ b/internal/service/appstream/user_stack_association_test.go
@@ -22,7 +22,7 @@ func TestAccAppStreamUserStackAssociation_basic(t *testing.T) {
 	resourceName := "aws_appstream_user_stack_association.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	authType := "USERPOOL"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	rEmail := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -56,7 +56,7 @@ func TestAccAppStreamUserStackAssociation_disappears(t *testing.T) {
 	resourceName := "aws_appstream_user_stack_association.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	authType := "USERPOOL"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	rEmail := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -84,7 +84,7 @@ func TestAccAppStreamUserStackAssociation_Disappears_user(t *testing.T) {
 	resourceName := "aws_appstream_user_stack_association.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	authType := "USERPOOL"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	rEmail := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -112,7 +112,7 @@ func TestAccAppStreamUserStackAssociation_Disappears_stack(t *testing.T) {
 	resourceName := "aws_appstream_user_stack_association.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	authType := "USERPOOL"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	rEmail := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -140,7 +140,7 @@ func TestAccAppStreamUserStackAssociation_complete(t *testing.T) {
 	resourceName := "aws_appstream_user_stack_association.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	authType := "USERPOOL"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	rEmail := acctest.RandomEmailAddress(domain)
 	rEmailUpdated := acctest.RandomEmailAddress(domain)
 

--- a/internal/service/appstream/user_test.go
+++ b/internal/service/appstream/user_test.go
@@ -22,7 +22,7 @@ func TestAccAppStreamUser_basic(t *testing.T) {
 	var userOutput awstypes.User
 	resourceName := "aws_appstream_user.test"
 	authType := "USERPOOL"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	rEmail := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -58,7 +58,7 @@ func TestAccAppStreamUser_disappears(t *testing.T) {
 	var userOutput awstypes.User
 	resourceName := "aws_appstream_user.test"
 	authType := "USERPOOL"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	rEmail := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -88,7 +88,7 @@ func TestAccAppStreamUser_complete(t *testing.T) {
 	authType := "USERPOOL"
 	firstName := "John"
 	lastName := "Doe"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	rEmail := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/arcregionswitch/plan_test.go
+++ b/internal/service/arcregionswitch/plan_test.go
@@ -210,7 +210,7 @@ func TestAccARCRegionSwitchPlan_route53HealthCheck(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, "tf-acc-test")
 	resourceName := "aws_arcregionswitch_plan.test"
 	dataSourceName := "data.aws_arcregionswitch_route53_health_checks.test"
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -257,8 +257,8 @@ func TestAccARCRegionSwitchPlan_complex(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, "tf-acc-test")
 	resourceName := "aws_arcregionswitch_plan.test"
 
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/arcregionswitch/route53_health_checks_data_source_test.go
+++ b/internal/service/arcregionswitch/route53_health_checks_data_source_test.go
@@ -20,8 +20,8 @@ func TestAccARCRegionSwitchRoute53HealthChecksDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_arcregionswitch_route53_health_checks.test"
 	resourceName := "aws_arcregionswitch_plan.test"
 
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -71,8 +71,8 @@ func TestAccARCRegionSwitchRoute53HealthChecksDataSource_regionOverride(t *testi
 					ctx := acctest.Context(t)
 					rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-					zoneName := acctest.RandomDomain()
-					recordName := zoneName.RandomSubdomain()
+					zoneName := acctest.RandomDomain(t)
+					recordName := zoneName.RandomSubdomain(t)
 
 					acctest.ParallelTest(ctx, t, resource.TestCase{
 						PreCheck: func() {

--- a/internal/service/budgets/budget_test.go
+++ b/internal/service/budgets/budget_test.go
@@ -381,7 +381,7 @@ func TestAccBudgetsBudget_notifications(t *testing.T) {
 	resourceName := "aws_budgets_budget.test"
 	snsTopicResourceName := "aws_sns_topic.test"
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	emailAddress1 := acctest.RandomEmailAddress(domain)
 	emailAddress2 := acctest.RandomEmailAddress(domain)
 	emailAddress3 := acctest.RandomEmailAddress(domain)

--- a/internal/service/ce/anomaly_subscription_identity_gen_test.go
+++ b/internal/service/ce/anomaly_subscription_identity_gen_test.go
@@ -28,7 +28,7 @@ func TestAccCEAnomalySubscription_Identity_basic(t *testing.T) {
 	var v awstypes.AnomalySubscription
 	resourceName := "aws_ce_anomaly_subscription.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	email_address := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -117,7 +117,7 @@ func TestAccCEAnomalySubscription_Identity_ExistingResource_basic(t *testing.T) 
 	var v awstypes.AnomalySubscription
 	resourceName := "aws_ce_anomaly_subscription.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	email_address := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -201,7 +201,7 @@ func TestAccCEAnomalySubscription_Identity_ExistingResource_noRefreshNoChange(t 
 	var v awstypes.AnomalySubscription
 	resourceName := "aws_ce_anomaly_subscription.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	email_address := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/ce/anomaly_subscription_test.go
+++ b/internal/service/ce/anomaly_subscription_test.go
@@ -23,7 +23,7 @@ func TestAccCEAnomalySubscription_basic(t *testing.T) {
 	var subscription awstypes.AnomalySubscription
 	resourceName := "aws_ce_anomaly_subscription.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	address := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -59,7 +59,7 @@ func TestAccCEAnomalySubscription_disappears(t *testing.T) {
 	var subscription awstypes.AnomalySubscription
 	resourceName := "aws_ce_anomaly_subscription.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	address := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -85,7 +85,7 @@ func TestAccCEAnomalySubscription_Frequency(t *testing.T) {
 	var subscription awstypes.AnomalySubscription
 	resourceName := "aws_ce_anomaly_subscription.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	address := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -123,7 +123,7 @@ func TestAccCEAnomalySubscription_MonitorARNList(t *testing.T) {
 	resourceName := "aws_ce_anomaly_subscription.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	rName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	address := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -161,7 +161,7 @@ func TestAccCEAnomalySubscription_Subscriber(t *testing.T) {
 	var subscription awstypes.AnomalySubscription
 	resourceName := "aws_ce_anomaly_subscription.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	address1 := acctest.RandomEmailAddress(domain)
 	address2 := acctest.RandomEmailAddress(domain)
 
@@ -229,7 +229,7 @@ func TestAccCEAnomalySubscription_tags(t *testing.T) {
 	var subscription awstypes.AnomalySubscription
 	resourceName := "aws_ce_anomaly_subscription.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	address := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/cognitoidentity/pool_data_source_test.go
+++ b/internal/service/cognitoidentity/pool_data_source_test.go
@@ -125,7 +125,7 @@ func TestAccCognitoIdentityPoolDataSource_samlProviderARNs(t *testing.T) {
 	}
 
 	name := acctest.RandString(t, 10)
-	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 	var ip cognitoidentity.DescribeIdentityPoolOutput
 	dataSourceName := "data.aws_cognito_identity_pool.test"
 	resourceName := "aws_cognito_identity_pool.test"

--- a/internal/service/cognitoidentity/pool_test.go
+++ b/internal/service/cognitoidentity/pool_test.go
@@ -202,8 +202,8 @@ func TestAccCognitoIdentityPool_samlProviderARNs(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v1, v2, v3 cognitoidentity.DescribeIdentityPoolOutput
 	name := acctest.RandString(t, 10)
-	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
-	secondaryIdpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
+	secondaryIdpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 	resourceName := "aws_cognito_identity_pool.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/cognitoidp/user_test.go
+++ b/internal/service/cognitoidp/user_test.go
@@ -297,7 +297,7 @@ func TestAccCognitoIDPUser_enabled(t *testing.T) {
 func TestAccCognitoIDPUser_v5560Regression(t *testing.T) {
 	ctx := acctest.Context(t)
 	rUserPoolName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	rUserName := acctest.RandomEmailAddress(domain)
 	resourceName := "aws_cognito_user.test"
 

--- a/internal/service/connect/instance_test.go
+++ b/internal/service/connect/instance_test.go
@@ -82,7 +82,7 @@ func testAccInstance_directory(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, "resource-test-terraform")
 	resourceName := "aws_connect_instance.test"
 
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/connect/user_data_source_test.go
+++ b/internal/service/connect/user_data_source_test.go
@@ -19,7 +19,7 @@ func testAccUserDataSource_userID(t *testing.T) {
 	rName3 := acctest.RandomWithPrefix(t, "resource-test-terraform")
 	rName4 := acctest.RandomWithPrefix(t, "resource-test-terraform")
 	rName5 := acctest.RandomWithPrefix(t, "resource-test-terraform")
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	email := acctest.RandomEmailAddress(domain)
 	secondaryEmail := acctest.RandomEmailAddress(domain)
 	resourceName := "aws_connect_user.test"
@@ -68,7 +68,7 @@ func testAccUserDataSource_name(t *testing.T) {
 	rName3 := acctest.RandomWithPrefix(t, "resource-test-terraform")
 	rName4 := acctest.RandomWithPrefix(t, "resource-test-terraform")
 	rName5 := acctest.RandomWithPrefix(t, "resource-test-terraform")
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	email := acctest.RandomEmailAddress(domain)
 	secondaryEmail := acctest.RandomEmailAddress(domain)
 	resourceName := "aws_connect_user.test"

--- a/internal/service/connect/user_test.go
+++ b/internal/service/connect/user_test.go
@@ -111,7 +111,7 @@ func testAccUser_updateIdentityInfo(t *testing.T) {
 	rName3 := acctest.RandomWithPrefix(t, "resource-test-terraform")
 	rName4 := acctest.RandomWithPrefix(t, "resource-test-terraform")
 	rName5 := acctest.RandomWithPrefix(t, "resource-test-terraform")
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	emailOriginal := acctest.RandomEmailAddress(domain)
 	firstNameOriginal := "example-first-name-original"
 	lastNameOriginal := "example-last-name-original"

--- a/internal/service/customerprofiles/profile_test.go
+++ b/internal/service/customerprofiles/profile_test.go
@@ -22,7 +22,7 @@ func TestAccCustomerProfilesProfile_full(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	accountNumber := acctest.RandString(t, 8)
 	accountNumberUpdated := acctest.RandString(t, 8)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	email := acctest.RandomEmailAddress(domain)
 	emailUpdated := acctest.RandomEmailAddress(domain)
 
@@ -179,7 +179,7 @@ func TestAccCustomerProfilesProfile_disappears(t *testing.T) {
 	resourceName := "aws_customerprofiles_profile.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	accountNumber := acctest.RandString(t, 8)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	email := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/datasync/location_fsx_windows_file_system_test.go
+++ b/internal/service/datasync/location_fsx_windows_file_system_test.go
@@ -24,7 +24,7 @@ func TestAccDataSyncLocationFSxWindowsFileSystem_basic(t *testing.T) {
 	resourceName := "aws_datasync_location_fsx_windows_file_system.test"
 	fsResourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -64,7 +64,7 @@ func TestAccDataSyncLocationFSxWindowsFileSystem_disappears(t *testing.T) {
 	var v datasync.DescribeLocationFsxWindowsOutput
 	resourceName := "aws_datasync_location_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -93,7 +93,7 @@ func TestAccDataSyncLocationFSxWindowsFileSystem_subdirectory(t *testing.T) {
 	var v datasync.DescribeLocationFsxWindowsOutput
 	resourceName := "aws_datasync_location_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -128,7 +128,7 @@ func TestAccDataSyncLocationFSxWindowsFileSystem_tags(t *testing.T) {
 	var v datasync.DescribeLocationFsxWindowsOutput
 	resourceName := "aws_datasync_location_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/datasync/location_hdfs_test.go
+++ b/internal/service/datasync/location_hdfs_test.go
@@ -140,7 +140,7 @@ func TestAccDataSyncLocationHDFS_kerberos(t *testing.T) {
 	var v datasync.DescribeLocationHdfsOutput
 	resourceName := "aws_datasync_location_hdfs.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	principal := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	principal := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },

--- a/internal/service/datasync/location_object_storage_identity_gen_test.go
+++ b/internal/service/datasync/location_object_storage_identity_gen_test.go
@@ -28,7 +28,7 @@ func TestAccDataSyncLocationObjectStorage_Identity_basic(t *testing.T) {
 	var v datasync.DescribeLocationObjectStorageOutput
 	resourceName := "aws_datasync_location_object_storage.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -121,7 +121,7 @@ func TestAccDataSyncLocationObjectStorage_Identity_regionOverride(t *testing.T) 
 
 	resourceName := "aws_datasync_location_object_storage.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -252,7 +252,7 @@ func TestAccDataSyncLocationObjectStorage_Identity_ExistingResource_basic(t *tes
 	var v datasync.DescribeLocationObjectStorageOutput
 	resourceName := "aws_datasync_location_object_storage.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -338,7 +338,7 @@ func TestAccDataSyncLocationObjectStorage_Identity_ExistingResource_noRefreshNoC
 	var v datasync.DescribeLocationObjectStorageOutput
 	resourceName := "aws_datasync_location_object_storage.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{

--- a/internal/service/datasync/location_object_storage_test.go
+++ b/internal/service/datasync/location_object_storage_test.go
@@ -27,7 +27,7 @@ func TestAccDataSyncLocationObjectStorage_basic(t *testing.T) {
 	var v datasync.DescribeLocationObjectStorageOutput
 	resourceName := "aws_datasync_location_object_storage.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
@@ -67,7 +67,7 @@ func TestAccDataSyncLocationObjectStorage_update(t *testing.T) {
 	var v datasync.DescribeLocationObjectStorageOutput
 	resourceName := "aws_datasync_location_object_storage.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
@@ -138,7 +138,7 @@ func TestAccDataSyncLocationObjectStorage_disappears(t *testing.T) {
 	var v datasync.DescribeLocationObjectStorageOutput
 	resourceName := "aws_datasync_location_object_storage.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
@@ -163,7 +163,7 @@ func TestAccDataSyncLocationObjectStorage_tags(t *testing.T) {
 	var v datasync.DescribeLocationObjectStorageOutput
 	resourceName := "aws_datasync_location_object_storage.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
@@ -210,7 +210,7 @@ func TestAccDataSyncLocationObjectStorage_serverCertificate(t *testing.T) {
 	var v datasync.DescribeLocationObjectStorageOutput
 	resourceName := "aws_datasync_location_object_storage.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(t, caKey)
 
@@ -247,7 +247,7 @@ func TestAccDataSyncLocationObjectStorage_emptyAgentARNs(t *testing.T) {
 	var v datasync.DescribeLocationObjectStorageOutput
 	resourceName := "aws_datasync_location_object_storage.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
@@ -283,7 +283,7 @@ func TestAccDataSyncLocationObjectStorage_noAgentARNs(t *testing.T) {
 	var v datasync.DescribeLocationObjectStorageOutput
 	resourceName := "aws_datasync_location_object_storage.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },

--- a/internal/service/datasync/task_test.go
+++ b/internal/service/datasync/task_test.go
@@ -628,7 +628,7 @@ func TestAccDataSyncTask_DefaultSyncOptions_securityDescriptorCopyFlags(t *testi
 	var task1, task2 datasync.DescribeTaskOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_datasync_task.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -463,7 +463,7 @@ func TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage(t *testing.T) {
 
 func TestAccDMSEndpoint_kafka(t *testing.T) {
 	ctx := acctest.Context(t)
-	domainName := acctest.RandomSubdomain()
+	domainName := acctest.RandomSubdomain(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_dms_endpoint.test"
 

--- a/internal/service/ds/conditional_forwarder_test.go
+++ b/internal/service/ds/conditional_forwarder_test.go
@@ -20,7 +20,7 @@ func TestAccDSConditionalForwarder_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_directory_service_conditional_forwarder.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	ip1, ip2, ip3 := "8.8.8.8", "1.1.1.1", "8.8.4.4"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -60,7 +60,7 @@ func TestAccDSConditionalForwarder_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_directory_service_conditional_forwarder.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	ip1, ip2 := "8.8.8.8", "1.1.1.1"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/ds/directory_data_source_test.go
+++ b/internal/service/ds/directory_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccDSDirectoryDataSource_simpleAD(t *testing.T) {
 	resourceName := "aws_directory_service_directory.test"
 	dataSourceName := "data.aws_directory_service_directory.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckDirectoryServiceSimpleDirectory(ctx, t) },
@@ -59,7 +59,7 @@ func TestAccDSDirectoryDataSource_microsoftAD(t *testing.T) {
 	resourceName := "aws_directory_service_directory.test"
 	dataSourceName := "data.aws_directory_service_directory.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -99,7 +99,7 @@ func TestAccDSDirectoryDataSource_connector(t *testing.T) {
 	resourceName := "aws_directory_service_directory.test"
 	dataSourceName := "data.aws_directory_service_directory.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -146,7 +146,7 @@ func TestAccDSDirectoryDataSource_sharedMicrosoftAD(t *testing.T) {
 	resourceName := "aws_directory_service_directory.test"
 	dataSourceName := "data.aws_directory_service_directory.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/ds/directory_test.go
+++ b/internal/service/ds/directory_test.go
@@ -22,7 +22,7 @@ func TestAccDSDirectory_basic(t *testing.T) {
 	var ds awstypes.DirectoryDescription
 	resourceName := "aws_directory_service_directory.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -75,7 +75,7 @@ func TestAccDSDirectory_disappears(t *testing.T) {
 	var ds awstypes.DirectoryDescription
 	resourceName := "aws_directory_service_directory.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -104,7 +104,7 @@ func TestAccDSDirectory_tags(t *testing.T) {
 	var ds awstypes.DirectoryDescription
 	resourceName := "aws_directory_service_directory.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -158,7 +158,7 @@ func TestAccDSDirectory_microsoft(t *testing.T) {
 	var ds awstypes.DirectoryDescription
 	resourceName := "aws_directory_service_directory.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckDirectoryService(ctx, t) },
@@ -206,7 +206,7 @@ func TestAccDSDirectory_microsoftStandard(t *testing.T) {
 	var ds awstypes.DirectoryDescription
 	resourceName := "aws_directory_service_directory.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckDirectoryService(ctx, t) },
@@ -254,7 +254,7 @@ func TestAccDSDirectory_connector(t *testing.T) {
 	var ds awstypes.DirectoryDescription
 	resourceName := "aws_directory_service_directory.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -309,7 +309,7 @@ func TestAccDSDirectory_withAliasAndSSO(t *testing.T) {
 	alias := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_directory_service_directory.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -375,7 +375,7 @@ func TestAccDSDirectory_desiredNumberOfDomainControllers(t *testing.T) {
 	var ds awstypes.DirectoryDescription
 	resourceName := "aws_directory_service_directory.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckDirectoryService(ctx, t) },
@@ -437,7 +437,7 @@ func TestAccDSDirectory_enableDirectoryDataAccess(t *testing.T) {
 	var ds awstypes.DirectoryDescription
 	resourceName := "aws_directory_service_directory.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckDirectoryService(ctx, t) },

--- a/internal/service/ds/log_subscription_test.go
+++ b/internal/service/ds/log_subscription_test.go
@@ -20,7 +20,7 @@ func TestAccDSLogSubscription_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_directory_service_log_subscription.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckDirectoryService(ctx, t) },
@@ -48,7 +48,7 @@ func TestAccDSLogSubscription_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_directory_service_log_subscription.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckDirectoryService(ctx, t) },

--- a/internal/service/ds/radius_settings_test.go
+++ b/internal/service/ds/radius_settings_test.go
@@ -29,7 +29,7 @@ func TestAccDSRadiusSettings_basic(t *testing.T) {
 	var v awstypes.RadiusSettings
 	resourceName := "aws_directory_service_region.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -77,7 +77,7 @@ func TestAccDSRadiusSettings_disappears(t *testing.T) {
 	var v awstypes.RadiusSettings
 	resourceName := "aws_directory_service_region.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/ds/region_test.go
+++ b/internal/service/ds/region_test.go
@@ -22,7 +22,7 @@ func TestAccDSRegion_basic(t *testing.T) {
 	var v awstypes.RegionDescription
 	resourceName := "aws_directory_service_region.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -57,7 +57,7 @@ func TestAccDSRegion_disappears(t *testing.T) {
 	var v awstypes.RegionDescription
 	resourceName := "aws_directory_service_region.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -86,7 +86,7 @@ func TestAccDSRegion_tags(t *testing.T) {
 	var v awstypes.RegionDescription
 	resourceName := "aws_directory_service_region.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -137,7 +137,7 @@ func TestAccDSRegion_desiredNumberOfDomainControllers(t *testing.T) {
 	var v awstypes.RegionDescription
 	resourceName := "aws_directory_service_region.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/ds/shared_directory_accepter_test.go
+++ b/internal/service/ds/shared_directory_accepter_test.go
@@ -20,7 +20,7 @@ func TestAccDSSharedDirectoryAccepter_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_directory_service_shared_directory_accepter.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/ds/shared_directory_test.go
+++ b/internal/service/ds/shared_directory_test.go
@@ -22,7 +22,7 @@ func TestAccDSSharedDirectory_basic(t *testing.T) {
 	var v awstypes.SharedDirectory
 	resourceName := "aws_directory_service_shared_directory.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -56,7 +56,7 @@ func TestAccDSSharedDirectory_disappears(t *testing.T) {
 	var v awstypes.SharedDirectory
 	resourceName := "aws_directory_service_shared_directory.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/ds/trust_test.go
+++ b/internal/service/ds/trust_test.go
@@ -27,8 +27,8 @@ func TestAccDSTrust_basic(t *testing.T) {
 	var v awstypes.Trust
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_directory_service_trust.test"
-	domainName := acctest.RandomDomainName()
-	domainNameOther := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
+	domainNameOther := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -78,8 +78,8 @@ func TestAccDSTrust_disappears(t *testing.T) {
 	var v awstypes.Trust
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_directory_service_trust.test"
-	domainName := acctest.RandomDomainName()
-	domainNameOther := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
+	domainNameOther := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -107,8 +107,8 @@ func TestAccDSTrust_Domain_TrailingPeriod(t *testing.T) {
 	var v awstypes.Trust
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_directory_service_trust.test"
-	domainName := acctest.RandomDomainName()
-	domainNameOther := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
+	domainNameOther := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -146,8 +146,8 @@ func TestAccDSTrust_twoWayBasic(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_directory_service_trust.test"
 	resourceOtherName := "aws_directory_service_trust.other"
-	domainName := acctest.RandomDomainName()
-	domainNameOther := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
+	domainNameOther := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -190,8 +190,8 @@ func TestAccDSTrust_oneWayBasic(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_directory_service_trust.test"
 	resourceOtherName := "aws_directory_service_trust.other"
-	domainName := acctest.RandomDomainName()
-	domainNameOther := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
+	domainNameOther := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -233,8 +233,8 @@ func TestAccDSTrust_SelectiveAuth(t *testing.T) {
 	var v awstypes.Trust
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_directory_service_trust.test"
-	domainName := acctest.RandomDomainName()
-	domainNameOther := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
+	domainNameOther := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -290,8 +290,8 @@ func TestAccDSTrust_twoWaySelectiveAuth(t *testing.T) {
 	var v awstypes.Trust
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_directory_service_trust.test"
-	domainName := acctest.RandomDomainName()
-	domainNameOther := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
+	domainNameOther := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -347,8 +347,8 @@ func TestAccDSTrust_TrustType(t *testing.T) {
 	var v awstypes.Trust
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_directory_service_trust.test"
-	domainName := acctest.RandomDomainName()
-	domainNameOther := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
+	domainNameOther := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -386,8 +386,8 @@ func TestAccDSTrust_TrustTypeSpecifyDefault(t *testing.T) {
 	var v awstypes.Trust
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_directory_service_trust.test"
-	domainName := acctest.RandomDomainName()
-	domainNameOther := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
+	domainNameOther := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -432,8 +432,8 @@ func TestAccDSTrust_ConditionalForwarderIPs(t *testing.T) {
 	var v awstypes.Trust
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_directory_service_trust.test"
-	domainName := acctest.RandomDomainName()
-	domainNameOther := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
+	domainNameOther := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -487,8 +487,8 @@ func TestAccDSTrust_deleteAssociatedConditionalForwarder(t *testing.T) {
 	var v awstypes.Trust
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_directory_service_trust.test"
-	domainName := acctest.RandomDomainName()
-	domainNameOther := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
+	domainNameOther := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/ec2/vpc_dhcp_options_test.go
+++ b/internal/service/ec2/vpc_dhcp_options_test.go
@@ -58,7 +58,7 @@ func TestAccVPCDHCPOptions_full(t *testing.T) {
 	var d awstypes.DhcpOptions
 	resourceName := "aws_vpc_dhcp_options.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/ec2/vpc_endpoint_service_private_dns_verification_test.go
+++ b/internal/service/ec2/vpc_endpoint_service_private_dns_verification_test.go
@@ -20,7 +20,7 @@ func TestAccVPCEndpointServicePrivateDNSVerification_basic(t *testing.T) {
 	}
 
 	rName := acctest.RandomWithPrefix(t, "tfacctest") // 32 character limit
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	resourceName := "aws_vpc_endpoint_service_private_dns_verification.test"
 	endpointServiceResourceName := "aws_vpc_endpoint_service.test"
 
@@ -50,7 +50,7 @@ func TestAccVPCEndpointServicePrivateDNSVerification_waitForVerification(t *test
 	}
 
 	rName := acctest.RandomWithPrefix(t, "tfacctest") // 32 character limit
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/ec2/vpc_endpoint_service_test.go
+++ b/internal/service/ec2/vpc_endpoint_service_test.go
@@ -288,8 +288,8 @@ func TestAccVPCEndpointService_privateDNSName(t *testing.T) {
 	var svcCfg awstypes.ServiceConfiguration
 	resourceName := "aws_vpc_endpoint_service.test"
 	rName := acctest.RandomWithPrefix(t, "tfacctest") // 32 character limit
-	domainName1 := acctest.RandomSubdomain()
-	domainName2 := acctest.RandomSubdomain()
+	domainName1 := acctest.RandomSubdomain(t)
+	domainName2 := acctest.RandomSubdomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/ec2/vpnclient_endpoint_test.go
+++ b/internal/service/ec2/vpnclient_endpoint_test.go
@@ -162,7 +162,7 @@ func testAccClientVPNEndpoint_msADAuth(t *testing.T, semaphore tfsync.Semaphore)
 	var v awstypes.ClientVpnEndpoint
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -201,7 +201,7 @@ func testAccClientVPNEndpoint_msADAuthAndMutualAuth(t *testing.T, semaphore tfsy
 	var v awstypes.ClientVpnEndpoint
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -242,7 +242,7 @@ func testAccClientVPNEndpoint_federatedAuth(t *testing.T, semaphore tfsync.Semap
 	ctx := acctest.Context(t)
 	var v awstypes.ClientVpnEndpoint
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	idpEntityID := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityID := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -277,7 +277,7 @@ func testAccClientVPNEndpoint_federatedAuthWithSelfServiceProvider(t *testing.T,
 	ctx := acctest.Context(t)
 	var v awstypes.ClientVpnEndpoint
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	idpEntityID := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityID := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -623,7 +623,7 @@ func testAccClientVPNEndpoint_selfServicePortal(t *testing.T, semaphore tfsync.S
 	ctx := acctest.Context(t)
 	var v awstypes.ClientVpnEndpoint
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	idpEntityID := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityID := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/ec2/vpnsite_customer_gateway_test.go
+++ b/internal/service/ec2/vpnsite_customer_gateway_test.go
@@ -224,7 +224,7 @@ func TestAccSiteVPNCustomerGateway_certificate(t *testing.T) {
 	acmRootCAResourceName := "aws_acmpca_certificate_authority.root"
 	acmSubordinateCAResourceName := "aws_acmpca_certificate_authority.test"
 	acmCertificateResourceName := "aws_acm_certificate.test"
-	rootDomain := acctest.RandomDomainName()
+	rootDomain := acctest.RandomDomainName(t)
 	subDomain := fmt.Sprintf("%s.%s", acctest.RandString(t, 8), rootDomain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -640,7 +640,7 @@ func TestAccECSTaskDefinition_fsxWinFileSystem(t *testing.T) {
 	var def awstypes.TaskDefinition
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")

--- a/internal/service/elasticsearch/domain_saml_options_test.go
+++ b/internal/service/elasticsearch/domain_saml_options_test.go
@@ -20,7 +20,7 @@ func TestAccElasticsearchDomainSAMLOptions_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, "acc-test")
 	rUserName := acctest.RandomWithPrefix(t, "es-master-user")
-	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 	resourceName := "aws_elasticsearch_domain_saml_options.main"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -52,7 +52,7 @@ func TestAccElasticsearchDomainSAMLOptions_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, "acc-test")
 	rUserName := acctest.RandomWithPrefix(t, "es-master-user")
-	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 	resourceName := "aws_elasticsearch_domain_saml_options.main"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -76,7 +76,7 @@ func TestAccElasticsearchDomainSAMLOptions_disappears_Domain(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, "acc-test")
 	rUserName := acctest.RandomWithPrefix(t, "es-master-user")
-	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 	resourceName := "aws_elasticsearch_domain_saml_options.main"
 	esDomainResourceName := "aws_elasticsearch_domain.example"
 
@@ -102,7 +102,7 @@ func TestAccElasticsearchDomainSAMLOptions_Update(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, "acc-test")
 	rUserName := acctest.RandomWithPrefix(t, "es-master-user")
-	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 	resourceName := "aws_elasticsearch_domain_saml_options.main"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -135,7 +135,7 @@ func TestAccElasticsearchDomainSAMLOptions_Disabled(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, "acc-test")
 	rUserName := acctest.RandomWithPrefix(t, "es-master-user")
-	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 	resourceName := "aws_elasticsearch_domain_saml_options.main"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/fsx/backup_test.go
+++ b/internal/service/fsx/backup_test.go
@@ -116,7 +116,7 @@ func TestAccFSxBackup_windowsBasic(t *testing.T) {
 	var backup awstypes.Backup
 	resourceName := "aws_fsx_backup.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },

--- a/internal/service/fsx/windows_file_system_data_source_test.go
+++ b/internal/service/fsx/windows_file_system_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccFSxWindowsFileSystemDataSource_basic(t *testing.T) {
 	resourceName := "aws_fsx_windows_file_system.test"
 	datasourceName := "data.aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/fsx/windows_file_system_test.go
+++ b/internal/service/fsx/windows_file_system_test.go
@@ -24,7 +24,7 @@ func TestAccFSxWindowsFileSystem_basic(t *testing.T) {
 	var filesystem awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -83,7 +83,7 @@ func TestAccFSxWindowsFileSystem_disappears(t *testing.T) {
 	var filesystem awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -108,7 +108,7 @@ func TestAccFSxWindowsFileSystem_singleAz2(t *testing.T) {
 	var filesystem awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -160,7 +160,7 @@ func TestAccFSxWindowsFileSystem_storageTypeHdd(t *testing.T) {
 	var filesystem awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -195,7 +195,7 @@ func TestAccFSxWindowsFileSystem_multiAz(t *testing.T) {
 	var filesystem awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -246,7 +246,7 @@ func TestAccFSxWindowsFileSystem_aliases(t *testing.T) {
 	var filesystem1, filesystem2, filesystem3 awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -300,7 +300,7 @@ func TestAccFSxWindowsFileSystem_automaticBackupRetentionDays(t *testing.T) {
 	var filesystem1, filesystem2, filesystem3 awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -350,7 +350,7 @@ func TestAccFSxWindowsFileSystem_copyTagsToBackups(t *testing.T) {
 	var filesystem1, filesystem2 awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -392,7 +392,7 @@ func TestAccFSxWindowsFileSystem_dailyAutomaticBackupStartTime(t *testing.T) {
 	var filesystem1, filesystem2 awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -434,7 +434,7 @@ func TestAccFSxWindowsFileSystem_deleteConfig(t *testing.T) {
 	var filesystem awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.SkipIfEnvVarNotSet(t, "AWS_FSX_CREATE_FINAL_BACKUP")
 
@@ -475,7 +475,7 @@ func TestAccFSxWindowsFileSystem_kmsKeyID(t *testing.T) {
 	kmsKeyResourceName2 := "aws_kms_key.test2"
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -517,7 +517,7 @@ func TestAccFSxWindowsFileSystem_securityGroupIDs(t *testing.T) {
 	var filesystem1, filesystem2 awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -559,7 +559,7 @@ func TestAccFSxWindowsFileSystem_selfManagedActiveDirectory(t *testing.T) {
 	var filesystem awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -594,7 +594,7 @@ func TestAccFSxWindowsFileSystem_SelfManagedActiveDirectory_passwordWO(t *testin
 	var filesystem awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -630,7 +630,7 @@ func TestAccFSxWindowsFileSystem_storageCapacity(t *testing.T) {
 	var filesystem1, filesystem2 awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -674,7 +674,7 @@ func TestAccFSxWindowsFileSystem_fromBackup(t *testing.T) {
 	var filesystem awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -709,7 +709,7 @@ func TestAccFSxWindowsFileSystem_tags(t *testing.T) {
 	var filesystem1, filesystem2, filesystem3 awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -763,7 +763,7 @@ func TestAccFSxWindowsFileSystem_throughputCapacity(t *testing.T) {
 	var filesystem1, filesystem2 awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -805,7 +805,7 @@ func TestAccFSxWindowsFileSystem_weeklyMaintenanceStartTime(t *testing.T) {
 	var filesystem1, filesystem2 awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -847,7 +847,7 @@ func TestAccFSxWindowsFileSystem_audit(t *testing.T) {
 	var filesystem awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -903,7 +903,7 @@ func TestAccFSxWindowsFileSystem_diskIops(t *testing.T) {
 	var filesystem1, filesystem2 awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
@@ -1585,7 +1585,7 @@ func TestAccFSxWindowsFileSystem_selfManagedActiveDirectoryWithSecret(t *testing
 	var filesystem awstypes.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },

--- a/internal/service/glue/connection_data_source_test.go
+++ b/internal/service/glue/connection_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccGlueConnectionDataSource_basic(t *testing.T) {
 	datasourceName := "data.aws_glue_connection.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	jdbcConnectionUrl := fmt.Sprintf("jdbc:mysql://%s/testdatabase", acctest.RandomDomainName())
+	jdbcConnectionUrl := fmt.Sprintf("jdbc:mysql://%s/testdatabase", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/glue/connection_test.go
+++ b/internal/service/glue/connection_test.go
@@ -25,7 +25,7 @@ func TestAccGlueConnection_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_glue_connection.test"
 
-	jdbcConnectionUrl := fmt.Sprintf("jdbc:mysql://%s/testdatabase", acctest.RandomDomainName())
+	jdbcConnectionUrl := fmt.Sprintf("jdbc:mysql://%s/testdatabase", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -63,7 +63,7 @@ func TestAccGlueConnection_tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_glue_connection.test"
 
-	jdbcConnectionUrl := fmt.Sprintf("jdbc:mysql://%s/testdatabase", acctest.RandomDomainName())
+	jdbcConnectionUrl := fmt.Sprintf("jdbc:mysql://%s/testdatabase", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -110,7 +110,7 @@ func TestAccGlueConnection_mongoDB(t *testing.T) {
 	var connection awstypes.Connection
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_glue_connection.test"
-	connectionURL := "mongodb://" + net.JoinHostPort(acctest.RandomDomainName(), "27017") + "/testdatabase"
+	connectionURL := "mongodb://" + net.JoinHostPort(acctest.RandomDomainName(t), "27017") + "/testdatabase"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -147,7 +147,7 @@ func TestAccGlueConnection_kafka(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_glue_connection.test"
 
-	bootstrapServers := fmt.Sprintf("%s:9094,%s:9094", acctest.RandomDomainName(), acctest.RandomDomainName())
+	bootstrapServers := fmt.Sprintf("%s:9094,%s:9094", acctest.RandomDomainName(t), acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -217,7 +217,7 @@ func TestAccGlueConnection_description(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_glue_connection.test"
 
-	jdbcConnectionUrl := fmt.Sprintf("jdbc:mysql://%s/testdatabase", acctest.RandomDomainName())
+	jdbcConnectionUrl := fmt.Sprintf("jdbc:mysql://%s/testdatabase", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -255,7 +255,7 @@ func TestAccGlueConnection_matchCriteria(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_glue_connection.test"
 
-	jdbcConnectionUrl := fmt.Sprintf("jdbc:mysql://%s/testdatabase", acctest.RandomDomainName())
+	jdbcConnectionUrl := fmt.Sprintf("jdbc:mysql://%s/testdatabase", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -346,7 +346,7 @@ func TestAccGlueConnection_disappears(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_glue_connection.test"
 
-	jdbcConnectionUrl := fmt.Sprintf("jdbc:mysql://%s/testdatabase", acctest.RandomDomainName())
+	jdbcConnectionUrl := fmt.Sprintf("jdbc:mysql://%s/testdatabase", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/glue/crawler_test.go
+++ b/internal/service/glue/crawler_test.go
@@ -188,7 +188,7 @@ func TestAccGlueCrawler_jdbcTarget(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_glue_crawler.test"
 
-	jdbcConnectionUrl := fmt.Sprintf("jdbc:mysql://%s/testdatabase", acctest.RandomDomainName())
+	jdbcConnectionUrl := fmt.Sprintf("jdbc:mysql://%s/testdatabase", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -289,7 +289,7 @@ func TestAccGlueCrawler_JDBCTarget_exclusions(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_glue_crawler.test"
 
-	jdbcConnectionUrl := fmt.Sprintf("jdbc:mysql://%s/testdatabase", acctest.RandomDomainName())
+	jdbcConnectionUrl := fmt.Sprintf("jdbc:mysql://%s/testdatabase", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -332,7 +332,7 @@ func TestAccGlueCrawler_JDBCTarget_multiple(t *testing.T) {
 	var crawler awstypes.Crawler
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_glue_crawler.test"
-	jdbcConnectionUrl := fmt.Sprintf("jdbc:mysql://%s/testdatabase", acctest.RandomDomainName())
+	jdbcConnectionUrl := fmt.Sprintf("jdbc:mysql://%s/testdatabase", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -393,7 +393,7 @@ func TestAccGlueCrawler_mongoDBTarget(t *testing.T) {
 	var crawler awstypes.Crawler
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_glue_crawler.test"
-	connectionURL := "mongodb://" + net.JoinHostPort(acctest.RandomDomainName(), "27017") + "/testdatabase"
+	connectionURL := "mongodb://" + net.JoinHostPort(acctest.RandomDomainName(t), "27017") + "/testdatabase"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -435,7 +435,7 @@ func TestAccGlueCrawler_MongoDBTargetScan_all(t *testing.T) {
 	var crawler awstypes.Crawler
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_glue_crawler.test"
-	connectionURL := "mongodb://" + net.JoinHostPort(acctest.RandomDomainName(), "27017") + "/testdatabase"
+	connectionURL := "mongodb://" + net.JoinHostPort(acctest.RandomDomainName(t), "27017") + "/testdatabase"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -487,7 +487,7 @@ func TestAccGlueCrawler_MongoDBTarget_multiple(t *testing.T) {
 	var crawler awstypes.Crawler
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_glue_crawler.test"
-	connectionURL := "mongodb://" + net.JoinHostPort(acctest.RandomDomainName(), "27017") + "/testdatabase"
+	connectionURL := "mongodb://" + net.JoinHostPort(acctest.RandomDomainName(t), "27017") + "/testdatabase"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -545,7 +545,7 @@ func TestAccGlueCrawler_deltaTarget(t *testing.T) {
 	var crawler awstypes.Crawler
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_glue_crawler.test"
-	connectionURL := "mongodb://" + net.JoinHostPort(acctest.RandomDomainName(), "27017") + "/testdatabase"
+	connectionURL := "mongodb://" + net.JoinHostPort(acctest.RandomDomainName(t), "27017") + "/testdatabase"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -591,7 +591,7 @@ func TestAccGlueCrawler_hudiTarget(t *testing.T) {
 	var crawler awstypes.Crawler
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_glue_crawler.test"
-	connectionURL := "mongodb://" + net.JoinHostPort(acctest.RandomDomainName(), "27017") + "/testdatabase"
+	connectionURL := "mongodb://" + net.JoinHostPort(acctest.RandomDomainName(t), "27017") + "/testdatabase"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -635,7 +635,7 @@ func TestAccGlueCrawler_icebergTarget(t *testing.T) {
 	var crawler awstypes.Crawler
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_glue_crawler.test"
-	connectionURL := "mongodb://" + net.JoinHostPort(acctest.RandomDomainName(), "27017") + "/testdatabase"
+	connectionURL := "mongodb://" + net.JoinHostPort(acctest.RandomDomainName(t), "27017") + "/testdatabase"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/iam/saml_provider_data_source_test.go
+++ b/internal/service/iam/saml_provider_data_source_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccIAMSAMLProviderDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	idpEntityID := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityID := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 	dataSourceName := "data.aws_iam_saml_provider.test"
 	resourceName := "aws_iam_saml_provider.test"
 

--- a/internal/service/iam/saml_provider_test.go
+++ b/internal/service/iam/saml_provider_test.go
@@ -19,8 +19,8 @@ import (
 func TestAccIAMSAMLProvider_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
-	idpEntityIdModified := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
+	idpEntityIdModified := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 	resourceName := "aws_iam_saml_provider.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -62,7 +62,7 @@ func TestAccIAMSAMLProvider_basic(t *testing.T) {
 func TestAccIAMSAMLProvider_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 	resourceName := "aws_iam_saml_provider.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -108,7 +108,7 @@ func TestAccIAMSAMLProvider_tags(t *testing.T) {
 func TestAccIAMSAMLProvider_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 	resourceName := "aws_iam_saml_provider.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/iam/server_certificate_tags_gen_test.go
+++ b/internal/service/iam/server_certificate_tags_gen_test.go
@@ -27,7 +27,7 @@ func TestAccIAMServerCertificate_tags(t *testing.T) {
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -247,7 +247,7 @@ func TestAccIAMServerCertificate_Tags_null(t *testing.T) {
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -330,7 +330,7 @@ func TestAccIAMServerCertificate_Tags_emptyMap(t *testing.T) {
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -409,7 +409,7 @@ func TestAccIAMServerCertificate_Tags_addOnUpdate(t *testing.T) {
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -506,7 +506,7 @@ func TestAccIAMServerCertificate_Tags_EmptyTag_onCreate(t *testing.T) {
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -617,7 +617,7 @@ func TestAccIAMServerCertificate_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -778,7 +778,7 @@ func TestAccIAMServerCertificate_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -883,7 +883,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_providerOnly(t *testing.T) {
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1102,7 +1102,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1292,7 +1292,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_overlapping(t *testing.T) {
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1498,7 +1498,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_updateToProviderOnly(t *testin
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1604,7 +1604,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_updateToResourceOnly(t *testin
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1709,7 +1709,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_emptyResourceTag(t *testing.T)
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1788,7 +1788,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_emptyProviderOnlyTag(t *testin
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1859,7 +1859,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_nullOverlappingResourceTag(t *
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1935,7 +1935,7 @@ func TestAccIAMServerCertificate_Tags_DefaultTags_nullNonOverlappingResourceTag(
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -2011,7 +2011,7 @@ func TestAccIAMServerCertificate_Tags_ComputedTag_onCreate(t *testing.T) {
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -2080,7 +2080,7 @@ func TestAccIAMServerCertificate_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -2193,7 +2193,7 @@ func TestAccIAMServerCertificate_Tags_ComputedTag_OnUpdate_replace(t *testing.T)
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -2296,7 +2296,7 @@ func TestAccIAMServerCertificate_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -2470,7 +2470,7 @@ func TestAccIAMServerCertificate_Tags_IgnoreTags_Overlap_resourceTag(t *testing.
 	resourceName := "aws_iam_server_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{

--- a/internal/service/identitystore/user_data_source_test.go
+++ b/internal/service/identitystore/user_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccIdentityStoreUserDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_identitystore_user.test"
 	resourceName := "aws_identitystore_user.test"
 	name := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	email := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	email := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -59,7 +59,7 @@ func TestAccIdentityStoreUserDataSource_uniqueAttributeUserName(t *testing.T) {
 	dataSourceName := "data.aws_identitystore_user.test"
 	resourceName := "aws_identitystore_user.test"
 	name := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	email := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	email := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -85,7 +85,7 @@ func TestAccIdentityStoreUserDataSource_email(t *testing.T) {
 	dataSourceName := "data.aws_identitystore_user.test"
 	resourceName := "aws_identitystore_user.test"
 	name := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	email := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	email := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -111,7 +111,7 @@ func TestAccIdentityStoreUserDataSource_userID(t *testing.T) {
 	dataSourceName := "data.aws_identitystore_user.test"
 	resourceName := "aws_identitystore_user.test"
 	name := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	email := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	email := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/identitystore/user_test.go
+++ b/internal/service/identitystore/user_test.go
@@ -196,8 +196,8 @@ func TestAccIdentityStoreUser_Emails(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_identitystore_user.test"
 
-	email1 := acctest.RandomEmailAddress(acctest.RandomDomainName())
-	email2 := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	email1 := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
+	email2 := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/identitystore/users_data_source_test.go
+++ b/internal/service/identitystore/users_data_source_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccIdentityStoreUsersDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rEmail := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	rEmail := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_identitystore_users.test"
 	userResourceName := "aws_identitystore_user.test"

--- a/internal/service/kafka/cluster_test.go
+++ b/internal/service/kafka/cluster_test.go
@@ -768,7 +768,7 @@ func TestAccKafkaCluster_ClientAuthenticationTLS_certificateAuthorityARNs(t *tes
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_msk_cluster.test"
 	acmCAResourceName := "aws_acmpca_certificate_authority.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
@@ -829,7 +829,7 @@ func TestAccKafkaCluster_ClientAuthenticationTLS_initiallyNoAuthentication(t *te
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_msk_cluster.test"
 	acmCAResourceName := "aws_acmpca_certificate_authority.test"
-	commonName := acctest.RandomDomainName()
+	commonName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },

--- a/internal/service/lightsail/certificate_test.go
+++ b/internal/service/lightsail/certificate_test.go
@@ -27,7 +27,7 @@ func TestAccLightsailCertificate_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_lightsail_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName())
+	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -62,8 +62,8 @@ func TestAccLightsailCertificate_subjectAlternativeNames(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_lightsail_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName())
-	subjectAlternativeName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName())
+	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName(t))
+	subjectAlternativeName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -129,7 +129,7 @@ func TestAccLightsailCertificate_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_lightsail_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName())
+	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -179,7 +179,7 @@ func TestAccLightsailCertificate_keyOnlyTags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_lightsail_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName())
+	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -229,7 +229,7 @@ func TestAccLightsailCertificate_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_lightsail_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName())
+	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName(t))
 
 	testDestroy := func(*terraform.State) error {
 		// reach out and DELETE the Certificate

--- a/internal/service/lightsail/domain_entry_test.go
+++ b/internal/service/lightsail/domain_entry_test.go
@@ -25,7 +25,7 @@ import (
 func testAccDomainEntry_basic(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_lightsail_domain_entry.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	domainEntryName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -69,7 +69,7 @@ func testAccDomainEntry_basic(t *testing.T, semaphore tfsync.Semaphore) {
 func testAccDomainEntry_underscore(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_lightsail_domain_entry.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	domainEntryName := "_" + acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -113,7 +113,7 @@ func testAccDomainEntry_underscore(t *testing.T, semaphore tfsync.Semaphore) {
 func testAccDomainEntry_apex(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_lightsail_domain_entry.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	domainEntryName := ""
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -157,7 +157,7 @@ func testAccDomainEntry_apex(t *testing.T, semaphore tfsync.Semaphore) {
 func testAccDomainEntry_disappears(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_lightsail_domain_entry.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	domainEntryName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -185,7 +185,7 @@ func testAccDomainEntry_disappears(t *testing.T, semaphore tfsync.Semaphore) {
 func testAccDomainEntry_typeAAAA(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_lightsail_domain_entry.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	domainEntryName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/lightsail/lb_certificate_attachment_test.go
+++ b/internal/service/lightsail/lb_certificate_attachment_test.go
@@ -18,7 +18,7 @@ func testAccLoadBalancerCertificateAttachment_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	lbName := acctest.RandomWithPrefix(t, "tf-acc-test")
 	cName := acctest.RandomWithPrefix(t, "tf-acc-test")
-	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName())
+	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName(t))
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/lightsail/lb_certificate_test.go
+++ b/internal/service/lightsail/lb_certificate_test.go
@@ -26,7 +26,7 @@ func testAccLoadBalancerCertificate_basic(t *testing.T) {
 	resourceName := "aws_lightsail_lb_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	lbName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName())
+	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName(t))
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -62,8 +62,8 @@ func testAccLoadBalancerCertificate_subjectAlternativeNames(t *testing.T) {
 	resourceName := "aws_lightsail_lb_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	lbName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName())
-	subjectAlternativeName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName())
+	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName(t))
+	subjectAlternativeName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName(t))
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -131,7 +131,7 @@ func testAccLoadBalancerCertificate_disappears(t *testing.T) {
 	resourceName := "aws_lightsail_lb_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	lbName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName())
+	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName(t))
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/networkfirewall/tls_inspection_configuration_identity_gen_test.go
+++ b/internal/service/networkfirewall/tls_inspection_configuration_identity_gen_test.go
@@ -28,8 +28,8 @@ func TestAccNetworkFirewallTLSInspectionConfiguration_Identity_basic(t *testing.
 	var v networkfirewall.DescribeTLSInspectionConfigurationOutput
 	resourceName := "aws_networkfirewall_tls_inspection_configuration.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	common_name := acctest.RandomDomain()
-	certificate_domain := common_name.RandomSubdomain()
+	common_name := acctest.RandomDomain(t)
+	certificate_domain := common_name.RandomSubdomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -127,8 +127,8 @@ func TestAccNetworkFirewallTLSInspectionConfiguration_Identity_regionOverride(t 
 
 	resourceName := "aws_networkfirewall_tls_inspection_configuration.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	common_name := acctest.RandomDomain()
-	certificate_domain := common_name.RandomSubdomain()
+	common_name := acctest.RandomDomain(t)
+	certificate_domain := common_name.RandomSubdomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -269,8 +269,8 @@ func TestAccNetworkFirewallTLSInspectionConfiguration_Identity_ExistingResource_
 	var v networkfirewall.DescribeTLSInspectionConfigurationOutput
 	resourceName := "aws_networkfirewall_tls_inspection_configuration.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	common_name := acctest.RandomDomain()
-	certificate_domain := common_name.RandomSubdomain()
+	common_name := acctest.RandomDomain(t)
+	certificate_domain := common_name.RandomSubdomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -357,8 +357,8 @@ func TestAccNetworkFirewallTLSInspectionConfiguration_Identity_ExistingResource_
 	var v networkfirewall.DescribeTLSInspectionConfigurationOutput
 	resourceName := "aws_networkfirewall_tls_inspection_configuration.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	common_name := acctest.RandomDomain()
-	certificate_domain := common_name.RandomSubdomain()
+	common_name := acctest.RandomDomain(t)
+	certificate_domain := common_name.RandomSubdomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{

--- a/internal/service/networkfirewall/tls_inspection_configuration_test.go
+++ b/internal/service/networkfirewall/tls_inspection_configuration_test.go
@@ -22,8 +22,8 @@ func TestAccNetworkFirewallTLSInspectionConfiguration_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v networkfirewall.DescribeTLSInspectionConfigurationOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	commonName := acctest.RandomDomain()
-	certificateDomainName := commonName.RandomSubdomain().String()
+	commonName := acctest.RandomDomain(t)
+	certificateDomainName := commonName.RandomSubdomain(t).String()
 	resourceName := "aws_networkfirewall_tls_inspection_configuration.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -78,8 +78,8 @@ func TestAccNetworkFirewallTLSInspectionConfiguration_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v networkfirewall.DescribeTLSInspectionConfigurationOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	commonName := acctest.RandomDomain()
-	certificateDomainName := commonName.RandomSubdomain().String()
+	commonName := acctest.RandomDomain(t)
+	certificateDomainName := commonName.RandomSubdomain(t).String()
 	resourceName := "aws_networkfirewall_tls_inspection_configuration.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -104,8 +104,8 @@ func TestAccNetworkFirewallTLSInspectionConfiguration_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v networkfirewall.DescribeTLSInspectionConfigurationOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	commonName := acctest.RandomDomain()
-	certificateDomainName := commonName.RandomSubdomain().String()
+	commonName := acctest.RandomDomain(t)
+	certificateDomainName := commonName.RandomSubdomain(t).String()
 	resourceName := "aws_networkfirewall_tls_inspection_configuration.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -153,8 +153,8 @@ func TestAccNetworkFirewallTLSInspectionConfiguration_encryptionConfiguration(t 
 	ctx := acctest.Context(t)
 	var v networkfirewall.DescribeTLSInspectionConfigurationOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	commonName := acctest.RandomDomain()
-	certificateDomainName := commonName.RandomSubdomain().String()
+	commonName := acctest.RandomDomain(t)
+	certificateDomainName := commonName.RandomSubdomain(t).String()
 	resourceName := "aws_networkfirewall_tls_inspection_configuration.test"
 	kmsKeyResourceName := "aws_kms_key.test"
 
@@ -215,8 +215,8 @@ func TestAccNetworkFirewallTLSInspectionConfiguration_checkCertificateRevocation
 	ctx := acctest.Context(t)
 	var v networkfirewall.DescribeTLSInspectionConfigurationOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	commonName := acctest.RandomDomain()
-	certificateDomainName := commonName.RandomSubdomain().String()
+	commonName := acctest.RandomDomain(t)
+	certificateDomainName := commonName.RandomSubdomain(t).String()
 	resourceName := "aws_networkfirewall_tls_inspection_configuration.test"
 	testExternalProviders := map[string]resource.ExternalProvider{
 		"tls": {

--- a/internal/service/notifications/channel_association_test.go
+++ b/internal/service/notifications/channel_association_test.go
@@ -22,7 +22,7 @@ import (
 func TestAccNotificationsChannelAssociation_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	rEmailAddress := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	rEmailAddress := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 	resourceName := "aws_notifications_channel_association.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -55,7 +55,7 @@ func TestAccNotificationsChannelAssociation_basic(t *testing.T) {
 func TestAccNotificationsChannelAssociation_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	rEmailAddress := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	rEmailAddress := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 	resourceName := "aws_notifications_channel_association.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/notifications/managed_notification_additional_channel_association_test.go
+++ b/internal/service/notifications/managed_notification_additional_channel_association_test.go
@@ -21,7 +21,7 @@ import (
 func TestAccNotificationsManagedNotificationAdditionalChannelAssociation_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	rEmailAddress := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	rEmailAddress := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 	resourceName := "aws_notifications_managed_notification_additional_channel_association.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -54,7 +54,7 @@ func TestAccNotificationsManagedNotificationAdditionalChannelAssociation_basic(t
 func TestAccNotificationsManagedNotificationAdditionalChannelAssociation_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	rEmailAddress := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	rEmailAddress := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 	resourceName := "aws_notifications_managed_notification_additional_channel_association.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/notificationscontacts/email_contact_test.go
+++ b/internal/service/notificationscontacts/email_contact_test.go
@@ -28,7 +28,7 @@ func TestAccNotificationsContactsEmailContact_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var emailcontact awstypes.EmailContact
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	rEmailAddress := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	rEmailAddress := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 	resourceName := "aws_notificationscontacts_email_contact.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -73,7 +73,7 @@ func TestAccNotificationsContactsEmailContact_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var emailcontact awstypes.EmailContact
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	rEmailAddress := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	rEmailAddress := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 	resourceName := "aws_notificationscontacts_email_contact.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -107,7 +107,7 @@ func TestAccNotificationsContactsEmailContact_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.EmailContact
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	rEmailAddress := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	rEmailAddress := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 	resourceName := "aws_notificationscontacts_email_contact.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/odb/cloud_autonomous_vm_cluster_data_source_test.go
+++ b/internal/service/odb/cloud_autonomous_vm_cluster_data_source_test.go
@@ -52,7 +52,7 @@ func TestAccODBCloudAutonomousVmClusterDataSource_basic(t *testing.T) {
 		CheckDestroy:             autonomousVMClusterDSTestEntity.testAccCheckCloudAutonomousVmClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: autonomousVMClusterDSTestEntity.avmcBasic(),
+				Config: autonomousVMClusterDSTestEntity.avmcBasic(t),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(avmcResource, names.AttrID, avmcDataSource, names.AttrID),
 				),
@@ -96,11 +96,11 @@ func (autonomousVMClusterDSTest) testAccPreCheck(ctx context.Context, t *testing
 	}
 }
 
-func (autonomousVMClusterDSTest) avmcBasic() string {
+func (autonomousVMClusterDSTest) avmcBasic(t *testing.T) string {
 	exaInfraDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.exaInfraDisplayNamePrefix)
 	odbNetworkDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.odbNetDisplayNamePrefix)
 	avmcDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.autonomousVmClusterDisplayNamePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	emailAddress := acctest.RandomEmailAddress(domain)
 	exaInfraRes := autonomousVMClusterDSTestEntity.exaInfra(exaInfraDisplayName, emailAddress)
 	odbNetRes := autonomousVMClusterDSTestEntity.oracleDBNetwork(odbNetworkDisplayName)

--- a/internal/service/odb/cloud_autonomous_vm_cluster_test.go
+++ b/internal/service/odb/cloud_autonomous_vm_cluster_test.go
@@ -62,7 +62,7 @@ func TestAccODBCloudAutonomousVmCluster_basic(t *testing.T) {
 		CheckDestroy:             autonomousVMClusterResourceTestEntity.testAccCheckCloudAutonomousVmClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: autonomousVMClusterResourceTestEntity.avmcBasic(),
+				Config: autonomousVMClusterResourceTestEntity.avmcBasic(t),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					autonomousVMClusterResourceTestEntity.checkCloudAutonomousVmClusterExists(ctx, resourceName, &cloudAVMC),
 				),
@@ -115,7 +115,7 @@ func TestAccODBCloudAutonomousVmCluster_usingARN(t *testing.T) {
 	var avmc1, avmc2 odbtypes.CloudAutonomousVmCluster
 	resourceName := "aws_odb_cloud_autonomous_vm_cluster.test"
 
-	avmcWithoutTag, avmcWithTag := autonomousVMClusterResourceTestEntity.autonomousVmClusterByARN()
+	avmcWithoutTag, avmcWithTag := autonomousVMClusterResourceTestEntity.autonomousVmClusterByARN(t)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
@@ -178,7 +178,7 @@ func TestAccODBCloudAutonomousVmCluster_withAllParams(t *testing.T) {
 		CheckDestroy:             autonomousVMClusterResourceTestEntity.testAccCheckCloudAutonomousVmClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: autonomousVMClusterResourceTestEntity.avmcAllParamsConfig(),
+				Config: autonomousVMClusterResourceTestEntity.avmcAllParamsConfig(t),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					autonomousVMClusterResourceTestEntity.checkCloudAutonomousVmClusterExists(ctx, resourceName, &cloudAVMC),
 				),
@@ -200,7 +200,7 @@ func TestAccODBCloudAutonomousVmCluster_tagging(t *testing.T) {
 
 	var avmc1, avmc2 odbtypes.CloudAutonomousVmCluster
 	resourceName := "aws_odb_cloud_autonomous_vm_cluster.test"
-	withoutTag, withTag := autonomousVMClusterResourceTestEntity.avmcNoTagWithTag()
+	withoutTag, withTag := autonomousVMClusterResourceTestEntity.avmcNoTagWithTag(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
@@ -260,7 +260,7 @@ func TestAccODBCloudAutonomousVmCluster_disappears(t *testing.T) {
 		CheckDestroy:             autonomousVMClusterResourceTestEntity.testAccCheckCloudAutonomousVmClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: autonomousVMClusterResourceTestEntity.avmcBasic(),
+				Config: autonomousVMClusterResourceTestEntity.avmcBasic(t),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					autonomousVMClusterResourceTestEntity.checkCloudAutonomousVmClusterExists(ctx, resourceName, &cloudautonomousvmcluster),
 					acctest.CheckFrameworkResourceDisappears(ctx, t, tfodb.ResourceCloudAutonomousVMCluster, resourceName),
@@ -351,11 +351,11 @@ func (autonomousVMClusterResourceTest) findAVMC(ctx context.Context, conn *odb.C
 	return out.CloudAutonomousVmCluster, nil
 }
 
-func (autonomousVMClusterResourceTest) avmcBasic() string {
+func (autonomousVMClusterResourceTest) avmcBasic(t *testing.T) string {
 	exaInfraDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.exaInfraDisplayNamePrefix)
 	odbNetworkDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.odbNetDisplayNamePrefix)
 	avmcDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.autonomousVmClusterDisplayNamePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	emailAddress := acctest.RandomEmailAddress(domain)
 	exaInfraRes := autonomousVMClusterResourceTestEntity.exaInfra(exaInfraDisplayName, emailAddress)
 	odbNetRes := autonomousVMClusterResourceTestEntity.oracleDBNetwork(odbNetworkDisplayName)
@@ -394,11 +394,11 @@ resource "aws_odb_cloud_autonomous_vm_cluster" "test" {
 	return res
 }
 
-func (autonomousVMClusterResourceTest) avmcNoTagWithTag() (string, string) {
+func (autonomousVMClusterResourceTest) avmcNoTagWithTag(t *testing.T) (string, string) {
 	exaInfraDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.exaInfraDisplayNamePrefix)
 	odbNetworkDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.odbNetDisplayNamePrefix)
 	avmcDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.autonomousVmClusterDisplayNamePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	emailAddress := acctest.RandomEmailAddress(domain)
 	exaInfraRes := autonomousVMClusterResourceTestEntity.exaInfra(exaInfraDisplayName, emailAddress)
 	odbNetRes := autonomousVMClusterResourceTestEntity.oracleDBNetwork(odbNetworkDisplayName)
@@ -471,11 +471,11 @@ resource "aws_odb_cloud_autonomous_vm_cluster" "test" {
 	return noTag, withTag
 }
 
-func (autonomousVMClusterResourceTest) avmcAllParamsConfig() string {
+func (autonomousVMClusterResourceTest) avmcAllParamsConfig(t *testing.T) string {
 	exaInfraDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.exaInfraDisplayNamePrefix)
 	odbNetworkDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.odbNetDisplayNamePrefix)
 	avmcDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.autonomousVmClusterDisplayNamePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	emailAddress := acctest.RandomEmailAddress(domain)
 	exaInfraRes := autonomousVMClusterResourceTestEntity.exaInfra(exaInfraDisplayName, emailAddress)
 	odbNetRes := autonomousVMClusterResourceTestEntity.oracleDBNetwork(odbNetworkDisplayName)
@@ -599,11 +599,11 @@ resource "aws_odb_cloud_autonomous_vm_cluster" "test" {
 `, rName)
 }
 
-func (autonomousVMClusterResourceTest) autonomousVmClusterByARN() (string, string) {
+func (autonomousVMClusterResourceTest) autonomousVmClusterByARN(t *testing.T) (string, string) {
 	exaInfraDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.exaInfraDisplayNamePrefix)
 	odbNetworkDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.odbNetDisplayNamePrefix)
 	avmcDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.autonomousVmClusterDisplayNamePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	emailAddress := acctest.RandomEmailAddress(domain)
 	exaInfraRes := autonomousVMClusterResourceTestEntity.exaInfra(exaInfraDisplayName, emailAddress)
 	odbNetRes := autonomousVMClusterResourceTestEntity.oracleDBNetwork(odbNetworkDisplayName)

--- a/internal/service/odb/cloud_exadata_infrastructure_data_source_test.go
+++ b/internal/service/odb/cloud_exadata_infrastructure_data_source_test.go
@@ -37,7 +37,7 @@ func TestAccODBCloudExadataInfrastructureDataSource_basic(t *testing.T) {
 	exaInfraResource := "aws_odb_cloud_exadata_infrastructure.test"
 	exaInfraDataSource := "data.aws_odb_cloud_exadata_infrastructure.test"
 	displayNameSuffix := sdkacctest.RandomWithPrefix(exaInfraDataSourceTestEntity.displayNamePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	emailAddress1 := acctest.RandomEmailAddress(domain)
 	emailAddress2 := acctest.RandomEmailAddress(domain)
 

--- a/internal/service/odb/cloud_exadata_infrastructure_test.go
+++ b/internal/service/odb/cloud_exadata_infrastructure_test.go
@@ -76,7 +76,7 @@ func TestAccODBCloudExadataInfrastructureResource_withAllParameters(t *testing.T
 	var cloudExaDataInfrastructure odbtypes.CloudExadataInfrastructure
 	resourceName := "aws_odb_cloud_exadata_infrastructure.test"
 	rName := sdkacctest.RandomWithPrefix(exaInfraTestResource.displayNamePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	emailAddress1 := acctest.RandomEmailAddress(domain)
 	emailAddress2 := acctest.RandomEmailAddress(domain)
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/opensearch/domain_saml_options_test.go
+++ b/internal/service/opensearch/domain_saml_options_test.go
@@ -23,7 +23,7 @@ func TestAccOpenSearchDomainSAMLOptions_basic(t *testing.T) {
 
 	rName := acctest.RandomWithPrefix(t, "acc-test")
 	rUserName := acctest.RandomWithPrefix(t, "opensearch-master-user")
-	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 
 	resourceName := "aws_opensearch_domain_saml_options.test"
 	esDomainResourceName := "aws_opensearch_domain.test"
@@ -58,7 +58,7 @@ func TestAccOpenSearchDomainSAMLOptions_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, "acc-test")
 	rUserName := acctest.RandomWithPrefix(t, "opensearch-master-user")
-	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 
 	resourceName := "aws_opensearch_domain_saml_options.test"
 	esDomainResourceName := "aws_opensearch_domain.test"
@@ -84,7 +84,7 @@ func TestAccOpenSearchDomainSAMLOptions_disappears_Domain(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, "acc-test")
 	rUserName := acctest.RandomWithPrefix(t, "opensearch-master-user")
-	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 
 	resourceName := "aws_opensearch_domain_saml_options.test"
 	esDomainResourceName := "aws_opensearch_domain.test"
@@ -111,7 +111,7 @@ func TestAccOpenSearchDomainSAMLOptions_Update(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, "acc-test")
 	rUserName := acctest.RandomWithPrefix(t, "opensearch-master-user")
-	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 
 	resourceName := "aws_opensearch_domain_saml_options.test"
 	esDomainResourceName := "aws_opensearch_domain.test"
@@ -146,7 +146,7 @@ func TestAccOpenSearchDomainSAMLOptions_Disabled(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, "acc-test")
 	rUserName := acctest.RandomWithPrefix(t, "opensearch-master-user")
-	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName())
+	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
 
 	resourceName := "aws_opensearch_domain_saml_options.test"
 	esDomainResourceName := "aws_opensearch_domain.test"

--- a/internal/service/pinpoint/email_channel_test.go
+++ b/internal/service/pinpoint/email_channel_test.go
@@ -22,7 +22,7 @@ func TestAccPinpointEmailChannel_basic(t *testing.T) {
 	var channel awstypes.EmailChannelResponse
 	resourceName := "aws_pinpoint_email_channel.test"
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	address1 := acctest.RandomEmailAddress(domain)
 	address2 := acctest.RandomEmailAddress(domain)
 
@@ -67,7 +67,7 @@ func TestAccPinpointEmailChannel_set(t *testing.T) {
 	resourceName := "aws_pinpoint_email_channel.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	address := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -98,7 +98,7 @@ func TestAccPinpointEmailChannel_noRole(t *testing.T) {
 	resourceName := "aws_pinpoint_email_channel.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	address := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -129,7 +129,7 @@ func TestAccPinpointEmailChannel_orchestrationSendingRoleARN(t *testing.T) {
 	resourceName := "aws_pinpoint_email_channel.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	address := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -159,7 +159,7 @@ func TestAccPinpointEmailChannel_disappears(t *testing.T) {
 	var channel awstypes.EmailChannelResponse
 	resourceName := "aws_pinpoint_email_channel.test"
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	address := acctest.RandomEmailAddress(domain)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -1136,7 +1136,7 @@ func TestAccRDSCluster_domain(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_rds_cluster.test"
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -3066,7 +3066,7 @@ func TestAccRDSInstance_ReplicateSourceDB_mssqlDomain(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	sourceResourceName := "aws_db_instance.source"
 	resourceName := "aws_db_instance.test"
-	domain := acctest.RandomDomain().String()
+	domain := acctest.RandomDomain(t).String()
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -4685,9 +4685,9 @@ func TestAccRDSInstance_MSSQL_domain(t *testing.T) {
 	resourceName := "aws_db_instance.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	domain := acctest.RandomDomain()
-	domain1 := domain.RandomSubdomain().String()
-	domain2 := domain.RandomSubdomain().String()
+	domain := acctest.RandomDomain(t)
+	domain1 := domain.RandomSubdomain(t).String()
+	domain2 := domain.RandomSubdomain(t).String()
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -4732,7 +4732,7 @@ func TestAccRDSInstance_MSSQL_domainSnapshotRestore(t *testing.T) {
 	resourceName := "aws_db_instance.test"
 	originResourceName := "aws_db_instance.origin"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -4768,9 +4768,9 @@ func TestAccRDSInstance_MSSQL_selfManagedDomain(t *testing.T) {
 	var vBefore, vAfter types.DBInstance
 	resourceName := "aws_db_instance.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomain().String()
+	domain := acctest.RandomDomain(t).String()
 	domainOu := fmt.Sprintf("OU=AWS,DC=%s,DC=%s", strings.Split(domain, ".")[0], strings.Split(domain, ".")[1])
-	domain1 := acctest.RandomDomain().String()
+	domain1 := acctest.RandomDomain(t).String()
 	domain1Ou := fmt.Sprintf("OU=AWS,DC=%s,DC=%s", strings.Split(domain1, ".")[0], strings.Split(domain1, ".")[1])
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -4817,7 +4817,7 @@ func TestAccRDSInstance_MSSQL_selfManagedDomainSingleDomainDNSIP(t *testing.T) {
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomain().String()
+	domain := acctest.RandomDomain(t).String()
 	domainOu := fmt.Sprintf("OU=AWS,DC=%s,DC=%s", strings.Split(domain, ".")[0], strings.Split(domain, ".")[1])
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -4857,7 +4857,7 @@ func TestAccRDSInstance_MSSQL_selfManagedDomainSnapshotRestore(t *testing.T) {
 	resourceName := "aws_db_instance.test"
 	originResourceName := "aws_db_instance.origin"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	domainOu := fmt.Sprintf("OU=AWS,DC=%s,DC=%s", strings.Split(domain, ".")[0], strings.Split(domain, ".")[1])
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/rolesanywhere/trust_anchor_test.go
+++ b/internal/service/rolesanywhere/trust_anchor_test.go
@@ -21,7 +21,7 @@ import (
 func TestAccRolesAnywhereTrustAnchor_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	caCommonName := acctest.RandomDomainName()
+	caCommonName := acctest.RandomDomainName(t)
 	resourceName := "aws_rolesanywhere_trust_anchor.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -55,7 +55,7 @@ func TestAccRolesAnywhereTrustAnchor_basic(t *testing.T) {
 func TestAccRolesAnywhereTrustAnchor_notificationSettings(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	caCommonName := acctest.RandomDomainName()
+	caCommonName := acctest.RandomDomainName(t)
 	resourceName := "aws_rolesanywhere_trust_anchor.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -99,7 +99,7 @@ func TestAccRolesAnywhereTrustAnchor_notificationSettings(t *testing.T) {
 func TestAccRolesAnywhereTrustAnchor_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	caCommonName := acctest.RandomDomainName()
+	caCommonName := acctest.RandomDomainName(t)
 	resourceName := "aws_rolesanywhere_trust_anchor.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -145,7 +145,7 @@ func TestAccRolesAnywhereTrustAnchor_tags(t *testing.T) {
 func TestAccRolesAnywhereTrustAnchor_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	caCommonName := acctest.RandomDomainName()
+	caCommonName := acctest.RandomDomainName(t)
 	resourceName := "aws_rolesanywhere_trust_anchor.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/route53/delegation_set_data_source_test.go
+++ b/internal/service/route53/delegation_set_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccRoute53DelegationSetDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_route53_delegation_set.dset"
 	resourceName := "aws_route53_delegation_set.dset"
 
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/route53/delegation_set_test.go
+++ b/internal/service/route53/delegation_set_test.go
@@ -56,7 +56,7 @@ func TestAccRoute53DelegationSet_withZones(t *testing.T) {
 	primaryZoneResourceName := "aws_route53_zone.primary"
 	secondaryZoneResourceName := "aws_route53_zone.secondary"
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	zoneName1 := fmt.Sprintf("primary.%s", domain)
 	zoneName2 := fmt.Sprintf("secondary.%s", domain)
 

--- a/internal/service/route53/hosted_zone_dnssec_test.go
+++ b/internal/service/route53/hosted_zone_dnssec_test.go
@@ -22,7 +22,7 @@ func TestAccRoute53HostedZoneDNSSEC_basic(t *testing.T) {
 	route53ZoneResourceName := "aws_route53_zone.test"
 	resourceName := "aws_route53_hosted_zone_dnssec.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckRegion(t, endpoints.UsEast1RegionID) },
@@ -51,7 +51,7 @@ func TestAccRoute53HostedZoneDNSSEC_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_route53_hosted_zone_dnssec.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckRegion(t, endpoints.UsEast1RegionID) },
@@ -75,7 +75,7 @@ func TestAccRoute53HostedZoneDNSSEC_signingStatus(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_route53_hosted_zone_dnssec.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckRegion(t, endpoints.UsEast1RegionID) },

--- a/internal/service/route53/key_signing_key_test.go
+++ b/internal/service/route53/key_signing_key_test.go
@@ -24,7 +24,7 @@ func TestAccRoute53KeySigningKey_basic(t *testing.T) {
 	route53ZoneResourceName := "aws_route53_zone.test"
 	resourceName := "aws_route53_key_signing_key.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckRegion(t, endpoints.UsEast1RegionID) },
@@ -65,7 +65,7 @@ func TestAccRoute53KeySigningKey_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_route53_key_signing_key.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckRegion(t, endpoints.UsEast1RegionID) },
@@ -89,7 +89,7 @@ func TestAccRoute53KeySigningKey_status(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_route53_key_signing_key.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckRegion(t, endpoints.UsEast1RegionID) },

--- a/internal/service/route53/query_log_test.go
+++ b/internal/service/route53/query_log_test.go
@@ -25,7 +25,7 @@ func TestAccRoute53QueryLog_basic(t *testing.T) {
 	resourceName := "aws_route53_query_log.test"
 	route53ZoneResourceName := "aws_route53_zone.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	var v awstypes.QueryLoggingConfig
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -62,7 +62,7 @@ func TestAccRoute53QueryLog_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_route53_query_log.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	var v awstypes.QueryLoggingConfig
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -88,7 +88,7 @@ func TestAccRoute53QueryLog_Disappears_hostedZone(t *testing.T) {
 	resourceName := "aws_route53_query_log.test"
 	route53ZoneResourceName := "aws_route53_zone.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	var v awstypes.QueryLoggingConfig
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/route53/record_identity_gen_test.go
+++ b/internal/service/route53/record_identity_gen_test.go
@@ -27,8 +27,8 @@ func TestAccRoute53Record_Identity_basic(t *testing.T) {
 
 	var v awstypes.ResourceRecordSet
 	resourceName := "aws_route53_record.test"
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -123,8 +123,8 @@ func TestAccRoute53Record_Identity_ExistingResource_basic(t *testing.T) {
 
 	var v awstypes.ResourceRecordSet
 	resourceName := "aws_route53_record.test"
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -188,8 +188,8 @@ func TestAccRoute53Record_Identity_ExistingResource_noRefreshNoChange(t *testing
 
 	var v awstypes.ResourceRecordSet
 	resourceName := "aws_route53_record.test"
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -35,8 +35,8 @@ func TestAccRoute53Record_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ResourceRecordSet
 	resourceName := "aws_route53_record.test"
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -231,8 +231,8 @@ func TestAccRoute53Record_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ResourceRecordSet
 	resourceName := "aws_route53_record.test"
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -255,7 +255,7 @@ func TestAccRoute53Record_disappears(t *testing.T) {
 func TestAccRoute53Record_Disappears_multipleRecords(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v1, v2, v3, v4, v5 awstypes.ResourceRecordSet
-	zoneName := acctest.RandomDomain()
+	zoneName := acctest.RandomDomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -816,8 +816,8 @@ func TestAccRoute53Record_cidr(t *testing.T) {
 	resourceName := "aws_route53_record.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	locationName := acctest.RandString(t, 16)
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -1735,8 +1735,8 @@ func TestAccRoute53Record_ttl0(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ResourceRecordSet
 	resourceName := "aws_route53_record.test"
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -1780,7 +1780,7 @@ func TestAccRoute53Record_aliasWildcardName(t *testing.T) {
 	var v awstypes.ResourceRecordSet
 	resourceName := "aws_route53_record.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	zoneName := acctest.RandomDomain()
+	zoneName := acctest.RandomDomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -1808,7 +1808,7 @@ func TestAccRoute53Record_escapedSlash(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ResourceRecordSet
 	resourceName := "aws_route53_record.test"
-	zoneName := "0/24." + acctest.RandomDomain()
+	zoneName := "0/24." + acctest.RandomDomain(t)
 	recordName := "0"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -1836,7 +1836,7 @@ func TestAccRoute53Record_escapedSpace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ResourceRecordSet
 	resourceName := "aws_route53_record.test"
-	zoneName := "a\\040b." + acctest.RandomDomain()
+	zoneName := "a\\040b." + acctest.RandomDomain(t)
 	recordName := "0\\040to\\0401"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -1865,7 +1865,7 @@ func TestAccRoute53Record_escapedJustSpace(t *testing.T) {
 	var v awstypes.ResourceRecordSet
 	resourceName := "aws_route53_record.test"
 	// zone name always needs an escape code if any
-	zoneName := "a\\040b." + acctest.RandomDomain()
+	zoneName := "a\\040b." + acctest.RandomDomain(t)
 	// as for record name, r53 API can accept a space as is but will send the escaped version of it back
 	recordName := "0 to 1"
 

--- a/internal/service/route53/records_data_source_test.go
+++ b/internal/service/route53/records_data_source_test.go
@@ -21,8 +21,8 @@ import (
 func TestAccRoute53RecordsDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_route53_records.test"
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -49,8 +49,8 @@ func TestAccRoute53RecordsDataSource_basic(t *testing.T) {
 // https://github.com/hashicorp/terraform-provider-aws/issues/46426.
 func TestAccRoute53RecordsDataSource_wildcardRegexInvalid(t *testing.T) {
 	ctx := acctest.Context(t)
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -68,8 +68,8 @@ func TestAccRoute53RecordsDataSource_wildcardRegexInvalid(t *testing.T) {
 func TestAccRoute53RecordsDataSource_wildcardRegex(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_route53_records.test"
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/route53/records_exclusive_test.go
+++ b/internal/service/route53/records_exclusive_test.go
@@ -34,8 +34,8 @@ func TestAccRoute53RecordsExclusive_basic(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
 	resourceName := "aws_route53_records_exclusive.test"
 	zoneResourceName := "aws_route53_zone.test"
 
@@ -78,8 +78,8 @@ func TestAccRoute53RecordsExclusive_disappears_Zone(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
 	resourceName := "aws_route53_records_exclusive.test"
 	zoneResourceName := "aws_route53_zone.test"
 
@@ -107,7 +107,7 @@ func TestAccRoute53RecordsExclusive_multiple(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	zoneName := acctest.RandomDomain()
+	zoneName := acctest.RandomDomain(t)
 	resourceName := "aws_route53_records_exclusive.test"
 	zoneResourceName := "aws_route53_zone.test"
 
@@ -233,8 +233,8 @@ func TestAccRoute53RecordsExclusive_upsert(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
 	resourceName := "aws_route53_records_exclusive.test"
 	zoneResourceName := "aws_route53_zone.test"
 
@@ -331,8 +331,8 @@ func TestAccRoute53RecordsExclusive_empty(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
 	resourceName := "aws_route53_records_exclusive.test"
 	recordResourceName := "aws_route53_record.test"
 
@@ -380,9 +380,9 @@ func TestAccRoute53RecordsExclusive_outOfBandAddition(t *testing.T) {
 	}
 
 	var zone route53.GetHostedZoneOutput
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
-	recordName2 := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
+	recordName2 := zoneName.RandomSubdomain(t)
 	resourceName := "aws_route53_records_exclusive.test"
 	zoneResourceName := "aws_route53_zone.test"
 
@@ -436,8 +436,8 @@ func TestAccRoute53RecordsExclusive_outOfBandRemoval(t *testing.T) {
 	}
 
 	var zone route53.GetHostedZoneOutput
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
 	resourceName := "aws_route53_records_exclusive.test"
 	zoneResourceName := "aws_route53_zone.test"
 
@@ -495,8 +495,8 @@ func TestAccRoute53RecordsExclusive_outOfBandUpdate(t *testing.T) {
 	}
 
 	var zone route53.GetHostedZoneOutput
-	zoneName := acctest.RandomDomain()
-	recordName := zoneName.RandomSubdomain()
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
 	resourceName := "aws_route53_records_exclusive.test"
 	zoneResourceName := "aws_route53_zone.test"
 

--- a/internal/service/route53/traffic_policy_instance_test.go
+++ b/internal/service/route53/traffic_policy_instance_test.go
@@ -28,7 +28,7 @@ func TestAccRoute53TrafficPolicyInstance_basic(t *testing.T) {
 	var v awstypes.TrafficPolicyInstance
 	resourceName := "aws_route53_traffic_policy_instance.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckTrafficPolicy(t) },
@@ -59,7 +59,7 @@ func TestAccRoute53TrafficPolicyInstance_disappears(t *testing.T) {
 	var v awstypes.TrafficPolicyInstance
 	resourceName := "aws_route53_traffic_policy_instance.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckTrafficPolicy(t) },
@@ -84,7 +84,7 @@ func TestAccRoute53TrafficPolicyInstance_update(t *testing.T) {
 	var v awstypes.TrafficPolicyInstance
 	resourceName := "aws_route53_traffic_policy_instance.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckTrafficPolicy(t) },

--- a/internal/service/route53/zone_association_test.go
+++ b/internal/service/route53/zone_association_test.go
@@ -20,7 +20,7 @@ import (
 func TestAccRoute53ZoneAssociation_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_route53_zone_association.test"
-	domainName := acctest.RandomFQDomainName()
+	domainName := acctest.RandomFQDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -47,7 +47,7 @@ func TestAccRoute53ZoneAssociation_basic(t *testing.T) {
 func TestAccRoute53ZoneAssociation_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_route53_zone_association.test"
-	domainName := acctest.RandomFQDomainName()
+	domainName := acctest.RandomFQDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -72,7 +72,7 @@ func TestAccRoute53ZoneAssociation_disappears_VPC(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_route53_zone_association.test"
 	vpcResourceName := "aws_vpc.bar"
-	domainName := acctest.RandomFQDomainName()
+	domainName := acctest.RandomFQDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -97,7 +97,7 @@ func TestAccRoute53ZoneAssociation_disappears_Zone(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_route53_zone_association.test"
 	route53ZoneResourceName := "aws_route53_zone.foo"
-	domainName := acctest.RandomFQDomainName()
+	domainName := acctest.RandomFQDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -121,7 +121,7 @@ func TestAccRoute53ZoneAssociation_disappears_Zone(t *testing.T) {
 func TestAccRoute53ZoneAssociation_crossAccount(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_route53_zone_association.test"
-	domainName := acctest.RandomFQDomainName()
+	domainName := acctest.RandomFQDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -152,7 +152,7 @@ func TestAccRoute53ZoneAssociation_crossAccount(t *testing.T) {
 func TestAccRoute53ZoneAssociation_crossRegion(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_route53_zone_association.test"
-	domainName := acctest.RandomFQDomainName()
+	domainName := acctest.RandomFQDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -183,7 +183,7 @@ func TestAccRoute53ZoneAssociation_crossRegion(t *testing.T) {
 func TestAccRoute53ZoneAssociation_crossAccountAndRegion(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_route53_zone_association.test"
-	domainName := acctest.RandomFQDomainName()
+	domainName := acctest.RandomFQDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/route53/zone_data_source_test.go
+++ b/internal/service/route53/zone_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccRoute53ZoneDataSource_id(t *testing.T) {
 	resourceName := "aws_route53_zone.test"
 	dataSourceName := "data.aws_route53_zone.test"
 
-	fqdn := acctest.RandomFQDomainName()
+	fqdn := acctest.RandomFQDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -46,7 +46,7 @@ func TestAccRoute53ZoneDataSource_name(t *testing.T) {
 	resourceName := "aws_route53_zone.test"
 	dataSourceName := "data.aws_route53_zone.test"
 
-	fqdn := acctest.RandomFQDomainName()
+	fqdn := acctest.RandomFQDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -81,7 +81,7 @@ func TestAccRoute53ZoneDataSource_name_idEmptyString(t *testing.T) {
 	resourceName := "aws_route53_zone.test"
 	dataSourceName := "data.aws_route53_zone.test"
 
-	fqdn := acctest.RandomFQDomainName()
+	fqdn := acctest.RandomFQDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -109,7 +109,7 @@ func TestAccRoute53ZoneDataSource_tags(t *testing.T) {
 	resourceName := "aws_route53_zone.test"
 	dataSourceName := "data.aws_route53_zone.test"
 
-	fqdn := acctest.RandomFQDomainName()
+	fqdn := acctest.RandomFQDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -137,7 +137,7 @@ func TestAccRoute53ZoneDataSource_tagsOnly(t *testing.T) {
 	resourceName := "aws_route53_zone.test"
 	dataSourceName := "data.aws_route53_zone.test"
 
-	fqdn := acctest.RandomFQDomainName()
+	fqdn := acctest.RandomFQDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/route53/zone_identity_gen_test.go
+++ b/internal/service/route53/zone_identity_gen_test.go
@@ -29,7 +29,7 @@ func TestAccRoute53Zone_Identity_basic(t *testing.T) {
 	var v route53.GetHostedZoneOutput
 	resourceName := "aws_route53_zone.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -122,7 +122,7 @@ func TestAccRoute53Zone_Identity_ExistingResource_basic(t *testing.T) {
 	var v route53.GetHostedZoneOutput
 	resourceName := "aws_route53_zone.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -182,7 +182,7 @@ func TestAccRoute53Zone_Identity_ExistingResource_noRefreshNoChange(t *testing.T
 	var v route53.GetHostedZoneOutput
 	resourceName := "aws_route53_zone.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{

--- a/internal/service/route53/zone_list_test.go
+++ b/internal/service/route53/zone_list_test.go
@@ -25,7 +25,7 @@ func TestAccRoute53Zone_List_basic(t *testing.T) {
 
 	resourceName1 := "aws_route53_zone.test[0]"
 	resourceName2 := "aws_route53_zone.test[1]"
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	identity1 := tfstatecheck.Identity()
 	identity2 := tfstatecheck.Identity()
@@ -83,7 +83,7 @@ func TestAccRoute53Zone_List_includeResource(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_route53_zone.test[0]"
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	identity1 := tfstatecheck.Identity()
 
@@ -156,7 +156,7 @@ func TestAccRoute53Zone_List_privateZone(t *testing.T) {
 
 	publicResourceName := "aws_route53_zone.public"
 	privateResourceName := "aws_route53_zone.private"
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	publicIdentity := tfstatecheck.Identity()
 	privateIdentity := tfstatecheck.Identity()

--- a/internal/service/route53/zone_test.go
+++ b/internal/service/route53/zone_test.go
@@ -29,7 +29,7 @@ func TestAccRoute53Zone_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var zone route53.GetHostedZoneOutput
 	resourceName := "aws_route53_zone.test"
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -83,7 +83,7 @@ func TestAccRoute53Zone_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var zone route53.GetHostedZoneOutput
 	resourceName := "aws_route53_zone.test"
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -106,7 +106,7 @@ func TestAccRoute53Zone_disappears(t *testing.T) {
 func TestAccRoute53Zone_multiple(t *testing.T) {
 	ctx := acctest.Context(t)
 	var zone0, zone1, zone2, zone3, zone4 route53.GetHostedZoneOutput
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -137,7 +137,7 @@ func TestAccRoute53Zone_comment(t *testing.T) {
 	ctx := acctest.Context(t)
 	var zone route53.GetHostedZoneOutput
 	resourceName := "aws_route53_zone.test"
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -184,7 +184,7 @@ func TestAccRoute53Zone_delegationSetID(t *testing.T) {
 	var zone route53.GetHostedZoneOutput
 	delegationSetResourceName := "aws_route53_delegation_set.test"
 	resourceName := "aws_route53_zone.test"
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -213,7 +213,7 @@ func TestAccRoute53Zone_forceDestroy(t *testing.T) {
 	ctx := acctest.Context(t)
 	var zone route53.GetHostedZoneOutput
 	resourceName := "aws_route53_zone.test"
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -238,7 +238,7 @@ func TestAccRoute53Zone_ForceDestroy_trailingPeriod(t *testing.T) {
 	ctx := acctest.Context(t)
 	var zone route53.GetHostedZoneOutput
 	resourceName := "aws_route53_zone.test"
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -263,7 +263,7 @@ func TestAccRoute53Zone_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var zone route53.GetHostedZoneOutput
 	resourceName := "aws_route53_zone.test"
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -336,7 +336,7 @@ func TestAccRoute53Zone_VPC_single(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_route53_zone.test"
 	vpcResourceName := "aws_vpc.test1"
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -369,7 +369,7 @@ func TestAccRoute53Zone_VPC_multiple(t *testing.T) {
 	resourceName := "aws_route53_zone.test"
 	vpcResourceName1 := "aws_vpc.test1"
 	vpcResourceName2 := "aws_vpc.test2"
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -403,7 +403,7 @@ func TestAccRoute53Zone_VPC_updates(t *testing.T) {
 	resourceName := "aws_route53_zone.test"
 	vpcResourceName1 := "aws_vpc.test1"
 	vpcResourceName2 := "aws_vpc.test2"
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -465,7 +465,7 @@ func TestAccRoute53Zone_VPC_single_forceDestroy(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_route53_zone.test"
 	vpcResourceName := "aws_vpc.test1"
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -492,7 +492,7 @@ func TestAccRoute53Zone_escapedCharacter(t *testing.T) {
 	ctx := acctest.Context(t)
 	var zone route53.GetHostedZoneOutput
 	resourceName := "aws_route53_zone.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -546,7 +546,7 @@ func TestAccRoute53Zone_escapedSlash(t *testing.T) {
 	ctx := acctest.Context(t)
 	var zone route53.GetHostedZoneOutput
 	resourceName := "aws_route53_zone.test"
-	zoneName := "0/24." + acctest.RandomDomainName()
+	zoneName := "0/24." + acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -575,7 +575,7 @@ func TestAccRoute53Zone_escapedSpace(t *testing.T) {
 	var zone route53.GetHostedZoneOutput
 	resourceName := "aws_route53_zone.test"
 	// double-escape is required for templating the tf resource
-	zoneName := "a\\\\040b." + acctest.RandomDomainName()
+	zoneName := "a\\\\040b." + acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -604,8 +604,8 @@ func TestAccRoute53Zone_enableAcceleratedRecovery(t *testing.T) {
 	var zone1, zone2 route53.GetHostedZoneOutput
 	resourceName1 := "aws_route53_zone.test1"
 	resourceName2 := "aws_route53_zone.test2"
-	zoneName1 := acctest.RandomDomainName()
-	zoneName2 := acctest.RandomDomainName()
+	zoneName1 := acctest.RandomDomainName(t)
+	zoneName2 := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -663,8 +663,8 @@ func TestAccRoute53Zone_nameUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var zone1, zone2 route53.GetHostedZoneOutput
 	resourceName := "aws_route53_zone.test"
-	zoneName1 := acctest.RandomDomainName()
-	zoneName2 := acctest.RandomDomainName()
+	zoneName1 := acctest.RandomDomainName(t)
+	zoneName2 := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/route53/zones_data_source_test.go
+++ b/internal/service/route53/zones_data_source_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccRoute53ZonesDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	zoneName := acctest.RandomDomainName()
+	zoneName := acctest.RandomDomainName(t)
 	dataSourceName := "data.aws_route53_zones.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/route53resolver/firewall_domain_list_data_source_test.go
+++ b/internal/service/route53resolver/firewall_domain_list_data_source_test.go
@@ -16,7 +16,7 @@ func TestAccRoute53ResolverFirewallDomainListDataSource_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_route53_resolver_firewall_domain_list.test"
 	resourceName := "aws_route53_resolver_firewall_domain_list.test"
-	domainName := acctest.RandomFQDomainName()
+	domainName := acctest.RandomFQDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },

--- a/internal/service/route53resolver/firewall_domain_list_test.go
+++ b/internal/service/route53resolver/firewall_domain_list_test.go
@@ -54,8 +54,8 @@ func TestAccRoute53ResolverFirewallDomainList_domains(t *testing.T) {
 	var v awstypes.FirewallDomainList
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_route53_resolver_firewall_domain_list.test"
-	domainName1 := acctest.RandomFQDomainName()
-	domainName2 := acctest.RandomFQDomainName()
+	domainName1 := acctest.RandomFQDomainName(t)
+	domainName2 := acctest.RandomFQDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },

--- a/internal/service/route53resolver/firewall_rules_data_source_test.go
+++ b/internal/service/route53resolver/firewall_rules_data_source_test.go
@@ -28,7 +28,7 @@ func TestAccRoute53ResolverFirewallRulesDataSource_basic(t *testing.T) {
 		}
 	}
 
-	fqdn := acctest.RandomFQDomainName()
+	fqdn := acctest.RandomFQDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	action := "ALLOW"
 	priority := "100"

--- a/internal/service/route53resolver/rule.go
+++ b/internal/service/route53resolver/rule.go
@@ -35,7 +35,7 @@ import (
 // @IdentityAttribute("id")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/route53resolver/types;awstypes.ResolverRule")
 // @Testing(preIdentityVersion="v6.10.0")
-// @Testing(generator="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.RandomDomainName()")
+// @Testing(generator="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.RandomDomainName(t)")
 func resourceRule() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRuleCreate,

--- a/internal/service/route53resolver/rule_association_identity_gen_test.go
+++ b/internal/service/route53resolver/rule_association_identity_gen_test.go
@@ -28,7 +28,7 @@ func TestAccRoute53ResolverRuleAssociation_Identity_basic(t *testing.T) {
 	var v awstypes.ResolverRuleAssociation
 	resourceName := "aws_route53_resolver_rule_association.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -117,7 +117,7 @@ func TestAccRoute53ResolverRuleAssociation_Identity_regionOverride(t *testing.T)
 
 	resourceName := "aws_route53_resolver_rule_association.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -211,7 +211,7 @@ func TestAccRoute53ResolverRuleAssociation_Identity_ExistingResource_basic(t *te
 	var v awstypes.ResolverRuleAssociation
 	resourceName := "aws_route53_resolver_rule_association.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -272,7 +272,7 @@ func TestAccRoute53ResolverRuleAssociation_Identity_ExistingResource_noRefreshNo
 	var v awstypes.ResolverRuleAssociation
 	resourceName := "aws_route53_resolver_rule_association.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{

--- a/internal/service/route53resolver/rule_association_list_test.go
+++ b/internal/service/route53resolver/rule_association_list_test.go
@@ -25,7 +25,7 @@ func TestAccRoute53ResolverRuleAssociation_List_basic(t *testing.T) {
 	resourceName1 := "aws_route53_resolver_rule_association.test[0]"
 	resourceName2 := "aws_route53_resolver_rule_association.test[1]"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	id1 := tfstatecheck.StateValue()
 	id2 := tfstatecheck.StateValue()

--- a/internal/service/route53resolver/rule_association_test.go
+++ b/internal/service/route53resolver/rule_association_test.go
@@ -25,7 +25,7 @@ func TestAccRoute53ResolverRuleAssociation_basic(t *testing.T) {
 	vpcResourceName := "aws_vpc.test"
 	ruleResourceName := "aws_route53_resolver_rule.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
@@ -56,7 +56,7 @@ func TestAccRoute53ResolverRuleAssociation_disappears(t *testing.T) {
 	var assn awstypes.ResolverRuleAssociation
 	resourceName := "aws_route53_resolver_rule_association.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
@@ -82,7 +82,7 @@ func TestAccRoute53ResolverRuleAssociation_Disappears_vpc(t *testing.T) {
 	resourceName := "aws_route53_resolver_rule_association.test"
 	vpcResourceName := "aws_vpc.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },

--- a/internal/service/route53resolver/rule_data_source_test.go
+++ b/internal/service/route53resolver/rule_data_source_test.go
@@ -18,7 +18,7 @@ func init() {
 
 func TestAccRoute53ResolverRuleDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_route53_resolver_rule.test"
 	ds1ResourceName := "data.aws_route53_resolver_rule.by_resolver_rule_id"
@@ -73,7 +73,7 @@ func TestAccRoute53ResolverRuleDataSource_basic(t *testing.T) {
 
 func TestAccRoute53ResolverRuleDataSource_resolverEndpointIdWithTags(t *testing.T) {
 	ctx := acctest.Context(t)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_route53_resolver_rule.test"
 	ds1ResourceName := "data.aws_route53_resolver_rule.by_resolver_endpoint_id"
@@ -107,7 +107,7 @@ func TestAccRoute53ResolverRuleDataSource_resolverEndpointIdWithTags(t *testing.
 
 func TestAccRoute53ResolverRuleDataSource_targetIPs(t *testing.T) {
 	ctx := acctest.Context(t)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_route53_resolver_rule.test"
 	dsResourceName := "data.aws_route53_resolver_rule.test"
@@ -140,7 +140,7 @@ func TestAccRoute53ResolverRuleDataSource_targetIPs(t *testing.T) {
 
 func TestAccRoute53ResolverRuleDataSource_sharedByMe(t *testing.T) {
 	ctx := acctest.Context(t)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_route53_resolver_rule.test"
 	ds1ResourceName := "data.aws_route53_resolver_rule.by_resolver_endpoint_id"
@@ -178,7 +178,7 @@ func TestAccRoute53ResolverRuleDataSource_sharedByMe(t *testing.T) {
 
 func TestAccRoute53ResolverRuleDataSource_sharedWithMe(t *testing.T) {
 	ctx := acctest.Context(t)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_route53_resolver_rule.test"
 	ds1ResourceName := "data.aws_route53_resolver_rule.by_resolver_endpoint_id"

--- a/internal/service/route53resolver/rule_identity_gen_test.go
+++ b/internal/service/route53resolver/rule_identity_gen_test.go
@@ -27,7 +27,7 @@ func TestAccRoute53ResolverRule_Identity_basic(t *testing.T) {
 
 	var v awstypes.ResolverRule
 	resourceName := "aws_route53_resolver_rule.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -111,7 +111,7 @@ func TestAccRoute53ResolverRule_Identity_regionOverride(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName := "aws_route53_resolver_rule.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -200,7 +200,7 @@ func TestAccRoute53ResolverRule_Identity_ExistingResource_basic(t *testing.T) {
 
 	var v awstypes.ResolverRule
 	resourceName := "aws_route53_resolver_rule.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -258,7 +258,7 @@ func TestAccRoute53ResolverRule_Identity_ExistingResource_noRefreshNoChange(t *t
 
 	var v awstypes.ResolverRule
 	resourceName := "aws_route53_resolver_rule.test"
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{

--- a/internal/service/route53resolver/rule_list_test.go
+++ b/internal/service/route53resolver/rule_list_test.go
@@ -27,7 +27,7 @@ func TestAccRoute53ResolverRule_List_basic(t *testing.T) {
 	resourceName1 := "aws_route53_resolver_rule.test[0]"
 	resourceName2 := "aws_route53_resolver_rule.test[1]"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	identity1 := tfstatecheck.Identity()
 	identity2 := tfstatecheck.Identity()
@@ -86,7 +86,7 @@ func TestAccRoute53ResolverRule_List_includeResource(t *testing.T) {
 
 	resourceName1 := "aws_route53_resolver_rule.test[0]"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	identity1 := tfstatecheck.Identity()
 	id1 := tfstatecheck.StateValue()
@@ -167,7 +167,7 @@ func TestAccRoute53ResolverRule_List_regionOverride(t *testing.T) {
 	resourceName1 := "aws_route53_resolver_rule.test[0]"
 	resourceName2 := "aws_route53_resolver_rule.test[1]"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	identity1 := tfstatecheck.Identity()
 	identity2 := tfstatecheck.Identity()

--- a/internal/service/route53resolver/rule_test.go
+++ b/internal/service/route53resolver/rule_test.go
@@ -21,7 +21,7 @@ import (
 func TestAccRoute53ResolverRule_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var rule awstypes.ResolverRule
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	resourceName := "aws_route53_resolver_rule.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -58,7 +58,7 @@ func TestAccRoute53ResolverRule_basic(t *testing.T) {
 func TestAccRoute53ResolverRule_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var rule awstypes.ResolverRule
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	resourceName := "aws_route53_resolver_rule.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -82,7 +82,7 @@ func TestAccRoute53ResolverRule_disappears(t *testing.T) {
 func TestAccRoute53ResolverRule_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var rule awstypes.ResolverRule
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	resourceName := "aws_route53_resolver_rule.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -191,7 +191,7 @@ func TestAccRoute53ResolverRule_updateName(t *testing.T) {
 	ctx := acctest.Context(t)
 	var rule1, rule2 awstypes.ResolverRule
 	resourceName := "aws_route53_resolver_rule.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	rName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	rName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
@@ -231,7 +231,7 @@ func TestAccRoute53ResolverRule_forward(t *testing.T) {
 	resourceName := "aws_route53_resolver_rule.test"
 	ep1ResourceName := "aws_route53_resolver_endpoint.test.0"
 	ep2ResourceName := "aws_route53_resolver_endpoint.test.1"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -309,7 +309,7 @@ func TestAccRoute53ResolverRule_forwardMultiProtocol(t *testing.T) {
 	var rule awstypes.ResolverRule
 	resourceName := "aws_route53_resolver_rule.test"
 	epResourceName := "aws_route53_resolver_endpoint.test.0"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -381,7 +381,7 @@ func TestAccRoute53ResolverRule_forward_ipv6(t *testing.T) {
 	resourceName := "aws_route53_resolver_rule.test"
 	ep1ResourceName := "aws_route53_resolver_endpoint.test.0"
 	ep2ResourceName := "aws_route53_resolver_endpoint.test.1"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -459,7 +459,7 @@ func TestAccRoute53ResolverRule_forwardEndpointRecreate(t *testing.T) {
 	var rule1, rule2 awstypes.ResolverRule
 	resourceName := "aws_route53_resolver_rule.test"
 	epResourceName := "aws_route53_resolver_endpoint.test.0"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -508,7 +508,7 @@ func TestAccRoute53ResolverRule_forwardEndpointRecreate_ipv6(t *testing.T) {
 	var rule1, rule2 awstypes.ResolverRule
 	resourceName := "aws_route53_resolver_rule.test"
 	epResourceName := "aws_route53_resolver_endpoint.test.0"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/route53resolver/rules_data_source_test.go
+++ b/internal/service/route53resolver/rules_data_source_test.go
@@ -35,8 +35,8 @@ func TestAccRoute53ResolverRulesDataSource_basic(t *testing.T) {
 
 func TestAccRoute53ResolverRulesDataSource_resolverEndpointID(t *testing.T) {
 	ctx := acctest.Context(t)
-	domainName1 := acctest.RandomDomainName()
-	domainName2 := acctest.RandomDomainName()
+	domainName1 := acctest.RandomDomainName(t)
+	domainName2 := acctest.RandomDomainName(t)
 	rName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	rName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	ds1ResourceName := "data.aws_route53_resolver_rules.by_resolver_endpoint_id"

--- a/internal/service/securityhub/member_test.go
+++ b/internal/service/securityhub/member_test.go
@@ -182,7 +182,7 @@ func testAccMember_inviteOrganizationMember(t *testing.T) {
 	providers := make(map[string]*schema.Provider)
 	var member types.Member
 	resourceName := "aws_securityhub_member.test"
-	rName := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	rName := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/servicecatalog/launch_paths_data_source_test.go
+++ b/internal/service/servicecatalog/launch_paths_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccServiceCatalogLaunchPathsDataSource_basic(t *testing.T) {
 	resourceNamePortfolio := "aws_servicecatalog_portfolio.test"
 
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/servicecatalog/product_data_source_test.go
+++ b/internal/service/servicecatalog/product_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccServiceCatalogProductDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_servicecatalog_product.test"
 
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -59,7 +59,7 @@ func TestAccServiceCatalogProductDataSource_physicalID(t *testing.T) {
 	dataSourceName := "data.aws_servicecatalog_product.test"
 
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/servicecatalog/product_portfolio_association_test.go
+++ b/internal/service/servicecatalog/product_portfolio_association_test.go
@@ -23,7 +23,7 @@ func TestAccServiceCatalogProductPortfolioAssociation_basic(t *testing.T) {
 	resourceName := "aws_servicecatalog_product_portfolio_association.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -53,7 +53,7 @@ func TestAccServiceCatalogProductPortfolioAssociation_disappears(t *testing.T) {
 	resourceName := "aws_servicecatalog_product_portfolio_association.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/servicecatalog/product_test.go
+++ b/internal/service/servicecatalog/product_test.go
@@ -30,7 +30,7 @@ func TestAccServiceCatalogProduct_basic(t *testing.T) {
 	resourceName := "aws_servicecatalog_product.test"
 
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -84,7 +84,7 @@ func TestAccServiceCatalogProduct_disappears(t *testing.T) {
 	resourceName := "aws_servicecatalog_product.test"
 
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -109,7 +109,7 @@ func TestAccServiceCatalogProduct_update(t *testing.T) {
 	resourceName := "aws_servicecatalog_product.test"
 
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -148,7 +148,7 @@ func TestAccServiceCatalogProduct_physicalID(t *testing.T) {
 	resourceName := "aws_servicecatalog_product.test"
 
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -192,7 +192,7 @@ func TestAccServiceCatalogProduct_regionOverride(t *testing.T) {
 	resourceName := "aws_servicecatalog_product.test"
 
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckMultipleRegion(t, 2) },

--- a/internal/service/servicecatalog/provisioning_artifact_test.go
+++ b/internal/service/servicecatalog/provisioning_artifact_test.go
@@ -26,7 +26,7 @@ func TestAccServiceCatalogProvisioningArtifact_basic(t *testing.T) {
 	resourceName := "aws_servicecatalog_provisioning_artifact.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -70,7 +70,7 @@ func TestAccServiceCatalogProvisioningArtifact_disappears(t *testing.T) {
 	resourceName := "aws_servicecatalog_provisioning_artifact.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -95,7 +95,7 @@ func TestAccServiceCatalogProvisioningArtifact_update(t *testing.T) {
 	resourceName := "aws_servicecatalog_provisioning_artifact.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -143,7 +143,7 @@ func TestAccServiceCatalogProvisioningArtifact_physicalID(t *testing.T) {
 	resourceName := "aws_servicecatalog_provisioning_artifact.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/servicecatalog/provisioning_artifacts_data_source_test.go
+++ b/internal/service/servicecatalog/provisioning_artifacts_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccServiceCatalogProvisioningArtifactsDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalog_provisioning_artifacts.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/servicediscovery/instance_test.go
+++ b/internal/service/servicediscovery/instance_test.go
@@ -20,7 +20,7 @@ func TestAccServiceDiscoveryInstance_private(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_service_discovery_instance.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -66,7 +66,7 @@ func TestAccServiceDiscoveryInstance_public(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_service_discovery_instance.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -112,7 +112,7 @@ func TestAccServiceDiscoveryInstance_http(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_service_discovery_instance.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/ses/domain_dkim_test.go
+++ b/internal/service/ses/domain_dkim_test.go
@@ -21,7 +21,7 @@ import (
 func TestAccSESDomainDKIM_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ses_domain_dkim.test"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -48,7 +48,7 @@ func TestAccSESDomainDKIM_basic(t *testing.T) {
 func TestAccSESDomainDKIM_Disappears_identity(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ses_domain_dkim.test"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/ses/domain_identity_data_source_test.go
+++ b/internal/service/ses/domain_identity_data_source_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccSESDomainIdentityDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	dataSourceName := "data.aws_ses_domain_identity.test"
 	resourceName := "aws_ses_domain_identity.test"

--- a/internal/service/ses/domain_identity_test.go
+++ b/internal/service/ses/domain_identity_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestAccSESDomainIdentity_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	resourceName := "aws_ses_domain_identity.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -45,7 +45,7 @@ func TestAccSESDomainIdentity_basic(t *testing.T) {
 
 func TestAccSESDomainIdentity_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	resourceName := "aws_ses_domain_identity.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -70,7 +70,7 @@ func TestAccSESDomainIdentity_disappears(t *testing.T) {
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/13510
 func TestAccSESDomainIdentity_trailingPeriod(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomFQDomainName()
+	domain := acctest.RandomFQDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },

--- a/internal/service/ses/domain_identity_verification_test.go
+++ b/internal/service/ses/domain_identity_verification_test.go
@@ -52,7 +52,7 @@ func TestAccSESDomainIdentityVerification_basic(t *testing.T) {
 
 func TestAccSESDomainIdentityVerification_timeout(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
@@ -70,7 +70,7 @@ func TestAccSESDomainIdentityVerification_timeout(t *testing.T) {
 
 func TestAccSESDomainIdentityVerification_nonexistent(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },

--- a/internal/service/ses/domain_mail_from_test.go
+++ b/internal/service/ses/domain_mail_from_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestAccSESDomainMailFrom_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	dn := acctest.RandomDomain()
+	dn := acctest.RandomDomain(t)
 	domain := dn.String()
 	mailFromDomain1 := dn.Subdomain("bounce1").String()
 	mailFromDomain2 := dn.Subdomain("bounce2").String()
@@ -60,7 +60,7 @@ func TestAccSESDomainMailFrom_basic(t *testing.T) {
 
 func TestAccSESDomainMailFrom_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	dn := acctest.RandomDomain()
+	dn := acctest.RandomDomain(t)
 	domain := dn.String()
 	mailFromDomain := dn.Subdomain("bounce").String()
 	resourceName := "aws_ses_domain_mail_from.test"
@@ -85,7 +85,7 @@ func TestAccSESDomainMailFrom_disappears(t *testing.T) {
 
 func TestAccSESDomainMailFrom_Disappears_identity(t *testing.T) {
 	ctx := acctest.Context(t)
-	dn := acctest.RandomDomain()
+	dn := acctest.RandomDomain(t)
 	domain := dn.String()
 	mailFromDomain := dn.Subdomain("bounce").String()
 	resourceName := "aws_ses_domain_mail_from.test"
@@ -110,7 +110,7 @@ func TestAccSESDomainMailFrom_Disappears_identity(t *testing.T) {
 
 func TestAccSESDomainMailFrom_behaviorOnMxFailure(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomDomain().String()
+	domain := acctest.RandomDomain(t).String()
 	resourceName := "aws_ses_domain_mail_from.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/ses/identity_notification_topic_test.go
+++ b/internal/service/ses/identity_notification_topic_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestAccSESIdentityNotificationTopic_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	topicName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_ses_identity_notification_topic.test"
 
@@ -60,7 +60,7 @@ func TestAccSESIdentityNotificationTopic_basic(t *testing.T) {
 // https://github.com/hashicorp/terraform-provider-aws/issues/36275.
 func TestAccSESIdentityNotificationTopic_Disappears_domainIdentity(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	resourceName := "aws_ses_identity_notification_topic.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/ses/identity_policy_test.go
+++ b/internal/service/ses/identity_policy_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestAccSESIdentityPolicy_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	resourceName := "aws_ses_identity_policy.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -46,7 +46,7 @@ func TestAccSESIdentityPolicy_basic(t *testing.T) {
 func TestAccSESIdentityPolicy_Identity_email(t *testing.T) {
 	ctx := acctest.Context(t)
 	emailPrefix := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	email := fmt.Sprintf("%s@%s", emailPrefix, acctest.RandomDomainName())
+	email := fmt.Sprintf("%s@%s", emailPrefix, acctest.RandomDomainName(t))
 	resourceName := "aws_ses_identity_policy.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -72,7 +72,7 @@ func TestAccSESIdentityPolicy_Identity_email(t *testing.T) {
 
 func TestAccSESIdentityPolicy_policy(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	resourceName := "aws_ses_identity_policy.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -104,7 +104,7 @@ func TestAccSESIdentityPolicy_policy(t *testing.T) {
 
 func TestAccSESIdentityPolicy_ignoreEquivalent(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_ses_identity_policy.test"
 

--- a/internal/service/sesv2/email_identity_feedback_attributes_test.go
+++ b/internal/service/sesv2/email_identity_feedback_attributes_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestAccSESV2EmailIdentityFeedbackAttributes_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	rName := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 	resourceName := "aws_sesv2_email_identity_feedback_attributes.test"
 	emailIdentityName := "aws_sesv2_email_identity.test"
 
@@ -46,7 +46,7 @@ func TestAccSESV2EmailIdentityFeedbackAttributes_basic(t *testing.T) {
 
 func TestAccSESV2EmailIdentityFeedbackAttributes_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	rName := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 	resourceName := "aws_sesv2_email_identity_feedback_attributes.test"
 	emailIdentityName := "aws_sesv2_email_identity.test"
 
@@ -70,7 +70,7 @@ func TestAccSESV2EmailIdentityFeedbackAttributes_disappears(t *testing.T) {
 
 func TestAccSESV2EmailIdentityFeedbackAttributes_disappears_emailIdentity(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	rName := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 	emailIdentityName := "aws_sesv2_email_identity.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -93,7 +93,7 @@ func TestAccSESV2EmailIdentityFeedbackAttributes_disappears_emailIdentity(t *tes
 
 func TestAccSESV2EmailIdentityFeedbackAttributes_emailForwardingEnabled(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	rName := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 	resourceName := "aws_sesv2_email_identity_feedback_attributes.test"
 	emailIdentityName := "aws_sesv2_email_identity.test"
 

--- a/internal/service/sesv2/email_identity_mail_from_attributes_data_source_test.go
+++ b/internal/service/sesv2/email_identity_mail_from_attributes_data_source_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestAccSESV2EmailIdentityMailFromAttributesDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomDomain()
+	domain := acctest.RandomDomain(t)
 	mailFromDomain1 := domain.Subdomain("test1")
 
 	rName := domain.String()

--- a/internal/service/sesv2/email_identity_mail_from_attributes_test.go
+++ b/internal/service/sesv2/email_identity_mail_from_attributes_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestAccSESV2EmailIdentityMailFromAttributes_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 	resourceName := "aws_sesv2_email_identity_mail_from_attributes.test"
 	emailIdentityName := "aws_sesv2_email_identity.test"
 
@@ -46,7 +46,7 @@ func TestAccSESV2EmailIdentityMailFromAttributes_basic(t *testing.T) {
 
 func TestAccSESV2EmailIdentityMailFromAttributes_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomDomain()
+	domain := acctest.RandomDomain(t)
 	mailFromDomain := domain.Subdomain("test")
 
 	rName := domain.String()
@@ -72,7 +72,7 @@ func TestAccSESV2EmailIdentityMailFromAttributes_disappears(t *testing.T) {
 
 func TestAccSESV2EmailIdentityMailFromAttributes_disappearsEmailIdentity(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 	resourceName := "aws_sesv2_email_identity_mail_from_attributes.test"
 	emailIdentityName := "aws_sesv2_email_identity.test"
 
@@ -96,7 +96,7 @@ func TestAccSESV2EmailIdentityMailFromAttributes_disappearsEmailIdentity(t *test
 
 func TestAccSESV2EmailIdentityMailFromAttributes_behaviorOnMXFailure(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomDomain()
+	domain := acctest.RandomDomain(t)
 	mailFromDomain := domain.Subdomain("test")
 
 	rName := domain.String()
@@ -133,7 +133,7 @@ func TestAccSESV2EmailIdentityMailFromAttributes_behaviorOnMXFailure(t *testing.
 
 func TestAccSESV2EmailIdentityMailFromAttributes_mailFromDomain(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomDomain()
+	domain := acctest.RandomDomain(t)
 	mailFromDomain1 := domain.Subdomain("test1")
 	mailFromDomain2 := domain.Subdomain("test2")
 

--- a/internal/service/sesv2/email_identity_policy_test.go
+++ b/internal/service/sesv2/email_identity_policy_test.go
@@ -20,7 +20,7 @@ func TestAccSESV2EmailIdentityPolicy_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_sesv2_email_identity_policy.test"
-	emailIdentity := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	emailIdentity := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -50,7 +50,7 @@ func TestAccSESV2EmailIdentityPolicy_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_sesv2_email_identity_policy.test"
-	emailIdentity := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	emailIdentity := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/sesv2/email_identity_test.go
+++ b/internal/service/sesv2/email_identity_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestAccSESV2EmailIdentity_basic_emailAddress(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	rName := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 	resourceName := "aws_sesv2_email_identity.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -59,7 +59,7 @@ func TestAccSESV2EmailIdentity_basic_emailAddress(t *testing.T) {
 
 func TestAccSESV2EmailIdentity_basic_domain(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 	resourceName := "aws_sesv2_email_identity.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -97,7 +97,7 @@ func TestAccSESV2EmailIdentity_basic_domain(t *testing.T) {
 
 func TestAccSESV2EmailIdentity_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	rName := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 	resourceName := "aws_sesv2_email_identity.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -120,7 +120,7 @@ func TestAccSESV2EmailIdentity_disappears(t *testing.T) {
 
 func TestAccSESV2EmailIdentity_configurationSetName(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := acctest.RandomEmailAddress(acctest.RandomDomainName())
+	rName := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
 	resourceName := "aws_sesv2_email_identity.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -154,7 +154,7 @@ func TestAccSESV2EmailIdentity_configurationSetName(t *testing.T) {
 
 func TestAccSESV2EmailIdentity_nextSigningKeyLength(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 	resourceName := "aws_sesv2_email_identity.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -190,7 +190,7 @@ func TestAccSESV2EmailIdentity_nextSigningKeyLength(t *testing.T) {
 
 func TestAccSESV2EmailIdentity_domainSigning(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := acctest.RandomDomainName()
+	rName := acctest.RandomDomainName(t)
 	resourceName := "aws_sesv2_email_identity.test"
 
 	key1 := inttypes.Base64EncodeOnce([]byte(acctest.TLSRSAPrivateKeyPEM(t, 2048)))

--- a/internal/service/shield/proactive_engagement_test.go
+++ b/internal/service/shield/proactive_engagement_test.go
@@ -20,7 +20,7 @@ import (
 
 func testAccProactiveEngagement_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	address1 := acctest.RandomEmailAddress(domain)
 	address2 := acctest.RandomEmailAddress(domain)
 	var proactiveengagementassociation []types.EmergencyContact
@@ -54,7 +54,7 @@ func testAccProactiveEngagement_basic(t *testing.T) {
 
 func testAccProactiveEngagement_disabled(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	address1 := acctest.RandomEmailAddress(domain)
 	address2 := acctest.RandomEmailAddress(domain)
 	var proactiveengagementassociation []types.EmergencyContact
@@ -83,7 +83,7 @@ func testAccProactiveEngagement_disabled(t *testing.T) {
 
 func testAccProactiveEngagement_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	address1 := acctest.RandomEmailAddress(domain)
 	address2 := acctest.RandomEmailAddress(domain)
 	var proactiveengagementassociation []types.EmergencyContact

--- a/internal/service/ssmcontacts/contact_channel_test.go
+++ b/internal/service/ssmcontacts/contact_channel_test.go
@@ -158,7 +158,7 @@ func testAccContactChannel_deliveryAddress(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	address1 := acctest.RandomEmailAddress(domain)
 	address2 := acctest.RandomEmailAddress(domain)
 	contactResourceName := "aws_ssmcontacts_contact.test"

--- a/internal/service/ssmcontacts/plan_test.go
+++ b/internal/service/ssmcontacts/plan_test.go
@@ -471,6 +471,7 @@ func testAccPlan_updateChannelTargetInfo(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	domain := acctest.RandomDomainName(t)
 	escalationPlanResourceName := "aws_ssmcontacts_contact.test_escalation_plan_one"
 	planResourceName := "aws_ssmcontacts_plan.test"
 	contactChannelOneResourceName := "aws_ssmcontacts_contact_channel.test_channel_one"
@@ -492,6 +493,7 @@ func testAccPlan_updateChannelTargetInfo(t *testing.T) {
 				Config: testAccPlanConfig_channelTargetInfo(
 					rName,
 					contactChannelOneResourceName,
+					domain,
 					oldRetryIntervalInMinutes,
 				),
 				Check: resource.ComposeTestCheckFunc(
@@ -520,6 +522,7 @@ func testAccPlan_updateChannelTargetInfo(t *testing.T) {
 				Config: testAccPlanConfig_channelTargetInfo(
 					rName,
 					contactChannelTwoResourceName,
+					domain,
 					newRetryIntervalInMinutes,
 				),
 				Check: resource.ComposeTestCheckFunc(
@@ -746,9 +749,7 @@ resource "aws_ssmcontacts_plan" "test" {
 `, isEssential, contactId))
 }
 
-func testAccPlanConfig_channelTargetInfo(rName, contactChannelResourceName string, retryIntervalInMinutes int) string {
-	domain := acctest.RandomDomainName()
-
+func testAccPlanConfig_channelTargetInfo(rName, contactChannelResourceName, domain string, retryIntervalInMinutes int) string {
 	return acctest.ConfigCompose(
 		testAccPlanConfig_base(rName),
 		fmt.Sprintf(`

--- a/internal/service/storagegateway/file_system_association_test.go
+++ b/internal/service/storagegateway/file_system_association_test.go
@@ -26,7 +26,7 @@ func TestAccStorageGatewayFileSystemAssociation_basic(t *testing.T) {
 	resourceName := "aws_storagegateway_file_system_association.test"
 	gatewayResourceName := "aws_storagegateway_gateway.test"
 	fsxResourceName := "aws_fsx_windows_file_system.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	username := "Admin"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -62,7 +62,7 @@ func TestAccStorageGatewayFileSystemAssociation_tags(t *testing.T) {
 	var fileSystemAssociation awstypes.FileSystemAssociationInfo
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_storagegateway_file_system_association.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	username := "Admin"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -114,7 +114,7 @@ func TestAccStorageGatewayFileSystemAssociation_cacheAttributes(t *testing.T) {
 	var fileSystemAssociation awstypes.FileSystemAssociationInfo
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_storagegateway_file_system_association.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	username := "Admin"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -154,7 +154,7 @@ func TestAccStorageGatewayFileSystemAssociation_auditDestination(t *testing.T) {
 	var fileSystemAssociation awstypes.FileSystemAssociationInfo
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_storagegateway_file_system_association.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	username := "Admin"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -198,7 +198,7 @@ func TestAccStorageGatewayFileSystemAssociation_disappears(t *testing.T) {
 	var fileSystemAssociation awstypes.FileSystemAssociationInfo
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_storagegateway_file_system_association.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	username := "Admin"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -224,7 +224,7 @@ func TestAccStorageGatewayFileSystemAssociation_Disappears_storageGateway(t *tes
 	var fileSystemAssociation awstypes.FileSystemAssociationInfo
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_storagegateway_file_system_association.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	username := "Admin"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -252,7 +252,7 @@ func TestAccStorageGatewayFileSystemAssociation_Disappears_fsxFileSystem(t *test
 	var fileSystemAssociation awstypes.FileSystemAssociationInfo
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_storagegateway_file_system_association.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	username := "Admin"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/storagegateway/gateway_test.go
+++ b/internal/service/storagegateway/gateway_test.go
@@ -419,7 +419,7 @@ func TestAccStorageGatewayGateway_smbActiveDirectorySettings(t *testing.T) {
 	var gateway awstypes.GatewayInfo
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_storagegateway_gateway.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -452,7 +452,7 @@ func TestAccStorageGatewayGateway_SMBActiveDirectorySettings_timeout(t *testing.
 	var gateway awstypes.GatewayInfo
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_storagegateway_gateway.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -484,7 +484,7 @@ func TestAccStorageGatewayGateway_smbMicrosoftActiveDirectorySettings(t *testing
 	var gateway awstypes.GatewayInfo
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_storagegateway_gateway.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 	username := "Admin"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -518,7 +518,7 @@ func TestAccStorageGatewayGateway_SMBMicrosoftActiveDirectorySettings_timeout(t 
 	var gateway awstypes.GatewayInfo
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_storagegateway_gateway.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/storagegateway/smb_file_share_test.go
+++ b/internal/service/storagegateway/smb_file_share_test.go
@@ -26,7 +26,7 @@ func TestAccStorageGatewaySMBFileShare_Authentication_activeDirectory(t *testing
 	gatewayResourceName := "aws_storagegateway_gateway.test"
 	bucketResourceName := "aws_s3_bucket.test"
 	iamResourceName := "aws_iam_role.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -445,7 +445,7 @@ func TestAccStorageGatewaySMBFileShare_invalidUserList(t *testing.T) {
 	var smbFileShare awstypes.SMBFileShareInfo
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_storagegateway_smb_file_share.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -671,7 +671,7 @@ func TestAccStorageGatewaySMBFileShare_validUserList(t *testing.T) {
 	var smbFileShare awstypes.SMBFileShareInfo
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_storagegateway_smb_file_share.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -714,7 +714,7 @@ func TestAccStorageGatewaySMBFileShare_SMB_acl(t *testing.T) {
 	var smbFileShare awstypes.SMBFileShareInfo
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_storagegateway_smb_file_share.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -905,7 +905,7 @@ func TestAccStorageGatewaySMBFileShare_adminUserList(t *testing.T) {
 	var smbFileShare awstypes.SMBFileShareInfo
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_storagegateway_smb_file_share.test"
-	domainName := acctest.RandomDomainName()
+	domainName := acctest.RandomDomainName(t)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/sts/web_identity_token_ephemeral_test.go
+++ b/internal/service/sts/web_identity_token_ephemeral_test.go
@@ -23,6 +23,7 @@ func TestAccSTSWebIdentityTokenEphemeral_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	echoResourceName := "echo.test"
 	dataPath := tfjsonpath.New("data")
+	domain := acctest.RandomDomain(t).String()
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -38,7 +39,7 @@ func TestAccSTSWebIdentityTokenEphemeral_basic(t *testing.T) {
 		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWebIdentityTokenEphemeralConfig_basic(),
+				Config: testAccWebIdentityTokenEphemeralConfig_basic(domain),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(echoResourceName, dataPath.AtMapKey("web_identity_token"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(echoResourceName, dataPath.AtMapKey("expiration"), knownvalue.NotNull()),
@@ -52,6 +53,7 @@ func TestAccSTSWebIdentityTokenEphemeral_full(t *testing.T) {
 	ctx := acctest.Context(t)
 	echoResourceName := "echo.test"
 	dataPath := tfjsonpath.New("data")
+	domain1, domain2 := acctest.RandomDomain(t).String(), acctest.RandomDomain(t).String()
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -67,7 +69,7 @@ func TestAccSTSWebIdentityTokenEphemeral_full(t *testing.T) {
 		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWebIdentityTokenEphemeralConfig_full(),
+				Config: testAccWebIdentityTokenEphemeralConfig_full(domain1, domain2),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(echoResourceName, dataPath.AtMapKey("web_identity_token"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(echoResourceName, dataPath.AtMapKey("expiration"), knownvalue.NotNull()),
@@ -95,7 +97,7 @@ func testAccWebIdentityTokenPreCheck(ctx context.Context, t *testing.T) {
 	}
 }
 
-func testAccWebIdentityTokenEphemeralConfig_basic() string {
+func testAccWebIdentityTokenEphemeralConfig_basic(domain string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigWithEchoProvider("ephemeral.aws_sts_web_identity_token.test"),
 		fmt.Sprintf(`
@@ -103,10 +105,10 @@ ephemeral "aws_sts_web_identity_token" "test" {
   audience          = [%[1]q]
   signing_algorithm = "RS256"
 }
-`, acctest.RandomDomain().String()))
+`, domain))
 }
 
-func testAccWebIdentityTokenEphemeralConfig_full() string {
+func testAccWebIdentityTokenEphemeralConfig_full(domain1, domain2 string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigWithEchoProvider("ephemeral.aws_sts_web_identity_token.test"),
 		fmt.Sprintf(`
@@ -120,5 +122,5 @@ ephemeral "aws_sts_web_identity_token" "test" {
     purpose     = "acceptance-testing"
   }
 }
-`, acctest.RandomDomain().String(), acctest.RandomDomain().String()))
+`, domain1, domain2))
 }

--- a/internal/service/transfer/certificate_test.go
+++ b/internal/service/transfer/certificate_test.go
@@ -21,7 +21,7 @@ func TestAccTransferCertificate_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.DescribedCertificate
 	resourceName := "aws_transfer_certificate.test"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	domainWildcard := fmt.Sprintf("*.%s", domain)
 	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(t, caKey)
@@ -101,7 +101,7 @@ func TestAccTransferCertificate_certificateChain(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.DescribedCertificate
 	resourceName := "aws_transfer_certificate.test"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	domainWildcard := fmt.Sprintf("*.%s", domain)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
@@ -143,7 +143,7 @@ func TestAccTransferCertificate_certificateKey(t *testing.T) {
 	var conf awstypes.DescribedCertificate
 	resourceName := "aws_transfer_certificate.test"
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, acctest.RandomSubdomain())
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, acctest.RandomSubdomain(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -180,7 +180,7 @@ func TestAccTransferCertificate_disappears(t *testing.T) {
 	var conf awstypes.DescribedCertificate
 	resourceName := "aws_transfer_certificate.test"
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, acctest.RandomSubdomain())
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, acctest.RandomSubdomain(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -209,7 +209,7 @@ func TestAccTransferCertificate_tags(t *testing.T) {
 	var conf awstypes.DescribedCertificate
 	resourceName := "aws_transfer_certificate.test"
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, acctest.RandomSubdomain())
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, acctest.RandomSubdomain(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -261,7 +261,7 @@ func TestAccTransferCertificate_description(t *testing.T) {
 	var conf awstypes.DescribedCertificate
 	resourceName := "aws_transfer_certificate.test"
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, acctest.RandomSubdomain())
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, acctest.RandomSubdomain(t))
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/transfer/profile_test.go
+++ b/internal/service/transfer/profile_test.go
@@ -60,7 +60,7 @@ func TestAccTransferProfile_certificateIDs(t *testing.T) {
 	var conf awstypes.DescribedProfile
 	resourceName := "aws_transfer_profile.test"
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, acctest.RandomSubdomain())
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, acctest.RandomSubdomain(t))
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/transfer/server_test.go
+++ b/internal/service/transfer/server_test.go
@@ -921,7 +921,7 @@ func testAccServer_protocols(t *testing.T) {
 	acmCAResourceName := "aws_acmpca_certificate_authority.test"
 	acmCertificateResourceName := "aws_acm_certificate.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	rootDomain := acctest.RandomDomainName()
+	rootDomain := acctest.RandomDomainName(t)
 	domain := acctest.ACMCertificateRandomSubDomain(rootDomain)
 
 	acctest.Test(ctx, t, resource.TestCase{
@@ -1131,7 +1131,7 @@ func testAccServer_directoryService(t *testing.T) {
 	var conf awstypes.DescribedServer
 	resourceName := "aws_transfer_server.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/wafv2/api_key_test.go
+++ b/internal/service/wafv2/api_key_test.go
@@ -23,7 +23,7 @@ func TestAccWAFV2APIKey_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var apiKey awstypes.APIKeySummary
 	resourceName := "aws_wafv2_api_key.test"
-	domain := []string{acctest.RandomDomainName()}
+	domain := []string{acctest.RandomDomainName(t)}
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckScopeRegional(ctx, t) },
@@ -57,7 +57,7 @@ func TestAccWAFV2APIKey_multipleTokenDomains(t *testing.T) {
 	resourceName := "aws_wafv2_api_key.test"
 	var domains []string
 	for range 4 {
-		domains = append(domains, acctest.RandomDomainName())
+		domains = append(domains, acctest.RandomDomainName(t))
 	}
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -90,8 +90,8 @@ func TestAccWAFV2APIKey_changeTokenDomainsForceNew(t *testing.T) {
 	ctx := acctest.Context(t)
 	var apiKey awstypes.APIKeySummary
 	resourceName := "aws_wafv2_api_key.test"
-	domain := []string{acctest.RandomDomainName()}
-	domainNew := []string{acctest.RandomDomainName()}
+	domain := []string{acctest.RandomDomainName(t)}
+	domainNew := []string{acctest.RandomDomainName(t)}
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckScopeRegional(ctx, t) },
@@ -125,7 +125,7 @@ func TestAccWAFV2APIKey_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var apiKey awstypes.APIKeySummary
 	resourceName := "aws_wafv2_api_key.test"
-	domain := []string{acctest.RandomDomainName()}
+	domain := []string{acctest.RandomDomainName(t)}
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckScopeRegional(ctx, t) },

--- a/internal/service/workspaces/connection_alias_test.go
+++ b/internal/service/workspaces/connection_alias_test.go
@@ -23,7 +23,7 @@ func TestAccWorkSpacesConnectionAlias_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var connectionalias awstypes.ConnectionAlias
-	rName := acctest.RandomFQDomainName()
+	rName := acctest.RandomFQDomainName(t)
 	resourceName := "aws_workspaces_connection_alias.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -58,7 +58,7 @@ func TestAccWorkSpacesConnectionAlias_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var connectionalias awstypes.ConnectionAlias
-	rName := acctest.RandomFQDomainName()
+	rName := acctest.RandomFQDomainName(t)
 	resourceName := "aws_workspaces_connection_alias.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -87,7 +87,7 @@ func TestAccWorkSpacesConnectionAlias_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var connectionalias awstypes.ConnectionAlias
-	rName := acctest.RandomFQDomainName()
+	rName := acctest.RandomFQDomainName(t)
 	resourceName := "aws_workspaces_connection_alias.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/workspaces/directory_data_source_test.go
+++ b/internal/service/workspaces/directory_data_source_test.go
@@ -17,7 +17,7 @@ import (
 func testAccDirectoryDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandString(t, 8)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	resourceName := "aws_workspaces_directory.test"
 	dataSourceName := "data.aws_workspaces_directory.test"

--- a/internal/service/workspaces/directory_test.go
+++ b/internal/service/workspaces/directory_test.go
@@ -28,7 +28,7 @@ func testAccDirectory_basic(t *testing.T) {
 	directoryResourceName := "aws_directory_service_directory.main"
 	iamRoleDataSourceName := "data.aws_iam_role.workspaces-default"
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -102,7 +102,7 @@ func testAccDirectory_disappears(t *testing.T) {
 
 	resourceName := "aws_workspaces_directory.main"
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -134,7 +134,7 @@ func testAccDirectory_subnetIDs(t *testing.T) {
 
 	resourceName := "aws_workspaces_directory.main"
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -170,7 +170,7 @@ func testAccDirectory_tags(t *testing.T) {
 
 	resourceName := "aws_workspaces_directory.main"
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -224,11 +224,11 @@ func testAccDirectory_SamlProperties(t *testing.T) {
 
 	resourceName := "aws_workspaces_directory.main"
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	rspn := acctest.RandString(t, 8)
 	arspn := acctest.RandString(t, 8)
-	uau := fmt.Sprintf("https://%s/", acctest.RandomDomainName())
-	auau := fmt.Sprintf("https://%s/", acctest.RandomDomainName())
+	uau := fmt.Sprintf("https://%s/", acctest.RandomDomainName(t))
+	auau := fmt.Sprintf("https://%s/", acctest.RandomDomainName(t))
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -302,7 +302,7 @@ func testAccDirectory_CertificateBasedAuthProperties(t *testing.T) {
 
 	resourceName := "aws_workspaces_directory.main"
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	certificateAuthorityID := "12345678-1234-1234-1234-123456789012"
 
@@ -364,7 +364,7 @@ func testAccDirectory_selfServicePermissions(t *testing.T) {
 
 	resourceName := "aws_workspaces_directory.main"
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -400,7 +400,7 @@ func testAccDirectory_workspaceAccessProperties(t *testing.T) {
 
 	resourceName := "aws_workspaces_directory.main"
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -440,7 +440,7 @@ func testAccDirectory_workspaceCreationProperties(t *testing.T) {
 	resourceName := "aws_workspaces_directory.main"
 	resourceSecurityGroup := "aws_security_group.test"
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -477,7 +477,7 @@ func testAccDirectory_workspaceCreationProperties_customSecurityGroupId_defaultO
 	resourceName := "aws_workspaces_directory.main"
 	resourceSecurityGroup := "aws_security_group.test"
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -529,7 +529,7 @@ func testAccDirectory_ipGroupIDs(t *testing.T) {
 
 	resourceName := "aws_workspaces_directory.test"
 
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckHasIAMRole(ctx, t, "workspaces_DefaultRole") },
@@ -1143,7 +1143,7 @@ func testAccDirectory_poolsADConfig(t *testing.T) {
 	rName := acctest.RandString(t, 8)
 
 	resourceName := "aws_workspaces_directory.pool"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -1219,7 +1219,7 @@ func testAccDirectory_poolsWorkspaceCreationAD(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDirectory
 	rName := acctest.RandString(t, 8)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	resourceName := "aws_workspaces_directory.pool"
 
@@ -1259,7 +1259,7 @@ func testAccDirectory_tenancy(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDirectory
 	rName := acctest.RandString(t, 8)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	resourceName := "aws_workspaces_directory.main"
 

--- a/internal/service/workspaces/ip_group_test.go
+++ b/internal/service/workspaces/ip_group_test.go
@@ -143,7 +143,7 @@ func testAccIPGroup_MultipleDirectories(t *testing.T) {
 	var d1, d2 types.WorkspaceDirectory
 
 	ipGroupName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	resourceName := "aws_workspaces_ip_group.test"
 	directoryResourceName1 := "aws_workspaces_directory.test1"

--- a/internal/service/workspaces/workspace_data_source_test.go
+++ b/internal/service/workspaces/workspace_data_source_test.go
@@ -17,7 +17,7 @@ import (
 func testAccWorkspaceDataSource_byWorkspaceID(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandString(t, 8)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	dataSourceName := "data.aws_workspaces_workspace.test"
 	resourceName := "aws_workspaces_workspace.test"
 
@@ -52,7 +52,7 @@ func testAccWorkspaceDataSource_byWorkspaceID(t *testing.T) {
 func testAccWorkspaceDataSource_byDirectoryID_userName(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandString(t, 8)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 	dataSourceName := "data.aws_workspaces_workspace.test"
 	resourceName := "aws_workspaces_workspace.test"
 

--- a/internal/service/workspaces/workspace_test.go
+++ b/internal/service/workspaces/workspace_test.go
@@ -25,7 +25,7 @@ func testAccWorkspace_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Workspace
 	rName := acctest.RandString(t, 8)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	resourceName := "aws_workspaces_workspace.test"
 	directoryResourceName := "aws_workspaces_directory.test"
@@ -77,7 +77,7 @@ func testAccWorkspace_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v1, v2, v3 types.Workspace
 	rName := acctest.RandString(t, 8)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	resourceName := "aws_workspaces_workspace.test"
 
@@ -131,7 +131,7 @@ func testAccWorkspace_workspaceProperties(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v1, v2, v3 types.Workspace
 	rName := acctest.RandString(t, 8)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	resourceName := "aws_workspaces_workspace.test"
 
@@ -196,7 +196,7 @@ func testAccWorkspace_workspaceProperties_runningModeAutoStopTimeoutInMinutes(t 
 	ctx := acctest.Context(t)
 	var v1 types.Workspace
 	rName := acctest.RandString(t, 8)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	resourceName := "aws_workspaces_workspace.test"
 
@@ -248,7 +248,7 @@ func testAccWorkspace_workspaceProperties_runningModeAlwaysOn(t *testing.T) {
 	var v1 types.Workspace
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_workspaces_workspace.test"
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -285,7 +285,7 @@ func testAccWorkspace_workspaceProperties_runningModeAlwaysOn(t *testing.T) {
 func testAccWorkspace_validateRootVolumeSize(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandString(t, 8)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -304,7 +304,7 @@ func testAccWorkspace_validateRootVolumeSize(t *testing.T) {
 func testAccWorkspace_validateUserVolumeSize(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandString(t, 8)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -324,7 +324,7 @@ func testAccWorkspace_recreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Workspace
 	rName := acctest.RandString(t, 8)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	resourceName := "aws_workspaces_workspace.test"
 
@@ -360,7 +360,7 @@ func testAccWorkspace_timeout(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Workspace
 	rName := acctest.RandString(t, 8)
-	domain := acctest.RandomDomainName()
+	domain := acctest.RandomDomainName(t)
 
 	resourceName := "aws_workspaces_workspace.test"
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Swaps out the random string generation functions underpinning `acctest.RandomDomain`, `acctest.RandomSubdomain`, and `acctest.RandomFQDomain` which a `go-vcr` compatible equivalent.

Successful replay from an acceptance test which previously failed due to missing interactions:

```console
% VCR_MODE=REPLAY_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/ make t K=fsx T=TestAccFSxWindowsFileSystem_SelfManagedActiveDirectory_passwordWO
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 tmp3 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/fsx/... -v -count 1 -parallel 20 -run='TestAccFSxWindowsFileSystem_SelfManagedActiveDirectory_passwordWO'  -timeout 360m -vet=off
2026/05/06 13:29:05 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/06 13:29:05 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccFSxWindowsFileSystem_SelfManagedActiveDirectory_passwordWO (15.26s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fsx        22.714s
```

**AI Disclosure:** This change was generated by AI. All modifications have been reviewed and I fully understand the scope of changes.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47769
Relates #25602
