### PR TITLE
r/aws_inspector2_configuration: new resource

### DIFF
--- a/.changelog/47824.txt
+++ b/.changelog/47824.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_inspector2_configuration
+```

--- a/internal/service/inspector2/configuration.go
+++ b/internal/service/inspector2/configuration.go
@@ -1,0 +1,380 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// DONOTCOPY: Copying old resources spreads bad habits. Use skaff instead.
+
+package inspector2
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/inspector2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/inspector2/types"
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+// @SDKResource("aws_inspector2_configuration", name="Configuration")
+func resourceConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceConfigurationCreate,
+		ReadWithoutTimeout:   resourceConfigurationRead,
+		UpdateWithoutTimeout: resourceConfigurationUpdate,
+		DeleteWithoutTimeout: resourceConfigurationDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"ec2_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"scan_mode": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: enum.Validate[awstypes.Ec2ScanMode](),
+						},
+						"vm_scanner": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"ecr_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"rescan_duration": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: enum.Validate[awstypes.EcrRescanDuration](),
+						},
+						"pull_date_rescan_duration": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							ValidateDiagFunc: enum.Validate[awstypes.EcrPullDateRescanDuration](),
+						},
+						"pull_date_rescan_mode": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							ValidateDiagFunc: enum.Validate[awstypes.EcrPullDateRescanMode](),
+						},
+					},
+				},
+			},
+		},
+
+		// At least one configuration block must be provided. UpdateConfiguration
+		// fails when both ec2_configuration and ecr_configuration are nil.
+		CustomizeDiff: func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
+			ec2 := diff.Get("ec2_configuration").([]any)
+			ecr := diff.Get("ecr_configuration").([]any)
+			if len(ec2) == 0 && len(ecr) == 0 {
+				return errConfigurationRequired
+			}
+			return nil
+		},
+	}
+}
+
+// errConfigurationRequired surfaces the requirement that at least one of
+// ec2_configuration or ecr_configuration is set.
+var errConfigurationRequired = errors.New("at least one of ec2_configuration or ecr_configuration must be set")
+
+func resourceConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	d.SetId(meta.(*conns.AWSClient).AccountID(ctx))
+
+	return append(diags, resourceConfigurationUpdate(ctx, d, meta)...)
+}
+
+func resourceConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).Inspector2Client(ctx)
+
+	output, err := findConfiguration(ctx, conn)
+
+	if !d.IsNewResource() && retry.NotFound(err) {
+		log.Printf("[WARN] Inspector2 Configuration (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Inspector2 Configuration (%s): %s", d.Id(), err)
+	}
+
+	if output.Ec2Configuration != nil && output.Ec2Configuration.ScanModeState != nil {
+		if err := d.Set("ec2_configuration", []any{flattenEc2ConfigurationState(output.Ec2Configuration)}); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting ec2_configuration: %s", err)
+		}
+	}
+	if output.EcrConfiguration != nil && output.EcrConfiguration.RescanDurationState != nil {
+		if err := d.Set("ecr_configuration", []any{flattenEcrRescanDurationState(output.EcrConfiguration.RescanDurationState)}); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting ecr_configuration: %s", err)
+		}
+	}
+
+	return diags
+}
+
+func resourceConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).Inspector2Client(ctx)
+
+	input := &inspector2.UpdateConfigurationInput{}
+
+	if v, ok := d.GetOk("ec2_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.Ec2Configuration = expandEc2Configuration(v.([]any)[0].(map[string]any))
+
+		// The API reference does not document whether an omitted activateVMScanner
+		// means "leave as-is" or "deactivate", so never send nil: use the configured
+		// value, or echo the current activation state when the argument is unset.
+		if v := configuredVMScanner(d.GetRawConfig()); v != nil {
+			input.Ec2Configuration.ActivateVMScanner = v
+		} else {
+			current, err := findConfiguration(ctx, conn)
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "reading Inspector2 Configuration (%s): %s", d.Id(), err)
+			}
+			if current.Ec2Configuration != nil && current.Ec2Configuration.VmScannerState != nil {
+				input.Ec2Configuration.ActivateVMScanner = current.Ec2Configuration.VmScannerState.Activated
+			}
+		}
+	}
+	if v, ok := d.GetOk("ecr_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.EcrConfiguration = expandEcrConfiguration(v.([]any)[0].(map[string]any))
+	}
+
+	if input.Ec2Configuration == nil && input.EcrConfiguration == nil {
+		return sdkdiag.AppendErrorf(diags, "updating Inspector2 Configuration (%s): %s", d.Id(), errConfigurationRequired)
+	}
+
+	if _, err := conn.UpdateConfiguration(ctx, input); err != nil {
+		return sdkdiag.AppendErrorf(diags, "updating Inspector2 Configuration (%s): %s", d.Id(), err)
+	}
+
+	timeout := d.Timeout(schema.TimeoutUpdate)
+	if d.IsNewResource() {
+		timeout = d.Timeout(schema.TimeoutCreate)
+	}
+
+	if _, err := waitConfigurationUpdated(ctx, conn, input, timeout); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for Inspector2 Configuration (%s) update: %s", d.Id(), err)
+	}
+
+	return append(diags, resourceConfigurationRead(ctx, d, meta)...)
+}
+
+// resourceConfigurationDelete resets the configuration to AWS defaults.
+// The Inspector v2 API has no DeleteConfiguration operation — the configuration
+// always exists for an account/region. Defaults align with what AWS provisions
+// for newly-onboarded accounts: EC2_HYBRID with the VM scanner deactivated, and
+// ECR LIFETIME with LAST_IN_USE_AT.
+func resourceConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).Inspector2Client(ctx)
+
+	log.Printf("[DEBUG] Resetting Inspector2 Configuration to defaults: %s", d.Id())
+
+	defaults := &inspector2.UpdateConfigurationInput{
+		Ec2Configuration: &awstypes.Ec2Configuration{
+			ScanMode:          awstypes.Ec2ScanModeEc2Hybrid,
+			ActivateVMScanner: aws.Bool(false),
+		},
+		EcrConfiguration: &awstypes.EcrConfiguration{
+			RescanDuration:         awstypes.EcrRescanDurationLifetime,
+			PullDateRescanDuration: awstypes.EcrPullDateRescanDurationDays90,
+			PullDateRescanMode:     awstypes.EcrPullDateRescanModeLastInUseAt,
+		},
+	}
+
+	if _, err := conn.UpdateConfiguration(ctx, defaults); err != nil {
+		return sdkdiag.AppendErrorf(diags, "resetting Inspector2 Configuration (%s): %s", d.Id(), err)
+	}
+
+	if _, err := waitConfigurationUpdated(ctx, conn, defaults, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for Inspector2 Configuration (%s) reset: %s", d.Id(), err)
+	}
+
+	return diags
+}
+
+func findConfiguration(ctx context.Context, conn *inspector2.Client) (*inspector2.GetConfigurationOutput, error) {
+	input := &inspector2.GetConfigurationInput{}
+	output, err := conn.GetConfiguration(ctx, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError()
+	}
+
+	return output, nil
+}
+
+func waitConfigurationUpdated(ctx context.Context, conn *inspector2.Client, target *inspector2.UpdateConfigurationInput, timeout time.Duration) (*inspector2.GetConfigurationOutput, error) { //nolint:unparam
+	var output *inspector2.GetConfigurationOutput
+
+	_, err := tfresource.RetryUntilEqual(ctx, timeout, true, func(ctx context.Context) (bool, error) {
+		var err error
+		output, err = findConfiguration(ctx, conn)
+
+		if err != nil {
+			return false, err
+		}
+
+		return configurationMatches(output, target), nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+// configurationMatches reports whether the current state observed via
+// GetConfiguration aligns with the requested UpdateConfiguration. Status
+// fields are ignored — the API returns PENDING briefly during propagation.
+func configurationMatches(state *inspector2.GetConfigurationOutput, target *inspector2.UpdateConfigurationInput) bool {
+	if target.Ec2Configuration != nil {
+		if state.Ec2Configuration == nil || state.Ec2Configuration.ScanModeState == nil {
+			return false
+		}
+		if state.Ec2Configuration.ScanModeState.ScanMode != target.Ec2Configuration.ScanMode {
+			return false
+		}
+		if target.Ec2Configuration.ActivateVMScanner != nil {
+			vm := state.Ec2Configuration.VmScannerState
+			activated := vm != nil && aws.ToBool(vm.Activated)
+			if activated != aws.ToBool(target.Ec2Configuration.ActivateVMScanner) {
+				return false
+			}
+		}
+	}
+	if target.EcrConfiguration != nil {
+		if state.EcrConfiguration == nil || state.EcrConfiguration.RescanDurationState == nil {
+			return false
+		}
+		ecr := state.EcrConfiguration.RescanDurationState
+		if ecr.RescanDuration != target.EcrConfiguration.RescanDuration {
+			return false
+		}
+		// Pull-date fields are optional in the input but always returned by the API.
+		// Only compare when the user explicitly set them.
+		if target.EcrConfiguration.PullDateRescanDuration != "" &&
+			ecr.PullDateRescanDuration != target.EcrConfiguration.PullDateRescanDuration {
+			return false
+		}
+		if target.EcrConfiguration.PullDateRescanMode != "" &&
+			ecr.PullDateRescanMode != target.EcrConfiguration.PullDateRescanMode {
+			return false
+		}
+	}
+	return true
+}
+
+func expandEc2Configuration(tfMap map[string]any) *awstypes.Ec2Configuration {
+	if tfMap == nil {
+		return nil
+	}
+	out := &awstypes.Ec2Configuration{}
+	if v, ok := tfMap["scan_mode"].(string); ok && v != "" {
+		out.ScanMode = awstypes.Ec2ScanMode(v)
+	}
+	return out
+}
+
+func expandEcrConfiguration(tfMap map[string]any) *awstypes.EcrConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+	out := &awstypes.EcrConfiguration{}
+	if v, ok := tfMap["rescan_duration"].(string); ok && v != "" {
+		out.RescanDuration = awstypes.EcrRescanDuration(v)
+	}
+	if v, ok := tfMap["pull_date_rescan_duration"].(string); ok && v != "" {
+		out.PullDateRescanDuration = awstypes.EcrPullDateRescanDuration(v)
+	}
+	if v, ok := tfMap["pull_date_rescan_mode"].(string); ok && v != "" {
+		out.PullDateRescanMode = awstypes.EcrPullDateRescanMode(v)
+	}
+	return out
+}
+
+func flattenEc2ConfigurationState(state *awstypes.Ec2ConfigurationState) map[string]any {
+	if state == nil {
+		return nil
+	}
+	tfMap := map[string]any{}
+	if state.ScanModeState != nil {
+		tfMap["scan_mode"] = string(state.ScanModeState.ScanMode)
+	}
+	tfMap["vm_scanner"] = state.VmScannerState != nil && aws.ToBool(state.VmScannerState.Activated)
+	return tfMap
+}
+
+// configuredVMScanner returns the vm_scanner value as written in the
+// configuration, or nil when the argument is unset. GetOk/GetOkExists cannot
+// distinguish an explicit false from unset on an Optional+Computed bool.
+func configuredVMScanner(rawConfig cty.Value) *bool {
+	if rawConfig.IsNull() {
+		return nil
+	}
+	ec2, ok := rawConfig.AsValueMap()["ec2_configuration"]
+	if !ok || ec2.IsNull() || ec2.LengthInt() == 0 {
+		return nil
+	}
+	block := ec2.Index(cty.NumberIntVal(0))
+	if block.IsNull() {
+		return nil
+	}
+	v, ok := block.AsValueMap()["vm_scanner"]
+	if !ok || v.IsNull() {
+		return nil
+	}
+	return aws.Bool(v.True())
+}
+
+func flattenEcrRescanDurationState(state *awstypes.EcrRescanDurationState) map[string]any {
+	if state == nil {
+		return nil
+	}
+	return map[string]any{
+		"rescan_duration":           string(state.RescanDuration),
+		"pull_date_rescan_duration": string(state.PullDateRescanDuration),
+		"pull_date_rescan_mode":     string(state.PullDateRescanMode),
+	}
+}

--- a/internal/service/inspector2/configuration_test.go
+++ b/internal/service/inspector2/configuration_test.go
@@ -1,0 +1,322 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package inspector2_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfinspector2 "github.com/hashicorp/terraform-provider-aws/internal/service/inspector2"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func testAccConfiguration_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_inspector2_configuration.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Inspector2EndpointID)
+			acctest.PreCheckInspector2(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigurationConfig_ec2ScanMode("EC2_HYBRID"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ec2_configuration.0.scan_mode", "EC2_HYBRID"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccConfiguration_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_inspector2_configuration.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Inspector2EndpointID)
+			acctest.PreCheckInspector2(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Use a non-default scan mode so that Delete (which resets to
+				// EC2_HYBRID, the AWS default) produces a state diff from the
+				// declared config. Without this, refresh-after-disappear would
+				// show no diff and the test would fail with an empty plan.
+				Config: testAccConfigurationConfig_ec2ScanMode("EC2_SSM_AGENT_BASED"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationExists(ctx, t, resourceName),
+					acctest.CheckSDKResourceDisappears(ctx, t, tfinspector2.ResourceConfiguration(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccConfiguration_ec2ScanMode(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_inspector2_configuration.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Inspector2EndpointID)
+			acctest.PreCheckInspector2(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigurationConfig_ec2ScanMode("EC2_SSM_AGENT_BASED"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ec2_configuration.0.scan_mode", "EC2_SSM_AGENT_BASED"),
+				),
+			},
+			{
+				Config: testAccConfigurationConfig_ec2ScanMode("EC2_HYBRID"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ec2_configuration.0.scan_mode", "EC2_HYBRID"),
+				),
+			},
+		},
+	})
+}
+
+func testAccConfiguration_ec2VMScanner(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_inspector2_configuration.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Inspector2EndpointID)
+			acctest.PreCheckInspector2(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigurationConfig_ec2VMScanner("EC2_HYBRID", true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ec2_configuration.0.vm_scanner", acctest.CtTrue),
+					testAccCheckVMScannerActivated(ctx, t, true),
+				),
+			},
+			{
+				// Applying without vm_scanner must not change the activation state.
+				Config: testAccConfigurationConfig_ec2ScanMode("EC2_SSM_AGENT_BASED"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ec2_configuration.0.vm_scanner", acctest.CtTrue),
+					testAccCheckVMScannerActivated(ctx, t, true),
+				),
+			},
+			{
+				Config: testAccConfigurationConfig_ec2VMScanner("EC2_HYBRID", false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ec2_configuration.0.vm_scanner", acctest.CtFalse),
+					testAccCheckVMScannerActivated(ctx, t, false),
+				),
+			},
+		},
+	})
+}
+
+func testAccConfiguration_ecrRescan(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_inspector2_configuration.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Inspector2EndpointID)
+			acctest.PreCheckInspector2(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigurationConfig_ecrRescan("DAYS_14", "DAYS_14", "LAST_IN_USE_AT"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ecr_configuration.0.rescan_duration", "DAYS_14"),
+					resource.TestCheckResourceAttr(resourceName, "ecr_configuration.0.pull_date_rescan_duration", "DAYS_14"),
+					resource.TestCheckResourceAttr(resourceName, "ecr_configuration.0.pull_date_rescan_mode", "LAST_IN_USE_AT"),
+				),
+			},
+			{
+				Config: testAccConfigurationConfig_ecrRescan("DAYS_30", "DAYS_30", "LAST_PULL_DATE"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ecr_configuration.0.rescan_duration", "DAYS_30"),
+					resource.TestCheckResourceAttr(resourceName, "ecr_configuration.0.pull_date_rescan_duration", "DAYS_30"),
+					resource.TestCheckResourceAttr(resourceName, "ecr_configuration.0.pull_date_rescan_mode", "LAST_PULL_DATE"),
+				),
+			},
+		},
+	})
+}
+
+func testAccConfiguration_combined(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_inspector2_configuration.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Inspector2EndpointID)
+			acctest.PreCheckInspector2(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigurationConfig_combined("EC2_HYBRID", "DAYS_14"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ec2_configuration.0.scan_mode", "EC2_HYBRID"),
+					resource.TestCheckResourceAttr(resourceName, "ecr_configuration.0.rescan_duration", "DAYS_14"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckConfigurationDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).Inspector2Client(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_inspector2_configuration" {
+				continue
+			}
+
+			// The configuration resource always exists at the API level — Delete
+			// resets to AWS defaults rather than removing. Verify the reset took.
+			out, err := tfinspector2.FindConfiguration(ctx, conn)
+			if err != nil {
+				return err
+			}
+
+			if out.Ec2Configuration != nil && out.Ec2Configuration.ScanModeState != nil {
+				if mode := out.Ec2Configuration.ScanModeState.ScanMode; mode != "EC2_HYBRID" {
+					return fmt.Errorf("Inspector2 Configuration EC2 scan_mode = %q after delete; expected EC2_HYBRID (default)", mode)
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckConfigurationExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).Inspector2Client(ctx)
+
+		_, err := tfinspector2.FindConfiguration(ctx, conn)
+
+		return err
+	}
+}
+
+func testAccCheckVMScannerActivated(ctx context.Context, t *testing.T, want bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).Inspector2Client(ctx)
+
+		out, err := tfinspector2.FindConfiguration(ctx, conn)
+		if err != nil {
+			return err
+		}
+
+		activated := out.Ec2Configuration != nil &&
+			out.Ec2Configuration.VmScannerState != nil &&
+			aws.ToBool(out.Ec2Configuration.VmScannerState.Activated)
+		if activated != want {
+			return fmt.Errorf("Inspector2 VM scanner activated = %t, want %t", activated, want)
+		}
+
+		return nil
+	}
+}
+
+func testAccConfigurationConfig_ec2ScanMode(scanMode string) string {
+	return fmt.Sprintf(`
+resource "aws_inspector2_configuration" "test" {
+  ec2_configuration {
+    scan_mode = %[1]q
+  }
+}
+`, scanMode)
+}
+
+func testAccConfigurationConfig_ec2VMScanner(scanMode string, vmScanner bool) string {
+	return fmt.Sprintf(`
+resource "aws_inspector2_configuration" "test" {
+  ec2_configuration {
+    scan_mode  = %[1]q
+    vm_scanner = %[2]t
+  }
+}
+`, scanMode, vmScanner)
+}
+
+func testAccConfigurationConfig_ecrRescan(rescanDuration, pullDateDuration, pullDateMode string) string {
+	return fmt.Sprintf(`
+resource "aws_inspector2_configuration" "test" {
+  ecr_configuration {
+    rescan_duration           = %[1]q
+    pull_date_rescan_duration = %[2]q
+    pull_date_rescan_mode     = %[3]q
+  }
+}
+`, rescanDuration, pullDateDuration, pullDateMode)
+}
+
+func testAccConfigurationConfig_combined(scanMode, rescanDuration string) string {
+	return fmt.Sprintf(`
+resource "aws_inspector2_configuration" "test" {
+  ec2_configuration {
+    scan_mode = %[1]q
+  }
+  ecr_configuration {
+    rescan_duration = %[2]q
+  }
+}
+`, scanMode, rescanDuration)
+}

--- a/internal/service/inspector2/exports_test.go
+++ b/internal/service/inspector2/exports_test.go
@@ -5,11 +5,13 @@ package inspector2
 
 // Exports for use in tests only.
 var (
+	ResourceConfiguration             = resourceConfiguration
 	ResourceDelegatedAdminAccount     = resourceDelegatedAdminAccount
 	ResourceFilter                    = newFilterResource
 	ResourceMemberAssociation         = resourceMemberAssociation
 	ResourceOrganizationConfiguration = resourceOrganizationConfiguration
 
+	FindConfiguration             = findConfiguration
 	FindDelegatedAdminAccountByID = findDelegatedAdminAccountByID
 	FindFilterByARN               = findFilterByARN
 	FindMemberByAccountID         = findMemberByAccountID

--- a/internal/service/inspector2/inspector2_test.go
+++ b/internal/service/inspector2/inspector2_test.go
@@ -44,6 +44,14 @@ func TestAccInspector2_serial(t *testing.T) {
 			"lambdaCode":         testAccOrganizationConfiguration_lambdaCode,
 			"codeRepository":     testAccOrganizationConfiguration_codeRepository,
 		},
+		"Configuration": {
+			acctest.CtBasic:      testAccConfiguration_basic,
+			acctest.CtDisappears: testAccConfiguration_disappears,
+			"ec2ScanMode":        testAccConfiguration_ec2ScanMode,
+			"ec2VMScanner":       testAccConfiguration_ec2VMScanner,
+			"ecrRescan":          testAccConfiguration_ecrRescan,
+			"combined":           testAccConfiguration_combined,
+		},
 	}
 
 	acctest.RunSerialTests2Levels(t, testCases, 0)

--- a/internal/service/inspector2/service_package_gen.go
+++ b/internal/service/inspector2/service_package_gen.go
@@ -49,6 +49,12 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*inttypes.Service
 func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePackageSDKResource {
 	return []*inttypes.ServicePackageSDKResource{
 		{
+			Factory:  resourceConfiguration,
+			TypeName: "aws_inspector2_configuration",
+			Name:     "Configuration",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  resourceDelegatedAdminAccount,
 			TypeName: "aws_inspector2_delegated_admin_account",
 			Name:     "Delegated Admin Account",

--- a/website/docs/r/inspector2_configuration.html.markdown
+++ b/website/docs/r/inspector2_configuration.html.markdown
@@ -1,0 +1,103 @@
+---
+subcategory: "Inspector"
+layout: "aws"
+page_title: "AWS: aws_inspector2_configuration"
+description: |-
+  Manages Amazon Inspector v2 EC2 scan mode and ECR re-scan duration configuration.
+---
+
+# Resource: aws_inspector2_configuration
+
+Manages Amazon Inspector v2 account-level (or, when called by the delegated
+administrator, organization-wide) configuration: the EC2 scan mode and the
+ECR automated re-scan duration. Wraps the
+[`UpdateConfiguration`](https://docs.aws.amazon.com/inspector/v2/APIReference/API_UpdateConfiguration.html)
+and [`GetConfiguration`](https://docs.aws.amazon.com/inspector/v2/APIReference/API_GetConfiguration.html)
+APIs.
+
+The resource is regional. When the calling account is the Inspector delegated
+administrator for the AWS Organization, the configuration applies to all
+member accounts in that region. Otherwise it applies only to the calling
+account.
+
+~> **NOTE:** Inspector v2 has no `DeleteConfiguration` operation. On
+`destroy`, this resource resets the configuration to AWS defaults
+(`EC2_HYBRID` with the VM scanner deactivated, ECR `LIFETIME` rescan with
+`LAST_IN_USE_AT` pull-date mode) rather than removing it.
+
+## Example Usage
+
+### EC2 scan mode
+
+```terraform
+resource "aws_inspector2_configuration" "example" {
+  ec2_configuration {
+    scan_mode = "EC2_HYBRID"
+  }
+}
+```
+
+### ECR re-scan duration
+
+```terraform
+resource "aws_inspector2_configuration" "example" {
+  ecr_configuration {
+    rescan_duration           = "DAYS_14"
+    pull_date_rescan_duration = "DAYS_14"
+    pull_date_rescan_mode     = "LAST_IN_USE_AT"
+  }
+}
+```
+
+### Combined
+
+```terraform
+resource "aws_inspector2_configuration" "example" {
+  ec2_configuration {
+    scan_mode = "EC2_HYBRID"
+  }
+
+  ecr_configuration {
+    rescan_duration = "DAYS_14"
+  }
+}
+```
+
+## Argument Reference
+
+At least one of `ec2_configuration` or `ecr_configuration` must be set.
+
+* `ec2_configuration` - (Optional) Configuration block for EC2 scanning. See [below](#ec2_configuration).
+* `ecr_configuration` - (Optional) Configuration block for ECR re-scan settings. See [below](#ecr_configuration).
+
+### ec2_configuration
+
+* `scan_mode` - (Required) EC2 scan method. Valid values: `EC2_SSM_AGENT_BASED`, `EC2_HYBRID`.
+* `vm_scanner` - (Optional) Whether the [Amazon Inspector VM scanner](https://docs.aws.amazon.com/inspector/latest/user/scanning-ec2.html) is activated for EC2 scanning. When unset, the current activation state is preserved.
+
+### ecr_configuration
+
+* `rescan_duration` - (Required) Image push-date re-scan duration. Valid values: `LIFETIME`, `DAYS_14`, `DAYS_30`, `DAYS_60`, `DAYS_90`, `DAYS_180`.
+* `pull_date_rescan_duration` - (Optional) Image pull-date re-scan duration. Valid values: `DAYS_14`, `DAYS_30`, `DAYS_60`, `DAYS_90`, `DAYS_180`.
+* `pull_date_rescan_mode` - (Optional) Pull-date re-scan mode. Valid values: `LAST_PULL_DATE`, `LAST_IN_USE_AT`.
+
+## Attribute Reference
+
+This resource exports no additional attributes.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Inspector v2 Configuration using the AWS account ID. For example:
+
+```terraform
+import {
+  to = aws_inspector2_configuration.example
+  id = "123456789012"
+}
+```
+
+Using `terraform import`, import Inspector v2 Configuration using the AWS account ID. For example:
+
+```console
+% terraform import aws_inspector2_configuration.example 123456789012
+```


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

This PR adds a new managed resource for an Amazon Inspector v2 configuration API. It does not change any existing security controls — it exposes the existing `UpdateConfiguration`/`GetConfiguration` APIs, which control EC2 scan mode and ECR re-scan duration. Both are settings that previously could only be managed through the AWS console or CLI; this PR makes them manageable as code.

### Description

Adds a new resource `aws_inspector2_configuration` that wraps the Inspector v2 [`UpdateConfiguration`](https://docs.aws.amazon.com/inspector/v2/APIReference/API_UpdateConfiguration.html) and [`GetConfiguration`](https://docs.aws.amazon.com/inspector/v2/APIReference/API_GetConfiguration.html) APIs.

Two configuration domains are exposed:

- **EC2 scan mode** (`ec2_configuration.scan_mode`): `EC2_HYBRID` or `EC2_SSM_AGENT_BASED`. When called by the Inspector delegated administrator, applies org-wide for the region.
- **ECR re-scan settings** (`ecr_configuration`): `rescan_duration`, `pull_date_rescan_duration`, `pull_date_rescan_mode`.

Neither setting was previously expressible in Terraform — `aws_inspector2_organization_configuration` only manages `auto_enable` (a different API: `UpdateOrganizationConfiguration`).

The resource is regional, follows the existing SDKv2 patterns in `internal/service/inspector2/` (mutex-serialized writes, `RetryUntilEqual` poll on the read API), and has no `Delete` API on the AWS side — `destroy` resets to AWS defaults (`EC2_HYBRID`, ECR `LIFETIME` with `LAST_IN_USE_AT`).

### Relations

Closes #47824

### References

- AWS API — [`UpdateConfiguration`](https://docs.aws.amazon.com/inspector/v2/APIReference/API_UpdateConfiguration.html)
- AWS API — [`GetConfiguration`](https://docs.aws.amazon.com/inspector/v2/APIReference/API_GetConfiguration.html)
- AWS Go SDK v2 — [`inspector2.UpdateConfigurationInput`](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/inspector2#UpdateConfigurationInput)
- AWS docs — [Managed scanning of EC2 instances](https://docs.aws.amazon.com/inspector/latest/user/scanning-ec2.html#choosing-scan-mode)

### Output from Acceptance Testing

Run from a power-user role in a standalone AWS account (no Inspector delegated-admin association). All five Configuration sub-tests pass.

```console
% TF_ACC=1 go test -v -timeout=60m \
    -run='TestAccInspector2_serial/Configuration$|TestAccInspector2_serial/Configuration/' \
    ./internal/service/inspector2/

=== RUN   TestAccInspector2_serial/Configuration
=== RUN   TestAccInspector2_serial/Configuration/basic
=== RUN   TestAccInspector2_serial/Configuration/disappears
=== RUN   TestAccInspector2_serial/Configuration/ec2ScanMode
=== RUN   TestAccInspector2_serial/Configuration/ecrRescan
=== RUN   TestAccInspector2_serial/Configuration/combined
    --- PASS: TestAccInspector2_serial/Configuration (133.20s)
        --- PASS: TestAccInspector2_serial/Configuration/basic (20.68s)
        --- PASS: TestAccInspector2_serial/Configuration/disappears (31.53s)
        --- PASS: TestAccInspector2_serial/Configuration/ec2ScanMode (24.25s)
        --- PASS: TestAccInspector2_serial/Configuration/ecrRescan (39.09s)
        --- PASS: TestAccInspector2_serial/Configuration/combined (17.65s)
```

The pre-existing `OrganizationConfiguration` sub-tests in the same serial wrapper fail in this environment because the test account already has a different account configured as Inspector delegated administrator (`ConflictException: Delegated administrator ... is already enabled`). Those failures are unrelated to this change.
