### PR TITLE
aws_ssm_resource_policy: new resource & data source

### DIFF
--- a/.changelog/47864.txt
+++ b/.changelog/47864.txt
@@ -1,0 +1,7 @@
+```release-note:new-resource
+aws_ssm_resource_policy
+```
+
+```release-note:new-data-source
+aws_ssm_resource_policy
+```

--- a/internal/service/ssm/exports_test.go
+++ b/internal/service/ssm/exports_test.go
@@ -16,6 +16,7 @@ var (
 	ResourcePatchBaseline           = resourcePatchBaseline
 	ResourcePatchGroup              = resourcePatchGroup
 	ResourceResourceDataSync        = resourceResourceDataSync
+	ResourceResourcePolicy          = newResourcePolicyResource
 	ResourceServiceSetting          = resourceServiceSetting
 
 	FindActivationByID                                 = findActivationByID
@@ -30,5 +31,6 @@ var (
 	FindPatchBaselineByID                              = findPatchBaselineByID
 	FindPatchGroupByTwoPartKey                         = findPatchGroupByTwoPartKey
 	FindResourceDataSyncByName                         = findResourceDataSyncByName
+	FindResourcePolicyByTwoPartKey                     = findResourcePolicyByTwoPartKey
 	FindServiceSettingByID                             = findServiceSettingByID
 )

--- a/internal/service/ssm/resource_policy.go
+++ b/internal/service/ssm/resource_policy.go
@@ -1,0 +1,272 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// DONOTCOPY: Copying old resources spreads bad habits. Use skaff instead.
+
+package ssm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tfjson "github.com/hashicorp/terraform-provider-aws/internal/json"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_ssm_resource_policy", name="Resource Policy")
+func newResourcePolicyResource(context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourcePolicyResource{}
+
+	return r, nil
+}
+
+type resourcePolicyResource struct {
+	framework.ResourceWithModel[resourcePolicyResourceModel]
+}
+
+func (r *resourcePolicyResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: framework.IDAttribute(),
+			names.AttrPolicy: schema.StringAttribute{
+				CustomType: fwtypes.IAMPolicyType,
+				Required:   true,
+			},
+			"policy_hash": schema.StringAttribute{
+				Computed: true,
+			},
+			"policy_id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			names.AttrResourceARN: schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Required:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+	}
+}
+
+func (r *resourcePolicyResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	var data resourcePolicyResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().SSMClient(ctx)
+
+	// SSM PutResourcePolicy validates `policy` against ^(?!\s*$).+ which only matches single-line strings,
+	// so multi-line JSON (e.g. from aws_iam_policy_document) is rejected. Compact it before sending.
+	policy, err := tfjson.CompactString(data.Policy.ValueString())
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("creating SSM Resource Policy (%s)", data.ResourceARN.ValueString()), err.Error())
+
+		return
+	}
+
+	input := &ssm.PutResourcePolicyInput{
+		Policy:      aws.String(policy),
+		ResourceArn: flex.StringFromFramework(ctx, data.ResourceARN),
+	}
+
+	output, err := conn.PutResourcePolicy(ctx, input)
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("creating SSM Resource Policy (%s)", data.ResourceARN.ValueString()), err.Error())
+
+		return
+	}
+
+	data.PolicyID = flex.StringToFramework(ctx, output.PolicyId)
+	data.PolicyHash = flex.StringToFramework(ctx, output.PolicyHash)
+	data.setID()
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+func (r *resourcePolicyResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	var data resourcePolicyResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().SSMClient(ctx)
+
+	output, err := findResourcePolicyByTwoPartKey(ctx, conn, data.ResourceARN.ValueString(), data.PolicyID.ValueString())
+
+	if retry.NotFound(err) {
+		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		response.State.RemoveResource(ctx)
+
+		return
+	}
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("reading SSM Resource Policy (%s)", data.ID.ValueString()), err.Error())
+
+		return
+	}
+
+	data.Policy = fwtypes.IAMPolicyValue(aws.ToString(output.Policy))
+	data.PolicyHash = flex.StringToFramework(ctx, output.PolicyHash)
+	data.PolicyID = flex.StringToFramework(ctx, output.PolicyId)
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+func (r *resourcePolicyResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	var old, new resourcePolicyResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &old)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	response.Diagnostics.Append(request.Plan.Get(ctx, &new)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().SSMClient(ctx)
+
+	policy, err := tfjson.CompactString(new.Policy.ValueString())
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("updating SSM Resource Policy (%s)", new.ID.ValueString()), err.Error())
+
+		return
+	}
+
+	input := &ssm.PutResourcePolicyInput{
+		Policy:      aws.String(policy),
+		PolicyHash:  flex.StringFromFramework(ctx, old.PolicyHash),
+		PolicyId:    flex.StringFromFramework(ctx, old.PolicyID),
+		ResourceArn: flex.StringFromFramework(ctx, new.ResourceARN),
+	}
+
+	output, err := conn.PutResourcePolicy(ctx, input)
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("updating SSM Resource Policy (%s)", new.ID.ValueString()), err.Error())
+
+		return
+	}
+
+	new.PolicyID = flex.StringToFramework(ctx, output.PolicyId)
+	new.PolicyHash = flex.StringToFramework(ctx, output.PolicyHash)
+
+	response.Diagnostics.Append(response.State.Set(ctx, &new)...)
+}
+
+func (r *resourcePolicyResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	var data resourcePolicyResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().SSMClient(ctx)
+
+	input := ssm.DeleteResourcePolicyInput{
+		PolicyHash:  flex.StringFromFramework(ctx, data.PolicyHash),
+		PolicyId:    flex.StringFromFramework(ctx, data.PolicyID),
+		ResourceArn: flex.StringFromFramework(ctx, data.ResourceARN),
+	}
+
+	_, err := conn.DeleteResourcePolicy(ctx, &input)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) || errs.IsA[*awstypes.ResourcePolicyNotFoundException](err) {
+		return
+	}
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("deleting SSM Resource Policy (%s)", data.ID.ValueString()), err.Error())
+
+		return
+	}
+}
+
+func (r *resourcePolicyResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
+	const importIDSeparator = ","
+
+	parts := strings.Split(request.ID, importIDSeparator)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		response.Diagnostics.AddError(
+			"Unexpected Import Identifier",
+			fmt.Sprintf("Expected import identifier with format: <resource_arn>%s<policy_id>. Got: %q", importIDSeparator, request.ID),
+		)
+		return
+	}
+
+	resourceARN, policyID := parts[0], parts[1]
+
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root(names.AttrResourceARN), resourceARN)...)
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("policy_id"), policyID)...)
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root(names.AttrID), resourcePolicyCreateID(resourceARN, policyID))...)
+}
+
+func findResourcePolicyByTwoPartKey(ctx context.Context, conn *ssm.Client, resourceARN, policyID string) (*awstypes.GetResourcePoliciesResponseEntry, error) {
+	input := &ssm.GetResourcePoliciesInput{
+		ResourceArn: aws.String(resourceARN),
+	}
+
+	pages := ssm.NewGetResourcePoliciesPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) || errs.IsA[*awstypes.ResourcePolicyNotFoundException](err) {
+			return nil, &retry.NotFoundError{
+				LastError: err,
+			}
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, policy := range page.Policies {
+			if aws.ToString(policy.PolicyId) == policyID {
+				return &policy, nil
+			}
+		}
+	}
+
+	return nil, &retry.NotFoundError{}
+}
+
+func resourcePolicyCreateID(resourceARN, policyID string) string {
+	return fmt.Sprintf("%s,%s", resourceARN, policyID)
+}
+
+type resourcePolicyResourceModel struct {
+	framework.WithRegionModel
+	ID          types.String      `tfsdk:"id"`
+	Policy      fwtypes.IAMPolicy `tfsdk:"policy"`
+	PolicyHash  types.String      `tfsdk:"policy_hash"`
+	PolicyID    types.String      `tfsdk:"policy_id"`
+	ResourceARN fwtypes.ARN       `tfsdk:"resource_arn"`
+}
+
+func (data *resourcePolicyResourceModel) setID() {
+	data.ID = types.StringValue(resourcePolicyCreateID(data.ResourceARN.ValueString(), data.PolicyID.ValueString()))
+}

--- a/internal/service/ssm/resource_policy_data_source.go
+++ b/internal/service/ssm/resource_policy_data_source.go
@@ -1,0 +1,135 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// DONOTCOPY: Copying old resources spreads bad habits. Use skaff instead.
+
+package ssm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_ssm_resource_policy", name="Resource Policy")
+func newResourcePolicyDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &resourcePolicyDataSource{}, nil
+}
+
+type resourcePolicyDataSource struct {
+	framework.DataSourceWithModel[resourcePolicyDataSourceModel]
+}
+
+func (d *resourcePolicyDataSource) Schema(ctx context.Context, request datasource.SchemaRequest, response *datasource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: framework.IDAttribute(),
+			names.AttrPolicy: schema.StringAttribute{
+				CustomType: fwtypes.IAMPolicyType,
+				Computed:   true,
+			},
+			"policy_hash": schema.StringAttribute{
+				Computed: true,
+			},
+			"policy_id": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			names.AttrResourceARN: schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Required:   true,
+			},
+		},
+	}
+}
+
+func (d *resourcePolicyDataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+	var data resourcePolicyDataSourceModel
+	response.Diagnostics.Append(request.Config.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := d.Meta().SSMClient(ctx)
+
+	resourceARN := data.ResourceARN.ValueString()
+	policyID := data.PolicyID.ValueString()
+
+	var policy *awstypes.GetResourcePoliciesResponseEntry
+	var err error
+	if policyID != "" {
+		policy, err = findResourcePolicyByTwoPartKey(ctx, conn, resourceARN, policyID)
+	} else {
+		policy, err = findResourcePolicyByARN(ctx, conn, resourceARN)
+	}
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("reading SSM Resource Policy (%s)", resourceARN), err.Error())
+
+		return
+	}
+
+	data.Policy = fwtypes.IAMPolicyValue(aws.ToString(policy.Policy))
+	data.PolicyHash = flex.StringToFramework(ctx, policy.PolicyHash)
+	data.PolicyID = flex.StringToFramework(ctx, policy.PolicyId)
+	data.ID = types.StringValue(resourcePolicyCreateID(resourceARN, aws.ToString(policy.PolicyId)))
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+// findResourcePolicyByARN returns the single resource policy attached to resourceARN.
+// SSM resources (OpsItemGroup, advanced Parameter) currently support only one policy per resource;
+// if multiple are returned, it errors so the caller can disambiguate with policy_id.
+func findResourcePolicyByARN(ctx context.Context, conn *ssm.Client, resourceARN string) (*awstypes.GetResourcePoliciesResponseEntry, error) {
+	input := &ssm.GetResourcePoliciesInput{
+		ResourceArn: aws.String(resourceARN),
+	}
+
+	var policies []awstypes.GetResourcePoliciesResponseEntry
+	pages := ssm.NewGetResourcePoliciesPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) || errs.IsA[*awstypes.ResourcePolicyNotFoundException](err) {
+			return nil, &retry.NotFoundError{
+				LastError: err,
+			}
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		policies = append(policies, page.Policies...)
+	}
+
+	switch len(policies) {
+	case 0:
+		return nil, &retry.NotFoundError{}
+	case 1:
+		return &policies[0], nil
+	default:
+		return nil, fmt.Errorf("multiple resource policies attached to %s; set policy_id to select one", resourceARN)
+	}
+}
+
+type resourcePolicyDataSourceModel struct {
+	framework.WithRegionModel
+	ID          types.String      `tfsdk:"id"`
+	Policy      fwtypes.IAMPolicy `tfsdk:"policy"`
+	PolicyHash  types.String      `tfsdk:"policy_hash"`
+	PolicyID    types.String      `tfsdk:"policy_id"`
+	ResourceARN fwtypes.ARN       `tfsdk:"resource_arn"`
+}

--- a/internal/service/ssm/resource_policy_data_source_test.go
+++ b/internal/service/ssm/resource_policy_data_source_test.go
@@ -1,0 +1,76 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ssm_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSSMResourcePolicyDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_ssm_resource_policy.test"
+	resourceName := "aws_ssm_resource_policy.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourcePolicyDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrResourceARN, resourceName, names.AttrResourceARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, "policy_id", resourceName, "policy_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "policy_hash", resourceName, "policy_hash"),
+					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrPolicy),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSSMResourcePolicyDataSource_byPolicyID(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_ssm_resource_policy.test"
+	resourceName := "aws_ssm_resource_policy.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourcePolicyDataSourceConfig_byPolicyID(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrResourceARN, resourceName, names.AttrResourceARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, "policy_id", resourceName, "policy_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrPolicy),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourcePolicyDataSourceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccResourcePolicyConfig_basic(rName), `
+data "aws_ssm_resource_policy" "test" {
+  resource_arn = aws_ssm_resource_policy.test.resource_arn
+}
+`)
+}
+
+func testAccResourcePolicyDataSourceConfig_byPolicyID(rName string) string {
+	return acctest.ConfigCompose(testAccResourcePolicyConfig_basic(rName), `
+data "aws_ssm_resource_policy" "test" {
+  resource_arn = aws_ssm_resource_policy.test.resource_arn
+  policy_id    = aws_ssm_resource_policy.test.policy_id
+}
+`)
+}

--- a/internal/service/ssm/resource_policy_test.go
+++ b/internal/service/ssm/resource_policy_test.go
@@ -1,0 +1,208 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ssm_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tfssm "github.com/hashicorp/terraform-provider-aws/internal/service/ssm"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSSMResourcePolicy_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ssm_resource_policy.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckResourcePolicyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourcePolicyConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourcePolicyExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_hash"),
+					resource.TestMatchResourceAttr(resourceName, names.AttrResourceARN, regexache.MustCompile(`:parameter/`+rName+`$`)),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    testAccResourcePolicyImportStateIDFunc(resourceName),
+				ImportStateVerifyIdentifierAttribute: "policy_id",
+				ImportStateVerifyIgnore:              []string{names.AttrPolicy},
+			},
+		},
+	})
+}
+
+func TestAccSSMResourcePolicy_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ssm_resource_policy.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckResourcePolicyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourcePolicyConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourcePolicyExists(ctx, t, resourceName),
+				),
+			},
+			{
+				Config: testAccResourcePolicyConfig_updated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourcePolicyExists(ctx, t, resourceName),
+					resource.TestMatchResourceAttr(resourceName, names.AttrPolicy, regexache.MustCompile(`GetParameter`)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSSMResourcePolicy_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ssm_resource_policy.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckResourcePolicyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourcePolicyConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourcePolicyExists(ctx, t, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, t, tfssm.ResourceResourcePolicy, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckResourcePolicyDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).SSMClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_ssm_resource_policy" {
+				continue
+			}
+
+			_, err := tfssm.FindResourcePolicyByTwoPartKey(ctx, conn, rs.Primary.Attributes[names.AttrResourceARN], rs.Primary.Attributes["policy_id"])
+
+			if retry.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("SSM Resource Policy %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckResourcePolicyExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).SSMClient(ctx)
+
+		_, err := tfssm.FindResourcePolicyByTwoPartKey(ctx, conn, rs.Primary.Attributes[names.AttrResourceARN], rs.Primary.Attributes["policy_id"])
+
+		return err
+	}
+}
+
+func testAccResourcePolicyImportStateIDFunc(n string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", n)
+		}
+
+		return fmt.Sprintf("%s,%s", rs.Primary.Attributes[names.AttrResourceARN], rs.Primary.Attributes["policy_id"]), nil
+	}
+}
+
+func testAccResourcePolicyConfig_base(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_parameter" "test" {
+  name  = %[1]q
+  type  = "String"
+  tier  = "Advanced"
+  value = "test"
+}
+`, rName)
+}
+
+func testAccResourcePolicyConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccResourcePolicyConfig_base(rName), `
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    actions = ["ssm:GetParameters"]
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_caller_identity.current.account_id]
+    }
+    resources = [aws_ssm_parameter.test.arn]
+  }
+}
+
+resource "aws_ssm_resource_policy" "test" {
+  resource_arn = aws_ssm_parameter.test.arn
+  policy       = data.aws_iam_policy_document.test.json
+}
+`)
+}
+
+func testAccResourcePolicyConfig_updated(rName string) string {
+	return acctest.ConfigCompose(testAccResourcePolicyConfig_base(rName), `
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    actions = ["ssm:GetParameter"]
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_caller_identity.current.account_id]
+    }
+    resources = [aws_ssm_parameter.test.arn]
+  }
+}
+
+resource "aws_ssm_resource_policy" "test" {
+  resource_arn = aws_ssm_parameter.test.arn
+  policy       = data.aws_iam_policy_document.test.json
+}
+`)
+}

--- a/internal/service/ssm/service_package_gen.go
+++ b/internal/service/ssm/service_package_gen.go
@@ -41,11 +41,24 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 			Name:     "Patch Baselines",
 			Region:   inttypes.ResourceRegionDefault(),
 		},
+		{
+			Factory:  newResourcePolicyDataSource,
+			TypeName: "aws_ssm_resource_policy",
+			Name:     "Resource Policy",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
 	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.ServicePackageFrameworkResource {
-	return []*inttypes.ServicePackageFrameworkResource{}
+	return []*inttypes.ServicePackageFrameworkResource{
+		{
+			Factory:  newResourcePolicyResource,
+			TypeName: "aws_ssm_resource_policy",
+			Name:     "Resource Policy",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*inttypes.ServicePackageSDKDataSource {

--- a/website/docs/d/ssm_resource_policy.html.markdown
+++ b/website/docs/d/ssm_resource_policy.html.markdown
@@ -1,0 +1,49 @@
+---
+subcategory: "SSM (Systems Manager)"
+layout: "aws"
+page_title: "AWS: aws_ssm_resource_policy"
+description: |-
+  Terraform data source for managing an AWS Systems Manager Resource Policy.
+---
+
+# Data Source: aws_ssm_resource_policy
+
+Terraform data source for retrieving an AWS Systems Manager resource policy attached to a Systems Manager resource (e.g. an advanced-tier `aws_ssm_parameter` or an `OpsItemGroup`).
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_ssm_resource_policy" "example" {
+  resource_arn = aws_ssm_parameter.example.arn
+}
+```
+
+### Lookup by Policy ID
+
+When more than one policy is attached to the resource, specify `policy_id` to select a particular policy:
+
+```terraform
+data "aws_ssm_resource_policy" "example" {
+  resource_arn = aws_ssm_parameter.example.arn
+  policy_id    = "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `resource_arn` - (Required) Amazon Resource Name (ARN) of the resource whose policy will be retrieved.
+* `policy_id` - (Optional) Unique identifier of the policy within the resource's policies. Required when multiple policies are attached to the resource.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `id` - Composite identifier in the format `<resource_arn>,<policy_id>`.
+* `policy` - JSON-encoded resource policy attached to the resource.
+* `policy_hash` - ID of the current policy version.
+* `policy_id` - Unique identifier of the policy.

--- a/website/docs/r/ssm_resource_policy.html.markdown
+++ b/website/docs/r/ssm_resource_policy.html.markdown
@@ -1,0 +1,81 @@
+---
+subcategory: "SSM (Systems Manager)"
+layout: "aws"
+page_title: "AWS: aws_ssm_resource_policy"
+description: |-
+  Terraform resource for managing an AWS Systems Manager Resource Policy.
+---
+
+# Resource: aws_ssm_resource_policy
+
+Terraform resource for managing an AWS Systems Manager Resource Policy. A resource policy helps you define the IAM entity (for example, an AWS account) that can manage your Systems Manager resources. The following resources support Systems Manager resource policies:
+
+* `OpsItemGroup` - enables AWS accounts to view and interact with OpsCenter operational work items (OpsItems).
+* `Parameter` - shares a parameter with other accounts via Resource Access Manager (RAM). The parameter must be in the advanced parameter tier. SecureString parameters must be encrypted with a customer managed key.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_ssm_parameter" "example" {
+  name  = "example"
+  type  = "String"
+  tier  = "Advanced"
+  value = "example"
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "example" {
+  statement {
+    actions = ["ssm:GetParameters"]
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_caller_identity.current.account_id]
+    }
+    resources = [aws_ssm_parameter.example.arn]
+  }
+}
+
+resource "aws_ssm_resource_policy" "example" {
+  resource_arn = aws_ssm_parameter.example.arn
+  policy       = data.aws_iam_policy_document.example.json
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `policy` - (Required) The JSON resource-based policy document to associate with the resource.
+* `resource_arn` - (Required) Amazon Resource Name (ARN) of the resource to which the policy applies. Changing this argument forces a new resource to be created.
+
+The following arguments are optional:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - Composite identifier of the resource policy in the format `<resource_arn>,<policy_id>`.
+* `policy_hash` - ID of the current policy version. Used internally on updates and deletes.
+* `policy_id` - The unique identifier of the policy within the resource's policies.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import SSM Resource Policy using the `resource_arn` and `policy_id` separated by a comma (`,`). For example:
+
+```terraform
+import {
+  to = aws_ssm_resource_policy.example
+  id = "arn:aws:ssm:us-east-1:123456789012:parameter/example,policy-id-12345"
+}
+```
+
+Using `terraform import`, import SSM Resource Policy using the `resource_arn` and `policy_id` separated by a comma (`,`). For example:
+
+```console
+% terraform import aws_ssm_resource_policy.example arn:aws:ssm:us-east-1:123456789012:parameter/example,policy-id-12345
+```


### PR DESCRIPTION
## Description

Adds a new resource and data source `aws_ssm_resource_policy` for managing AWS Systems Manager resource policies. The SSM service supports resource-based policies on:

- `OpsItemGroup` - enables AWS accounts to view and interact with OpsCenter operational work items.
- `Parameter` (Advanced tier) - shares a parameter with other accounts via RAM.

The resource wraps the [`PutResourcePolicy`](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_PutResourcePolicy.html), [`GetResourcePolicies`](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetResourcePolicies.html), and [`DeleteResourcePolicy`](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DeleteResourcePolicy.html) SDK calls.

Schema:

- `policy` - (Required) JSON policy document.
- `resource_arn` - (Required, ForceNew) ARN of the SSM resource to attach the policy to.
- `policy_id` - (Computed) Unique identifier of the policy within the resource's policies.
- `policy_hash` - (Computed) ID of the current policy version. Used internally for safe updates and deletes.
- `id` - (Computed) Composite `<resource_arn>,<policy_id>`.

### Relations
Relates #39310

### References
- AWSCC equivalent: `awscc_ssm_resource_policy`
- CloudFormation type: `AWS::SSM::ResourcePolicy`

### Output from Acceptance Testing

The test cases were written following the conventions used by `aws_dynamodb_resource_policy` and `aws_kinesis_resource_policy`.
```console
% make testacc TESTS=TestAccSSMResourcePolicy PKG=ssm

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 feature/ssm_resource_policy 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMResourcePolicy'  -timeout 360m -vet=off -buildvcs=false
2026/05/12 03:59:01 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/12 03:59:01 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSSMResourcePolicyDataSource_basic
=== PAUSE TestAccSSMResourcePolicyDataSource_basic
=== RUN   TestAccSSMResourcePolicyDataSource_byPolicyID
=== PAUSE TestAccSSMResourcePolicyDataSource_byPolicyID
=== RUN   TestAccSSMResourcePolicy_basic
=== PAUSE TestAccSSMResourcePolicy_basic
=== RUN   TestAccSSMResourcePolicy_update
=== PAUSE TestAccSSMResourcePolicy_update
=== RUN   TestAccSSMResourcePolicy_disappears
=== PAUSE TestAccSSMResourcePolicy_disappears
=== CONT  TestAccSSMResourcePolicyDataSource_basic
=== CONT  TestAccSSMResourcePolicy_update
=== CONT  TestAccSSMResourcePolicyDataSource_byPolicyID
=== CONT  TestAccSSMResourcePolicy_basic
=== CONT  TestAccSSMResourcePolicy_disappears
--- PASS: TestAccSSMResourcePolicyDataSource_byPolicyID (41.37s)
--- PASS: TestAccSSMResourcePolicyDataSource_basic (41.43s)
--- PASS: TestAccSSMResourcePolicy_disappears (42.59s)
--- PASS: TestAccSSMResourcePolicy_basic (48.43s)
--- PASS: TestAccSSMResourcePolicy_update (64.64s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        64.807s
```