### PR TITLE
[bugfix] d/aws_opensearch_domain: Add missing `jwt_options` block to fix "Invalid address to set" error

### DIFF
--- a/.changelog/47874.txt
+++ b/.changelog/47874.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_opensearch_domain: Add `jwt_options` block to fix "Invalid address to set" error
+```

--- a/internal/service/opensearch/domain_data_source.go
+++ b/internal/service/opensearch/domain_data_source.go
@@ -52,6 +52,30 @@ func dataSourceDomain() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
+						"jwt_options": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									names.AttrEnabled: {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									names.AttrPublicKey: {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"roles_key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"subject_key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/internal/service/opensearch/domain_data_source_test.go
+++ b/internal/service/opensearch/domain_data_source_test.go
@@ -90,6 +90,34 @@ func TestAccOpenSearchDomainDataSource_complex(t *testing.T) {
 	})
 }
 
+func TestAccOpenSearchDomainDataSource_advancedSecurityOptionsJWTOptions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	ctx := acctest.Context(t)
+	rName := testAccRandomDomainName(t)
+	datasourceName := "data.aws_opensearch_domain.test"
+	resourceName := "aws_opensearch_domain.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainDataSourceConfig_advancedSecurityOptionsJWTOptions(rName, "OpenSearch", "2.11", "sub", "roles"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "advanced_security_options.0.jwt_options.#", resourceName, "advanced_security_options.0.jwt_options.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "advanced_security_options.0.jwt_options.0.enabled", resourceName, "advanced_security_options.0.jwt_options.0.enabled"),
+					resource.TestCheckResourceAttrPair(datasourceName, "advanced_security_options.0.jwt_options.0.subject_key", resourceName, "advanced_security_options.0.jwt_options.0.subject_key"),
+					resource.TestCheckResourceAttrPair(datasourceName, "advanced_security_options.0.jwt_options.0.roles_key", resourceName, "advanced_security_options.0.jwt_options.0.roles_key"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDomainDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccDomainConfig_basic(rName), `
 data "aws_opensearch_domain" "test" {
@@ -100,6 +128,14 @@ data "aws_opensearch_domain" "test" {
 
 func testAccDomainDataSourceConfig_complex(rName string) string {
 	return acctest.ConfigCompose(testAccDomainConfig_complex(rName), `
+data "aws_opensearch_domain" "test" {
+  domain_name = aws_opensearch_domain.test.domain_name
+}
+`)
+}
+
+func testAccDomainDataSourceConfig_advancedSecurityOptionsJWTOptions(rName, engineType, version, subjectKey, rolesKey string) string {
+	return acctest.ConfigCompose(testAccDomainConfig_advancedSecurityOptionsJWTOptions(rName, engineType, version, subjectKey, rolesKey), `
 data "aws_opensearch_domain" "test" {
   domain_name = aws_opensearch_domain.test.domain_name
 }

--- a/website/docs/d/opensearch_domain.html.markdown
+++ b/website/docs/d/opensearch_domain.html.markdown
@@ -32,8 +32,14 @@ This data source exports the following attributes in addition to the arguments a
 * `access_policies` - Policy document attached to the domain.
 * `advanced_options` - Key-value string pairs to specify advanced configuration options.
 * `advanced_security_options` - Status of the OpenSearch domain's advanced security options. The block consists of the following attributes:
+    * `anonymous_auth_enabled` - Whether Anonymous auth is enabled.
     * `enabled` - Whether advanced security is enabled.
     * `internal_user_database_enabled` - Whether the internal user database is enabled.
+    * `jwt_options` - Block for JWT authentication.
+        * `enabled` - Whether JWT authentication is enabled.
+        * `public_key` - PEM-encoded public key used to verify JWT signatures.
+        * `role_key` - Element of the JWT assertion to use for roles.
+        * `subject_key` - Element of the JWT assertion to use for the user name.
 * `arn` - ARN of the domain.
 * `auto_tune_options` - Configuration of the Auto-Tune options of the domain.
     * `desired_state` - Auto-Tune desired state for the domain.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR adds the missing `jwt_options` block to the schema of the `aws_opensearch_domain` data source.

PR #46439 added the `jwt_options` block to the `aws_opensearch_domain` resource. To support this configuration block, the flattener for `advanced_security_options` was updated.

Because this flattener is also used by the `aws_opensearch_domain` data source, the schema in the data source should have been updated as well.



### Relations

Closes #47789



### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccOpenSearchDomainDataSource_advancedSecurityOptionsJWTOptions' PKG=opensearch
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     5.702s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 5.573s
make: Running acceptance tests on branch: 🌿 b-aws_opensearch_domain-add_jwt_options_to_data_source 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchDomainDataSource_advancedSecurityOptionsJWTOptions'  -timeout 360m -vet=off -buildvcs=false
2026/05/13 00:59:09 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/13 00:59:09 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccOpenSearchDomainDataSource_advancedSecurityOptionsJWTOptions
=== PAUSE TestAccOpenSearchDomainDataSource_advancedSecurityOptionsJWTOptions
=== CONT  TestAccOpenSearchDomainDataSource_advancedSecurityOptionsJWTOptions
--- PASS: TestAccOpenSearchDomainDataSource_advancedSecurityOptionsJWTOptions (1479.53s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 1485.227s

```
