### PR TITLE
[Tests/Docs] aws_lambda_function: Support S3 Files file system

### DIFF
--- a/.changelog/47838.txt
+++ b/.changelog/47838.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lambda_function: Support mounting Amazon S3 buckets as file systems with S3 Files
+```

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -906,6 +906,45 @@ func TestAccLambdaFunction_fileSystem(t *testing.T) {
 	})
 }
 
+func TestAccLambdaFunction_s3FileSystem(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var conf lambda.GetFunctionOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_lambda_function.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFunctionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Ensure a function with lambda file system configuration can be created
+			{
+				Config: testAccFunctionConfig_s3FileSystem(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
+					testAccCheckFunctionInvokeARN(resourceName, &conf),
+					testAccCheckFunctionQualifiedInvokeARN(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "file_system_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "file_system_config.0.arn", "aws_s3files_access_point.for_lambda", names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "file_system_config.0.local_mount_path", "/mnt/s3files"),
+				),
+			},
+			// Ensure configuration can be imported
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
+			},
+		},
+	})
+}
+
 func TestAccLambdaFunction_image(t *testing.T) {
 	ctx := acctest.Context(t)
 	key := "AWS_LAMBDA_IMAGE_LATEST_ID"
@@ -3834,6 +3873,263 @@ resource "aws_lambda_function" "test" {
   }
 
   depends_on = [aws_efs_mount_target.test]
+}
+`, rName))
+}
+
+func testAccFunctionConfig_s3FileSystem(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLambdaBase(rName, rName, rName),
+		fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_s3_bucket" "lambda_file_system" {
+  bucket           = "%[1]s-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}-an"
+  bucket_namespace = "account-regional"
+  force_destroy    = true
+}
+
+resource "aws_s3_bucket_versioning" "lambda_file_system" {
+  bucket = aws_s3_bucket.lambda_file_system.bucket
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+data "aws_iam_policy_document" "s3files_policy" {
+  statement {
+    actions = [
+      "s3:ListBucket",
+      "s3:ListBucketVersions"
+    ]
+    effect = "Allow"
+    resources = [
+      aws_s3_bucket.lambda_file_system.arn
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+  statement {
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:DeleteObject*",
+      "s3:GetObject*",
+      "s3:List*",
+      "s3:PutObject*"
+    ]
+    effect = "Allow"
+    resources = [
+      "${aws_s3_bucket.lambda_file_system.arn}/*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+  statement {
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncryptFrom",
+      "kms:ReEncryptTo"
+    ]
+    effect    = "Allow"
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"]
+    condition {
+      test     = "StringLike"
+      variable = "kms:ViaService"
+      values   = ["s3.${data.aws_region.current.region}.amazonaws.com"]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "kms:EncryptionContext:aws:s3:arn"
+      values = [
+        aws_s3_bucket.lambda_file_system.arn,
+        "${aws_s3_bucket.lambda_file_system.arn}/*"
+      ]
+    }
+  }
+  statement {
+    actions = [
+      "events:DeleteRule",
+      "events:DisableRule",
+      "events:EnableRule",
+      "events:PutRule",
+      "events:PutTargets",
+      "events:RemoveTargets"
+    ]
+    effect = "Allow"
+    resources = [
+      "arn:aws:events:*:*:rule/DO-NOT-DELETE-S3-Files*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "events:ManagedBy"
+      values   = ["elasticfilesystem.amazonaws.com"]
+    }
+  }
+  statement {
+    actions = [
+      "events:DescribeRule",
+      "events:ListRuleNamesByTarget",
+      "events:ListRules",
+      "events:ListTargetsByRule"
+    ]
+    effect = "Allow"
+    resources = [
+      "arn:aws:events:*:*:rule/*"
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "assume_role_s3files" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["elasticfilesystem.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:s3files:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:file-system/*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "s3files" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role_s3files.json
+  name               = "%[1]s-s3files-lambda-role"
+}
+
+resource "aws_iam_role_policy" "s3files" {
+  policy = data.aws_iam_policy_document.s3files_policy.json
+  role   = aws_iam_role.s3files.name
+}
+
+resource "aws_s3files_file_system" "for_lambda" {
+  bucket   = aws_s3_bucket.lambda_file_system.arn
+  role_arn = aws_iam_role.s3files.arn
+
+  depends_on = [
+    aws_s3_bucket_versioning.lambda_file_system
+  ]
+}
+
+resource "aws_s3files_access_point" "for_lambda" {
+  file_system_id = aws_s3files_file_system.for_lambda.id
+
+  root_directory {
+    path = "/lambda"
+    creation_permissions {
+      owner_gid   = 1000
+      owner_uid   = 1000
+      permissions = "755"
+    }
+  }
+
+  posix_user {
+    gid = 1000
+    uid = 1000
+  }
+}
+
+resource "aws_security_group" "s3files_mount_targets" {
+  name        = "%[1]s-s3files-mount-targets-sg"
+  vpc_id      = aws_vpc.vpc_for_lambda.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "s3files_mount_targets_nfs" {
+  ip_protocol                  = "tcp"
+  from_port                    = 2049
+  to_port                      = 2049
+  referenced_security_group_id = aws_security_group.lambda_s3files.id
+  security_group_id            = aws_security_group.s3files_mount_targets.id
+}
+
+resource "aws_s3files_mount_target" "for_lambda" {
+  file_system_id  = aws_s3files_file_system.for_lambda.id
+  subnet_id       = aws_subnet.subnet_for_lambda_az2.id
+  security_groups = [aws_security_group.s3files_mount_targets.id]
+}
+
+data "aws_iam_policy_document" "lambda_s3files" {
+  statement {
+    actions = [
+      "s3files:ClientMount",
+      "s3files:ClientWrite",
+      "s3files:ListFileSystems",
+      "s3files:ListAccessPoints",
+      "s3files:GetFileSystem",
+      "s3files:GetAccessPoint",
+      "s3files:CreateAccessPoint"
+    ]
+    effect    = "Allow"
+    resources = ["*"]
+  }
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion"
+    ]
+    effect    = "Allow"
+    resources = ["${aws_s3_bucket.lambda_file_system.arn}/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda_s3files" {
+  policy = data.aws_iam_policy_document.lambda_s3files.json
+  role   = aws_iam_role.iam_for_lambda.name
+}
+
+// Use more restricted security groups than that provided by acctest.ConfigLambdaBase
+resource "aws_security_group" "lambda_s3files" {
+  name        = "%[1]s-lambda-s3files-sg"
+  vpc_id      = aws_vpc.vpc_for_lambda.id
+}
+
+resource "aws_vpc_security_group_egress_rule" "lambda_s3files_nfs" {
+  ip_protocol                  = "tcp"
+  security_group_id            = aws_security_group.lambda_s3files.id
+  from_port                    = 2049
+  to_port                      = 2049
+  referenced_security_group_id = aws_security_group.s3files_mount_targets.id
+}
+
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambda_invocation.zip"
+  function_name = %[1]q
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "lambda_invocation.handler"
+  runtime       = "nodejs24.x"
+
+  vpc_config {
+    subnet_ids         = [aws_subnet.subnet_for_lambda_az2.id]
+    security_group_ids = [aws_security_group.lambda_s3files.id]
+  }
+
+  file_system_config {
+    arn              = aws_s3files_access_point.for_lambda.arn
+    local_mount_path = "/mnt/s3files"
+  }
+  depends_on = [aws_s3files_mount_target.for_lambda]
+}
+
+resource "aws_lambda_invocation" "test" {
+  function_name = aws_lambda_function.test.function_name
+  input         = jsonencode({})
 }
 `, rName))
 }

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -4096,8 +4096,8 @@ resource "aws_iam_role_policy" "lambda_s3files" {
 
 // Use more restricted security groups than that provided by acctest.ConfigLambdaBase
 resource "aws_security_group" "lambda_s3files" {
-  name        = "%[1]s-lambda-s3files-sg"
-  vpc_id      = aws_vpc.vpc_for_lambda.id
+  name   = "%[1]s-lambda-s3files-sg"
+  vpc_id = aws_vpc.vpc_for_lambda.id
 }
 
 resource "aws_vpc_security_group_egress_rule" "lambda_s3files_nfs" {

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -3940,7 +3940,7 @@ data "aws_iam_policy_document" "s3files_policy" {
       "kms:ReEncryptTo"
     ]
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"]
+    resources = ["arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"]
     condition {
       test     = "StringLike"
       variable = "kms:ViaService"
@@ -3966,7 +3966,7 @@ data "aws_iam_policy_document" "s3files_policy" {
     ]
     effect = "Allow"
     resources = [
-      "arn:aws:events:*:*:rule/DO-NOT-DELETE-S3-Files*"
+      "arn:${data.aws_partition.current.partition}:events:*:*:rule/DO-NOT-DELETE-S3-Files*"
     ]
     condition {
       test     = "StringEquals"
@@ -3983,7 +3983,7 @@ data "aws_iam_policy_document" "s3files_policy" {
     ]
     effect = "Allow"
     resources = [
-      "arn:aws:events:*:*:rule/*"
+      "arn:${data.aws_partition.current.partition}:events:*:*:rule/*"
     ]
   }
 }
@@ -4004,7 +4004,7 @@ data "aws_iam_policy_document" "assume_role_s3files" {
     condition {
       test     = "ArnLike"
       variable = "aws:SourceArn"
-      values   = ["arn:aws:s3files:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:file-system/*"]
+      values   = ["arn:${data.aws_partition.current.partition}:s3files:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:file-system/*"]
     }
   }
 }
@@ -4047,8 +4047,8 @@ resource "aws_s3files_access_point" "for_lambda" {
 }
 
 resource "aws_security_group" "s3files_mount_targets" {
-  name        = "%[1]s-s3files-mount-targets-sg"
-  vpc_id      = aws_vpc.vpc_for_lambda.id
+  name   = "%[1]s-s3files-mount-targets-sg"
+  vpc_id = aws_vpc.vpc_for_lambda.id
 }
 
 resource "aws_vpc_security_group_ingress_rule" "s3files_mount_targets_nfs" {
@@ -4094,7 +4094,7 @@ resource "aws_iam_role_policy" "lambda_s3files" {
   role   = aws_iam_role.iam_for_lambda.name
 }
 
-// Use more restricted security groups than that provided by acctest.ConfigLambdaBase
+# Use more restricted security groups than that provided by acctest.ConfigLambdaBase
 resource "aws_security_group" "lambda_s3files" {
   name   = "%[1]s-lambda-s3files-sg"
   vpc_id = aws_vpc.vpc_for_lambda.id

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -849,7 +849,7 @@ func TestAccLambdaFunction_nilDeadLetter(t *testing.T) {
 	})
 }
 
-func TestAccLambdaFunction_fileSystem(t *testing.T) {
+func TestAccLambdaFunction_efsFileSystem(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -867,7 +867,7 @@ func TestAccLambdaFunction_fileSystem(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Ensure a function with lambda file system configuration can be created
 			{
-				Config: testAccFunctionConfig_fileSystem(rName),
+				Config: testAccFunctionConfig_efsFileSystem(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
 					testAccCheckFunctionInvokeARN(resourceName, &conf),
@@ -886,7 +886,7 @@ func TestAccLambdaFunction_fileSystem(t *testing.T) {
 			},
 			// Ensure lambda file system configuration can be updated
 			{
-				Config: testAccFunctionConfig_fileSystemUpdate(rName),
+				Config: testAccFunctionConfig_efsFileSystemUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "file_system_config.#", "1"),
@@ -3763,7 +3763,7 @@ resource "aws_lambda_function" "test" {
 `, rName))
 }
 
-func testAccFunctionConfig_fileSystem(rName string) string {
+func testAccFunctionConfig_efsFileSystem(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLambdaBase(rName, rName, rName),
 		fmt.Sprintf(`
@@ -3820,7 +3820,7 @@ resource "aws_lambda_function" "test" {
 `, rName))
 }
 
-func testAccFunctionConfig_fileSystemUpdate(rName string) string {
+func testAccFunctionConfig_efsFileSystemUpdate(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLambdaBase(rName, rName, rName),
 		fmt.Sprintf(`

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -921,6 +921,12 @@ func TestAccLambdaFunction_s3FileSystem(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFunctionDestroy(ctx, t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "0.12.1",
+			},
+		},
 		Steps: []resource.TestStep{
 			// Ensure a function with lambda file system configuration can be created
 			{
@@ -4127,9 +4133,17 @@ resource "aws_lambda_function" "test" {
   depends_on = [aws_s3files_mount_target.for_lambda]
 }
 
+# Wait for the Security Group attached to the Lambda Function
+# to eventually take effect before invoking it
+resource "time_sleep" "wait_for_sg_ready" {
+  create_duration = "10s"
+  depends_on      = [aws_lambda_function.test]
+}
+
 resource "aws_lambda_invocation" "test" {
   function_name = aws_lambda_function.test.function_name
   input         = jsonencode({})
+  depends_on    = [time_sleep.wait_for_sg_ready]
 }
 `, rName))
 }

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -286,8 +286,8 @@ resource "aws_vpc_security_group_ingress_rule" "s3files_mount_targets_nfs" {
 }
 
 resource "aws_security_group" "lambda_s3files" {
-  name        = "example-lambda-s3files-sg"
-  vpc_id      = aws_vpc.vpc_for_lambda.id
+  name   = "example-lambda-s3files-sg"
+  vpc_id = aws_vpc.vpc_for_lambda.id
 }
 
 resource "aws_vpc_security_group_egress_rule" "lambda_s3files_nfs" {

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -575,7 +575,7 @@ The following arguments are optional:
 * `durable_config` - (Optional) Configuration block for durable function settings. [See below](#durable_config-configuration-block). `durable_config` may only be available in [limited regions](https://builder.aws.com/build/capabilities), including `us-east-2`.
 * `environment` - (Optional) Configuration block for environment variables. [See below](#environment-configuration-block).
 * `ephemeral_storage` - (Optional) Amount of ephemeral storage (`/tmp`) to allocate for the Lambda Function. [See below](#ephemeral_storage-configuration-block).
-* `file_system_config` - (Optional) Configuration block for EFS file system. [See below](#file_system_config-configuration-block).
+* `file_system_config` - (Optional) Configuration block for EFS or S3 Files file system. [See below](#file_system_config-configuration-block).
 * `filename` - (Optional) Path to the function's deployment package within the local filesystem. Conflicts with `image_uri` and `s3_bucket`. One of `filename`, `image_uri`, or `s3_bucket` must be specified.
 * `handler` - (Optional) Function entry point in your code. Required if `package_type` is `Zip`.
 * `image_config` - (Optional) Container image configuration values. [See below](#image_config-configuration-block).
@@ -638,7 +638,7 @@ The following arguments are optional:
 
 ### file_system_config Configuration Block
 
-* `arn` - (Required) ARN of the Amazon EFS Access Point.
+* `arn` - (Required) ARN of the Amazon EFS Access Point, or the Amazon S3 Files access point.
 * `local_mount_path` - (Required) Path where the function can access the file system. Must start with `/mnt/`.
 
 ### image_config Configuration Block

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -244,7 +244,7 @@ resource "aws_s3_bucket_versioning" "lambda_file_system" {
 }
 
 resource "aws_s3files_file_system" "for_lambda" {
-  bucket   = aws_s3_bucket.lambda_file_system.arn
+  bucket = aws_s3_bucket.lambda_file_system.arn
   # For required IAM permissions to use S3Files file system,
   # see https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-prereq-policies.html#s3-files-prereq-iam
   role_arn = aws_iam_role.s3files.arn
@@ -273,8 +273,8 @@ resource "aws_s3files_access_point" "for_lambda" {
 }
 
 resource "aws_security_group" "s3files_mount_targets" {
-  name        = "example-s3files-mount-targets-sg"
-  vpc_id      = aws_vpc.vpc_for_lambda.id
+  name   = "example-s3files-mount-targets-sg"
+  vpc_id = aws_vpc.vpc_for_lambda.id
 }
 
 resource "aws_vpc_security_group_ingress_rule" "s3files_mount_targets_nfs" {
@@ -303,9 +303,9 @@ resource "aws_lambda_function" "example" {
   function_name = "example_s3files_function"
   # For required IAM permissions to use S3Files with Lambda,
   # see https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-prereq-policies.html#s3-files-prereq-iam
-  role          = aws_iam_role.iam_for_lambda.arn
-  handler       = "exports.example"
-  runtime       = "nodejs24.x"
+  role    = aws_iam_role.iam_for_lambda.arn
+  handler = "exports.example"
+  runtime = "nodejs24.x"
 
   vpc_config {
     subnet_ids         = [aws_subnet.subnet_for_lambda_az1.id]

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -225,6 +225,101 @@ resource "aws_lambda_function" "example" {
 }
 ```
 
+### Function with S3 Files File System
+
+```terraform
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_s3_bucket" "lambda_file_system" {
+  bucket           = "example-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}-an"
+  bucket_namespace = "account-regional"
+}
+
+resource "aws_s3_bucket_versioning" "lambda_file_system" {
+  bucket = aws_s3_bucket.lambda_file_system.bucket
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3files_file_system" "for_lambda" {
+  bucket   = aws_s3_bucket.lambda_file_system.arn
+  # For required IAM permissions to use S3Files file system,
+  # see https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-prereq-policies.html#s3-files-prereq-iam
+  role_arn = aws_iam_role.s3files.arn
+
+  depends_on = [
+    aws_s3_bucket_versioning.lambda_file_system
+  ]
+}
+
+resource "aws_s3files_access_point" "for_lambda" {
+  file_system_id = aws_s3files_file_system.for_lambda.id
+
+  root_directory {
+    path = "/lambda"
+    creation_permissions {
+      owner_gid   = 1000
+      owner_uid   = 1000
+      permissions = "755"
+    }
+  }
+
+  posix_user {
+    gid = 1000
+    uid = 1000
+  }
+}
+
+resource "aws_security_group" "s3files_mount_targets" {
+  name        = "example-s3files-mount-targets-sg"
+  vpc_id      = aws_vpc.vpc_for_lambda.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "s3files_mount_targets_nfs" {
+  ip_protocol                  = "tcp"
+  from_port                    = 2049
+  to_port                      = 2049
+  referenced_security_group_id = aws_security_group.lambda_s3files.id
+  security_group_id            = aws_security_group.s3files_mount_targets.id
+}
+
+resource "aws_security_group" "lambda_s3files" {
+  name        = "example-lambda-s3files-sg"
+  vpc_id      = aws_vpc.vpc_for_lambda.id
+}
+
+resource "aws_vpc_security_group_egress_rule" "lambda_s3files_nfs" {
+  ip_protocol                  = "tcp"
+  security_group_id            = aws_security_group.lambda_s3files.id
+  from_port                    = 2049
+  to_port                      = 2049
+  referenced_security_group_id = aws_security_group.s3files_mount_targets.id
+}
+
+resource "aws_lambda_function" "example" {
+  filename      = "function.zip"
+  function_name = "example_s3files_function"
+  # For required IAM permissions to use S3Files with Lambda,
+  # see https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-prereq-policies.html#s3-files-prereq-iam
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "exports.example"
+  runtime       = "nodejs24.x"
+
+  vpc_config {
+    subnet_ids         = [aws_subnet.subnet_for_lambda_az1.id]
+    security_group_ids = [aws_security_group.lambda_s3files.id]
+  }
+
+  file_system_config {
+    arn              = aws_s3files_access_point.for_lambda.arn
+    local_mount_path = "/mnt/s3files"
+  }
+  depends_on = [aws_s3files_mount_target.for_lambda]
+}
+```
+
 ### Function with Advanced Logging
 
 ```terraform


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR adds an acceptance test for `file_system_config` using the S3 Files file system for the `aws_lambda_function` resource, along with updates to the resource documentation.

* The AWS API schema was not changed to introduce this feature, and therefore no changes to the AWS Provider implementation are necessary.
* To verify this behavior, this PR adds an acceptance test that configures `file_system_config` with S3 Files.

  * The acceptance test uses `aws_lambda_invocation` to invoke the Lambda function and verify that the required configuration, such as IAM roles and security groups, is properly set up for successful invocation.
* An example usage of `file_system_config` with S3 Files is also added, based on the newly added acceptance test.

Although this PR only updates tests and documentation, a CHANGELOG entry is included to announce the support in the release notes.


### References
https://aws.amazon.com/about-aws/whats-new/2026/04/aws-lambda-amazon-s3/
https://docs.aws.amazon.com/lambda/latest/api/API_FileSystemConfig.html

### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccLambdaFunction_s3FileSystem' PKG=lambda
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 t-d-aws_lambda_function-s3files 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunction_s3FileSystem'  -timeout 360m -vet=off -buildvcs=false
2026/05/10 03:41:52 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/10 03:41:52 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaFunction_s3FileSystem
=== PAUSE TestAccLambdaFunction_s3FileSystem
=== CONT  TestAccLambdaFunction_s3FileSystem
--- PASS: TestAccLambdaFunction_s3FileSystem (937.85s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     943.574s

```
