### PR TITLE
Replace `reflect.Ptr` with modern `reflect.Pointer`

### DIFF
--- a/internal/cty/to_framework.go
+++ b/internal/cty/to_framework.go
@@ -27,7 +27,7 @@ func ToFramework(ctx context.Context, source cty.Value, target any) error {
 	}
 
 	vTarget := reflect.ValueOf(target)
-	if kind := vTarget.Kind(); kind != reflect.Ptr { //nolint:govet // wants us to inline constant which would be less readable
+	if kind := vTarget.Kind(); kind != reflect.Pointer {
 		return fmt.Errorf("target must be a pointer, got %T (Kind: %s)", target, kind)
 	}
 	vTarget = vTarget.Elem()

--- a/internal/framework/flex/autoflex_expand.go
+++ b/internal/framework/flex/autoflex_expand.go
@@ -188,7 +188,7 @@ func (expander autoExpander) convert(ctx context.Context, sourcePath path.Path, 
 	// No need to set the target value if there's no source value.
 	if vFrom.IsNull() {
 		// Special case: if target is XML wrapper struct and no omitempty, create zero-value
-		if vTo.Kind() == reflect.Ptr && !fieldOpts.omitempty { //nolint:govet // wants us to inline constant which would be less readable
+		if vTo.Kind() == reflect.Pointer && !fieldOpts.omitempty {
 			targetType := vTo.Type().Elem()
 			if targetType.Kind() == reflect.Struct && potentialXMLWrapperStruct(targetType) {
 				tflog.SubsystemDebug(ctx, subsystemName, "Source is null but target is XML wrapper without omitempty - creating zero-value struct")
@@ -200,7 +200,7 @@ func (expander autoExpander) convert(ctx context.Context, sourcePath path.Path, 
 					itemsField.Set(reflect.MakeSlice(itemsField.Type(), 0, 0))
 				}
 				quantityField := zeroStruct.Elem().FieldByName(xmlWrapperFieldQuantity)
-				if quantityField.IsValid() && quantityField.Kind() == reflect.Ptr { //nolint:govet // wants us to inline constant which would be less readable
+				if quantityField.IsValid() && quantityField.Kind() == reflect.Pointer {
 					zero := int32(0)
 					quantityField.Set(reflect.ValueOf(&zero))
 				}
@@ -211,7 +211,7 @@ func (expander autoExpander) convert(ctx context.Context, sourcePath path.Path, 
 					if fieldType.Name == wrapperFieldName || fieldType.Name == xmlWrapperFieldQuantity {
 						continue
 					}
-					if field.Kind() == reflect.Ptr && field.CanSet() && field.IsNil() { //nolint:govet // wants us to inline constant which would be less readable
+					if field.Kind() == reflect.Pointer && field.CanSet() && field.IsNil() {
 						switch fieldType.Type.Elem().Kind() {
 						case reflect.Bool:
 							falseVal := false
@@ -1993,7 +1993,7 @@ func (expander *autoExpander) nestedObjectCollectionToXMLWrapper(ctx context.Con
 		})
 
 		// Handle pointer to struct (which is what NestedObjectCollection contains)
-		if nestedObj.Kind() == reflect.Ptr && !nestedObj.IsNil() { //nolint:govet // wants us to inline constant which would be less readable
+		if nestedObj.Kind() == reflect.Pointer && !nestedObj.IsNil() {
 			structObj := nestedObj.Elem()
 			if structObj.Kind() == reflect.Struct {
 				// Check if the struct has a wrapper field - indicates Rule 2
@@ -2548,7 +2548,7 @@ func (expander autoExpander) buildGenericXMLWrapperCollapse(ctx context.Context,
 					if itemsField.IsValid() && itemsField.Kind() == reflect.Slice {
 						itemsField.Set(reflect.MakeSlice(itemsField.Type(), 0, 0))
 					}
-					if quantityField.IsValid() && quantityField.Kind() == reflect.Ptr && quantityField.Type().Elem().Kind() == reflect.Int32 { //nolint:govet // wants us to inline constant which would be less readable
+					if quantityField.IsValid() && quantityField.Kind() == reflect.Pointer && quantityField.Type().Elem().Kind() == reflect.Int32 {
 						zero := int32(0)
 						quantityField.Set(reflect.ValueOf(&zero))
 					}
@@ -2562,7 +2562,7 @@ func (expander autoExpander) buildGenericXMLWrapperCollapse(ctx context.Context,
 							continue
 						}
 						// Set zero value for pointer fields
-						if field.Kind() == reflect.Ptr && field.CanSet() && field.IsNil() { //nolint:govet // wants us to inline constant which would be less readable
+						if field.Kind() == reflect.Pointer && field.CanSet() && field.IsNil() {
 							switch fieldType.Type.Elem().Kind() {
 							case reflect.Bool:
 								falseVal := false
@@ -2617,7 +2617,7 @@ func (expander autoExpander) buildGenericXMLWrapperCollapse(ctx context.Context,
 						if itemsField.Kind() == reflect.Slice {
 							itemsField.Set(reflect.MakeSlice(itemsField.Type(), 0, 0))
 						}
-						if quantityField.Kind() == reflect.Ptr && quantityField.Type().Elem().Kind() == reflect.Int32 { //nolint:govet // wants us to inline constant which would be less readable
+						if quantityField.Kind() == reflect.Pointer && quantityField.Type().Elem().Kind() == reflect.Int32 {
 							zero := int32(0)
 							quantityField.Set(reflect.ValueOf(&zero))
 						}

--- a/internal/framework/flex/autoflex_flatten.go
+++ b/internal/framework/flex/autoflex_flatten.go
@@ -1013,7 +1013,7 @@ func (flattener autoFlattener) map_(ctx context.Context, sourcePath path.Path, v
 						}
 						tflog.SubsystemTrace(ctx, subsystemName, "Flattening with NewMapValueOf", map[string]any{
 							logAttrKeySourcePath: sourcePath.AtMapKey(k).String(),
-							logAttrKeySourceType: fullTypeName(reflect.TypeOf(v)),
+							logAttrKeySourceType: fullTypeName(reflect.TypeFor[map[string]string]()),
 							logAttrKeySourceSize: len(v),
 							logAttrKeyTargetPath: targetPath.AtMapKey(k).String(),
 							logAttrKeyTargetType: fullTypeName(reflect.TypeFor[map[string]attr.Value]()),
@@ -1054,7 +1054,7 @@ func (flattener autoFlattener) map_(ctx context.Context, sourcePath path.Path, v
 						}
 						tflog.SubsystemTrace(ctx, subsystemName, "Flattening with NewMapValueOf", map[string]any{
 							logAttrKeySourcePath: sourcePath.AtMapKey(k).String(),
-							logAttrKeySourceType: fullTypeName(reflect.TypeOf(v)),
+							logAttrKeySourceType: fullTypeName(reflect.TypeFor[map[string]*string]()),
 							logAttrKeySourceSize: len(v),
 							logAttrKeyTargetPath: targetPath.AtMapKey(k).String(),
 							logAttrKeyTargetType: fullTypeName(reflect.TypeFor[map[string]attr.Value]()),
@@ -1741,7 +1741,7 @@ func (flattener *autoFlattener) xmlWrapperFlatten(ctx context.Context, sourcePat
 		// Rule 2 detection: check if source AWS struct has more than 2 fields
 		// (Items, Quantity, plus additional fields like Enabled)
 		sourceStructType := vFrom.Type()
-		if sourceStructType.Kind() == reflect.Ptr { //nolint:govet // wants us to inline constant which would be less readable
+		if sourceStructType.Kind() == reflect.Pointer {
 			sourceStructType = sourceStructType.Elem()
 		}
 

--- a/internal/framework/flex/autoflex_primitives_test.go
+++ b/internal/framework/flex/autoflex_primitives_test.go
@@ -477,7 +477,7 @@ func runBasicRoundtripTest[T any](t *testing.T, testName string, variant string,
 			v := reflect.ValueOf(awsStruct).Elem()
 			field := v.FieldByName("Field1")
 			awsFieldType := field.Type()
-			if awsFieldType.Kind() == reflect.Ptr { //nolint:govet // wants us to inline constant which would be less readable
+			if awsFieldType.Kind() == reflect.Pointer {
 				if field.IsValid() && field.CanSet() {
 					field.Set(reflect.ValueOf(typeInfo.GetAWSNil()))
 				}
@@ -491,7 +491,7 @@ func runBasicRoundtripTest[T any](t *testing.T, testName string, variant string,
 			v := reflect.ValueOf(awsStruct).Elem()
 			field := v.FieldByName("Field1")
 			awsFieldType := field.Type()
-			if awsFieldType.Kind() == reflect.Ptr { //nolint:govet // wants us to inline constant which would be less readable
+			if awsFieldType.Kind() == reflect.Pointer {
 				if field.IsValid() && field.CanSet() {
 					field.Set(reflect.ValueOf(typeInfo.GetAWSNil()))
 				}
@@ -505,7 +505,7 @@ func runBasicRoundtripTest[T any](t *testing.T, testName string, variant string,
 			v := reflect.ValueOf(awsStruct).Elem()
 			field := v.FieldByName("Field1")
 			awsFieldType := field.Type()
-			if awsFieldType.Kind() == reflect.Ptr { //nolint:govet // wants us to inline constant which would be less readable
+			if awsFieldType.Kind() == reflect.Pointer {
 				if field.IsValid() && field.CanSet() {
 					field.Set(reflect.ValueOf(typeInfo.CreateAWSValue(value)))
 				}
@@ -523,7 +523,7 @@ func runBasicRoundtripTest[T any](t *testing.T, testName string, variant string,
 			awsFieldType := field.Type()
 			// For null values with non-pointer AWS fields, set to zero value
 			// For pointer fields, leave unset (nil is already the zero value)
-			if awsFieldType.Kind() != reflect.Ptr { //nolint:govet // wants us to inline constant which would be less readable
+			if awsFieldType.Kind() != reflect.Pointer {
 				if field.IsValid() && field.CanSet() {
 					field.Set(reflect.ValueOf(typeInfo.GetZeroValue()))
 				}
@@ -533,7 +533,7 @@ func runBasicRoundtripTest[T any](t *testing.T, testName string, variant string,
 			v := reflect.ValueOf(awsStruct).Elem()
 			field := v.FieldByName("Field1")
 			awsFieldType := field.Type()
-			if awsFieldType.Kind() == reflect.Ptr { //nolint:govet // wants us to inline constant which would be less readable
+			if awsFieldType.Kind() == reflect.Pointer {
 				if field.IsValid() && field.CanSet() {
 					field.Set(reflect.ValueOf(typeInfo.CreateAWSValue(value)))
 				}

--- a/internal/framework/flex/diff.go
+++ b/internal/framework/flex/diff.go
@@ -94,7 +94,7 @@ func Diff(ctx context.Context, plan, state any, options ...ChangeOption) (*Resul
 }
 
 func dereferencePointer(value reflect.Value) reflect.Value {
-	if value.Kind() == reflect.Ptr { //nolint:govet // wants us to inline constant which would be less readable
+	if value.Kind() == reflect.Pointer {
 		return value.Elem()
 	}
 	return value

--- a/internal/framework/types/attrtypes.go
+++ b/internal/framework/types/attrtypes.go
@@ -23,7 +23,7 @@ func AttributeTypes[T any](ctx context.Context) (map[string]attr.Type, diag.Diag
 	val := reflect.ValueOf(t)
 	typ := val.Type()
 
-	if typ.Kind() == reflect.Ptr && typ.Elem().Kind() == reflect.Struct { //nolint:govet // reflect.Ptr is a constant
+	if typ.Kind() == reflect.Pointer && typ.Elem().Kind() == reflect.Struct { 
 		val = reflect.New(typ.Elem()).Elem()
 		typ = typ.Elem()
 	}

--- a/internal/framework/types/attrtypes.go
+++ b/internal/framework/types/attrtypes.go
@@ -23,7 +23,7 @@ func AttributeTypes[T any](ctx context.Context) (map[string]attr.Type, diag.Diag
 	val := reflect.ValueOf(t)
 	typ := val.Type()
 
-	if typ.Kind() == reflect.Pointer && typ.Elem().Kind() == reflect.Struct { 
+	if typ.Kind() == reflect.Pointer && typ.Elem().Kind() == reflect.Struct {
 		val = reflect.New(typ.Elem()).Elem()
 		typ = typ.Elem()
 	}

--- a/internal/framework/with_list.go
+++ b/internal/framework/with_list.go
@@ -106,7 +106,7 @@ func setZeroValueAttrFieldsToNull(ctx context.Context, target any) diag.Diagnost
 		return diags
 	}
 
-	if value.Kind() != reflect.Ptr { //nolint:govet // reflect.Ptr is a constant
+	if value.Kind() != reflect.Pointer {
 		diags.AddError("Normalizing List Result", fmt.Sprintf("target must be a pointer, got %T", target))
 		return diags
 	}

--- a/internal/provider/framework/listresource/list_result_intercept.go
+++ b/internal/provider/framework/listresource/list_result_intercept.go
@@ -240,7 +240,7 @@ func (r defaultObjectInterceptor) Read(ctx context.Context, params InterceptorPa
 	var diags diag.Diagnostics
 	switch params.When {
 	case Before:
-		if reflect.ValueOf(params.Data).Kind() != reflect.Ptr { //nolint:govet // wants us to inline constant which would be less readable
+		if reflect.ValueOf(params.Data).Kind() != reflect.Pointer {
 			diags.AddError(
 				"Internal Error",
 				"data object must be a pointer")
@@ -298,7 +298,7 @@ func (r defaultObjectInterceptor) Read(ctx context.Context, params InterceptorPa
 }
 
 func dereferencePointer(value reflect.Value) reflect.Value {
-	if value.Kind() == reflect.Ptr { //nolint:govet // wants us to inline constant which would be less readable
+	if value.Kind() == reflect.Pointer {
 		return value.Elem()
 	}
 	return value

--- a/internal/provider/sdkv2/provider_acc_test.go
+++ b/internal/provider/sdkv2/provider_acc_test.go
@@ -1014,8 +1014,7 @@ func funcHasConnFuncSignature(method reflect.Value) bool {
 		return false
 	}
 
-	fn := func(ctx context.Context) {}
-	ftyp := reflect.TypeOf(fn)
+	ftyp := reflect.TypeFor[func(ctx context.Context)]()
 
 	return typ.In(0) == ftyp.In(0)
 }

--- a/internal/reflect/struct.go
+++ b/internal/reflect/struct.go
@@ -77,7 +77,7 @@ func ExportedStructFields(typ reflect.Type) iter.Seq[reflect.StructField] {
 // Tag options (e.g. ",omitempty") are stripped before comparison.
 func FieldByTag(v any, tagKey, tagValue string) (reflect.StructField, bool) {
 	t := reflect.TypeOf(v)
-	if t.Kind() == reflect.Pointer { 
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	if t.Kind() != reflect.Struct {

--- a/internal/reflect/struct.go
+++ b/internal/reflect/struct.go
@@ -77,7 +77,7 @@ func ExportedStructFields(typ reflect.Type) iter.Seq[reflect.StructField] {
 // Tag options (e.g. ",omitempty") are stripped before comparison.
 func FieldByTag(v any, tagKey, tagValue string) (reflect.StructField, bool) {
 	t := reflect.TypeOf(v)
-	if t.Kind() == reflect.Ptr { //nolint:govet // wants us to inline constant which would be less readable
+	if t.Kind() == reflect.Pointer { 
 		t = t.Elem()
 	}
 	if t.Kind() != reflect.Struct {

--- a/internal/service/lakeformation/prettify.go
+++ b/internal/service/lakeformation/prettify.go
@@ -26,7 +26,7 @@ const indentValue = 2
 // prettifyInternal will recursively walk value v to build a textual
 // representation of the value.
 func prettifyInternal(v reflect.Value, indent int, buf *bytes.Buffer) {
-	for v.Kind() == reflect.Pointer { 
+	for v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 
@@ -50,7 +50,7 @@ func prettifyInternal(v reflect.Value, indent int, buf *bytes.Buffer) {
 			if name[0:1] == strings.ToLower(name[0:1]) {
 				continue // ignore unexported fields
 			}
-			if (f.Kind() == reflect.Pointer || f.Kind() == reflect.Slice || f.Kind() == reflect.Map) && f.IsNil() { 
+			if (f.Kind() == reflect.Pointer || f.Kind() == reflect.Slice || f.Kind() == reflect.Map) && f.IsNil() {
 				continue // ignore unset fields
 			}
 			names = append(names, name)

--- a/internal/service/lakeformation/prettify.go
+++ b/internal/service/lakeformation/prettify.go
@@ -26,7 +26,7 @@ const indentValue = 2
 // prettifyInternal will recursively walk value v to build a textual
 // representation of the value.
 func prettifyInternal(v reflect.Value, indent int, buf *bytes.Buffer) {
-	for v.Kind() == reflect.Ptr { //nolint:govet // wants us to inline constant which would be less readable
+	for v.Kind() == reflect.Pointer { 
 		v = v.Elem()
 	}
 
@@ -50,7 +50,7 @@ func prettifyInternal(v reflect.Value, indent int, buf *bytes.Buffer) {
 			if name[0:1] == strings.ToLower(name[0:1]) {
 				continue // ignore unexported fields
 			}
-			if (f.Kind() == reflect.Ptr || f.Kind() == reflect.Slice || f.Kind() == reflect.Map) && f.IsNil() { //nolint:govet // wants us to inline constant which would be less readable
+			if (f.Kind() == reflect.Pointer || f.Kind() == reflect.Slice || f.Kind() == reflect.Map) && f.IsNil() { 
 				continue // ignore unset fields
 			}
 			names = append(names, name)

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -1123,7 +1123,7 @@ func walkWebACLJSON(v reflect.Value) {
 		},
 	}
 
-	for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface { //nolint:govet // wants us to inline a readable constant
+	for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
 		v = v.Elem()
 	}
 
@@ -1170,7 +1170,7 @@ func walkRulesGroupJSON(v reflect.Value) {
 		},
 	}
 
-	for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface { //nolint:govet // wants us to inline a readable constant
+	for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
 		v = v.Elem()
 	}
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

The `reflect.Kind` value `reflect.Ptr` has been replaced with the canonical modern version `reflect.Pointer`. In many places our code used `reflect.Ptr`. `reflect.Ptr` has a `//go:fix inline` declaration.

Ran `go fix ./...` to automatically apply the fix

This also applied several `reflect.TypeOf` to `reflect.TypeFor` optimizations.
