### PR TITLE
resource/aws_cloudfront_distribution_tenant: fix unbounded deploy wait loop

### DIFF
--- a/.changelog/47829.txt
+++ b/.changelog/47829.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudfront_distribution_tenant: Fix potential indefinite hang when waiting for deploy status by using existing `retry.StateChangeConf` waiter with 30-minute timeout
+```

--- a/internal/service/cloudfront/distribution_tenant.go
+++ b/internal/service/cloudfront/distribution_tenant.go
@@ -769,7 +769,7 @@ func waitManagedCertificateReady(ctx context.Context, conn *cloudfront.Client, i
 	}
 
 	// Wait for distribution tenant to be deployed first
-	dtOutput, err := waitForDistributionTenantDeployed(ctx, conn, id)
+	dtOutput, err := waitDistributionTenantDeployed(ctx, conn, id)
 	if err != nil {
 		return fmt.Errorf("waiting for CloudFront Distribution Tenant (%s) deploy: %w", id, err)
 	}
@@ -784,21 +784,6 @@ func waitManagedCertificateReady(ctx context.Context, conn *cloudfront.Client, i
 	return updateDistributionTenantWithManagedCertificate(ctx, conn, dtOutput, mcOutput)
 }
 
-func waitForDistributionTenantDeployed(ctx context.Context, conn *cloudfront.Client, id string) (*cloudfront.GetDistributionTenantOutput, error) {
-	// Simple loop to wait for deployment - reuse existing logic if needed
-	for {
-		dtOutput, err := findDistributionTenantByIdentifier(ctx, conn, id)
-		if err != nil {
-			return nil, fmt.Errorf("failed reading CloudFront Distribution Tenant (%s): %w", id, err)
-		}
-
-		if aws.ToString(dtOutput.DistributionTenant.Status) == distributionTenantStatusDeployed {
-			return dtOutput, nil
-		}
-
-		time.Sleep(distributionTenantPollInterval)
-	}
-}
 
 func waitForManagedCertificateIssued(ctx context.Context, conn *cloudfront.Client, id string) (*cloudfront.GetManagedCertificateDetailsOutput, error) {
 	timeout := 3 * time.Hour
@@ -877,7 +862,7 @@ func updateDistributionTenantWithManagedCertificate(ctx context.Context, conn *c
 	}
 
 	// Wait for the distribution tenant update to be deployed
-	_, err = waitForDistributionTenantDeployed(ctx, conn, aws.ToString(dtOutput.DistributionTenant.Id))
+	_, err = waitDistributionTenantDeployed(ctx, conn, aws.ToString(dtOutput.DistributionTenant.Id))
 	if err != nil {
 		return fmt.Errorf("failed waiting for CloudFront Distribution Tenant (%s) deploy: %w", aws.ToString(dtOutput.DistributionTenant.Id), err)
 	}


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

`waitForDistributionTenantDeployed` used a raw `for {}` loop with no timeout or deadline to poll for deploy status. If the distribution tenant never reached `Deployed` status (e.g., due to a configuration error or AWS-side issue), Terraform would hang indefinitely. The `time.Sleep` inside the loop also did not respect context cancellation.

An equivalent waiter, `waitDistributionTenantDeployed`, already exists in the same file (line 697) using `retry.StateChangeConf` with a 30-minute timeout, 15-second minimum poll interval, and proper context support. Both functions call `findDistributionTenantByIdentifier` internally and have identical signatures.

This commit replaces the two call sites of the unbounded function with the existing waiter, and removes the duplicate function entirely.

Introduced in #45088 (2025-11-03). The function's own comment (`// Simple loop to wait for deployment - reuse existing logic if needed`) suggests this was always intended to be replaced.

### Relations

Relates #45088

### Output from Acceptance Testing

N/A (no behavioral change beyond adding a 30-minute timeout to a previously unbounded wait)