### PR TITLE
feat(aws_route53_records_exclusive): add ability to manage one `name` in a zone

### DIFF
--- a/.changelog/47837.txt
+++ b/.changelog/47837.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_route53_records_exclusive: Add ability to manage one `name` in a hosted zone
+```

--- a/internal/service/route53/exports_test.go
+++ b/internal/service/route53/exports_test.go
@@ -31,6 +31,7 @@ var (
 	FindQueryLoggingConfigByID                  = findQueryLoggingConfigByID
 	FindResourceRecordSetByFourPartKey          = findResourceRecordSetByFourPartKey
 	FindResourceRecordSetsForHostedZone         = findResourceRecordSetsForHostedZone
+	FindResourceRecordSetsForHostedZoneByName   = findResourceRecordSetsForHostedZoneByName
 	FindTrafficPolicyByID                       = findTrafficPolicyByID
 	FindTrafficPolicyInstanceByID               = findTrafficPolicyInstanceByID
 	FindVPCAssociationAuthorizationByTwoPartKey = findVPCAssociationAuthorizationByTwoPartKey

--- a/internal/service/route53/records_exclusive.go
+++ b/internal/service/route53/records_exclusive.go
@@ -8,6 +8,8 @@ package route53
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -63,6 +65,16 @@ func (r *recordsExclusiveResource) Schema(ctx context.Context, req resource.Sche
 				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			names.AttrName: schema.StringAttribute{
+				CustomType: fwtypes.DNSNameStringType,
+				Optional:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthAtMost(1024),
 				},
 			},
 		},
@@ -268,11 +280,21 @@ func (r *recordsExclusiveResource) Schema(ctx context.Context, req resource.Sche
 	}
 }
 
+func (r *recordsExclusiveResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config recordsExclusiveResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(validateRecordsExclusiveNames(ctx, config)...)
+}
+
 func (r *recordsExclusiveResource) syncRecordSets(ctx context.Context, plan recordsExclusiveResourceModel, timeout time.Duration) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := r.Meta().Route53Client(ctx)
 
-	have, err := findResourceRecordSetsForHostedZone(ctx, conn, plan.ZoneID.ValueString())
+	have, err := findResourceRecordSetsForRecordsExclusive(ctx, conn, plan)
 	if err != nil {
 		diags.AddError(
 			create.ProblemStandardMessage(names.Route53, "Syncronizing", ResNameRecordsExclusive, plan.ZoneID.String(), err),
@@ -370,7 +392,7 @@ func (r *recordsExclusiveResource) Read(ctx context.Context, req resource.ReadRe
 	}
 
 	conn := r.Meta().Route53Client(ctx)
-	output, err := findResourceRecordSetsForHostedZone(ctx, conn, state.ZoneID.ValueString())
+	output, err := findResourceRecordSetsForRecordsExclusive(ctx, conn, state)
 	if retry.NotFound(err) {
 		resp.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
 		resp.State.RemoveResource(ctx)
@@ -415,7 +437,64 @@ func (r *recordsExclusiveResource) Update(ctx context.Context, req resource.Upda
 }
 
 func (r *recordsExclusiveResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	if strings.Contains(req.ID, intflex.ResourceIdSeparator) {
+		parts, err := intflex.ExpandResourceId(req.ID, recordsExclusiveResourceIDPartCount, false)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Unexpected Import Identifier",
+				fmt.Sprintf("Expected import identifier with format: zone_id%sname. Got: %q", intflex.ResourceIdSeparator, req.ID),
+			)
+			return
+		}
+
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("zone_id"), parts[0])...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(names.AttrName), parts[1])...)
+		return
+	}
+
 	resource.ImportStatePassthroughID(ctx, path.Root("zone_id"), req, resp)
+}
+
+const recordsExclusiveResourceIDPartCount = 2
+
+func validateRecordsExclusiveNames(ctx context.Context, data recordsExclusiveResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if data.ResourceRecordSet.IsNull() || data.ResourceRecordSet.IsUnknown() {
+		return diags
+	}
+
+	recordSets, d := data.ResourceRecordSet.ToSlice(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+
+	nameScoped := !data.Name.IsNull() && !data.Name.IsUnknown()
+	scopeName := data.Name.ValueString()
+	for _, recordSet := range recordSets {
+		if recordSet == nil || !nameScoped || recordSet.Name.IsNull() || recordSet.Name.IsUnknown() {
+			continue
+		}
+
+		if normalizeDomainName(recordSet.Name.ValueString()) != normalizeDomainName(scopeName) {
+			diags.AddAttributeError(
+				path.Root("resource_record_set"),
+				"Invalid Record Set Name",
+				fmt.Sprintf("When the top-level name argument is configured, each resource_record_set name must match %q.", scopeName),
+			)
+		}
+	}
+
+	return diags
+}
+
+func findResourceRecordSetsForRecordsExclusive(ctx context.Context, conn *route53.Client, data recordsExclusiveResourceModel) ([]awstypes.ResourceRecordSet, error) {
+	if data.Name.IsNull() || data.Name.IsUnknown() {
+		return findResourceRecordSetsForHostedZone(ctx, conn, data.ZoneID.ValueString())
+	}
+
+	return findResourceRecordSetsForHostedZoneByName(ctx, conn, data.ZoneID.ValueString(), data.Name.ValueString())
 }
 
 func findResourceRecordSetsForHostedZone(ctx context.Context, conn *route53.Client, zoneID string) ([]awstypes.ResourceRecordSet, error) {
@@ -440,8 +519,39 @@ func findResourceRecordSetsForHostedZone(ctx context.Context, conn *route53.Clie
 	return findResourceRecordSets(ctx, conn, &input, morePages, filter)
 }
 
+func findResourceRecordSetsForHostedZoneByName(ctx context.Context, conn *route53.Client, zoneID, recordName string) ([]awstypes.ResourceRecordSet, error) {
+	hostedZone, err := findHostedZoneByID(ctx, conn, zoneID)
+	if err != nil {
+		return nil, err
+	}
+	hostedZoneName := aws.ToString(hostedZone.HostedZone.Name)
+	normalizedRecordName := normalizeDomainName(recordName)
+
+	input := route53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(zoneID),
+		StartRecordName: aws.String(fqdn(normalizedRecordName)),
+	}
+	morePages := func(page *route53.ListResourceRecordSetsOutput) bool {
+		return page.IsTruncated && normalizeDomainName(page.NextRecordName) == normalizedRecordName
+	}
+	filter := func(v *awstypes.ResourceRecordSet) bool {
+		if normalizeDomainName(v.Name) != normalizedRecordName {
+			return false
+		}
+
+		// Zone NS & SOA records are created by default and not managed by this resource
+		if normalizedRecordName == normalizeDomainName(hostedZoneName) && (v.Type == awstypes.RRTypeNs || v.Type == awstypes.RRTypeSoa) {
+			return false
+		}
+		return true
+	}
+
+	return findResourceRecordSets(ctx, conn, &input, morePages, filter)
+}
+
 type recordsExclusiveResourceModel struct {
 	ResourceRecordSet fwtypes.SetNestedObjectValueOf[resourceRecordSetModel] `tfsdk:"resource_record_set"`
+	Name              fwtypes.DNSNameString                                  `tfsdk:"name"`
 	Timeouts          timeouts.Value                                         `tfsdk:"timeouts"`
 	ZoneID            types.String                                           `tfsdk:"zone_id"`
 }

--- a/internal/service/route53/records_exclusive_name_test.go
+++ b/internal/service/route53/records_exclusive_name_test.go
@@ -1,0 +1,501 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package route53_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	"github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tfroute53 "github.com/hashicorp/terraform-provider-aws/internal/service/route53"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccRoute53RecordsExclusive_name_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
+	resourceName := "aws_route53_records_exclusive.test"
+	zoneResourceName := "aws_route53_zone.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordsExclusiveDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecordsExclusiveNameConfig_basic(zoneName.String(), recordName.String()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRecordsExclusiveNameExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "zone_id", zoneResourceName, names.AttrID),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, recordName.String()),
+					resource.TestCheckResourceAttr(resourceName, "resource_record_set.#", "3"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "resource_record_set.*", map[string]string{
+						names.AttrType:       string(types.RRTypeA),
+						"ttl":                "300",
+						"resource_records.#": "1",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "resource_record_set.*", map[string]string{
+						names.AttrType:       string(types.RRTypeMx),
+						"ttl":                "300",
+						"resource_records.#": "1",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "resource_record_set.*", map[string]string{
+						names.AttrType:       string(types.RRTypeTxt),
+						"ttl":                "300",
+						"resource_records.#": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    testAccRecordsExclusiveNameImportStateIdFunc(resourceName),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "zone_id",
+				// The custom type will handle suppressing differences like trailing periods
+				// and case sensitivity, but the initial import will still flag the difference.
+				ImportStateVerifyIgnore: []string{
+					"resource_record_set.0.name",
+					"resource_record_set.1.name",
+					"resource_record_set.2.name",
+				},
+			},
+		},
+	})
+}
+
+func TestAccRoute53RecordsExclusive_name_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
+	resourceName := "aws_route53_records_exclusive.test"
+	zoneResourceName := "aws_route53_zone.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordsExclusiveDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecordsExclusiveNameConfig_basic(zoneName.String(), recordName.String()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRecordsExclusiveNameExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "zone_id", zoneResourceName, names.AttrID),
+					resource.TestCheckResourceAttr(resourceName, "resource_record_set.#", "3"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				Config: testAccRecordsExclusiveNameConfig_update(zoneName.String(), recordName.String()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRecordsExclusiveNameExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "resource_record_set.#", "3"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "resource_record_set.*", map[string]string{
+						names.AttrType: string(types.RRTypeA),
+						"ttl":          "60",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "resource_record_set.*", map[string]string{
+						names.AttrType: string(types.RRTypeAaaa),
+						"ttl":          "300",
+					}),
+					testAccCheckRecordsExclusiveNameRecordAbsent(ctx, t, zoneResourceName, recordName.String(), string(types.RRTypeMx)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccRoute53RecordsExclusive_name_outOfBandAddition(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var zone route53.GetHostedZoneOutput
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
+	resourceName := "aws_route53_records_exclusive.test"
+	zoneResourceName := "aws_route53_zone.test"
+
+	addRecord := types.ResourceRecordSet{
+		Type: types.RRTypeAaaa,
+		Name: aws.String(recordName.String()),
+		TTL:  aws.Int64(300),
+		ResourceRecords: []types.ResourceRecord{
+			{
+				Value: aws.String("2001:db8::1"),
+			},
+		},
+	}
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordsExclusiveDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecordsExclusiveNameConfig_basic(zoneName.String(), recordName.String()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRecordsExclusiveNameExists(ctx, t, resourceName),
+					testAccCheckZoneExists(ctx, t, zoneResourceName, &zone),
+					testAccCheckRecordsExclusiveChangeRecord(ctx, t, &zone, types.ChangeActionCreate, &addRecord),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccRecordsExclusiveNameConfig_basic(zoneName.String(), recordName.String()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRecordsExclusiveNameExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "resource_record_set.#", "3"),
+					testAccCheckRecordsExclusiveNameRecordAbsent(ctx, t, zoneResourceName, recordName.String(), string(types.RRTypeAaaa)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccRoute53RecordsExclusive_name_preservesOtherNames(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var otherRecord types.ResourceRecordSet
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
+	otherRecordName := zoneName.RandomSubdomain(t)
+	resourceName := "aws_route53_records_exclusive.test"
+	otherResourceName := "aws_route53_record.other"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordsExclusiveDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecordsExclusiveNameConfig_preservesOtherNames(zoneName.String(), recordName.String(), otherRecordName.String()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRecordsExclusiveNameExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "resource_record_set.#", "3"),
+					testAccCheckRecordExists(ctx, t, otherResourceName, &otherRecord),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRoute53RecordsExclusive_name_empty(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var otherRecord types.ResourceRecordSet
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
+	otherRecordName := zoneName.RandomSubdomain(t)
+	resourceName := "aws_route53_records_exclusive.test"
+	zoneResourceName := "aws_route53_zone.test"
+	otherResourceName := "aws_route53_record.other"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordsExclusiveDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecordsExclusiveNameConfig_empty(zoneName.String(), recordName.String(), otherRecordName.String()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRecordsExclusiveNameExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "resource_record_set.#", "0"),
+					testAccCheckRecordsExclusiveNameRecordAbsent(ctx, t, zoneResourceName, recordName.String(), string(types.RRTypeA)),
+					testAccCheckRecordExists(ctx, t, otherResourceName, &otherRecord),
+				),
+				// The scoped exclusive resource removes aws_route53_record.same, resulting in
+				// a non-empty plan for that record on the post-apply check.
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckRecordsExclusiveNameExists(ctx context.Context, t *testing.T, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.Route53, create.ErrActionCheckingExistence, tfroute53.ResNameRecordsExclusive, name, errors.New("not found"))
+		}
+
+		zoneID := rs.Primary.Attributes["zone_id"]
+		if zoneID == "" {
+			return create.Error(names.Route53, create.ErrActionCheckingExistence, tfroute53.ResNameRecordsExclusive, name, errors.New("zone_id not set"))
+		}
+
+		recordName := rs.Primary.Attributes[names.AttrName]
+		if recordName == "" {
+			return create.Error(names.Route53, create.ErrActionCheckingExistence, tfroute53.ResNameRecordsExclusive, name, errors.New("name not set"))
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).Route53Client(ctx)
+		out, err := tfroute53.FindResourceRecordSetsForHostedZoneByName(ctx, conn, zoneID, recordName)
+		if err != nil {
+			return create.Error(names.Route53, create.ErrActionCheckingExistence, tfroute53.ResNameRecordsExclusive, zoneID, err)
+		}
+
+		recordCount := rs.Primary.Attributes["resource_record_set.#"]
+		if recordCount != strconv.Itoa(len(out)) {
+			return create.Error(names.Route53, create.ErrActionCheckingExistence, tfroute53.ResNameRecordsExclusive, zoneID, errors.New("unexpected resource_record_set count"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckRecordsExclusiveNameRecordAbsent(ctx context.Context, t *testing.T, zoneResourceName, recordName, recordType string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[zoneResourceName]
+		if !ok {
+			return create.Error(names.Route53, create.ErrActionCheckingExistence, tfroute53.ResNameRecordsExclusive, zoneResourceName, errors.New("not found"))
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).Route53Client(ctx)
+		_, _, err := tfroute53.FindResourceRecordSetByFourPartKey(ctx, conn, rs.Primary.Attributes[names.AttrID], recordName, recordType, "")
+		if retry.NotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		return create.Error(names.Route53, create.ErrActionCheckingDestroyed, tfroute53.ResNameRecordsExclusive, recordName, errors.New("not destroyed"))
+	}
+}
+
+func testAccRecordsExclusiveNameImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s%s%s", rs.Primary.Attributes["zone_id"], intflex.ResourceIdSeparator, rs.Primary.Attributes[names.AttrName]), nil
+	}
+}
+
+func testAccRecordsExclusiveNameConfig_basic(zoneName, recordName string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "test" {
+  name          = %[1]q
+  force_destroy = true
+}
+
+resource "aws_route53_records_exclusive" "test" {
+  zone_id = aws_route53_zone.test.zone_id
+  name    = %[2]q
+
+  resource_record_set {
+    name = %[2]q
+    type = "A"
+    ttl  = 300
+
+    resource_records {
+      value = "192.0.2.10"
+    }
+  }
+
+  resource_record_set {
+    name = %[2]q
+    type = "MX"
+    ttl  = 300
+
+    resource_records {
+      value = "10 mail.%[1]s."
+    }
+  }
+
+  resource_record_set {
+    name = %[2]q
+    type = "TXT"
+    ttl  = 300
+
+    resource_records {
+      value = "\"some-app-config\""
+    }
+  }
+}
+`, zoneName, recordName)
+}
+
+func testAccRecordsExclusiveNameConfig_update(zoneName, recordName string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "test" {
+  name          = %[1]q
+  force_destroy = true
+}
+
+resource "aws_route53_records_exclusive" "test" {
+  zone_id = aws_route53_zone.test.zone_id
+  name    = %[2]q
+
+  resource_record_set {
+    name = %[2]q
+    type = "A"
+    ttl  = 60
+
+    resource_records {
+      value = "192.0.2.20"
+    }
+  }
+
+  resource_record_set {
+    name = %[2]q
+    type = "AAAA"
+    ttl  = 300
+
+    resource_records {
+      value = "2001:db8::10"
+    }
+  }
+
+  resource_record_set {
+    name = %[2]q
+    type = "TXT"
+    ttl  = 300
+
+    resource_records {
+      value = "\"some-app-config\""
+    }
+  }
+}
+`, zoneName, recordName)
+}
+
+func testAccRecordsExclusiveNameConfig_preservesOtherNames(zoneName, recordName, otherRecordName string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "test" {
+  name          = %[1]q
+  force_destroy = true
+}
+
+resource "aws_route53_record" "other" {
+  zone_id = aws_route53_zone.test.zone_id
+  name    = %[3]q
+  type    = "A"
+  ttl     = 300
+  records = ["192.0.2.30"]
+}
+
+resource "aws_route53_records_exclusive" "test" {
+  zone_id = aws_route53_zone.test.zone_id
+  name    = %[2]q
+
+  depends_on = [aws_route53_record.other]
+
+  resource_record_set {
+    name = %[2]q
+    type = "A"
+    ttl  = 300
+
+    resource_records {
+      value = "192.0.2.10"
+    }
+  }
+
+  resource_record_set {
+    name = %[2]q
+    type = "MX"
+    ttl  = 300
+
+    resource_records {
+      value = "10 mail.%[1]s."
+    }
+  }
+
+  resource_record_set {
+    name = %[2]q
+    type = "TXT"
+    ttl  = 300
+
+    resource_records {
+      value = "\"some-app-config\""
+    }
+  }
+}
+`, zoneName, recordName, otherRecordName)
+}
+
+func testAccRecordsExclusiveNameConfig_empty(zoneName, recordName, otherRecordName string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "test" {
+  name          = %[1]q
+  force_destroy = true
+}
+
+resource "aws_route53_record" "same" {
+  zone_id = aws_route53_zone.test.zone_id
+  name    = %[2]q
+  type    = "A"
+  ttl     = 300
+  records = ["192.0.2.10"]
+}
+
+resource "aws_route53_record" "other" {
+  zone_id = aws_route53_zone.test.zone_id
+  name    = %[3]q
+  type    = "A"
+  ttl     = 300
+  records = ["192.0.2.30"]
+}
+
+resource "aws_route53_records_exclusive" "test" {
+  zone_id = aws_route53_zone.test.zone_id
+  name    = %[2]q
+
+  depends_on = [
+    aws_route53_record.same,
+    aws_route53_record.other,
+  ]
+}
+`, zoneName, recordName, otherRecordName)
+}

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a Route53 record resource.
 
+~> When updating between records of different types for the same `name`, such as replacing a CNAME with an A and TXT record, the change is not applied atomically and may temporarily or (in the case of errors during apply) persistently exist in an inconsistent state. To avoid this, use the `aws_route53_records_exclusive` resource instead, either for a particular `name` or entire hosted zone.
+
 ## Example Usage
 
 ### Simple routing policy

--- a/website/docs/r/route53_records_exclusive.html.markdown
+++ b/website/docs/r/route53_records_exclusive.html.markdown
@@ -9,7 +9,7 @@ description: |-
 
 Terraform resource for maintaining exclusive management of resource record sets defined in an AWS Route53 hosted zone.
 
-!> This resource takes exclusive ownership over resource record sets defined in a hosted zone. This includes removal of record sets which are not explicitly configured. To prevent persistent drift, ensure any `aws_route53_record` resources managed alongside this resource have an equivalent `resource_record_set` argument.
+!> This resource takes exclusive ownership over resource record sets defined in a hosted zone, or over records matching a particular `name` if set. This includes removal of matching records which are not explicitly configured. To prevent persistent drift, ensure any `aws_route53_record` resources managed alongside this resource have an equivalent `resource_record_set` argument, or are outside the configured `name` scope.
 
 ~> Destruction of this resource means Terraform will no longer manage reconciliation of the configured resource record sets. It __will not__ delete the configured record sets from the hosted zone.
 
@@ -43,6 +43,35 @@ resource "aws_route53_records_exclusive" "test" {
 }
 ```
 
+Or to instead manage all records for a particular DNS name within the zone:
+
+```terraform
+resource "aws_route53_records_exclusive" "subdomain2" {
+  zone_id = aws_route53_zone.example.zone_id
+  name    = "subdomain2.example.com"
+
+  resource_record_set {
+    name = "subdomain2.example.com"
+    type = "A"
+    ttl  = 300
+
+    resource_records {
+      value = "192.0.2.10"
+    }
+  }
+
+  resource_record_set {
+    name = "subdomain2.example.com"
+    type = "MX"
+    ttl  = 300
+
+    resource_records {
+      value = "10 mail.example.com."
+    }
+  }
+}
+```
+
 ### Disallow Record Sets
 
 To automatically remove any configured record sets, omit a `resource_record_set` block.
@@ -63,6 +92,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
+* `name` - (Optional) DNS name whose resource record sets are exclusively managed. When omitted, all non-default record sets in the hosted zone are managed.
 * `resource_record_set` - (Optional) A list of all resource record sets associated with the hosted zone.
 See [`resource_record_set`](#resource_record_set) below.
 
@@ -70,9 +100,9 @@ See [`resource_record_set`](#resource_record_set) below.
 
 The following arguments are required:
 
-* `name` - (Required) Name of the record.
 * `type` - (Required) Record type.
 Valid values are `A`, `AAAA`, `CAA`, `CNAME`, `DS`, `MX`, `NAPTR`, `NS`, `PTR`, `SOA`, `SPF`, `SRV`, `TXT`, `TLSA`, `SSHFP`, `SVCB`, and `HTTPS`.
+* `name` - (Required) Name of the record. When the top-level `name` argument is configured, this argument must match the top-level `name`.
 
 The following arguments are optional:
 
@@ -177,4 +207,19 @@ Using `terraform import`, import Route 53 Records Exclusive using the `zone_id`.
 
 ```console
 % terraform import aws_route53_records_exclusive.example ABCD1234
+```
+
+To import a scoped Route 53 Records Exclusive resource, use the `zone_id,name` format. For example:
+
+```terraform
+import {
+  to = aws_route53_records_exclusive.example
+  id = "ABCD1234,app.example.com"
+}
+```
+
+Using `terraform import`, import a scoped Route 53 Records Exclusive resource using the `zone_id,name` format. For example:
+
+```console
+% terraform import aws_route53_records_exclusive.example ABCD1234,app.example.com
 ```


### PR DESCRIPTION
As mentioned in #43500, aws_route53_record `type` changes are currently not atomic. This could be fixed by itself (I'm actually a bit fuzzy on why ForceNew was added in 2f27987b6263b317aac34b98cba4dd65220d49c3) but regardless, there is a need to be able to swap a CNAME for multiple records atomically, which is not possible even if aws_route53_record itself supported atomic changes.

This PR introduces the ability to use route53_records_exclusive to manage all records for a single `name` within a zone (instead of only an entire zone as today), such that changes are applied atomically with a single ChangeResourceRecordSets request. This can be used when some records in the zone are to be unmanaged in Terraform or managed by a different Terraform project.

### Relations

Relates #43500 (arguably could close it)

### Output from Acceptance Testing

```console
% make testacc PKG=route53 TESTS='TestAccRoute53RecordsExclusive_'
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	(cached)
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go test ./internal/service/route53/... -v -count 1 -parallel 20 -run='TestAccRoute53RecordsExclusive_'  -timeout 360m -vet=off -buildvcs=false
2026/05/09 14:08:17 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/09 14:08:17 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRoute53RecordsExclusive_name_basic
=== PAUSE TestAccRoute53RecordsExclusive_name_basic
=== RUN   TestAccRoute53RecordsExclusive_name_update
=== PAUSE TestAccRoute53RecordsExclusive_name_update
=== RUN   TestAccRoute53RecordsExclusive_name_outOfBandAddition
=== PAUSE TestAccRoute53RecordsExclusive_name_outOfBandAddition
=== RUN   TestAccRoute53RecordsExclusive_name_preservesOtherNames
=== PAUSE TestAccRoute53RecordsExclusive_name_preservesOtherNames
=== RUN   TestAccRoute53RecordsExclusive_name_empty
=== PAUSE TestAccRoute53RecordsExclusive_name_empty
=== RUN   TestAccRoute53RecordsExclusive_basic
=== PAUSE TestAccRoute53RecordsExclusive_basic
=== RUN   TestAccRoute53RecordsExclusive_disappears_Zone
=== PAUSE TestAccRoute53RecordsExclusive_disappears_Zone
=== RUN   TestAccRoute53RecordsExclusive_multiple
=== PAUSE TestAccRoute53RecordsExclusive_multiple
=== RUN   TestAccRoute53RecordsExclusive_upsert
=== PAUSE TestAccRoute53RecordsExclusive_upsert
=== RUN   TestAccRoute53RecordsExclusive_empty
=== PAUSE TestAccRoute53RecordsExclusive_empty
=== RUN   TestAccRoute53RecordsExclusive_outOfBandAddition
=== PAUSE TestAccRoute53RecordsExclusive_outOfBandAddition
=== RUN   TestAccRoute53RecordsExclusive_outOfBandRemoval
=== PAUSE TestAccRoute53RecordsExclusive_outOfBandRemoval
=== RUN   TestAccRoute53RecordsExclusive_outOfBandUpdate
=== PAUSE TestAccRoute53RecordsExclusive_outOfBandUpdate
=== CONT  TestAccRoute53RecordsExclusive_name_basic
=== CONT  TestAccRoute53RecordsExclusive_multiple
=== CONT  TestAccRoute53RecordsExclusive_name_empty
=== CONT  TestAccRoute53RecordsExclusive_name_outOfBandAddition
=== CONT  TestAccRoute53RecordsExclusive_name_update
=== CONT  TestAccRoute53RecordsExclusive_disappears_Zone
=== CONT  TestAccRoute53RecordsExclusive_outOfBandAddition
=== CONT  TestAccRoute53RecordsExclusive_outOfBandUpdate
=== CONT  TestAccRoute53RecordsExclusive_outOfBandRemoval
=== CONT  TestAccRoute53RecordsExclusive_empty
=== CONT  TestAccRoute53RecordsExclusive_upsert
=== CONT  TestAccRoute53RecordsExclusive_name_preservesOtherNames
=== CONT  TestAccRoute53RecordsExclusive_basic
--- PASS: TestAccRoute53RecordsExclusive_disappears_Zone (159.74s)
--- PASS: TestAccRoute53RecordsExclusive_multiple (164.28s)
--- PASS: TestAccRoute53RecordsExclusive_name_basic (165.97s)
--- PASS: TestAccRoute53RecordsExclusive_basic (166.17s)
--- PASS: TestAccRoute53RecordsExclusive_name_empty (181.53s)
--- PASS: TestAccRoute53RecordsExclusive_name_update (200.69s)
--- PASS: TestAccRoute53RecordsExclusive_outOfBandUpdate (218.76s)
--- PASS: TestAccRoute53RecordsExclusive_name_preservesOtherNames (222.34s)
--- PASS: TestAccRoute53RecordsExclusive_outOfBandAddition (235.55s)
--- PASS: TestAccRoute53RecordsExclusive_outOfBandRemoval (237.15s)
--- PASS: TestAccRoute53RecordsExclusive_name_outOfBandAddition (237.23s)
--- PASS: TestAccRoute53RecordsExclusive_empty (238.27s)
--- PASS: TestAccRoute53RecordsExclusive_upsert (246.91s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	252.366s
%
```
