### PR TITLE
r/aws_dynamodb_table: Fix plan/apply does not detect `hash_key` type changes in DynamoDB GSI

### DIFF
--- a/.changelog/47867.txt
+++ b/.changelog/47867.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Ensure diffs are shown for GSI hash key type changes
+```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -1171,7 +1171,7 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 	// will signal the problems.
 	var gsiUpdates []awstypes.GlobalSecondaryIndexUpdate
 
-	if d.HasChange("global_secondary_index") || d.HasChange("attribute") {
+	if d.HasChanges("global_secondary_index", "attribute") {
 		oldGSI, newGSI := d.GetChange("global_secondary_index")
 		oldAttr, newAttr := d.GetChange("attribute")
 

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -136,6 +136,20 @@ func resourceTable() *schema.Resource {
 				}
 
 				if diff.HasChange("attribute") && !diff.HasChange("global_secondary_index") {
+					// Only suppress the attribute diff if no attribute's type changed.
+					// A type change on a GSI key attribute requires the index to be recreated.
+					o, n := diff.GetChange("attribute")
+					oldTypes := map[string]string{}
+					for _, a := range o.(*schema.Set).List() {
+						attr := a.(map[string]any)
+						oldTypes[attr[names.AttrName].(string)] = attr[names.AttrType].(string)
+					}
+					for _, a := range n.(*schema.Set).List() {
+						attr := a.(map[string]any)
+						if t, ok := oldTypes[attr[names.AttrName].(string)]; ok && t != attr[names.AttrType].(string) {
+							return nil
+						}
+					}
 					return diff.Clear("attribute")
 				}
 

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -136,20 +136,6 @@ func resourceTable() *schema.Resource {
 				}
 
 				if diff.HasChange("attribute") && !diff.HasChange("global_secondary_index") {
-					// Only suppress the attribute diff if no attribute's type changed.
-					// A type change on a GSI key attribute requires the index to be recreated.
-					o, n := diff.GetChange("attribute")
-					oldTypes := map[string]string{}
-					for _, a := range o.(*schema.Set).List() {
-						attr := a.(map[string]any)
-						oldTypes[attr[names.AttrName].(string)] = attr[names.AttrType].(string)
-					}
-					for _, a := range n.(*schema.Set).List() {
-						attr := a.(map[string]any)
-						if t, ok := oldTypes[attr[names.AttrName].(string)]; ok && t != attr[names.AttrType].(string) {
-							return nil
-						}
-					}
 					return diff.Clear("attribute")
 				}
 
@@ -183,7 +169,7 @@ func resourceTable() *schema.Resource {
 							},
 						},
 					},
-					Set: sdkv2.SimpleSchemaSetFunc(names.AttrName),
+					Set: sdkv2.SimpleSchemaSetFunc(names.AttrName, names.AttrType),
 				},
 				"billing_mode": {
 					Type:             schema.TypeString,
@@ -1185,11 +1171,23 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 	// will signal the problems.
 	var gsiUpdates []awstypes.GlobalSecondaryIndexUpdate
 
-	if d.HasChange("global_secondary_index") {
-		var err error
-		o, n := d.GetChange("global_secondary_index")
-		gsiUpdates, err = updateDiffGSI(o.(*schema.Set).List(), n.(*schema.Set).List(), newBillingMode)
+	if d.HasChange("global_secondary_index") || d.HasChange("attribute") {
+		oldGSI, newGSI := d.GetChange("global_secondary_index")
+		oldAttr, newAttr := d.GetChange("attribute")
 
+		oldAttrTypes := map[string]string{}
+		for _, a := range oldAttr.(*schema.Set).List() {
+			attr := a.(map[string]any)
+			oldAttrTypes[attr[names.AttrName].(string)] = attr[names.AttrType].(string)
+		}
+		newAttrTypes := map[string]string{}
+		for _, a := range newAttr.(*schema.Set).List() {
+			attr := a.(map[string]any)
+			newAttrTypes[attr[names.AttrName].(string)] = attr[names.AttrType].(string)
+		}
+
+		var err error
+		gsiUpdates, err = updateDiffGSI(oldGSI.(*schema.Set).List(), newGSI.(*schema.Set).List(), newBillingMode, oldAttrTypes, newAttrTypes)
 		if err != nil {
 			return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionUpdating, resNameTable, d.Id(), fmt.Errorf("computing GSI difference: %w", err))
 		}
@@ -2099,7 +2097,7 @@ func updateWarmThroughput(ctx context.Context, conn *dynamodb.Client, warmList [
 	return nil
 }
 
-func updateDiffGSI(oldGsi, newGsi []any, billingMode awstypes.BillingMode) ([]awstypes.GlobalSecondaryIndexUpdate, error) {
+func updateDiffGSI(oldGsi, newGsi []any, billingMode awstypes.BillingMode, oldAttrTypes, newAttrTypes map[string]string) ([]awstypes.GlobalSecondaryIndexUpdate, error) {
 	// Transform slices into maps
 	oldGsis := make(map[string]any)
 	for _, gsidata := range oldGsi {
@@ -2204,7 +2202,7 @@ func updateDiffGSI(oldGsi, newGsi []any, billingMode awstypes.BillingMode) ([]aw
 			// ordinal of elements in its equality (which we actually don't care about)
 			nonKeyAttributesChanged := checkIfNonKeyAttributesChanged(oldMap, newMap)
 
-			recreateAttributesChanged := checkIfGSIRecreateAttributesChanged(oldMap, newMap)
+			recreateAttributesChanged := checkIfGSIRecreateAttributesChanged(oldMap, newMap, oldAttrTypes, newAttrTypes)
 
 			gsiNeedsRecreate := nonKeyAttributesChanged || recreateAttributesChanged || warmThroughPutDecreased
 
@@ -2292,7 +2290,7 @@ func checkIfNonKeyAttributesChanged(oldMap, newMap map[string]any) bool {
 	return oldNkaExists != newNkaExists
 }
 
-func checkIfGSIRecreateAttributesChanged(oldMap, newMap map[string]any) bool {
+func checkIfGSIRecreateAttributesChanged(oldMap, newMap map[string]any, oldAttrTypes, newAttrTypes map[string]string) bool {
 	oldAttributes := stripGSIUpdatableAttributes(oldMap)
 
 	newAttributes := stripGSIUpdatableAttributes(newMap)
@@ -2319,7 +2317,21 @@ func checkIfGSIRecreateAttributesChanged(oldMap, newMap map[string]any) bool {
 		delete(newAttributes, "range_key")
 	}
 
-	return !reflect.DeepEqual(oldAttributes, newAttributes)
+	if !reflect.DeepEqual(oldAttributes, newAttributes) {
+		return true
+	}
+
+	// Check if the type of any key attribute used by this GSI changed.
+	for _, keyAttr := range []string{oldMap["hash_key"].(string), oldMap["range_key"].(string)} {
+		if keyAttr == "" {
+			continue
+		}
+		if oldAttrTypes[keyAttr] != newAttrTypes[keyAttr] {
+			return true
+		}
+	}
+
+	return false
 }
 
 func deleteTable(ctx context.Context, conn *dynamodb.Client, tableName string) error {

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -861,7 +861,7 @@ func TestUpdateDiffGSI_Provisioned(t *testing.T) {
 				tc.New[i] = normalizeGSIMapValue(v.(map[string]any))
 			}
 
-			ops, err := tfdynamodb.UpdateDiffGSI(tc.Old, tc.New, awstypes.BillingModeProvisioned)
+			ops, err := tfdynamodb.UpdateDiffGSI(tc.Old, tc.New, awstypes.BillingModeProvisioned, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1756,7 +1756,7 @@ func TestUpdateDiffGSI_OnDemand(t *testing.T) {
 				tc.New[i] = normalizeGSIMapValue(v.(map[string]any))
 			}
 
-			ops, err := tfdynamodb.UpdateDiffGSI(tc.Old, tc.New, awstypes.BillingModePayPerRequest)
+			ops, err := tfdynamodb.UpdateDiffGSI(tc.Old, tc.New, awstypes.BillingModePayPerRequest, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1800,9 +1800,11 @@ func TestCheckIfGSIRecreateAttributesChanged(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		Old      map[string]any
-		New      map[string]any
-		Expected bool
+		Old          map[string]any
+		New          map[string]any
+		OldAttrTypes map[string]string
+		NewAttrTypes map[string]string
+		Expected     bool
 	}{
 		"key_schema syntax unchanged": {
 			// State has hash_key/range_key, config only has key_schema
@@ -1888,13 +1890,70 @@ func TestCheckIfGSIRecreateAttributesChanged(t *testing.T) {
 			},
 			Expected: true,
 		},
+		"hash_key attribute type changed S to N": {
+			Old: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "alternate_id",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			New: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "alternate_id",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			OldAttrTypes: map[string]string{"alternate_id": "S"},
+			NewAttrTypes: map[string]string{"alternate_id": "N"},
+			Expected:     true,
+		},
+		"hash_key attribute type unchanged": {
+			Old: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "alternate_id",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			New: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "alternate_id",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			OldAttrTypes: map[string]string{"alternate_id": "S"},
+			NewAttrTypes: map[string]string{"alternate_id": "S"},
+			Expected:     false,
+		},
+		"range_key attribute type changed S to N": {
+			Old: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "pk",
+				"range_key":       "sk",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			New: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "pk",
+				"range_key":       "sk",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			OldAttrTypes: map[string]string{"pk": "S", "sk": "S"},
+			NewAttrTypes: map[string]string{"pk": "S", "sk": "N"},
+			Expected:     true,
+		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := tfdynamodb.CheckIfGSIRecreateAttributesChanged(tc.Old, tc.New)
+			got := tfdynamodb.CheckIfGSIRecreateAttributesChanged(tc.Old, tc.New, tc.OldAttrTypes, tc.NewAttrTypes)
 			if got != tc.Expected {
 				t.Errorf("expected %v, got %v", tc.Expected, got)
 			}

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -4853,6 +4853,23 @@ func TestAccDynamoDBTable_attributeUpdate(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(ctx, t, resourceName, &conf),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("attribute"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName: knownvalue.StringExact("staticHashKey"),
+							names.AttrType: knownvalue.StringExact("S"),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName: knownvalue.StringExact("firstKey"),
+							names.AttrType: knownvalue.StringExact("S"),
+						}),
+					})),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -4864,18 +4881,73 @@ func TestAccDynamoDBTable_attributeUpdate(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(ctx, t, resourceName, &conf),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("attribute"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName: knownvalue.StringExact("staticHashKey"),
+							names.AttrType: knownvalue.StringExact("S"),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName: knownvalue.StringExact("firstKey"),
+							names.AttrType: knownvalue.StringExact("N"),
+						}),
+					})),
+				},
 			},
 			{ // New attribute addition (index update)
 				Config: testAccTableConfig_twoAttributes(rName, "firstKey", "secondKey", "firstKey", "N", "secondKey", "S"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(ctx, t, resourceName, &conf),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("attribute"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName: knownvalue.StringExact("staticHashKey"),
+							names.AttrType: knownvalue.StringExact("S"),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName: knownvalue.StringExact("firstKey"),
+							names.AttrType: knownvalue.StringExact("N"),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName: knownvalue.StringExact("secondKey"),
+							names.AttrType: knownvalue.StringExact("S"),
+						}),
+					})),
+				},
 			},
 			{ // Attribute removal (index update)
 				Config: testAccTableConfig_oneAttribute(rName, "firstKey", "firstKey", "S"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(ctx, t, resourceName, &conf),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("attribute"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName: knownvalue.StringExact("staticHashKey"),
+							names.AttrType: knownvalue.StringExact("S"),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName: knownvalue.StringExact("firstKey"),
+							names.AttrType: knownvalue.StringExact("S"),
+						}),
+					})),
+				},
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->


### Description

Fixes no diff seen bug for GSI when the type of `hash_key' changes , for example from "S" to "N".
See - https://github.com/hashicorp/terraform-provider-aws/issues/14476


### Relations

Closes #14476 



### Output from  Testing


#### Unit test result 

```console
make test PKG=dynamodb
make: Running unit tests on branch: 🌿 b_aws_dynamodb_table-gsi-hash_key-type-no-diff 🌿...
Testing single service: dynamodb
Testing with -parallel 14
```

#### ACC tests


**TLDR VERSION : Two acc test failed and its not related to this change and I was able to reproduce those two acc test failures in `main` too.**

```console
make testacc PKG=dynamodb TESTS=TestAccDynamoDBTable
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     12.393s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 10.305s
make: Running acceptance tests on branch: 🌿 b_aws_dynamodb_table-gsi-hash_key-type-no-diff 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable'  -timeout 360m -vet=off -buildvcs=false
2026/05/11 18:59:45 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/11 18:59:45 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDynamoDBTableDataSource_tags
=== PAUSE TestAccDynamoDBTableDataSource_tags
=== RUN   TestAccDynamoDBTableDataSource_Tags_nullMap
=== PAUSE TestAccDynamoDBTableDataSource_Tags_nullMap
=== RUN   TestAccDynamoDBTableDataSource_Tags_emptyMap
=== PAUSE TestAccDynamoDBTableDataSource_Tags_emptyMap
=== RUN   TestAccDynamoDBTableDataSource_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccDynamoDBTableDataSource_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccDynamoDBTableDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccDynamoDBTableDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccDynamoDBTableDataSource_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccDynamoDBTableDataSource_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccDynamoDBTableDataSource_basic
=== PAUSE TestAccDynamoDBTableDataSource_basic
=== RUN   TestAccDynamoDBTableDataSource_onDemandThroughput
=== PAUSE TestAccDynamoDBTableDataSource_onDemandThroughput
=== RUN   TestAccDynamoDBTableDataSource_pointInTimeRecovery
=== PAUSE TestAccDynamoDBTableDataSource_pointInTimeRecovery
=== RUN   TestAccDynamoDBTableExport_Identity_basic
=== PAUSE TestAccDynamoDBTableExport_Identity_basic
=== RUN   TestAccDynamoDBTableExport_Identity_regionOverride
=== PAUSE TestAccDynamoDBTableExport_Identity_regionOverride
=== RUN   TestAccDynamoDBTableExport_Identity_ExistingResource_basic
=== PAUSE TestAccDynamoDBTableExport_Identity_ExistingResource_basic
=== RUN   TestAccDynamoDBTableExport_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccDynamoDBTableExport_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccDynamoDBTableExport_basic
=== PAUSE TestAccDynamoDBTableExport_basic
=== RUN   TestAccDynamoDBTableExport_kms
=== PAUSE TestAccDynamoDBTableExport_kms
=== RUN   TestAccDynamoDBTableExport_s3Prefix
=== PAUSE TestAccDynamoDBTableExport_s3Prefix
=== RUN   TestAccDynamoDBTableExport_incrementalExport
=== PAUSE TestAccDynamoDBTableExport_incrementalExport
=== RUN   TestAccDynamoDBTable_Identity_basic
=== PAUSE TestAccDynamoDBTable_Identity_basic
=== RUN   TestAccDynamoDBTable_Identity_regionOverride
=== PAUSE TestAccDynamoDBTable_Identity_regionOverride
=== RUN   TestAccDynamoDBTable_Identity_ExistingResource_basic
=== PAUSE TestAccDynamoDBTable_Identity_ExistingResource_basic
=== RUN   TestAccDynamoDBTable_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccDynamoDBTable_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccDynamoDBTableItemDataSource_basic
=== PAUSE TestAccDynamoDBTableItemDataSource_basic
=== RUN   TestAccDynamoDBTableItemDataSource_projectionExpression
=== PAUSE TestAccDynamoDBTableItemDataSource_projectionExpression
=== RUN   TestAccDynamoDBTableItemDataSource_expressionAttributeNames
=== PAUSE TestAccDynamoDBTableItemDataSource_expressionAttributeNames
=== RUN   TestAccDynamoDBTableItem_basic
=== PAUSE TestAccDynamoDBTableItem_basic
=== RUN   TestAccDynamoDBTableItem_rangeKey
=== PAUSE TestAccDynamoDBTableItem_rangeKey
=== RUN   TestAccDynamoDBTableItem_withMultipleItems
=== PAUSE TestAccDynamoDBTableItem_withMultipleItems
=== RUN   TestAccDynamoDBTableItem_withDuplicateItemsSameRangeKey
=== PAUSE TestAccDynamoDBTableItem_withDuplicateItemsSameRangeKey
=== RUN   TestAccDynamoDBTableItem_withDuplicateItemsDifferentRangeKey
=== PAUSE TestAccDynamoDBTableItem_withDuplicateItemsDifferentRangeKey
=== RUN   TestAccDynamoDBTableItem_wonkyItems
=== PAUSE TestAccDynamoDBTableItem_wonkyItems
=== RUN   TestAccDynamoDBTableItem_update
=== PAUSE TestAccDynamoDBTableItem_update
=== RUN   TestAccDynamoDBTableItem_updateWithRangeKey
=== PAUSE TestAccDynamoDBTableItem_updateWithRangeKey
=== RUN   TestAccDynamoDBTableItem_disappears
=== PAUSE TestAccDynamoDBTableItem_disappears
=== RUN   TestAccDynamoDBTableItem_mapOutOfBandUpdate
=== PAUSE TestAccDynamoDBTableItem_mapOutOfBandUpdate
=== RUN   TestAccDynamoDBTableReplica_tags
=== PAUSE TestAccDynamoDBTableReplica_tags
=== RUN   TestAccDynamoDBTableReplica_Tags_null
=== PAUSE TestAccDynamoDBTableReplica_Tags_null
=== RUN   TestAccDynamoDBTableReplica_Tags_emptyMap
=== PAUSE TestAccDynamoDBTableReplica_Tags_emptyMap
=== RUN   TestAccDynamoDBTableReplica_Tags_addOnUpdate
=== PAUSE TestAccDynamoDBTableReplica_Tags_addOnUpdate
=== RUN   TestAccDynamoDBTableReplica_Tags_EmptyTag_onCreate
=== PAUSE TestAccDynamoDBTableReplica_Tags_EmptyTag_onCreate
=== RUN   TestAccDynamoDBTableReplica_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccDynamoDBTableReplica_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccDynamoDBTableReplica_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccDynamoDBTableReplica_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccDynamoDBTableReplica_Tags_DefaultTags_providerOnly
=== PAUSE TestAccDynamoDBTableReplica_Tags_DefaultTags_providerOnly
=== RUN   TestAccDynamoDBTableReplica_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccDynamoDBTableReplica_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccDynamoDBTableReplica_Tags_DefaultTags_overlapping
=== PAUSE TestAccDynamoDBTableReplica_Tags_DefaultTags_overlapping
=== RUN   TestAccDynamoDBTableReplica_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccDynamoDBTableReplica_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccDynamoDBTableReplica_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccDynamoDBTableReplica_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccDynamoDBTableReplica_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccDynamoDBTableReplica_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccDynamoDBTableReplica_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccDynamoDBTableReplica_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccDynamoDBTableReplica_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccDynamoDBTableReplica_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccDynamoDBTableReplica_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccDynamoDBTableReplica_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccDynamoDBTableReplica_Tags_ComputedTag_onCreate
=== PAUSE TestAccDynamoDBTableReplica_Tags_ComputedTag_onCreate
=== RUN   TestAccDynamoDBTableReplica_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccDynamoDBTableReplica_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccDynamoDBTableReplica_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccDynamoDBTableReplica_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccDynamoDBTableReplica_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccDynamoDBTableReplica_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccDynamoDBTableReplica_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccDynamoDBTableReplica_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccDynamoDBTableReplica_basic
=== PAUSE TestAccDynamoDBTableReplica_basic
=== RUN   TestAccDynamoDBTableReplica_disappears
=== PAUSE TestAccDynamoDBTableReplica_disappears
=== RUN   TestAccDynamoDBTableReplica_pitr
=== PAUSE TestAccDynamoDBTableReplica_pitr
=== RUN   TestAccDynamoDBTableReplica_pitrKMS
=== PAUSE TestAccDynamoDBTableReplica_pitrKMS
=== RUN   TestAccDynamoDBTableReplica_pitrDefault
=== PAUSE TestAccDynamoDBTableReplica_pitrDefault
=== RUN   TestAccDynamoDBTableReplica_tableClass
=== PAUSE TestAccDynamoDBTableReplica_tableClass
=== RUN   TestAccDynamoDBTableReplica_keys
=== PAUSE TestAccDynamoDBTableReplica_keys
=== RUN   TestAccDynamoDBTableReplica_deletionProtection
=== PAUSE TestAccDynamoDBTableReplica_deletionProtection
=== RUN   TestAccDynamoDBTable_tags
=== PAUSE TestAccDynamoDBTable_tags
=== RUN   TestAccDynamoDBTable_Tags_null
=== PAUSE TestAccDynamoDBTable_Tags_null
=== RUN   TestAccDynamoDBTable_Tags_emptyMap
=== PAUSE TestAccDynamoDBTable_Tags_emptyMap
=== RUN   TestAccDynamoDBTable_Tags_addOnUpdate
=== PAUSE TestAccDynamoDBTable_Tags_addOnUpdate
=== RUN   TestAccDynamoDBTable_Tags_EmptyTag_onCreate
=== PAUSE TestAccDynamoDBTable_Tags_EmptyTag_onCreate
=== RUN   TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccDynamoDBTable_Tags_DefaultTags_providerOnly
=== PAUSE TestAccDynamoDBTable_Tags_DefaultTags_providerOnly
=== RUN   TestAccDynamoDBTable_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccDynamoDBTable_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccDynamoDBTable_Tags_DefaultTags_overlapping
=== PAUSE TestAccDynamoDBTable_Tags_DefaultTags_overlapping
=== RUN   TestAccDynamoDBTable_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccDynamoDBTable_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccDynamoDBTable_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccDynamoDBTable_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccDynamoDBTable_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccDynamoDBTable_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccDynamoDBTable_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccDynamoDBTable_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccDynamoDBTable_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccDynamoDBTable_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccDynamoDBTable_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccDynamoDBTable_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccDynamoDBTable_Tags_ComputedTag_onCreate
=== PAUSE TestAccDynamoDBTable_Tags_ComputedTag_onCreate
=== RUN   TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccDynamoDBTable_basic
=== PAUSE TestAccDynamoDBTable_basic
=== RUN   TestAccDynamoDBTable_deletion_protection
=== PAUSE TestAccDynamoDBTable_deletion_protection
=== RUN   TestAccDynamoDBTable_disappears
=== PAUSE TestAccDynamoDBTable_disappears
=== RUN   TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
=== PAUSE TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
=== RUN   TestAccDynamoDBTable_extended
=== PAUSE TestAccDynamoDBTable_extended
=== RUN   TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleHashKeys
=== PAUSE TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleHashKeys
=== RUN   TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleHashKey
=== PAUSE TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleHashKey
=== RUN   TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleRangeKey
=== PAUSE TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleRangeKey
=== RUN   TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_noChange
=== PAUSE TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_noChange
=== RUN   TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_noChange
=== PAUSE TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_noChange
=== RUN   TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_addHashKey
=== PAUSE TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_addHashKey
=== RUN   TestAccDynamoDBTable_GSI_keySchema_addHashKey
=== PAUSE TestAccDynamoDBTable_GSI_keySchema_addHashKey
=== RUN   TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_removeKey
=== PAUSE TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_removeKey
=== RUN   TestAccDynamoDBTable_GSI_keySchema_removeHashKey
=== PAUSE TestAccDynamoDBTable_GSI_keySchema_removeHashKey
=== RUN   TestAccDynamoDBTable_GSI_keySchema_maxSet
=== PAUSE TestAccDynamoDBTable_GSI_keySchema_maxSet
=== RUN   TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleRangeKeys
=== PAUSE TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleRangeKeys
=== RUN   TestAccDynamoDBTable_GSI_keySchema_addRangeKey
=== PAUSE TestAccDynamoDBTable_GSI_keySchema_addRangeKey
=== RUN   TestAccDynamoDBTable_GSI_keySchema_removeRangeKey
=== PAUSE TestAccDynamoDBTable_GSI_keySchema_removeRangeKey
=== RUN   TestAccDynamoDBTable_GSI_keySchema_removeGSI
=== PAUSE TestAccDynamoDBTable_GSI_keySchema_removeGSI
=== RUN   TestAccDynamoDBTable_GSI_rangeKeyExplicitEmptyString
=== PAUSE TestAccDynamoDBTable_GSI_rangeKeyExplicitEmptyString
=== RUN   TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema
=== PAUSE TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema
=== RUN   TestAccDynamoDBTable_GSI_validate_exactlyOneOfKeySchemaHashKey
=== PAUSE TestAccDynamoDBTable_GSI_validate_exactlyOneOfKeySchemaHashKey
=== RUN   TestAccDynamoDBTable_GSI_validate_keySchema_tooManyHashKeys
=== PAUSE TestAccDynamoDBTable_GSI_validate_keySchema_tooManyHashKeys
=== RUN   TestAccDynamoDBTable_GSIvalidate_keySchema_tooManyRangeKeys
=== PAUSE TestAccDynamoDBTable_GSIvalidate_keySchema_tooManyRangeKeys
=== RUN   TestAccDynamoDBTable_enablePITR
=== PAUSE TestAccDynamoDBTable_enablePITR
=== RUN   TestAccDynamoDBTable_enablePITRWithCustomRecoveryPeriod
=== PAUSE TestAccDynamoDBTable_enablePITRWithCustomRecoveryPeriod
=== RUN   TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== PAUSE TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== RUN   TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
=== PAUSE TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
=== RUN   TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
=== PAUSE TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
=== RUN   TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
=== PAUSE TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
=== RUN   TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
=== PAUSE TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
=== RUN   TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
=== PAUSE TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
=== RUN   TestAccDynamoDBTable_BillingMode_payPerRequestBasic
=== PAUSE TestAccDynamoDBTable_BillingMode_payPerRequestBasic
=== RUN   TestAccDynamoDBTable_onDemandThroughput
=== PAUSE TestAccDynamoDBTable_onDemandThroughput
=== RUN   TestAccDynamoDBTable_gsiOnDemandThroughput
=== PAUSE TestAccDynamoDBTable_gsiOnDemandThroughput
=== RUN   TestAccDynamoDBTable_streamSpecification
=== PAUSE TestAccDynamoDBTable_streamSpecification
=== RUN   TestAccDynamoDBTable_streamSpecificationDiffs
=== PAUSE TestAccDynamoDBTable_streamSpecificationDiffs
=== RUN   TestAccDynamoDBTable_streamSpecificationValidation
=== PAUSE TestAccDynamoDBTable_streamSpecificationValidation
=== RUN   TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_SameAsTable
=== PAUSE TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_SameAsTable
=== RUN   TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_DifferentFromTable
=== PAUSE TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_DifferentFromTable
=== RUN   TestAccDynamoDBTable_gsiUpdateOtherAttributes
=== PAUSE TestAccDynamoDBTable_gsiUpdateOtherAttributes
=== RUN   TestAccDynamoDBTable_lsiNonKeyAttributes
=== PAUSE TestAccDynamoDBTable_lsiNonKeyAttributes
=== RUN   TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
=== PAUSE TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
=== RUN   TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
=== PAUSE TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
=== RUN   TestAccDynamoDBTable_TTL_enabled
=== PAUSE TestAccDynamoDBTable_TTL_enabled
=== RUN   TestAccDynamoDBTable_TTL_disabled
=== PAUSE TestAccDynamoDBTable_TTL_disabled
=== RUN   TestAccDynamoDBTable_TTL_updateEnable
=== PAUSE TestAccDynamoDBTable_TTL_updateEnable
=== RUN   TestAccDynamoDBTable_TTL_updateDisable
=== PAUSE TestAccDynamoDBTable_TTL_updateDisable
=== RUN   TestAccDynamoDBTable_TTL_validate
=== PAUSE TestAccDynamoDBTable_TTL_validate
=== RUN   TestAccDynamoDBTable_attributeUpdate
=== PAUSE TestAccDynamoDBTable_attributeUpdate
=== RUN   TestAccDynamoDBTable_lsiUpdate
=== PAUSE TestAccDynamoDBTable_lsiUpdate
=== RUN   TestAccDynamoDBTable_attributeUpdateValidation
=== PAUSE TestAccDynamoDBTable_attributeUpdateValidation
=== RUN   TestAccDynamoDBTable_encryption
=== PAUSE TestAccDynamoDBTable_encryption
=== RUN   TestAccDynamoDBTable_restoreCrossRegion
=== PAUSE TestAccDynamoDBTable_restoreCrossRegion
=== RUN   TestAccDynamoDBTable_Replica_multiple
=== PAUSE TestAccDynamoDBTable_Replica_multiple
=== RUN   TestAccDynamoDBTable_Replica_single
=== PAUSE TestAccDynamoDBTable_Replica_single
=== RUN   TestAccDynamoDBTable_Replica_singleStreamSpecification
=== PAUSE TestAccDynamoDBTable_Replica_singleStreamSpecification
=== RUN   TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted
=== PAUSE TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted
=== RUN   TestAccDynamoDBTable_Replica_singleDefaultKeyEncryptedAmazonOwned
=== PAUSE TestAccDynamoDBTable_Replica_singleDefaultKeyEncryptedAmazonOwned
=== RUN   TestAccDynamoDBTable_Replica_singleCMK
=== PAUSE TestAccDynamoDBTable_Replica_singleCMK
=== RUN   TestAccDynamoDBTable_Replica_doubleAddCMK
=== PAUSE TestAccDynamoDBTable_Replica_doubleAddCMK
=== RUN   TestAccDynamoDBTable_Replica_pitr
=== PAUSE TestAccDynamoDBTable_Replica_pitr
=== RUN   TestAccDynamoDBTable_Replica_pitrKMS
=== PAUSE TestAccDynamoDBTable_Replica_pitrKMS
=== RUN   TestAccDynamoDBTable_Replica_tags_updateIsPropagated_oneOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_tags_updateIsPropagated_oneOfTwo
=== RUN   TestAccDynamoDBTable_Replica_tags_updateIsPropagated_twoOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_tags_updateIsPropagated_twoOfTwo
=== RUN   TestAccDynamoDBTable_Replica_tags_propagateToAddedReplica
=== PAUSE TestAccDynamoDBTable_Replica_tags_propagateToAddedReplica
=== RUN   TestAccDynamoDBTable_Replica_tags_notPropagatedToAddedReplica
=== PAUSE TestAccDynamoDBTable_Replica_tags_notPropagatedToAddedReplica
=== RUN   TestAccDynamoDBTable_Replica_tags_nonPropagatedTagsAreUnmanaged
=== PAUSE TestAccDynamoDBTable_Replica_tags_nonPropagatedTagsAreUnmanaged
=== RUN   TestAccDynamoDBTable_Replica_tagsUpdate
=== PAUSE TestAccDynamoDBTable_Replica_tagsUpdate
=== RUN   TestAccDynamoDBTable_Replica_MRSC_Create
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_Create
=== RUN   TestAccDynamoDBTable_Replica_MRSC_Create_witness
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_Create_witness
=== RUN   TestAccDynamoDBTable_Replica_MRSC_Create_witness_too_many_replicas
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_Create_witness_too_many_replicas
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_doubleAddCMK
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_witness_doubleAddCMK
=== RUN   TestAccDynamoDBTable_Replica_MRSC_doubleAddCMK
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_doubleAddCMK
=== RUN   TestAccDynamoDBTable_Replica_MRSC_pitr
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_pitr
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_pitr
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_witness_pitr
=== RUN   TestAccDynamoDBTable_Replica_MRSC_pitrKMS
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_pitrKMS
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_pitrKMS
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_witness_pitrKMS
=== RUN   TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_oneOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_oneOfTwo
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_oneOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_oneOfTwo
=== RUN   TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_twoOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_twoOfTwo
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_twoOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_twoOfTwo
=== RUN   TestAccDynamoDBTable_Replica_MRSC_tags_propagateToAddedReplica
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_tags_propagateToAddedReplica
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_tags_notPropagatedToAddedReplica
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_witness_tags_notPropagatedToAddedReplica
=== RUN   TestAccDynamoDBTable_Replica_MRSC_tags_nonPropagatedTagsAreUnmanaged
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_tags_nonPropagatedTagsAreUnmanaged
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_tags_nonPropagatedTagsAreUnmanaged
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_witness_tags_nonPropagatedTagsAreUnmanaged
=== RUN   TestAccDynamoDBTable_Replica_MRSC_tagsUpdate
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_tagsUpdate
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_tagsUpdate
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_witness_tagsUpdate
=== RUN   TestAccDynamoDBTable_Replica_MRSC_TooManyReplicas
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_TooManyReplicas
=== RUN   TestAccDynamoDBTable_Replica_MRSC_NotEnoughReplicas
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_NotEnoughReplicas
=== RUN   TestAccDynamoDBTable_Replica_MRSC_MixedConsistencyModes
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_MixedConsistencyModes
=== RUN   TestAccDynamoDBTable_Replica_MRSC_CreateEventuallyConsistent
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_CreateEventuallyConsistent
=== RUN   TestAccDynamoDBTable_Replica_upgradeV6_2_0
=== PAUSE TestAccDynamoDBTable_Replica_upgradeV6_2_0
=== RUN   TestAccDynamoDBTable_Replica_deletionProtection
=== PAUSE TestAccDynamoDBTable_Replica_deletionProtection
=== RUN   TestAccDynamoDBTable_restoreBackupARN
=== PAUSE TestAccDynamoDBTable_restoreBackupARN
=== RUN   TestAccDynamoDBTable_tableClassInfrequentAccess
=== PAUSE TestAccDynamoDBTable_tableClassInfrequentAccess
=== RUN   TestAccDynamoDBTable_tableClassExplicitDefault
=== PAUSE TestAccDynamoDBTable_tableClassExplicitDefault
=== RUN   TestAccDynamoDBTable_tableClass_ConcurrentModification
=== PAUSE TestAccDynamoDBTable_tableClass_ConcurrentModification
=== RUN   TestAccDynamoDBTable_tableClass_migrate
=== PAUSE TestAccDynamoDBTable_tableClass_migrate
=== RUN   TestAccDynamoDBTable_backupEncryption
=== PAUSE TestAccDynamoDBTable_backupEncryption
=== RUN   TestAccDynamoDBTable_backup_overrideEncryption
=== PAUSE TestAccDynamoDBTable_backup_overrideEncryption
=== RUN   TestAccDynamoDBTable_importTable
=== PAUSE TestAccDynamoDBTable_importTable
=== RUN   TestAccDynamoDBTable_warmThroughput
=== PAUSE TestAccDynamoDBTable_warmThroughput
=== RUN   TestAccDynamoDBTable_warmThroughputDefault
=== PAUSE TestAccDynamoDBTable_warmThroughputDefault
=== RUN   TestAccDynamoDBTable_gsiWarmThroughput_billingProvisioned
=== PAUSE TestAccDynamoDBTable_gsiWarmThroughput_billingProvisioned
=== RUN   TestAccDynamoDBTable_gsiWarmThroughput_billingPayPerRequest
=== PAUSE TestAccDynamoDBTable_gsiWarmThroughput_billingPayPerRequest
=== RUN   TestAccDynamoDBTable_gsiWarmThroughput_switchBilling
=== PAUSE TestAccDynamoDBTable_gsiWarmThroughput_switchBilling
=== RUN   TestAccDynamoDBTable_nameKnownAfterApply
=== PAUSE TestAccDynamoDBTable_nameKnownAfterApply
=== RUN   TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed
=== PAUSE TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed
=== RUN   TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed_onUpdate
=== PAUSE TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed_onUpdate
=== RUN   TestAccDynamoDBTable_GSI_unknown
=== PAUSE TestAccDynamoDBTable_GSI_unknown
=== RUN   TestAccDynamoDBTable_GSI_keySchema_unknown
=== PAUSE TestAccDynamoDBTable_GSI_keySchema_unknown
=== RUN   TestAccDynamoDBTables_basic
=== PAUSE TestAccDynamoDBTables_basic
=== CONT  TestAccDynamoDBTableDataSource_tags
=== CONT  TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_doubleAddCMK
=== CONT  TestAccDynamoDBTable_Replica_upgradeV6_2_0
=== CONT  TestAccDynamoDBTable_warmThroughputDefault
=== CONT  TestAccDynamoDBTable_tableClass_migrate
=== CONT  TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed
=== CONT  TestAccDynamoDBTable_attributeUpdateValidation
=== CONT  TestAccDynamoDBTable_importTable
=== CONT  TestAccDynamoDBTable_Replica_pitrKMS
=== CONT  TestAccDynamoDBTable_Replica_tags_nonPropagatedTagsAreUnmanaged
=== CONT  TestAccDynamoDBTable_backup_overrideEncryption
=== CONT  TestAccDynamoDBTable_gsiWarmThroughput_switchBilling
=== CONT  TestAccDynamoDBTable_gsiWarmThroughput_billingPayPerRequest
=== CONT  TestAccDynamoDBTable_gsiWarmThroughput_billingProvisioned
=== CONT  TestAccDynamoDBTable_GSI_keySchema_unknown
=== CONT  TestAccDynamoDBTable_GSI_unknown
=== CONT  TestAccDynamoDBTables_basic
=== CONT  TestAccDynamoDBTable_nameKnownAfterApply
=== CONT  TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed_onUpdate
--- PASS: TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed (9.70s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (17.64s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_Create
=== NAME  TestAccDynamoDBTable_tableClass_migrate
    table_test.go:8264: Step 1/2 error: Post-apply refresh state check(s) failed:
        error checking value for attribute at path: aws_dynamodb_table.test.table_class, err: expected value  for StringExact check, got: STANDARD
=== NAME  TestAccDynamoDBTable_Replica_MRSC_Create
    table_test.go:6241: Step 1/1 error: Error running apply: exit status 1
        
        Error: creating AWS DynamoDB Table (tf-acc-test-1090177717065365065): replicas: operation error DynamoDB: UpdateTable, https response error StatusCode: 400, RequestID: 5VE9C0N1R2M6O5EFJO6T3Q5097VV4KQNSO5AEMVJF66Q9ASUAAJG, api error AccessDeniedException: 'UnrecognizedClientException':'The security token included in the request is invalid. (Service: AmazonDynamoDBv2; Status Code: 400; Error Code: UnrecognizedClientException; Request ID: AMEB2G3ALNLDNDP2SRMQNP8HJ7VV4KQNSO5AEMVJF66Q9ASUAAJG; Proxy: null)'.
        
          with aws_dynamodb_table.test_mrsc,
          on terraform_plugin_test.tf line 34, in resource "aws_dynamodb_table" "test_mrsc":
          34: resource "aws_dynamodb_table" "test_mrsc" {
        
=== NAME  TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica
    table_test.go:7309: Step 1/2 error: Error running apply: exit status 1
        
        Error: creating AWS DynamoDB Table (tf-acc-test-7259071896292974641): replicas: operation error DynamoDB: UpdateTable, https response error StatusCode: 400, RequestID: HTQ4LIIOIDAEF4AA571NLTDEIVVV4KQNSO5AEMVJF66Q9ASUAAJG, api error AccessDeniedException: 'UnrecognizedClientException':'The security token included in the request is invalid. (Service: AmazonDynamoDBv2; Status Code: 400; Error Code: UnrecognizedClientException; Request ID: 77JFKA6FA7HTF2RNGSE5SUL5GNVV4KQNSO5AEMVJF66Q9ASUAAJG; Proxy: null)'.
        
          with aws_dynamodb_table.test,
          on terraform_plugin_test.tf line 26, in resource "aws_dynamodb_table" "test":
          26: resource "aws_dynamodb_table" "test" {
        
--- FAIL: TestAccDynamoDBTable_tableClass_migrate (48.41s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_CreateEventuallyConsistent
--- PASS: TestAccDynamoDBTables_basic (48.69s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_Create_witness_too_many_replicas
--- PASS: TestAccDynamoDBTableDataSource_tags (50.78s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_MixedConsistencyModes
=== CONT  TestAccDynamoDBTable_Replica_MRSC_Create_witness
--- PASS: TestAccDynamoDBTable_nameKnownAfterApply (50.86s)
--- PASS: TestAccDynamoDBTable_GSI_unknown (52.50s)
=== CONT  TestAccDynamoDBTable_lsiUpdate
--- PASS: TestAccDynamoDBTable_warmThroughputDefault (53.30s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_NotEnoughReplicas
--- PASS: TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed_onUpdate (57.81s)
=== CONT  TestAccDynamoDBTable_warmThroughput
=== NAME  TestAccDynamoDBTable_Replica_MRSC_Create
    panic.go:694: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting AWS DynamoDB Table (tf-acc-test-1090177717065365065): deleting replica(s): operation error DynamoDB: UpdateTable, https response error StatusCode: 400, RequestID: DDI8HQ1IJ7PER572HPT74GPBOVVV4KQNSO5AEMVJF66Q9ASUAAJG, api error ValidationException: Update table operation with more than one create or delete replica actions not allowed
        
--- FAIL: TestAccDynamoDBTable_Replica_MRSC_Create (41.44s)
=== CONT  TestAccDynamoDBTable_attributeUpdate
--- FAIL: TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica (57.45s)
=== CONT  TestAccDynamoDBTable_Replica_tags_propagateToAddedReplica
--- PASS: TestAccDynamoDBTable_GSI_keySchema_unknown (84.99s)
=== CONT  TestAccDynamoDBTable_TTL_validate
--- PASS: TestAccDynamoDBTable_TTL_validate (2.38s)
=== CONT  TestAccDynamoDBTable_TTL_updateDisable
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create_witness_too_many_replicas (50.04s)
=== CONT  TestAccDynamoDBTable_TTL_updateEnable
--- PASS: TestAccDynamoDBTable_Replica_MRSC_MixedConsistencyModes (52.47s)
=== CONT  TestAccDynamoDBTable_TTL_disabled
--- PASS: TestAccDynamoDBTable_Replica_MRSC_NotEnoughReplicas (55.20s)
=== CONT  TestAccDynamoDBTable_TTL_enabled
--- PASS: TestAccDynamoDBTable_lsiUpdate (101.32s)
=== CONT  TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
--- PASS: TestAccDynamoDBTable_TTL_disabled (65.62s)
=== CONT  TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
--- PASS: TestAccDynamoDBTable_TTL_updateEnable (70.42s)
=== CONT  TestAccDynamoDBTable_lsiNonKeyAttributes
--- PASS: TestAccDynamoDBTable_importTable (170.95s)
=== CONT  TestAccDynamoDBTable_gsiUpdateOtherAttributes
--- PASS: TestAccDynamoDBTable_TTL_enabled (65.67s)
=== CONT  TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_DifferentFromTable
--- PASS: TestAccDynamoDBTable_warmThroughput (155.38s)
=== CONT  TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_SameAsTable
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (45.31s)
=== CONT  TestAccDynamoDBTable_streamSpecificationValidation
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (2.20s)
=== CONT  TestAccDynamoDBTable_streamSpecificationDiffs
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (228.82s)
=== CONT  TestAccDynamoDBTable_streamSpecification
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (84.95s)
=== CONT  TestAccDynamoDBTable_gsiOnDemandThroughput
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_switchBilling (255.16s)
=== CONT  TestAccDynamoDBTable_onDemandThroughput
--- PASS: TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_DifferentFromTable (94.59s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestBasic
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create_witness (219.15s)
=== CONT  TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
--- PASS: TestAccDynamoDBTable_streamSpecification (75.41s)
=== CONT  TestAccDynamoDBTable_Replica_tags_notPropagatedToAddedReplica
--- PASS: TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_SameAsTable (106.15s)
=== CONT  TestAccDynamoDBTable_tableClassInfrequentAccess
--- PASS: TestAccDynamoDBTable_gsiOnDemandThroughput (106.20s)
=== CONT  TestAccDynamoDBTable_tableClass_ConcurrentModification
--- PASS: TestAccDynamoDBTable_onDemandThroughput (133.02s)
=== CONT  TestAccDynamoDBTable_Replica_tags_updateIsPropagated_twoOfTwo
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (77.51s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_oneOfTwo
--- PASS: TestAccDynamoDBTable_tableClass_ConcurrentModification (84.44s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_tags_propagateToAddedReplica
--- PASS: TestAccDynamoDBTable_streamSpecificationDiffs (230.59s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_twoOfTwo
--- PASS: TestAccDynamoDBTable_Replica_upgradeV6_2_0 (532.25s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_twoOfTwo
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (301.44s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_oneOfTwo
--- PASS: TestAccDynamoDBTable_Replica_tags_nonPropagatedTagsAreUnmanaged (585.51s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tags_nonPropagatedTagsAreUnmanaged
--- PASS: TestAccDynamoDBTable_Replica_MRSC_CreateEventuallyConsistent (597.24s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tagsUpdate
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_propagateToAddedReplica (254.84s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_tagsUpdate
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_billingPayPerRequest (686.97s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_pitr
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_oneOfTwo (293.29s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_pitrKMS
--- PASS: TestAccDynamoDBTable_Replica_tags_propagateToAddedReplica (632.76s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_pitrKMS
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_billingProvisioned (722.26s)
=== CONT  TestAccDynamoDBTableReplica_pitr
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_twoOfTwo (284.90s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_doubleAddCMK (736.86s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (599.03s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
--- PASS: TestAccDynamoDBTable_Replica_pitrKMS (773.37s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
--- PASS: TestAccDynamoDBTable_Replica_tags_notPropagatedToAddedReplica (514.66s)
=== CONT  TestAccDynamoDBTable_enablePITRWithCustomRecoveryPeriod
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_twoOfTwo (297.54s)
=== CONT  TestAccDynamoDBTable_enablePITR
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_oneOfTwo (267.93s)
=== CONT  TestAccDynamoDBTable_GSIvalidate_keySchema_tooManyRangeKeys
--- PASS: TestAccDynamoDBTable_GSIvalidate_keySchema_tooManyRangeKeys (1.38s)
=== CONT  TestAccDynamoDBTable_GSI_validate_keySchema_tooManyHashKeys
--- PASS: TestAccDynamoDBTable_GSI_validate_keySchema_tooManyHashKeys (1.37s)
=== CONT  TestAccDynamoDBTable_GSI_validate_exactlyOneOfKeySchemaHashKey
--- PASS: TestAccDynamoDBTable_GSI_validate_exactlyOneOfKeySchemaHashKey (1.50s)
=== CONT  TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema
--- PASS: TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema (1.60s)
=== CONT  TestAccDynamoDBTable_GSI_rangeKeyExplicitEmptyString
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestBasic (577.20s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_removeGSI
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (848.13s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_removeRangeKey
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_nonPropagatedTagsAreUnmanaged (275.26s)
=== CONT  TestAccDynamoDBTable_tableClassExplicitDefault
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (143.21s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_addRangeKey
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (184.57s)
=== CONT  TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (181.90s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleRangeKeys
--- PASS: TestAccDynamoDBTable_tableClassExplicitDefault (70.55s)
=== CONT  TestAccDynamoDBTable_Replica_pitr
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_pitr (245.84s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_maxSet
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (168.06s)
=== CONT  TestAccDynamoDBTable_Replica_doubleAddCMK
--- PASS: TestAccDynamoDBTable_GSI_rangeKeyExplicitEmptyString (103.48s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_removeHashKey
--- PASS: TestAccDynamoDBTable_enablePITR (127.72s)
=== CONT  TestAccDynamoDBTable_Replica_singleCMK
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeGSI (121.76s)
=== CONT  TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_removeKey
--- PASS: TestAccDynamoDBTable_enablePITRWithCustomRecoveryPeriod (153.75s)
=== CONT  TestAccDynamoDBTable_Replica_singleDefaultKeyEncryptedAmazonOwned
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleRangeKeys (72.82s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccDynamoDBTableReplica_pitr (271.59s)
=== CONT  TestAccDynamoDBTable_Replica_deletionProtection
--- PASS: TestAccDynamoDBTable_GSI_keySchema_maxSet (68.49s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_emptyProviderOnlyTag (49.24s)
=== CONT  TestAccDynamoDBTable_Replica_tags_updateIsPropagated_oneOfTwo
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_emptyResourceTag (46.66s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccDynamoDBTable_Replica_tags_updateIsPropagated_twoOfTwo (671.43s)
=== CONT  TestAccDynamoDBTable_Tags_addOnUpdate
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tagsUpdate (446.91s)
=== CONT  TestAccDynamoDBTable_Tags_emptyMap
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_updateToResourceOnly (67.26s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccDynamoDBTable_Tags_addOnUpdate (70.24s)
=== CONT  TestAccDynamoDBTable_Tags_null
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_pitrKMS (450.67s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_overlapping
--- PASS: TestAccDynamoDBTable_Tags_emptyMap (60.29s)
=== CONT  TestAccDynamoDBTable_tags
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tagsUpdate (470.31s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_updateToProviderOnly (66.24s)
=== CONT  TestAccDynamoDBTableReplica_deletionProtection
--- PASS: TestAccDynamoDBTable_Tags_null (63.14s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_providerOnly
--- PASS: TestAccDynamoDBTable_Replica_MRSC_pitrKMS (502.04s)
=== CONT  TestAccDynamoDBTableReplica_keys
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted (327.76s)
=== CONT  TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccDynamoDBTable_Replica_singleCMK (296.33s)
=== CONT  TestAccDynamoDBTableReplica_tableClass
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_overlapping (119.19s)
=== CONT  TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nonOverlapping (118.02s)
=== CONT  TestAccDynamoDBTableReplica_pitrDefault
--- PASS: TestAccDynamoDBTable_tags (146.64s)
=== CONT  TestAccDynamoDBTable_Tags_EmptyTag_onCreate
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (1144.35s)
=== CONT  TestAccDynamoDBTableReplica_pitrKMS
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_replace (72.93s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_tags_nonPropagatedTagsAreUnmanaged
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_providerOnly (162.47s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_pitr
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_add (114.77s)
=== CONT  TestAccDynamoDBTable_Replica_multiple
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_onCreate (83.86s)
=== CONT  TestAccDynamoDBTable_Replica_singleStreamSpecification
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncryptedAmazonOwned (509.18s)
=== CONT  TestAccDynamoDBTable_backupEncryption
=== NAME  TestAccDynamoDBTableReplica_keys
    table_replica_test.go:254: Step 3/3 error: Error running apply: exit status 1
        
        Error: creating AWS DynamoDB Table Replica (arn:aws:dynamodb:us-east-1:927163995318:table/tf-acc-test-8548653016688797135): operation error DynamoDB: UpdateTable, https response error StatusCode: 400, RequestID: 85R0PFSR1MIG4FGRJNAQ9KPGDJVV4KQNSO5AEMVJF66Q9ASUAAJG, api error ValidationException: Failed to create a the new replica of table with name: ‘tf-acc-test-8548653016688797135’ because one or more replicas already existed as tables.
        
          with aws_dynamodb_table_replica.test,
          on terraform_plugin_test.tf line 75, in resource "aws_dynamodb_table_replica" "test":
          75: resource "aws_dynamodb_table_replica" "test" {
        
=== NAME  TestAccDynamoDBTableReplica_tableClass
    table_replica_test.go:216: Step 3/3 error: Error running apply: exit status 1
        
        Error: creating AWS DynamoDB Table Replica (arn:aws:dynamodb:us-east-1:927163995318:table/tf-acc-test-8988226590376040593): operation error DynamoDB: UpdateTable, https response error StatusCode: 400, RequestID: EFQ70DG6GSHUGNOQH1KLP45P3RVV4KQNSO5AEMVJF66Q9ASUAAJG, api error ValidationException: Failed to create a the new replica of table with name: ‘tf-acc-test-8988226590376040593’ because one or more replicas already existed as tables.
        
          with aws_dynamodb_table_replica.test,
          on terraform_plugin_test.tf line 48, in resource "aws_dynamodb_table_replica" "test":
          48: resource "aws_dynamodb_table_replica" "test" {
        
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeRangeKey (665.79s)
=== CONT  TestAccDynamoDBTable_Replica_single
--- FAIL: TestAccDynamoDBTableReplica_keys (317.46s)
=== CONT  TestAccDynamoDBTable_Replica_tagsUpdate
--- FAIL: TestAccDynamoDBTableReplica_tableClass (276.14s)
=== CONT  TestAccDynamoDBTableItem_wonkyItems
--- PASS: TestAccDynamoDBTable_GSI_keySchema_addRangeKey (632.49s)
=== CONT  TestAccDynamoDBTableReplica_disappears
--- PASS: TestAccDynamoDBTable_Replica_pitr (615.11s)
=== CONT  TestAccDynamoDBTableReplica_basic
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeHashKey (611.22s)
=== CONT  TestAccDynamoDBTableReplica_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_removeKey (596.20s)
=== CONT  TestAccDynamoDBTableExport_s3Prefix
--- PASS: TestAccDynamoDBTableItem_wonkyItems (41.64s)
=== CONT  TestAccDynamoDBTableItem_withDuplicateItemsDifferentRangeKey
--- PASS: TestAccDynamoDBTable_Replica_tags_updateIsPropagated_oneOfTwo (569.77s)
=== CONT  TestAccDynamoDBTableItem_withDuplicateItemsSameRangeKey
--- PASS: TestAccDynamoDBTableItem_withDuplicateItemsDifferentRangeKey (39.20s)
=== CONT  TestAccDynamoDBTableItem_withMultipleItems
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_nonPropagatedTagsAreUnmanaged (294.45s)
=== CONT  TestAccDynamoDBTableItem_rangeKey
--- PASS: TestAccDynamoDBTableReplica_pitrDefault (339.96s)
=== CONT  TestAccDynamoDBTableItem_basic
--- PASS: TestAccDynamoDBTable_Replica_MRSC_pitr (266.56s)
=== CONT  TestAccDynamoDBTableItemDataSource_expressionAttributeNames
--- PASS: TestAccDynamoDBTableItem_withDuplicateItemsSameRangeKey (25.01s)
=== CONT  TestAccDynamoDBTableItemDataSource_projectionExpression
--- PASS: TestAccDynamoDBTableItem_withMultipleItems (38.01s)
=== CONT  TestAccDynamoDBTableItemDataSource_basic
--- PASS: TestAccDynamoDBTableItem_basic (39.64s)
=== CONT  TestAccDynamoDBTable_Identity_ExistingResource_noRefreshNoChange
--- PASS: TestAccDynamoDBTableItem_rangeKey (43.61s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_TooManyReplicas
--- PASS: TestAccDynamoDBTableItemDataSource_expressionAttributeNames (43.03s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccDynamoDBTableItemDataSource_projectionExpression (38.80s)
=== CONT  TestAccDynamoDBTable_restoreBackupARN
=== NAME  TestAccDynamoDBTable_Identity_ExistingResource_noRefreshNoChange
    table_identity_gen_test.go:263: Step 1/2 error: Post-apply refresh state check(s) failed:
        aws_dynamodb_table.test - Identity found in state, and was not expected.
--- PASS: TestAccDynamoDBTableItemDataSource_basic (39.53s)
=== CONT  TestAccDynamoDBTable_disappears
--- FAIL: TestAccDynamoDBTable_Identity_ExistingResource_noRefreshNoChange (45.59s)
=== CONT  TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_noChange
--- PASS: TestAccDynamoDBTable_Replica_MRSC_TooManyReplicas (46.95s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_addHashKey
--- PASS: TestAccDynamoDBTable_Replica_singleStreamSpecification (320.69s)
=== CONT  TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_addHashKey
--- PASS: TestAccDynamoDBTableReplica_pitrKMS (396.70s)
=== CONT  TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_noChange
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nullOverlappingResourceTag (51.22s)
=== CONT  TestAccDynamoDBTable_restoreCrossRegion
--- PASS: TestAccDynamoDBTable_attributeUpdate (1661.77s)
=== CONT  TestAccDynamoDBTable_encryption
--- PASS: TestAccDynamoDBTable_disappears (37.86s)
=== CONT  TestAccDynamoDBTable_Identity_regionOverride
--- PASS: TestAccDynamoDBTableReplica_basic (223.61s)
=== CONT  TestAccDynamoDBTable_Identity_basic
--- PASS: TestAccDynamoDBTable_Identity_regionOverride (65.69s)
=== CONT  TestAccDynamoDBTableExport_incrementalExport
--- PASS: TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_noChange (97.95s)
=== CONT  TestAccDynamoDBTable_deletion_protection
--- PASS: TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_noChange (94.96s)
=== CONT  TestAccDynamoDBTableDataSource_pointInTimeRecovery
--- PASS: TestAccDynamoDBTableReplica_disappears (265.89s)
=== CONT  TestAccDynamoDBTable_basic
--- PASS: TestAccDynamoDBTable_Identity_basic (64.60s)
=== CONT  TestAccDynamoDBTableExport_kms
--- PASS: TestAccDynamoDBTable_basic (39.45s)
=== CONT  TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccDynamoDBTableDataSource_pointInTimeRecovery (50.13s)
=== CONT  TestAccDynamoDBTableExport_basic
--- PASS: TestAccDynamoDBTable_deletion_protection (70.42s)
=== CONT  TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccDynamoDBTableReplica_Tags_IgnoreTags_Overlap_resourceTag (328.72s)
=== CONT  TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccDynamoDBTable_encryption (171.63s)
=== CONT  TestAccDynamoDBTableExport_Identity_ExistingResource_noRefreshNoChange
--- PASS: TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_resourceTag (100.53s)
=== CONT  TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_defaultTag (91.27s)
=== CONT  TestAccDynamoDBTableExport_Identity_ExistingResource_basic
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_replace (82.45s)
=== CONT  TestAccDynamoDBTable_Tags_ComputedTag_onCreate
--- PASS: TestAccDynamoDBTableReplica_deletionProtection (821.90s)
=== CONT  TestAccDynamoDBTableExport_Identity_regionOverride
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_onCreate (49.35s)
=== CONT  TestAccDynamoDBTable_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_add (79.64s)
=== CONT  TestAccDynamoDBTableExport_Identity_basic
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nullNonOverlappingResourceTag (42.70s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_doubleAddCMK
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (738.89s)
=== CONT  TestAccDynamoDBTableReplica_Tags_DefaultTags_providerOnly
--- PASS: TestAccDynamoDBTable_backupEncryption (820.97s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleHashKey
--- PASS: TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_addHashKey (599.80s)
=== CONT  TestAccDynamoDBTableReplica_Tags_null
--- PASS: TestAccDynamoDBTable_GSI_keySchema_addHashKey (650.54s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleRangeKey
--- PASS: TestAccDynamoDBTable_Replica_deletionProtection (1372.86s)
=== CONT  TestAccDynamoDBTableReplica_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccDynamoDBTable_Replica_single (853.77s)
=== CONT  TestAccDynamoDBTableReplica_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleHashKey (67.46s)
=== CONT  TestAccDynamoDBTableItem_disappears
--- PASS: TestAccDynamoDBTableItem_disappears (40.68s)
=== CONT  TestAccDynamoDBTableReplica_Tags_EmptyTag_onCreate
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleRangeKey (82.89s)
=== CONT  TestAccDynamoDBTableReplica_tags
--- PASS: TestAccDynamoDBTable_Replica_multiple (1078.00s)
=== CONT  TestAccDynamoDBTableReplica_Tags_addOnUpdate
--- PASS: TestAccDynamoDBTableExport_s3Prefix (919.48s)
=== CONT  TestAccDynamoDBTableItem_mapOutOfBandUpdate
--- PASS: TestAccDynamoDBTable_restoreBackupARN (840.64s)
=== CONT  TestAccDynamoDBTableReplica_Tags_emptyMap
--- PASS: TestAccDynamoDBTableExport_Identity_regionOverride (528.23s)
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tags_notPropagatedToAddedReplica
--- PASS: TestAccDynamoDBTableItem_mapOutOfBandUpdate (59.95s)
=== CONT  TestAccDynamoDBTableReplica_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccDynamoDBTable_restoreCrossRegion (862.92s)
=== CONT  TestAccDynamoDBTableReplica_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccDynamoDBTableReplica_Tags_EmptyTag_OnUpdate_replace (244.92s)
=== CONT  TestAccDynamoDBTableDataSource_basic
--- PASS: TestAccDynamoDBTableReplica_Tags_null (308.73s)
=== CONT  TestAccDynamoDBTableReplica_Tags_ComputedTag_onCreate
--- PASS: TestAccDynamoDBTable_Replica_doubleAddCMK (1680.58s)
=== CONT  TestAccDynamoDBTableDataSource_onDemandThroughput
--- PASS: TestAccDynamoDBTableDataSource_basic (63.21s)
=== CONT  TestAccDynamoDBTableReplica_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccDynamoDBTableDataSource_onDemandThroughput (64.22s)
=== CONT  TestAccDynamoDBTable_extended
--- PASS: TestAccDynamoDBTableReplica_Tags_EmptyTag_onCreate (305.54s)
=== CONT  TestAccDynamoDBTableReplica_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccDynamoDBTableReplica_Tags_DefaultTags_providerOnly (458.53s)
=== CONT  TestAccDynamoDBTableReplica_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccDynamoDBTableReplica_Tags_addOnUpdate (266.43s)
=== CONT  TestAccDynamoDBTableReplica_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccDynamoDBTableReplica_Tags_EmptyTag_OnUpdate_add (352.45s)
=== CONT  TestAccDynamoDBTableReplica_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccDynamoDBTableReplica_Tags_emptyMap (206.19s)
=== CONT  TestAccDynamoDBTableReplica_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccDynamoDBTableExport_kms (951.55s)
=== CONT  TestAccDynamoDBTableDataSource_Tags_emptyMap
--- PASS: TestAccDynamoDBTableExport_basic (952.76s)
=== CONT  TestAccDynamoDBTableReplica_Tags_DefaultTags_overlapping
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_notPropagatedToAddedReplica (289.41s)
=== CONT  TestAccDynamoDBTableDataSource_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccDynamoDBTableDataSource_Tags_emptyMap (37.04s)
=== CONT  TestAccDynamoDBTableReplica_Tags_DefaultTags_nonOverlapping
=== NAME  TestAccDynamoDBTableExport_Identity_ExistingResource_noRefreshNoChange
    table_export_identity_gen_test.go:317: Step 1/2 error: Post-apply refresh state check(s) failed:
        aws_dynamodb_table_export.test - Identity found in state, and was not expected.
--- PASS: TestAccDynamoDBTableReplica_Tags_ComputedTag_OnUpdate_replace (308.53s)
=== CONT  TestAccDynamoDBTableItem_updateWithRangeKey
--- FAIL: TestAccDynamoDBTableExport_Identity_ExistingResource_noRefreshNoChange (960.25s)
=== CONT  TestAccDynamoDBTableDataSource_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccDynamoDBTableReplica_tags (420.46s)
=== CONT  TestAccDynamoDBTableDataSource_Tags_nullMap
--- PASS: TestAccDynamoDBTableReplica_Tags_ComputedTag_OnUpdate_add (277.27s)
=== CONT  TestAccDynamoDBTableItem_update
--- PASS: TestAccDynamoDBTableReplica_Tags_DefaultTags_nullNonOverlappingResourceTag (183.14s)
=== CONT  TestAccDynamoDBTableReplica_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccDynamoDBTableReplica_Tags_ComputedTag_onCreate (246.00s)
=== CONT  TestAccDynamoDBTable_Identity_ExistingResource_basic
--- PASS: TestAccDynamoDBTableDataSource_Tags_DefaultTags_nonOverlapping (46.36s)
=== CONT  TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleHashKeys
=== NAME  TestAccDynamoDBTableExport_Identity_ExistingResource_basic
    table_export_identity_gen_test.go:238: Step 1/3 error: Post-apply refresh state check(s) failed:
        aws_dynamodb_table_export.test - Identity found in state, and was not expected.
--- FAIL: TestAccDynamoDBTableExport_Identity_ExistingResource_basic (927.55s)
=== CONT  TestAccDynamoDBTableDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== NAME  TestAccDynamoDBTable_Identity_ExistingResource_basic
    table_identity_gen_test.go:205: Step 1/2 error: Post-apply refresh state check(s) failed:
        aws_dynamodb_table.test - Identity found in state, and was not expected.
--- PASS: TestAccDynamoDBTableDataSource_Tags_IgnoreTags_Overlap_resourceTag (46.17s)
=== CONT  TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
--- PASS: TestAccDynamoDBTableDataSource_Tags_nullMap (45.15s)
--- FAIL: TestAccDynamoDBTable_Identity_ExistingResource_basic (44.88s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_doubleAddCMK (846.84s)
--- PASS: TestAccDynamoDBTableItem_updateWithRangeKey (58.34s)
--- PASS: TestAccDynamoDBTableItem_update (63.02s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleHashKeys (56.71s)
--- PASS: TestAccDynamoDBTableDataSource_Tags_IgnoreTags_Overlap_defaultTag (47.44s)
--- PASS: TestAccDynamoDBTableReplica_Tags_DefaultTags_emptyResourceTag (237.48s)
--- PASS: TestAccDynamoDBTableReplica_Tags_DefaultTags_emptyProviderOnlyTag (242.09s)
--- PASS: TestAccDynamoDBTableReplica_Tags_DefaultTags_nullOverlappingResourceTag (243.47s)
--- PASS: TestAccDynamoDBTableReplica_Tags_DefaultTags_updateToResourceOnly (241.12s)
--- PASS: TestAccDynamoDBTableExport_Identity_basic (939.46s)
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (122.23s)
--- PASS: TestAccDynamoDBTableReplica_Tags_DefaultTags_updateToProviderOnly (357.13s)
--- PASS: TestAccDynamoDBTableReplica_Tags_DefaultTags_nonOverlapping (375.80s)
--- PASS: TestAccDynamoDBTableReplica_Tags_IgnoreTags_Overlap_defaultTag (344.18s)
--- PASS: TestAccDynamoDBTableReplica_Tags_DefaultTags_overlapping (392.61s)
--- PASS: TestAccDynamoDBTable_extended (618.18s)
--- PASS: TestAccDynamoDBTableExport_incrementalExport (1889.87s)
--- PASS: TestAccDynamoDBTable_TTL_updateDisable (3694.52s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   3790.615s
FAIL
make: *** [testacc] Error 1
```

The failed tests are : 

```console
TestAccDynamoDBTable_tableClass_migrate
TestAccDynamoDBTable_Replica_MRSC_Create
TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica
TestAccDynamoDBTableReplica_keys
TestAccDynamoDBTableReplica_tableClass
TestAccDynamoDBTable_Identity_ExistingResource_noRefreshNoChange
TestAccDynamoDBTable_Identity_ExistingResource_basic
TestAccDynamoDBTableExport_Identity_ExistingResource_noRefreshNoChange
TestAccDynamoDBTableExport_Identity_ExistingResource_basic
```


The Identity test failed because of known reason with local build , which got fixed after altering `.terraformrc` file.

```console
make testacc PKG=dynamodb TESTS=TestAccDynamoDBTable_Identity_ExistingResource_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 b_aws_dynamodb_table-gsi-hash_key-type-no-diff 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_Identity_ExistingResource_'  -timeout 360m -vet=off -buildvcs=false
2026/05/11 20:31:14 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/11 20:31:14 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDynamoDBTable_Identity_ExistingResource_basic
=== PAUSE TestAccDynamoDBTable_Identity_ExistingResource_basic
=== RUN   TestAccDynamoDBTable_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccDynamoDBTable_Identity_ExistingResource_noRefreshNoChange
=== CONT  TestAccDynamoDBTable_Identity_ExistingResource_basic
=== CONT  TestAccDynamoDBTable_Identity_ExistingResource_noRefreshNoChange
--- PASS: TestAccDynamoDBTable_Identity_ExistingResource_noRefreshNoChange (93.86s)
--- PASS: TestAccDynamoDBTable_Identity_ExistingResource_basic (103.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   111.304s
```



That leaves with : 

```console
TestAccDynamoDBTable_tableClass_migrate
TestAccDynamoDBTable_Replica_MRSC_Create
TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica
TestAccDynamoDBTableReplica_keys
TestAccDynamoDBTableReplica_tableClass
```

Some passed on retry : 

```console
make testacc PKG=dynamodb TESTS=TestAccDynamoDBTable_tableClass_migrate
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 b_aws_dynamodb_table-gsi-hash_key-type-no-diff 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_tableClass_migrate'  -timeout 360m -vet=off -buildvcs=false
2026/05/11 22:34:35 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/11 22:34:35 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDynamoDBTable_tableClass_migrate
=== PAUSE TestAccDynamoDBTable_tableClass_migrate
=== CONT  TestAccDynamoDBTable_tableClass_migrate
--- PASS: TestAccDynamoDBTable_tableClass_migrate (87.60s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   95.798s
```


```console
make testacc PKG=dynamodb TESTS=TestAccDynamoDBTable_Replica_MRSC_Create
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 b_aws_dynamodb_table-gsi-hash_key-type-no-diff 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_Replica_MRSC_Create'  -timeout 360m -vet=off -buildvcs=false
2026/05/11 22:48:06 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/11 22:48:06 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDynamoDBTable_Replica_MRSC_Create
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_Create
=== RUN   TestAccDynamoDBTable_Replica_MRSC_Create_witness
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_Create_witness
=== RUN   TestAccDynamoDBTable_Replica_MRSC_Create_witness_too_many_replicas
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_Create_witness_too_many_replicas
=== RUN   TestAccDynamoDBTable_Replica_MRSC_CreateEventuallyConsistent
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_CreateEventuallyConsistent
=== CONT  TestAccDynamoDBTable_Replica_MRSC_Create
=== CONT  TestAccDynamoDBTable_Replica_MRSC_Create_witness_too_many_replicas
=== CONT  TestAccDynamoDBTable_Replica_MRSC_Create_witness
=== CONT  TestAccDynamoDBTable_Replica_MRSC_CreateEventuallyConsistent
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create_witness_too_many_replicas (36.26s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create_witness (231.07s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create (240.70s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_CreateEventuallyConsistent (533.13s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   541.028s
```


```console
make testacc PKG=dynamodb TESTS=TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 b_aws_dynamodb_table-gsi-hash_key-type-no-diff 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica'  -timeout 360m -vet=off -buildvcs=false
2026/05/11 22:58:46 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/11 22:58:46 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica
=== PAUSE TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica
=== CONT  TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica (245.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   253.452s
```


**That leaves with `TestAccDynamoDBTableReplica_keys` and `TestAccDynamoDBTableReplica_tableClass` which are failing in dev but these failure do not relate to this change as these errors were reproduced in main branch too.**


Two test cases failed in dev branch : 


```console
make testacc PKG=dynamodb TESTS=TestAccDynamoDBTableReplica_keys
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      [github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2](http://github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2)     (cached)
ok      [github.com/hashicorp/terraform-provider-aws/internal/provider/framework](http://github.com/hashicorp/terraform-provider-aws/internal/provider/framework) (cached)
make: Running acceptance tests on branch: :herb: b_aws_dynamodb_table-gsi-hash_key-type-no-diff :herb:...
TF_ACC=1 go1.26.2 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTableReplica_keys'  -timeout 360m -vet=off -buildvcs=false
2026/05/11 23:08:44 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/11 23:08:44 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDynamoDBTableReplica_keys
=== PAUSE TestAccDynamoDBTableReplica_keys
=== CONT  TestAccDynamoDBTableReplica_keys
    table_replica_test.go:254: Step 3/3 error: Error running apply: exit status 1

        Error: creating AWS DynamoDB Table Replica (arn:aws:dynamodb:us-east-1:xxxxxxx:table/tf-acc-test-1619340740454422841): operation error DynamoDB: UpdateTable, https response error StatusCode: 400, RequestID: xxxxxx, api error ValidationException: Failed to create a the new replica of table with name: ‘tf-acc-test-xxxxxxx’ because one or more replicas already existed as tables.

          with aws_dynamodb_table_replica.test,
          on terraform_plugin_test.tf line 75, in resource "aws_dynamodb_table_replica" "test":
          75: resource "aws_dynamodb_table_replica" "test" {

--- FAIL: TestAccDynamoDBTableReplica_keys (284.43s)
FAIL
FAIL    [github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb](http://github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb)   292.291s
FAIL
make: *** [testacc] Error 1
```



```console
make testacc PKG=dynamodb TESTS=TestAccDynamoDBTableReplica_tableClass
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      [github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2](http://github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2)     (cached)
ok      [github.com/hashicorp/terraform-provider-aws/internal/provider/framework](http://github.com/hashicorp/terraform-provider-aws/internal/provider/framework) (cached)
make: Running acceptance tests on branch: :herb: b_aws_dynamodb_table-gsi-hash_key-type-no-diff :herb:...
TF_ACC=1 go1.26.2 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTableReplica_tableClass'  -timeout 360m -vet=off -buildvcs=false
2026/05/11 23:23:53 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/11 23:23:53 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDynamoDBTableReplica_tableClass
=== PAUSE TestAccDynamoDBTableReplica_tableClass
=== CONT  TestAccDynamoDBTableReplica_tableClass
    table_replica_test.go:216: Step 3/3 error: Error running apply: exit status 1

        Error: creating AWS DynamoDB Table Replica (arn:aws:dynamodb:us-east-1:xxxxxxxx:table/tf-acc-test-xxxxxxxxx): operation error DynamoDB: UpdateTable, https response error StatusCode: 400, RequestID: xxxxxxxxx, api error ValidationException: Failed to create a the new replica of table with name: ‘tf-acc-test-xxxxxxx’ because one or more replicas already existed as tables.

          with aws_dynamodb_table_replica.test,
          on terraform_plugin_test.tf line 48, in resource "aws_dynamodb_table_replica" "test":
          48: resource "aws_dynamodb_table_replica" "test" {

--- FAIL: TestAccDynamoDBTableReplica_tableClass (215.67s)
FAIL
FAIL    [github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb](http://github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb)   223.550s
FAIL
make: *** [testacc] Error 1
```



But these two error were reproduced in `main` too : 

```console
make testacc PKG=dynamodb TESTS=TestAccDynamoDBTableReplica_tableClass
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     7.788s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 7.926s
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTableReplica_tableClass'  -timeout 360m -vet=off -buildvcs=false
2026/05/12 00:36:08 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/12 00:36:08 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDynamoDBTableReplica_tableClass
=== PAUSE TestAccDynamoDBTableReplica_tableClass
=== CONT  TestAccDynamoDBTableReplica_tableClass
    table_replica_test.go:216: Step 3/3 error: Error running apply: exit status 1

        Error: creating AWS DynamoDB Table Replica (arn:aws:dynamodb:us-east-1:927163995318:table/tf-acc-test-8863297135966501823): operation error DynamoDB: UpdateTable, https response error StatusCode: 400, RequestID: 0CSHP85K6UDVHBMQH9CK34FTTJVV4KQNSO5AEMVJF66Q9ASUAAJG, api error ValidationException: Failed to create a the new replica of table with name: 'tf-acc-test-8863297135966501823' because one or more replicas already existed as tables.

          with aws_dynamodb_table_replica.test,
          on terraform_plugin_test.tf line 48, in resource "aws_dynamodb_table_replica" "test":
          48: resource "aws_dynamodb_table_replica" "test" {

--- FAIL: TestAccDynamoDBTableReplica_tableClass (220.63s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   228.668s
FAIL
make: *** [testacc] Error 1
```


```console
make testacc PKG=dynamodb TESTS=TestAccDynamoDBTableReplica_keys
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     8.151s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 7.979s
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go1.26.2 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTableReplica_keys'  -timeout 360m -vet=off -buildvcs=false
2026/05/12 00:36:14 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/12 00:36:14 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDynamoDBTableReplica_keys
=== PAUSE TestAccDynamoDBTableReplica_keys
=== CONT  TestAccDynamoDBTableReplica_keys
    table_replica_test.go:254: Step 3/3 error: Error running apply: exit status 1

        Error: creating AWS DynamoDB Table Replica (arn:aws:dynamodb:us-east-1:927163995318:table/tf-acc-test-3737315982756214687): operation error DynamoDB: UpdateTable, https response error StatusCode: 400, RequestID: 76IK24GTAG9RI7617KVKGA3CF3VV4KQNSO5AEMVJF66Q9ASUAAJG, api error ValidationException: Failed to create a the new replica of table with name: 'tf-acc-test-3737315982756214687' because one or more replicas already existed as tables.

          with aws_dynamodb_table_replica.test,
          on terraform_plugin_test.tf line 75, in resource "aws_dynamodb_table_replica" "test":
          75: resource "aws_dynamodb_table_replica" "test" {

--- FAIL: TestAccDynamoDBTableReplica_keys (323.41s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   335.745s
FAIL
make: *** [testacc] Error 1
```
