### PR TITLE
r/s3_bucket: error when updating empty source replication

### DIFF
--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -2837,6 +2837,48 @@ func TestAccS3Bucket_Namespace_AccountRegional_namePrefix(t *testing.T) {
 	})
 }
 
+func TestAccS3Bucket_selectionCriteria(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_s3_bucket.source"
+	rgResourceName := "aws_s3_bucket_replication_configuration.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBucketDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketConfig_sourceSelectionCriteria(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(rgResourceName, "rule.0.source_selection_criteria.#", "1"),
+					resource.TestCheckResourceAttr(rgResourceName, "rule.0.source_selection_criteria.0.replica_modifications.0.status", "Disabled"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				Config: testAccBucketConfig_sourceSelectionCriteria(rName, rName+"-updated"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(rgResourceName, "rule.0.source_selection_criteria.#", "1"),
+					resource.TestCheckResourceAttr(rgResourceName, "rule.0.source_selection_criteria.0.replica_modifications.0.status", "Disabled"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestValidBucketName(t *testing.T) {
 	t.Parallel()
 
@@ -4976,4 +5018,89 @@ resource "aws_s3_bucket" "duplicate" {
 }
   `, bucketName),
 	)
+}
+
+func testAccBucketConfig_sourceSelectionCriteria(rName, tag string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+data "aws_service_principal" "current" {
+  service_name = "s3"
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "${data.aws_service_principal.current.name}"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_s3_bucket" "destination" {
+  region = %[2]q
+
+  bucket = "%[1]s-destination"
+}
+
+resource "aws_s3_bucket_versioning" "destination" {
+  region = %[2]q
+
+  bucket = aws_s3_bucket.destination.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket" "source" {
+  bucket = "%[1]s-source"
+
+  tags = {
+    Name = %[3]q
+  }
+}
+
+resource "aws_s3_bucket_versioning" "source" {
+  bucket = aws_s3_bucket.source.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [
+    aws_s3_bucket_versioning.source,
+  ]
+  bucket = aws_s3_bucket.source.bucket
+  role   = aws_iam_role.test.arn
+  rule {
+    status = "Enabled"
+    filter {
+      prefix = ""
+    }
+    destination {
+      bucket = aws_s3_bucket.destination.arn
+    }
+
+    delete_marker_replication {
+      status = "Enabled"
+    }
+
+    source_selection_criteria {
+      replica_modifications {
+        status = "Disabled"
+      }
+    }
+  }
+}`, rName, acctest.AlternateRegion(), tag)
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When bucket is updated an error is produced when source replication is empty on the bucket.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

### test to reproduce
```console
% make testacc TESTARGS='-run=TestAccS3Bucket_selectionCriteria' PKG=s3

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/s3/... -v -count 1 -parallel 20  -run=TestAccS3Bucket_selectionCriteria -timeout 360m -vet=off -buildvcs=false
2026/05/13 16:30:18 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/13 16:30:18 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3Bucket_selectionCriteria
=== PAUSE TestAccS3Bucket_selectionCriteria
=== CONT  TestAccS3Bucket_selectionCriteria
    bucket_test.go:2846: Step 2/2 error: Error running apply: exit status 1
        
        Error: putting S3 Bucket (tf-acc-test-6178215943093789421-source) replication configuration: operation error S3: PutBucketReplication, https response error StatusCode: 400, RequestID: PCDKTPAHTD95DDJA, HostID: 9piXUW5dPCplsN1AOJ4qxAcGg5Pa+PSXLkn4xJ821oJzrv2au3HutLaw1OSHZTPRZW1aLyFCGpI=, api error InvalidRequest: SourceSelectionCriteria cannot be empty.
        
          with aws_s3_bucket.source,
          on terraform_plugin_test.tf line 52, in resource "aws_s3_bucket" "source":
          52: resource "aws_s3_bucket" "source" {
        
--- FAIL: TestAccS3Bucket_selectionCriteria (30.46s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/s3 39.008s
FAIL
make: *** [testacc] Error 1
```
