### PR TITLE
[Docs] aws_timestreaminfluxdb_db_instance: Add missing `maintenance_schedule` block description

### DIFF
--- a/website/docs/r/timestreaminfluxdb_db_instance.html.markdown
+++ b/website/docs/r/timestreaminfluxdb_db_instance.html.markdown
@@ -239,12 +239,17 @@ The following arguments are optional:
 
 * `s3_configuration` - (Required) Configuration for S3 bucket log delivery.
 
+#### `maintenance_schedule`
+
+* `preferred_maintenance_window` - (Required) Preferred maintenance window in the format `ddd:HH:MM-ddd:HH:MM`. Day must be one of `Mon`, `Tue`, `Wed`, `Thu`, `Fri`, `Sat`, or `Sun`. Provide an empty string to let the system choose a window.
+* `timezone` - (Required) IANA timezone identifier for the maintenance window. For example, `America/New_York` or `UTC`.
+
 #### `s3_configuration`
 
 * `bucket_name` - (Required) Name of the S3 bucket to deliver logs to.
 * `enabled` - (Required) Indicates whether log delivery to the S3 bucket is enabled.
 
-**Note**: The following arguments do updates in-place: `db_parameter_group_identifier`, `log_delivery_configuration`, `port`, `deployment_type`, `db_instance_type`, and `tags`. Changes to any other argument after a DB instance has been deployed will cause destruction and re-creation of the DB instance. Additionally, when `db_parameter_group_identifier` is added to a DB instance or modified, the DB instance will be updated in-place but if `db_parameter_group_identifier` is removed from a DB instance, the DB instance will be destroyed and re-created.
+**Note**: The following arguments do updates in-place: `db_parameter_group_identifier`, `log_delivery_configuration`, `maintenance_schedule`, `port`, `deployment_type`, `db_instance_type`, and `tags`. Changes to any other argument after a DB instance has been deployed will cause destruction and re-creation of the DB instance. Additionally, when `db_parameter_group_identifier` is added to a DB instance or modified, the DB instance will be updated in-place but if `db_parameter_group_identifier` is removed from a DB instance, the DB instance will be destroyed and re-created.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

The `maintenance_schedule` block was added to the `aws_timestreaminfluxdb_db_instance` resource in #47853.
However, the documentation update was incomplete, and the description for this block was omitted.

This PR updates the documentation to include the `maintenance_schedule` block description. The added description is exactly the same as the one in the `aws_timestreaminfluxdb_db_cluster` documentation.

### Relations
Relates #47853

### References
`aws_timestreaminfluxdb_db_cluster` documentation
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/timestreaminfluxdb_db_cluster#nested-fields