### PR TITLE
Linting: Exclude agentic markdown from `markdown-lint`

### DIFF
--- a/.agents/contributor.md
+++ b/.agents/contributor.md
@@ -6,16 +6,13 @@
 You are a senior Go developer focusing on AWS services.
 
 ### Tone & Style
-
 - Direct, concise, and focused on code implementation.
 - Favor standard Go idioms.
 
 ### Responsibilities
-
 - Contributes code in the form of bugfixes, enhancements to existing resources, and new resources.
 - Write tests alongside code.
 - Make clarifications and corrections to existing documentation.
 
 ### Constraints
-
 - Do not review PRs. Refer to `@maintainer`.

--- a/.agents/maintainer.md
+++ b/.agents/maintainer.md
@@ -6,11 +6,9 @@
 You are a senior Go developer focusing on AWS services.
 
 ### Tone & Style
-
 - Accurate, thorough, and focused on code and test implementations.
 
 ### Responsibilities
-
 - You are a steward of the project, responsible for both internal and external quality.
 - Review contributions for
   - Correctness
@@ -33,5 +31,4 @@ You are a senior Go developer focusing on AWS services.
     - Any unbounded loops or unconstrained data fetching?
 
 ### Constraints
-
 - Do not contribute PRs. Refer to `@contributor`.

--- a/.agents/tcm.md
+++ b/.agents/tcm.md
@@ -6,17 +6,14 @@
 You are a senior community manager focusing on AWS services.
 
 ### Tone & Style
-
 - Direct, concise, and friendly communications.
 - Accurate analysis.
 
 ### Responsibilities
-
 - Triage incoming GitHub issues and PRs.
 - Engage with community members to answer technical and process questions.
 - Suggest workarounds and alternatives to reported bugs.
 
 ### Constraints
-
 - Do not contribute PRs. Refer to `@contributor`.
 - Do not review PRs. Refer to `@maintainer`.

--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -463,7 +463,7 @@ jobs:
       - uses: avto-dev/markdown-lint@04d43ee9191307b50935a753da3b775ab695eceb # v1.5.0
         with:
           args: "."
-          ignore: "./docs ./website/docs ./CHANGELOG.md ./internal/service/cloudformation/test-fixtures/examplecompany-exampleservice-exampleresource/docs"
+          ignore: "./.agents ./docs ./website/docs ./AGENTS.md ./CHANGELOG.md ./internal/service/cloudformation/test-fixtures/examplecompany-exampleservice-exampleresource/docs"
 
   misspell:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,13 +15,11 @@ This is the Go-based Terraform AWS Provider (`github.com/hashicorp/terraform-pro
 This project uses specialized personas for different tasks.
 
 ### Available Personas
-
 - **`@contributor`**: [Contributor Persona](./.agents/contributor.md) - Contributes code in the form of bugfixes, enhancements to existing resources, and new resources. Makes clarifications and corrections to existing documentation.
 - **`@maintainer`**: [Maintainer Persona](./.agents/maintainer.md) - Steward of the project, responsible for both internal and external quality. Reviews contributions. Maintains provider-level features, including new Terraform language constructs.
 - **`@tcm`**: [TCM Persona](./.agents/tcm.md) - Triages incoming GitHub issues and PRs. Engages with community members to answer technical and process questions. Suggests workarounds and alternatives to reported bugs.
 
 ### Global Rules
-
 - Always use the requested persona for tasks.
 - If no persona is specified, default to `@contributor`.
 - A persona defines a role with a perspective and responsibilities.
@@ -39,7 +37,6 @@ Skills are loaded from `./.agents/skills`. Each skill supplies step-by-step inst
 ## Global Rules
 
 ### Non-negotiables
-
 - Verification is a hard exit criterion for every task. Without it, the task is not done.
 - Prefer the boring, obvious solution.
 - Touch only what you’re asked to touch.
@@ -152,7 +149,6 @@ Net-new resources must use Terraform Plugin Framework. Existing SDKv2 resources 
 ### Code Style and Conventions
 
 #### Naming
-
 - Service packages: `internal/service/<serviceidentifier>` — lowercase, no underscores, prefer the shorter AWS SDK/CLI name.
 - Go files: `snake_case.go`; data sources end with `_data_source.go`; tests end with `_test.go`.
 - Main constructors: `Resource<Name>()` and `DataSource<Name>()`.
@@ -172,13 +168,11 @@ Required aliases:
 - `github.com/hashicorp/terraform-provider-aws/internal/types` → `inttypes`
 
 #### Schema
-
 - Prefer `Optional: true` + `Computed: true` for attributes with server-side defaults; avoid provider defaults.
 - Use AWS SDK constants instead of duplicating string values.
 - For Framework resources, use `internal/framework/flex` AutoFlex before writing custom conversion code.
 
 #### Error Handling
-
 - Name error variables `err`; use early returns.
 - Wrap errors: `fmt.Errorf("doing thing: %w", err)`.
 - Use `tfawserr.ErrCodeEquals` / `tfawserr.ErrMessageContains` for AWS API error matching.
@@ -194,7 +188,6 @@ AutoFlex ignores `Tags` by default. Keep tagging logic separate.
 Must name the specific linter and explain why: `//nolint:staticcheck // reason`.
 
 ### Testing Conventions
-
 - Unit tests: `Test<FunctionName>` — no service name, usually no underscores, always call `t.Parallel()`.
 - Acceptance tests: `TestAcc<Service><Resource>_<case>` — e.g., `TestAccIAMRole_basic`, `TestAccIAMRole_tags`.
 - Serialized acceptance helpers: `testAcc<Resource>_<case>` (lowercase `t`, no service name).
@@ -203,7 +196,6 @@ Must name the specific linter and explain why: `//nolint:staticcheck // reason`.
 - Place unit tests before acceptance tests in the same file.
 
 ### Pre-PR Checklist
-
 1. `make quick-fix PKG=<service>` — auto-fix formatting, imports, HCL, copyright.
 2. `make test PKG=<service>` — unit tests pass.
 3. `make golangci-lint PKG=<service>` — no new lint errors.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -527,8 +527,10 @@ provider-markdown-lint: ## [CI] Provider Check / markdown-lint
 		-v "$(PWD):/markdown" \
 		avtodev/markdown-lint:v1.5.0 \
 		--config markdown/.markdownlint.yml \
+		--ignore markdown/.agents \
 		--ignore markdown/docs \
 		--ignore markdown/website/docs \
+		--ignore markdown/AGENTS.md \
 		--ignore markdown/CHANGELOG.md \
 		--ignore markdown/internal/service/cloudformation/test-fixtures/examplecompany-exampleservice-exampleresource/docs \
 		/markdown/**/*.md


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Exclude agentic markdown from `markdown-lint` checks:

* `AGENTS.md`
* Everything below `.agents`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/47302.