### PR TITLE
Technical debt: Add and fix semgrep rule `list-iterator-calls-stopped-yield`

### DIFF
--- a/.ci/semgrep/list/callback-pagination.yaml
+++ b/.ci/semgrep/list/callback-pagination.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: list-iterator-calls-stopped-yield
+    message: >-
+      List iterator function uses callback-based paginated finder (lastPage pattern)
+      without ensuring that a stopped yield isn't called on error.
+    languages: [go]
+    severity: WARNING
+    patterns:
+      - pattern: |
+          $ERR := $PAGES_FN($...PARGS, func($PAGE $PTYPE, lastPage bool) bool {
+            $...BODY
+          })
+      - pattern-inside: |
+          return func(yield func($T, error) bool) {
+            $...ALL
+          }
+      - pattern-not-inside: |
+          var stopped bool
+          $...REST

--- a/.ci/semgrep/list/callback-pagination.yaml
+++ b/.ci/semgrep/list/callback-pagination.yaml
@@ -1,3 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# "SPDX-License-Identifier: MPL-2.0"
+
 rules:
   - id: list-iterator-calls-stopped-yield
     message: >-

--- a/internal/service/apigatewayv2/api_list.go
+++ b/internal/service/apigatewayv2/api_list.go
@@ -95,19 +95,21 @@ type listAPIModel struct {
 
 func listAPIs(ctx context.Context, conn *apigatewayv2.Client, input *apigatewayv2.GetApisInput) iter.Seq2[awstypes.Api, error] {
 	return func(yield func(awstypes.Api, error) bool) {
+		var stopped bool
 		err := getAPIsPages(ctx, conn, input, func(page *apigatewayv2.GetApisOutput, lastPage bool) bool {
 			if page == nil {
 				return !lastPage
 			}
 			for _, item := range page.Items {
 				if !yield(item, nil) {
+					stopped = true
 					return false
 				}
 			}
 			return !lastPage
 		})
-		if err != nil {
-			yield(awstypes.Api{}, fmt.Errorf("listing API Gateway V2 API resources: %w", err))
+		if !stopped && err != nil {
+			yield(inttypes.Zero[awstypes.Api](), fmt.Errorf("listing API Gateway V2 APIs: %w", err))
 		}
 	}
 }

--- a/internal/service/apigatewayv2/route_list.go
+++ b/internal/service/apigatewayv2/route_list.go
@@ -115,19 +115,21 @@ type listRouteModel struct {
 
 func listRoutes(ctx context.Context, conn *apigatewayv2.Client, input *apigatewayv2.GetRoutesInput) iter.Seq2[awstypes.Route, error] {
 	return func(yield func(awstypes.Route, error) bool) {
+		var stopped bool
 		err := getRoutesPages(ctx, conn, input, func(page *apigatewayv2.GetRoutesOutput, lastPage bool) bool {
 			if page == nil {
 				return !lastPage
 			}
 			for _, item := range page.Items {
 				if !yield(item, nil) {
+					stopped = true
 					return false
 				}
 			}
 			return !lastPage
 		})
-		if err != nil {
-			yield(awstypes.Route{}, fmt.Errorf("listing API Gateway V2 Route resources: %w", err))
+		if !stopped && err != nil {
+			yield(inttypes.Zero[awstypes.Route](), fmt.Errorf("listing API Gateway V2 Routes: %w", err))
 		}
 	}
 }

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -5365,6 +5365,7 @@ func findTransitGatewayMeteringPolicies(ctx context.Context, conn *ec2.Client, i
 
 func listTransitGatewayMeteringPolicies(ctx context.Context, conn *ec2.Client, input *ec2.DescribeTransitGatewayMeteringPoliciesInput) iter.Seq2[awstypes.TransitGatewayMeteringPolicy, error] {
 	return func(yield func(awstypes.TransitGatewayMeteringPolicy, error) bool) {
+		var stopped bool
 		err := describeTransitGatewayMeteringPoliciesPages(ctx, conn, input, func(page *ec2.DescribeTransitGatewayMeteringPoliciesOutput, lastPage bool) bool {
 			if page == nil {
 				return !lastPage
@@ -5372,6 +5373,7 @@ func listTransitGatewayMeteringPolicies(ctx context.Context, conn *ec2.Client, i
 
 			for _, v := range page.TransitGatewayMeteringPolicies {
 				if !yield(v, nil) {
+					stopped = true
 					return false
 				}
 			}
@@ -5379,7 +5381,7 @@ func listTransitGatewayMeteringPolicies(ctx context.Context, conn *ec2.Client, i
 			return !lastPage
 		})
 
-		if err != nil {
+		if !stopped && err != nil {
 			yield(inttypes.Zero[awstypes.TransitGatewayMeteringPolicy](), fmt.Errorf("listing EC2 Transit Gateway Metering Policies: %w", err))
 			return
 		}

--- a/internal/service/events/rule_list.go
+++ b/internal/service/events/rule_list.go
@@ -105,17 +105,14 @@ func listRules(ctx context.Context, conn *eventbridge.Client, input *eventbridge
 			if page == nil {
 				return !lastPage
 			}
-
 			for _, item := range page.Rules {
 				if !yield(item, nil) {
 					stopped = true
 					return false
 				}
 			}
-
 			return !lastPage
 		})
-
 		if !stopped && err != nil {
 			yield(inttypes.Zero[awstypes.Rule](), fmt.Errorf("listing EventBridge Rules: %w", err))
 			return

--- a/internal/service/events/rule_list.go
+++ b/internal/service/events/rule_list.go
@@ -100,16 +100,24 @@ type listRuleModel struct {
 
 func listRules(ctx context.Context, conn *eventbridge.Client, input *eventbridge.ListRulesInput) iter.Seq2[awstypes.Rule, error] {
 	return func(yield func(awstypes.Rule, error) bool) {
+		var stopped bool
 		err := listRulesPages(ctx, conn, input, func(page *eventbridge.ListRulesOutput, lastPage bool) bool {
+			if page == nil {
+				return !lastPage
+			}
+
 			for _, item := range page.Rules {
 				if !yield(item, nil) {
-					return !lastPage
+					stopped = true
+					return false
 				}
 			}
+
 			return !lastPage
 		})
-		if err != nil {
-			yield(awstypes.Rule{}, fmt.Errorf("listing EventBridge Rule resources: %w", err))
+
+		if !stopped && err != nil {
+			yield(inttypes.Zero[awstypes.Rule](), fmt.Errorf("listing EventBridge Rules: %w", err))
 			return
 		}
 	}

--- a/internal/service/events/target_list.go
+++ b/internal/service/events/target_list.go
@@ -115,22 +115,21 @@ type listTargetModel struct {
 
 func listTargets(ctx context.Context, conn *eventbridge.Client, input *eventbridge.ListTargetsByRuleInput) iter.Seq2[awstypes.Target, error] {
 	return func(yield func(awstypes.Target, error) bool) {
+		var stopped bool
 		err := listTargetsByRulePages(ctx, conn, input, func(page *eventbridge.ListTargetsByRuleOutput, lastPage bool) bool {
 			if page == nil {
 				return !lastPage
 			}
-
 			for _, item := range page.Targets {
 				if !yield(item, nil) {
-					return !lastPage
+					stopped = true
+					return false
 				}
 			}
-
 			return !lastPage
 		})
-
-		if err != nil {
-			yield(awstypes.Target{}, fmt.Errorf("listing EventBridge Target resources: %w", err))
+		if !stopped && err != nil {
+			yield(inttypes.Zero[awstypes.Target](), fmt.Errorf("listing EventBridge Targets: %w", err))
 			return
 		}
 	}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Ensure that a stopped `yield` function isn't called when a list iterator uses a callback-style paged finder.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/47844.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
