### PR TITLE
Provider: Removes run-time validation for SDKv2-based resource types

### DIFF
--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -845,9 +845,14 @@ func (p *sdkProvider) initialize(ctx context.Context) (map[string]conns.ServiceP
 
 // validateResourceSchemas is called from `New` to validate Terraform Plugin SDK v2-style resource schemas.
 func (p *sdkProvider) validateResourceSchemas(ctx context.Context) error {
+	return validateResourceSchemas(ctx, p.servicePackages)
+}
+
+// validateResourceSchemas is called from `New` to validate Terraform Plugin SDK v2-style resource schemas.
+func validateResourceSchemas(ctx context.Context, servicePackages iter.Seq2[int, conns.ServicePackage]) error {
 	var errs []error
 
-	for _, sp := range p.servicePackages {
+	for _, sp := range servicePackages {
 		for _, v := range sp.SDKDataSources(ctx) {
 			typeName := v.TypeName
 			r := v.Factory()

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -543,12 +543,6 @@ func (p *sdkProvider) initialize(ctx context.Context) (map[string]conns.ServiceP
 
 			r := v.Factory()
 
-			// Ensure that the correct CRUD handler variants are used.
-			if r.Read != nil || r.ReadContext != nil {
-				errs = append(errs, fmt.Errorf("incorrect Read handler variant: %s data source", typeName))
-				continue
-			}
-
 			var isRegionOverrideEnabled bool
 			if v := v.Region; !tfunique.IsHandleNil(v) && v.Value().IsOverrideEnabled {
 				isRegionOverrideEnabled = true
@@ -642,24 +636,6 @@ func (p *sdkProvider) initialize(ctx context.Context) (map[string]conns.ServiceP
 			}
 
 			r := resource.Factory()
-
-			// Ensure that the correct CRUD handler variants are used.
-			if r.Create != nil || r.CreateContext != nil {
-				errs = append(errs, fmt.Errorf("incorrect Create handler variant: %s resource", typeName))
-				continue
-			}
-			if r.Read != nil || r.ReadContext != nil {
-				errs = append(errs, fmt.Errorf("incorrect Read handler variant: %s resource", typeName))
-				continue
-			}
-			if r.Update != nil || r.UpdateContext != nil {
-				errs = append(errs, fmt.Errorf("incorrect Update handler variant: %s resource", typeName))
-				continue
-			}
-			if r.Delete != nil || r.DeleteContext != nil {
-				errs = append(errs, fmt.Errorf("incorrect Delete handler variant: %s resource", typeName))
-				continue
-			}
 
 			var isRegionOverrideEnabled bool
 			if v := resource.Region; !tfunique.IsHandleNil(v) && v.Value().IsOverrideEnabled {

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -38,10 +38,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-var (
-	resourceSchemasValidated bool
-)
-
 type sdkProvider struct {
 	provider        *schema.Provider
 	servicePackages iter.Seq2[int, conns.ServicePackage]
@@ -314,24 +310,6 @@ func NewProvider(ctx context.Context) (*schema.Provider, error) {
 	}
 
 	sdkProvider.provider.ConfigureContextFunc = sdkProvider.configure
-
-	// Acceptance tests call this function multiple times, potentially in parallel.
-	// To avoid "fatal error: concurrent map writes", take a lock.
-	const (
-		mutexKVKey = "provider.New"
-	)
-	conns.GlobalMutexKV.Lock(mutexKVKey)
-	defer conns.GlobalMutexKV.Unlock(mutexKVKey)
-
-	// Because we try and share resource schemas as much as possible,
-	// we need to ensure that we only validate the resource schemas once.
-	if !resourceSchemasValidated {
-		if err := sdkProvider.validateResourceSchemas(ctx); err != nil {
-			return nil, err
-		}
-
-		resourceSchemasValidated = true
-	}
 
 	servicePackageMap, err := sdkProvider.initialize(ctx)
 
@@ -841,90 +819,6 @@ func (p *sdkProvider) initialize(ctx context.Context) (map[string]conns.ServiceP
 	}
 
 	return servicePackageMap, errors.Join(errs...)
-}
-
-// validateResourceSchemas is called from `New` to validate Terraform Plugin SDK v2-style resource schemas.
-func (p *sdkProvider) validateResourceSchemas(ctx context.Context) error {
-	return validateResourceSchemas(ctx, p.servicePackages)
-}
-
-// validateResourceSchemas is called from `New` to validate Terraform Plugin SDK v2-style resource schemas.
-func validateResourceSchemas(ctx context.Context, servicePackages iter.Seq2[int, conns.ServicePackage]) error {
-	var errs []error
-
-	for _, sp := range servicePackages {
-		for _, v := range sp.SDKDataSources(ctx) {
-			typeName := v.TypeName
-			r := v.Factory()
-			s := r.SchemaMap()
-
-			if v := v.Region; !tfunique.IsHandleNil(v) && v.Value().IsOverrideEnabled {
-				if _, ok := s[names.AttrRegion]; ok {
-					errs = append(errs, fmt.Errorf("`%s` attribute is defined: %s data source", names.AttrRegion, typeName))
-					continue
-				}
-			}
-
-			if !tfunique.IsHandleNil(v.Tags) {
-				// The data source has opted in to transparent tagging.
-				// Ensure that the schema look OK.
-				if v, ok := s[names.AttrTags]; ok {
-					if !v.Computed {
-						errs = append(errs, fmt.Errorf("`%s` attribute must be Computed: %s data source", names.AttrTags, typeName))
-						continue
-					}
-				} else {
-					errs = append(errs, fmt.Errorf("no `%s` attribute defined in schema: %s data source", names.AttrTags, typeName))
-					continue
-				}
-			}
-		}
-
-		for _, resource := range sp.SDKResources(ctx) {
-			typeName := resource.TypeName
-			r := resource.Factory()
-			s := r.SchemaMap()
-
-			if v := resource.Region; !tfunique.IsHandleNil(v) && v.Value().IsOverrideEnabled {
-				if _, ok := s[names.AttrRegion]; ok {
-					errs = append(errs, fmt.Errorf("`%s` attribute is defined: %s resource", names.AttrRegion, typeName))
-					continue
-				}
-			}
-
-			if !tfunique.IsHandleNil(resource.Tags) {
-				// The resource has opted in to transparent tagging.
-				// Ensure that the schema look OK.
-				if v, ok := s[names.AttrTags]; ok {
-					if v.Computed {
-						errs = append(errs, fmt.Errorf("`%s` attribute cannot be Computed: %s resource", names.AttrTags, typeName))
-						continue
-					}
-				} else {
-					errs = append(errs, fmt.Errorf("no `%s` attribute defined in schema: %s resource", names.AttrTags, typeName))
-					continue
-				}
-				if v, ok := s[names.AttrTagsAll]; ok {
-					if !v.Computed {
-						errs = append(errs, fmt.Errorf("`%s` attribute must be Computed: %s resource", names.AttrTags, typeName))
-						continue
-					}
-				} else {
-					errs = append(errs, fmt.Errorf("no `%s` attribute defined in schema: %s resource", names.AttrTagsAll, typeName))
-					continue
-				}
-			}
-
-			if resource.Identity.IsCustomInherentRegion {
-				if resource.Identity.IsGlobalResource {
-					errs = append(errs, fmt.Errorf("`IsCustomInherentRegion` is not supported for Global resources: %s resource", typeName))
-					continue
-				}
-			}
-		}
-	}
-
-	return errors.Join(errs...)
 }
 
 func assumeRoleSchema() *schema.Schema {

--- a/internal/provider/sdkv2/provider_test.go
+++ b/internal/provider/sdkv2/provider_test.go
@@ -461,6 +461,13 @@ func validateResourceSchemas(ctx context.Context, servicePackages iter.Seq2[int,
 		for _, v := range sp.SDKDataSources(ctx) {
 			typeName := v.TypeName
 			r := v.Factory()
+
+			// Ensure that the correct CRUD handler variants are used.
+			if r.Read != nil || r.ReadContext != nil {
+				errs = append(errs, fmt.Errorf("incorrect Read handler variant: %s data source", typeName))
+				continue
+			}
+
 			s := r.SchemaMap()
 
 			if v := v.Region; !tfunique.IsHandleNil(v) && v.Value().IsOverrideEnabled {
@@ -488,6 +495,24 @@ func validateResourceSchemas(ctx context.Context, servicePackages iter.Seq2[int,
 		for _, resource := range sp.SDKResources(ctx) {
 			typeName := resource.TypeName
 			r := resource.Factory()
+
+			// Ensure that the correct CRUD handler variants are used.
+			if r.Create != nil || r.CreateContext != nil {
+				errs = append(errs, fmt.Errorf("incorrect Create handler variant: %s resource", typeName))
+				continue
+			}
+			if r.Read != nil || r.ReadContext != nil {
+				errs = append(errs, fmt.Errorf("incorrect Read handler variant: %s resource", typeName))
+				continue
+			}
+			if r.Update != nil || r.UpdateContext != nil {
+				errs = append(errs, fmt.Errorf("incorrect Update handler variant: %s resource", typeName))
+				continue
+			}
+			if r.Delete != nil || r.DeleteContext != nil {
+				errs = append(errs, fmt.Errorf("incorrect Delete handler variant: %s resource", typeName))
+				continue
+			}
 			s := r.SchemaMap()
 
 			if v := resource.Region; !tfunique.IsHandleNil(v) && v.Value().IsOverrideEnabled {

--- a/internal/provider/sdkv2/provider_test.go
+++ b/internal/provider/sdkv2/provider_test.go
@@ -4,6 +4,10 @@
 package sdkv2
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
 	"os"
 	"slices"
 	"strings"
@@ -13,8 +17,10 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	tfunique "github.com/hashicorp/terraform-provider-aws/internal/unique"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -24,11 +30,6 @@ func BenchmarkSDKProviderInitialization(b *testing.B) {
 	ctx := b.Context()
 	for b.Loop() {
 		_, err := NewProvider(ctx)
-		if err != nil {
-			b.Fatal(err)
-		}
-
-		err = validateResourceSchemas(ctx, slices.All(servicePackages(ctx)))
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -450,4 +451,83 @@ func popEnv(env []string) {
 		k, v, _ := strings.Cut(e, "=")
 		os.Setenv(k, v)
 	}
+}
+
+// validateResourceSchemas is called from `New` to validate Terraform Plugin SDK v2-style resource schemas.
+func validateResourceSchemas(ctx context.Context, servicePackages iter.Seq2[int, conns.ServicePackage]) error {
+	var errs []error
+
+	for _, sp := range servicePackages {
+		for _, v := range sp.SDKDataSources(ctx) {
+			typeName := v.TypeName
+			r := v.Factory()
+			s := r.SchemaMap()
+
+			if v := v.Region; !tfunique.IsHandleNil(v) && v.Value().IsOverrideEnabled {
+				if _, ok := s[names.AttrRegion]; ok {
+					errs = append(errs, fmt.Errorf("`%s` attribute is defined: %s data source", names.AttrRegion, typeName))
+					continue
+				}
+			}
+
+			if !tfunique.IsHandleNil(v.Tags) {
+				// The data source has opted in to transparent tagging.
+				// Ensure that the schema look OK.
+				if v, ok := s[names.AttrTags]; ok {
+					if !v.Computed {
+						errs = append(errs, fmt.Errorf("`%s` attribute must be Computed: %s data source", names.AttrTags, typeName))
+						continue
+					}
+				} else {
+					errs = append(errs, fmt.Errorf("no `%s` attribute defined in schema: %s data source", names.AttrTags, typeName))
+					continue
+				}
+			}
+		}
+
+		for _, resource := range sp.SDKResources(ctx) {
+			typeName := resource.TypeName
+			r := resource.Factory()
+			s := r.SchemaMap()
+
+			if v := resource.Region; !tfunique.IsHandleNil(v) && v.Value().IsOverrideEnabled {
+				if _, ok := s[names.AttrRegion]; ok {
+					errs = append(errs, fmt.Errorf("`%s` attribute is defined: %s resource", names.AttrRegion, typeName))
+					continue
+				}
+			}
+
+			if !tfunique.IsHandleNil(resource.Tags) {
+				// The resource has opted in to transparent tagging.
+				// Ensure that the schema look OK.
+				if v, ok := s[names.AttrTags]; ok {
+					if v.Computed {
+						errs = append(errs, fmt.Errorf("`%s` attribute cannot be Computed: %s resource", names.AttrTags, typeName))
+						continue
+					}
+				} else {
+					errs = append(errs, fmt.Errorf("no `%s` attribute defined in schema: %s resource", names.AttrTags, typeName))
+					continue
+				}
+				if v, ok := s[names.AttrTagsAll]; ok {
+					if !v.Computed {
+						errs = append(errs, fmt.Errorf("`%s` attribute must be Computed: %s resource", names.AttrTags, typeName))
+						continue
+					}
+				} else {
+					errs = append(errs, fmt.Errorf("no `%s` attribute defined in schema: %s resource", names.AttrTagsAll, typeName))
+					continue
+				}
+			}
+
+			if resource.Identity.IsCustomInherentRegion {
+				if resource.Identity.IsGlobalResource {
+					errs = append(errs, fmt.Errorf("`IsCustomInherentRegion` is not supported for Global resources: %s resource", typeName))
+					continue
+				}
+			}
+		}
+	}
+
+	return errors.Join(errs...)
 }

--- a/internal/provider/sdkv2/provider_test.go
+++ b/internal/provider/sdkv2/provider_test.go
@@ -5,6 +5,7 @@ package sdkv2
 
 import (
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -26,6 +27,11 @@ func BenchmarkSDKProviderInitialization(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
+
+		err = validateResourceSchemas(ctx, slices.All(servicePackages(ctx)))
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -36,6 +42,11 @@ func TestProviderInit(t *testing.T) {
 	p, err := NewProvider(ctx)
 	if err != nil {
 		t.Fatalf("Initializing SDKv2 provider: %s", err)
+	}
+
+	err = validateResourceSchemas(ctx, slices.All(servicePackages(ctx)))
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	p.TerraformVersion = "1.0.0"

--- a/internal/service/sns/platform_application.go
+++ b/internal/service/sns/platform_application.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"maps"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -119,7 +120,7 @@ func resourcePlatformApplication() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: platformApplicationSchema,
+		Schema: maps.Clone(platformApplicationSchema),
 	}
 }
 

--- a/internal/service/sns/sms_preferences.go
+++ b/internal/service/sns/sms_preferences.go
@@ -8,6 +8,7 @@ package sns
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go-v2/service/sns"
@@ -133,7 +134,7 @@ func resourceSMSPreferences() *schema.Resource {
 		UpdateWithoutTimeout: resourceSMSPreferencesSet,
 		DeleteWithoutTimeout: resourceSMSPreferencesDelete,
 
-		Schema: smsPreferencesSchema,
+		Schema: maps.Clone(smsPreferencesSchema),
 	}
 }
 

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"maps"
 	"regexp"
 	"strconv"
 	"time"
@@ -229,7 +230,7 @@ func resourceTopic() *schema.Resource {
 
 		CustomizeDiff: resourceTopicCustomizeDiff,
 
-		Schema: topicSchema,
+		Schema: maps.Clone(topicSchema),
 	}
 }
 

--- a/internal/service/sns/topic_subscription.go
+++ b/internal/service/sns/topic_subscription.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"maps"
 	"strings"
 	"time"
 
@@ -144,7 +145,7 @@ func resourceTopicSubscription() *schema.Resource {
 
 		CustomizeDiff: resourceTopicSubscriptionCustomizeDiff,
 
-		Schema: subscriptionSchema,
+		Schema: maps.Clone(subscriptionSchema),
 	}
 }
 

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -211,7 +212,7 @@ func resourceQueue() *schema.Resource {
 
 		CustomizeDiff: resourceQueueCustomizeDiff,
 
-		Schema: queueSchema,
+		Schema: maps.Clone(queueSchema),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(3 * time.Minute),


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Removes run-time validation for SDKv2-based resource types and adds validation step to Makefile directives.

This reduces some memory allocation at initialization time, but hard-coded `Schema` values and `provider.InternalValidate` mask this reduction. The impact will grow as hard-coded `Schema` values are removed.

Relates: #47003
