### PR TITLE
r/aws_db_instance: Fix `password_wo` value not sent when migrating from `password`

### DIFF
--- a/.changelog/47904.txt
+++ b/.changelog/47904.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_instance: Fix `password_wo` value not being sent to RDS when migrating an existing instance from `password` to `password_wo`
+```

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -2319,7 +2319,11 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta an
 				log.Println("[INFO] Only settings updating, instance changes will be applied in next maintenance window")
 			}
 
-			dbInstancePopulateModify(input, d)
+			_, di := dbInstancePopulateModify(input, d)
+			diags = append(diags, di...)
+			if diags.HasError() {
+				return diags
+			}
 
 			if d.HasChange(names.AttrEngineVersion) {
 				input.EngineVersion = aws.String(d.Get(names.AttrEngineVersion).(string))
@@ -2626,23 +2630,26 @@ func dbInstancePopulateModify(input *rds.ModifyDBInstanceInput, d *schema.Resour
 		input.OptionGroupName = aws.String(d.Get("option_group_name").(string))
 	}
 
-	if d.HasChange(names.AttrPassword) {
+	// Handle changes to either `password` or `password_wo` (driven by `password_wo_version`).
+	// This unified handling also covers the migration from `password` to `password_wo` where
+	// the `password` attribute is removed in the same plan that introduces `password_wo` and
+	// `password_wo_version`.
+	if d.HasChange(names.AttrPassword) || d.HasChange("password_wo_version") {
 		needsModify = true
+
 		// With ManageMasterUserPassword set to true, the password is no longer needed, so we omit it from the API call.
 		if v, ok := d.GetOk(names.AttrPassword); ok {
 			input.MasterUserPassword = aws.String(v.(string))
-		}
-	}
+		} else {
+			passwordWO, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath("password_wo"))
+			diags = append(diags, di...)
+			if diags.HasError() {
+				return false, diags
+			}
 
-	if d.HasChange("password_wo_version") {
-		passwordWO, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath("password_wo"))
-		diags = append(diags, di...)
-		if diags.HasError() {
-			return false, diags
-		}
-
-		if passwordWO != "" {
-			input.MasterUserPassword = aws.String(passwordWO)
+			if passwordWO != "" {
+				input.MasterUserPassword = aws.String(passwordWO)
+			}
 		}
 	}
 

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -1029,6 +1029,52 @@ func TestAccRDSInstance_passwordWriteOnly(t *testing.T) {
 	})
 }
 
+// TestAccRDSInstance_passwordMigrationToWriteOnly verifies that migrating an
+// existing aws_db_instance from the plain `password` attribute to the
+// write-only `password_wo` + `password_wo_version` pair updates the master
+// user password in-place (without recreating the instance and without
+// silently clearing the password). Regression test for issue #42582.
+func TestAccRDSInstance_passwordMigrationToWriteOnly(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	// All RDS Instance tests should skip for testing.Short() except the 20 shortest running tests.
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v1, v2 types.DBInstance
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_db_instance.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		CheckDestroy: testAccCheckDBInstanceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_password(rName, "valid-password-1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDBInstanceExists(ctx, t, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, names.AttrPassword, "valid-password-1"),
+				),
+			},
+			{
+				Config: testAccInstanceConfig_passwordWriteOnly(rName, "valid-password-2", 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDBInstanceExists(ctx, t, resourceName, &v2),
+					testAccCheckDBInstanceNotRecreated(&v1, &v2),
+					resource.TestCheckResourceAttr(resourceName, "password_wo_version", "1"),
+					resource.TestCheckNoResourceAttr(resourceName, names.AttrPassword),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRDSInstance_ManageMasterPassword_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 


### PR DESCRIPTION
## Description

Fixes the migration path from the plain `password` attribute to the write-only `password_wo` + `password_wo_version` pair on `aws_db_instance`. Today, when a user removes `password` from their config and adds `password_wo` / `password_wo_version`, the `ModifyDBInstance` call is issued without `MasterUserPassword` and the master user password ends up effectively cleared on the running database.

Root cause is in [`internal/service/rds/instance.go`](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/rds/instance.go), in `dbInstancePopulateModify`:

```go
if d.HasChange(names.AttrPassword) {
    needsModify = true
    if v, ok := d.GetOk(names.AttrPassword); ok {
        input.MasterUserPassword = aws.String(v.(string))
    }
}

if d.HasChange("password_wo_version") {
    passwordWO, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath("password_wo"))
    diags = append(diags, di...)
    if diags.HasError() {
        return false, diags
    }
    if passwordWO != "" {
        input.MasterUserPassword = aws.String(passwordWO)
    }
}
```

In the migration scenario the first block fires (password removed -> nil), but it intentionally does not set `MasterUserPassword` because the new value is empty. The second block was expected to take over, but the two handlers are uncoordinated and the result is that `MasterUserPassword` may end up unset. Compounding this, the caller at line 2322 silently discarded the `diag.Diagnostics` returned by `dbInstancePopulateModify`, so any error reading the write-only attribute from the raw config was hidden from the user.

## Changes

- **`internal/service/rds/instance.go`** — Unify the `password` and `password_wo_version` handlers in `dbInstancePopulateModify`. Whenever either attribute changes, the new master user password is taken from `password` if set, otherwise from `password_wo` resolved via `flex.GetWriteOnlyStringValue`. Propagate diagnostics returned by `dbInstancePopulateModify` at the caller (`resourceInstanceUpdate`) so any failure to resolve `password_wo` surfaces as a real error.
- **`internal/service/rds/instance_test.go`** — Add `TestAccRDSInstance_passwordMigrationToWriteOnly`, a regression acceptance test that creates an instance with `password = "valid-password-1"`, then in a second step switches to `password_wo = "valid-password-2"` + `password_wo_version = 1`, and asserts the instance is not recreated, `password_wo_version` is recorded, and `password` is no longer present in state. Modeled on the existing `TestAccRDSInstance_password` and `TestAccRDSInstance_passwordWriteOnly` tests.

A changelog entry will be added in a follow-up commit using the PR number once this is opened, per `docs/changelog-process.md`.

## Closes

Closes #42582

## Acceptance test

`make testacc TESTS=TestAccRDSInstance_passwordMigrationToWriteOnly PKG=rds` — not yet run by submitter (no AWS credentials available); please verify in your acceptance test environment.

## Output from acceptance testing

_To be filled in by reviewers._

## Notes

- I did not change the `manage_master_user_password` path; that branch remains driven by its own `HasChange` block elsewhere.
- The reporter also noted similar-looking behavior on `aws_secretsmanager_secret_version` `secret_string_wo`. That is a different resource and out of scope here — happy to open a separate issue/PR if you confirm it is also affected.

Made with [Cursor](https://cursor.com)