### PR TITLE
47836: Made aws_imagebuilder_image_recipe.component optional

### DIFF
--- a/.changelog/47870.txt
+++ b/.changelog/47870.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_imagebuilder_image_recipe: Made component optional to align with AWS API specification
+```

--- a/internal/service/imagebuilder/image_recipe.go
+++ b/internal/service/imagebuilder/image_recipe.go
@@ -144,9 +144,8 @@ func resourceImageRecipe() *schema.Resource {
 			},
 			"component": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
-				MinItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"component_arn": {

--- a/internal/service/imagebuilder/image_recipe_test.go
+++ b/internal/service/imagebuilder/image_recipe_test.go
@@ -512,6 +512,33 @@ func TestAccImageBuilderImageRecipe_component(t *testing.T) {
 	})
 }
 
+func TestAccImageBuilderImageRecipe_noComponent(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_imagebuilder_image_recipe.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ImageBuilderServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckImageRecipeDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageRecipeConfig_noComponent(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImageRecipeExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "component.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccImageBuilderImageRecipe_componentParameter(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -1169,6 +1196,18 @@ resource "aws_imagebuilder_image_recipe" "test" {
     component_arn = aws_imagebuilder_component.test.arn
   }
 
+  name         = %[1]q
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
+  version      = "1.0.0"
+}
+`, rName))
+}
+
+func testAccImageRecipeConfig_noComponent(rName string) string {
+	return acctest.ConfigCompose(
+		testAccImageRecipeBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_imagebuilder_image_recipe" "test" {
   name         = %[1]q
   parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR fixes a bug in the `aws_imagebuilder_image_recipe` resource. Namely, it makes the `component` list optional, therefore aligning the AWS API specification with the Terraform provider.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47836

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccImageBuilderImageRecipe PKG=imagebuilder
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderImageRecipe'  -timeout 360m -vet=off -buildvcs=false
2026/05/12 13:43:16 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/12 13:43:16 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccImageBuilderImageRecipeDataSource_arn
=== PAUSE TestAccImageBuilderImageRecipeDataSource_arn
=== RUN   TestAccImageBuilderImageRecipe_Identity_basic
=== PAUSE TestAccImageBuilderImageRecipe_Identity_basic
=== RUN   TestAccImageBuilderImageRecipe_Identity_regionOverride
=== PAUSE TestAccImageBuilderImageRecipe_Identity_regionOverride
=== RUN   TestAccImageBuilderImageRecipe_Identity_ExistingResource_basic
=== PAUSE TestAccImageBuilderImageRecipe_Identity_ExistingResource_basic
=== RUN   TestAccImageBuilderImageRecipe_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccImageBuilderImageRecipe_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccImageBuilderImageRecipe_basic
=== PAUSE TestAccImageBuilderImageRecipe_basic
=== RUN   TestAccImageBuilderImageRecipe_disappears
=== PAUSE TestAccImageBuilderImageRecipe_disappears
=== RUN   TestAccImageBuilderImageRecipe_amiTags
=== PAUSE TestAccImageBuilderImageRecipe_amiTags
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_throughput
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_throughput
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName
=== RUN   TestAccImageBuilderImageRecipe_component
=== PAUSE TestAccImageBuilderImageRecipe_component
=== RUN   TestAccImageBuilderImageRecipe_noComponent
=== PAUSE TestAccImageBuilderImageRecipe_noComponent
=== RUN   TestAccImageBuilderImageRecipe_componentParameter
=== PAUSE TestAccImageBuilderImageRecipe_componentParameter
=== RUN   TestAccImageBuilderImageRecipe_description
=== PAUSE TestAccImageBuilderImageRecipe_description
=== RUN   TestAccImageBuilderImageRecipe_tags
=== PAUSE TestAccImageBuilderImageRecipe_tags
=== RUN   TestAccImageBuilderImageRecipe_workingDirectory
=== PAUSE TestAccImageBuilderImageRecipe_workingDirectory
=== RUN   TestAccImageBuilderImageRecipe_pipelineUpdateDependency
=== PAUSE TestAccImageBuilderImageRecipe_pipelineUpdateDependency
=== RUN   TestAccImageBuilderImageRecipe_systemsManagerAgent
=== PAUSE TestAccImageBuilderImageRecipe_systemsManagerAgent
=== RUN   TestAccImageBuilderImageRecipe_updateDependency
=== PAUSE TestAccImageBuilderImageRecipe_updateDependency
=== RUN   TestAccImageBuilderImageRecipe_userDataBase64
=== PAUSE TestAccImageBuilderImageRecipe_userDataBase64
=== RUN   TestAccImageBuilderImageRecipe_windowsBaseImage
=== PAUSE TestAccImageBuilderImageRecipe_windowsBaseImage
=== RUN   TestAccImageBuilderImageRecipesDataSource_owner
=== PAUSE TestAccImageBuilderImageRecipesDataSource_owner
=== RUN   TestAccImageBuilderImageRecipesDataSource_filter
=== PAUSE TestAccImageBuilderImageRecipesDataSource_filter
=== RUN   TestAccImageBuilderImageRecipesDataSource_amiTags
=== PAUSE TestAccImageBuilderImageRecipesDataSource_amiTags
=== CONT  TestAccImageBuilderImageRecipeDataSource_arn
=== CONT  TestAccImageBuilderImageRecipesDataSource_amiTags
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID
=== CONT  TestAccImageBuilderImageRecipe_tags
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_throughput
=== CONT  TestAccImageBuilderImageRecipe_userDataBase64
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName
=== CONT  TestAccImageBuilderImageRecipe_amiTags
=== CONT  TestAccImageBuilderImageRecipe_disappears
=== CONT  TestAccImageBuilderImageRecipe_basic
=== CONT  TestAccImageBuilderImageRecipe_Identity_ExistingResource_noRefreshNoChange
=== CONT  TestAccImageBuilderImageRecipe_Identity_ExistingResource_basic
=== CONT  TestAccImageBuilderImageRecipe_Identity_basic
=== CONT  TestAccImageBuilderImageRecipe_description
=== CONT  TestAccImageBuilderImageRecipe_Identity_regionOverride
--- PASS: TestAccImageBuilderImageRecipeDataSource_arn (75.36s)
=== CONT  TestAccImageBuilderImageRecipe_componentParameter
--- PASS: TestAccImageBuilderImageRecipesDataSource_amiTags (88.86s)
=== CONT  TestAccImageBuilderImageRecipe_noComponent
--- PASS: TestAccImageBuilderImageRecipe_disappears (90.70s)
=== CONT  TestAccImageBuilderImageRecipe_component
--- PASS: TestAccImageBuilderImageRecipe_description (95.35s)
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName (97.69s)
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted (98.23s)
--- PASS: TestAccImageBuilderImageRecipe_basic (98.72s)
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination (100.04s)
=== CONT  TestAccImageBuilderImageRecipesDataSource_owner
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops (100.32s)
=== CONT  TestAccImageBuilderImageRecipesDataSource_filter
--- PASS: TestAccImageBuilderImageRecipe_userDataBase64 (103.50s)
=== CONT  TestAccImageBuilderImageRecipe_windowsBaseImage
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID (104.56s)
=== CONT  TestAccImageBuilderImageRecipe_systemsManagerAgent
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_throughput (105.76s)
=== CONT  TestAccImageBuilderImageRecipe_updateDependency
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize (110.78s)
=== CONT  TestAccImageBuilderImageRecipe_pipelineUpdateDependency
--- PASS: TestAccImageBuilderImageRecipe_Identity_ExistingResource_noRefreshNoChange (130.43s)
=== CONT  TestAccImageBuilderImageRecipe_workingDirectory
--- PASS: TestAccImageBuilderImageRecipe_Identity_ExistingResource_basic (138.47s)
--- PASS: TestAccImageBuilderImageRecipe_componentParameter (68.80s)
--- PASS: TestAccImageBuilderImageRecipe_Identity_basic (149.85s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID (165.75s)
--- PASS: TestAccImageBuilderImageRecipe_noComponent (77.02s)
--- PASS: TestAccImageBuilderImageRecipesDataSource_owner (66.47s)
--- PASS: TestAccImageBuilderImageRecipesDataSource_filter (66.44s)
--- PASS: TestAccImageBuilderImageRecipe_Identity_regionOverride (168.90s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice (73.89s)
--- PASS: TestAccImageBuilderImageRecipe_component (81.39s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3 (74.41s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName (77.47s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2 (74.63s)
--- PASS: TestAccImageBuilderImageRecipe_windowsBaseImage (71.16s)
--- PASS: TestAccImageBuilderImageRecipe_systemsManagerAgent (71.31s)
=== NAME  TestAccImageBuilderImageRecipe_pipelineUpdateDependency
    image_recipe_test.go:673: Step 2/2 error: Error running apply: exit status 1

        Error: deleting Image Builder Image Recipe (arn:aws:imagebuilder:us-west-2:696687625928:image-recipe/tf-acc-test-7864844183342199818/1.0.0): operation error imagebuilder: DeleteImageRecipe, https response error StatusCode: 400, RequestID: a00ee2a5-f62c-4569-ad87-237f91406acc, ResourceDependencyException: Resource dependency error: The resource ARN 'arn:aws:imagebuilder:us-west-2:696687625928:image-recipe/tf-acc-test-7864844183342199818/1.0.0' has other resources depended on it.

--- PASS: TestAccImageBuilderImageRecipe_tags (180.36s)
--- PASS: TestAccImageBuilderImageRecipe_amiTags (181.88s)
--- PASS: TestAccImageBuilderImageRecipe_workingDirectory (55.03s)
--- FAIL: TestAccImageBuilderImageRecipe_pipelineUpdateDependency (77.70s)
--- PASS: TestAccImageBuilderImageRecipe_updateDependency (97.47s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       203.387s
FAIL
make: *** [GNUmakefile:929: testacc] Error 1
...
```

Please advise regarding test "TestAccImageBuilderImageRecipe_pipelineUpdateDependency". I don't see how many changes affect this test but am happy to be educated.