### PR TITLE
[Enhancement] aws_cloudfront_distribution: Add `cache_tag_config` configuration block

### DIFF
--- a/.changelog/47872.txt
+++ b/.changelog/47872.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudfront_distribution: Add `cache_tag_config` configuration block
+```

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -93,6 +93,19 @@ func resourceDistribution() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"cache_tag_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"header_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
 			names.AttrComment: {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -1066,6 +1079,9 @@ func resourceDistributionFlatten(ctx context.Context, awsClient *conns.AWSClient
 	if aws.ToString(distributionConfig.Comment) != "" {
 		d.Set(names.AttrComment, distributionConfig.Comment)
 	}
+	if err := d.Set("cache_tag_config", flattenCacheTagConfig(distributionConfig.CacheTagConfig)); err != nil {
+		return fmt.Errorf("setting cache_tag_config: %w", err)
+	}
 	if distributionConfig.ConnectionFunctionAssociation != nil {
 		if err := d.Set("connection_function_association", []any{flattenConnectionFunctionAssociation(distributionConfig.ConnectionFunctionAssociation)}); err != nil {
 			return fmt.Errorf("setting connection_function_association: %w", err)
@@ -1482,6 +1498,10 @@ func expandDistributionConfig(d *schema.ResourceData) *awstypes.DistributionConf
 
 	if v, ok := d.GetOk("caller_reference"); ok {
 		apiObject.CallerReference = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("cache_tag_config"); ok {
+		apiObject.CacheTagConfig = expandCacheTagConfig(v.([]any))
 	}
 
 	if v, ok := d.GetOk("connection_function_association"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
@@ -2835,6 +2855,30 @@ func flattenAliases(apiObject *awstypes.Aliases) []any {
 	}
 
 	return []any{}
+}
+
+func expandCacheTagConfig(tfList []any) *awstypes.CacheTagConfig {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap := tfList[0].(map[string]any)
+	apiObject := &awstypes.CacheTagConfig{
+		HeaderName: aws.String(tfMap["header_name"].(string)),
+	}
+
+	return apiObject
+}
+
+func flattenCacheTagConfig(apiObject *awstypes.CacheTagConfig) []any {
+	if apiObject == nil {
+		return nil
+	}
+	tfMap := map[string]any{
+		"header_name": aws.ToString(apiObject.HeaderName),
+	}
+
+	return []any{tfMap}
 }
 
 func expandRestrictions(tfMap map[string]any) *awstypes.Restrictions {

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -40,6 +40,7 @@ func TestAccCloudFrontDistribution_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "origin.0.response_completion_timeout", "0"),
 					resource.TestCheckResourceAttr(resourceName, "logging_v1_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "cache_tag_config.#", "0"),
 				),
 			},
 			{
@@ -1938,6 +1939,53 @@ func TestAccCloudFrontDistribution_viewerMtlsConfig(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDistributionExists(ctx, t, resourceName, &distribution),
 					resource.TestCheckResourceAttr(resourceName, "viewer_mtls_config.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudFrontDistribution_cacheTagConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	var distribution awstypes.Distribution
+	resourceName := "aws_cloudfront_distribution.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDistributionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistributionConfig_cacheTagConfig(false, false, "x-amz-meta-cache-tag1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionExists(ctx, t, resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "cache_tag_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cache_tag_config.0.header_name", "x-amz-meta-cache-tag1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
+			},
+			{
+				Config: testAccDistributionConfig_cacheTagConfig(false, false, "x-amz-meta-cache-tag2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionExists(ctx, t, resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "cache_tag_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cache_tag_config.0.header_name", "x-amz-meta-cache-tag2"),
+				),
+			},
+			{
+				Config: testAccDistributionConfig_enabled(false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionExists(ctx, t, resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "cache_tag_config.#", "0"),
 				),
 			},
 		},
@@ -5738,4 +5786,54 @@ resource "aws_cloudfront_distribution" "test" {
 
 }
 `)
+}
+
+func testAccDistributionConfig_cacheTagConfig(enabled, retainOnDelete bool, cacheTagConfigHeaderName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_distribution" "test" {
+  enabled          = %[1]t
+  retain_on_delete = %[2]t
+
+  cache_tag_config {
+    header_name = %[3]q
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "test"
+    viewer_protocol_policy = "allow-all"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  origin {
+    domain_name = "www.example.com"
+    origin_id   = "test"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+`, enabled, retainOnDelete, cacheTagConfigHeaderName)
 }

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -1974,6 +1974,7 @@ func TestAccCloudFrontDistribution_cacheTagConfig(t *testing.T) {
 				},
 			},
 			{
+				// Update cache_tag_config.header_name
 				Config: testAccDistributionConfig_cacheTagConfig(false, false, "x-amz-meta-cache-tag2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDistributionExists(ctx, t, resourceName, &distribution),
@@ -1982,6 +1983,7 @@ func TestAccCloudFrontDistribution_cacheTagConfig(t *testing.T) {
 				),
 			},
 			{
+				// Remove cache_tag_config block
 				Config: testAccDistributionConfig_enabled(false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDistributionExists(ctx, t, resourceName, &distribution),

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -426,6 +426,7 @@ This resource supports the following arguments:
 
 * `aliases` (Optional) - Extra CNAMEs (alternate domain names), if any, for this distribution.
 * `anycast_ip_list_id` (Optional) - ID of the Anycast static IP list that is associated with the distribution.
+* `cache_tag_config` (Optional) -  [Cache tag configuration](#cache-tag-config-arguments) block for cache tag extraction from origin responses (maximum one). See the [AWS documentation](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/invalidation-by-tags.html) for more information about cache tags.
 * `comment` (Optional) - Any comments you want to include about the distribution.
 * `connection_function_association` (Optional) - A [connection function association](#connection-function-association-arguments) configuration block (maximum one).
 * `continuous_deployment_policy_id` (Optional) - Identifier of a continuous deployment policy. This argument should only be set on a production distribution. See the [`aws_cloudfront_continuous_deployment_policy` resource](./cloudfront_continuous_deployment_policy.html.markdown) for additional details.
@@ -639,6 +640,10 @@ The arguments of `geo_restriction` are:
 * `iam_certificate_id` - IAM certificate identifier of the custom viewer certificate for this distribution if you are using a custom domain. Specify this, `acm_certificate_arn`, or `cloudfront_default_certificate`.
 * `minimum_protocol_version` - Minimum version of the SSL protocol that you want CloudFront to use for HTTPS connections. Can only be set if `cloudfront_default_certificate = false`. See all possible values in [this](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html) table under "Security policy." Some examples include: `TLSv1.2_2019` and `TLSv1.2_2021`. Default: `TLSv1`. **NOTE**: If you are using a custom certificate (specified with `acm_certificate_arn` or `iam_certificate_id`), and have specified `sni-only` in `ssl_support_method`, `TLSv1` or later must be specified. If you have specified `vip` in `ssl_support_method`, only `SSLv3` or `TLSv1` can be specified. If you have specified `cloudfront_default_certificate`, `TLSv1` must be specified.
 * `ssl_support_method` - How you want CloudFront to serve HTTPS requests. One of `vip`, `sni-only`, or `static-ip`. Required if you specify `acm_certificate_arn` or `iam_certificate_id`. **NOTE:** `vip` causes CloudFront to use a dedicated IP address and may incur extra charges.
+
+#### Cache Tag Config Arguments
+
+* `header_name` (Required) - Name of the HTTP header to extract cache tags. The header value must contain comma-separated tag values.
 
 #### Connection Function Association Arguments
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
This PR adds `cache_tag_config` configuration block to `aws_cloudfront_distribution` resource.

### Relations

Closes #47865

### References
https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateDistribution.html
https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateDistribution.html#cloudfront-CreateDistribution-request-CacheTagConfig

### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccCloudFrontDistribution_' PKG=cloudfront
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_cloudfront_distribution-add_cache_tag_config 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontDistribution_'  -timeout 360m -vet=off -buildvcs=false
2026/05/12 22:21:19 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/12 22:21:19 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudFrontDistribution_Identity_basic
=== PAUSE TestAccCloudFrontDistribution_Identity_basic
=== RUN   TestAccCloudFrontDistribution_Identity_ExistingResource_basic
=== PAUSE TestAccCloudFrontDistribution_Identity_ExistingResource_basic
=== RUN   TestAccCloudFrontDistribution_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccCloudFrontDistribution_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccCloudFrontDistribution_List_basic
=== PAUSE TestAccCloudFrontDistribution_List_basic
=== RUN   TestAccCloudFrontDistribution_List_includeResource
=== PAUSE TestAccCloudFrontDistribution_List_includeResource
=== RUN   TestAccCloudFrontDistribution_basic
=== PAUSE TestAccCloudFrontDistribution_basic
=== RUN   TestAccCloudFrontDistribution_disappears
=== PAUSE TestAccCloudFrontDistribution_disappears
=== RUN   TestAccCloudFrontDistribution_tags
=== PAUSE TestAccCloudFrontDistribution_tags
=== RUN   TestAccCloudFrontDistribution_s3Origin
=== PAUSE TestAccCloudFrontDistribution_s3Origin
=== RUN   TestAccCloudFrontDistribution_includeCookieWhenV1loggingDisabled
=== PAUSE TestAccCloudFrontDistribution_includeCookieWhenV1loggingDisabled
=== RUN   TestAccCloudFrontDistribution_customOrigin
=== PAUSE TestAccCloudFrontDistribution_customOrigin
=== RUN   TestAccCloudFrontDistribution_customOriginIPAddressType
=== PAUSE TestAccCloudFrontDistribution_customOriginIPAddressType
=== RUN   TestAccCloudFrontDistribution_originPolicyDefault
=== PAUSE TestAccCloudFrontDistribution_originPolicyDefault
=== RUN   TestAccCloudFrontDistribution_originPolicyOrdered
=== PAUSE TestAccCloudFrontDistribution_originPolicyOrdered
=== RUN   TestAccCloudFrontDistribution_multiOrigin
=== PAUSE TestAccCloudFrontDistribution_multiOrigin
=== RUN   TestAccCloudFrontDistribution_orderedCacheBehavior
=== PAUSE TestAccCloudFrontDistribution_orderedCacheBehavior
=== RUN   TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== PAUSE TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== RUN   TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy
=== PAUSE TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy
=== RUN   TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
=== PAUSE TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
=== RUN   TestAccCloudFrontDistribution_Origin_emptyDomainName
=== PAUSE TestAccCloudFrontDistribution_Origin_emptyDomainName
=== RUN   TestAccCloudFrontDistribution_Origin_emptyOriginID
=== PAUSE TestAccCloudFrontDistribution_Origin_emptyOriginID
=== RUN   TestAccCloudFrontDistribution_Origin_connectionAttempts
=== PAUSE TestAccCloudFrontDistribution_Origin_connectionAttempts
=== RUN   TestAccCloudFrontDistribution_Origin_connectionTimeout
=== PAUSE TestAccCloudFrontDistribution_Origin_connectionTimeout
=== RUN   TestAccCloudFrontDistribution_Origin_originShield
=== PAUSE TestAccCloudFrontDistribution_Origin_originShield
=== RUN   TestAccCloudFrontDistribution_Origin_originAccessControl
=== PAUSE TestAccCloudFrontDistribution_Origin_originAccessControl
=== RUN   TestAccCloudFrontDistribution_noOptionalItems
=== PAUSE TestAccCloudFrontDistribution_noOptionalItems
=== RUN   TestAccCloudFrontDistribution_http11
=== PAUSE TestAccCloudFrontDistribution_http11
=== RUN   TestAccCloudFrontDistribution_isIPV6Enabled
=== PAUSE TestAccCloudFrontDistribution_isIPV6Enabled
=== RUN   TestAccCloudFrontDistribution_noCustomErrorResponse
=== PAUSE TestAccCloudFrontDistribution_noCustomErrorResponse
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
=== RUN   TestAccCloudFrontDistribution_connectionFunctionAssociation
=== PAUSE TestAccCloudFrontDistribution_connectionFunctionAssociation
=== RUN   TestAccCloudFrontDistribution_connectionFunctionAssociationUpdate
=== PAUSE TestAccCloudFrontDistribution_connectionFunctionAssociationUpdate
=== RUN   TestAccCloudFrontDistribution_connectionFunctionAssociationRemove
=== PAUSE TestAccCloudFrontDistribution_connectionFunctionAssociationRemove
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
=== RUN   TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
=== PAUSE TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
=== RUN   TestAccCloudFrontDistribution_enabled
=== PAUSE TestAccCloudFrontDistribution_enabled
=== RUN   TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
=== PAUSE TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
=== RUN   TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
=== PAUSE TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
=== RUN   TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
=== PAUSE TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
=== RUN   TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate
=== PAUSE TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate
=== RUN   TestAccCloudFrontDistribution_waitForDeployment
=== PAUSE TestAccCloudFrontDistribution_waitForDeployment
=== RUN   TestAccCloudFrontDistribution_preconditionFailed
=== PAUSE TestAccCloudFrontDistribution_preconditionFailed
=== RUN   TestAccCloudFrontDistribution_originGroups
=== PAUSE TestAccCloudFrontDistribution_originGroups
=== RUN   TestAccCloudFrontDistribution_vpcOriginConfig
=== PAUSE TestAccCloudFrontDistribution_vpcOriginConfig
=== RUN   TestAccCloudFrontDistribution_vpcOriginConfigOwnerAccountID
=== PAUSE TestAccCloudFrontDistribution_vpcOriginConfigOwnerAccountID
=== RUN   TestAccCloudFrontDistribution_responseCompletionTimeout
=== PAUSE TestAccCloudFrontDistribution_responseCompletionTimeout
=== RUN   TestAccCloudFrontDistribution_grpcConfig
=== PAUSE TestAccCloudFrontDistribution_grpcConfig
=== RUN   TestAccCloudFrontDistribution_viewerMtlsConfig
=== PAUSE TestAccCloudFrontDistribution_viewerMtlsConfig
=== RUN   TestAccCloudFrontDistribution_cacheTagConfig
=== PAUSE TestAccCloudFrontDistribution_cacheTagConfig
=== CONT  TestAccCloudFrontDistribution_Identity_basic
=== CONT  TestAccCloudFrontDistribution_http11
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy
=== CONT  TestAccCloudFrontDistribution_originPolicyOrdered
=== CONT  TestAccCloudFrontDistribution_vpcOriginConfig
=== CONT  TestAccCloudFrontDistribution_noOptionalItems
=== CONT  TestAccCloudFrontDistribution_Origin_originAccessControl
=== CONT  TestAccCloudFrontDistribution_Origin_originShield
=== CONT  TestAccCloudFrontDistribution_Origin_connectionTimeout
=== CONT  TestAccCloudFrontDistribution_Origin_connectionAttempts
=== CONT  TestAccCloudFrontDistribution_Origin_emptyOriginID
=== CONT  TestAccCloudFrontDistribution_Origin_emptyDomainName
=== CONT  TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
=== CONT  TestAccCloudFrontDistribution_cacheTagConfig
=== CONT  TestAccCloudFrontDistribution_viewerMtlsConfig
=== CONT  TestAccCloudFrontDistribution_grpcConfig
=== CONT  TestAccCloudFrontDistribution_responseCompletionTimeout
=== CONT  TestAccCloudFrontDistribution_vpcOriginConfigOwnerAccountID
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
--- PASS: TestAccCloudFrontDistribution_Origin_emptyOriginID (7.57s)
=== CONT  TestAccCloudFrontDistribution_enabled
--- PASS: TestAccCloudFrontDistribution_Origin_emptyDomainName (7.68s)
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames (259.50s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers (261.59s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN (266.51s)
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehavior
--- PASS: TestAccCloudFrontDistribution_grpcConfig (291.73s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
--- PASS: TestAccCloudFrontDistribution_Identity_basic (326.34s)
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy
--- PASS: TestAccCloudFrontDistribution_cacheTagConfig (411.33s)
=== CONT  TestAccCloudFrontDistribution_connectionFunctionAssociation
--- PASS: TestAccCloudFrontDistribution_responseCompletionTimeout (413.53s)
=== CONT  TestAccCloudFrontDistribution_connectionFunctionAssociationRemove
--- PASS: TestAccCloudFrontDistribution_viewerMtlsConfig (459.51s)
=== CONT  TestAccCloudFrontDistribution_connectionFunctionAssociationUpdate
--- PASS: TestAccCloudFrontDistribution_http11 (468.96s)
=== CONT  TestAccCloudFrontDistribution_originGroups
--- PASS: TestAccCloudFrontDistribution_originPolicyOrdered (469.65s)
=== CONT  TestAccCloudFrontDistribution_preconditionFailed
--- PASS: TestAccCloudFrontDistribution_Origin_connectionAttempts (493.69s)
=== CONT  TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
--- PASS: TestAccCloudFrontDistribution_Origin_connectionTimeout (493.90s)
=== CONT  TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners (233.53s)
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy (497.45s)
=== CONT  TestAccCloudFrontDistribution_noCustomErrorResponse
--- PASS: TestAccCloudFrontDistribution_noOptionalItems (498.58s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
--- PASS: TestAccCloudFrontDistribution_Origin_originShield (500.37s)
=== CONT  TestAccCloudFrontDistribution_tags
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups (233.28s)
=== CONT  TestAccCloudFrontDistribution_originPolicyDefault
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN (281.26s)
=== CONT  TestAccCloudFrontDistribution_customOriginIPAddressType
--- PASS: TestAccCloudFrontDistribution_forwardedValuesToCachePolicy (547.82s)
=== CONT  TestAccCloudFrontDistribution_customOrigin
--- PASS: TestAccCloudFrontDistribution_Origin_originAccessControl (555.15s)
=== CONT  TestAccCloudFrontDistribution_includeCookieWhenV1loggingDisabled
--- PASS: TestAccCloudFrontDistribution_connectionFunctionAssociation (239.56s)
=== CONT  TestAccCloudFrontDistribution_s3Origin
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames (213.94s)
=== CONT  TestAccCloudFrontDistribution_multiOrigin
--- PASS: TestAccCloudFrontDistribution_enabled (708.29s)
=== CONT  TestAccCloudFrontDistribution_disappears
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers (228.29s)
=== CONT  TestAccCloudFrontDistribution_isIPV6Enabled
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehavior (449.44s)
=== CONT  TestAccCloudFrontDistribution_Identity_ExistingResource_noRefreshNoChange
--- PASS: TestAccCloudFrontDistribution_connectionFunctionAssociationRemove (310.73s)
=== CONT  TestAccCloudFrontDistribution_List_includeResource
--- PASS: TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN (246.93s)
=== CONT  TestAccCloudFrontDistribution_List_basic
--- PASS: TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate (246.96s)
=== CONT  TestAccCloudFrontDistribution_basic
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy (415.99s)
=== CONT  TestAccCloudFrontDistribution_Identity_ExistingResource_basic
--- PASS: TestAccCloudFrontDistribution_tags (283.50s)
=== CONT  TestAccCloudFrontDistribution_waitForDeployment
--- PASS: TestAccCloudFrontDistribution_connectionFunctionAssociationUpdate (328.96s)
--- PASS: TestAccCloudFrontDistribution_originGroups (425.46s)
--- PASS: TestAccCloudFrontDistribution_noCustomErrorResponse (443.52s)
--- PASS: TestAccCloudFrontDistribution_disappears (242.52s)
--- PASS: TestAccCloudFrontDistribution_preconditionFailed (494.73s)
--- PASS: TestAccCloudFrontDistribution_List_includeResource (242.45s)
--- PASS: TestAccCloudFrontDistribution_originPolicyDefault (447.23s)
--- PASS: TestAccCloudFrontDistribution_includeCookieWhenV1loggingDisabled (417.47s)
--- PASS: TestAccCloudFrontDistribution_customOrigin (426.19s)
--- PASS: TestAccCloudFrontDistribution_List_basic (244.15s)
--- PASS: TestAccCloudFrontDistribution_basic (254.31s)
--- PASS: TestAccCloudFrontDistribution_Identity_ExistingResource_noRefreshNoChange (274.92s)
--- PASS: TestAccCloudFrontDistribution_Identity_ExistingResource_basic (268.38s)
--- PASS: TestAccCloudFrontDistribution_customOriginIPAddressType (498.84s)
--- PASS: TestAccCloudFrontDistribution_s3Origin (468.92s)
--- PASS: TestAccCloudFrontDistribution_multiOrigin (422.52s)
--- PASS: TestAccCloudFrontDistribution_isIPV6Enabled (412.41s)
--- PASS: TestAccCloudFrontDistribution_waitForDeployment (458.43s)
--- PASS: TestAccCloudFrontDistribution_vpcOriginConfig (1509.18s)
--- PASS: TestAccCloudFrontDistribution_vpcOriginConfigOwnerAccountID (1523.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 1529.566s
```
