### PR TITLE
fix: aws_iam_role with force_detach_policies=false should not detach external policies

### DIFF
--- a/.changelog/47856.txt
+++ b/.changelog/47856.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iam_role: Fix `force_detach_policies=false` incorrectly detaching externally managed policies before role deletion
+```

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -510,10 +510,23 @@ func resourceRoleDelete(ctx context.Context, d *schema.ResourceData, meta any) d
 }
 
 func deleteRole(ctx context.Context, conn *iam.Client, roleName string, forceDetach, hasInline, hasManaged bool) error {
+
 	if err := deleteRoleInstanceProfiles(ctx, conn, roleName); err != nil {
 		return err
-	}
-
+	}		
+	  if !forceDetach {
+        // When force_detach_policies = false, skip all detaching
+        // Let AWS return DeleteConflictException naturally
+        input := iam.DeleteRoleInput{
+            RoleName: aws.String(roleName),
+        }
+        _, err := conn.DeleteRole(ctx, &input)
+        if errs.IsA[*awstypes.NoSuchEntityException](err) {
+            return nil
+        }
+        return err
+    }
+	
 	if forceDetach || hasManaged {
 		policyARNs, err := findRoleAttachedPolicies(ctx, conn, roleName)
 
@@ -546,9 +559,9 @@ func deleteRole(ctx context.Context, conn *iam.Client, roleName string, forceDet
 		RoleName: aws.String(roleName),
 	}
 
-	_, err := tfresource.RetryWhenIsA[any, *awstypes.DeleteConflictException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
-		return conn.DeleteRole(ctx, &input)
-	})
+   _, err := tfresource.RetryWhenIsA[any, *awstypes.DeleteConflictException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
+    return conn.DeleteRole(ctx, &input)
+})
 
 	if errs.IsA[*awstypes.NoSuchEntityException](err) {
 		return nil

--- a/internal/service/iam/role_test.go
+++ b/internal/service/iam/role_test.go
@@ -2479,3 +2479,81 @@ EOF
 }
 `, roleName, policyName)
 }
+
+func TestAccIAMRole_forceDetachPoliciesFalseWithExternalPolicy(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_iam_role.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoleConfig_forceDetachFalseExternalPolicy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "force_detach_policies", "false"),
+					testAccRoleAttachPolicyExternal(ctx, t, rName),
+				),
+			},
+			{
+				Config:      testAccRoleConfig_forceDetachFalseExternalPolicy(rName),
+				Destroy:     true,
+				ExpectError: regexache.MustCompile(`DeleteConflict`),
+			},
+			{
+				// Detach external policy so cleanup can succeed
+				Config: testAccRoleConfig_forceDetachFalseExternalPolicy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccRoleDetachPolicyExternal(ctx, t, rName),
+				),
+			},
+		},
+	})
+}
+
+func testAccRoleAttachPolicyExternal(ctx context.Context, t *testing.T, roleName string) resource.TestCheckFunc {
+    return func(s *terraform.State) error {
+        conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
+        _, err := conn.AttachRolePolicy(ctx, &iam.AttachRolePolicyInput{
+            RoleName:  aws.String(roleName),
+            PolicyArn: aws.String("arn:aws:iam::aws:policy/ReadOnlyAccess"),
+        })
+        return err
+    }
+}
+func testAccRoleDetachPolicyExternal(ctx context.Context, t *testing.T, roleName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).IAMClient(ctx)
+		_, err := conn.DetachRolePolicy(ctx, &iam.DetachRolePolicyInput{
+			RoleName:  aws.String(roleName),
+			PolicyArn: aws.String("arn:aws:iam::aws:policy/ReadOnlyAccess"),
+		})
+		return err
+	}
+}
+
+func testAccRoleConfig_forceDetachFalseExternalPolicy(rName string) string {
+    return fmt.Sprintf(`
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
+resource "aws_iam_role" "test" {
+  name                  = %[1]q
+  force_detach_policies = false
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Principal = {
+        Service = data.aws_service_principal.ec2.name
+      }
+      Effect = "Allow"
+      Sid    = ""
+    }]
+  })
+}
+`, rName)
+}


### PR DESCRIPTION
## Summary

Fixes #47855

## Problem
When `force_detach_policies = false`, Terraform was silently detaching 
externally attached policies and deleting the role without error. This 
happened because Terraform refreshes state before delete, picking up 
externally attached policies and setting `hasManaged = true`, which 
caused all policies to be detached regardless of the flag.

## Fix
Added an early return in `deleteRole` when `forceDetach = false` that 
skips all policy detachment and attempts to delete the role directly, 
allowing AWS to naturally return a `DeleteConflictException` if any 
policies are still attached.

## Test
Added acceptance test `TestAccIAMRole_forceDetachPoliciesFalseWithExternalPolicy` 
that verifies destroy fails with `DeleteConflict` when external policies 
are present and `force_detach_policies = false`.