### PR TITLE
add hosted_zone_id lookup to aws_s3_bucket_website_configuration

### DIFF
--- a/.changelog/47917.txt
+++ b/.changelog/47917.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket_website_configuration: Add `hosted_zone_id` attribute to support Route 53 alias records
+```

--- a/internal/service/s3/bucket_website_configuration.go
+++ b/internal/service/s3/bucket_website_configuration.go
@@ -179,6 +179,10 @@ func resourceBucketWebsiteConfiguration() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			names.AttrHostedZoneID: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta any) error {
@@ -324,6 +328,11 @@ func resourceBucketWebsiteConfigurationRead(ctx context.Context, d *schema.Resou
 		endpoint, domain := bucketWebsiteEndpointAndDomain(bucket, string(output.LocationConstraint))
 		d.Set("website_domain", domain)
 		d.Set("website_endpoint", endpoint)
+		if hostedZoneID, err := hostedZoneIDForRegion(string(output.LocationConstraint)); err == nil {
+			d.Set(names.AttrHostedZoneID, hostedZoneID)
+		} else {
+			log.Printf("[WARN] %s", err)
+		}
 	}
 
 	return diags

--- a/website/docs/r/s3_bucket_website_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_website_configuration.html.markdown
@@ -130,6 +130,7 @@ The `redirect` configuration block supports the following arguments:
 This resource exports the following attributes in addition to the arguments above:
 
 * `id` - The `bucket` or `bucket` and `expected_bucket_owner` separated by a comma (`,`) if the latter is provided.
+* `hosted_zone_id` - [Route 53](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-object-lambda-cloudfront.html) hosted zone ID for the S3 website endpoint. This is used to create Route 53 alias records.
 * `website_domain` - Domain of the website endpoint. This is used to create Route 53 alias records.
 * `website_endpoint` - Website endpoint.
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request?

No

### Description
Pretty minor change to add attribute lookup and avoid any functionality regression in the deprecation of website_configuration on `aws_s3_bucket`


### Relations
Closes #37509

### Output from Acceptance Testing

```console
% make testacc PKG=s3 TESTS=TestAccS3BucketWebsiteConfiguration_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 add_hosted_zone_id_to_aws_s3_bucket_website_configuration 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketWebsiteConfiguration_basic'  -timeout 360m -vet=off -buildvcs=false
2026/05/14 12:23:58 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/14 12:23:58 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3BucketWebsiteConfiguration_basic
=== PAUSE TestAccS3BucketWebsiteConfiguration_basic
=== CONT  TestAccS3BucketWebsiteConfiguration_basic
--- PASS: TestAccS3BucketWebsiteConfiguration_basic (15.88s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 19.916s
```
