### PR TITLE
.ci/semgrep: add `disappears-expect-resource-action` rule

### DIFF
--- a/.ci/semgrep/acctest/disappears.go
+++ b/.ci/semgrep/acctest/disappears.go
@@ -1,0 +1,259 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func testSDKDisappearsWithoutPlanCheck(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	const resourceName = "aws_example_thing.test"
+
+	acctest.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExists(ctx, t, resourceName),
+					// ruleid: disappears-expect-resource-action
+					acctest.CheckSDKResourceDisappears(ctx, t, ResourceThing(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testSDKDisappearsWithPlanCheck(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	const resourceName = "aws_example_thing.test"
+
+	acctest.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExists(ctx, t, resourceName),
+					// ok: disappears-expect-resource-action
+					acctest.CheckSDKResourceDisappears(ctx, t, ResourceThing(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testSDKDisappearsWithWrongAction(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	const resourceName = "aws_example_thing.test"
+
+	acctest.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExists(ctx, t, resourceName),
+					// ruleid: disappears-expect-resource-action
+					acctest.CheckSDKResourceDisappears(ctx, t, ResourceThing(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testFrameworkDisappearsWithoutPlanCheck(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	const resourceName = "aws_example_thing.test"
+
+	acctest.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckExists(ctx, t, resourceName),
+					// ruleid: disappears-expect-resource-action
+					acctest.CheckFrameworkResourceDisappears(ctx, t, ResourceThing, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testFrameworkDisappearsWithPlanCheck(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	const resourceName = "aws_example_thing.test"
+
+	acctest.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckExists(ctx, t, resourceName),
+					// ok: disappears-expect-resource-action
+					acctest.CheckFrameworkResourceDisappears(ctx, t, ResourceThing, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testFrameworkDisappearsWithWrongAction(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	const resourceName = "aws_example_thing.test"
+
+	acctest.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckExists(ctx, t, resourceName),
+					// ruleid: disappears-expect-resource-action
+					acctest.CheckFrameworkResourceDisappears(ctx, t, ResourceThing, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testFrameworkStateFuncDisappearsWithoutPlanCheck(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	const resourceName = "aws_example_thing.test"
+
+	acctest.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExists(ctx, t, resourceName),
+					// ruleid: disappears-expect-resource-action
+					acctest.CheckFrameworkResourceDisappearsWithStateFunc(ctx, t, ResourceThing, resourceName, stateFunc),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testFrameworkStateFuncDisappearsWithPlanCheck(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	const resourceName = "aws_example_thing.test"
+
+	acctest.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExists(ctx, t, resourceName),
+					// ok: disappears-expect-resource-action
+					acctest.CheckFrameworkResourceDisappearsWithStateFunc(ctx, t, ResourceThing, resourceName, stateFunc),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testFrameworkStateFuncDisappearsWithWrongAction(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	const resourceName = "aws_example_thing.test"
+
+	acctest.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExists(ctx, t, resourceName),
+					// ruleid: disappears-expect-resource-action
+					acctest.CheckFrameworkResourceDisappearsWithStateFunc(ctx, t, ResourceThing, resourceName, stateFunc),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}

--- a/.ci/semgrep/acctest/disappears.yml
+++ b/.ci/semgrep/acctest/disappears.yml
@@ -22,3 +22,46 @@ rules:
     pattern: acctest.CheckFrameworkResourceDisappearsWithStateFunc(ctx, acctest.Provider, $RES, $NAME, $F)
     fix: acctest.CheckFrameworkResourceDisappearsWithStateFunc(ctx, t, $RES, $NAME, $F)
     severity: ERROR
+
+  - id: disappears-expect-resource-action
+    languages: [go]
+    message: |
+      Disappears acceptance tests should include `ConfigPlanChecks` with a `PostApplyPostRefresh` plan check
+      using `plancheck.ExpectResourceAction` to verify the resource is planned for re-creation.
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: acctest.CheckSDKResourceDisappears(...)
+          - pattern: acctest.CheckFrameworkResourceDisappears(...)
+          - pattern: acctest.CheckFrameworkResourceDisappearsWithStateFunc(...)
+      - pattern-inside: |
+          Steps: []resource.TestStep{
+            ...,
+          }
+      - pattern-not-inside: |
+          {
+            ...,
+            ConfigPlanChecks: resource.ConfigPlanChecks{
+              ...,
+              PostApplyPostRefresh: []plancheck.PlanCheck{
+                ...,
+                plancheck.ExpectResourceAction($NAME, plancheck.ResourceActionCreate),
+                ...,
+              },
+              ...,
+            },
+            ...,
+          }
+    # To roll out gradually, only fully-compliant services are included in the
+    # paths list below. As each service is updated, add its path to the list.
+    paths:
+      include:
+        - "/internal/service/bedrockagentcore/*_test.go"
+        - "/internal/service/billing/*_test.go"
+        - "/internal/service/cur/*_test.go"
+        - "/internal/service/networkflowmonitor/*_test.go"
+        - "/internal/service/notifications/*_test.go"
+        - "/internal/service/notificationscontacts/*_test.go"
+        - "/internal/service/observabilityadmin/*_test.go"
+        - "/internal/service/timestreaminfluxdb/*_test.go"
+        - "/internal/service/workmail/*_test.go"


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This rule requires that `_disappears` acceptance tests include a `PostApplyPostRefresh` config plan check that asserts the resource under test is planned for creation. This ensures that the expected non-empty plan is caused by the resource being tested and not a dependency or other side-effect of the apply.

**AI Disclosure:** An AI agent was used to write this `semgrep` rule. All changes were manually reviewed and edited for correctness as needed. I fully understand all additions made.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #42261
Relates #47911
Relates #47888 

