### PR TITLE
Feature: support elasticache serverless networy type

### DIFF
--- a/.changelog/47822.txt
+++ b/.changelog/47822.txt
@@ -1,0 +1,6 @@
+```release-note:enhancement
+resource/aws_elasticache_serverless_cache: Support `network_type` attribute.
+```
+```release-note:enhancement
+data/aws_elasticache_serverless_cache: Retrieve `network_type` attribute.
+```

--- a/internal/service/elasticache/serverless_cache.go
+++ b/internal/service/elasticache/serverless_cache.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -181,6 +182,16 @@ func (r *serverlessCacheResource) Schema(ctx context.Context, request resource.S
 				Computed:    true,
 				PlanModifiers: []planmodifier.Set{
 					setplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"network_type": schema.StringAttribute{
+				Optional:         true,
+				Computed:         true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.OneOf(string(awstypes.NetworkTypeIpv4), string(awstypes.NetworkTypeIpv6), string(awstypes.NetworkTypeDualStack)),
 				},
 			},
 			"snapshot_arns_to_restore": schema.ListAttribute{

--- a/internal/service/elasticache/serverless_cache.go
+++ b/internal/service/elasticache/serverless_cache.go
@@ -185,8 +185,8 @@ func (r *serverlessCacheResource) Schema(ctx context.Context, request resource.S
 				},
 			},
 			"network_type": schema.StringAttribute{
-				Optional:         true,
-				Computed:         true,
+				Optional: true,
+				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -633,6 +633,7 @@ type serverlessCacheResourceModel struct {
 	ID                     types.String                                           `tfsdk:"id"`
 	KmsKeyID               types.String                                           `tfsdk:"kms_key_id"`
 	MajorEngineVersion     types.String                                           `tfsdk:"major_engine_version"`
+	NetworkType            types.String                                           `tfsdk:"network_type"`
 	ReaderEndpoint         fwtypes.ListNestedObjectValueOf[endpointModel]         `tfsdk:"reader_endpoint"`
 	SecurityGroupIDs       fwtypes.SetValueOf[types.String]                       `tfsdk:"security_group_ids"`
 	ServerlessCacheName    types.String                                           `tfsdk:"name"`

--- a/internal/service/elasticache/serverless_cache_data_source.go
+++ b/internal/service/elasticache/serverless_cache_data_source.go
@@ -77,6 +77,10 @@ func (d *serverlessCacheDataSource) Schema(ctx context.Context, request datasour
 				CustomType: fwtypes.ListOfStringType,
 				Computed:   true,
 			},
+			"network_type": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.NetworkType](),
+				Computed: true,
+			},
 			"snapshot_retention_limit": schema.Int64Attribute{
 				Computed: true,
 			},
@@ -136,6 +140,7 @@ type serverlessCacheDataSourceModel struct {
 	Name                   types.String                              `tfsdk:"name"`
 	ReaderEndpoint         fwtypes.ObjectValueOf[dsEndpoint]         `tfsdk:"reader_endpoint"`
 	SecurityGroupIDs       fwtypes.ListValueOf[types.String]         `tfsdk:"security_group_ids"`
+	NetworkType            types.String                              `tfsdk:"network_type"`
 	SnapshotRetentionLimit types.Int64                               `tfsdk:"snapshot_retention_limit"`
 	Status                 types.String                              `tfsdk:"status"`
 	SubnetIDs              fwtypes.ListValueOf[types.String]         `tfsdk:"subnet_ids"`

--- a/internal/service/elasticache/serverless_cache_data_source.go
+++ b/internal/service/elasticache/serverless_cache_data_source.go
@@ -79,7 +79,7 @@ func (d *serverlessCacheDataSource) Schema(ctx context.Context, request datasour
 			},
 			"network_type": schema.StringAttribute{
 				CustomType: fwtypes.StringEnumType[awstypes.NetworkType](),
-				Computed: true,
+				Computed:   true,
 			},
 			"snapshot_retention_limit": schema.Int64Attribute{
 				Computed: true,
@@ -140,7 +140,7 @@ type serverlessCacheDataSourceModel struct {
 	Name                   types.String                              `tfsdk:"name"`
 	ReaderEndpoint         fwtypes.ObjectValueOf[dsEndpoint]         `tfsdk:"reader_endpoint"`
 	SecurityGroupIDs       fwtypes.ListValueOf[types.String]         `tfsdk:"security_group_ids"`
-	NetworkType            types.String                              `tfsdk:"network_type"`
+	NetworkType            fwtypes.StringEnum[awstypes.NetworkType]  `tfsdk:"network_type"`
 	SnapshotRetentionLimit types.Int64                               `tfsdk:"snapshot_retention_limit"`
 	Status                 types.String                              `tfsdk:"status"`
 	SubnetIDs              fwtypes.ListValueOf[types.String]         `tfsdk:"subnet_ids"`

--- a/internal/service/elasticache/serverless_cache_data_source_test.go
+++ b/internal/service/elasticache/serverless_cache_data_source_test.go
@@ -98,6 +98,7 @@ func TestAccElastiCacheServerlessCacheDataSource_Valkey_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "endpoint.port", resourceName, "endpoint.0.port"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "reader_endpoint.address", resourceName, "reader_endpoint.0.address"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "reader_endpoint.port", resourceName, "reader_endpoint.0.port"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "network_type", resourceName, "network_type"),
 				),
 			},
 		},

--- a/internal/service/elasticache/serverless_cache_test.go
+++ b/internal/service/elasticache/serverless_cache_test.go
@@ -806,10 +806,10 @@ func TestAccElastiCacheServerlessCache_networkType(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccServerlessCacheConfig_networkType(rName, "ipv6"),
+				Config: testAccServerlessCacheConfig_networkType(rName, "dual_stack"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckServerlessCacheExists(ctx, t, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "network_type", string(awstypes.NetworkTypeIpv6)),
+					resource.TestCheckResourceAttr(resourceName, "network_type", string(awstypes.NetworkTypeDualStack)),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -818,10 +818,10 @@ func TestAccElastiCacheServerlessCache_networkType(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccServerlessCacheConfig_networkType(rName, "dual_stack"),
+				Config: testAccServerlessCacheConfig_networkType(rName, "ipv6"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckServerlessCacheExists(ctx, t, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "network_type", string(awstypes.NetworkTypeDualStack)),
+					resource.TestCheckResourceAttr(resourceName, "network_type", string(awstypes.NetworkTypeIpv6)),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -1252,11 +1252,46 @@ resource "aws_elasticache_serverless_cache" "test" {
 }
 
 func testAccServerlessCacheConfig_networkType(rName, networkType string) string {
-	return fmt.Sprintf(`
-resource "aws_elasticache_serverless_cache" "test" {
-  name        = %[1]q
-  engine = "valkey"
-  network_type = %[2]q
+	if networkType == "ipv6" {
+		return acctest.ConfigCompose(acctest.ConfigVPCWithSubnetsIPv6(rName, 2),
+			ConfigSubnetsIPv6Native(rName, 2),
+			fmt.Sprintf(`
+		resource "aws_elasticache_serverless_cache" "test" {
+		name        = %[1]q
+		engine       = "valkey"
+		network_type = %[2]q
+		subnet_ids   = aws_subnet.test_ipv6_native[*].id
+		}
+		`, rName, networkType))
+	}
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnetsIPv6(rName, 2), fmt.Sprintf(`
+	resource "aws_elasticache_serverless_cache" "test" {
+	name        = %[1]q
+	engine       = "valkey"
+	network_type = %[2]q
+	subnet_ids   = aws_subnet.test[*].id
+	}
+	`, rName, networkType))
 }
-`, rName, networkType)
+
+func ConfigSubnetsIPv6Native(rName string, subnetCount int) string {
+	// Avoid colliding with the other subnets
+	return fmt.Sprintf(`
+resource "aws_subnet" "test_ipv6_native" {
+  count = %[2]d
+
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  ipv6_native = true
+  ipv6_cidr_block = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, count.index + 3)
+  enable_resource_name_dns_aaaa_record_on_launch = true
+
+  assign_ipv6_address_on_creation = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, subnetCount)
 }

--- a/internal/service/elasticache/serverless_cache_test.go
+++ b/internal/service/elasticache/serverless_cache_test.go
@@ -777,6 +777,68 @@ func TestAccElastiCacheServerlessCache_tags(t *testing.T) {
 	})
 }
 
+
+func TestAccElastiCacheServerlessCache_networkType(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_elasticache_serverless_cache.test"
+	var v awstypes.ServerlessCache
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckServerlessCacheDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServerlessCacheConfig_networkType(rName, "ipv4"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "network_type", string(awstypes.NetworkTypeIpv4)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				Config: testAccServerlessCacheConfig_networkType(rName, "ipv6"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "network_type", string(awstypes.NetworkTypeIpv6)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccServerlessCacheConfig_networkType(rName, "dual_stack"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "network_type", string(awstypes.NetworkTypeDualStack)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckServerlessCacheExists(ctx context.Context, t *testing.T, n string, v *awstypes.ServerlessCache) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1193,4 +1255,13 @@ resource "aws_elasticache_serverless_cache" "test" {
 %[2]s
 }
 `, rName, tags)
+}
+
+func testAccServerlessCacheConfig_networkType(rName, networkType string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_serverless_cache" "test" {
+  name        = %[1]q
+  network_type = %[2]q
+}
+`, rName, networkType)
 }

--- a/internal/service/elasticache/serverless_cache_test.go
+++ b/internal/service/elasticache/serverless_cache_test.go
@@ -777,7 +777,6 @@ func TestAccElastiCacheServerlessCache_tags(t *testing.T) {
 	})
 }
 
-
 func TestAccElastiCacheServerlessCache_networkType(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -814,14 +813,9 @@ func TestAccElastiCacheServerlessCache_networkType(t *testing.T) {
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
 					},
 				},
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 			{
 				Config: testAccServerlessCacheConfig_networkType(rName, "dual_stack"),
@@ -1261,6 +1255,7 @@ func testAccServerlessCacheConfig_networkType(rName, networkType string) string 
 	return fmt.Sprintf(`
 resource "aws_elasticache_serverless_cache" "test" {
   name        = %[1]q
+  engine = "valkey"
   network_type = %[2]q
 }
 `, rName, networkType)


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

N/A

### Description
Allows to define network_type for elasticache serverless instances as ipv4, dual_stack or ipv6.
Changing the network type forces to recreate a new resource, modifications are not allowed.
IPv6 can only be set when subnets are ipv6 native.

Also adds the network type in the data source.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes 
--->

Closes #47805

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Is supported in the sdk: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/elasticache


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
For resource creation:
```console
% make test PKG=elasticache TESTS=TestAccElastiCacheServerlessCache_network TESTARGS='-v'
make: Running unit tests on branch: 🌿 feature/serverless-elasticache-network-type 🌿...
Testing single service: elasticache
Testing with -parallel 12
2026/05/07 23:23:17 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/07 23:23:17 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccElastiCacheServerlessCache_networkType
=== PAUSE TestAccElastiCacheServerlessCache_networkType
=== CONT  TestAccElastiCacheServerlessCache_networkType
--- PASS: TestAccElastiCacheServerlessCache_networkType (1018.24s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        1023.473s
```

For data source:
```console
% make test PKG=elasticache TESTS=TestAccElastiCacheServerlessCacheDataSource_Valkey_basic TESTARGS='-v'
make: Running unit tests on branch: 🌿 feature/serverless-elasticache-network-type 🌿...
Testing single service: elasticache
Testing with -parallel 12
2026/05/07 23:44:49 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/07 23:44:49 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccElastiCacheServerlessCacheDataSource_Valkey_basic
=== PAUSE TestAccElastiCacheServerlessCacheDataSource_Valkey_basic
=== CONT  TestAccElastiCacheServerlessCacheDataSource_Valkey_basic
--- PASS: TestAccElastiCacheServerlessCacheDataSource_Valkey_basic (310.78s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        316.047s
```


## Doubts
Should I add the documentation in `website/docs/d` and `website/docs/r` for the new var type or is this generated?