### PR TITLE
.ci/semgrep: add `testcase-use-paralleltest` rule 

### DIFF
--- a/.ci/semgrep/acctest/paralleltest.go
+++ b/.ci/semgrep/acctest/paralleltest.go
@@ -1,0 +1,60 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccBar_usesTest(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	// ruleid: testcase-use-paralleltest
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: "# test",
+			},
+		},
+	})
+}
+
+// ok: testcase-use-paralleltest
+func TestAccBar_usesParallelTest(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: "# test",
+			},
+		},
+	})
+}
+
+// ok: testcase-use-paralleltest
+func testAccBar_serialHelper(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: "# test",
+			},
+		},
+	})
+}

--- a/.ci/semgrep/acctest/paralleltest.yml
+++ b/.ci/semgrep/acctest/paralleltest.yml
@@ -1,0 +1,20 @@
+# Copyright IBM Corp. 2014, 2026
+# "SPDX-License-Identifier: MPL-2.0"
+
+rules:
+  - id: testcase-use-paralleltest
+    languages: [go]
+    message: "Acceptance tests should use acctest.ParallelTest if not serialized."
+    severity: ERROR
+    patterns:
+      - pattern-inside: |
+          func $FUNC($T *testing.T) {
+            ...
+          }
+      - metavariable-regex:
+          metavariable: $FUNC
+          regex: ^TestAcc
+      - pattern: acctest.Test(...)
+    paths:
+      include:
+        - "**/*_test.go"

--- a/internal/service/amp/workspace_data_source_test.go
+++ b/internal/service/amp/workspace_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccAMPWorkspaceDataSource_basic(t *testing.T) {
 	resourceName := "aws_prometheus_workspace.test"
 	dataSourceName := "data.aws_prometheus_workspace.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.AMPEndpointID)

--- a/internal/service/amp/workspaces_data_source_test.go
+++ b/internal/service/amp/workspaces_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccAMPWorkspacesDataSource_basic(t *testing.T) { // nosemgrep:ci.caps0-
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_prometheus_workspaces.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.AMPEndpointID)
@@ -48,7 +48,7 @@ func TestAccAMPWorkspacesDataSource_aliasPrefix(t *testing.T) { // nosemgrep:ci.
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_prometheus_workspaces.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.AMPEndpointID)

--- a/internal/service/athena/workgroup_test.go
+++ b/internal/service/athena/workgroup_test.go
@@ -1919,7 +1919,20 @@ func TestAccAthenaWorkGroup_monitoringConfiguration(t *testing.T) {
 	})
 }
 
-func TestAccAthenaWorkGroup_QueryResultsS3AccessGrantsConfiguration_basic(t *testing.T) {
+// SSO Admin is an account-level singleton. Tests that interact with Identity
+// Center configuration must not run in parallel.
+func TestAccAthenaWorkGroup_QueryResultsS3AccessGrantsConfiguration_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		acctest.CtBasic: testAccWorkGroup_QueryResultsS3AccessGrantsConfiguration_basic,
+		"update":        testAccWorkGroup_QueryResultsS3AccessGrantsConfiguration_update,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccWorkGroup_QueryResultsS3AccessGrantsConfiguration_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var workgroup1 types.WorkGroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -1959,7 +1972,7 @@ func TestAccAthenaWorkGroup_QueryResultsS3AccessGrantsConfiguration_basic(t *tes
 	})
 }
 
-func TestAccAthenaWorkGroup_QueryResultsS3AccessGrantsConfiguration_update(t *testing.T) {
+func testAccWorkGroup_QueryResultsS3AccessGrantsConfiguration_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	var workgroup1, workgroup2 types.WorkGroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)

--- a/internal/service/athena/workgroup_test.go
+++ b/internal/service/athena/workgroup_test.go
@@ -1919,8 +1919,7 @@ func TestAccAthenaWorkGroup_monitoringConfiguration(t *testing.T) {
 	})
 }
 
-// SSO Admin is an account-level singleton. Tests that interact with Identity
-// Center configuration must not run in parallel.
+// SSO Admin is an account-level singleton.
 func TestAccAthenaWorkGroup_QueryResultsS3AccessGrantsConfiguration_serial(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/batch/scheduling_policy_data_source_test.go
+++ b/internal/service/batch/scheduling_policy_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccBatchSchedulingPolicyDataSource_basic(t *testing.T) {
 	resourceName := "aws_batch_scheduling_policy.test"
 	dataSourceName := "data.aws_batch_scheduling_policy.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/bedrock/guardrail_version_test.go
+++ b/internal/service/bedrock/guardrail_version_test.go
@@ -92,7 +92,7 @@ func TestAccBedrockGuardrailVersion_skipDestroy(t *testing.T) {
 	resourceName := "aws_bedrock_guardrail_version.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	var guardrailversion bedrock.GetGuardrailOutput
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)

--- a/internal/service/cloudfront/multitenant_distribution_test.go
+++ b/internal/service/cloudfront/multitenant_distribution_test.go
@@ -20,13 +20,11 @@ import (
 )
 
 func TestAccCloudFrontMultiTenantDistribution_basic(t *testing.T) {
-	t.Parallel()
-
 	ctx := acctest.Context(t)
 	var distribution awstypes.Distribution
 	resourceName := "aws_cloudfront_multitenant_distribution.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -78,14 +76,12 @@ func TestAccCloudFrontMultiTenantDistribution_disappears(t *testing.T) {
 }
 
 func TestAccCloudFrontMultiTenantDistribution_comprehensive(t *testing.T) {
-	t.Parallel()
-
 	ctx := acctest.Context(t)
 	var distribution awstypes.Distribution
 	resourceName := "aws_cloudfront_multitenant_distribution.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -158,14 +154,12 @@ func TestAccCloudFrontMultiTenantDistribution_comprehensive(t *testing.T) {
 }
 
 func TestAccCloudFrontMultiTenantDistribution_s3OriginWithOAC(t *testing.T) {
-	t.Parallel()
-
 	ctx := acctest.Context(t)
 	var distribution awstypes.Distribution
 	resourceName := "aws_cloudfront_multitenant_distribution.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -192,13 +186,11 @@ func TestAccCloudFrontMultiTenantDistribution_s3OriginWithOAC(t *testing.T) {
 
 // Ref: https://github.com/hashicorp/terraform-provider-aws/issues/46302
 func TestAccCloudFrontMultiTenantDistribution_customErrorResponseWithoutResponsePagePath(t *testing.T) {
-	t.Parallel()
-
 	ctx := acctest.Context(t)
 	var distribution awstypes.Distribution
 	resourceName := "aws_cloudfront_multitenant_distribution.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -228,13 +220,11 @@ func TestAccCloudFrontMultiTenantDistribution_customErrorResponseWithoutResponse
 }
 
 func TestAccCloudFrontMultiTenantDistribution_tags(t *testing.T) {
-	t.Parallel()
-
 	ctx := acctest.Context(t)
 	var distribution awstypes.Distribution
 	resourceName := "aws_cloudfront_multitenant_distribution.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -277,13 +267,11 @@ func TestAccCloudFrontMultiTenantDistribution_tags(t *testing.T) {
 
 // Ref: https://github.com/hashicorp/terraform-provider-aws/issues/46045
 func TestAccCloudFrontMultiTenantDistribution_originSwapOrder(t *testing.T) {
-	t.Parallel()
-
 	ctx := acctest.Context(t)
 	var distribution awstypes.Distribution
 	resourceName := "aws_cloudfront_multitenant_distribution.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -315,13 +303,11 @@ func TestAccCloudFrontMultiTenantDistribution_originSwapOrder(t *testing.T) {
 }
 
 func TestAccCloudFrontMultiTenantDistribution_update(t *testing.T) {
-	t.Parallel()
-
 	ctx := acctest.Context(t)
 	var distribution awstypes.Distribution
 	resourceName := "aws_cloudfront_multitenant_distribution.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -357,7 +343,6 @@ func TestAccCloudFrontMultiTenantDistribution_update(t *testing.T) {
 }
 
 func TestAccCloudFrontMultiTenantDistribution_functionAssociationSwapBlocks(t *testing.T) {
-	t.Parallel()
 	// Ref: https://github.com/hashicorp/terraform-provider-aws/issues/46377
 
 	ctx := acctest.Context(t)
@@ -365,7 +350,7 @@ func TestAccCloudFrontMultiTenantDistribution_functionAssociationSwapBlocks(t *t
 	resourceName := "aws_cloudfront_multitenant_distribution.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -400,7 +385,6 @@ func TestAccCloudFrontMultiTenantDistribution_functionAssociationSwapBlocks(t *t
 }
 
 func TestAccCloudFrontMultiTenantDistribution_lambdaFunctionAssociationSwapBlocks(t *testing.T) {
-	t.Parallel()
 	// Ref: https://github.com/hashicorp/terraform-provider-aws/issues/46377
 
 	// This test requires creating Lambda@Edge functions which may hang around for hours after distribution
@@ -412,7 +396,7 @@ func TestAccCloudFrontMultiTenantDistribution_lambdaFunctionAssociationSwapBlock
 	resourceName := "aws_cloudfront_multitenant_distribution.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID)

--- a/internal/service/codepipeline/webhook_test.go
+++ b/internal/service/codepipeline/webhook_test.go
@@ -21,8 +21,7 @@ import (
 )
 
 // Webhook tests share the same GitHub OAuth token and target the same
-// external repo (lifesum-terraform/test). Parallel execution would cause
-// webhook registration conflicts at GitHub.
+// external repo (lifesum-terraform/test).
 func TestAccCodePipelineWebhook_serial(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/codepipeline/webhook_test.go
+++ b/internal/service/codepipeline/webhook_test.go
@@ -20,7 +20,25 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccCodePipelineWebhook_basic(t *testing.T) {
+// Webhook tests share the same GitHub OAuth token and target the same
+// external repo (lifesum-terraform/test). Parallel execution would cause
+// webhook registration conflicts at GitHub.
+func TestAccCodePipelineWebhook_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		acctest.CtBasic:                    testAccWebhook_basic,
+		"ipAuth":                           testAccWebhook_ipAuth,
+		"unauthenticated":                  testAccWebhook_unauthenticated,
+		"tags":                             testAccWebhook_tags,
+		acctest.CtDisappears:               testAccWebhook_disappears,
+		"UpdateAuthentication_secretToken": testAccWebhook_UpdateAuthentication_secretToken,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccWebhook_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	ghToken := acctest.SkipIfEnvVarNotSet(t, envvar.GithubToken)
 	var v types.ListWebhookItem
@@ -90,7 +108,7 @@ func TestAccCodePipelineWebhook_basic(t *testing.T) {
 	})
 }
 
-func TestAccCodePipelineWebhook_ipAuth(t *testing.T) {
+func testAccWebhook_ipAuth(t *testing.T) {
 	ctx := acctest.Context(t)
 	ghToken := acctest.SkipIfEnvVarNotSet(t, envvar.GithubToken)
 	var v types.ListWebhookItem
@@ -125,7 +143,7 @@ func TestAccCodePipelineWebhook_ipAuth(t *testing.T) {
 	})
 }
 
-func TestAccCodePipelineWebhook_unauthenticated(t *testing.T) {
+func testAccWebhook_unauthenticated(t *testing.T) {
 	ctx := acctest.Context(t)
 	ghToken := acctest.SkipIfEnvVarNotSet(t, envvar.GithubToken)
 	var v types.ListWebhookItem
@@ -158,7 +176,7 @@ func TestAccCodePipelineWebhook_unauthenticated(t *testing.T) {
 	})
 }
 
-func TestAccCodePipelineWebhook_tags(t *testing.T) {
+func testAccWebhook_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	ghToken := acctest.SkipIfEnvVarNotSet(t, envvar.GithubToken)
 	var v types.ListWebhookItem
@@ -208,7 +226,7 @@ func TestAccCodePipelineWebhook_tags(t *testing.T) {
 	})
 }
 
-func TestAccCodePipelineWebhook_disappears(t *testing.T) {
+func testAccWebhook_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	ghToken := acctest.SkipIfEnvVarNotSet(t, envvar.GithubToken)
 	var v types.ListWebhookItem
@@ -236,7 +254,7 @@ func TestAccCodePipelineWebhook_disappears(t *testing.T) {
 	})
 }
 
-func TestAccCodePipelineWebhook_UpdateAuthentication_secretToken(t *testing.T) {
+func testAccWebhook_UpdateAuthentication_secretToken(t *testing.T) {
 	ctx := acctest.Context(t)
 	ghToken := acctest.SkipIfEnvVarNotSet(t, envvar.GithubToken)
 	var v1, v2 types.ListWebhookItem

--- a/internal/service/cognitoidentity/pool_test.go
+++ b/internal/service/cognitoidentity/pool_test.go
@@ -317,7 +317,7 @@ func TestAccCognitoIdentityPool_addingNewProviderKeepsOldProvider(t *testing.T) 
 	name := acctest.RandString(t, 10)
 	resourceName := "aws_cognito_identity_pool.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIdentityServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/configservice/configservice_test.go
+++ b/internal/service/configservice/configservice_test.go
@@ -133,6 +133,10 @@ func TestAccConfigService_serial(t *testing.T) {
 			"ListIncludeResource": testAccRemediationConfiguration_List_includeResource,
 			"ListRegionOverride":  testAccRemediationConfiguration_List_regionOverride,
 		},
+		"ConfigurationAggregator": {
+			"organization": testAccConfigurationAggregator_organization,
+			"switch":       testAccConfigurationAggregator_switch,
+		},
 		"RetentionConfiguration": {
 			acctest.CtBasic:      testAccRetentionConfiguration_basic,
 			acctest.CtDisappears: testAccRetentionConfiguration_disappears,

--- a/internal/service/configservice/configuration_aggregator_test.go
+++ b/internal/service/configservice/configuration_aggregator_test.go
@@ -54,7 +54,7 @@ func TestAccConfigServiceConfigurationAggregator_account(t *testing.T) {
 	})
 }
 
-func TestAccConfigServiceConfigurationAggregator_organization(t *testing.T) {
+func testAccConfigurationAggregator_organization(t *testing.T) {
 	ctx := acctest.Context(t)
 	var ca types.ConfigurationAggregator
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -85,7 +85,7 @@ func TestAccConfigServiceConfigurationAggregator_organization(t *testing.T) {
 	})
 }
 
-func TestAccConfigServiceConfigurationAggregator_switch(t *testing.T) {
+func testAccConfigurationAggregator_switch(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_config_configuration_aggregator.test"

--- a/internal/service/ec2/ec2_eip_test.go
+++ b/internal/service/ec2/ec2_eip_test.go
@@ -652,7 +652,20 @@ func TestAccEC2EIP_BYOIPAddress_default(t *testing.T) {
 	})
 }
 
-func TestAccEC2EIP_BYOIPAddress_custom(t *testing.T) {
+// BYOIP tests share the same IP address from AWS_EC2_EIP_BYOIP_ADDRESS.
+// Only one EIP allocation can hold a given address at a time.
+func TestAccEC2EIP_BYOIPAddress_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		"custom":                   testAccEIP_BYOIPAddress_custom,
+		"customWithPublicIPv4Pool": testAccEIP_BYOIPAddress_customWithPublicIPv4Pool,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccEIP_BYOIPAddress_custom(t *testing.T) {
 	ctx := acctest.Context(t)
 	key := "AWS_EC2_EIP_BYOIP_ADDRESS"
 	address := os.Getenv(key)
@@ -681,7 +694,7 @@ func TestAccEC2EIP_BYOIPAddress_custom(t *testing.T) {
 	})
 }
 
-func TestAccEC2EIP_BYOIPAddress_customWithPublicIPv4Pool(t *testing.T) {
+func testAccEIP_BYOIPAddress_customWithPublicIPv4Pool(t *testing.T) {
 	ctx := acctest.Context(t)
 	key := "AWS_EC2_EIP_BYOIP_ADDRESS"
 	address := os.Getenv(key)

--- a/internal/service/ec2/vpc_endpoint_connection_accepter_test.go
+++ b/internal/service/ec2/vpc_endpoint_connection_accepter_test.go
@@ -21,7 +21,7 @@ func TestAccVPCEndpointConnectionAccepter_crossAccount(t *testing.T) {
 	resourceName := "aws_vpc_endpoint_connection_accepter.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckAlternateAccount(t)

--- a/internal/service/ecr/authorization_token_data_source_test.go
+++ b/internal/service/ecr/authorization_token_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccECRAuthorizationTokenDataSource_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_ecr_authorization_token.repo"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/ecr/lifecycle_policy_document_data_source_test.go
+++ b/internal/service/ecr/lifecycle_policy_document_data_source_test.go
@@ -16,7 +16,7 @@ func TestAccECRLifecyclePolicyDocumentDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ecr_lifecycle_policy_document.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -35,7 +35,7 @@ func TestAccECRLifecyclePolicyDocumentDataSource_storageClassTransition(t *testi
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ecr_lifecycle_policy_document.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/ecr/repository_creation_template_data_source_test.go
+++ b/internal/service/ecr/repository_creation_template_data_source_test.go
@@ -47,7 +47,7 @@ func TestAccECRRepositoryCreationTemplateDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccECRRepositoryCreationTemplateDataSource_root(t *testing.T) {
+func testAccRepositoryCreationTemplateDataSource_root(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSource := "data.aws_ecr_repository_creation_template.root"
 
@@ -71,7 +71,7 @@ func TestAccECRRepositoryCreationTemplateDataSource_mutabilityWithExclusion(t *t
 	repositoryPrefix := "tf-test-" + acctest.RandString(t, 8)
 	dataSource := "data.aws_ecr_repository_creation_template.root"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/ecr/repository_creation_template_test.go
+++ b/internal/service/ecr/repository_creation_template_test.go
@@ -25,7 +25,7 @@ func TestAccECRRepositoryCreationTemplate_serial(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]func(t *testing.T){
-		"root":          testAccRepositoryCreationTemplate_root,
+		"root":           testAccRepositoryCreationTemplate_root,
 		"rootDataSource": testAccRepositoryCreationTemplateDataSource_root,
 	}
 

--- a/internal/service/ecr/repository_creation_template_test.go
+++ b/internal/service/ecr/repository_creation_template_test.go
@@ -19,6 +19,19 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+// ROOT prefix is a per-registry singleton — only one template with prefix
+// "ROOT" can exist. These tests must be serialized to avoid conflicts.
+func TestAccECRRepositoryCreationTemplate_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		"root":          testAccRepositoryCreationTemplate_root,
+		"rootDataSource": testAccRepositoryCreationTemplateDataSource_root,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
 func TestAccECRRepositoryCreationTemplate_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	repositoryPrefix := "tf-test-" + acctest.RandString(t, 8)
@@ -176,7 +189,7 @@ func TestAccECRRepositoryCreationTemplate_repository(t *testing.T) {
 	})
 }
 
-func TestAccECRRepositoryCreationTemplate_root(t *testing.T) {
+func testAccRepositoryCreationTemplate_root(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ecr_repository_creation_template.root"
 

--- a/internal/service/ecr/repository_creation_template_test.go
+++ b/internal/service/ecr/repository_creation_template_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 // ROOT prefix is a per-registry singleton — only one template with prefix
-// "ROOT" can exist. These tests must be serialized to avoid conflicts.
+// "ROOT" can exist.
 func TestAccECRRepositoryCreationTemplate_serial(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/ecrpublic/authorization_token_data_source_test.go
+++ b/internal/service/ecrpublic/authorization_token_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccECRPublicAuthorizationTokenDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ecrpublic_authorization_token.repo"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckRegion(t, endpoints.UsEast1RegionID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/eks/node_group_data_source_test.go
+++ b/internal/service/eks/node_group_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccEKSNodeGroupDataSource_basic(t *testing.T) {
 	dataSourceResourceName := "data.aws_eks_node_group.test"
 	resourceName := "aws_eks_node_group.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/eks/node_groups_data_source_test.go
+++ b/internal/service/eks/node_groups_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccEKSNodeGroupsDataSource_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceResourceName := "data.aws_eks_node_groups.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/elbv2/load_balancer_test.go
+++ b/internal/service/elbv2/load_balancer_test.go
@@ -1025,7 +1025,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_IPAMPools_modify(t *testin
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_lb.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{ // nosemgrep:ci.semgrep.acctest.testcase-use-paralleltest -- skipped test, IPAM pools are scarce shared resources
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1076,7 +1076,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_IPAMPools_unassign(t *test
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_lb.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{ // nosemgrep:ci.semgrep.acctest.testcase-use-paralleltest -- skipped test, IPAM pools are scarce shared resources
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/elbv2/load_balancer_test.go
+++ b/internal/service/elbv2/load_balancer_test.go
@@ -993,7 +993,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_IPAMPools_basic(t *testing
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_lb.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{ // nosemgrep:ci.semgrep.acctest.testcase-use-paralleltest -- skipped test, IPAM pools are scarce shared resources
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/iam/openid_connect_provider_test.go
+++ b/internal/service/iam/openid_connect_provider_test.go
@@ -65,12 +65,27 @@ func TestAccIAMOpenIDConnectProvider_basic(t *testing.T) {
 	})
 }
 
-func TestAccIAMOpenIDConnectProvider_Thumbprints_none(t *testing.T) {
+// Thumbprint tests all use the hardcoded accounts.google.com URL. Only one
+// OIDC provider per URL can exist per account, so these cannot run in
+// parallel.
+func TestAccIAMOpenIDConnectProvider_Thumbprints_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		"none":          testAccOpenIDConnectProvider_Thumbprints_none,
+		"withToWithout": testAccOpenIDConnectProvider_Thumbprints_withToWithout,
+		"withoutToWith": testAccOpenIDConnectProvider_Thumbprints_withoutToWith,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccOpenIDConnectProvider_Thumbprints_none(t *testing.T) {
 	ctx := acctest.Context(t)
 	url := "accounts.google.com"
 	resourceName := "aws_iam_openid_connect_provider.test"
 
-	acctest.Test(ctx, t, resource.TestCase{ // can't run in parallel b/c of google URL, needed for no thumbprints
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -93,12 +108,12 @@ func TestAccIAMOpenIDConnectProvider_Thumbprints_none(t *testing.T) {
 	})
 }
 
-func TestAccIAMOpenIDConnectProvider_Thumbprints_withToWithout(t *testing.T) {
+func testAccOpenIDConnectProvider_Thumbprints_withToWithout(t *testing.T) {
 	ctx := acctest.Context(t)
 	url := "accounts.google.com"
 	resourceName := "aws_iam_openid_connect_provider.test"
 
-	acctest.Test(ctx, t, resource.TestCase{ // can't run in parallel b/c of google URL, needed for no thumbprints
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -138,12 +153,12 @@ func TestAccIAMOpenIDConnectProvider_Thumbprints_withToWithout(t *testing.T) {
 	})
 }
 
-func TestAccIAMOpenIDConnectProvider_Thumbprints_withoutToWith(t *testing.T) {
+func testAccOpenIDConnectProvider_Thumbprints_withoutToWith(t *testing.T) {
 	ctx := acctest.Context(t)
 	url := "accounts.google.com"
 	resourceName := "aws_iam_openid_connect_provider.test"
 
-	acctest.Test(ctx, t, resource.TestCase{ // can't run in parallel b/c of google URL, needed for no thumbprints
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/iam/openid_connect_provider_test.go
+++ b/internal/service/iam/openid_connect_provider_test.go
@@ -66,8 +66,7 @@ func TestAccIAMOpenIDConnectProvider_basic(t *testing.T) {
 }
 
 // Thumbprint tests all use the hardcoded accounts.google.com URL. Only one
-// OIDC provider per URL can exist per account, so these cannot run in
-// parallel.
+// OIDC provider per URL can exist per account.
 func TestAccIAMOpenIDConnectProvider_Thumbprints_serial(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/imagebuilder/distribution_configuration_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_test.go
@@ -340,7 +340,19 @@ func TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLau
 	})
 }
 
-func TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_organizationARNs(t *testing.T) {
+// Organization-dependent tests use AWS Organizations (account singleton).
+func TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		"organizationARNs": testAccDistributionConfiguration_DistributionAMIDistributionLaunchPermission_organizationARNs,
+		"ouARNs":           testAccDistributionConfiguration_DistributionAMIDistributionLaunchPermission_ouARNs,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccDistributionConfiguration_DistributionAMIDistributionLaunchPermission_organizationARNs(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	organizationResourceName := "aws_organizations_organization.test"
@@ -372,7 +384,7 @@ func TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLau
 	})
 }
 
-func TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_ouARNs(t *testing.T) {
+func testAccDistributionConfiguration_DistributionAMIDistributionLaunchPermission_ouARNs(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	organizationalUnitResourceName := "aws_organizations_organizational_unit.test"

--- a/internal/service/lexmodels/bot_test.go
+++ b/internal/service/lexmodels/bot_test.go
@@ -91,6 +91,7 @@ func TestAccLexModelsBot_Version_serial(t *testing.T) {
 
 	testCases := map[string]func(t *testing.T){
 		"LexBot_createVersion":         testAccBot_createVersion,
+		"LexBot_computeVersion":        testAccBot_computeVersion,
 		"LexBotAlias_botVersion":       testAccBotAlias_botVersion,
 		"DataSourceLexBot_withVersion": testAccBotDataSource_withVersion,
 		"DataSourceLexBotAlias_basic":  testAccBotAliasDataSource_basic,
@@ -577,7 +578,7 @@ func TestAccLexModelsBot_intents(t *testing.T) {
 	})
 }
 
-func TestAccLexModelsBot_computeVersion(t *testing.T) {
+func testAccBot_computeVersion(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v1 lexmodelbuildingservice.GetBotOutput
 	var v2 lexmodelbuildingservice.GetBotAliasOutput

--- a/internal/service/meta/service_principal_data_source_test.go
+++ b/internal/service/meta/service_principal_data_source_test.go
@@ -62,7 +62,7 @@ func TestAccMetaServicePrincipalDataSource_ByRegion(t *testing.T) {
 	for _, region := range regions {
 		t.Run(region, func(t *testing.T) {
 			t.Parallel()
-			acctest.Test(ctx, t, resource.TestCase{
+			acctest.Test(ctx, t, resource.TestCase{ // nosemgrep:ci.semgrep.acctest.testcase-use-paralleltest -- subtests handle own parallelism via t.Parallel()
 				PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 				ErrorCheck:               acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -134,7 +134,7 @@ func TestAccMetaServicePrincipalDataSource_UniqueForServiceInRegion(t *testing.T
 	for _, testCase := range testCases {
 		t.Run(fmt.Sprintf("%s/%s", testCase.Region, testCase.Service), func(t *testing.T) {
 			t.Parallel()
-			acctest.Test(ctx, t, resource.TestCase{
+			acctest.Test(ctx, t, resource.TestCase{ // nosemgrep:ci.semgrep.acctest.testcase-use-paralleltest -- subtests handle own parallelism via t.Parallel()
 				PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 				ErrorCheck:               acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/networkfirewall/firewall_policy_test.go
+++ b/internal/service/networkfirewall/firewall_policy_test.go
@@ -985,7 +985,20 @@ func TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAct
 	})
 }
 
-func TestAccNetworkFirewallFirewallPolicy_tlsInspectionConfigurationARN(t *testing.T) {
+// Tests which depend on TLS inspection configuration ARN(s) provided
+// via environment variables.
+func TestAccNetworkFirewallFirewallPolicy_tlsInspectionConfigurationARN_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		"tlsInspectionConfigurationArn": testAccFirewallPolicy_tlsInspectionConfigurationARN,
+		"enableTLSSessionHolding":       testAccFirewallPolicy_enableTLSSessionHolding,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccFirewallPolicy_tlsInspectionConfigurationARN(t *testing.T) {
 	ctx := acctest.Context(t)
 	var firewallPolicy networkfirewall.DescribeFirewallPolicyOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -1019,6 +1032,62 @@ func TestAccNetworkFirewallFirewallPolicy_tlsInspectionConfigurationARN(t *testi
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccFirewallPolicy_enableTLSSessionHolding(t *testing.T) {
+	ctx := acctest.Context(t)
+	var firewallPolicy networkfirewall.DescribeFirewallPolicyOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_networkfirewall_firewall_policy.test"
+	arn1 := acctest.SkipIfEnvVarNotSet(t, "AWS_NETWORKFIREWALL_TLS_INSPECTION_CONFIGURATION_ARN_1")
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkFirewallServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFirewallPolicyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirewallPolicyConfig_enableTLSSessionHolding(rName, arn1, true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckFirewallPolicyExists(ctx, t, resourceName, &firewallPolicy),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "network-firewall", fmt.Sprintf("firewall-policy/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.enable_tls_session_holding", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccFirewallPolicyConfig_enableTLSSessionHolding(rName, arn1, false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckFirewallPolicyExists(ctx, t, resourceName, &firewallPolicy),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "network-firewall", fmt.Sprintf("firewall-policy/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.enable_tls_session_holding", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
+				),
 			},
 		},
 	})
@@ -1196,62 +1265,6 @@ func TestAccNetworkFirewallFirewallPolicy_activeThreatDefense_strictOrder(t *tes
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"firewall_policy.0.stateful_rule_group_reference.0.priority"},
-			},
-		},
-	})
-}
-
-func TestAccNetworkFirewallFirewallPolicy_enableTLSSessionHolding(t *testing.T) {
-	ctx := acctest.Context(t)
-	var firewallPolicy networkfirewall.DescribeFirewallPolicyOutput
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	resourceName := "aws_networkfirewall_firewall_policy.test"
-	arn1 := acctest.SkipIfEnvVarNotSet(t, "AWS_NETWORKFIREWALL_TLS_INSPECTION_CONFIGURATION_ARN_1")
-
-	acctest.ParallelTest(ctx, t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkFirewallServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckFirewallPolicyDestroy(ctx, t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFirewallPolicyConfig_enableTLSSessionHolding(rName, arn1, true),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
-					},
-				},
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckFirewallPolicyExists(ctx, t, resourceName, &firewallPolicy),
-					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "network-firewall", fmt.Sprintf("firewall-policy/%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
-					resource.TestCheckResourceAttr(resourceName, "firewall_policy.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.enable_tls_session_holding", acctest.CtTrue),
-					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccFirewallPolicyConfig_enableTLSSessionHolding(rName, arn1, false),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
-					},
-				},
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckFirewallPolicyExists(ctx, t, resourceName, &firewallPolicy),
-					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "network-firewall", fmt.Sprintf("firewall-policy/%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
-					resource.TestCheckResourceAttr(resourceName, "firewall_policy.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.enable_tls_session_holding", acctest.CtFalse),
-					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
-				),
 			},
 		},
 	})

--- a/internal/service/organizations/organizations_test.go
+++ b/internal/service/organizations/organizations_test.go
@@ -113,6 +113,12 @@ func TestAccOrganizations_serial(t *testing.T) {
 			acctest.CtBasic: testAccDelegatedServicesDataSource_basic,
 			"multiple":      testAccDelegatedServicesDataSource_multiple,
 		},
+		"PoliciesDataSource": {
+			acctest.CtBasic: testAccPoliciesDataSource_basic,
+		},
+		"PoliciesForTargetDataSource": {
+			acctest.CtBasic: testAccPoliciesForTargetDataSource_basic,
+		},
 		"ResourceTags": {
 			acctest.CtBasic: testAccResourceTagsDataSource_basic,
 		},

--- a/internal/service/organizations/policies_data_source_test.go
+++ b/internal/service/organizations/policies_data_source_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccOrganizationsPoliciesDataSource_basic(t *testing.T) {
+func testAccPoliciesDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	serviceControlPolicyContent := `{"Version": "2012-10-17", "Statement": { "Effect": "Deny", "Action": "*", "Resource": "*"}}`

--- a/internal/service/organizations/policies_for_target_data_source_test.go
+++ b/internal/service/organizations/policies_for_target_data_source_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccOrganizationsPoliciesForTargetDataSource_basic(t *testing.T) {
+func testAccPoliciesForTargetDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	datasourceName := "data.aws_organizations_policies_for_target.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)

--- a/internal/service/pinpoint/apns_channel_test.go
+++ b/internal/service/pinpoint/apns_channel_test.go
@@ -95,7 +95,7 @@ func testAccAPNSChannelTokenConfigurationFromEnv(t *testing.T) *testAccAPNSChann
 }
 
 // APNS tests share credentials from environment variables tied to a single
-// Apple Developer identity. Concurrent registration would conflict.
+// Apple Developer identity.
 func TestAccPinpointAPNSChannel_serial(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/pinpoint/apns_channel_test.go
+++ b/internal/service/pinpoint/apns_channel_test.go
@@ -94,7 +94,20 @@ func testAccAPNSChannelTokenConfigurationFromEnv(t *testing.T) *testAccAPNSChann
 	return &conf
 }
 
-func TestAccPinpointAPNSChannel_basicCertificate(t *testing.T) {
+// APNS tests share credentials from environment variables tied to a single
+// Apple Developer identity. Concurrent registration would conflict.
+func TestAccPinpointAPNSChannel_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		"basicCertificate": testAccAPNSChannel_basicCertificate,
+		"basicToken":       testAccAPNSChannel_basicToken,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccAPNSChannel_basicCertificate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var channel awstypes.APNSChannelResponse
 	resourceName := "aws_pinpoint_apns_channel.test_apns_channel"
@@ -129,7 +142,7 @@ func TestAccPinpointAPNSChannel_basicCertificate(t *testing.T) {
 	})
 }
 
-func TestAccPinpointAPNSChannel_basicToken(t *testing.T) {
+func testAccAPNSChannel_basicToken(t *testing.T) {
 	ctx := acctest.Context(t)
 	var channel awstypes.APNSChannelResponse
 	resourceName := "aws_pinpoint_apns_channel.test_apns_channel"

--- a/internal/service/pinpoint/apns_sandbox_channel_test.go
+++ b/internal/service/pinpoint/apns_sandbox_channel_test.go
@@ -94,7 +94,20 @@ func testAccAPNSSandboxChannelTokenConfigurationFromEnv(t *testing.T) *testAccAP
 	return &conf
 }
 
-func TestAccPinpointAPNSSandboxChannel_basicCertificate(t *testing.T) {
+// APNS tests share credentials from environment variables tied to a single
+// Apple Developer identity. Concurrent registration would conflict.
+func TestAccPinpointAPNSSandboxChannel_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		"basicCertificate": testAccAPNSSandboxChannel_basicCertificate,
+		"basicToken":       testAccAPNSSandboxChannel_basicToken,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccAPNSSandboxChannel_basicCertificate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var channel awstypes.APNSSandboxChannelResponse
 	resourceName := "aws_pinpoint_apns_sandbox_channel.test_channel"
@@ -129,7 +142,7 @@ func TestAccPinpointAPNSSandboxChannel_basicCertificate(t *testing.T) {
 	})
 }
 
-func TestAccPinpointAPNSSandboxChannel_basicToken(t *testing.T) {
+func testAccAPNSSandboxChannel_basicToken(t *testing.T) {
 	ctx := acctest.Context(t)
 	var channel awstypes.APNSSandboxChannelResponse
 	resourceName := "aws_pinpoint_apns_sandbox_channel.test_channel"

--- a/internal/service/pinpoint/apns_sandbox_channel_test.go
+++ b/internal/service/pinpoint/apns_sandbox_channel_test.go
@@ -95,7 +95,7 @@ func testAccAPNSSandboxChannelTokenConfigurationFromEnv(t *testing.T) *testAccAP
 }
 
 // APNS tests share credentials from environment variables tied to a single
-// Apple Developer identity. Concurrent registration would conflict.
+// Apple Developer identity.
 func TestAccPinpointAPNSSandboxChannel_serial(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/pinpoint/apns_voip_channel_test.go
+++ b/internal/service/pinpoint/apns_voip_channel_test.go
@@ -94,7 +94,20 @@ func testAccAPNSVoIPChannelTokenConfigurationFromEnv(t *testing.T) *testAccAPNSV
 	return &conf
 }
 
-func TestAccPinpointAPNSVoIPChannel_basicCertificate(t *testing.T) {
+// APNS tests share credentials from environment variables tied to a single
+// Apple Developer identity. Concurrent registration would conflict.
+func TestAccPinpointAPNSVoIPChannel_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		"basicCertificate": testAccAPNSVoIPChannel_basicCertificate,
+		"basicToken":       testAccAPNSVoIPChannel_basicToken,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccAPNSVoIPChannel_basicCertificate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var channel awstypes.APNSVoipChannelResponse
 	resourceName := "aws_pinpoint_apns_voip_channel.test_channel"
@@ -129,7 +142,7 @@ func TestAccPinpointAPNSVoIPChannel_basicCertificate(t *testing.T) {
 	})
 }
 
-func TestAccPinpointAPNSVoIPChannel_basicToken(t *testing.T) {
+func testAccAPNSVoIPChannel_basicToken(t *testing.T) {
 	ctx := acctest.Context(t)
 	var channel awstypes.APNSVoipChannelResponse
 	resourceName := "aws_pinpoint_apns_voip_channel.test_channel"

--- a/internal/service/pinpoint/apns_voip_channel_test.go
+++ b/internal/service/pinpoint/apns_voip_channel_test.go
@@ -95,7 +95,7 @@ func testAccAPNSVoIPChannelTokenConfigurationFromEnv(t *testing.T) *testAccAPNSV
 }
 
 // APNS tests share credentials from environment variables tied to a single
-// Apple Developer identity. Concurrent registration would conflict.
+// Apple Developer identity.
 func TestAccPinpointAPNSVoIPChannel_serial(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/pinpoint/apns_voip_sandbox_channel_test.go
+++ b/internal/service/pinpoint/apns_voip_sandbox_channel_test.go
@@ -95,7 +95,7 @@ func testAccAPNSVoIPSandboxChannelTokenConfigurationFromEnv(t *testing.T) *testA
 }
 
 // APNS tests share credentials from environment variables tied to a single
-// Apple Developer identity. Concurrent registration would conflict.
+// Apple Developer identity.
 func TestAccPinpointAPNSVoIPSandboxChannel_serial(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/pinpoint/apns_voip_sandbox_channel_test.go
+++ b/internal/service/pinpoint/apns_voip_sandbox_channel_test.go
@@ -94,7 +94,20 @@ func testAccAPNSVoIPSandboxChannelTokenConfigurationFromEnv(t *testing.T) *testA
 	return &conf
 }
 
-func TestAccPinpointAPNSVoIPSandboxChannel_basicCertificate(t *testing.T) {
+// APNS tests share credentials from environment variables tied to a single
+// Apple Developer identity. Concurrent registration would conflict.
+func TestAccPinpointAPNSVoIPSandboxChannel_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		"basicCertificate": testAccAPNSVoIPSandboxChannel_basicCertificate,
+		"basicToken":       testAccAPNSVoIPSandboxChannel_basicToken,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccAPNSVoIPSandboxChannel_basicCertificate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var channel awstypes.APNSVoipSandboxChannelResponse
 	resourceName := "aws_pinpoint_apns_voip_sandbox_channel.test_channel"
@@ -129,7 +142,7 @@ func TestAccPinpointAPNSVoIPSandboxChannel_basicCertificate(t *testing.T) {
 	})
 }
 
-func TestAccPinpointAPNSVoIPSandboxChannel_basicToken(t *testing.T) {
+func testAccAPNSVoIPSandboxChannel_basicToken(t *testing.T) {
 	ctx := acctest.Context(t)
 	var channel awstypes.APNSVoipSandboxChannelResponse
 	resourceName := "aws_pinpoint_apns_voip_sandbox_channel.test_channel"

--- a/internal/service/route53/delegation_set_data_source_test.go
+++ b/internal/service/route53/delegation_set_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccRoute53DelegationSetDataSource_basic(t *testing.T) {
 
 	zoneName := acctest.RandomDomainName(t)
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/route53resolver/firewall_config_data_source_test.go
+++ b/internal/service/route53resolver/firewall_config_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccRoute53ResolverFirewallConfigDataSource_basic(t *testing.T) {
 	resourceName := "aws_route53_resolver_firewall_config.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ResolverServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/route53resolver/firewall_domain_list_data_source_test.go
+++ b/internal/service/route53resolver/firewall_domain_list_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccRoute53ResolverFirewallDomainListDataSource_basic(t *testing.T) {
 	resourceName := "aws_route53_resolver_firewall_domain_list.test"
 	domainName := acctest.RandomFQDomainName(t)
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ResolverServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/route53resolver/firewall_rule_group_association_data_source_test.go
+++ b/internal/service/route53resolver/firewall_rule_group_association_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccRoute53ResolverRuleGroupAssociationDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_route53_resolver_firewall_rule_group_association.test"
 	resourceName := "aws_route53_resolver_firewall_rule_group_association.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ResolverServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/route53resolver/firewall_rule_group_data_source_test.go
+++ b/internal/service/route53resolver/firewall_rule_group_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccRoute53ResolverFirewallRuleGroupDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_route53_resolver_firewall_rule_group.test"
 	resourceName := "aws_route53_resolver_firewall_rule_group.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ResolverServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/sagemaker/app_image_config_test.go
+++ b/internal/service/sagemaker/app_image_config_test.go
@@ -271,7 +271,7 @@ func TestAccSageMakerAppImageConfig_tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_app_image_config.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{ // nosemgrep:ci.semgrep.acctest.testcase-use-paralleltest -- generated tags test
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/sagemaker/feature_group_test.go
+++ b/internal/service/sagemaker/feature_group_test.go
@@ -28,12 +28,12 @@ func TestAccSageMakerFeatureGroup_serial(t *testing.T) {
 		"featureDefinition_collectionType":   testAccFeatureGroup_featureDefinition_collectionType,
 		"featureDefinition_collectionConfig": testAccFeatureGroup_featureDefinition_collectionConfig,
 		"description":                        testAccFeatureGroup_description,
-		acctest.CtDisappears:                 TestAccSageMakerFeatureGroup_disappears,
+		acctest.CtDisappears:                 testAccFeatureGroup_disappears,
 		"multipleFeatures":                   testAccFeatureGroup_multipleFeatures,
 		"offlineConfig_basic":                testAccFeatureGroup_offlineConfig_basic,
 		"offlineConfig_format":               testAccFeatureGroup_offlineConfig_format,
 		"offlineConfig_createCatalog":        testAccFeatureGroup_offlineConfig_createCatalog,
-		"offlineConfig_providedCatalog":      TestAccSageMakerFeatureGroup_Offline_providedCatalog,
+		"offlineConfig_providedCatalog":      testAccFeatureGroup_Offline_providedCatalog,
 		"onlineConfigSecurityConfig":         testAccFeatureGroup_onlineConfigSecurityConfig,
 		"onlineConfig_TTLDuration":           testAccFeatureGroup_onlineConfigTTLDuration,
 		"throughputConfig":                   testAccFeatureGroup_throughputConfig,
@@ -407,7 +407,7 @@ func testAccFeatureGroup_offlineConfig_createCatalog(t *testing.T) {
 	})
 }
 
-func TestAccSageMakerFeatureGroup_Offline_providedCatalog(t *testing.T) {
+func testAccFeatureGroup_Offline_providedCatalog(t *testing.T) {
 	ctx := acctest.Context(t)
 	var featureGroup sagemaker.DescribeFeatureGroupOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -556,7 +556,7 @@ func testAccFeatureGroup_featureDefinition_collectionConfig(t *testing.T) {
 	})
 }
 
-func TestAccSageMakerFeatureGroup_disappears(t *testing.T) {
+func testAccFeatureGroup_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var featureGroup sagemaker.DescribeFeatureGroupOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)

--- a/internal/service/sagemaker/human_task_ui_test.go
+++ b/internal/service/sagemaker/human_task_ui_test.go
@@ -17,7 +17,19 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccSageMakerHumanTaskUI_basic(t *testing.T) {
+func TestAccSageMakerHumanTaskUI_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		acctest.CtBasic:      testAccHumanTaskUI_basic,
+		"tags":               testAccHumanTaskUI_tags,
+		acctest.CtDisappears: testAccHumanTaskUI_disappears,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccHumanTaskUI_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var humanTaskUi sagemaker.DescribeHumanTaskUiOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -49,7 +61,7 @@ func TestAccSageMakerHumanTaskUI_basic(t *testing.T) {
 	})
 }
 
-func TestAccSageMakerHumanTaskUI_tags(t *testing.T) {
+func testAccHumanTaskUI_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var humanTaskUi sagemaker.DescribeHumanTaskUiOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -96,7 +108,7 @@ func TestAccSageMakerHumanTaskUI_tags(t *testing.T) {
 	})
 }
 
-func TestAccSageMakerHumanTaskUI_disappears(t *testing.T) {
+func testAccHumanTaskUI_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var humanTaskUi sagemaker.DescribeHumanTaskUiOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)

--- a/internal/service/sagemaker/human_task_ui_test.go
+++ b/internal/service/sagemaker/human_task_ui_test.go
@@ -17,25 +17,13 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccSageMakerHumanTaskUI_serial(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:      testAccHumanTaskUI_basic,
-		"tags":               testAccHumanTaskUI_tags,
-		acctest.CtDisappears: testAccHumanTaskUI_disappears,
-	}
-
-	acctest.RunSerialTests1Level(t, testCases, 0)
-}
-
-func testAccHumanTaskUI_basic(t *testing.T) {
+func TestAccSageMakerHumanTaskUI_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var humanTaskUi sagemaker.DescribeHumanTaskUiOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_human_task_ui.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -61,13 +49,13 @@ func testAccHumanTaskUI_basic(t *testing.T) {
 	})
 }
 
-func testAccHumanTaskUI_tags(t *testing.T) {
+func TestAccSageMakerHumanTaskUI_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var humanTaskUi sagemaker.DescribeHumanTaskUiOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_human_task_ui.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -108,13 +96,13 @@ func testAccHumanTaskUI_tags(t *testing.T) {
 	})
 }
 
-func testAccHumanTaskUI_disappears(t *testing.T) {
+func TestAccSageMakerHumanTaskUI_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var humanTaskUi sagemaker.DescribeHumanTaskUiOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_human_task_ui.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/sagemaker/pipeline_test.go
+++ b/internal/service/sagemaker/pipeline_test.go
@@ -18,34 +18,21 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccSageMakerPipeline_serial(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:      testAccPipeline_basic,
-		"parallelism":        testAccPipeline_parallelism,
-		"tags":               testAccPipeline_tags,
-		acctest.CtDisappears: testAccPipeline_disappears,
-	}
-
-	acctest.RunSerialTests1Level(t, testCases, 0)
-}
-
-func testAccPipeline_basic(t *testing.T) {
+func TestAccSageMakerPipeline_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var pipeline sagemaker.DescribePipelineOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	rNameUpdated := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_pipeline.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckPipelineDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPipelinePipelineConfig_basic(rName, rName),
+				Config: testAccPipelineConfig_basic(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPipelineExists(ctx, t, resourceName, &pipeline),
 					resource.TestCheckResourceAttr(resourceName, "pipeline_name", rName),
@@ -62,7 +49,7 @@ func testAccPipeline_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccPipelinePipelineConfig_basic(rName, rNameUpdated),
+				Config: testAccPipelineConfig_basic(rName, rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPipelineExists(ctx, t, resourceName, &pipeline),
 					resource.TestCheckResourceAttr(resourceName, "pipeline_name", rName),
@@ -77,20 +64,20 @@ func testAccPipeline_basic(t *testing.T) {
 	})
 }
 
-func testAccPipeline_parallelism(t *testing.T) {
+func TestAccSageMakerPipeline_parallelism(t *testing.T) {
 	ctx := acctest.Context(t)
 	var pipeline sagemaker.DescribePipelineOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_pipeline.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckPipelineDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPipelinePipelineConfig_parallelism(rName),
+				Config: testAccPipelineConfig_parallelism(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPipelineExists(ctx, t, resourceName, &pipeline),
 					resource.TestCheckResourceAttr(resourceName, "pipeline_name", rName),
@@ -107,20 +94,20 @@ func testAccPipeline_parallelism(t *testing.T) {
 	})
 }
 
-func testAccPipeline_tags(t *testing.T) {
+func TestAccSageMakerPipeline_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var pipeline sagemaker.DescribePipelineOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_pipeline.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckPipelineDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPipelinePipelineConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
+				Config: testAccPipelineConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPipelineExists(ctx, t, resourceName, &pipeline),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
@@ -133,7 +120,7 @@ func testAccPipeline_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccPipelinePipelineConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
+				Config: testAccPipelineConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPipelineExists(ctx, t, resourceName, &pipeline),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
@@ -142,7 +129,7 @@ func testAccPipeline_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccPipelinePipelineConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
+				Config: testAccPipelineConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPipelineExists(ctx, t, resourceName, &pipeline),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
@@ -153,20 +140,20 @@ func testAccPipeline_tags(t *testing.T) {
 	})
 }
 
-func testAccPipeline_disappears(t *testing.T) {
+func TestAccSageMakerPipeline_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var pipeline sagemaker.DescribePipelineOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_pipeline.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckPipelineDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPipelinePipelineConfig_basic(rName, rName),
+				Config: testAccPipelineConfig_basic(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPipelineExists(ctx, t, resourceName, &pipeline),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfsagemaker.ResourcePipeline(), resourceName),
@@ -228,7 +215,7 @@ func testAccCheckPipelineExists(ctx context.Context, t *testing.T, n string, pip
 	}
 }
 
-func testAccPipelinePipelineConfig_base(rName string) string {
+func testAccPipelineConfig_base(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name               = %[1]q
@@ -249,8 +236,8 @@ data "aws_iam_policy_document" "test" {
 `, rName)
 }
 
-func testAccPipelinePipelineConfig_basic(rName, dispName string) string {
-	return acctest.ConfigCompose(testAccPipelinePipelineConfig_base(rName), fmt.Sprintf(`
+func testAccPipelineConfig_basic(rName, dispName string) string {
+	return acctest.ConfigCompose(testAccPipelineConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_pipeline" "test" {
   pipeline_name         = %[1]q
   pipeline_display_name = %[2]q
@@ -270,8 +257,8 @@ resource "aws_sagemaker_pipeline" "test" {
 `, rName, dispName))
 }
 
-func testAccPipelinePipelineConfig_parallelism(rName string) string {
-	return acctest.ConfigCompose(testAccPipelinePipelineConfig_base(rName), fmt.Sprintf(`
+func testAccPipelineConfig_parallelism(rName string) string {
+	return acctest.ConfigCompose(testAccPipelineConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_pipeline" "test" {
   pipeline_name         = %[1]q
   pipeline_display_name = %[1]q
@@ -295,8 +282,8 @@ resource "aws_sagemaker_pipeline" "test" {
 `, rName))
 }
 
-func testAccPipelinePipelineConfig_tags1(rName, tagKey1, tagValue1 string) string {
-	return acctest.ConfigCompose(testAccPipelinePipelineConfig_base(rName), fmt.Sprintf(`
+func testAccPipelineConfig_tags1(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(testAccPipelineConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_pipeline" "test" {
   pipeline_name         = %[1]q
   pipeline_display_name = %[1]q
@@ -320,8 +307,8 @@ resource "aws_sagemaker_pipeline" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccPipelinePipelineConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccPipelinePipelineConfig_base(rName), fmt.Sprintf(`
+func testAccPipelineConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(testAccPipelineConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_pipeline" "test" {
   pipeline_name         = %[1]q
   pipeline_display_name = %[1]q

--- a/internal/service/sagemaker/pipeline_test.go
+++ b/internal/service/sagemaker/pipeline_test.go
@@ -18,7 +18,20 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccSageMakerPipeline_basic(t *testing.T) {
+func TestAccSageMakerPipeline_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		acctest.CtBasic:      testAccPipeline_basic,
+		"parallelism":        testAccPipeline_parallelism,
+		"tags":               testAccPipeline_tags,
+		acctest.CtDisappears: testAccPipeline_disappears,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccPipeline_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var pipeline sagemaker.DescribePipelineOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -64,7 +77,7 @@ func TestAccSageMakerPipeline_basic(t *testing.T) {
 	})
 }
 
-func TestAccSageMakerPipeline_parallelism(t *testing.T) {
+func testAccPipeline_parallelism(t *testing.T) {
 	ctx := acctest.Context(t)
 	var pipeline sagemaker.DescribePipelineOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -94,7 +107,7 @@ func TestAccSageMakerPipeline_parallelism(t *testing.T) {
 	})
 }
 
-func TestAccSageMakerPipeline_tags(t *testing.T) {
+func testAccPipeline_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var pipeline sagemaker.DescribePipelineOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -140,7 +153,7 @@ func TestAccSageMakerPipeline_tags(t *testing.T) {
 	})
 }
 
-func TestAccSageMakerPipeline_disappears(t *testing.T) {
+func testAccPipeline_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var pipeline sagemaker.DescribePipelineOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)

--- a/internal/service/sagemaker/studio_lifecycle_config_test.go
+++ b/internal/service/sagemaker/studio_lifecycle_config_test.go
@@ -17,7 +17,19 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccSageMakerStudioLifecycleConfig_basic(t *testing.T) {
+func TestAccSageMakerStudioLifecycleConfig_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		acctest.CtBasic:      testAccStudioLifecycleConfig_basic,
+		"tags":               testAccStudioLifecycleConfig_tags,
+		acctest.CtDisappears: testAccStudioLifecycleConfig_disappears,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccStudioLifecycleConfig_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var config sagemaker.DescribeStudioLifecycleConfigOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -49,7 +61,7 @@ func TestAccSageMakerStudioLifecycleConfig_basic(t *testing.T) {
 	})
 }
 
-func TestAccSageMakerStudioLifecycleConfig_tags(t *testing.T) {
+func testAccStudioLifecycleConfig_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var config sagemaker.DescribeStudioLifecycleConfigOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -95,7 +107,7 @@ func TestAccSageMakerStudioLifecycleConfig_tags(t *testing.T) {
 	})
 }
 
-func TestAccSageMakerStudioLifecycleConfig_disappears(t *testing.T) {
+func testAccStudioLifecycleConfig_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var config sagemaker.DescribeStudioLifecycleConfigOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)

--- a/internal/service/sagemaker/studio_lifecycle_config_test.go
+++ b/internal/service/sagemaker/studio_lifecycle_config_test.go
@@ -17,25 +17,13 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccSageMakerStudioLifecycleConfig_serial(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:      testAccStudioLifecycleConfig_basic,
-		"tags":               testAccStudioLifecycleConfig_tags,
-		acctest.CtDisappears: testAccStudioLifecycleConfig_disappears,
-	}
-
-	acctest.RunSerialTests1Level(t, testCases, 0)
-}
-
-func testAccStudioLifecycleConfig_basic(t *testing.T) {
+func TestAccSageMakerStudioLifecycleConfig_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var config sagemaker.DescribeStudioLifecycleConfigOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_studio_lifecycle_config.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -61,13 +49,13 @@ func testAccStudioLifecycleConfig_basic(t *testing.T) {
 	})
 }
 
-func testAccStudioLifecycleConfig_tags(t *testing.T) {
+func TestAccSageMakerStudioLifecycleConfig_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var config sagemaker.DescribeStudioLifecycleConfigOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_studio_lifecycle_config.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -107,13 +95,13 @@ func testAccStudioLifecycleConfig_tags(t *testing.T) {
 	})
 }
 
-func testAccStudioLifecycleConfig_disappears(t *testing.T) {
+func TestAccSageMakerStudioLifecycleConfig_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var config sagemaker.DescribeStudioLifecycleConfigOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_studio_lifecycle_config.test"
 
-	acctest.Test(ctx, t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/sns/platform_application_test.go
+++ b/internal/service/sns/platform_application_test.go
@@ -364,7 +364,7 @@ func TestAccSNSPlatformApplication_basicAttributes(t *testing.T) {
 				t.Run(fmt.Sprintf("%s/%s", platform.Name, tc.AttributeKey), func(*testing.T) {
 					name := fmt.Sprintf("tf-acc-%d", acctest.RandInt(t))
 
-					acctest.Test(ctx, t, resource.TestCase{
+					acctest.Test(ctx, t, resource.TestCase{ // nosemgrep:ci.semgrep.acctest.testcase-use-paralleltest -- sequential subtests within parallel platform loop to avoid credential conflicts
 						PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 						ErrorCheck:               acctest.ErrorCheck(t, names.SNSServiceID),
 						ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/transfer/connector_test.go
+++ b/internal/service/transfer/connector_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccTransferConnector_basic(t *testing.T) {
+func testAccConnector_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.DescribedConnector
 	resourceName := "aws_transfer_connector.test"
@@ -60,7 +60,7 @@ func TestAccTransferConnector_basic(t *testing.T) {
 	})
 }
 
-func TestAccTransferConnector_sftpConfig(t *testing.T) {
+func testAccConnector_sftpConfig(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.DescribedConnector
 	resourceName := "aws_transfer_connector.test"
@@ -95,7 +95,7 @@ func TestAccTransferConnector_sftpConfig(t *testing.T) {
 	})
 }
 
-func TestAccTransferConnector_securityPolicyName(t *testing.T) {
+func testAccConnector_securityPolicyName(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.DescribedConnector
 	resourceName := "aws_transfer_connector.test"
@@ -130,7 +130,7 @@ func TestAccTransferConnector_securityPolicyName(t *testing.T) {
 	})
 }
 
-func TestAccTransferConnector_disappears(t *testing.T) {
+func testAccConnector_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.DescribedConnector
 	resourceName := "aws_transfer_connector.test"
@@ -158,7 +158,7 @@ func TestAccTransferConnector_disappears(t *testing.T) {
 	})
 }
 
-func TestAccTransferConnector_egressConfig(t *testing.T) {
+func testAccConnector_egressConfig(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.DescribedConnector
 	resourceName := "aws_transfer_connector.test"
@@ -194,7 +194,7 @@ func TestAccTransferConnector_egressConfig(t *testing.T) {
 	})
 }
 
-func TestAccTransferConnector_egressConfigUpdate(t *testing.T) {
+func testAccConnector_egressConfigUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.DescribedConnector
 	resourceName := "aws_transfer_connector.test"
@@ -233,7 +233,7 @@ func TestAccTransferConnector_egressConfigUpdate(t *testing.T) {
 	})
 }
 
-func TestAccTransferConnector_tags(t *testing.T) {
+func testAccConnector_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.DescribedConnector
 	resourceName := "aws_transfer_connector.test"

--- a/internal/service/transfer/transfer_test.go
+++ b/internal/service/transfer/transfer_test.go
@@ -69,6 +69,23 @@ func TestAccTransfer_serial(t *testing.T) {
 			"VPCSecurityGroupIDs":                                    testAccServer_vpcSecurityGroupIDs,
 			"Workflow":                                               testAccServer_workflowDetails,
 		},
+		"Connector": {
+			acctest.CtBasic:      testAccConnector_basic,
+			"sftpConfig":         testAccConnector_sftpConfig,
+			"securityPolicyName": testAccConnector_securityPolicyName,
+			acctest.CtDisappears: testAccConnector_disappears,
+			"egressConfig":       testAccConnector_egressConfig,
+			"egressConfigUpdate": testAccConnector_egressConfigUpdate,
+			"tags":               testAccConnector_tags,
+		},
+		"Workflow": {
+			acctest.CtBasic:      testAccWorkflow_basic,
+			"onExceptionSteps":   testAccWorkflow_onExceptionSteps,
+			"description":        testAccWorkflow_description,
+			"tags":               testAccWorkflow_tags,
+			acctest.CtDisappears: testAccWorkflow_disappears,
+			"allSteps":           testAccWorkflow_allSteps,
+		},
 		"SSHKey": {
 			acctest.CtBasic:      testAccSSHKey_basic,
 			acctest.CtDisappears: testAccSSHKey_disappears,

--- a/internal/service/transfer/workflow_test.go
+++ b/internal/service/transfer/workflow_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccTransferWorkflow_basic(t *testing.T) {
+func testAccWorkflow_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.DescribedWorkflow
 	resourceName := "aws_transfer_workflow.test"
@@ -58,7 +58,7 @@ func TestAccTransferWorkflow_basic(t *testing.T) {
 	})
 }
 
-func TestAccTransferWorkflow_onExceptionSteps(t *testing.T) {
+func testAccWorkflow_onExceptionSteps(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.DescribedWorkflow
 	resourceName := "aws_transfer_workflow.test"
@@ -105,7 +105,7 @@ func TestAccTransferWorkflow_onExceptionSteps(t *testing.T) {
 	})
 }
 
-func TestAccTransferWorkflow_description(t *testing.T) {
+func testAccWorkflow_description(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.DescribedWorkflow
 	resourceName := "aws_transfer_workflow.test"
@@ -133,7 +133,7 @@ func TestAccTransferWorkflow_description(t *testing.T) {
 	})
 }
 
-func TestAccTransferWorkflow_tags(t *testing.T) {
+func testAccWorkflow_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.DescribedWorkflow
 	resourceName := "aws_transfer_workflow.test"
@@ -179,7 +179,7 @@ func TestAccTransferWorkflow_tags(t *testing.T) {
 	})
 }
 
-func TestAccTransferWorkflow_disappears(t *testing.T) {
+func testAccWorkflow_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.DescribedWorkflow
 	resourceName := "aws_transfer_workflow.test"
@@ -203,7 +203,7 @@ func TestAccTransferWorkflow_disappears(t *testing.T) {
 	})
 }
 
-func TestAccTransferWorkflow_allSteps(t *testing.T) {
+func testAccWorkflow_allSteps(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.DescribedWorkflow
 	resourceName := "aws_transfer_workflow.test"


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds a new `semgrep` rule to enforce the use of `acctest.ParallelTest` on all exported acceptance tests. This explicitly enforces tests requiring serialized execution to be unexported and passed into a `_serial` test runner. 

There were 70+ existing violations of this rule which have been resolved by either:

1. Switching to `acctest.ParallelTest` when serialization is not necessary
2. Unexporting the test and wrapping in a `_serial` test runner
3. Adding a `nosemgrep` comment when a non-standard (but correct) testing pattern is being used 


**AI Disclosure:** An AI agent was used to write this `semgrep` rule and refactor impacted tests. All changes were manually reviewed and edited for correctness as needed. I fully understand all changes made.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #47888 

