### PR TITLE
docs: fix broken examples for cognito log delivery configuration

### DIFF
--- a/website/docs/r/cognito_log_delivery_configuration.html.markdown
+++ b/website/docs/r/cognito_log_delivery_configuration.html.markdown
@@ -41,7 +41,8 @@ resource "aws_cognito_log_delivery_configuration" "example" {
 
 ```terraform
 resource "aws_cognito_user_pool" "example" {
-  name = "example"
+  name           = "example"
+  user_pool_tier = "PLUS"
 }
 
 resource "aws_cloudwatch_log_group" "example" {
@@ -120,7 +121,7 @@ resource "aws_cognito_log_delivery_configuration" "example" {
 
   log_configurations {
     event_source = "userAuthEvents"
-    log_level    = "ERROR"
+    log_level    = "INFO"
 
     firehose_configuration {
       stream_arn = aws_kinesis_firehose_delivery_stream.example.arn
@@ -133,7 +134,8 @@ resource "aws_cognito_log_delivery_configuration" "example" {
 
 ```terraform
 resource "aws_cognito_user_pool" "example" {
-  name = "example"
+  name           = "example"
+  user_pool_tier = "PLUS"
 }
 
 resource "aws_s3_bucket" "example" {
@@ -145,8 +147,8 @@ resource "aws_cognito_log_delivery_configuration" "example" {
   user_pool_id = aws_cognito_user_pool.example.id
 
   log_configurations {
-    event_source = "userNotification"
-    log_level    = "ERROR"
+    event_source = "userAuthEvents"
+    log_level    = "INFO"
 
     s3_configuration {
       bucket_arn = aws_s3_bucket.example.arn


### PR DESCRIPTION

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes implemented.

### Description

Update two examples in the documentation of resource [`aws_cognito_log_delivery_configuration`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_log_delivery_configuration) 

- When using `userAuthEvents` the cognito user pool needs to have `user_pool_tier = "PLUS"` configured
- `userAuthEvents` requires log level `INFO`.
- `S3Configuration` works with `userAuthEvents` but not `userNotification`.

All of this is mentioned in the referenced document for the LogConfiguration type.

### Relations

Closes #47790 

### References

- [AWS API Docs - LogConfigurationType](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_LogConfigurationType.html)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.