### PR TITLE
[Enhancement] aws_acm_certificate/aws_acm_certificate_validation: Add `created_at` and `issued_at` attributes

### DIFF
--- a/.changelog/47900.txt
+++ b/.changelog/47900.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_acm_certificate: Add `created_at` and `issued_at` attributes
+```
+
+```release-note:enhancement
+data-source/aws_acm_certificate: Add `created_at` and `issued_at` attributes
+```
+
+```release-note:enhancement
+resource/aws_acm_certificate_validation: Add `issued_at` attribute
+```

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -93,6 +93,10 @@ func resourceCertificate() *schema.Resource {
 				Optional:      true,
 				ConflictsWith: []string{"certificate_authority_arn", names.AttrDomainName, "validation_method"},
 			},
+			names.AttrCreatedAt: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			names.AttrDomainName: {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -132,6 +136,10 @@ func resourceCertificate() *schema.Resource {
 				Optional:         true,
 				ValidateDiagFunc: validateHybridDuration,
 				ConflictsWith:    []string{"certificate_body", names.AttrCertificateChain, names.AttrPrivateKey, "validation_method"},
+			},
+			"issued_at": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"key_algorithm": {
 				Type:             schema.TypeString,
@@ -436,6 +444,7 @@ func resourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta a
 
 	d.Set(names.AttrARN, certificate.CertificateArn)
 	d.Set("certificate_authority_arn", certificate.CertificateAuthorityArn)
+	d.Set(names.AttrCreatedAt, aws.ToTime(certificate.CreatedAt).Format(time.RFC3339))
 	d.Set(names.AttrDomainName, certificate.DomainName)
 	d.Set("early_renewal_duration", d.Get("early_renewal_duration"))
 	if err := d.Set("domain_validation_options", domainValidationOptions); err != nil {
@@ -449,6 +458,11 @@ func resourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta a
 			keyAlgorithmValue = v
 			break
 		}
+	}
+	if certificate.IssuedAt != nil {
+		d.Set("issued_at", aws.ToTime(certificate.IssuedAt).Format(time.RFC3339))
+	} else {
+		d.Set("issued_at", nil)
 	}
 	d.Set("key_algorithm", keyAlgorithmValue)
 	if certificate.NotAfter != nil {

--- a/internal/service/acm/certificate_data_source.go
+++ b/internal/service/acm/certificate_data_source.go
@@ -47,11 +47,19 @@ func dataSourceCertificate() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			names.AttrCreatedAt: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			names.AttrDomain: {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
 				AtLeastOneOf: []string{names.AttrDomain, names.AttrTags},
+			},
+			"issued_at": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"key_types": {
 				Type:     schema.TypeSet,
@@ -221,7 +229,13 @@ func dataSourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta
 
 	d.SetId(aws.ToString(matchedCertificate.CertificateArn))
 	d.Set(names.AttrARN, matchedCertificate.CertificateArn)
+	d.Set(names.AttrCreatedAt, aws.ToTime(matchedCertificate.CreatedAt).Format(time.RFC3339))
 	d.Set(names.AttrDomain, matchedCertificate.DomainName)
+	if matchedCertificate.IssuedAt != nil {
+		d.Set("issued_at", aws.ToTime(matchedCertificate.IssuedAt).Format(time.RFC3339))
+	} else {
+		d.Set("issued_at", nil)
+	}
 	d.Set(names.AttrStatus, matchedCertificate.Status)
 
 	return diags

--- a/internal/service/acm/certificate_data_source_test.go
+++ b/internal/service/acm/certificate_data_source_test.go
@@ -31,7 +31,9 @@ func TestAccACMCertificateDataSource_byDomain(t *testing.T) {
 				Config: testAccCertificateDataSourceConfig_byDomain(domain, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key)),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrCreatedAt, resourceName, names.AttrCreatedAt),
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrDomain, domain),
+					resource.TestCheckResourceAttrPair(dataSourceName, "issued_at", resourceName, "issued_at"),
 				),
 			},
 		},

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -45,9 +45,11 @@ func TestAccACMCertificate_emailValidation(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "acm", regexache.MustCompile("certificate/.+$")),
+					acctest.CheckResourceAttrRFC3339(resourceName, names.AttrCreatedAt),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, domain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "early_renewal_duration", ""),
+					resource.TestCheckResourceAttr(resourceName, "issued_at", ""),
 					resource.TestCheckResourceAttr(resourceName, "not_after", ""),
 					resource.TestCheckResourceAttr(resourceName, "not_before", ""),
 					resource.TestCheckResourceAttr(resourceName, "options.#", "1"),
@@ -1770,6 +1772,38 @@ func TestAccACMCertificate_optionExport(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccACMCertificate_nonEmptyIssuedAt(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_acm_certificate.test"
+	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
+	var v types.CertificateDetail
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCertificateDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateConfig_optionsWithValidation(rootDomain, types.ValidationMethodDns, "DISABLED"),
+				Check:  testAccCheckCertificateExists(ctx, t, resourceName, &v),
+			},
+			// Check the certificate's attributes once the validation has been applied.
+			{
+				Config: testAccCertificateConfig_optionsWithValidation(rootDomain, types.ValidationMethodDns, "DISABLED"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCertificateExists(ctx, t, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "acm", regexache.MustCompile("certificate/.+$")),
+					acctest.CheckResourceAttrRFC3339(resourceName, names.AttrCreatedAt),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, rootDomain),
+					acctest.CheckResourceAttrRFC3339(resourceName, "issued_at"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusIssued)),
+				),
 			},
 		},
 	})

--- a/internal/service/acm/certificate_validation.go
+++ b/internal/service/acm/certificate_validation.go
@@ -49,6 +49,10 @@ func resourceCertificateValidation() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"issued_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"validation_record_fqdns": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -134,6 +138,11 @@ func resourceCertificateValidationRead(ctx context.Context, d *schema.ResourceDa
 
 	d.Set(names.AttrCertificateARN, certificate.CertificateArn)
 
+	if certificate.IssuedAt != nil {
+		d.Set("issued_at", aws.ToTime(certificate.IssuedAt).Format(time.RFC3339))
+	} else {
+		d.Set("issued_at", nil)
+	}
 	return diags
 }
 

--- a/internal/service/acm/certificate_validation_test.go
+++ b/internal/service/acm/certificate_validation_test.go
@@ -36,6 +36,7 @@ func TestAccACMCertificateValidation_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCertificateValidationExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrCertificateARN, certificateResourceName, names.AttrARN),
+					acctest.CheckResourceAttrRFC3339(resourceName, "issued_at"),
 				),
 			},
 		},

--- a/website/docs/d/acm_certificate.html.markdown
+++ b/website/docs/d/acm_certificate.html.markdown
@@ -53,7 +53,9 @@ This data source supports the following arguments:
 This data source exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN of the found certificate, suitable for referencing in other resources that support ACM certificates.
+* `created_at` - Time at which the certificate was requested.
 * `id` - ARN of the found certificate, suitable for referencing in other resources that support ACM certificates.
+* `issued_at` - Time at which the certificate was issued. This value exists only when the certificate type is `AMAZON_ISSUED`.
 * `status` - Status of the found certificate.
 * `certificate` - ACM-issued certificate.
 * `certificate_chain` - Certificates forming the requested ACM-issued certificate's chain of trust. The chain consists of the certificate of the issuing CA and the intermediate certificates of any other subordinate CAs.

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -183,10 +183,12 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `id` - ARN of the certificate
 * `arn` - ARN of the certificate
+* `created_at` - Time at which the certificate was requested.
 * `domain_name` - Domain name for which the certificate is issued
 * `domain_validation_options` - Set of domain validation objects which can be used to complete certificate validation.
   Can have more than one element, e.g., if SANs are defined.
   Only set if `DNS`-validation was used.
+* `issued_at` - Time at which the certificate was issued. This value exists only when the certificate type is `AMAZON_ISSUED`.
 * `not_after` - Expiration date and time of the certificate.
 * `not_before` - Start of the validity period of the certificate.
 * `pending_renewal` - `true` if a Private certificate eligible for managed renewal is within the `early_renewal_duration` period.

--- a/website/docs/r/acm_certificate_validation.html.markdown
+++ b/website/docs/r/acm_certificate_validation.html.markdown
@@ -138,6 +138,7 @@ This resource supports the following arguments:
 This resource exports the following attributes in addition to the arguments above:
 
 * `id` - Time at which the certificate was issued
+* `issued_at` - Time at which the certificate was issued.
 
 ## Timeouts
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR adds the following computed attributes:

* `aws_acm_certificate` resource: `created_at` and `issued_at`
* `aws_acm_certificate` data source: `created_at` and `issued_at`
* `aws_acm_certificate_validation` resource: `issued_at`

Note that `issued_at` is nullable and is `null` when a certificate has not been issued.

Because `aws.ToTime(nil)` returns a zero-value `time.Time` (i.e. the zero timestamp), `nil` is explicitly set when the AWS API returns `null` for `issuedAt`.

This follows the same pattern as existing time attributes such as `not_before` and `not_after`.


### Relations

Closes #47654 
Closes #47655

### References
https://docs.aws.amazon.com/ja_jp/acm/latest/APIReference/API_CertificateDetail.html#ACM-Type-CertificateDetail-CreatedAt

### Output from Acceptance Testing

```console
$ ACM_CERTIFICATE_ROOT_DOMAIN="xxxxx" make testacc TESTS='(^TestAccACMCertificate_emailValidation$$|^TestAccACMCertificateValidation_basic$$|^TestAccACMCertificateDataSource_byDomain$$|^TestAccACMCertificate_nonEmptyIssuedAt$$)' PKG=acm
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_acm_certificate-add_created_at 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/acm/... -v -count 1 -parallel 20 -run='(^TestAccACMCertificate_emailValidation$|^TestAccACMCertificateValidation_basic$|^TestAccACMCertificateDataSource_byDomain$|^TestAccACMCertificate_nonEmptyIssuedAt$)'  -timeout 360m -vet=off -buildvcs=false
2026/05/14 23:02:28 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/14 23:02:28 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccACMCertificateDataSource_byDomain
=== PAUSE TestAccACMCertificateDataSource_byDomain
=== RUN   TestAccACMCertificate_emailValidation
=== PAUSE TestAccACMCertificate_emailValidation
=== RUN   TestAccACMCertificate_nonEmptyIssuedAt
=== PAUSE TestAccACMCertificate_nonEmptyIssuedAt
=== RUN   TestAccACMCertificateValidation_basic
=== PAUSE TestAccACMCertificateValidation_basic
=== CONT  TestAccACMCertificateDataSource_byDomain
=== CONT  TestAccACMCertificate_nonEmptyIssuedAt
=== CONT  TestAccACMCertificateValidation_basic
=== CONT  TestAccACMCertificate_emailValidation
--- PASS: TestAccACMCertificateDataSource_byDomain (29.39s)
--- PASS: TestAccACMCertificate_emailValidation (33.27s)
--- PASS: TestAccACMCertificateValidation_basic (101.28s)
--- PASS: TestAccACMCertificate_nonEmptyIssuedAt (119.26s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/acm        124.909s
```
