### PR TITLE
Schema caching: Caches `enum` validators

### DIFF
--- a/internal/enum/validate.go
+++ b/internal/enum/validate.go
@@ -4,10 +4,13 @@
 package enum
 
 import (
+	"reflect"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/sync"
 )
 
 func Validate[T Valueser[T]]() schema.SchemaValidateDiagFunc {
@@ -19,7 +22,18 @@ func ValidateIgnoreCase[T Valueser[T]]() schema.SchemaValidateDiagFunc {
 }
 
 func validate[T Valueser[T]](ignoreCase bool) schema.SchemaValidateDiagFunc {
-	return validation.ToDiagFunc(validation.StringInSlice(Values[T](), ignoreCase))
+	id := validateIdentity{
+		typ:        reflect.TypeFor[T](),
+		ignoreCase: ignoreCase,
+	}
+
+	s, ok := validateCache.Load(id)
+	if ok {
+		return s
+	}
+
+	// Separates the slow path so that the fast path can be inlined
+	return validateSlow[T](id)
 }
 
 func FrameworkValidateIgnoreCase[T Valueser[T]]() validator.String {
@@ -29,4 +43,19 @@ func FrameworkValidateIgnoreCase[T Valueser[T]]() validator.String {
 // TODO Move to internal/framework/validators or replace with custom types.
 func FrameworkValidate[T Valueser[T]]() validator.String {
 	return stringvalidator.OneOf(Values[T]()...)
+}
+
+type validateIdentity struct {
+	typ        reflect.Type
+	ignoreCase bool
+}
+
+var validateCache tfsync.Map[validateIdentity, schema.SchemaValidateDiagFunc]
+
+func validateSlow[T Valueser[T]](id validateIdentity) schema.SchemaValidateDiagFunc {
+	s, _ := validateCache.LoadOrStore(
+		id,
+		validation.ToDiagFunc(validation.StringInSlice(Values[T](), id.ignoreCase)),
+	)
+	return s
 }

--- a/internal/enum/validate.go
+++ b/internal/enum/validate.go
@@ -36,15 +36,6 @@ func validate[T Valueser[T]](ignoreCase bool) schema.SchemaValidateDiagFunc {
 	return validateSlow[T](id)
 }
 
-func FrameworkValidateIgnoreCase[T Valueser[T]]() validator.String {
-	return stringvalidator.OneOfCaseInsensitive(Values[T]()...)
-}
-
-// TODO Move to internal/framework/validators or replace with custom types.
-func FrameworkValidate[T Valueser[T]]() validator.String {
-	return stringvalidator.OneOf(Values[T]()...)
-}
-
 type validateIdentity struct {
 	typ        reflect.Type
 	ignoreCase bool
@@ -58,4 +49,13 @@ func validateSlow[T Valueser[T]](id validateIdentity) schema.SchemaValidateDiagF
 		validation.ToDiagFunc(validation.StringInSlice(Values[T](), id.ignoreCase)),
 	)
 	return s
+}
+
+func FrameworkValidateIgnoreCase[T Valueser[T]]() validator.String {
+	return stringvalidator.OneOfCaseInsensitive(Values[T]()...)
+}
+
+// TODO Move to internal/framework/validators or replace with custom types.
+func FrameworkValidate[T Valueser[T]]() validator.String {
+	return stringvalidator.OneOf(Values[T]()...)
 }

--- a/internal/enum/validate_test.go
+++ b/internal/enum/validate_test.go
@@ -1,0 +1,16 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package enum
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
+)
+
+func BenchmarkValidate(b *testing.B) {
+	for b.Loop() {
+		Validate[types.AclPermission]()
+	}
+}

--- a/internal/enum/values.go
+++ b/internal/enum/values.go
@@ -32,14 +32,6 @@ func Values[T Valueser[T]]() []string {
 	return valuesSlow[T]()
 }
 
-func EnumSlice[T ~string](l ...T) []T {
-	return l
-}
-
-func Slice[T ~string](l ...T) []string {
-	return tfslices.Strings(l)
-}
-
 var valuesCache tfsync.Map[reflect.Type, []string]
 
 func valuesSlow[T Valueser[T]]() []string {
@@ -49,4 +41,12 @@ func valuesSlow[T Valueser[T]]() []string {
 		tfslices.Strings(EnumValues[T]()),
 	)
 	return s
+}
+
+func EnumSlice[T ~string](l ...T) []T {
+	return l
+}
+
+func Slice[T ~string](l ...T) []string {
+	return tfslices.Strings(l)
 }

--- a/internal/enum/values.go
+++ b/internal/enum/values.go
@@ -4,7 +4,10 @@
 package enum
 
 import (
+	"reflect"
+
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/sync"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 )
 
@@ -18,7 +21,15 @@ func EnumValues[T Valueser[T]]() []T {
 }
 
 func Values[T Valueser[T]]() []string {
-	return tfslices.Strings(EnumValues[T]())
+	typ := reflect.TypeFor[T]()
+
+	s, ok := valuesCache.Load(typ)
+	if ok {
+		return s
+	}
+
+	// Separates the slow path so that the fast path can be inlined
+	return valuesSlow[T]()
 }
 
 func EnumSlice[T ~string](l ...T) []T {
@@ -27,4 +38,15 @@ func EnumSlice[T ~string](l ...T) []T {
 
 func Slice[T ~string](l ...T) []string {
 	return tfslices.Strings(l)
+}
+
+var valuesCache tfsync.Map[reflect.Type, []string]
+
+func valuesSlow[T Valueser[T]]() []string {
+	typ := reflect.TypeFor[T]()
+	s, _ := valuesCache.LoadOrStore(
+		typ,
+		tfslices.Strings(EnumValues[T]()),
+	)
+	return s
 }

--- a/internal/enum/values_test.go
+++ b/internal/enum/values_test.go
@@ -26,3 +26,9 @@ func TestValues(t *testing.T) {
 		t.Errorf("unexpected diff (+wanted, -got): %s", diff)
 	}
 }
+
+func BenchmarkValues(b *testing.B) {
+	for b.Loop() {
+		Values[types.AclPermission]()
+	}
+}

--- a/internal/service/quicksight/schema/template.go
+++ b/internal/service/quicksight/schema/template.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/sync"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -133,7 +134,7 @@ func (x attrHandling) isComputed() bool {
 	return x&attrComputed != 0
 }
 
-var arnStringSchemaCache syncMap[attrHandling, *schema.Schema]
+var arnStringSchemaCache tfsync.Map[attrHandling, *schema.Schema]
 
 func arnStringSchema(handling attrHandling) *schema.Schema {
 	if handling == attrComputed {
@@ -164,7 +165,7 @@ func arnStringDataSourceSchema() *schema.Schema {
 	return arnStringSchema(attrComputed)
 }
 
-var utcTimestampStringSchemaCache syncMap[attrHandling, *schema.Schema]
+var utcTimestampStringSchemaCache tfsync.Map[attrHandling, *schema.Schema]
 
 func utcTimestampStringSchema(handling attrHandling) *schema.Schema {
 	s, ok := utcTimestampStringSchemaCache.Load(handling)
@@ -192,7 +193,7 @@ type stringLenBetweenIdentity struct {
 	min, max int
 }
 
-var stringLenBetweenSchemaCache syncMap[stringLenBetweenIdentity, *schema.Schema]
+var stringLenBetweenSchemaCache tfsync.Map[stringLenBetweenIdentity, *schema.Schema]
 
 func stringLenBetweenSchema(handling attrHandling, min, max int) *schema.Schema {
 	if handling == attrComputed {
@@ -230,7 +231,7 @@ type stringMatchIdentity struct {
 	re, message string
 }
 
-var stringMatchSchemaCache syncMap[stringMatchIdentity, *schema.Schema]
+var stringMatchSchemaCache tfsync.Map[stringMatchIdentity, *schema.Schema]
 
 func stringMatchSchema(handling attrHandling, re, message string) *schema.Schema {
 	if handling == attrComputed {
@@ -268,7 +269,7 @@ type stringEnumIdentity struct {
 	typ      reflect.Type
 }
 
-var stringEnumSchemaCache syncMap[stringEnumIdentity, *schema.Schema]
+var stringEnumSchemaCache tfsync.Map[stringEnumIdentity, *schema.Schema]
 
 func stringEnumSchema[T enum.Valueser[T]](handling attrHandling) *schema.Schema {
 	if handling == attrComputed {
@@ -332,31 +333,12 @@ var floatComputedOnly = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
-// syncMap is a type-safe wrapper around `sync.Map`
-type syncMap[K comparable, V any] struct {
-	m sync.Map
-}
-
-func (m *syncMap[K, V]) Load(k K) (V, bool) {
-	if a, b := m.m.Load(k); b {
-		return a.(V), true
-	} else {
-		var zero V
-		return zero, false
-	}
-}
-
-func (m *syncMap[K, V]) LoadOrStore(k K, v V) (V, bool) {
-	a, b := m.m.LoadOrStore(k, v)
-	return a.(V), b
-}
-
 type intBetweenIdentity struct {
 	handling attrHandling
 	min, max int
 }
 
-var intBetweenSchemaCache syncMap[intBetweenIdentity, *schema.Schema]
+var intBetweenSchemaCache tfsync.Map[intBetweenIdentity, *schema.Schema]
 
 func intBetweenSchema(handling attrHandling, min, max int) *schema.Schema {
 	id := intBetweenIdentity{
@@ -417,7 +399,7 @@ type floatBetweenIdentity struct {
 	min, max float64
 }
 
-var floatBetweenSchemaCache syncMap[floatBetweenIdentity, *schema.Schema]
+var floatBetweenSchemaCache tfsync.Map[floatBetweenIdentity, *schema.Schema]
 
 func floatBetweenSchema(handling attrHandling, min, max float64) *schema.Schema {
 	id := floatBetweenIdentity{
@@ -446,7 +428,7 @@ func floatBetweenSchema(handling attrHandling, min, max float64) *schema.Schema 
 	return s
 }
 
-var aggregationFunctionSchemaCache syncMap[bool, *schema.Schema]
+var aggregationFunctionSchemaCache tfsync.Map[bool, *schema.Schema]
 
 func aggregationFunctionSchema(required bool) *schema.Schema {
 	s, ok := aggregationFunctionSchemaCache.Load(required)
@@ -520,7 +502,7 @@ var calculatedFieldsDataSourceSchema = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
-var numericalAggregationFunctionSchemaCache syncMap[bool, *schema.Schema]
+var numericalAggregationFunctionSchemaCache tfsync.Map[bool, *schema.Schema]
 
 func numericalAggregationFunctionSchema(required bool) *schema.Schema {
 	s, ok := numericalAggregationFunctionSchemaCache.Load(required)
@@ -598,7 +580,7 @@ var idDataSourceSchema = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
-var columnSchemaCache syncMap[bool, *schema.Schema]
+var columnSchemaCache tfsync.Map[bool, *schema.Schema]
 
 func columnSchema(required bool) *schema.Schema {
 	s, ok := columnSchemaCache.Load(required)

--- a/internal/service/quicksight/schema/visual_fields.go
+++ b/internal/service/quicksight/schema/visual_fields.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/sync"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -31,7 +32,7 @@ const (
 
 type dimensionFieldSchemaIdentity dimensionFieldSize
 
-var dimensionFieldSchemaCache syncMap[dimensionFieldSchemaIdentity, *schema.Schema]
+var dimensionFieldSchemaCache tfsync.Map[dimensionFieldSchemaIdentity, *schema.Schema]
 
 func dimensionFieldSchema(maxItems dimensionFieldSize) *schema.Schema {
 	id := dimensionFieldSchemaIdentity(maxItems)
@@ -152,7 +153,7 @@ var dimensionFieldDataSourceSchema = sync.OnceValue(func() *schema.Schema {
 
 type meaureFieldSchemaIdentity measureFieldsSize
 
-var measureFieldSchemaCache syncMap[meaureFieldSchemaIdentity, *schema.Schema]
+var measureFieldSchemaCache tfsync.Map[meaureFieldSchemaIdentity, *schema.Schema]
 
 func measureFieldSchema(maxItems measureFieldsSize) *schema.Schema {
 	id := meaureFieldSchemaIdentity(maxItems)

--- a/internal/sync/map.go
+++ b/internal/sync/map.go
@@ -1,0 +1,32 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package sync
+
+import (
+	"sync"
+)
+
+// Map is a type-safe wrapper around sync.Map from the Go standard library
+type Map[K comparable, V any] struct {
+	m sync.Map
+}
+
+// Load returns the value stored in the map for a key, or nil if no value is present.
+// The ok result indicates whether value was found in the map.
+func (m *Map[K, V]) Load(k K) (V, bool) {
+	if a, b := m.m.Load(k); b {
+		return a.(V), true
+	} else {
+		var zero V
+		return zero, false
+	}
+}
+
+// LoadOrStore returns the existing value for the key if present.
+// Otherwise, it stores and returns the given value.
+// The loaded result is true if the value was loaded, false if stored.
+func (m *Map[K, V]) LoadOrStore(k K, v V) (V, bool) {
+	a, b := m.m.LoadOrStore(k, v)
+	return a.(V), b
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Caches SDKv2 `enum` validators and results of `enum.Values` conversion to `string`

|        | Iteration Count | Time per Operation | Bytes per Operation | Allocations per Operation |
|--------|----------------:|-------------------:|--------------------:|--------------------------:|
| Before | 126 | 9421101 ns/op | 18,502,251 B/op | 104,871 allocs/op |
| After  | 134 | 8927013 ns/op | 17,803,273 B/op |  95,370 allocs/op |


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #47003
