### PR TITLE
workmail: handle `Deleted` state when sweeping

### DIFF
--- a/internal/service/workmail/sweep.go
+++ b/internal/service/workmail/sweep.go
@@ -36,9 +36,11 @@ func sweepOrganizations(ctx context.Context, client *conns.AWSClient) ([]sweep.S
 		}
 
 		for _, v := range page.OrganizationSummaries {
-			sweepResources = append(sweepResources, sweepfw.NewSweepResource(newOrganizationResource, client,
-				sweepfw.NewAttribute("organization_id", aws.ToString(v.OrganizationId))),
-			)
+			if aws.ToString(v.State) != statusDeleted {
+				sweepResources = append(sweepResources, sweepfw.NewSweepResource(newOrganizationResource, client,
+					sweepfw.NewAttribute("organization_id", aws.ToString(v.OrganizationId))),
+				)
+			}
 		}
 	}
 
@@ -57,6 +59,10 @@ func sweepGroups(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepabl
 		}
 
 		for _, organization := range page.OrganizationSummaries {
+			if aws.ToString(organization.State) == statusDeleted {
+				continue
+			}
+
 			organizationID := aws.ToString(organization.OrganizationId)
 
 			input := workmail.ListGroupsInput{
@@ -95,6 +101,10 @@ func sweepUsers(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable
 		}
 
 		for _, organization := range page.OrganizationSummaries {
+			if aws.ToString(organization.State) == statusDeleted {
+				continue
+			}
+
 			organizationID := aws.ToString(organization.OrganizationId)
 
 			input := workmail.ListUsersInput{


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Ignores organizations in a `Deleted` state when sweeping organizations, users, and groups. This prevents sweeper failures similar to:

```
2026/05/13 13:31:32 [ERROR] Error running Sweeper (aws_workmail_user) in region (us-west-2): listing "aws_workmail_user" (us-west-2): operation error WorkMail: ListUsers, https response error StatusCode: 400, RequestID: 5262d711-5060-4048-a821-7a1417ee484a, OrganizationStateException: Organization m-1cab861fe2af419092df2a8aeb21d2b6 is not Active, state: Deleted
```
