### PR TITLE
🤖🤖🤖 resource/aws_launch_template: Fix `latest_version` and `default_version` not marked as computed when `description` changes

### DIFF
--- a/.changelog/47909.txt
+++ b/.changelog/47909.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_launch_template: Fix `latest_version` and `default_version` not being marked as computed when `description` changes
+```

--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -1078,7 +1078,7 @@ func resourceLaunchTemplate() *schema.Resource {
 			customdiff.ComputedIf("default_version", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				for _, changedKey := range diff.GetChangedKeysPrefix("") {
 					switch changedKey {
-					case "name", "name_prefix", "description":
+					case "name", "name_prefix":
 						continue
 					default:
 						return diff.Get("update_default_version").(bool)
@@ -1089,7 +1089,7 @@ func resourceLaunchTemplate() *schema.Resource {
 			customdiff.ComputedIf("latest_version", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				for _, changedKey := range diff.GetChangedKeysPrefix("") {
 					switch changedKey {
-					case "name", "name_prefix", "description", "default_version", "update_default_version":
+					case "name", "name_prefix", "default_version", "update_default_version":
 						continue
 					default:
 						return true


### PR DESCRIPTION
### Description

When `description` is the only attribute changed on an `aws_launch_template`, the `CustomizeDiff` logic incorrectly skips it in the `ComputedIf` evaluation for both `latest_version` and `default_version`. This causes Terraform to report these attributes as unchanged during plan, even though the Update function calls `CreateLaunchTemplateVersion` (because `description` is in `updateKeys`), which increments `latest_version`.

The practical impact is that downstream resources referencing `latest_version` (e.g., an `aws_autoscaling_group` using `$Latest`) are not updated in the same apply cycle — requiring a second plan/apply to converge.

This fix removes `"description"` from the skip list in both `ComputedIf` functions so that Terraform correctly anticipates the version change during plan.

### AI Usage Disclosure

This change was developed with the assistance of an AI coding agent (Devin by Cognition AI). The human author has reviewed and understands the change completely.

### Relations

Closes #43559

### References

- `description` is included in `updateKeys` ([line ~1195](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/ec2_launch_template.go#L1195)) which triggers `CreateLaunchTemplateVersion`
- The `ComputedIf` for `latest_version` and `default_version` previously excluded `description` from triggering computed state, contradicting the update behavior

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccEC2LaunchTemplate_ PKG=ec2

...