### PR TITLE
sweep(ses): fix pagination error handling in sweepIdentities

### DIFF
--- a/.changelog/47828.txt
+++ b/.changelog/47828.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ses_domain_identity: Fix panic in resource sweeper when pagination fails
+```

--- a/internal/service/ses/sweep.go
+++ b/internal/service/ses/sweep.go
@@ -104,8 +104,13 @@ func sweepIdentities(region, identityType string) error {
 
 	for paginator.HasMorePages() {
 		output, err := paginator.NextPage(ctx)
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping SES Identities sweep for %s: %s", region, err)
+			return sweeperErrs.ErrorOrNil()
+		}
 		if err != nil {
-			log.Printf("[ERROR] %s", sweeperErrs)
+			sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("retrieving SES Identities: %w", err))
+			return sweeperErrs.ErrorOrNil()
 		}
 
 		for _, identity := range output.Identities {
@@ -120,14 +125,6 @@ func sweepIdentities(region, identityType string) error {
 				continue
 			}
 		}
-	}
-
-	if awsv2.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping SES Identities sweep for %s: %s", region, err)
-		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
-	}
-	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("retrieving SES Identities: %w", err))
 	}
 
 	return sweeperErrs.ErrorOrNil()


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Fix three error-handling bugs in the SES identity sweeper (`sweepIdentities`):

1. On pagination error, `log.Printf` logged `sweeperErrs` (the accumulated deletion errors) instead of `err` (the actual pagination error), silently discarding the real error.
2. After logging, there was no `continue` or `return`, so execution fell through to iterate `output.Identities` on a nil `output`, causing a panic.
3. The error handling after the loop (lines 125-131) checked a variable shadowed by the loop-scoped `:=` declaration on line 106, making it dead code.

These bugs were introduced in #38568 during the AWS SDK v2 migration (2024-07-19).

The fix moves error handling into the pagination loop, matching the pattern used by `sweepConfigurationSets` in the same file (lines 54-62).

### Relations

Relates #38568

### Output from Acceptance Testing

N/A (sweep infrastructure only, no resource behavior change)