### PR TITLE
[Enhancement] aws_vpclattice_resource_gateway: Add `resource_config_dns_resolution` argument

### DIFF
--- a/.changelog/47879.txt
+++ b/.changelog/47879.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_vpclattice_resource_gateway: Add `resource_config_dns_resolution` argument
+```

--- a/internal/service/vpclattice/resource_gateway.go
+++ b/internal/service/vpclattice/resource_gateway.go
@@ -92,6 +92,15 @@ func (r *resourceGatewayResource) Schema(ctx context.Context, request resource.S
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"resource_config_dns_resolution": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.ResourceConfigDnsResolution](),
+				Optional:   true,
+				Computed:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			names.AttrSecurityGroupIDs: schema.SetAttribute{
 				CustomType:  fwtypes.SetOfStringType,
 				Optional:    true,
@@ -374,16 +383,17 @@ func waitResourceGatewayDeleted(ctx context.Context, conn *vpclattice.Client, id
 
 type resourceGatewayResourceModel struct {
 	framework.WithRegionModel
-	ARN                 types.String                                              `tfsdk:"arn"`
-	ID                  types.String                                              `tfsdk:"id"`
-	IPAddressType       fwtypes.StringEnum[awstypes.ResourceGatewayIpAddressType] `tfsdk:"ip_address_type"`
-	IPV4AddressesPerEni types.Int32                                               `tfsdk:"ipv4_addresses_per_eni"`
-	Name                types.String                                              `tfsdk:"name"`
-	SecurityGroupIDs    fwtypes.SetOfString                                       `tfsdk:"security_group_ids"`
-	Status              fwtypes.StringEnum[awstypes.ResourceGatewayStatus]        `tfsdk:"status"`
-	SubnetIDs           fwtypes.SetOfString                                       `tfsdk:"subnet_ids"`
-	Tags                tftags.Map                                                `tfsdk:"tags"`
-	TagsAll             tftags.Map                                                `tfsdk:"tags_all"`
-	Timeouts            timeouts.Value                                            `tfsdk:"timeouts"`
-	VPCID               types.String                                              `tfsdk:"vpc_id"`
+	ARN                         types.String                                              `tfsdk:"arn"`
+	ID                          types.String                                              `tfsdk:"id"`
+	IPAddressType               fwtypes.StringEnum[awstypes.ResourceGatewayIpAddressType] `tfsdk:"ip_address_type"`
+	IPV4AddressesPerEni         types.Int32                                               `tfsdk:"ipv4_addresses_per_eni"`
+	Name                        types.String                                              `tfsdk:"name"`
+	ResourceConfigDNSResolution fwtypes.StringEnum[awstypes.ResourceConfigDnsResolution]  `tfsdk:"resource_config_dns_resolution"`
+	SecurityGroupIDs            fwtypes.SetOfString                                       `tfsdk:"security_group_ids"`
+	Status                      fwtypes.StringEnum[awstypes.ResourceGatewayStatus]        `tfsdk:"status"`
+	SubnetIDs                   fwtypes.SetOfString                                       `tfsdk:"subnet_ids"`
+	Tags                        tftags.Map                                                `tfsdk:"tags"`
+	TagsAll                     tftags.Map                                                `tfsdk:"tags_all"`
+	Timeouts                    timeouts.Value                                            `tfsdk:"timeouts"`
+	VPCID                       types.String                                              `tfsdk:"vpc_id"`
 }

--- a/internal/service/vpclattice/resource_gateway_test.go
+++ b/internal/service/vpclattice/resource_gateway_test.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
@@ -38,6 +40,7 @@ func TestAccVPCLatticeResourceGateway_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGatewayExists(ctx, t, resourceName, &resourcegateway),
 					resource.TestCheckResourceAttr(resourceName, names.AttrIPAddressType, "IPV4"),
+					resource.TestCheckResourceAttr(resourceName, "resource_config_dns_resolution", string(awstypes.ResourceConfigDnsResolutionPublic)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "ACTIVE"),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "1"),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "vpc-lattice", regexache.MustCompile(`resourcegateway/rgw-.+`)),
@@ -268,6 +271,62 @@ func TestAccVPCLatticeResourceGateway_update(t *testing.T) {
 	})
 }
 
+func TestAccVPCLatticeResourceGateway_resourceConfigDNSResolution(t *testing.T) {
+	ctx := acctest.Context(t)
+	var resourcegateway vpclattice.GetResourceGatewayOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_vpclattice_resource_gateway.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.VPCLatticeEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckResourceGatewayDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceGatewayConfig_resourceConfigDNSResolution(rName, string(awstypes.ResourceConfigDnsResolutionInVpc)),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGatewayExists(ctx, t, resourceName, &resourcegateway),
+					resource.TestCheckResourceAttr(resourceName, names.AttrIPAddressType, "IPV4"),
+					resource.TestCheckResourceAttr(resourceName, "resource_config_dns_resolution", string(awstypes.ResourceConfigDnsResolutionInVpc)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "ACTIVE"),
+					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "1"),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "vpc-lattice", regexache.MustCompile(`resourcegateway/rgw-.+`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccResourceGatewayConfig_resourceConfigDNSResolution(rName, string(awstypes.ResourceConfigDnsResolutionPublic)),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGatewayExists(ctx, t, resourceName, &resourcegateway),
+					resource.TestCheckResourceAttr(resourceName, names.AttrIPAddressType, "IPV4"),
+					resource.TestCheckResourceAttr(resourceName, "resource_config_dns_resolution", string(awstypes.ResourceConfigDnsResolutionPublic)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "ACTIVE"),
+					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "1"),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "vpc-lattice", regexache.MustCompile(`resourcegateway/rgw-.+`)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccVPCLatticeResourceGateway_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var resourcegateway vpclattice.GetResourceGatewayOutput
@@ -462,4 +521,16 @@ resource "aws_vpclattice_resource_gateway" "test" {
   ip_address_type    = "IPV4"
 }
 `, rName))
+}
+
+func testAccResourceGatewayConfig_resourceConfigDNSResolution(rName, dnsResolution string) string {
+	return acctest.ConfigCompose(testAccResourceGatewayConfig_base(rName), fmt.Sprintf(`
+resource "aws_vpclattice_resource_gateway" "test" {
+  name       = %[1]q
+  vpc_id     = aws_vpc.test.id
+  subnet_ids = [aws_subnet.test.id]
+
+  resource_config_dns_resolution = %[2]q
+}
+`, rName, dnsResolution))
 }

--- a/website/docs/r/vpclattice_resource_gateway.html.markdown
+++ b/website/docs/r/vpclattice_resource_gateway.html.markdown
@@ -64,6 +64,7 @@ The following arguments are optional:
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `ip_address_type` - (Optional) IP address type used by the resource gateway. Valid values are `IPV4`, `IPV6`, and `DUALSTACK`. The IP address type of a resource gateway must be compatible with the subnets of the resource gateway and the IP address type of the resource.
 * `ipv4_addresses_per_eni` - (Optional) The number of IPv4 addresses per ENI for your resource. This argument is only applicable to `IPV4` and `DUALSTACK` IP address types. Defaults to `16`.
+* `resource_config_dns_resolution` - (Optional) Indicates how DNS is resolved for resource configurations associated to this resource gateway. Valid values are `IN_VPC` and `PUBLIC`. Defaults to `PUBLIC`. Changing this value will trigger a resource replacement.
 * `security_group_ids` - (Optional) Security group IDs associated with the resource gateway. The security groups must be in the same VPC.
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR adds the `resource_config_dns_resolution` argument to the `aws_vpclattice_resource_gateway` resource.

* Even when `resource_config_dns_resolution` is not specified, the AWS API returns it as `PUBLIC`. Therefore, it is marked as `Computed`.

* The [API reference](https://docs.aws.amazon.com/vpc-lattice/latest/APIReference/API_CreateResourceGateway.html#vpclattice-CreateResourceGateway-request-resourceConfigDnsResolution) states that `ResourceConfigDnsResolution` is set at creation time and cannot be changed. Therefore, it is marked as `ForceNew`.

### Relations
Closes #47878 

### References
Announcement
https://aws.amazon.com/about-aws/whats-new/2026/05/amazon-vpc-lattice/

API reference
https://docs.aws.amazon.com/ja_jp/vpc-lattice/latest/APIReference/API_CreateResourceGateway.html#vpclattice-CreateResourceGateway-request-resourceConfigDnsResolution

### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccVPCLatticeResourceGateway_' PKG=vpclattice 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_vpclattice_resource_gateway-add_resource_config_dns_resolution 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/vpclattice/... -v -count 1 -parallel 20 -run='TestAccVPCLatticeResourceGateway_'  -timeout 360m -vet=off -buildvcs=false
2026/05/13 07:04:36 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/13 07:04:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCLatticeResourceGateway_tags
=== PAUSE TestAccVPCLatticeResourceGateway_tags
=== RUN   TestAccVPCLatticeResourceGateway_Tags_null
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_null
=== RUN   TestAccVPCLatticeResourceGateway_Tags_emptyMap
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_emptyMap
=== RUN   TestAccVPCLatticeResourceGateway_Tags_addOnUpdate
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_addOnUpdate
=== RUN   TestAccVPCLatticeResourceGateway_Tags_EmptyTag_onCreate
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_EmptyTag_onCreate
=== RUN   TestAccVPCLatticeResourceGateway_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccVPCLatticeResourceGateway_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccVPCLatticeResourceGateway_Tags_DefaultTags_providerOnly
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_DefaultTags_providerOnly
=== RUN   TestAccVPCLatticeResourceGateway_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccVPCLatticeResourceGateway_Tags_DefaultTags_overlapping
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_DefaultTags_overlapping
=== RUN   TestAccVPCLatticeResourceGateway_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccVPCLatticeResourceGateway_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccVPCLatticeResourceGateway_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccVPCLatticeResourceGateway_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccVPCLatticeResourceGateway_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccVPCLatticeResourceGateway_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccVPCLatticeResourceGateway_Tags_ComputedTag_onCreate
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_ComputedTag_onCreate
=== RUN   TestAccVPCLatticeResourceGateway_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccVPCLatticeResourceGateway_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccVPCLatticeResourceGateway_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccVPCLatticeResourceGateway_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccVPCLatticeResourceGateway_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccVPCLatticeResourceGateway_basic
=== PAUSE TestAccVPCLatticeResourceGateway_basic
=== RUN   TestAccVPCLatticeResourceGateway_addressTypeDualstack
=== PAUSE TestAccVPCLatticeResourceGateway_addressTypeDualstack
=== RUN   TestAccVPCLatticeResourceGateway_addressTypeIPv6
=== PAUSE TestAccVPCLatticeResourceGateway_addressTypeIPv6
=== RUN   TestAccVPCLatticeResourceGateway_multipleSubnets
=== PAUSE TestAccVPCLatticeResourceGateway_multipleSubnets
=== RUN   TestAccVPCLatticeResourceGateway_ipv4AddressesPerEni
=== PAUSE TestAccVPCLatticeResourceGateway_ipv4AddressesPerEni
=== RUN   TestAccVPCLatticeResourceGateway_update
=== PAUSE TestAccVPCLatticeResourceGateway_update
=== RUN   TestAccVPCLatticeResourceGateway_resourceConfigDNSResolution
=== PAUSE TestAccVPCLatticeResourceGateway_resourceConfigDNSResolution
=== RUN   TestAccVPCLatticeResourceGateway_disappears
=== PAUSE TestAccVPCLatticeResourceGateway_disappears
=== CONT  TestAccVPCLatticeResourceGateway_tags
=== CONT  TestAccVPCLatticeResourceGateway_Tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccVPCLatticeResourceGateway_Tags_ComputedTag_OnUpdate_replace
=== CONT  TestAccVPCLatticeResourceGateway_addressTypeDualstack
=== CONT  TestAccVPCLatticeResourceGateway_disappears
=== CONT  TestAccVPCLatticeResourceGateway_resourceConfigDNSResolution
=== CONT  TestAccVPCLatticeResourceGateway_update
=== CONT  TestAccVPCLatticeResourceGateway_ipv4AddressesPerEni
=== CONT  TestAccVPCLatticeResourceGateway_multipleSubnets
=== CONT  TestAccVPCLatticeResourceGateway_addressTypeIPv6
=== CONT  TestAccVPCLatticeResourceGateway_basic
=== CONT  TestAccVPCLatticeResourceGateway_Tags_IgnoreTags_Overlap_defaultTag
=== CONT  TestAccVPCLatticeResourceGateway_Tags_EmptyTag_onCreate
=== CONT  TestAccVPCLatticeResourceGateway_Tags_DefaultTags_providerOnly
=== CONT  TestAccVPCLatticeResourceGateway_Tags_EmptyTag_OnUpdate_replace
=== CONT  TestAccVPCLatticeResourceGateway_Tags_EmptyTag_OnUpdate_add
=== CONT  TestAccVPCLatticeResourceGateway_Tags_ComputedTag_OnUpdate_add
=== CONT  TestAccVPCLatticeResourceGateway_Tags_DefaultTags_nonOverlapping
=== CONT  TestAccVPCLatticeResourceGateway_Tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccVPCLatticeResourceGateway_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccVPCLatticeResourceGateway_disappears (64.00s)
=== CONT  TestAccVPCLatticeResourceGateway_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccVPCLatticeResourceGateway_basic (69.67s)
=== CONT  TestAccVPCLatticeResourceGateway_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccVPCLatticeResourceGateway_multipleSubnets (135.62s)
=== CONT  TestAccVPCLatticeResourceGateway_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccVPCLatticeResourceGateway_Tags_DefaultTags_emptyProviderOnlyTag (87.54s)
=== CONT  TestAccVPCLatticeResourceGateway_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccVPCLatticeResourceGateway_Tags_ComputedTag_OnUpdate_replace (158.35s)
=== CONT  TestAccVPCLatticeResourceGateway_Tags_DefaultTags_overlapping
--- PASS: TestAccVPCLatticeResourceGateway_Tags_DefaultTags_emptyResourceTag (98.41s)
=== CONT  TestAccVPCLatticeResourceGateway_Tags_emptyMap
--- PASS: TestAccVPCLatticeResourceGateway_update (198.00s)
=== CONT  TestAccVPCLatticeResourceGateway_Tags_addOnUpdate
--- PASS: TestAccVPCLatticeResourceGateway_addressTypeDualstack (203.56s)
=== CONT  TestAccVPCLatticeResourceGateway_Tags_null
--- PASS: TestAccVPCLatticeResourceGateway_Tags_EmptyTag_OnUpdate_replace (204.41s)
=== CONT  TestAccVPCLatticeResourceGateway_Tags_ComputedTag_onCreate
--- PASS: TestAccVPCLatticeResourceGateway_Tags_DefaultTags_nullOverlappingResourceTag (219.19s)
--- PASS: TestAccVPCLatticeResourceGateway_addressTypeIPv6 (223.82s)
--- PASS: TestAccVPCLatticeResourceGateway_Tags_IgnoreTags_Overlap_resourceTag (224.38s)
--- PASS: TestAccVPCLatticeResourceGateway_resourceConfigDNSResolution (224.52s)
--- PASS: TestAccVPCLatticeResourceGateway_Tags_DefaultTags_nullNonOverlappingResourceTag (225.24s)
--- PASS: TestAccVPCLatticeResourceGateway_Tags_IgnoreTags_Overlap_defaultTag (246.68s)
--- PASS: TestAccVPCLatticeResourceGateway_Tags_emptyMap (111.66s)
--- PASS: TestAccVPCLatticeResourceGateway_Tags_ComputedTag_OnUpdate_add (304.51s)
--- PASS: TestAccVPCLatticeResourceGateway_Tags_EmptyTag_OnUpdate_add (311.16s)
--- PASS: TestAccVPCLatticeResourceGateway_ipv4AddressesPerEni (313.47s)
--- PASS: TestAccVPCLatticeResourceGateway_Tags_null (111.15s)
--- PASS: TestAccVPCLatticeResourceGateway_Tags_DefaultTags_updateToResourceOnly (180.60s)
--- PASS: TestAccVPCLatticeResourceGateway_Tags_ComputedTag_onCreate (117.43s)
--- PASS: TestAccVPCLatticeResourceGateway_Tags_DefaultTags_updateToProviderOnly (176.12s)
--- PASS: TestAccVPCLatticeResourceGateway_Tags_DefaultTags_providerOnly (328.24s)
--- PASS: TestAccVPCLatticeResourceGateway_Tags_addOnUpdate (143.83s)
--- PASS: TestAccVPCLatticeResourceGateway_Tags_EmptyTag_onCreate (344.22s)
--- PASS: TestAccVPCLatticeResourceGateway_tags (346.87s)
--- PASS: TestAccVPCLatticeResourceGateway_Tags_DefaultTags_overlapping (214.17s)
--- PASS: TestAccVPCLatticeResourceGateway_Tags_DefaultTags_nonOverlapping (384.26s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice 389.747s
```
