### PR TITLE
(For changelog agent testing) - r/aws_dynamodb_table: Fix plan/apply does not detect hash_key type changes in DynamoDB GSI (For changelog agent testing)

### DIFF
--- a/.changelog/47867.txt
+++ b/.changelog/47867.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Ensure diffs are shown for GSI hash key type changes
+```

--- a/.changelog/47867.txt
+++ b/.changelog/47867.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/aws_dynamodb_table: Ensure diffs are shown for GSI hash key type changes
-```

--- a/.changelog/47869.txt
+++ b/.changelog/47869.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Fix no-diff bug where changes to the `type` of a `hash_key` or `range_key` attribute used in a Global Secondary Index (GSI) were not detected during plan/apply
+```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -136,20 +136,6 @@ func resourceTable() *schema.Resource {
 				}
 
 				if diff.HasChange("attribute") && !diff.HasChange("global_secondary_index") {
-					// Only suppress the attribute diff if no attribute's type changed.
-					// A type change on a GSI key attribute requires the index to be recreated.
-					o, n := diff.GetChange("attribute")
-					oldTypes := map[string]string{}
-					for _, a := range o.(*schema.Set).List() {
-						attr := a.(map[string]any)
-						oldTypes[attr[names.AttrName].(string)] = attr[names.AttrType].(string)
-					}
-					for _, a := range n.(*schema.Set).List() {
-						attr := a.(map[string]any)
-						if t, ok := oldTypes[attr[names.AttrName].(string)]; ok && t != attr[names.AttrType].(string) {
-							return nil
-						}
-					}
 					return diff.Clear("attribute")
 				}
 
@@ -183,7 +169,7 @@ func resourceTable() *schema.Resource {
 							},
 						},
 					},
-					Set: sdkv2.SimpleSchemaSetFunc(names.AttrName),
+					Set: sdkv2.SimpleSchemaSetFunc(names.AttrName, names.AttrType),
 				},
 				"billing_mode": {
 					Type:             schema.TypeString,
@@ -1193,11 +1179,23 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 	// will signal the problems.
 	var gsiUpdates []awstypes.GlobalSecondaryIndexUpdate
 
-	if d.HasChange("global_secondary_index") {
-		var err error
-		o, n := d.GetChange("global_secondary_index")
-		gsiUpdates, err = updateDiffGSI(o.(*schema.Set).List(), n.(*schema.Set).List(), newBillingMode)
+	if d.HasChange("global_secondary_index") || d.HasChange("attribute") {
+		oldGSI, newGSI := d.GetChange("global_secondary_index")
+		oldAttr, newAttr := d.GetChange("attribute")
 
+		oldAttrTypes := map[string]string{}
+		for _, a := range oldAttr.(*schema.Set).List() {
+			attr := a.(map[string]any)
+			oldAttrTypes[attr[names.AttrName].(string)] = attr[names.AttrType].(string)
+		}
+		newAttrTypes := map[string]string{}
+		for _, a := range newAttr.(*schema.Set).List() {
+			attr := a.(map[string]any)
+			newAttrTypes[attr[names.AttrName].(string)] = attr[names.AttrType].(string)
+		}
+
+		var err error
+		gsiUpdates, err = updateDiffGSI(oldGSI.(*schema.Set).List(), newGSI.(*schema.Set).List(), newBillingMode, oldAttrTypes, newAttrTypes)
 		if err != nil {
 			return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionUpdating, resNameTable, d.Id(), fmt.Errorf("computing GSI difference: %w", err))
 		}
@@ -2107,7 +2105,7 @@ func updateWarmThroughput(ctx context.Context, conn *dynamodb.Client, warmList [
 	return nil
 }
 
-func updateDiffGSI(oldGsi, newGsi []any, billingMode awstypes.BillingMode) ([]awstypes.GlobalSecondaryIndexUpdate, error) {
+func updateDiffGSI(oldGsi, newGsi []any, billingMode awstypes.BillingMode, oldAttrTypes, newAttrTypes map[string]string) ([]awstypes.GlobalSecondaryIndexUpdate, error) {
 	// Transform slices into maps
 	oldGsis := make(map[string]any)
 	for _, gsidata := range oldGsi {
@@ -2212,7 +2210,7 @@ func updateDiffGSI(oldGsi, newGsi []any, billingMode awstypes.BillingMode) ([]aw
 			// ordinal of elements in its equality (which we actually don't care about)
 			nonKeyAttributesChanged := checkIfNonKeyAttributesChanged(oldMap, newMap)
 
-			recreateAttributesChanged := checkIfGSIRecreateAttributesChanged(oldMap, newMap)
+			recreateAttributesChanged := checkIfGSIRecreateAttributesChanged(oldMap, newMap, oldAttrTypes, newAttrTypes)
 
 			gsiNeedsRecreate := nonKeyAttributesChanged || recreateAttributesChanged || warmThroughPutDecreased
 
@@ -2300,7 +2298,7 @@ func checkIfNonKeyAttributesChanged(oldMap, newMap map[string]any) bool {
 	return oldNkaExists != newNkaExists
 }
 
-func checkIfGSIRecreateAttributesChanged(oldMap, newMap map[string]any) bool {
+func checkIfGSIRecreateAttributesChanged(oldMap, newMap map[string]any, oldAttrTypes, newAttrTypes map[string]string) bool {
 	oldAttributes := stripGSIUpdatableAttributes(oldMap)
 
 	newAttributes := stripGSIUpdatableAttributes(newMap)
@@ -2327,7 +2325,21 @@ func checkIfGSIRecreateAttributesChanged(oldMap, newMap map[string]any) bool {
 		delete(newAttributes, "range_key")
 	}
 
-	return !reflect.DeepEqual(oldAttributes, newAttributes)
+	if !reflect.DeepEqual(oldAttributes, newAttributes) {
+		return true
+	}
+
+	// Check if the type of any key attribute used by this GSI changed.
+	for _, keyAttr := range []string{oldMap["hash_key"].(string), oldMap["range_key"].(string)} {
+		if keyAttr == "" {
+			continue
+		}
+		if oldAttrTypes[keyAttr] != newAttrTypes[keyAttr] {
+			return true
+		}
+	}
+
+	return false
 }
 
 func deleteTable(ctx context.Context, conn *dynamodb.Client, tableName string) error {

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -1179,7 +1179,7 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 	// will signal the problems.
 	var gsiUpdates []awstypes.GlobalSecondaryIndexUpdate
 
-	if d.HasChange("global_secondary_index") || d.HasChange("attribute") {
+	if d.HasChanges("global_secondary_index", "attribute") {
 		oldGSI, newGSI := d.GetChange("global_secondary_index")
 		oldAttr, newAttr := d.GetChange("attribute")
 

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -136,6 +136,20 @@ func resourceTable() *schema.Resource {
 				}
 
 				if diff.HasChange("attribute") && !diff.HasChange("global_secondary_index") {
+					// Only suppress the attribute diff if no attribute's type changed.
+					// A type change on a GSI key attribute requires the index to be recreated.
+					o, n := diff.GetChange("attribute")
+					oldTypes := map[string]string{}
+					for _, a := range o.(*schema.Set).List() {
+						attr := a.(map[string]any)
+						oldTypes[attr[names.AttrName].(string)] = attr[names.AttrType].(string)
+					}
+					for _, a := range n.(*schema.Set).List() {
+						attr := a.(map[string]any)
+						if t, ok := oldTypes[attr[names.AttrName].(string)]; ok && t != attr[names.AttrType].(string) {
+							return nil
+						}
+					}
 					return diff.Clear("attribute")
 				}
 

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -861,7 +861,7 @@ func TestUpdateDiffGSI_Provisioned(t *testing.T) {
 				tc.New[i] = normalizeGSIMapValue(v.(map[string]any))
 			}
 
-			ops, err := tfdynamodb.UpdateDiffGSI(tc.Old, tc.New, awstypes.BillingModeProvisioned)
+			ops, err := tfdynamodb.UpdateDiffGSI(tc.Old, tc.New, awstypes.BillingModeProvisioned, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1756,7 +1756,7 @@ func TestUpdateDiffGSI_OnDemand(t *testing.T) {
 				tc.New[i] = normalizeGSIMapValue(v.(map[string]any))
 			}
 
-			ops, err := tfdynamodb.UpdateDiffGSI(tc.Old, tc.New, awstypes.BillingModePayPerRequest)
+			ops, err := tfdynamodb.UpdateDiffGSI(tc.Old, tc.New, awstypes.BillingModePayPerRequest, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1800,9 +1800,11 @@ func TestCheckIfGSIRecreateAttributesChanged(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		Old      map[string]any
-		New      map[string]any
-		Expected bool
+		Old          map[string]any
+		New          map[string]any
+		OldAttrTypes map[string]string
+		NewAttrTypes map[string]string
+		Expected     bool
 	}{
 		"key_schema syntax unchanged": {
 			// State has hash_key/range_key, config only has key_schema
@@ -1888,13 +1890,70 @@ func TestCheckIfGSIRecreateAttributesChanged(t *testing.T) {
 			},
 			Expected: true,
 		},
+		"hash_key attribute type changed S to N": {
+			Old: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "alternate_id",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			New: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "alternate_id",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			OldAttrTypes: map[string]string{"alternate_id": "S"},
+			NewAttrTypes: map[string]string{"alternate_id": "N"},
+			Expected:     true,
+		},
+		"hash_key attribute type unchanged": {
+			Old: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "alternate_id",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			New: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "alternate_id",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			OldAttrTypes: map[string]string{"alternate_id": "S"},
+			NewAttrTypes: map[string]string{"alternate_id": "S"},
+			Expected:     false,
+		},
+		"range_key attribute type changed S to N": {
+			Old: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "pk",
+				"range_key":       "sk",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			New: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "pk",
+				"range_key":       "sk",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			OldAttrTypes: map[string]string{"pk": "S", "sk": "S"},
+			NewAttrTypes: map[string]string{"pk": "S", "sk": "N"},
+			Expected:     true,
+		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := tfdynamodb.CheckIfGSIRecreateAttributesChanged(tc.Old, tc.New)
+			got := tfdynamodb.CheckIfGSIRecreateAttributesChanged(tc.Old, tc.New, tc.OldAttrTypes, tc.NewAttrTypes)
 			if got != tc.Expected {
 				t.Errorf("expected %v, got %v", tc.Expected, got)
 			}


### PR DESCRIPTION
Description

Fixes no diff seen bug for GSI when the type of `hash_key' changes , for example from "S" to "N".
See - https://github.com/hashicorp/terraform-provider-aws/issues/14476

Relations

Closes https://github.com/hashicorp/terraform-provider-aws/issues/14476