### PR TITLE
.ci/semgrep: additional acceptance test rules

### DIFF
--- a/.ci/semgrep/acctest/context.go
+++ b/.ci/semgrep/acctest/context.go
@@ -1,0 +1,115 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// ruleid: testcase-missing-context
+func TestAccFoo_noContext(t *testing.T) {
+	acctest.ParallelTest(nil, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(nil, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: "# test",
+			},
+		},
+	})
+}
+
+// ok: testcase-missing-context
+func TestAccFoo_withContext(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: "# test",
+			},
+		},
+	})
+}
+
+// ok: testcase-missing-context
+func TestAccFoo_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		acctest.CtBasic: testAccBar_withContext,
+	}
+
+	acctest.RunSerialTests2Levels(t, testCases, 0)
+}
+
+// ok: testcase-missing-context
+func TestAccFoo_serial1Level(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		acctest.CtBasic: testAccBar_withContext,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+// ok: testcase-missing-context
+func TestAccFoo_serialSemaphore(t *testing.T) {
+	t.Parallel()
+
+	semaphore := tfsync.GetSemaphore("Foo", "AWS_FOO_LIMIT", 5)
+	testCases := map[string]map[string]func(*testing.T, tfsync.Semaphore){
+		acctest.CtBasic: {
+			acctest.CtBasic: testAccFooSemaphore_basic,
+		},
+	}
+
+	acctest.RunLimitedConcurrencyTests2Levels(t, semaphore, testCases)
+}
+
+// ruleid: testcase-missing-context
+func testAccBar_noContext(t *testing.T) {
+	acctest.Test(nil, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(nil, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: "# test",
+			},
+		},
+	})
+}
+
+// ok: testcase-missing-context
+func testAccBar_withContext(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: "# test",
+			},
+		},
+	})
+}
+
+// ok: testcase-missing-context
+func testAccBar_utilityHelper(t *testing.T) resource.ErrorCheckFunc {
+	return acctest.ErrorCheckSkipMessagesContaining(t,
+		"some error message",
+	)
+}

--- a/.ci/semgrep/acctest/context.yml
+++ b/.ci/semgrep/acctest/context.yml
@@ -1,0 +1,38 @@
+# Copyright IBM Corp. 2014, 2026
+# "SPDX-License-Identifier: MPL-2.0"
+
+rules:
+  - id: testcase-missing-context
+    languages: [go]
+    message: "Acceptance tests must create a context with acctest.Context(t)"
+    severity: ERROR
+    patterns:
+      - pattern: |
+          func $FUNC($T *testing.T) {
+            ...
+          }
+      - metavariable-regex:
+          metavariable: $FUNC
+          regex: ^[Tt]estAcc
+      - pattern-either:
+          - pattern: |
+              func $FUNC($T *testing.T) {
+                ...
+                acctest.Test(...)
+                ...
+              }
+          - pattern: |
+              func $FUNC($T *testing.T) {
+                ...
+                acctest.ParallelTest(...)
+                ...
+              }
+      - pattern-not: |
+          func $FUNC($T *testing.T) {
+            ...
+            acctest.Context(...)
+            ...
+          }
+    paths:
+      include:
+        - "**/*_test.go"

--- a/.ci/semgrep/acctest/errorcheck.go
+++ b/.ci/semgrep/acctest/errorcheck.go
@@ -1,0 +1,43 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func testErrorcheck_missing(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	// ruleid: testcase-missing-errorcheck
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: "# test",
+			},
+		},
+	})
+}
+
+func testErrorcheck_present(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	// ok: testcase-missing-errorcheck
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: "# test",
+			},
+		},
+	})
+}

--- a/.ci/semgrep/acctest/errorcheck.yml
+++ b/.ci/semgrep/acctest/errorcheck.yml
@@ -1,0 +1,22 @@
+# Copyright IBM Corp. 2014, 2026
+# "SPDX-License-Identifier: MPL-2.0"
+
+rules:
+  - id: testcase-missing-errorcheck
+    languages: [go]
+    message: "All acceptance tests must include an ErrorCheck in the resource.TestCase"
+    severity: ERROR
+    patterns:
+      - pattern: |
+          resource.TestCase{
+            ...,
+          }
+      - pattern-not: |
+          resource.TestCase{
+            ...,
+            ErrorCheck: $ERRORCHECK,
+            ...,
+          }
+    paths:
+      include:
+        - "internal/service/**/*_test.go"

--- a/.ci/semgrep/acctest/precheck.go
+++ b/.ci/semgrep/acctest/precheck.go
@@ -1,0 +1,45 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func testPrecheck_missing(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	// ruleid: testcase-missing-precheck
+	resource.ParallelTest(t, resource.TestCase{
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: "# test",
+			},
+		},
+	})
+
+	_ = ctx
+}
+
+func testPrecheck_present(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	// ok: testcase-missing-precheck
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: "# test",
+			},
+		},
+	})
+}

--- a/.ci/semgrep/acctest/precheck.yml
+++ b/.ci/semgrep/acctest/precheck.yml
@@ -1,0 +1,22 @@
+# Copyright IBM Corp. 2014, 2026
+# "SPDX-License-Identifier: MPL-2.0"
+
+rules:
+  - id: testcase-missing-precheck
+    languages: [go]
+    message: "All acceptance tests must include a PreCheck in the resource.TestCase"
+    severity: ERROR
+    patterns:
+      - pattern: |
+          resource.TestCase{
+            ...,
+          }
+      - pattern-not: |
+          resource.TestCase{
+            ...,
+            PreCheck: $PRECHECK,
+            ...,
+          }
+    paths:
+      include:
+        - "internal/service/**/*_test.go"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 *~
 /.kiro
 /.bob
+/.opencode
 /pkg/
 aws/testdata/service/cloudformation/examplecompany-exampleservice-exampleresource/bin/handler
 bin/

--- a/internal/service/customerprofiles/domain_test.go
+++ b/internal/service/customerprofiles/domain_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfcustomerprofiles "github.com/hashicorp/terraform-provider-aws/internal/service/customerprofiles"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccCustomerProfilesDomain_basic(t *testing.T) {
@@ -22,6 +23,7 @@ func TestAccCustomerProfilesDomain_basic(t *testing.T) {
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CustomerProfilesServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -55,6 +57,7 @@ func TestAccCustomerProfilesDomain_full(t *testing.T) {
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CustomerProfilesServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -158,6 +161,7 @@ func TestAccCustomerProfilesDomain_tags(t *testing.T) {
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CustomerProfilesServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -202,6 +206,7 @@ func TestAccCustomerProfilesDomain_disappears(t *testing.T) {
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CustomerProfilesServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainDestroy(ctx, t),
 		Steps: []resource.TestStep{

--- a/internal/service/customerprofiles/profile_test.go
+++ b/internal/service/customerprofiles/profile_test.go
@@ -28,6 +28,7 @@ func TestAccCustomerProfilesProfile_full(t *testing.T) {
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CustomerProfilesServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -184,6 +185,7 @@ func TestAccCustomerProfilesProfile_disappears(t *testing.T) {
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CustomerProfilesServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProfileDestroy(ctx, t),
 		Steps: []resource.TestStep{

--- a/internal/service/ec2/ec2_image_block_public_access_test.go
+++ b/internal/service/ec2/ec2_image_block_public_access_test.go
@@ -29,6 +29,7 @@ func testAccImageBlockPublicAccess_basic(t *testing.T) {
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{

--- a/internal/service/redshift/scheduled_action_test.go
+++ b/internal/service/redshift/scheduled_action_test.go
@@ -9,9 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/YakDriver/regexache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -482,38 +480,4 @@ resource "aws_redshift_scheduled_action" "test" {
   }
 }
 `, rName, schedule, classic, clusterType, nodeType, numberOfNodes))
-}
-
-func TestAccRedshiftScheduledAction_validScheduleName(t *testing.T) {
-	t.Parallel()
-
-	var f = validation.StringMatch(regexache.MustCompile(`^[0-9a-z-]{1,63}$`), "")
-
-	validIds := []string{
-		"tf-test-schedule-action-1",
-		acctest.ResourcePrefix,
-		acctest.RandomWithPrefix(t, acctest.ResourcePrefix),
-	}
-
-	for _, s := range validIds {
-		_, errors := f(s, "")
-		if len(errors) > 0 {
-			t.Fatalf("%q should be a valid replication instance id: %v", s, errors)
-		}
-	}
-
-	invalidIds := []string{
-		"tf_test_schedule-action_1",
-		"tfTestScheduleACtion",
-		"tf.test.schedule.action.1",
-		"tf test schedule action 1",
-		"tf-test-schedule-action-1!",
-	}
-
-	for _, s := range invalidIds {
-		_, errors := f(s, "")
-		if len(errors) == 0 {
-			t.Fatalf("%q should not be a valid replication instance id: %v", s, errors)
-		}
-	}
 }

--- a/internal/service/shield/application_layer_automatic_response_test.go
+++ b/internal/service/shield/application_layer_automatic_response_test.go
@@ -29,6 +29,7 @@ func TestAccShieldApplicationLayerAutomaticResponse_basic(t *testing.T) {
 			acctest.PreCheckWAFV2CloudFrontScope(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckApplicationLayerAutomaticResponseDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -67,6 +68,7 @@ func TestAccShieldApplicationLayerAutomaticResponse_disappears(t *testing.T) {
 			acctest.PreCheckWAFV2CloudFrontScope(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckApplicationLayerAutomaticResponseDestroy(ctx, t),
 		Steps: []resource.TestStep{

--- a/internal/service/shield/drt_access_log_bucket_association_test.go
+++ b/internal/service/shield/drt_access_log_bucket_association_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfshield "github.com/hashicorp/terraform-provider-aws/internal/service/shield"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func testAccDRTAccessLogBucketAssociation_basic(t *testing.T) {
@@ -27,6 +28,7 @@ func testAccDRTAccessLogBucketAssociation_basic(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckLogBucket(ctx, t)
 		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDRTAccessLogBucketAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -61,6 +63,7 @@ func testAccDRTAccessLogBucketAssociation_multiBucket(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckLogBucket(ctx, t)
 		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDRTAccessLogBucketAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -86,6 +89,7 @@ func testAccDRTAccessLogBucketAssociation_disappears(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckLogBucket(ctx, t)
 		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDRTAccessLogBucketAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{

--- a/internal/service/shield/drt_access_role_arn_association_test.go
+++ b/internal/service/shield/drt_access_role_arn_association_test.go
@@ -27,6 +27,7 @@ func testAccDRTAccessRoleARNAssociation_basic(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckRoleARN(ctx, t)
 		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDRTAccessRoleARNAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -63,6 +64,7 @@ func testAccDRTAccessRoleARNAssociation_disappears(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckRoleARN(ctx, t)
 		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDRTAccessRoleARNAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{

--- a/internal/service/shield/proactive_engagement_test.go
+++ b/internal/service/shield/proactive_engagement_test.go
@@ -32,6 +32,7 @@ func testAccProactiveEngagement_basic(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckProactiveEngagement(ctx, t)
 		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProactiveEngagementAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -66,6 +67,7 @@ func testAccProactiveEngagement_disabled(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckProactiveEngagement(ctx, t)
 		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProactiveEngagementAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
@@ -95,6 +97,7 @@ func testAccProactiveEngagement_disappears(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckProactiveEngagement(ctx, t)
 		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProactiveEngagementAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds `semgrep` rules to ensure acceptance tests:

- Include a `PreCheck`
- Include an `ErrorCheck`
- Use `acctest.Context` to construct test case context

This enforces best practices already documented in the contributor guide: https://hashicorp.github.io/terraform-provider-aws/running-and-writing-acceptance-tests/

