### PR TITLE
[CHANGELOG] aws_lambda_function/aws_lambda_layer_version: Add changelog for adding support of `ruby4.0` runtime

### DIFF
--- a/.changelog/47841.txt
+++ b/.changelog/47841.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_lambda_function: Add support for `ruby4.0` as a `runtime` value
+```
+
+```release-note:enhancement
+resource/aws_lambda_layer_version: Add support for `ruby4.0` as a `compatible_runtimes` value
+```


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

AWS recently announced support for the `ruby4.0` runtime for Lambda.

Although the new runtime became automatically supported in the AWS Provider through an update to AWS SDK for Go v2, this PR adds a CHANGELOG entry to announce the support in the Provider release notes, in the same manner as #45024.


### References
https://aws.amazon.com/about-aws/whats-new/2026/04/aws-lambda-adds-ruby/
https://docs.aws.amazon.com/lambda/latest/api/API_CreateFunction.html#lambda-CreateFunction-request-Runtime
https://github.com/aws/aws-sdk-go-v2/blob/main/service/lambda/CHANGELOG.md#v1900-2026-04-22