### PR TITLE
resource/aws_bedrockagent_agent: Raise `idle_session_ttl_in_seconds` upper bound to 5400

### DIFF
--- a/.changelog/47890.txt
+++ b/.changelog/47890.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagent_agent: Increase maximum value of `idle_session_ttl_in_seconds` from `3600` to `5400` to match the AWS API limit
+```

--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -126,7 +126,7 @@ func (r *agentResource) Schema(ctx context.Context, request resource.SchemaReque
 					int64planmodifier.UseStateForUnknown(),
 				},
 				Validators: []validator.Int64{
-					int64validator.Between(60, 3600),
+					int64validator.Between(60, 5400),
 				},
 			},
 			"instruction": schema.StringAttribute{


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None.

### Description

The schema validator for `aws_bedrockagent_agent.idle_session_ttl_in_seconds` rejects any value above `3600`, but the AWS Bedrock [`CreateAgent`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_CreateAgent.html) / [`UpdateAgent`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_UpdateAgent.html) APIs accept up to `5400` seconds.

This PR raises the upper bound of the validator from `3600` to `5400` to match the AWS API.

### Relations

N/A

### References

- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_CreateAgent.html (`idleSessionTTLInSeconds`)

### Output from Acceptance Testing

N/A