### PR TITLE
[bugfix] fix engine version change aws_neptune_global_cluster

### DIFF
--- a/.changelog/47803.txt
+++ b/.changelog/47803.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_neptune_cluster: Skip engine version update when cluster is part of a global cluster
+```

--- a/internal/service/neptune/cluster.go
+++ b/internal/service/neptune/cluster.go
@@ -670,8 +670,10 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 
 		if d.HasChange(names.AttrEngineVersion) {
-			input.EngineVersion = aws.String(d.Get(names.AttrEngineVersion).(string))
-			input.DBClusterParameterGroupName = aws.String(d.Get("neptune_cluster_parameter_group_name").(string))
+			if _, ok := d.GetOk("global_cluster_identifier"); !ok {
+				input.EngineVersion = aws.String(d.Get(names.AttrEngineVersion).(string))
+				input.DBClusterParameterGroupName = aws.String(d.Get("neptune_cluster_parameter_group_name").(string))
+			}
 		}
 
 		if d.HasChange("iam_database_authentication_enabled") {

--- a/internal/service/neptune/cluster_test.go
+++ b/internal/service/neptune/cluster_test.go
@@ -873,6 +873,55 @@ func TestAccNeptuneCluster_GlobalUpgrade_minorTertiary(t *testing.T) {
 	})
 }
 
+func TestAccNeptuneCluster_GlobalCluster_engineVersionIgnore(t *testing.T) {
+	ctx := acctest.Context(t)
+	var providers []*schema.Provider
+	var p, s awstypes.DBCluster
+	var globalCluster awstypes.GlobalCluster
+	resourceNamePrimary := "aws_neptune_cluster.primary"
+	resourceNameSecondary := "aws_neptune_cluster.secondary"
+	globalClusterResourceName := "aws_neptune_global_cluster.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+			testAccPreCheckGlobalCluster(ctx, t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, names.NeptuneServiceID),
+		CheckDestroy: testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5FactoriesPlusProvidersAlternate(ctx, t, &providers),
+				Config:                   testAccClusterConfig_globalClusterEngineVersion(rName, "1.4.1.0"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGlobalClusterExists(ctx, t, globalClusterResourceName, &globalCluster),
+					testAccCheckClusterExistsWithProvider(ctx, resourceNamePrimary, &p, acctest.RegionProviderFunc(ctx, acctest.Region(), &providers)),
+					testAccCheckClusterExistsWithProvider(ctx, resourceNameSecondary, &s, acctest.RegionProviderFunc(ctx, acctest.AlternateRegion(), &providers)),
+					resource.TestCheckResourceAttr(resourceNamePrimary, names.AttrEngineVersion, "1.4.1.0"),
+					resource.TestCheckResourceAttr(resourceNamePrimary, "global_cluster_identifier", rName),
+					resource.TestCheckResourceAttr(resourceNameSecondary, names.AttrEngineVersion, "1.4.1.0"),
+					resource.TestCheckResourceAttr(resourceNameSecondary, "global_cluster_identifier", rName),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5FactoriesPlusProvidersAlternate(ctx, t, &providers),
+				Config:                   testAccClusterConfig_globalClusterEngineVersion(rName, "1.4.3.0"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGlobalClusterExists(ctx, t, globalClusterResourceName, &globalCluster),
+					testAccCheckClusterExistsWithProvider(ctx, resourceNamePrimary, &p, acctest.RegionProviderFunc(ctx, acctest.Region(), &providers)),
+					testAccCheckClusterExistsWithProvider(ctx, resourceNameSecondary, &s, acctest.RegionProviderFunc(ctx, acctest.AlternateRegion(), &providers)),
+					resource.TestCheckResourceAttr(resourceNamePrimary, names.AttrEngineVersion, "1.4.3.0"),
+					resource.TestCheckResourceAttr(resourceNamePrimary, "global_cluster_identifier", rName),
+					resource.TestCheckResourceAttr(resourceNameSecondary, names.AttrEngineVersion, "1.4.3.0"),
+					resource.TestCheckResourceAttr(resourceNameSecondary, "global_cluster_identifier", rName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNeptuneCluster_deleteProtection(t *testing.T) {
 	ctx := acctest.Context(t)
 	var dbCluster awstypes.DBCluster
@@ -1714,6 +1763,100 @@ resource "aws_neptune_cluster_instance" "secondary" {
   instance_class     = "db.r6g.large"
 }
 `, rNameGlobal, rNamePrimary, rNameSecondary))
+}
+
+func testAccClusterConfig_globalClusterEngineVersion(rName, engineVersion string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(2),
+		fmt.Sprintf(`
+data "aws_availability_zones" "alternate" {
+  provider = "awsalternate"
+  state    = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_neptune_global_cluster" "test" {
+  global_cluster_identifier = %[1]q
+  engine                    = "neptune"
+  engine_version            = %[2]q
+}
+
+resource "aws_neptune_cluster" "primary" {
+  apply_immediately         = true
+  cluster_identifier        = "%[1]s-primary"
+  engine                    = aws_neptune_global_cluster.test.engine
+  engine_version            = aws_neptune_global_cluster.test.engine_version
+  global_cluster_identifier = aws_neptune_global_cluster.test.global_cluster_identifier
+  skip_final_snapshot       = true
+}
+
+resource "aws_neptune_cluster_instance" "primary" {
+  apply_immediately  = true
+  cluster_identifier = aws_neptune_cluster.primary.id
+  engine             = aws_neptune_cluster.primary.engine
+  engine_version     = aws_neptune_cluster.primary.engine_version
+  identifier         = "%[1]s-primary"
+  instance_class     = "db.r6g.large"
+}
+
+resource "aws_vpc" "alternate" {
+  provider   = "awsalternate"
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "%[1]s-secondary"
+  }
+}
+
+resource "aws_subnet" "alternate" {
+  provider          = "awsalternate"
+  count             = 3
+  vpc_id            = aws_vpc.alternate.id
+  availability_zone = data.aws_availability_zones.alternate.names[count.index]
+  cidr_block        = "10.0.${count.index}.0/24"
+
+  tags = {
+    Name = "%[1]s-secondary"
+  }
+}
+
+resource "aws_neptune_subnet_group" "alternate" {
+  provider   = "awsalternate"
+  name       = "%[1]s-secondary"
+  subnet_ids = aws_subnet.alternate[*].id
+}
+
+resource "aws_neptune_cluster" "secondary" {
+  provider                  = "awsalternate"
+  apply_immediately         = true
+  cluster_identifier        = "%[1]s-secondary"
+  engine                    = aws_neptune_global_cluster.test.engine
+  engine_version            = aws_neptune_global_cluster.test.engine_version
+  global_cluster_identifier = aws_neptune_global_cluster.test.global_cluster_identifier
+  neptune_subnet_group_name = aws_neptune_subnet_group.alternate.name
+  skip_final_snapshot       = true
+
+  depends_on = [aws_neptune_cluster_instance.primary]
+
+  lifecycle {
+    ignore_changes = [replication_source_identifier]
+  }
+}
+
+resource "aws_neptune_cluster_instance" "secondary" {
+  provider           = "awsalternate"
+  apply_immediately  = true
+  cluster_identifier = aws_neptune_cluster.secondary.id
+  engine             = aws_neptune_cluster.secondary.engine
+  engine_version     = aws_neptune_cluster.secondary.engine_version
+  identifier         = "%[1]s-secondary"
+  instance_class     = "db.r6g.large"
+}
+`, rName, engineVersion))
 }
 
 func testAccClusterConfig_restoreFromSnapshot(rName string) string {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes a timeout error when upgrading `engine_version` on `aws_neptune_global_cluster` that has member clusters.

When a Neptune cluster is part of a global cluster, engine version upgrades are managed by the global cluster resource. Previously, when the global cluster upgraded the engine version (e.g., from 1.4.1.0 to 1.4.3.0), the provider would also attempt to call `ModifyDBCluster` with the new engine version directly on each member cluster. This caused a conflict - the global cluster upgrade was already in progress, and the member cluster modification would time out waiting for the cluster to become available (stuck in upgrading state).

This change skips the engine version update in `resourceClusterUpdate()` when the cluster has a `global_cluster_identifier` set, allowing the global cluster to manage version upgrades for its members without conflict.

This also removes the need for users to add `lifecycle { ignore_changes = [engine_version] }` on member clusters as a workaround.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47861
Closes #46181

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccNeptuneCluster_GlobalCluster_engineVersionIgnore PKG=neptune ACCTEST_PARALLELISM=1 ACCTEST_TIMEOUT=4880m
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-neptune-global-cluster-engineversion 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/neptune/... -v -count 1 -parallel 1 -run='TestAccNeptuneCluster_GlobalCluster_engineVersionIgnore'  -timeout 4880m -vet=off
2026/05/06 12:33:36 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/06 12:33:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccNeptuneCluster_GlobalCluster_engineVersionIgnore
=== PAUSE TestAccNeptuneCluster_GlobalCluster_engineVersionIgnore
=== CONT  TestAccNeptuneCluster_GlobalCluster_engineVersionIgnore
--- PASS: TestAccNeptuneCluster_GlobalCluster_engineVersionIgnore (4011.32s)
PASS
ok  
