### PR TITLE
docs: fix allowed value for exception_level in Bedrock AgentCore Gateway

### DIFF
--- a/website/docs/r/bedrockagentcore_gateway.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway.html.markdown
@@ -124,7 +124,7 @@ The following arguments are optional:
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `authorizer_configuration` - (Optional) Configuration for request authorization. Required when `authorizer_type` is set to `CUSTOM_JWT`. See [`authorizer_configuration`](#authorizer_configuration) below.
 * `description` - (Optional) Description of the gateway.
-* `exception_level` - (Optional) Exception level for the gateway. Valid values: `INFO`, `WARN`, `ERROR`.
+* `exception_level` - (Optional) Exception level for the gateway. Valid values: `DEBUG`.
 * `interceptor_configuration` - (Optional) List of interceptor configurations for the gateway. Minimum of 1, maximum of 2. See [`interceptor_configuration`](#interceptor_configuration) below.
 * `kms_key_arn` - (Optional) ARN of the KMS key used to encrypt the gateway data.
 * `protocol_configuration` - (Optional) Protocol-specific configuration for the gateway. See [`protocol_configuration`](#protocol_configuration) below.


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Replace invalid values for [`aws_bedrockagentcore_gateway.exception_level`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagentcore_gateway#exception_level-1) with the valid one.

### Relations

Closes #47827

### References

- [AWS Docs- CreateGateway](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_CreateGateway.html)
- [AWS  Docs- UpdateGateway](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html#bedrockagentcorecontrol-UpdateGateway-request-exceptionLevel)

  Both showing the allowed value for `exceptionLevel`: `DEBUG`
- [AWS SDK Go v2- ExceptionLevel](https://github.com/aws/aws-sdk-go-v2/blame/e5c93f424528436a368e9ba357814f744130add0/service/bedrockagentcorecontrol/types/enums.go#L599)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.