### PR TITLE
resource/aws_secretsmanager_secret_version: Allow switching from `secret_string` to `secret_string_wo` without re-creating

### DIFF
--- a/.changelog/47815.txt
+++ b/.changelog/47815.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_secretsmanager_secret_version: Allow switching from `secret_string` to `secret_string_wo` without re-creating the resource.
+```

--- a/internal/service/secretsmanager/exports_test.go
+++ b/internal/service/secretsmanager/exports_test.go
@@ -19,4 +19,6 @@ var (
 
 	ValidSecretName       = validSecretName
 	ValidSecretNamePrefix = validSecretNamePrefix
+
+	SecretVersionForceNewCustomDiffInner = secretVersionForceNewCustomDiffInner
 )

--- a/internal/service/secretsmanager/secret_version.go
+++ b/internal/service/secretsmanager/secret_version.go
@@ -75,7 +75,6 @@ func resourceSecretVersion() *schema.Resource {
 			"secret_string": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ForceNew:      true,
 				Sensitive:     true,
 				ConflictsWith: []string{"secret_binary", "secret_string_wo"},
 			},
@@ -90,7 +89,6 @@ func resourceSecretVersion() *schema.Resource {
 			"secret_string_wo_version": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ForceNew:     true,
 				RequiredWith: []string{"secret_string_wo"},
 			},
 			"version_id": {
@@ -104,6 +102,8 @@ func resourceSecretVersion() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
+
+		CustomizeDiff: secretVersionForceNewCustomDiff,
 	}
 }
 
@@ -506,4 +506,98 @@ func (secretVersionImportID) Parse(id string) (string, map[string]any, error) {
 	}
 
 	return id, results, nil
+}
+
+func secretVersionForceNewCustomDiff(ctx context.Context, rd *schema.ResourceDiff, meta any) error {
+	return secretVersionForceNewCustomDiffInner(ctx, rd, meta)
+}
+
+type rawDiffer interface {
+	GetRawState() cty.Value
+	GetRawConfig() cty.Value
+	ForceNew(key string) error
+}
+
+func secretVersionForceNewCustomDiffInner(ctx context.Context, diff rawDiffer, meta any) error {
+	rawState := diff.GetRawState()
+	if rawState.IsNull() {
+		return nil
+	}
+
+	rawConfig := diff.GetRawConfig()
+	if rawConfig.IsNull() {
+		return nil
+	}
+
+	stateStringValue := rawState.GetAttr("secret_string")
+	hasStateString := stateStringValue.IsKnown() && !stateStringValue.IsNull()
+	if hasStateString {
+		hasStateString = stateStringValue.AsString() != ""
+	}
+
+	if hasStateString {
+		configStringValue := rawConfig.GetAttr("secret_string")
+		hasConfigString := configStringValue.IsKnown() && !configStringValue.IsNull()
+		if hasConfigString {
+			hasConfigString = configStringValue.AsString() != ""
+		}
+
+		if hasConfigString {
+			stateString := stateStringValue.AsString()
+			configString := configStringValue.AsString()
+			if stateString != configString {
+				if err := diff.ForceNew("secret_string"); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+
+		configStringWOValue := rawConfig.GetAttr("secret_string_wo")
+		hasStateStringWO := configStringWOValue.IsKnown() && !configStringWOValue.IsNull()
+		if hasStateStringWO {
+			stateString := stateStringValue.AsString()
+			configString := configStringWOValue.AsString()
+			if stateString != configString {
+				if err := diff.ForceNew("secret_string"); err != nil {
+					return err
+				}
+				if err := diff.ForceNew("secret_string_wo"); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	}
+
+	stateStringWoVersionValue := rawState.GetAttr("secret_string_wo_version")
+	hasStateStringWoVersion := stateStringWoVersionValue.IsKnown() && !stateStringWoVersionValue.IsNull()
+
+	if hasStateStringWoVersion {
+		configStringWoVersionValue := rawConfig.GetAttr("secret_string_wo_version")
+		if !configStringWoVersionValue.IsKnown() {
+			return nil
+		}
+
+		if !configStringWoVersionValue.IsNull() {
+			if configStringWoVersionValue.Equals(stateStringWoVersionValue).False() {
+				if err := diff.ForceNew("secret_string_wo_version"); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+
+		configStringValue := rawConfig.GetAttr("secret_string")
+		if !configStringValue.IsKnown() {
+			return nil
+		}
+		if !configStringValue.IsNull() {
+			if err := diff.ForceNew("secret_string"); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/internal/service/secretsmanager/secret_version.go
+++ b/internal/service/secretsmanager/secret_version.go
@@ -253,78 +253,80 @@ func resourceSecretVersionUpdate(ctx context.Context, d *schema.ResourceData, me
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	o, n := d.GetChange("version_stages")
-	os, ns := o.(*schema.Set), n.(*schema.Set)
-	add, del := flex.ExpandStringValueSet(ns.Difference(os)), flex.ExpandStringValueSet(os.Difference(ns))
+	if d.HasChange("version_stages") {
+		o, n := d.GetChange("version_stages")
+		os, ns := o.(*schema.Set), n.(*schema.Set)
+		add, del := flex.ExpandStringValueSet(ns.Difference(os)), flex.ExpandStringValueSet(os.Difference(ns))
 
-	var listedVersionIDs bool
-	for _, stage := range add {
-		inputU := &secretsmanager.UpdateSecretVersionStageInput{
-			MoveToVersionId: aws.String(versionID),
-			SecretId:        aws.String(secretID),
-			VersionStage:    aws.String(stage),
-		}
+		var listedVersionIDs bool
+		for _, stage := range add {
+			inputU := &secretsmanager.UpdateSecretVersionStageInput{
+				MoveToVersionId: aws.String(versionID),
+				SecretId:        aws.String(secretID),
+				VersionStage:    aws.String(stage),
+			}
 
-		if !listedVersionIDs {
-			if stage == secretVersionStageCurrent {
-				inputL := &secretsmanager.ListSecretVersionIdsInput{
-					SecretId: aws.String(secretID),
-				}
-				var versionStageCurrentVersionID string
-
-				paginator := secretsmanager.NewListSecretVersionIdsPaginator(conn, inputL)
-			listVersionIDs:
-				for paginator.HasMorePages() {
-					page, err := paginator.NextPage(ctx)
-
-					if err != nil {
-						return sdkdiag.AppendErrorf(diags, "listing Secrets Manager Secret (%s) version IDs: %s", secretID, err)
+			if !listedVersionIDs {
+				if stage == secretVersionStageCurrent {
+					inputL := &secretsmanager.ListSecretVersionIdsInput{
+						SecretId: aws.String(secretID),
 					}
+					var versionStageCurrentVersionID string
 
-					for _, version := range page.Versions {
-						for _, versionStage := range version.VersionStages {
-							if versionStage == secretVersionStageCurrent {
-								versionStageCurrentVersionID = aws.ToString(version.VersionId)
-								break listVersionIDs
+					paginator := secretsmanager.NewListSecretVersionIdsPaginator(conn, inputL)
+				listVersionIDs:
+					for paginator.HasMorePages() {
+						page, err := paginator.NextPage(ctx)
+
+						if err != nil {
+							return sdkdiag.AppendErrorf(diags, "listing Secrets Manager Secret (%s) version IDs: %s", secretID, err)
+						}
+
+						for _, version := range page.Versions {
+							for _, versionStage := range version.VersionStages {
+								if versionStage == secretVersionStageCurrent {
+									versionStageCurrentVersionID = aws.ToString(version.VersionId)
+									break listVersionIDs
+								}
 							}
 						}
 					}
-				}
 
-				inputU.RemoveFromVersionId = aws.String(versionStageCurrentVersionID)
-				listedVersionIDs = true
+					inputU.RemoveFromVersionId = aws.String(versionStageCurrentVersionID)
+					listedVersionIDs = true
+				}
+			}
+
+			_, err := conn.UpdateSecretVersionStage(ctx, inputU)
+
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "adding Secrets Manager Secret Version (%s) stage (%s): %s", d.Id(), stage, err)
 			}
 		}
 
-		_, err := conn.UpdateSecretVersionStage(ctx, inputU)
+		for _, stage := range del {
+			// InvalidParameterException: You can only move staging label AWSCURRENT to a different secret version. It can’t be completely removed.
+			if stage == secretVersionStageCurrent {
+				log.Printf("[INFO] Skipping removal of AWSCURRENT staging label for secret %q version %q", secretID, versionID)
+				continue
+			}
 
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "adding Secrets Manager Secret Version (%s) stage (%s): %s", d.Id(), stage, err)
-		}
-	}
+			// If we added AWSCURRENT to this version then any AWSPREVIOUS label will have been moved to another version.
+			if listedVersionIDs && stage == secretVersionStagePrevious {
+				continue
+			}
 
-	for _, stage := range del {
-		// InvalidParameterException: You can only move staging label AWSCURRENT to a different secret version. It can’t be completely removed.
-		if stage == secretVersionStageCurrent {
-			log.Printf("[INFO] Skipping removal of AWSCURRENT staging label for secret %q version %q", secretID, versionID)
-			continue
-		}
+			input := &secretsmanager.UpdateSecretVersionStageInput{
+				RemoveFromVersionId: aws.String(versionID),
+				SecretId:            aws.String(secretID),
+				VersionStage:        aws.String(stage),
+			}
 
-		// If we added AWSCURRENT to this version then any AWSPREVIOUS label will have been moved to another version.
-		if listedVersionIDs && stage == secretVersionStagePrevious {
-			continue
-		}
+			_, err := conn.UpdateSecretVersionStage(ctx, input)
 
-		input := &secretsmanager.UpdateSecretVersionStageInput{
-			RemoveFromVersionId: aws.String(versionID),
-			SecretId:            aws.String(secretID),
-			VersionStage:        aws.String(stage),
-		}
-
-		_, err := conn.UpdateSecretVersionStage(ctx, input)
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "deleting Secrets Manager Secret Version (%s) stage (%s): %s", d.Id(), stage, err)
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "deleting Secrets Manager Secret Version (%s) stage (%s): %s", d.Id(), stage, err)
+			}
 		}
 	}
 

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -488,6 +488,11 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnly_stages(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "AWSCURRENT"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "two"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				Config: testAccSecretVersionConfig_stringWriteOnly_stagesMultiple(rName, "test-secret", 1),
@@ -499,6 +504,11 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnly_stages(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "two"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "one"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -37,7 +37,7 @@ func TestAccSecretsManagerSecretVersion_basicString(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSecretVersionConfig_string(rName, "test-string"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string"),
 					resource.TestCheckResourceAttrSet(resourceName, "version_id"),
@@ -71,7 +71,7 @@ func TestAccSecretsManagerSecretVersion_base64Binary(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSecretVersionConfig_binary(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					resource.TestCheckResourceAttr(resourceName, "secret_binary", inttypes.Base64EncodeOnce([]byte("test-binary"))),
 					resource.TestCheckResourceAttrSet(resourceName, "version_id"),
@@ -104,7 +104,7 @@ func TestAccSecretsManagerSecretVersion_versionStages(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSecretVersionConfig_stagesSingle(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string"),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "2"),
@@ -114,7 +114,7 @@ func TestAccSecretsManagerSecretVersion_versionStages(t *testing.T) {
 			},
 			{
 				Config: testAccSecretVersionConfig_stagesSingleUpdated(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string"),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "2"),
@@ -124,7 +124,7 @@ func TestAccSecretsManagerSecretVersion_versionStages(t *testing.T) {
 			},
 			{
 				Config: testAccSecretVersionConfig_stagesMultiple(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string"),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "3"),
@@ -157,7 +157,7 @@ func TestAccSecretsManagerSecretVersion_versionStagesExternalUpdate(t *testing.T
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSecretVersionConfig_stagesSingle(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string"),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "2"),
@@ -179,7 +179,7 @@ func TestAccSecretsManagerSecretVersion_versionStagesExternalUpdate(t *testing.T
 					}
 				},
 				Config: testAccSecretVersionConfig_stagesSingle(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string"),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "2"),
@@ -205,7 +205,7 @@ func TestAccSecretsManagerSecretVersion_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSecretVersionConfig_string(rName, "test-string"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfsecretsmanager.ResourceSecretVersion(), resourceName),
 				),
@@ -231,7 +231,7 @@ func TestAccSecretsManagerSecretVersion_Disappears_secret(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSecretVersionConfig_string(rName, "test-string"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfsecretsmanager.ResourceSecret(), secretResourceName),
 				),
@@ -257,7 +257,7 @@ func TestAccSecretsManagerSecretVersion_multipleVersions(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSecretVersionConfig_multipleVersions(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resource1Name, &version1),
 					resource.TestCheckResourceAttr(resource1Name, "version_stages.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resource1Name, "version_stages.*", "one"),
@@ -294,7 +294,7 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnly(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSecretVersionConfig_stringWriteOnly(rName, "test-secret", 1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					testAccCheckSecretVersionExistsWriteOnly(ctx, t, resourceName, &versionWriteOnly),
 					testAccCheckSecretVersionWriteOnlyValueEqual(t, &version, "test-secret"),
@@ -304,7 +304,7 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnly(t *testing.T) {
 			},
 			{
 				Config: testAccSecretVersionConfig_stringWriteOnly(rName, "test-secret2", 2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					testAccCheckSecretVersionExistsWriteOnly(ctx, t, resourceName, &versionWriteOnly),
 					testAccCheckSecretVersionWriteOnlyValueEqual(t, &version, "test-secret2"),
@@ -338,7 +338,7 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnlyLimitedPermissions(t *tes
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSecretVersionConfig_stringWriteOnlyLimitedPermissions(rName, "test-secret", 1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					testAccCheckSecretVersionWriteOnlyValueEqual(t, &version, "test-secret"),
 					resource.TestCheckResourceAttr(resourceName, "has_secret_string_wo", acctest.CtTrue),
@@ -347,7 +347,7 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnlyLimitedPermissions(t *tes
 			},
 			{
 				Config: testAccSecretVersionConfig_string(rName, "test-string"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string"),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
@@ -376,7 +376,7 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnly_stages(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSecretVersionConfig_stringWriteOnly_stagesSingle(rName, "test-secret", 1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					testAccCheckSecretVersionExistsWriteOnly(ctx, t, resourceName, &versionWriteOnly),
 					testAccCheckSecretVersionWriteOnlyValueEmpty(t, &versionWriteOnly),
@@ -389,7 +389,7 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnly_stages(t *testing.T) {
 			},
 			{
 				Config: testAccSecretVersionConfig_stringWriteOnly_stagesSingleUpdated(rName, "test-secret", 1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					testAccCheckSecretVersionExistsWriteOnly(ctx, t, resourceName, &versionWriteOnly),
 					testAccCheckSecretVersionWriteOnlyValueEmpty(t, &versionWriteOnly),
@@ -402,7 +402,7 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnly_stages(t *testing.T) {
 			},
 			{
 				Config: testAccSecretVersionConfig_stringWriteOnly_stagesMultiple(rName, "test-secret", 1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					testAccCheckSecretVersionExistsWriteOnly(ctx, t, resourceName, &versionWriteOnly),
 					testAccCheckSecretVersionWriteOnlyValueEmpty(t, &versionWriteOnly),

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -324,7 +324,6 @@ func TestAccSecretsManagerSecretVersion_multipleVersions(t *testing.T) {
 func TestAccSecretsManagerSecretVersion_stringWriteOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var version secretsmanager.GetSecretValueOutput
-	var versionWriteOnly secretsmanager.GetSecretValueOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_secretsmanager_secret_version.test"
 	secretResourceName := "aws_secretsmanager_secret.test"
@@ -343,11 +342,9 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnly(t *testing.T) {
 				Config: testAccSecretVersionConfig_stringWriteOnly(rName, "test-secret", 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
-					testAccCheckSecretVersionExistsWriteOnly(ctx, t, resourceName, &versionWriteOnly),
 					testAccCheckSecretVersionWriteOnlyValueEqual(t, &version, "test-secret"),
-					testAccCheckSecretVersionWriteOnlyValueEmpty(t, &versionWriteOnly),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
-					resource.TestCheckNoResourceAttr(resourceName, "has_secret_string_wo"),
+					resource.TestCheckResourceAttr(resourceName, "has_secret_string_wo", acctest.CtTrue),
 					resource.TestCheckResourceAttrPair(resourceName, "secret_id", secretResourceName, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "secret_binary", ""),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", ""),
@@ -362,9 +359,7 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnly(t *testing.T) {
 				Config: testAccSecretVersionConfig_stringWriteOnly(rName, "test-secret2", 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
-					testAccCheckSecretVersionExistsWriteOnly(ctx, t, resourceName, &versionWriteOnly),
 					testAccCheckSecretVersionWriteOnlyValueEqual(t, &version, "test-secret2"),
-					testAccCheckSecretVersionWriteOnlyValueEmpty(t, &versionWriteOnly),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -421,7 +416,6 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnlyLimitedPermissions(t *tes
 func TestAccSecretsManagerSecretVersion_stringWriteOnly_stages(t *testing.T) {
 	ctx := acctest.Context(t)
 	var version secretsmanager.GetSecretValueOutput
-	var versionWriteOnly secretsmanager.GetSecretValueOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_secretsmanager_secret_version.test"
 	secretResourceName := "aws_secretsmanager_secret.test"
@@ -439,40 +433,31 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnly_stages(t *testing.T) {
 				Config: testAccSecretVersionConfig_stringWriteOnly_stagesSingle(rName, "test-secret", 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
-					testAccCheckSecretVersionExistsWriteOnly(ctx, t, resourceName, &versionWriteOnly),
-					testAccCheckSecretVersionWriteOnlyValueEmpty(t, &versionWriteOnly),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "AWSCURRENT"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "one"),
-					testAccCheckSecretVersionWriteOnlyStagesEqual(t, &versionWriteOnly, []string{"one", "AWSCURRENT"}),
 				),
 			},
 			{
 				Config: testAccSecretVersionConfig_stringWriteOnly_stagesSingleUpdated(rName, "test-secret", 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
-					testAccCheckSecretVersionExistsWriteOnly(ctx, t, resourceName, &versionWriteOnly),
-					testAccCheckSecretVersionWriteOnlyValueEmpty(t, &versionWriteOnly),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "AWSCURRENT"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "two"),
-					testAccCheckSecretVersionWriteOnlyStagesEqual(t, &versionWriteOnly, []string{"AWSCURRENT", "two"}),
 				),
 			},
 			{
 				Config: testAccSecretVersionConfig_stringWriteOnly_stagesMultiple(rName, "test-secret", 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
-					testAccCheckSecretVersionExistsWriteOnly(ctx, t, resourceName, &versionWriteOnly),
-					testAccCheckSecretVersionWriteOnlyValueEmpty(t, &versionWriteOnly),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "3"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "AWSCURRENT"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "two"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "one"),
-					testAccCheckSecretVersionWriteOnlyStagesEqual(t, &versionWriteOnly, []string{"one", "AWSCURRENT", "two"}),
 				),
 			},
 		},
@@ -545,52 +530,6 @@ func testAccCheckSecretVersionWriteOnlyValueEqual(t *testing.T, param *secretsma
 	return func(s *terraform.State) error {
 		if aws.ToString(param.SecretString) != writeOnlyValue {
 			t.Fatalf("Expected SecretsManger SecretString to be %v, but got %v", writeOnlyValue, aws.ToString(param.SecretString))
-		}
-		return nil
-	}
-}
-
-func testAccCheckSecretVersionExistsWriteOnly(ctx context.Context, t *testing.T, n string, v *secretsmanager.GetSecretValueOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		conn := acctest.ProviderMeta(ctx, t).SecretsManagerClient(ctx)
-
-		arn, versionEntry, err := tfsecretsmanager.FindSecretVersionEntryByTwoPartKey(ctx, conn, rs.Primary.Attributes["secret_id"], rs.Primary.Attributes["version_id"])
-
-		if err != nil {
-			return err
-		}
-
-		// Construct a GetSecretValueOutput-like structure from ListSecretVersionIds result
-		result := &secretsmanager.GetSecretValueOutput{
-			ARN:           arn,
-			VersionId:     versionEntry.VersionId,
-			VersionStages: versionEntry.VersionStages,
-		}
-
-		*v = *result
-
-		return nil
-	}
-}
-
-func testAccCheckSecretVersionWriteOnlyValueEmpty(t *testing.T, param *secretsmanager.GetSecretValueOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if aws.ToString(param.SecretString) != "" {
-			t.Fatalf("Expected SecretsManger SecretString to be an empty string, but got %v", aws.ToString(param.SecretString))
-		}
-		return nil
-	}
-}
-
-func testAccCheckSecretVersionWriteOnlyStagesEqual(t *testing.T, param *secretsmanager.GetSecretValueOutput, stages []string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if !reflect.DeepEqual(param.VersionStages, stages) {
-			t.Fatalf("Expected SecretsManger VersionStages to be %v, but got %v", stages, param.VersionStages)
 		}
 		return nil
 	}

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -97,7 +97,7 @@ func TestSecretVersionForceNewXXX(t *testing.T) {
 			}),
 			expectedForceNew: []string{"secret_string"},
 		},
-		"secret_string unkown": {
+		"secret_string unknown": {
 			state: secretVersionValuesObjectState(map[string]cty.Value{
 				"secret_string": cty.StringVal("old"),
 			}),

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -734,6 +734,200 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnly_stages(t *testing.T) {
 	})
 }
 
+func TestAccSecretsManagerSecretVersion_ConvertStringToStringWriteOnly_noChange(t *testing.T) {
+	ctx := acctest.Context(t)
+	var version secretsmanager.GetSecretValueOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_secretsmanager_secret_version.test"
+	secretResourceName := "aws_secretsmanager_secret.test"
+	secretValue := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck: acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfcversion.Must(tfcversion.NewVersion("1.11.0"))),
+		},
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecretVersionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: Create with `secret_string`
+			{
+				Config: testAccSecretVersionConfig_convertStringToStringWriteOnly_string(rName, secretValue),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
+					resource.TestCheckResourceAttr(resourceName, "secret_string", secretValue),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_string_wo"),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_string_wo_version"),
+				),
+			},
+			// Step 2: Convert to `secret_string_wo`
+			{
+				Config: testAccSecretVersionConfig_convertStringToStringWriteOnly_stringWriteOnly(rName, secretValue, 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
+					testAccCheckSecretVersionWriteOnlyValueEqual(t, &version, secretValue),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "secret_string", ""),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_string_wo"),
+					resource.TestCheckResourceAttr(resourceName, "secret_string_wo_version", "1"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccSecretsManagerSecretVersion_ConvertStringToStringWriteOnly_withChange(t *testing.T) {
+	ctx := acctest.Context(t)
+	var version secretsmanager.GetSecretValueOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_secretsmanager_secret_version.test"
+	secretResourceName := "aws_secretsmanager_secret.test"
+	secretValue := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	secretValueUpdated := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck: acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfcversion.Must(tfcversion.NewVersion("1.11.0"))),
+		},
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecretVersionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: Create with `secret_string`
+			{
+				Config: testAccSecretVersionConfig_convertStringToStringWriteOnly_string(rName, secretValue),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
+					resource.TestCheckResourceAttr(resourceName, "secret_string", secretValue),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_string_wo"),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_string_wo_version"),
+				),
+			},
+			// Step 2: Convert to `secret_string_wo`
+			{
+				Config: testAccSecretVersionConfig_convertStringToStringWriteOnly_stringWriteOnly(rName, secretValueUpdated, 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
+					testAccCheckSecretVersionWriteOnlyValueEqual(t, &version, secretValueUpdated),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "secret_string", ""),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_string_wo"),
+					resource.TestCheckResourceAttr(resourceName, "secret_string_wo_version", "1"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccSecretsManagerSecretVersion_ConvertStringWriteOnlyToString_noChange(t *testing.T) {
+	ctx := acctest.Context(t)
+	var version secretsmanager.GetSecretValueOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_secretsmanager_secret_version.test"
+	secretResourceName := "aws_secretsmanager_secret.test"
+	secretValue := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck: acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfcversion.Must(tfcversion.NewVersion("1.11.0"))),
+		},
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecretVersionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: Create with `secret_string_wo`
+			{
+				Config: testAccSecretVersionConfig_convertStringToStringWriteOnly_stringWriteOnly(rName, secretValue, 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
+					testAccCheckSecretVersionWriteOnlyValueEqual(t, &version, secretValue),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "secret_string", ""),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_string_wo"),
+					resource.TestCheckResourceAttr(resourceName, "secret_string_wo_version", "1"),
+				),
+			},
+			// Step 2: Convert to `secret_string`
+			{
+				Config: testAccSecretVersionConfig_convertStringToStringWriteOnly_string(rName, secretValue),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
+					resource.TestCheckResourceAttr(resourceName, "secret_string", secretValue),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_string_wo"),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_string_wo_version"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccSecretsManagerSecretVersion_ConvertStringWriteOnlyToString_withChange(t *testing.T) {
+	ctx := acctest.Context(t)
+	var version secretsmanager.GetSecretValueOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_secretsmanager_secret_version.test"
+	secretResourceName := "aws_secretsmanager_secret.test"
+	secretValue := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	secretValueUpdated := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck: acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfcversion.Must(tfcversion.NewVersion("1.11.0"))),
+		},
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecretVersionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: Create with `secret_string_wo`
+			{
+				Config: testAccSecretVersionConfig_convertStringToStringWriteOnly_stringWriteOnly(rName, secretValue, 0),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
+					testAccCheckSecretVersionWriteOnlyValueEqual(t, &version, secretValue),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "secret_string", ""),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_string_wo"),
+					resource.TestCheckResourceAttr(resourceName, "secret_string_wo_version", "0"),
+				),
+			},
+			// Step 2: Convert to `secret_string`
+			{
+				Config: testAccSecretVersionConfig_convertStringToStringWriteOnly_string(rName, secretValueUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
+					resource.TestCheckResourceAttr(resourceName, "secret_string", secretValueUpdated),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_string_wo"),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_string_wo_version"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckSecretVersionDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).SecretsManagerClient(ctx)
@@ -1009,6 +1203,33 @@ resource "aws_secretsmanager_secret_version" "test" {
   secret_string_wo_version = %[3]d
 
   version_stages = ["one", "two", "AWSCURRENT"]
+}
+`, rName, secret, version)
+}
+
+func testAccSecretVersionConfig_convertStringToStringWriteOnly_string(rName, secret string) string {
+	return fmt.Sprintf(`
+resource "aws_secretsmanager_secret_version" "test" {
+  secret_id     = aws_secretsmanager_secret.test.id
+  secret_string = %[2]q
+}
+
+resource "aws_secretsmanager_secret" "test" {
+  name = %[1]q
+}
+`, rName, secret)
+}
+
+func testAccSecretVersionConfig_convertStringToStringWriteOnly_stringWriteOnly(rName, secret string, version int) string {
+	return fmt.Sprintf(`
+resource "aws_secretsmanager_secret_version" "test" {
+  secret_id                = aws_secretsmanager_secret.test.id
+  secret_string_wo         = %[2]q
+  secret_string_wo_version = %[3]d
+}
+
+resource "aws_secretsmanager_secret" "test" {
+  name = %[1]q
 }
 `, rName, secret, version)
 }

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	tfcversion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -246,6 +247,41 @@ func TestAccSecretsManagerSecretVersion_Disappears_secret(t *testing.T) {
 					acctest.CheckSDKResourceDisappears(ctx, t, tfsecretsmanager.ResourceSecret(), secretResourceName),
 				),
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccSecretsManagerSecretVersion_UpdateForcesReplacement_string(t *testing.T) {
+	ctx := acctest.Context(t)
+	var version secretsmanager.GetSecretValueOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_secretsmanager_secret_version.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecretVersionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretVersionConfig_string(rName, "test-string"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
+					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string"),
+				),
+			},
+			{
+				Config: testAccSecretVersionConfig_string(rName, "test-string-updated"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
+					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string-updated"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
 			},
 		},
 	})

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -6,7 +6,6 @@ package secretsmanager_test
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -321,7 +320,7 @@ func TestAccSecretsManagerSecretVersion_multipleVersions(t *testing.T) {
 	})
 }
 
-func TestAccSecretsManagerSecretVersion_stringWriteOnly(t *testing.T) {
+func TestAccSecretsManagerSecretVersion_StringWriteOnly_changeWOVersion(t *testing.T) {
 	ctx := acctest.Context(t)
 	var version secretsmanager.GetSecretValueOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -365,6 +364,47 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnly(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccSecretsManagerSecretVersion_StringWriteOnly_sameWOVersion(t *testing.T) {
+	ctx := acctest.Context(t)
+	var version secretsmanager.GetSecretValueOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_secretsmanager_secret_version.test"
+	secretResourceName := "aws_secretsmanager_secret.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck: acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfcversion.Must(tfcversion.NewVersion("1.11.0"))),
+		},
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecretVersionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretVersionConfig_stringWriteOnly(rName, "test-secret", 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
+					testAccCheckSecretVersionWriteOnlyValueEqual(t, &version, "test-secret"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
+				),
+			},
+			{
+				Config: testAccSecretVersionConfig_stringWriteOnly(rName, "test-secret2", 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
+					testAccCheckSecretVersionWriteOnlyValueEqual(t, &version, "test-secret"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
 					},
 				},
 			},

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -39,11 +39,16 @@ func TestAccSecretsManagerSecretVersion_basicString(t *testing.T) {
 				Config: testAccSecretVersionConfig_string(rName, "test-string"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
+					resource.TestCheckNoResourceAttr(resourceName, "has_secret_string_wo"),
+					resource.TestCheckResourceAttrPair(resourceName, "secret_id", secretResourceName, names.AttrID),
+					resource.TestCheckResourceAttr(resourceName, "secret_binary", ""),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string"),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_string_wo"),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_string_wo_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "version_id"),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "AWSCURRENT"),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
 				),
 			},
 			{
@@ -73,11 +78,16 @@ func TestAccSecretsManagerSecretVersion_base64Binary(t *testing.T) {
 				Config: testAccSecretVersionConfig_binary(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
+					resource.TestCheckNoResourceAttr(resourceName, "has_secret_string_wo"),
+					resource.TestCheckResourceAttrPair(resourceName, "secret_id", secretResourceName, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "secret_binary", inttypes.Base64EncodeOnce([]byte("test-binary"))),
+					resource.TestCheckResourceAttr(resourceName, "secret_string", ""),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_string_wo"),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_string_wo_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "version_id"),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "AWSCURRENT"),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
 				),
 			},
 			{
@@ -292,6 +302,7 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnly(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckSecretVersionDestroy(ctx, t),
 		Steps: []resource.TestStep{
+			// This is the `basic` test for `secret_string_wo`
 			{
 				Config: testAccSecretVersionConfig_stringWriteOnly(rName, "test-secret", 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -300,6 +311,15 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnly(t *testing.T) {
 					testAccCheckSecretVersionWriteOnlyValueEqual(t, &version, "test-secret"),
 					testAccCheckSecretVersionWriteOnlyValueEmpty(t, &versionWriteOnly),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
+					resource.TestCheckNoResourceAttr(resourceName, "has_secret_string_wo"),
+					resource.TestCheckResourceAttrPair(resourceName, "secret_id", secretResourceName, names.AttrID),
+					resource.TestCheckResourceAttr(resourceName, "secret_binary", ""),
+					resource.TestCheckResourceAttr(resourceName, "secret_string", ""),
+					resource.TestCheckNoResourceAttr(resourceName, "secret_string_wo"),
+					resource.TestCheckResourceAttr(resourceName, "secret_string_wo_version", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "version_id"),
+					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "AWSCURRENT"),
 				),
 			},
 			{

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -31,7 +31,7 @@ type mockRawDiffer struct {
 	forceNew []string
 }
 
-func (d *mockRawDiffer) GetRawState() cty.Value {
+func (d *mockRawDiffer) GetRawState() cty.Value { // nosemgrep:ci.aws-in-func-name
 	return d.state
 }
 
@@ -82,10 +82,10 @@ func TestSecretVersionForceNewXXX(t *testing.T) {
 
 		"secret_string no change": {
 			state: secretVersionValuesObjectState(map[string]cty.Value{
-				"secret_string": cty.StringVal("value"),
+				"secret_string": cty.StringVal(names.AttrValue),
 			}),
 			config: secretVersionValuesObjectConfig(map[string]cty.Value{
-				"secret_string": cty.StringVal("value"),
+				"secret_string": cty.StringVal(names.AttrValue),
 			}),
 		},
 		"secret_string with change": {
@@ -134,19 +134,19 @@ func TestSecretVersionForceNewXXX(t *testing.T) {
 
 		"secret_string to secret_string_wo no change": {
 			state: secretVersionValuesObjectState(map[string]cty.Value{
-				"secret_string": cty.StringVal("value"),
+				"secret_string": cty.StringVal(names.AttrValue),
 			}),
 			config: secretVersionValuesObjectConfig(map[string]cty.Value{
-				"secret_string_wo":         cty.StringVal("value"),
+				"secret_string_wo":         cty.StringVal(names.AttrValue),
 				"secret_string_wo_version": cty.NumberIntVal(1),
 			}),
 		},
 		"secret_string to secret_string_wo no change version unknown": {
 			state: secretVersionValuesObjectState(map[string]cty.Value{
-				"secret_string": cty.StringVal("value"),
+				"secret_string": cty.StringVal(names.AttrValue),
 			}),
 			config: secretVersionValuesObjectConfig(map[string]cty.Value{
-				"secret_string_wo":         cty.StringVal("value"),
+				"secret_string_wo":         cty.StringVal(names.AttrValue),
 				"secret_string_wo_version": cty.UnknownVal(cty.Number),
 			}),
 		},
@@ -172,11 +172,11 @@ func TestSecretVersionForceNewXXX(t *testing.T) {
 
 		"secret_string_wo to secret_string no change": {
 			state: secretVersionValuesObjectState(map[string]cty.Value{
-				"secret_string_wo":         cty.StringVal("value"),
+				"secret_string_wo":         cty.StringVal(names.AttrValue),
 				"secret_string_wo_version": cty.NumberIntVal(1),
 			}),
 			config: secretVersionValuesObjectConfig(map[string]cty.Value{
-				"secret_string": cty.StringVal("value"),
+				"secret_string": cty.StringVal(names.AttrValue),
 			}),
 			expectedForceNew: []string{"secret_string"},
 		},
@@ -192,7 +192,7 @@ func TestSecretVersionForceNewXXX(t *testing.T) {
 		},
 		"secret_string_wo to secret_string unknown": {
 			state: secretVersionValuesObjectState(map[string]cty.Value{
-				"secret_string_wo":         cty.StringVal("value"),
+				"secret_string_wo":         cty.StringVal(names.AttrValue),
 				"secret_string_wo_version": cty.NumberIntVal(1),
 			}),
 			config: secretVersionValuesObjectConfig(map[string]cty.Value{

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -121,6 +121,11 @@ func TestAccSecretsManagerSecretVersion_versionStages(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "AWSCURRENT"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "one"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			{
 				Config: testAccSecretVersionConfig_stagesSingleUpdated(rName),
@@ -131,6 +136,11 @@ func TestAccSecretsManagerSecretVersion_versionStages(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "AWSCURRENT"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "two"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				Config: testAccSecretVersionConfig_stagesMultiple(rName),
@@ -142,6 +152,11 @@ func TestAccSecretsManagerSecretVersion_versionStages(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "one"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "two"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:            resourceName,
@@ -196,6 +211,11 @@ func TestAccSecretsManagerSecretVersion_versionStagesExternalUpdate(t *testing.T
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "AWSCURRENT"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "one"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -6,10 +6,13 @@ package secretsmanager_test
 import (
 	"context"
 	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-cty/cty"
 	tfcversion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,6 +24,203 @@ import (
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
+
+type mockRawDiffer struct {
+	state    cty.Value
+	config   cty.Value
+	forceNew []string
+}
+
+func (d *mockRawDiffer) GetRawState() cty.Value {
+	return d.state
+}
+
+func (d *mockRawDiffer) GetRawConfig() cty.Value {
+	return d.config
+}
+
+func (d *mockRawDiffer) ForceNew(key string) error {
+	d.forceNew = append(d.forceNew, key)
+	return nil
+}
+
+func secretVersionValuesObjectState(values map[string]cty.Value) cty.Value {
+	allValues := map[string]cty.Value{
+		"secret_binary":            cty.StringVal(""),
+		"secret_string":            cty.StringVal(""),
+		"secret_string_wo":         cty.NullVal(cty.String),
+		"secret_string_wo_version": cty.NullVal(cty.Number),
+	}
+
+	maps.Copy(allValues, values)
+
+	return cty.ObjectVal(allValues)
+}
+
+func secretVersionValuesObjectConfig(values map[string]cty.Value) cty.Value {
+	allValues := map[string]cty.Value{
+		"secret_binary":            cty.NullVal(cty.String),
+		"secret_string":            cty.NullVal(cty.String),
+		"secret_string_wo":         cty.NullVal(cty.String),
+		"secret_string_wo_version": cty.NullVal(cty.Number),
+	}
+
+	maps.Copy(allValues, values)
+
+	return cty.ObjectVal(allValues)
+}
+
+func TestSecretVersionForceNewXXX(t *testing.T) {
+	t.Parallel()
+
+	testcases := map[string]struct {
+		state            cty.Value
+		config           cty.Value
+		expectedForceNew []string
+	}{
+		"new resource": {},
+
+		"secret_string no change": {
+			state: secretVersionValuesObjectState(map[string]cty.Value{
+				"secret_string": cty.StringVal("value"),
+			}),
+			config: secretVersionValuesObjectConfig(map[string]cty.Value{
+				"secret_string": cty.StringVal("value"),
+			}),
+		},
+		"secret_string with change": {
+			state: secretVersionValuesObjectState(map[string]cty.Value{
+				"secret_string": cty.StringVal("old"),
+			}),
+			config: secretVersionValuesObjectConfig(map[string]cty.Value{
+				"secret_string": cty.StringVal("new"),
+			}),
+			expectedForceNew: []string{"secret_string"},
+		},
+		"secret_string unkown": {
+			state: secretVersionValuesObjectState(map[string]cty.Value{
+				"secret_string": cty.StringVal("old"),
+			}),
+			config: secretVersionValuesObjectConfig(map[string]cty.Value{
+				"secret_string": cty.UnknownVal(cty.String),
+			}),
+		},
+
+		"secret_string_wo_version no change": {
+			state: secretVersionValuesObjectState(map[string]cty.Value{
+				"secret_string_wo_version": cty.NumberIntVal(1),
+			}),
+			config: secretVersionValuesObjectConfig(map[string]cty.Value{
+				"secret_string_wo_version": cty.NumberIntVal(1),
+			}),
+		},
+		"secret_string_wo_version with change": {
+			state: secretVersionValuesObjectState(map[string]cty.Value{
+				"secret_string_wo_version": cty.NumberIntVal(1),
+			}),
+			config: secretVersionValuesObjectConfig(map[string]cty.Value{
+				"secret_string_wo_version": cty.NumberIntVal(2),
+			}),
+			expectedForceNew: []string{"secret_string_wo_version"},
+		},
+		"secret_string_wo_version unknown": {
+			state: secretVersionValuesObjectState(map[string]cty.Value{
+				"secret_string_wo_version": cty.NumberIntVal(1),
+			}),
+			config: secretVersionValuesObjectConfig(map[string]cty.Value{
+				"secret_string_wo_version": cty.UnknownVal(cty.Number),
+			}),
+		},
+
+		"secret_string to secret_string_wo no change": {
+			state: secretVersionValuesObjectState(map[string]cty.Value{
+				"secret_string": cty.StringVal("value"),
+			}),
+			config: secretVersionValuesObjectConfig(map[string]cty.Value{
+				"secret_string_wo":         cty.StringVal("value"),
+				"secret_string_wo_version": cty.NumberIntVal(1),
+			}),
+		},
+		"secret_string to secret_string_wo no change version unknown": {
+			state: secretVersionValuesObjectState(map[string]cty.Value{
+				"secret_string": cty.StringVal("value"),
+			}),
+			config: secretVersionValuesObjectConfig(map[string]cty.Value{
+				"secret_string_wo":         cty.StringVal("value"),
+				"secret_string_wo_version": cty.UnknownVal(cty.Number),
+			}),
+		},
+		"secret_string to secret_string_wo with change": {
+			state: secretVersionValuesObjectState(map[string]cty.Value{
+				"secret_string": cty.StringVal("old"),
+			}),
+			config: secretVersionValuesObjectConfig(map[string]cty.Value{
+				"secret_string_wo":         cty.StringVal("new"),
+				"secret_string_wo_version": cty.NumberIntVal(1),
+			}),
+			expectedForceNew: []string{"secret_string", "secret_string_wo"},
+		},
+		"secret_string to secret_string_wo with change version unknown": {
+			state: secretVersionValuesObjectState(map[string]cty.Value{
+				"secret_string": cty.StringVal("old"),
+			}),
+			config: secretVersionValuesObjectConfig(map[string]cty.Value{
+				"secret_string_wo":         cty.StringVal("old"),
+				"secret_string_wo_version": cty.UnknownVal(cty.Number),
+			}),
+		},
+
+		"secret_string_wo to secret_string no change": {
+			state: secretVersionValuesObjectState(map[string]cty.Value{
+				"secret_string_wo":         cty.StringVal("value"),
+				"secret_string_wo_version": cty.NumberIntVal(1),
+			}),
+			config: secretVersionValuesObjectConfig(map[string]cty.Value{
+				"secret_string": cty.StringVal("value"),
+			}),
+			expectedForceNew: []string{"secret_string"},
+		},
+		"secret_string_wo to secret_string with change": {
+			state: secretVersionValuesObjectState(map[string]cty.Value{
+				"secret_string_wo":         cty.StringVal("old"),
+				"secret_string_wo_version": cty.NumberIntVal(1),
+			}),
+			config: secretVersionValuesObjectConfig(map[string]cty.Value{
+				"secret_string": cty.StringVal("new"),
+			}),
+			expectedForceNew: []string{"secret_string"},
+		},
+		"secret_string_wo to secret_string unknown": {
+			state: secretVersionValuesObjectState(map[string]cty.Value{
+				"secret_string_wo":         cty.StringVal("value"),
+				"secret_string_wo_version": cty.NumberIntVal(1),
+			}),
+			config: secretVersionValuesObjectConfig(map[string]cty.Value{
+				"secret_string": cty.UnknownVal(cty.String),
+			}),
+		},
+	}
+
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			diff := mockRawDiffer{
+				state:  testcase.state,
+				config: testcase.config,
+			}
+
+			err := tfsecretsmanager.SecretVersionForceNewCustomDiffInner(t.Context(), &diff, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if diff := cmp.Diff(testcase.expectedForceNew, diff.forceNew); diff != "" {
+				t.Errorf("unexpected differences: %s", diff)
+			}
+		})
+	}
+}
 
 func TestAccSecretsManagerSecretVersion_basicString(t *testing.T) {
 	ctx := acctest.Context(t)

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -36,7 +36,7 @@ func TestAccSecretsManagerSecretVersion_basicString(t *testing.T) {
 		CheckDestroy:             testAccCheckSecretVersionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretVersionConfig_string(rName),
+				Config: testAccSecretVersionConfig_string(rName, "test-string"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string"),
@@ -204,7 +204,7 @@ func TestAccSecretsManagerSecretVersion_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckSecretVersionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretVersionConfig_string(rName),
+				Config: testAccSecretVersionConfig_string(rName, "test-string"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfsecretsmanager.ResourceSecretVersion(), resourceName),
@@ -230,7 +230,7 @@ func TestAccSecretsManagerSecretVersion_Disappears_secret(t *testing.T) {
 		CheckDestroy:             testAccCheckSecretVersionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretVersionConfig_string(rName),
+				Config: testAccSecretVersionConfig_string(rName, "test-string"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfsecretsmanager.ResourceSecret(), secretResourceName),
@@ -346,7 +346,7 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnlyLimitedPermissions(t *tes
 				),
 			},
 			{
-				Config: testAccSecretVersionConfig_string(rName),
+				Config: testAccSecretVersionConfig_string(rName, "test-string"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string"),
@@ -535,7 +535,7 @@ func testAccCheckSecretVersionWriteOnlyStagesEqual(t *testing.T, param *secretsm
 	}
 }
 
-func testAccSecretVersionConfig_string(rName string) string {
+func testAccSecretVersionConfig_string(rName, secret string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name = %[1]q
@@ -543,9 +543,9 @@ resource "aws_secretsmanager_secret" "test" {
 
 resource "aws_secretsmanager_secret_version" "test" {
   secret_id     = aws_secretsmanager_secret.test.id
-  secret_string = "test-string"
+  secret_string = %[2]q
 }
-`, rName)
+`, rName, secret)
 }
 
 func testAccSecretVersionConfig_stringWriteOnly(rName, secret string, version int) string {

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -367,6 +367,11 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnly(t *testing.T) {
 					testAccCheckSecretVersionWriteOnlyValueEmpty(t, &versionWriteOnly),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Allows switching from `secret_string` to `secret_string_wo` without re-creating the resource

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=secretsmanager TESTS=TestAccSecretsManagerSecretVersion_

--- SKIP: TestAccSecretsManagerSecretVersion_stringWriteOnlyLimitedPermissions (2.82s)
--- PASS: TestAccSecretsManagerSecretVersion_disappears (123.36s)
--- PASS: TestAccSecretsManagerSecretVersion_multipleVersions (121.39s)
--- PASS: TestAccSecretsManagerSecretVersion_Disappears_secret (131.53s)
--- PASS: TestAccSecretsManagerSecretVersion_List_basic (132.13s)
--- PASS: TestAccSecretsManagerSecretVersion_base64Binary (147.74s)
--- PASS: TestAccSecretsManagerSecretVersion_basicString (148.12s)
--- PASS: TestAccSecretsManagerSecretVersion_Identity_ExistingResource_noRefreshNoChange (158.60s)
--- PASS: TestAccSecretsManagerSecretVersion_Identity_ExistingResource_basic (163.66s)
--- PASS: TestAccSecretsManagerSecretVersion_StringWriteOnly_sameWOVersion (171.69s)
--- PASS: TestAccSecretsManagerSecretVersion_StringWriteOnly_changeWOVersion (175.27s)
--- PASS: TestAccSecretsManagerSecretVersion_ConvertStringToStringWriteOnly_noChange (175.28s)
--- PASS: TestAccSecretsManagerSecretVersion_ConvertStringToStringWriteOnly_withChange (175.54s)
--- PASS: TestAccSecretsManagerSecretVersion_UpdateForcesReplacement_string (175.66s)
--- PASS: TestAccSecretsManagerSecretVersion_versionStagesExternalUpdate (175.67s)
--- PASS: TestAccSecretsManagerSecretVersion_ConvertStringWriteOnlyToString_noChange (175.69s)
--- PASS: TestAccSecretsManagerSecretVersion_ConvertStringWriteOnlyToString_withChange (175.85s)
--- PASS: TestAccSecretsManagerSecretVersion_Identity_regionOverride (179.24s)
--- PASS: TestAccSecretsManagerSecretVersion_Identity_basic (180.05s)
--- PASS: TestAccSecretsManagerSecretVersion_stringWriteOnly_stages (188.67s)
--- PASS: TestAccSecretsManagerSecretVersion_versionStages (193.90s)
```
